### PR TITLE
(PC-22604)[API] feat: comment flask admin routes

### DIFF
--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -5,49 +5,54 @@ from flask_admin.base import Admin
 from sqlalchemy.orm.session import Session
 
 from pcapi.admin.custom_views import offer_view
-from pcapi.admin.custom_views.admin_user_view import AdminUserView
-from pcapi.admin.custom_views.allocine_pivot_view import AllocinePivotView
-from pcapi.admin.custom_views.api_key_view import ApiKeyView
-from pcapi.admin.custom_views.beneficiary_user_view import BeneficiaryUserView
-from pcapi.admin.custom_views.booking_view import BookingView
-from pcapi.admin.custom_views.booking_view import CollectiveBookingView
-from pcapi.admin.custom_views.category_view import CategoryView
-from pcapi.admin.custom_views.category_view import SubcategoryView
-from pcapi.admin.custom_views.criteria_view import CriteriaView
-from pcapi.admin.custom_views.cultural_survey_view import CulturalSurveyView
-from pcapi.admin.custom_views.custom_reimbursement_rule_view import CustomReimbursementRuleView
-from pcapi.admin.custom_views.feature_view import FeatureView
-from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
-from pcapi.admin.custom_views.offerer_tag_category_view import OffererTagCategoryView
-from pcapi.admin.custom_views.offerer_tag_view import OffererTagView
-from pcapi.admin.custom_views.offerer_view import OffererView
-from pcapi.admin.custom_views.partner_user_view import PartnerUserView
-from pcapi.admin.custom_views.pro_user_view import ProUserView
-from pcapi.admin.custom_views.provider_view import ProviderView
-from pcapi.admin.custom_views.support_view import view
-from pcapi.admin.custom_views.suspend_fraudulent_users_by_email_providers import (
-    SuspendFraudulentUsersByEmailProvidersView,
-)
-from pcapi.admin.custom_views.user_email_history_view import UserEmailHistoryView
-from pcapi.admin.custom_views.user_offerer_view import UserOffererView
-from pcapi.admin.custom_views.venue_provider_view import VenueProviderView
-from pcapi.admin.custom_views.venue_view import VenueForOffererSubview
-from pcapi.admin.custom_views.venue_view import VenueView
-import pcapi.core.criteria.models as criteria_models
-import pcapi.core.educational.models as educational_models
-import pcapi.core.finance.models as finance_models
-import pcapi.core.offerers.models as offerers_models
+
+# from pcapi.admin.custom_views.admin_user_view import AdminUserView
+# from pcapi.admin.custom_views.allocine_pivot_view import AllocinePivotView
+# from pcapi.admin.custom_views.api_key_view import ApiKeyView
+# from pcapi.admin.custom_views.beneficiary_user_view import BeneficiaryUserView
+# from pcapi.admin.custom_views.booking_view import BookingView
+# from pcapi.admin.custom_views.booking_view import CollectiveBookingView
+# from pcapi.admin.custom_views.category_view import CategoryView
+# from pcapi.admin.custom_views.category_view import SubcategoryView
+# from pcapi.admin.custom_views.criteria_view import CriteriaView
+# from pcapi.admin.custom_views.cultural_survey_view import CulturalSurveyView
+# from pcapi.admin.custom_views.custom_reimbursement_rule_view import CustomReimbursementRuleView
+# from pcapi.admin.custom_views.feature_view import FeatureView
+# from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
+# from pcapi.admin.custom_views.offerer_tag_category_view import OffererTagCategoryView
+# from pcapi.admin.custom_views.offerer_tag_view import OffererTagView
+# from pcapi.admin.custom_views.offerer_view import OffererView
+# from pcapi.admin.custom_views.partner_user_view import PartnerUserView
+# from pcapi.admin.custom_views.pro_user_view import ProUserView
+# from pcapi.admin.custom_views.provider_view import ProviderView
+# from pcapi.admin.custom_views.support_view import view
+# from pcapi.admin.custom_views.suspend_fraudulent_users_by_email_providers import (
+#     SuspendFraudulentUsersByEmailProvidersView,
+# )
+# from pcapi.admin.custom_views.user_email_history_view import UserEmailHistoryView
+# from pcapi.admin.custom_views.user_offerer_view import UserOffererView
+# from pcapi.admin.custom_views.venue_provider_view import VenueProviderView
+# from pcapi.admin.custom_views.venue_view import VenueForOffererSubview
+# from pcapi.admin.custom_views.venue_view import VenueView
+# import pcapi.core.criteria.models as criteria_models
+# import pcapi.core.educational.models as educational_models
+# import pcapi.core.finance.models as finance_models
+# import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
-import pcapi.core.providers.models as providers_models
-import pcapi.core.users.models as users_models
-from pcapi.models.feature import Feature
 
 from . import base_configuration
 from . import templating
-from .custom_views.boost_pivot_view import BoostPivotView
-from .custom_views.cgr_pivot_view import CGRPivotView
-from .custom_views.cine_office_pivot_view import CineOfficePivotView
-from .custom_views.suspend_fraudulent_users_by_ids import SuspendFraudulentUsersByUserIdsView
+
+
+# import pcapi.core.providers.models as providers_models
+# import pcapi.core.users.models as users_models
+# from pcapi.models.feature import Feature
+
+
+# from .custom_views.boost_pivot_view import BoostPivotView
+# from .custom_views.cgr_pivot_view import CGRPivotView
+# from .custom_views.cine_office_pivot_view import CineOfficePivotView
+# from .custom_views.suspend_fraudulent_users_by_ids import SuspendFraudulentUsersByUserIdsView
 
 
 class Category(Enum):
@@ -75,206 +80,206 @@ def install_views(admin: Admin, session: Session) -> None:
     admin.add_view(
         offer_view.OfferView(offers_models.Offer, session, name="Offres", category=Category.OFFRES_STRUCTURES_LIEUX)
     )
-    admin.add_view(
-        view.BeneficiaryView(
-            users_models.User, session, name="Bénéficiaires", endpoint="support_beneficiary", category=Category.SUPPORT
-        )
-    )
-    admin.add_view(
-        offer_view.OfferForVenueSubview(
-            offers_models.Offer,
-            session,
-            name="Offres pour un lieu",
-            endpoint="offer_for_venue",
-        )
-    )
-    admin.add_view(
-        CriteriaView(
-            criteria_models.Criterion,
-            session,
-            name="Tags des offres et des lieux",
-            category=Category.OFFRES_STRUCTURES_LIEUX,
-        )
-    )
-    admin.add_view(
-        OffererTagView(
-            offerers_models.OffererTag, session, name="Tags des structures", category=Category.OFFRES_STRUCTURES_LIEUX
-        )
-    )
-    admin.add_view(
-        OffererTagCategoryView(
-            offerers_models.OffererTagCategory,
-            session,
-            name="Catégories de tags des structures",
-            category=Category.OFFRES_STRUCTURES_LIEUX,
-        )
-    )
-    admin.add_view(
-        OffererView(offerers_models.Offerer, session, name="Structures", category=Category.OFFRES_STRUCTURES_LIEUX)
-    )
-    admin.add_view(VenueView(offerers_models.Venue, session, name="Lieux", category=Category.OFFRES_STRUCTURES_LIEUX))
-    admin.add_view(
-        VenueForOffererSubview(
-            offerers_models.Venue,
-            session,
-            name="Lieux pour une structure",
-            endpoint="venue_for_offerer",
-        )
-    )
-    admin.add_view(
-        UserOffererView(
-            offerers_models.UserOfferer,
-            session,
-            name="Lien Utilisateurs/Structures",
-            category=Category.OFFRES_STRUCTURES_LIEUX,
-        )
-    )
-    admin.add_view(
-        ProUserView(
-            users_models.User,
-            session,
-            name="Comptes Pros",
-            category=Category.USERS,
-            endpoint="pro_users",
-        )
-    )
-    admin.add_view(
-        VenueProviderView(
-            providers_models.VenueProvider,
-            session,
-            name="Imports automatiques",
-            endpoint="venue_providers",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
-    admin.add_view(
-        AdminUserView(
-            users_models.User,
-            session,
-            name="Comptes admin",
-            category=Category.USERS,
-            endpoint="admin_users",
-        )
-    )
-    admin.add_view(
-        BeneficiaryUserView(
-            users_models.User,
-            session,
-            name="Comptes Bénéficiaires",
-            category=Category.USERS,
-            endpoint="beneficiary_users",
-        )
-    )
-    admin.add_view(
-        PartnerUserView(
-            users_models.User,
-            session,
-            name="Comptes Jeune et Grand Public",
-            category=Category.USERS,
-            endpoint="partner_users",
-        )
-    )
-    admin.add_view(FeatureView(Feature, session, name="Feature Flipping", category=None))
-    admin.add_view(ApiKeyView(offerers_models.ApiKey, session, name="Clés API", category=Category.USERS))
-    admin.add_view(
-        UserEmailHistoryView(
-            users_models.UserEmailHistory,
-            session,
-            name="Historique des modifications emails",
-            category=Category.USERS,
-            endpoint="user_email_history",
-        )
-    )
-    admin.add_view(
-        AllocinePivotView(
-            providers_models.AllocinePivot, session, name="Pivot Allocine", category=Category.OFFRES_STRUCTURES_LIEUX
-        )
-    )
-    admin.add_view(
-        CineOfficePivotView(
-            providers_models.CDSCinemaDetails,
-            session,
-            name="Pivot Ciné Office",
-            endpoint="cine-office",
-            category=Category.OFFRES_STRUCTURES_LIEUX,
-        )
-    )
-    admin.add_view(
-        BoostPivotView(
-            providers_models.BoostCinemaDetails,
-            session,
-            name="Pivot Boost",
-            endpoint="boost",
-            category=Category.OFFRES_STRUCTURES_LIEUX,
-        )
-    )
-    admin.add_view(
-        CGRPivotView(
-            providers_models.CGRCinemaDetails,
-            session,
-            name="Pivot CGR",
-            endpoint="cgr",
-            category=Category.OFFRES_STRUCTURES_LIEUX,
-        )
-    )
-    admin.add_view(
-        ProviderView(
-            providers_models.Provider,
-            session,
-            name="Fournisseurs d'import",
-            endpoint="providers",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
-    admin.add_view(
-        ManyOffersOperationsView(
-            name="Opérations sur plusieurs offres",
-            endpoint="many_offers_operations",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
-    admin.add_view(
-        BookingView(
-            name="Réservations",
-            endpoint="bookings",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
-    admin.add_view(
-        CollectiveBookingView(
-            name="Réservations collectives",
-            endpoint="collective-bookings",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
-    admin.add_view(
-        offer_view.ValidationOfferView(
-            offers_models.Offer,
-            session,
-            name="Validation",
-            endpoint="validation",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
-    admin.add_view(
-        offer_view.ValidationCollectiveOfferView(
-            educational_models.CollectiveOffer,
-            session,
-            name="Validation d'offres collectives",
-            endpoint="validation-collective-offer",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
+    # admin.add_view(
+    #     view.BeneficiaryView(
+    #         users_models.User, session, name="Bénéficiaires", endpoint="support_beneficiary", category=Category.SUPPORT
+    #     )
+    # )
+    # admin.add_view(
+    #     offer_view.OfferForVenueSubview(
+    #         offers_models.Offer,
+    #         session,
+    #         name="Offres pour un lieu",
+    #         endpoint="offer_for_venue",
+    #     )
+    # )
+    # admin.add_view(
+    #     CriteriaView(
+    #         criteria_models.Criterion,
+    #         session,
+    #         name="Tags des offres et des lieux",
+    #         category=Category.OFFRES_STRUCTURES_LIEUX,
+    #     )
+    # )
+    # admin.add_view(
+    #     OffererTagView(
+    #         offerers_models.OffererTag, session, name="Tags des structures", category=Category.OFFRES_STRUCTURES_LIEUX
+    #     )
+    # )
+    # admin.add_view(
+    #     OffererTagCategoryView(
+    #         offerers_models.OffererTagCategory,
+    #         session,
+    #         name="Catégories de tags des structures",
+    #         category=Category.OFFRES_STRUCTURES_LIEUX,
+    #     )
+    # )
+    # admin.add_view(
+    #     OffererView(offerers_models.Offerer, session, name="Structures", category=Category.OFFRES_STRUCTURES_LIEUX)
+    # )
+    # admin.add_view(VenueView(offerers_models.Venue, session, name="Lieux", category=Category.OFFRES_STRUCTURES_LIEUX))
+    # admin.add_view(
+    #     VenueForOffererSubview(
+    #         offerers_models.Venue,
+    #         session,
+    #         name="Lieux pour une structure",
+    #         endpoint="venue_for_offerer",
+    #     )
+    # )
+    # admin.add_view(
+    #     UserOffererView(
+    #         offerers_models.UserOfferer,
+    #         session,
+    #         name="Lien Utilisateurs/Structures",
+    #         category=Category.OFFRES_STRUCTURES_LIEUX,
+    #     )
+    # )
+    # admin.add_view(
+    #     ProUserView(
+    #         users_models.User,
+    #         session,
+    #         name="Comptes Pros",
+    #         category=Category.USERS,
+    #         endpoint="pro_users",
+    #     )
+    # )
+    # admin.add_view(
+    #     VenueProviderView(
+    #         providers_models.VenueProvider,
+    #         session,
+    #         name="Imports automatiques",
+    #         endpoint="venue_providers",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
+    # admin.add_view(
+    #     AdminUserView(
+    #         users_models.User,
+    #         session,
+    #         name="Comptes admin",
+    #         category=Category.USERS,
+    #         endpoint="admin_users",
+    #     )
+    # )
+    # admin.add_view(
+    #     BeneficiaryUserView(
+    #         users_models.User,
+    #         session,
+    #         name="Comptes Bénéficiaires",
+    #         category=Category.USERS,
+    #         endpoint="beneficiary_users",
+    #     )
+    # )
+    # admin.add_view(
+    #     PartnerUserView(
+    #         users_models.User,
+    #         session,
+    #         name="Comptes Jeune et Grand Public",
+    #         category=Category.USERS,
+    #         endpoint="partner_users",
+    #     )
+    # )
+    # admin.add_view(FeatureView(Feature, session, name="Feature Flipping", category=None))
+    # admin.add_view(ApiKeyView(offerers_models.ApiKey, session, name="Clés API", category=Category.USERS))
+    # admin.add_view(
+    #     UserEmailHistoryView(
+    #         users_models.UserEmailHistory,
+    #         session,
+    #         name="Historique des modifications emails",
+    #         category=Category.USERS,
+    #         endpoint="user_email_history",
+    #     )
+    # )
+    # admin.add_view(
+    #     AllocinePivotView(
+    #         providers_models.AllocinePivot, session, name="Pivot Allocine", category=Category.OFFRES_STRUCTURES_LIEUX
+    #     )
+    # )
+    # admin.add_view(
+    #     CineOfficePivotView(
+    #         providers_models.CDSCinemaDetails,
+    #         session,
+    #         name="Pivot Ciné Office",
+    #         endpoint="cine-office",
+    #         category=Category.OFFRES_STRUCTURES_LIEUX,
+    #     )
+    # )
+    # admin.add_view(
+    #     BoostPivotView(
+    #         providers_models.BoostCinemaDetails,
+    #         session,
+    #         name="Pivot Boost",
+    #         endpoint="boost",
+    #         category=Category.OFFRES_STRUCTURES_LIEUX,
+    #     )
+    # )
+    # admin.add_view(
+    #     CGRPivotView(
+    #         providers_models.CGRCinemaDetails,
+    #         session,
+    #         name="Pivot CGR",
+    #         endpoint="cgr",
+    #         category=Category.OFFRES_STRUCTURES_LIEUX,
+    #     )
+    # )
+    # admin.add_view(
+    #     ProviderView(
+    #         providers_models.Provider,
+    #         session,
+    #         name="Fournisseurs d'import",
+    #         endpoint="providers",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
+    # admin.add_view(
+    #     ManyOffersOperationsView(
+    #         name="Opérations sur plusieurs offres",
+    #         endpoint="many_offers_operations",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
+    # admin.add_view(
+    #     BookingView(
+    #         name="Réservations",
+    #         endpoint="bookings",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
+    # admin.add_view(
+    #     CollectiveBookingView(
+    #         name="Réservations collectives",
+    #         endpoint="collective-bookings",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
+    # admin.add_view(
+    #     offer_view.ValidationOfferView(
+    #         offers_models.Offer,
+    #         session,
+    #         name="Validation",
+    #         endpoint="validation",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
+    # admin.add_view(
+    #     offer_view.ValidationCollectiveOfferView(
+    #         educational_models.CollectiveOffer,
+    #         session,
+    #         name="Validation d'offres collectives",
+    #         endpoint="validation-collective-offer",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
 
-    admin.add_view(
-        offer_view.ValidationCollectiveOfferTemplateView(
-            educational_models.CollectiveOfferTemplate,
-            session,
-            name="Validation d'offres collectives vitrines",
-            endpoint="validation-collective-offer-template",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
+    # admin.add_view(
+    #     offer_view.ValidationCollectiveOfferTemplateView(
+    #         educational_models.CollectiveOfferTemplate,
+    #         session,
+    #         name="Validation d'offres collectives vitrines",
+    #         endpoint="validation-collective-offer-template",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
 
     admin.add_view(
         offer_view.ImportConfigValidationOfferView(
@@ -286,54 +291,54 @@ def install_views(admin: Admin, session: Session) -> None:
         )
     )
 
-    admin.add_view(
-        SuspendFraudulentUsersByEmailProvidersView(
-            name="Suspension d'utilisateurs via noms de domaine",
-            endpoint="suspend_fraud_users_by_email_providers",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
+    # admin.add_view(
+    #     SuspendFraudulentUsersByEmailProvidersView(
+    #         name="Suspension d'utilisateurs via noms de domaine",
+    #         endpoint="suspend_fraud_users_by_email_providers",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
 
-    admin.add_view(
-        SuspendFraudulentUsersByUserIdsView(
-            name="Suspension d'utilisateurs via identifiants",
-            endpoint="suspend_fraud_users_by_user_ids",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
+    # admin.add_view(
+    #     SuspendFraudulentUsersByUserIdsView(
+    #         name="Suspension d'utilisateurs via identifiants",
+    #         endpoint="suspend_fraud_users_by_user_ids",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
 
-    admin.add_view(
-        CategoryView(
-            name="Catégories",
-            endpoint="categories",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
+    # admin.add_view(
+    #     CategoryView(
+    #         name="Catégories",
+    #         endpoint="categories",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
 
-    admin.add_view(
-        CulturalSurveyView(
-            name="Questionnaire de pratiques initiales",
-            endpoint="cultural_survey_answers",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
+    # admin.add_view(
+    #     CulturalSurveyView(
+    #         name="Questionnaire de pratiques initiales",
+    #         endpoint="cultural_survey_answers",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
 
-    admin.add_view(
-        SubcategoryView(
-            name="Sous-catégories",
-            endpoint="subcategories",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
+    # admin.add_view(
+    #     SubcategoryView(
+    #         name="Sous-catégories",
+    #         endpoint="subcategories",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
 
-    admin.add_view(
-        CustomReimbursementRuleView(
-            finance_models.CustomReimbursementRule,
-            session,
-            name="Règles de remboursement personnalisées",
-            category=Category.CUSTOM_OPERATIONS,
-        )
-    )
+    # admin.add_view(
+    #     CustomReimbursementRuleView(
+    #         finance_models.CustomReimbursementRule,
+    #         session,
+    #         name="Règles de remboursement personnalisées",
+    #         category=Category.CUSTOM_OPERATIONS,
+    #     )
+    # )
 
 
 def install_admin_autocomplete_views() -> None:

--- a/api/tests/admin/custom_views/admin_user_view_test.py
+++ b/api/tests/admin/custom_views/admin_user_view_test.py
@@ -1,165 +1,165 @@
-from dataclasses import asdict
-from datetime import datetime
-from datetime import timedelta
-from unittest.mock import patch
+# from dataclasses import asdict
+# from datetime import datetime
+# from datetime import timedelta
+# from unittest.mock import patch
 
-import pcapi.core.mails.testing as mails_testing
-from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
-from pcapi.core.testing import override_settings
-import pcapi.core.users.constants as users_constants
-import pcapi.core.users.factories as users_factories
-from pcapi.core.users.models import Token
-from pcapi.core.users.models import TokenType
-from pcapi.core.users.models import User
+# import pcapi.core.mails.testing as mails_testing
+# from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+# from pcapi.core.testing import override_settings
+# import pcapi.core.users.constants as users_constants
+# import pcapi.core.users.factories as users_factories
+# from pcapi.core.users.models import Token
+# from pcapi.core.users.models import TokenType
+# from pcapi.core.users.models import User
 
-from tests.conftest import TestClient
-from tests.conftest import clean_database
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
 
 
-class AdminUserViewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_admin_user_creation(self, mocked_validate_csrf_token, app):
-        users_factories.AdminFactory(email="admin@example.com")
+# class AdminUserViewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_admin_user_creation(self, mocked_validate_csrf_token, app):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        data = dict(
-            email="NEW-ADMIN@example.com",
-            firstName="Powerful",
-            lastName="Admin",
-            departementCode="76",
-            postalCode="76001",
-        )
+#         data = dict(
+#             email="NEW-ADMIN@example.com",
+#             firstName="Powerful",
+#             lastName="Admin",
+#             departementCode="76",
+#             postalCode="76001",
+#         )
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/admin_users/new", form=data)
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/admin_users/new", form=data)
 
-        assert response.status_code == 302
+#         assert response.status_code == 302
 
-        user_created = User.query.filter_by(email="new-admin@example.com").one()
-        assert user_created.firstName == "Powerful"
-        assert user_created.lastName == "Admin"
-        assert user_created.dateOfBirth is None
-        assert user_created.departementCode == "76"
-        assert user_created.postalCode == "76001"
-        assert user_created.has_admin_role is True
-        assert not user_created.has_beneficiary_role
-        assert user_created.has_admin_role
-        assert user_created.hasSeenProTutorials is True
-        assert user_created.hasSeenProRgs is True
-        assert user_created.needsToFillCulturalSurvey is False
+#         user_created = User.query.filter_by(email="new-admin@example.com").one()
+#         assert user_created.firstName == "Powerful"
+#         assert user_created.lastName == "Admin"
+#         assert user_created.dateOfBirth is None
+#         assert user_created.departementCode == "76"
+#         assert user_created.postalCode == "76001"
+#         assert user_created.has_admin_role is True
+#         assert not user_created.has_beneficiary_role
+#         assert user_created.has_admin_role
+#         assert user_created.hasSeenProTutorials is True
+#         assert user_created.hasSeenProRgs is True
+#         assert user_created.needsToFillCulturalSurvey is False
 
-        token = Token.query.filter_by(userId=user_created.id).first()
-        assert token.type == TokenType.RESET_PASSWORD
-        assert token.expirationDate > datetime.utcnow() + timedelta(hours=20)
+#         token = Token.query.filter_by(userId=user_created.id).first()
+#         assert token.type == TokenType.RESET_PASSWORD
+#         assert token.expirationDate > datetime.utcnow() + timedelta(hours=20)
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_admin_user_receive_a_reset_password_token(self, mocked_validate_csrf_token, app):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_admin_user_receive_a_reset_password_token(self, mocked_validate_csrf_token, app):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        data = dict(
-            email="new-admin@example.com",
-            firstName="Powerful",
-            lastName="Admin",
-            departementCode="76",
-            postalCode="76000",
-        )
+#         data = dict(
+#             email="new-admin@example.com",
+#             firstName="Powerful",
+#             lastName="Admin",
+#             departementCode="76",
+#             postalCode="76000",
+#         )
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/admin_users/new", form=data)
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/admin_users/new", form=data)
 
-        assert response.status_code == 302
+#         assert response.status_code == 302
 
-        user_created = User.query.filter_by(email="new-admin@example.com").one()
-        assert len(user_created.tokens) == 1
-        assert user_created.tokens[0].type == TokenType.RESET_PASSWORD
+#         user_created = User.query.filter_by(email="new-admin@example.com").one()
+#         assert len(user_created.tokens) == 1
+#         assert user_created.tokens[0].type == TokenType.RESET_PASSWORD
 
-        assert len(mails_testing.outbox) == 1
-        assert mails_testing.outbox[0].sent_data["params"] == {
-            "EMAIL_VALIDATION_LINK": "http://localhost:3001/mot-de-passe-perdu?token=" + user_created.tokens[0].value
-        }
-        assert mails_testing.outbox[0].sent_data["template"] == asdict(TransactionalEmail.EMAIL_VALIDATION_TO_PRO.value)
+#         assert len(mails_testing.outbox) == 1
+#         assert mails_testing.outbox[0].sent_data["params"] == {
+#             "EMAIL_VALIDATION_LINK": "http://localhost:3001/mot-de-passe-perdu?token=" + user_created.tokens[0].value
+#         }
+#         assert mails_testing.outbox[0].sent_data["template"] == asdict(TransactionalEmail.EMAIL_VALIDATION_TO_PRO.value)
 
-    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_admin_user_creation_is_restricted_in_prod(self, mocked_validate_csrf_token, app, db_session):
-        users_factories.AdminFactory(email="user@example.com")
+#     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_admin_user_creation_is_restricted_in_prod(self, mocked_validate_csrf_token, app, db_session):
+#         users_factories.AdminFactory(email="user@example.com")
 
-        data = dict(
-            email="new-admin@example.com",
-            firstName="Powerful",
-            lastName="Admin",
-            departementCode="76",
-            postalCode="76000",
-        )
+#         data = dict(
+#             email="new-admin@example.com",
+#             firstName="Powerful",
+#             lastName="Admin",
+#             departementCode="76",
+#             postalCode="76000",
+#         )
 
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/admin_users/new", form=data)
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/admin_users/new", form=data)
 
-        assert response.status_code == 302
+#         assert response.status_code == 302
 
-        filtered_users = User.query.filter_by(email="new-admin@example.com").all()
-        assert len(filtered_users) == 0
+#         filtered_users = User.query.filter_by(email="new-admin@example.com").all()
+#         assert len(filtered_users) == 0
 
-    @clean_database
-    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_super_admin_can_suspend_then_unsuspend_simple_admin(self, mocked_validate_csrf_token, app):
-        super_admin = users_factories.AdminFactory(email="superadmin@example.com")
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        client = TestClient(app.test_client()).with_session_auth(super_admin.email)
+#     @clean_database
+#     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_super_admin_can_suspend_then_unsuspend_simple_admin(self, mocked_validate_csrf_token, app):
+#         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         client = TestClient(app.test_client()).with_session_auth(super_admin.email)
 
-        # Suspend
-        url = f"/pc/back-office/admin_users/suspend?user_id={admin.id}"
-        suspend_response = client.post(
-            url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
-        )
-        assert suspend_response.status_code == 302
-        assert not admin.isActive
+#         # Suspend
+#         url = f"/pc/back-office/admin_users/suspend?user_id={admin.id}"
+#         suspend_response = client.post(
+#             url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
+#         )
+#         assert suspend_response.status_code == 302
+#         assert not admin.isActive
 
-        # Unsuspend
-        url = f"/pc/back-office/admin_users/unsuspend?user_id={admin.id}"
-        unsuspend_response = client.post(
-            url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
-        )
-        assert unsuspend_response.status_code == 302
-        assert admin.isActive
+#         # Unsuspend
+#         url = f"/pc/back-office/admin_users/unsuspend?user_id={admin.id}"
+#         unsuspend_response = client.post(
+#             url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
+#         )
+#         assert unsuspend_response.status_code == 302
+#         assert admin.isActive
 
-    @clean_database
-    @override_settings(IS_PROD=True)
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_simple_admin_can_not_suspend_admin(self, mocked_validate_csrf_token, app):
-        admin_1 = users_factories.AdminFactory(email="admin1@example.com")
-        admin_2 = users_factories.AdminFactory(email="admin2@example.com")
-        client = TestClient(app.test_client()).with_session_auth(admin_1.email)
+#     @clean_database
+#     @override_settings(IS_PROD=True)
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_simple_admin_can_not_suspend_admin(self, mocked_validate_csrf_token, app):
+#         admin_1 = users_factories.AdminFactory(email="admin1@example.com")
+#         admin_2 = users_factories.AdminFactory(email="admin2@example.com")
+#         client = TestClient(app.test_client()).with_session_auth(admin_1.email)
 
-        # admin_1 tries to suspend admin_2 (and fails to)
-        url = f"/pc/back-office/admin_users/suspend?user_id={admin_2.id}"
-        response = client.post(url, form={"reason": "fraud", "csrf_token": "token"})
+#         # admin_1 tries to suspend admin_2 (and fails to)
+#         url = f"/pc/back-office/admin_users/suspend?user_id={admin_2.id}"
+#         response = client.post(url, form={"reason": "fraud", "csrf_token": "token"})
 
-        assert response.status_code == 403
-        assert admin_2.isActive
+#         assert response.status_code == 403
+#         assert admin_2.isActive
 
-    @clean_database
-    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_simple_admin_can_not_unsuspend_simple_admin(self, mocked_validate_csrf_token, app):
-        super_admin = users_factories.AdminFactory(email="superadmin@example.com")
-        admin_1 = users_factories.AdminFactory(email="admin1@example.com")
-        admin_2 = users_factories.AdminFactory(email="admin2@example.com")
-        super_admin_client = TestClient(app.test_client()).with_session_auth(super_admin.email)
-        admin_1_client = TestClient(app.test_client()).with_session_auth(admin_1.email)
+#     @clean_database
+#     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_simple_admin_can_not_unsuspend_simple_admin(self, mocked_validate_csrf_token, app):
+#         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
+#         admin_1 = users_factories.AdminFactory(email="admin1@example.com")
+#         admin_2 = users_factories.AdminFactory(email="admin2@example.com")
+#         super_admin_client = TestClient(app.test_client()).with_session_auth(super_admin.email)
+#         admin_1_client = TestClient(app.test_client()).with_session_auth(admin_1.email)
 
-        # super_admin suspends admin_2
-        url = f"/pc/back-office/admin_users/suspend?user_id={admin_2.id}"
-        suspend_response = super_admin_client.post(
-            url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
-        )
-        assert suspend_response.status_code == 302
-        assert not admin_2.isActive
+#         # super_admin suspends admin_2
+#         url = f"/pc/back-office/admin_users/suspend?user_id={admin_2.id}"
+#         suspend_response = super_admin_client.post(
+#             url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
+#         )
+#         assert suspend_response.status_code == 302
+#         assert not admin_2.isActive
 
-        # admin_1 tries to unsuspend admin_2 (and fails to)
-        url = f"/pc/back-office/admin_users/unsuspend?user_id={admin_2.id}"
-        unsuspend_response = admin_1_client.post(url, form={"reason": "fraud", "csrf_token": "token"})
-        assert unsuspend_response.status_code == 403
-        assert not admin_2.isActive
+#         # admin_1 tries to unsuspend admin_2 (and fails to)
+#         url = f"/pc/back-office/admin_users/unsuspend?user_id={admin_2.id}"
+#         unsuspend_response = admin_1_client.post(url, form={"reason": "fraud", "csrf_token": "token"})
+#         assert unsuspend_response.status_code == 403
+#         assert not admin_2.isActive

--- a/api/tests/admin/custom_views/api_key_view_test.py
+++ b/api/tests/admin/custom_views/api_key_view_test.py
@@ -1,43 +1,43 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-import pcapi.core.offerers.factories as offerers_factories
-from pcapi.core.offerers.models import ApiKey
-import pcapi.core.users.factories as users_factories
+# import pcapi.core.offerers.factories as offerers_factories
+# from pcapi.core.offerers.models import ApiKey
+# import pcapi.core.users.factories as users_factories
 
-from tests.conftest import TestClient
-from tests.conftest import clean_database
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
 
 
-class ApiKeyViewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_api_key_creation(self, mocked_validate_csrf_token, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        offerer = offerers_factories.OffererFactory(siren=123456789)
+# class ApiKeyViewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_api_key_creation(self, mocked_validate_csrf_token, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         offerer = offerers_factories.OffererFactory(siren=123456789)
 
-        data = dict(
-            offererSiren=offerer.siren,
-        )
+#         data = dict(
+#             offererSiren=offerer.siren,
+#         )
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/apikey/new", form=data)
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/apikey/new", form=data)
 
-        assert response.status_code == 302
+#         assert response.status_code == 302
 
-        api_key = ApiKey.query.filter_by(offererId=offerer.id).one()
-        assert api_key.prefix is not None
-        assert api_key.secret is not None
+#         api_key = ApiKey.query.filter_by(offererId=offerer.id).one()
+#         assert api_key.prefix is not None
+#         assert api_key.secret is not None
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_api_key_creation_with_wrong_siren(self, mocked_validate_csrf_token, app):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_api_key_creation_with_wrong_siren(self, mocked_validate_csrf_token, app):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        data = dict(
-            offererSiren=123456789,
-        )
+#         data = dict(
+#             offererSiren=123456789,
+#         )
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/apikey/new", form=data)
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/apikey/new", form=data)
 
-        assert response.status_code == 200
+#         assert response.status_code == 200

--- a/api/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/api/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -1,446 +1,446 @@
-import datetime
-from unittest.mock import patch
-
-from dateutil.relativedelta import relativedelta
-import freezegun
-import pytest
-from requests.auth import _basic_auth_str
-
-from pcapi import settings
-from pcapi.admin.custom_views.beneficiary_user_view import BeneficiaryUserView
-from pcapi.admin.custom_views.beneficiary_user_view import _update_underage_beneficiary_deposit_expiration_date
-from pcapi.admin.custom_views.mixins.suspension_mixin import _allow_suspension_and_unsuspension
-from pcapi.core import testing
-import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import BookingStatus
-import pcapi.core.finance.models as finance_models
-import pcapi.core.mails.testing as mails_testing
-from pcapi.core.testing import override_settings
-from pcapi.core.users import testing as sendinblue_testing
-import pcapi.core.users.factories as users_factories
-from pcapi.core.users.models import User
-import pcapi.notifications.push.testing as push_testing
-
-from tests.conftest import TestClient
-from tests.conftest import clean_database
-
-
-@pytest.mark.usefixtures("db_session")
-class BeneficiaryUserViewUnitTest:
-    def test_update_underage_beneficiary_deposit_expiration_date_when_both_dates_in_the_past(self):
-        three_month_in_the_past = datetime.date.today() - relativedelta(months=3)
-        six_month_in_the_past = datetime.date.today() - relativedelta(months=6)
-
-        user_previous_18th_birth_day = six_month_in_the_past
-        user_new_18th_birth_day = three_month_in_the_past
-
-        user = users_factories.UnderageBeneficiaryFactory(
-            deposit__expirationDate=user_previous_18th_birth_day,
-            validatedBirthDate=user_new_18th_birth_day - relativedelta(years=18),
-        )
-
-        _update_underage_beneficiary_deposit_expiration_date(user)
-
-        assert user.deposit.expirationDate == datetime.datetime.combine(
-            user_previous_18th_birth_day, datetime.datetime.min.time()
-        )
-
-    def test_update_underage_beneficiary_deposit_expiration_date_when_new_expiration_date_after_previous_one(self):
-        three_month_in_the_past = datetime.date.today() - relativedelta(months=3)
-        six_month_in_the_future = datetime.date.today() + relativedelta(months=6)
-
-        user_previous_18th_birth_day = three_month_in_the_past
-        user_new_18th_birth_day = six_month_in_the_future
-
-        user = users_factories.UnderageBeneficiaryFactory(
-            deposit__expirationDate=user_previous_18th_birth_day,
-            validatedBirthDate=user_new_18th_birth_day - relativedelta(years=18),
-        )
-
-        _update_underage_beneficiary_deposit_expiration_date(user)
-
-        assert user.deposit.expirationDate == datetime.datetime.combine(
-            six_month_in_the_future, datetime.datetime.min.time()
-        )
-
-    @freezegun.freeze_time("2020-01-01 12:03:27")
-    def test_update_underage_beneficiary_deposit_expiration_date_when_new_expiration_date_before_previous_one_and_in_the_past(
-        self,
-    ):
-        three_month_in_the_past = datetime.date.today() - relativedelta(months=3)
-        six_month_in_the_future = datetime.date.today() + relativedelta(months=6)
-
-        user_previous_18th_birth_day = six_month_in_the_future
-        user_new_18th_birth_day = three_month_in_the_past
-
-        user = users_factories.UnderageBeneficiaryFactory(
-            deposit__expirationDate=user_previous_18th_birth_day,
-            validatedBirthDate=user_new_18th_birth_day - relativedelta(years=18),
-        )
-
-        _update_underage_beneficiary_deposit_expiration_date(user)
-
-        assert user.deposit.expirationDate == datetime.datetime.utcnow()
-
-    def test_update_underage_beneficiary_deposit_expiration_date_when_new_expiration_date_before_previous_one_and_in_the_future(
-        self,
-    ):
-        three_month_in_the_future = datetime.date.today() + relativedelta(months=3)
-        six_month_in_the_future = datetime.date.today() + relativedelta(months=6)
-
-        user_previous_18th_birth_day = six_month_in_the_future
-        user_new_18th_birth_day = three_month_in_the_future
-
-        user = users_factories.UnderageBeneficiaryFactory(
-            deposit__expirationDate=user_previous_18th_birth_day,
-            validatedBirthDate=user_new_18th_birth_day - relativedelta(years=18),
-        )
-
-        _update_underage_beneficiary_deposit_expiration_date(user)
-
-        assert user.deposit.expirationDate == datetime.datetime.combine(
-            user_new_18th_birth_day, datetime.datetime.min.time()
-        )
-
-
-class BeneficiaryUserViewTest:
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.date.today() - relativedelta(years=18, months=4)
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_list_beneficiaries(self, mocked_validate_csrf_token, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        users_factories.BeneficiaryGrant18Factory.create_batch(3)
-
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        with testing.assert_no_duplicated_queries():
-            response = client.get("/pc/back-office/beneficiary_users")
-
-        assert response.status_code == 200
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_beneficiary_user_creation_for_deposit_v2(self, mocked_validate_csrf_token, app):
-        users_factories.AdminFactory(email="user@example.com")
-
-        data = dict(
-            email="toto@example.com",
-            firstName="Serge",
-            lastName="Lama",
-            validatedBirthDate=f"{self.AGE18_ELIGIBLE_BIRTH_DATE:%Y-%m-%d}",
-            departementCode="93",
-            postalCode="93000",
-            phoneNumber="0601020304",
-            depositVersion="2",
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/beneficiary_users/new", form=data)
-
-        assert response.status_code == 302
-
-        user_created = User.query.filter_by(email="toto@example.com").one()
-        assert user_created.firstName == "Serge"
-        assert user_created.lastName == "Lama"
-        assert user_created.validatedBirthDate == self.AGE18_ELIGIBLE_BIRTH_DATE
-        assert user_created.departementCode == "93"
-        assert user_created.postalCode == "93000"
-        assert user_created.phoneNumber == "+33601020304"
-        assert len(user_created.deposits) == 1
-        assert user_created.deposit.version == 2
-        assert user_created.deposit.source == "pass-culture-admin"
-        assert user_created.deposit.amount == 300
-
-        assert push_testing.requests[0]["attribute_values"]["u.credit"] == 30000
-
-    @clean_database
-    def test_the_deposit_version_is_specified(self, app, db_session):
-        # Given
-        beneficiary_view = BeneficiaryUserView(User, db_session)
-        beneficiary_view_create_form = beneficiary_view.get_create_form()
-        data = dict(
-            email="toto@example.com",
-            firstName="Serge",
-            lastName="Lama",
-            dateOfBirth=f"{self.AGE18_ELIGIBLE_BIRTH_DATE:%Y-%m-%d %H:%M:%S}",
-            departementCode="93",
-            postalCode="93000",
-            phoneNumber="0601020304",
-            depositVersion="2",
-        )
-
-        form = beneficiary_view_create_form(data=data)
-        user = users_factories.UserFactory(dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE)
-
-        # When
-        beneficiary_view.on_model_change(form, user, True)
-
-        # Then
-        assert user.deposit_version == 2
-
-    @clean_database
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["admin@example.com"])
-    def test_form_has_no_deposit_field_for_production(self, app, db_session):
-        # We need an authenticated user to initialize the admin class
-        # and call `get_create_form()`, because `scaffold_form()` is
-        # called, which in turn calls the `form_columns` property,
-        # which expects to see an authenticated user.
-        admin = users_factories.AdminFactory()
-        headers = {"Authorization": _basic_auth_str(admin.email, settings.TEST_DEFAULT_PASSWORD)}
-        with app.test_request_context(headers=headers):
-            form_class = BeneficiaryUserView(User, db_session)
-            form = form_class.get_create_form()
-        assert hasattr(form, "phoneNumber")
-        assert not hasattr(form, "depositVersion")
-
-    @clean_database
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
-    def test_beneficiary_user_creation_is_restricted_in_prod(self, app, db_session):
-        users_factories.AdminFactory(email="user@example.com")
-
-        data = dict(
-            email="toto@example.com",
-            firstName="Serge",
-            lastName="Lama",
-            dateOfBirth=f"{self.AGE18_ELIGIBLE_BIRTH_DATE:%Y-%m-%d %H:%M:%S}",
-            departementCode="93",
-            postalCode="93000",
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/beneficiary_users/new", form=data)
-
-        assert response.status_code == 302
-
-        filtered_users = User.query.filter_by(email="toto@example.com").all()
-        deposits = finance_models.Deposit.query.all()
-        assert len(filtered_users) == 0
-        assert len(deposits) == 0
-        assert len(push_testing.requests) == 0
-
-    @clean_database
-    # FIXME (dbaty, 2020-12-16): I could not find a quick way to
-    #  generate a valid CSRF token in tests. This should be fixed.
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_suspend_beneficiary(self, mocked_validate_csrf_token, app):
-        admin = users_factories.AdminFactory(email="admin15@example.com")
-        booking = bookings_factories.BookingFactory()
-        beneficiary = booking.user
-
-        client = TestClient(app.test_client()).with_session_auth(admin.email)
-        url = f"/pc/back-office/beneficiary_users/suspend?user_id={beneficiary.id}"
-        data = {
-            "reason": "fraud suspicion",
-            "csrf_token": "token",
-        }
-        response = client.post(url, form=data)
-
-        assert response.status_code == 302
-        assert not beneficiary.isActive
-        assert booking.status is BookingStatus.CANCELLED
-
-    @clean_database
-    # FIXME (dbaty, 2020-12-16): I could not find a quick way to
-    #  generate a valid CSRF token in tests. This should be fixed.
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_unsuspend_beneficiary(self, mocked_validate_csrf_token, app):
-        admin = users_factories.AdminFactory(email="admin15@example.com")
-        beneficiary = users_factories.BeneficiaryGrant18Factory(email="user15@example.com", isActive=False)
-
-        client = TestClient(app.test_client()).with_session_auth(admin.email)
-        url = f"/pc/back-office/beneficiary_users/unsuspend?user_id={beneficiary.id}"
-        data = {
-            "reason": "fraud",
-            "csrf_token": "token",
-        }
-        response = client.post(url, form=data)
-
-        assert response.status_code == 302
-        assert beneficiary.isActive
-
-    @clean_database
-    @patch("pcapi.settings.IS_PROD", True)
-    def test_suspend_beneficiary_is_restricted(self, app):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        beneficiary = users_factories.BeneficiaryGrant18Factory(email="user@example.com")
-
-        client = TestClient(app.test_client()).with_session_auth(admin.email)
-        url = f"/pc/back-office/beneficiary_users/suspend?user_id={beneficiary.id}"
-        data = {
-            "reason": "fraud",
-            "csrf_token": "token",
-        }
-        response = client.post(url, form=data)
-
-        assert response.status_code == 403
-
-    @testing.override_settings(
-        IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super-admin@example.com", "boss@example.com"]
-    )
-    @pytest.mark.usefixtures("db_session")
-    def test_allow_suspension_and_unsuspension(self):
-        basic_admin = users_factories.AdminFactory(email="admin@example.com")
-        assert not _allow_suspension_and_unsuspension(basic_admin)
-        super_admin = users_factories.AdminFactory(email="super-admin@example.com")
-        assert _allow_suspension_and_unsuspension(super_admin)
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_beneficiary_user_edition_does_not_send_email(self, mocked_validate_csrf_token, app):
-        users_factories.AdminFactory(email="user@example.com")
-        user_to_edit = users_factories.BeneficiaryGrant18Factory(email="not_yet_edited@email.com")
-
-        data = dict(
-            email="edited@email.com",
-            firstName=user_to_edit.firstName,
-            lastName=user_to_edit.lastName,
-            dateOfBirth=user_to_edit.dateOfBirth.isoformat(sep=" ", timespec="seconds"),
-            departementCode=user_to_edit.departementCode,
-            postalCode="76000",
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/beneficiary_users/edit/?id={user_to_edit.id}", form=data)
-
-        assert response.status_code == 302
-
-        user_edited = User.query.filter_by(email="edited@email.com").one_or_none()
-        assert user_edited is not None
-        assert len(push_testing.requests) == 2
-
-        assert not mails_testing.outbox
-        assert len(push_testing.requests) == 2
-        assert len(sendinblue_testing.sendinblue_requests) == 1
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
-    def test_resend_validation_email_to_beneficiary(
-        self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
-    ):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        beneficiary = users_factories.BeneficiaryGrant18Factory(email="partner@example.com", isEmailValidated=False)
-        client = TestClient(app.test_client()).with_session_auth(admin.email)
-
-        url = f"/pc/back-office/beneficiary_users/resend-validation-email?user_id={beneficiary.id}"
-        resend_validation_email_response = client.post(url, form={"csrf_token": "token"})
-        assert resend_validation_email_response.status_code == 302
-        mocked_request_email_confirmation.assert_called_once_with(beneficiary)
-
-
-@override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-@pytest.mark.usefixtures("db_session")
-class BeneficiaryUserUpdateTest:
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_update_idpiecenumber(self, token, client):
-        super_admin = users_factories.AdminFactory(email="superadmin@example.com")
-        client.with_session_auth(super_admin.email)
-
-        user_to_update = users_factories.BeneficiaryGrant18Factory(departementCode="92", postalCode="92700")
-
-        url = f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}"
-        client.post(
-            url,
-            form={
-                "id": user_to_update.id,
-                "idPieceNumber": "123123123",
-                "departementCode": user_to_update.departementCode,
-                "csrf_token": "token",
-                "email": user_to_update.email,
-                "postalCode": user_to_update.postalCode,
-            },
-        )
-
-        assert user_to_update.idPieceNumber == "123123123"
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_clear_idpiecenumber(self, token, client):
-        super_admin = users_factories.AdminFactory(email="superadmin@example.com")
-        client.with_session_auth(super_admin.email)
-
-        user_to_update = users_factories.BeneficiaryGrant18Factory(
-            departementCode="92", postalCode="92700", idPieceNumber="123123123"
-        )
-
-        client.post(
-            f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}",
-            form={
-                "id": user_to_update.id,
-                "idPieceNumber": "",
-                "departementCode": user_to_update.departementCode,
-                "csrf_token": "token",
-                "email": user_to_update.email,
-                "postalCode": user_to_update.postalCode,
-            },
-        )
-
-        assert user_to_update.idPieceNumber is None
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_update_idpiecenumber_not_updated(self, token, client):
-        admin = users_factories.AdminFactory()  # not superadmin
-
-        user_to_update = users_factories.BeneficiaryGrant18Factory(departementCode="92", postalCode="92700")
-        client.with_session_auth(admin.email)
-
-        url = f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}"
-        client.post(
-            url,
-            form={
-                "idPieceNumber": "123123123",
-                "departementCode": user_to_update.departementCode,
-                "csrf_token": "token",
-                "email": user_to_update.email,
-                "postalCode": user_to_update.postalCode,
-            },
-        )
-
-        assert user_to_update.idPieceNumber != "123123123"
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_clear_ine_hash(self, token, client):
-        super_admin = users_factories.AdminFactory(email="superadmin@example.com")
-        client.with_session_auth(super_admin.email)
-
-        user_to_update = users_factories.BeneficiaryGrant18Factory(
-            departementCode="92", postalCode="92700", ineHash="123123123"
-        )
-
-        client.post(
-            f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}",
-            form={
-                "id": user_to_update.id,
-                "ineHash": "",
-                "departementCode": user_to_update.departementCode,
-                "csrf_token": "token",
-                "email": user_to_update.email,
-                "postalCode": user_to_update.postalCode,
-            },
-        )
-
-        assert user_to_update.ineHash is None
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_deposit_expiration_date_updated_when_user_is_underage_beneficiary(self, token, client):
-        super_admin = users_factories.AdminFactory(email="superadmin@example.com")
-        client.with_session_auth(super_admin.email)
-
-        user_to_update = users_factories.UnderageBeneficiaryFactory(postalCode="92700")
-
-        old_deposit_expiration_date = user_to_update.deposit.expirationDate
-        old_user_birth_date = user_to_update.validatedBirthDate
-        new_user_birth_date = old_user_birth_date + relativedelta(months=1)
-
-        client.post(
-            f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}",
-            form={
-                "id": user_to_update.id,
-                "validatedBirthDate": new_user_birth_date,
-                "csrf_token": "token",
-                "email": user_to_update.email,
-                "postalCode": user_to_update.postalCode,
-            },
-        )
-
-        assert user_to_update.validatedBirthDate == new_user_birth_date
-        assert user_to_update.deposit.expirationDate == old_deposit_expiration_date + relativedelta(months=1)
+# import datetime
+# from unittest.mock import patch
+
+# from dateutil.relativedelta import relativedelta
+# import freezegun
+# import pytest
+# from requests.auth import _basic_auth_str
+
+# from pcapi import settings
+# from pcapi.admin.custom_views.beneficiary_user_view import BeneficiaryUserView
+# from pcapi.admin.custom_views.beneficiary_user_view import _update_underage_beneficiary_deposit_expiration_date
+# from pcapi.admin.custom_views.mixins.suspension_mixin import _allow_suspension_and_unsuspension
+# from pcapi.core import testing
+# import pcapi.core.bookings.factories as bookings_factories
+# from pcapi.core.bookings.models import BookingStatus
+# import pcapi.core.finance.models as finance_models
+# import pcapi.core.mails.testing as mails_testing
+# from pcapi.core.testing import override_settings
+# from pcapi.core.users import testing as sendinblue_testing
+# import pcapi.core.users.factories as users_factories
+# from pcapi.core.users.models import User
+# import pcapi.notifications.push.testing as push_testing
+
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
+
+
+# @pytest.mark.usefixtures("db_session")
+# class BeneficiaryUserViewUnitTest:
+#     def test_update_underage_beneficiary_deposit_expiration_date_when_both_dates_in_the_past(self):
+#         three_month_in_the_past = datetime.date.today() - relativedelta(months=3)
+#         six_month_in_the_past = datetime.date.today() - relativedelta(months=6)
+
+#         user_previous_18th_birth_day = six_month_in_the_past
+#         user_new_18th_birth_day = three_month_in_the_past
+
+#         user = users_factories.UnderageBeneficiaryFactory(
+#             deposit__expirationDate=user_previous_18th_birth_day,
+#             validatedBirthDate=user_new_18th_birth_day - relativedelta(years=18),
+#         )
+
+#         _update_underage_beneficiary_deposit_expiration_date(user)
+
+#         assert user.deposit.expirationDate == datetime.datetime.combine(
+#             user_previous_18th_birth_day, datetime.datetime.min.time()
+#         )
+
+#     def test_update_underage_beneficiary_deposit_expiration_date_when_new_expiration_date_after_previous_one(self):
+#         three_month_in_the_past = datetime.date.today() - relativedelta(months=3)
+#         six_month_in_the_future = datetime.date.today() + relativedelta(months=6)
+
+#         user_previous_18th_birth_day = three_month_in_the_past
+#         user_new_18th_birth_day = six_month_in_the_future
+
+#         user = users_factories.UnderageBeneficiaryFactory(
+#             deposit__expirationDate=user_previous_18th_birth_day,
+#             validatedBirthDate=user_new_18th_birth_day - relativedelta(years=18),
+#         )
+
+#         _update_underage_beneficiary_deposit_expiration_date(user)
+
+#         assert user.deposit.expirationDate == datetime.datetime.combine(
+#             six_month_in_the_future, datetime.datetime.min.time()
+#         )
+
+#     @freezegun.freeze_time("2020-01-01 12:03:27")
+#     def test_update_underage_beneficiary_deposit_expiration_date_when_new_expiration_date_before_previous_one_and_in_the_past(
+#         self,
+#     ):
+#         three_month_in_the_past = datetime.date.today() - relativedelta(months=3)
+#         six_month_in_the_future = datetime.date.today() + relativedelta(months=6)
+
+#         user_previous_18th_birth_day = six_month_in_the_future
+#         user_new_18th_birth_day = three_month_in_the_past
+
+#         user = users_factories.UnderageBeneficiaryFactory(
+#             deposit__expirationDate=user_previous_18th_birth_day,
+#             validatedBirthDate=user_new_18th_birth_day - relativedelta(years=18),
+#         )
+
+#         _update_underage_beneficiary_deposit_expiration_date(user)
+
+#         assert user.deposit.expirationDate == datetime.datetime.utcnow()
+
+#     def test_update_underage_beneficiary_deposit_expiration_date_when_new_expiration_date_before_previous_one_and_in_the_future(
+#         self,
+#     ):
+#         three_month_in_the_future = datetime.date.today() + relativedelta(months=3)
+#         six_month_in_the_future = datetime.date.today() + relativedelta(months=6)
+
+#         user_previous_18th_birth_day = six_month_in_the_future
+#         user_new_18th_birth_day = three_month_in_the_future
+
+#         user = users_factories.UnderageBeneficiaryFactory(
+#             deposit__expirationDate=user_previous_18th_birth_day,
+#             validatedBirthDate=user_new_18th_birth_day - relativedelta(years=18),
+#         )
+
+#         _update_underage_beneficiary_deposit_expiration_date(user)
+
+#         assert user.deposit.expirationDate == datetime.datetime.combine(
+#             user_new_18th_birth_day, datetime.datetime.min.time()
+#         )
+
+
+# class BeneficiaryUserViewTest:
+#     AGE18_ELIGIBLE_BIRTH_DATE = datetime.date.today() - relativedelta(years=18, months=4)
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_list_beneficiaries(self, mocked_validate_csrf_token, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         users_factories.BeneficiaryGrant18Factory.create_batch(3)
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         with testing.assert_no_duplicated_queries():
+#             response = client.get("/pc/back-office/beneficiary_users")
+
+#         assert response.status_code == 200
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_beneficiary_user_creation_for_deposit_v2(self, mocked_validate_csrf_token, app):
+#         users_factories.AdminFactory(email="user@example.com")
+
+#         data = dict(
+#             email="toto@example.com",
+#             firstName="Serge",
+#             lastName="Lama",
+#             validatedBirthDate=f"{self.AGE18_ELIGIBLE_BIRTH_DATE:%Y-%m-%d}",
+#             departementCode="93",
+#             postalCode="93000",
+#             phoneNumber="0601020304",
+#             depositVersion="2",
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/beneficiary_users/new", form=data)
+
+#         assert response.status_code == 302
+
+#         user_created = User.query.filter_by(email="toto@example.com").one()
+#         assert user_created.firstName == "Serge"
+#         assert user_created.lastName == "Lama"
+#         assert user_created.validatedBirthDate == self.AGE18_ELIGIBLE_BIRTH_DATE
+#         assert user_created.departementCode == "93"
+#         assert user_created.postalCode == "93000"
+#         assert user_created.phoneNumber == "+33601020304"
+#         assert len(user_created.deposits) == 1
+#         assert user_created.deposit.version == 2
+#         assert user_created.deposit.source == "pass-culture-admin"
+#         assert user_created.deposit.amount == 300
+
+#         assert push_testing.requests[0]["attribute_values"]["u.credit"] == 30000
+
+#     @clean_database
+#     def test_the_deposit_version_is_specified(self, app, db_session):
+#         # Given
+#         beneficiary_view = BeneficiaryUserView(User, db_session)
+#         beneficiary_view_create_form = beneficiary_view.get_create_form()
+#         data = dict(
+#             email="toto@example.com",
+#             firstName="Serge",
+#             lastName="Lama",
+#             dateOfBirth=f"{self.AGE18_ELIGIBLE_BIRTH_DATE:%Y-%m-%d %H:%M:%S}",
+#             departementCode="93",
+#             postalCode="93000",
+#             phoneNumber="0601020304",
+#             depositVersion="2",
+#         )
+
+#         form = beneficiary_view_create_form(data=data)
+#         user = users_factories.UserFactory(dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE)
+
+#         # When
+#         beneficiary_view.on_model_change(form, user, True)
+
+#         # Then
+#         assert user.deposit_version == 2
+
+#     @clean_database
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["admin@example.com"])
+#     def test_form_has_no_deposit_field_for_production(self, app, db_session):
+#         # We need an authenticated user to initialize the admin class
+#         # and call `get_create_form()`, because `scaffold_form()` is
+#         # called, which in turn calls the `form_columns` property,
+#         # which expects to see an authenticated user.
+#         admin = users_factories.AdminFactory()
+#         headers = {"Authorization": _basic_auth_str(admin.email, settings.TEST_DEFAULT_PASSWORD)}
+#         with app.test_request_context(headers=headers):
+#             form_class = BeneficiaryUserView(User, db_session)
+#             form = form_class.get_create_form()
+#         assert hasattr(form, "phoneNumber")
+#         assert not hasattr(form, "depositVersion")
+
+#     @clean_database
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
+#     def test_beneficiary_user_creation_is_restricted_in_prod(self, app, db_session):
+#         users_factories.AdminFactory(email="user@example.com")
+
+#         data = dict(
+#             email="toto@example.com",
+#             firstName="Serge",
+#             lastName="Lama",
+#             dateOfBirth=f"{self.AGE18_ELIGIBLE_BIRTH_DATE:%Y-%m-%d %H:%M:%S}",
+#             departementCode="93",
+#             postalCode="93000",
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/beneficiary_users/new", form=data)
+
+#         assert response.status_code == 302
+
+#         filtered_users = User.query.filter_by(email="toto@example.com").all()
+#         deposits = finance_models.Deposit.query.all()
+#         assert len(filtered_users) == 0
+#         assert len(deposits) == 0
+#         assert len(push_testing.requests) == 0
+
+#     @clean_database
+#     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
+#     #  generate a valid CSRF token in tests. This should be fixed.
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_suspend_beneficiary(self, mocked_validate_csrf_token, app):
+#         admin = users_factories.AdminFactory(email="admin15@example.com")
+#         booking = bookings_factories.BookingFactory()
+#         beneficiary = booking.user
+
+#         client = TestClient(app.test_client()).with_session_auth(admin.email)
+#         url = f"/pc/back-office/beneficiary_users/suspend?user_id={beneficiary.id}"
+#         data = {
+#             "reason": "fraud suspicion",
+#             "csrf_token": "token",
+#         }
+#         response = client.post(url, form=data)
+
+#         assert response.status_code == 302
+#         assert not beneficiary.isActive
+#         assert booking.status is BookingStatus.CANCELLED
+
+#     @clean_database
+#     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
+#     #  generate a valid CSRF token in tests. This should be fixed.
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_unsuspend_beneficiary(self, mocked_validate_csrf_token, app):
+#         admin = users_factories.AdminFactory(email="admin15@example.com")
+#         beneficiary = users_factories.BeneficiaryGrant18Factory(email="user15@example.com", isActive=False)
+
+#         client = TestClient(app.test_client()).with_session_auth(admin.email)
+#         url = f"/pc/back-office/beneficiary_users/unsuspend?user_id={beneficiary.id}"
+#         data = {
+#             "reason": "fraud",
+#             "csrf_token": "token",
+#         }
+#         response = client.post(url, form=data)
+
+#         assert response.status_code == 302
+#         assert beneficiary.isActive
+
+#     @clean_database
+#     @patch("pcapi.settings.IS_PROD", True)
+#     def test_suspend_beneficiary_is_restricted(self, app):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         beneficiary = users_factories.BeneficiaryGrant18Factory(email="user@example.com")
+
+#         client = TestClient(app.test_client()).with_session_auth(admin.email)
+#         url = f"/pc/back-office/beneficiary_users/suspend?user_id={beneficiary.id}"
+#         data = {
+#             "reason": "fraud",
+#             "csrf_token": "token",
+#         }
+#         response = client.post(url, form=data)
+
+#         assert response.status_code == 403
+
+#     @testing.override_settings(
+#         IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super-admin@example.com", "boss@example.com"]
+#     )
+#     @pytest.mark.usefixtures("db_session")
+#     def test_allow_suspension_and_unsuspension(self):
+#         basic_admin = users_factories.AdminFactory(email="admin@example.com")
+#         assert not _allow_suspension_and_unsuspension(basic_admin)
+#         super_admin = users_factories.AdminFactory(email="super-admin@example.com")
+#         assert _allow_suspension_and_unsuspension(super_admin)
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_beneficiary_user_edition_does_not_send_email(self, mocked_validate_csrf_token, app):
+#         users_factories.AdminFactory(email="user@example.com")
+#         user_to_edit = users_factories.BeneficiaryGrant18Factory(email="not_yet_edited@email.com")
+
+#         data = dict(
+#             email="edited@email.com",
+#             firstName=user_to_edit.firstName,
+#             lastName=user_to_edit.lastName,
+#             dateOfBirth=user_to_edit.dateOfBirth.isoformat(sep=" ", timespec="seconds"),
+#             departementCode=user_to_edit.departementCode,
+#             postalCode="76000",
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/beneficiary_users/edit/?id={user_to_edit.id}", form=data)
+
+#         assert response.status_code == 302
+
+#         user_edited = User.query.filter_by(email="edited@email.com").one_or_none()
+#         assert user_edited is not None
+#         assert len(push_testing.requests) == 2
+
+#         assert not mails_testing.outbox
+#         assert len(push_testing.requests) == 2
+#         assert len(sendinblue_testing.sendinblue_requests) == 1
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
+#     def test_resend_validation_email_to_beneficiary(
+#         self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
+#     ):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         beneficiary = users_factories.BeneficiaryGrant18Factory(email="partner@example.com", isEmailValidated=False)
+#         client = TestClient(app.test_client()).with_session_auth(admin.email)
+
+#         url = f"/pc/back-office/beneficiary_users/resend-validation-email?user_id={beneficiary.id}"
+#         resend_validation_email_response = client.post(url, form={"csrf_token": "token"})
+#         assert resend_validation_email_response.status_code == 302
+#         mocked_request_email_confirmation.assert_called_once_with(beneficiary)
+
+
+# @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
+# @pytest.mark.usefixtures("db_session")
+# class BeneficiaryUserUpdateTest:
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_update_idpiecenumber(self, token, client):
+#         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
+#         client.with_session_auth(super_admin.email)
+
+#         user_to_update = users_factories.BeneficiaryGrant18Factory(departementCode="92", postalCode="92700")
+
+#         url = f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}"
+#         client.post(
+#             url,
+#             form={
+#                 "id": user_to_update.id,
+#                 "idPieceNumber": "123123123",
+#                 "departementCode": user_to_update.departementCode,
+#                 "csrf_token": "token",
+#                 "email": user_to_update.email,
+#                 "postalCode": user_to_update.postalCode,
+#             },
+#         )
+
+#         assert user_to_update.idPieceNumber == "123123123"
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_clear_idpiecenumber(self, token, client):
+#         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
+#         client.with_session_auth(super_admin.email)
+
+#         user_to_update = users_factories.BeneficiaryGrant18Factory(
+#             departementCode="92", postalCode="92700", idPieceNumber="123123123"
+#         )
+
+#         client.post(
+#             f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}",
+#             form={
+#                 "id": user_to_update.id,
+#                 "idPieceNumber": "",
+#                 "departementCode": user_to_update.departementCode,
+#                 "csrf_token": "token",
+#                 "email": user_to_update.email,
+#                 "postalCode": user_to_update.postalCode,
+#             },
+#         )
+
+#         assert user_to_update.idPieceNumber is None
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_update_idpiecenumber_not_updated(self, token, client):
+#         admin = users_factories.AdminFactory()  # not superadmin
+
+#         user_to_update = users_factories.BeneficiaryGrant18Factory(departementCode="92", postalCode="92700")
+#         client.with_session_auth(admin.email)
+
+#         url = f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}"
+#         client.post(
+#             url,
+#             form={
+#                 "idPieceNumber": "123123123",
+#                 "departementCode": user_to_update.departementCode,
+#                 "csrf_token": "token",
+#                 "email": user_to_update.email,
+#                 "postalCode": user_to_update.postalCode,
+#             },
+#         )
+
+#         assert user_to_update.idPieceNumber != "123123123"
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_clear_ine_hash(self, token, client):
+#         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
+#         client.with_session_auth(super_admin.email)
+
+#         user_to_update = users_factories.BeneficiaryGrant18Factory(
+#             departementCode="92", postalCode="92700", ineHash="123123123"
+#         )
+
+#         client.post(
+#             f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}",
+#             form={
+#                 "id": user_to_update.id,
+#                 "ineHash": "",
+#                 "departementCode": user_to_update.departementCode,
+#                 "csrf_token": "token",
+#                 "email": user_to_update.email,
+#                 "postalCode": user_to_update.postalCode,
+#             },
+#         )
+
+#         assert user_to_update.ineHash is None
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_deposit_expiration_date_updated_when_user_is_underage_beneficiary(self, token, client):
+#         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
+#         client.with_session_auth(super_admin.email)
+
+#         user_to_update = users_factories.UnderageBeneficiaryFactory(postalCode="92700")
+
+#         old_deposit_expiration_date = user_to_update.deposit.expirationDate
+#         old_user_birth_date = user_to_update.validatedBirthDate
+#         new_user_birth_date = old_user_birth_date + relativedelta(months=1)
+
+#         client.post(
+#             f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}",
+#             form={
+#                 "id": user_to_update.id,
+#                 "validatedBirthDate": new_user_birth_date,
+#                 "csrf_token": "token",
+#                 "email": user_to_update.email,
+#                 "postalCode": user_to_update.postalCode,
+#             },
+#         )
+
+#         assert user_to_update.validatedBirthDate == new_user_birth_date
+#         assert user_to_update.deposit.expirationDate == old_deposit_expiration_date + relativedelta(months=1)

--- a/api/tests/admin/custom_views/booking_view_test.py
+++ b/api/tests/admin/custom_views/booking_view_test.py
@@ -1,312 +1,312 @@
-import datetime
-from unittest import mock
-
-from dateutil.relativedelta import relativedelta
-from freezegun import freeze_time
-import pytest
-
-import pcapi.core.bookings.factories as bookings_factories
-from pcapi.core.bookings.models import Booking
-from pcapi.core.bookings.models import BookingStatus
-import pcapi.core.educational.factories as educational_factories
-from pcapi.core.educational.models import CollectiveBooking
-from pcapi.core.educational.models import CollectiveBookingCancellationReasons
-from pcapi.core.educational.models import CollectiveBookingStatus
-import pcapi.core.finance.factories as finance_factories
-import pcapi.core.users.factories as users_factories
-
-from tests.conftest import TestClient
-
-
-@pytest.mark.usefixtures("db_session")
-@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token", lambda *args, **kwargs: True)
-class BookingViewTest:
-    def test_search_booking(self, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = bookings_factories.BookingFactory()
-
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/bookings/", form={"token": booking.token})
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert booking.email in content
-        assert "Désannuler" not in content
-
-    def test_show_mark_as_used_button(self, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        bookings_factories.CancelledBookingFactory(token="ABCDEF")
-
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/bookings/", form={"token": "abcdeF"})
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert "Désannuler" in content
-
-    def test_uncancel_and_mark_as_used(self, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = bookings_factories.CancelledBookingFactory()
-
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        route = f"/pc/back-office/bookings/mark-as-used/{booking.id}"
-        response = client.post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
-        response = client.get(response.location)
-        content = response.data.decode(response.charset)
-        assert "La réservation a été dés-annulée et marquée comme utilisée." in content
-        booking = Booking.query.get(booking.id)
-        assert booking.status is not BookingStatus.CANCELLED
-        assert booking.status is BookingStatus.USED
-
-    def test_fail_to_uncancel_and_mark_as_used(self, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = bookings_factories.BookingFactory(status=BookingStatus.CONFIRMED)
-
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        route = f"/pc/back-office/bookings/mark-as-used/{booking.id}"
-        response = client.post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
-        response = client.get(response.location)
-        content = response.data.decode(response.charset)
-        assert "ne peut pas être validée via ce formulaire." in content
-        booking = Booking.query.get(booking.id)
-        assert booking.status is BookingStatus.CONFIRMED
-
-    def test_cancel_booking(self, app, client):
-        admin = users_factories.AdminFactory()
-        booking = bookings_factories.BookingFactory()
-
-        route = f"/pc/back-office/bookings/cancel/{booking.id}"
-        response = client.with_session_auth(admin.email).post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
-
-        response = client.get(response.location)
-        content = response.data.decode(response.charset)
-        assert "La réservation a été marquée comme annulée" in content
-
-        booking = Booking.query.get(booking.id)
-        assert booking.status == BookingStatus.CANCELLED
-
-    def test_can_not_cancel_refunded_booking(self, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = bookings_factories.UsedBookingFactory()
-        finance_factories.PaymentFactory(booking=booking)
-
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        route = f"/pc/back-office/bookings/cancel/{booking.id}"
-        response = client.post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
-
-        response = client.get(response.location)
-        content = response.data.decode(response.charset)
-        assert "L&#39;opération a échoué : la réservation a déjà été remboursée" in content
-
-        booking = Booking.query.get(booking.id)
-        assert not booking.status == BookingStatus.CANCELLED
-
-    def test_cant_cancel_cancelled_booking(self, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = bookings_factories.CancelledBookingFactory()
-
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        route = f"/pc/back-office/bookings/cancel/{booking.id}"
-        response = client.post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
-
-        response = client.get(response.location)
-        content = response.data.decode(response.charset)
-        assert "L&#39;opération a échoué : la réservation a déjà été annulée" in content
-
-        booking = Booking.query.get(booking.id)
-        assert booking.status == BookingStatus.CANCELLED
-
-    def test_cancel_used_booking_without_payment(self, app):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = bookings_factories.UsedBookingFactory()
-
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        route = f"/pc/back-office/bookings/cancel/{booking.id}"
-        response = client.post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
-
-        response = client.get(response.location)
-        content = response.data.decode(response.charset)
-        assert "La réservation a été marquée comme annulée" in content
-
-        booking = Booking.query.get(booking.id)
-        assert booking.status == BookingStatus.CANCELLED
-
-
-@pytest.mark.usefixtures("db_session")
-@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token", lambda *args, **kwargs: True)
-class CollectiveBookingViewTest:
-    def test_search_booking(self, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = educational_factories.CollectiveBookingFactory()
-
-        response = client.with_session_auth("admin@example.com").post(
-            "/pc/back-office/collective-bookings/", form={"booking_id": booking.id}
-        )
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert booking.collectiveStock.collectiveOffer.name in content
-        assert "Désannuler" not in content
-
-    def test_show_mark_as_used_button(self, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = educational_factories.CollectiveBookingFactory(
-            cancellationDate=datetime.datetime.utcnow(),
-            cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
-            status=CollectiveBookingStatus.CANCELLED,
-        )
-
-        response = client.with_session_auth("admin@example.com").post(
-            "/pc/back-office/collective-bookings/", form={"booking_id": booking.id}
-        )
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert "Désannuler" in content
-
-    def test_uncancel_and_mark_as_confirmed(self, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = educational_factories.CollectiveBookingFactory(
-            cancellationDate=datetime.datetime.utcnow(),
-            cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
-            status=CollectiveBookingStatus.CANCELLED,
-        )
-
-        route = f"/pc/back-office/collective-bookings/mark-as-used/{booking.id}"
-        response = client.with_session_auth("admin@example.com").post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
-        response = client.with_session_auth("admin@example.com").get(response.location)
-        content = response.data.decode(response.charset)
-        assert "La réservation a été dés-annulée et marquée comme confirmé ou préreservé." in content
-        booking = CollectiveBooking.query.get(booking.id)
-        assert booking.status is not CollectiveBookingStatus.CANCELLED
-        assert booking.status is CollectiveBookingStatus.CONFIRMED
-
-    def test_fail_to_uncancel_and_mark_as_used(self, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = educational_factories.CollectiveBookingFactory(status=CollectiveBookingStatus.CONFIRMED)
-
-        route = f"/pc/back-office/collective-bookings/mark-as-used/{booking.id}"
-        response = client.with_session_auth("admin@example.com").post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
-        response = client.with_session_auth("admin@example.com").get(response.location)
-        content = response.data.decode(response.charset)
-        assert "ne peut pas être validée via ce formulaire." in content
-        booking = CollectiveBooking.query.get(booking.id)
-        assert booking.status is CollectiveBookingStatus.CONFIRMED
-
-    def test_cancel_booking(self, app, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = educational_factories.CollectiveBookingFactory()
-
-        route = f"/pc/back-office/collective-bookings/cancel/{booking.id}"
-        response = client.with_session_auth("admin@example.com").post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
-
-        response = client.with_session_auth("admin@example.com").get(response.location)
-        content = response.data.decode(response.charset)
-        assert "La réservation a été marquée comme annulée" in content
-
-        booking = CollectiveBooking.query.get(booking.id)
-        assert booking.status == CollectiveBookingStatus.CANCELLED
-
-    def test_can_not_cancel_refunded_booking(self, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = educational_factories.CollectiveBookingFactory(status=CollectiveBookingStatus.USED)
-        finance_factories.PaymentFactory(collectiveBooking=booking)
-
-        route = f"/pc/back-office/collective-bookings/cancel/{booking.id}"
-        response = client.with_session_auth("admin@example.com").post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
-
-        response = client.with_session_auth("admin@example.com").get(response.location)
-        content = response.data.decode(response.charset)
-        assert "L&#39;opération a échoué : la réservation a déjà été remboursée" in content
-
-        booking = CollectiveBooking.query.get(booking.id)
-        assert not booking.status == BookingStatus.CANCELLED
-
-    def test_cant_cancel_cancelled_booking(self, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = educational_factories.CollectiveBookingFactory(
-            cancellationDate=datetime.datetime.utcnow(),
-            cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
-            status=CollectiveBookingStatus.CANCELLED,
-        )
-
-        route = f"/pc/back-office/collective-bookings/cancel/{booking.id}"
-        response = client.with_session_auth("admin@example.com").post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
-
-        response = client.with_session_auth("admin@example.com").get(response.location)
-        content = response.data.decode(response.charset)
-        assert "L&#39;opération a échoué : la réservation a déjà été annulée" in content
-
-        booking = CollectiveBooking.query.get(booking.id)
-        assert booking.status == CollectiveBookingStatus.CANCELLED
-
-    def test_cancel_used_booking_without_payment(self, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        booking = educational_factories.CollectiveBookingFactory(status=CollectiveBookingStatus.USED)
-
-        route = f"/pc/back-office/collective-bookings/cancel/{booking.id}"
-        response = client.with_session_auth("admin@example.com").post(route, form={})
-
-        assert response.status_code == 302
-        assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
-
-        response = client.get(response.location)
-        content = response.data.decode(response.charset)
-        assert "La réservation a été marquée comme annulée" in content
-
-        booking = CollectiveBooking.query.get(booking.id)
-        assert booking.status == CollectiveBookingStatus.CANCELLED
-
-    @freeze_time("2023-02-02 15:00:00")
-    def test_uncancel_with_datetime_before_now(self, client):
-        users_factories.AdminFactory(email="admin@example.com")
-
-        stock = educational_factories.CollectiveStockFactory(
-            beginningDatetime=datetime.datetime.utcnow() - relativedelta(days=1)
-        )
-        booking = educational_factories.CollectiveBookingFactory(
-            collectiveStock=stock,
-            cancellationDate=datetime.datetime.utcnow(),
-            cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
-            status=CollectiveBookingStatus.CANCELLED,
-        )
-
-        route = f"/pc/back-office/collective-bookings/mark-as-used/{booking.id}"
-        response = client.with_session_auth("admin@example.com").post(route, form={})
-
-        assert response.status_code == 302
-        assert booking.status is CollectiveBookingStatus.USED
-        assert booking.dateUsed == datetime.datetime.utcnow()
+# import datetime
+# from unittest import mock
+
+# from dateutil.relativedelta import relativedelta
+# from freezegun import freeze_time
+# import pytest
+
+# import pcapi.core.bookings.factories as bookings_factories
+# from pcapi.core.bookings.models import Booking
+# from pcapi.core.bookings.models import BookingStatus
+# import pcapi.core.educational.factories as educational_factories
+# from pcapi.core.educational.models import CollectiveBooking
+# from pcapi.core.educational.models import CollectiveBookingCancellationReasons
+# from pcapi.core.educational.models import CollectiveBookingStatus
+# import pcapi.core.finance.factories as finance_factories
+# import pcapi.core.users.factories as users_factories
+
+# from tests.conftest import TestClient
+
+
+# @pytest.mark.usefixtures("db_session")
+# @mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token", lambda *args, **kwargs: True)
+# class BookingViewTest:
+#     def test_search_booking(self, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = bookings_factories.BookingFactory()
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/bookings/", form={"token": booking.token})
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert booking.email in content
+#         assert "Désannuler" not in content
+
+#     def test_show_mark_as_used_button(self, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         bookings_factories.CancelledBookingFactory(token="ABCDEF")
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/bookings/", form={"token": "abcdeF"})
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert "Désannuler" in content
+
+#     def test_uncancel_and_mark_as_used(self, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = bookings_factories.CancelledBookingFactory()
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         route = f"/pc/back-office/bookings/mark-as-used/{booking.id}"
+#         response = client.post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
+#         response = client.get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "La réservation a été dés-annulée et marquée comme utilisée." in content
+#         booking = Booking.query.get(booking.id)
+#         assert booking.status is not BookingStatus.CANCELLED
+#         assert booking.status is BookingStatus.USED
+
+#     def test_fail_to_uncancel_and_mark_as_used(self, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = bookings_factories.BookingFactory(status=BookingStatus.CONFIRMED)
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         route = f"/pc/back-office/bookings/mark-as-used/{booking.id}"
+#         response = client.post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
+#         response = client.get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "ne peut pas être validée via ce formulaire." in content
+#         booking = Booking.query.get(booking.id)
+#         assert booking.status is BookingStatus.CONFIRMED
+
+#     def test_cancel_booking(self, app, client):
+#         admin = users_factories.AdminFactory()
+#         booking = bookings_factories.BookingFactory()
+
+#         route = f"/pc/back-office/bookings/cancel/{booking.id}"
+#         response = client.with_session_auth(admin.email).post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
+
+#         response = client.get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "La réservation a été marquée comme annulée" in content
+
+#         booking = Booking.query.get(booking.id)
+#         assert booking.status == BookingStatus.CANCELLED
+
+#     def test_can_not_cancel_refunded_booking(self, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = bookings_factories.UsedBookingFactory()
+#         finance_factories.PaymentFactory(booking=booking)
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         route = f"/pc/back-office/bookings/cancel/{booking.id}"
+#         response = client.post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
+
+#         response = client.get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "L&#39;opération a échoué : la réservation a déjà été remboursée" in content
+
+#         booking = Booking.query.get(booking.id)
+#         assert not booking.status == BookingStatus.CANCELLED
+
+#     def test_cant_cancel_cancelled_booking(self, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = bookings_factories.CancelledBookingFactory()
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         route = f"/pc/back-office/bookings/cancel/{booking.id}"
+#         response = client.post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
+
+#         response = client.get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "L&#39;opération a échoué : la réservation a déjà été annulée" in content
+
+#         booking = Booking.query.get(booking.id)
+#         assert booking.status == BookingStatus.CANCELLED
+
+#     def test_cancel_used_booking_without_payment(self, app):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = bookings_factories.UsedBookingFactory()
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         route = f"/pc/back-office/bookings/cancel/{booking.id}"
+#         response = client.post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/bookings/?id={booking.id}"
+
+#         response = client.get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "La réservation a été marquée comme annulée" in content
+
+#         booking = Booking.query.get(booking.id)
+#         assert booking.status == BookingStatus.CANCELLED
+
+
+# @pytest.mark.usefixtures("db_session")
+# @mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token", lambda *args, **kwargs: True)
+# class CollectiveBookingViewTest:
+#     def test_search_booking(self, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = educational_factories.CollectiveBookingFactory()
+
+#         response = client.with_session_auth("admin@example.com").post(
+#             "/pc/back-office/collective-bookings/", form={"booking_id": booking.id}
+#         )
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert booking.collectiveStock.collectiveOffer.name in content
+#         assert "Désannuler" not in content
+
+#     def test_show_mark_as_used_button(self, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = educational_factories.CollectiveBookingFactory(
+#             cancellationDate=datetime.datetime.utcnow(),
+#             cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
+#             status=CollectiveBookingStatus.CANCELLED,
+#         )
+
+#         response = client.with_session_auth("admin@example.com").post(
+#             "/pc/back-office/collective-bookings/", form={"booking_id": booking.id}
+#         )
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert "Désannuler" in content
+
+#     def test_uncancel_and_mark_as_confirmed(self, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = educational_factories.CollectiveBookingFactory(
+#             cancellationDate=datetime.datetime.utcnow(),
+#             cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
+#             status=CollectiveBookingStatus.CANCELLED,
+#         )
+
+#         route = f"/pc/back-office/collective-bookings/mark-as-used/{booking.id}"
+#         response = client.with_session_auth("admin@example.com").post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
+#         response = client.with_session_auth("admin@example.com").get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "La réservation a été dés-annulée et marquée comme confirmé ou préreservé." in content
+#         booking = CollectiveBooking.query.get(booking.id)
+#         assert booking.status is not CollectiveBookingStatus.CANCELLED
+#         assert booking.status is CollectiveBookingStatus.CONFIRMED
+
+#     def test_fail_to_uncancel_and_mark_as_used(self, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = educational_factories.CollectiveBookingFactory(status=CollectiveBookingStatus.CONFIRMED)
+
+#         route = f"/pc/back-office/collective-bookings/mark-as-used/{booking.id}"
+#         response = client.with_session_auth("admin@example.com").post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
+#         response = client.with_session_auth("admin@example.com").get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "ne peut pas être validée via ce formulaire." in content
+#         booking = CollectiveBooking.query.get(booking.id)
+#         assert booking.status is CollectiveBookingStatus.CONFIRMED
+
+#     def test_cancel_booking(self, app, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = educational_factories.CollectiveBookingFactory()
+
+#         route = f"/pc/back-office/collective-bookings/cancel/{booking.id}"
+#         response = client.with_session_auth("admin@example.com").post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
+
+#         response = client.with_session_auth("admin@example.com").get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "La réservation a été marquée comme annulée" in content
+
+#         booking = CollectiveBooking.query.get(booking.id)
+#         assert booking.status == CollectiveBookingStatus.CANCELLED
+
+#     def test_can_not_cancel_refunded_booking(self, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = educational_factories.CollectiveBookingFactory(status=CollectiveBookingStatus.USED)
+#         finance_factories.PaymentFactory(collectiveBooking=booking)
+
+#         route = f"/pc/back-office/collective-bookings/cancel/{booking.id}"
+#         response = client.with_session_auth("admin@example.com").post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
+
+#         response = client.with_session_auth("admin@example.com").get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "L&#39;opération a échoué : la réservation a déjà été remboursée" in content
+
+#         booking = CollectiveBooking.query.get(booking.id)
+#         assert not booking.status == BookingStatus.CANCELLED
+
+#     def test_cant_cancel_cancelled_booking(self, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = educational_factories.CollectiveBookingFactory(
+#             cancellationDate=datetime.datetime.utcnow(),
+#             cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
+#             status=CollectiveBookingStatus.CANCELLED,
+#         )
+
+#         route = f"/pc/back-office/collective-bookings/cancel/{booking.id}"
+#         response = client.with_session_auth("admin@example.com").post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
+
+#         response = client.with_session_auth("admin@example.com").get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "L&#39;opération a échoué : la réservation a déjà été annulée" in content
+
+#         booking = CollectiveBooking.query.get(booking.id)
+#         assert booking.status == CollectiveBookingStatus.CANCELLED
+
+#     def test_cancel_used_booking_without_payment(self, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         booking = educational_factories.CollectiveBookingFactory(status=CollectiveBookingStatus.USED)
+
+#         route = f"/pc/back-office/collective-bookings/cancel/{booking.id}"
+#         response = client.with_session_auth("admin@example.com").post(route, form={})
+
+#         assert response.status_code == 302
+#         assert response.location == f"http://localhost/pc/back-office/collective-bookings/?id={booking.id}"
+
+#         response = client.get(response.location)
+#         content = response.data.decode(response.charset)
+#         assert "La réservation a été marquée comme annulée" in content
+
+#         booking = CollectiveBooking.query.get(booking.id)
+#         assert booking.status == CollectiveBookingStatus.CANCELLED
+
+#     @freeze_time("2023-02-02 15:00:00")
+#     def test_uncancel_with_datetime_before_now(self, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+
+#         stock = educational_factories.CollectiveStockFactory(
+#             beginningDatetime=datetime.datetime.utcnow() - relativedelta(days=1)
+#         )
+#         booking = educational_factories.CollectiveBookingFactory(
+#             collectiveStock=stock,
+#             cancellationDate=datetime.datetime.utcnow(),
+#             cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
+#             status=CollectiveBookingStatus.CANCELLED,
+#         )
+
+#         route = f"/pc/back-office/collective-bookings/mark-as-used/{booking.id}"
+#         response = client.with_session_auth("admin@example.com").post(route, form={})
+
+#         assert response.status_code == 302
+#         assert booking.status is CollectiveBookingStatus.USED
+#         assert booking.dateUsed == datetime.datetime.utcnow()

--- a/api/tests/admin/custom_views/boost_pivot_view_test.py
+++ b/api/tests/admin/custom_views/boost_pivot_view_test.py
@@ -1,353 +1,353 @@
-import datetime
-from unittest.mock import patch
+# import datetime
+# from unittest.mock import patch
 
-from freezegun import freeze_time
+# from freezegun import freeze_time
 
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.providers.factories as providers_factories
-import pcapi.core.providers.models as providers_models
-import pcapi.core.providers.repository as providers_repository
-from pcapi.core.users.factories import AdminFactory
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.providers.factories as providers_factories
+# import pcapi.core.providers.models as providers_models
+# import pcapi.core.providers.repository as providers_repository
+# from pcapi.core.users.factories import AdminFactory
 
-from tests.conftest import TestClient
-from tests.conftest import clean_database
-
-
-class CreateBoostPivotTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_create_boost_information_api_ok(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="admin@example.fr")
-        venue = offerers_factories.VenueFactory()
-        requests_mock.post(
-            "https://test.com/api/vendors/login?ignore_device=True",
-            json={"message": "Login successful", "token": "jwt-token"},
-        )
-
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": "12",
-            "username": "username_test",
-            "password": "password_test",
-            "cinema_url": "https://test.com",
-        }
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/boost/new", form=data)
-
-        assert response.status_code == 302
-        cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
-            providers_models.CinemaProviderPivot.venueId == venue.id
-        ).one()
-        assert cinema_provider_pivot.idAtProvider == "12"
-        boost_cinema_details = providers_models.BoostCinemaDetails.query.filter(
-            providers_models.BoostCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
-        ).one()
-        assert boost_cinema_details.username == "username_test"
-        assert boost_cinema_details.password == "password_test"
-        assert boost_cinema_details.cinemaUrl == "https://test.com/"
-        flash_mock.assert_called_once_with("Connexion à l'API OK.")
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_create_boost_information_api_ko(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="admin@example.fr")
-        venue = offerers_factories.VenueFactory()
-        requests_mock.post(
-            "https://test.com/api/vendors/login?ignore_device=True",
-            status_code=401,
-            json={"message": "Login fail"},
-        )
-
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": "12",
-            "username": "username_test",
-            "password": "password_test",
-            "cinema_url": "https://test.com",
-        }
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/boost/new", form=data)
-
-        assert response.status_code == 302
-        cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
-            providers_models.CinemaProviderPivot.venueId == venue.id
-        ).one()
-        assert cinema_provider_pivot.idAtProvider == "12"
-        boost_cinema_details = providers_models.BoostCinemaDetails.query.filter(
-            providers_models.BoostCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
-        ).one()
-        assert boost_cinema_details.username == "username_test"
-        assert boost_cinema_details.password == "password_test"
-        assert boost_cinema_details.cinemaUrl == "https://test.com/"
-        flash_mock.assert_called_once_with("Connexion à l'API KO.", "error")
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_id_at_provider_unicity(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
-        _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=boost_provider, idAtProvider="cinema_test"
-        )
-        venue_2 = offerers_factories.VenueFactory()
-
-        data = {
-            "venue_id": venue_2.id,
-            "account_id": "account_test",
-            "cinema_id": "cinema_test",
-            "api_token": "token_test",
-        }
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/boost/new", form=data)
-
-        assert response.status_code == 200
-        assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
-        assert providers_models.CinemaProviderPivot.query.count() == 1
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_boost_information_when_venue_already_has_cinema_provider(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
-        _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=boost_provider, idAtProvider="cinema1_test"
-        )
-
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": "cinema2_test",
-            "username": "username_test",
-            "password": "password_test",
-            "cinema_url": "https://test.com",
-        }
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/boost/new", form=data)
-        assert response.status_code == 200
-        assert "Des identifiants cinéma existent déjà pour ce lieu id=" in response.data.decode("utf8")
-        assert providers_models.CinemaProviderPivot.query.count() == 1
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
 
 
-class EditBoostPivotTest:
-    @clean_database
-    @freeze_time("2022-10-12 17:09:25")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_update_boost_information(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="admin@example.fr")
-        boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
-        venue = offerers_factories.VenueFactory()
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=boost_provider, idAtProvider="12"
-        )
-        boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot,
-            cinemaUrl="https://test.com/",
-            username="username_test",
-            password="password_test",
-            token=None,
-        )
-        requests_mock.post(
-            "https://new-url.com/api/vendors/login?ignore_device=True",
-            json={"message": "Login successful", "token": "jwt-token"},
-        )
+# class CreateBoostPivotTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_create_boost_information_api_ok(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="admin@example.fr")
+#         venue = offerers_factories.VenueFactory()
+#         requests_mock.post(
+#             "https://test.com/api/vendors/login?ignore_device=True",
+#             json={"message": "Login successful", "token": "jwt-token"},
+#         )
 
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": "13",
-            "username": "new_username",
-            "password": "new_password",
-            "cinema_url": "https://new-url.com/",
-        }
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": "12",
+#             "username": "username_test",
+#             "password": "password_test",
+#             "cinema_url": "https://test.com",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/boost/new", form=data)
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post(f"/pc/back-office/boost/edit/?id={boost_cinema_details.id}", form=data)
+#         assert response.status_code == 302
+#         cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
+#             providers_models.CinemaProviderPivot.venueId == venue.id
+#         ).one()
+#         assert cinema_provider_pivot.idAtProvider == "12"
+#         boost_cinema_details = providers_models.BoostCinemaDetails.query.filter(
+#             providers_models.BoostCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
+#         ).one()
+#         assert boost_cinema_details.username == "username_test"
+#         assert boost_cinema_details.password == "password_test"
+#         assert boost_cinema_details.cinemaUrl == "https://test.com/"
+#         flash_mock.assert_called_once_with("Connexion à l'API OK.")
 
-        assert response.status_code == 302
-        assert cinema_provider_pivot.idAtProvider == "13"
-        assert boost_cinema_details.username == "new_username"
-        assert boost_cinema_details.password == "new_password"
-        assert boost_cinema_details.cinemaUrl == "https://new-url.com/"
-        assert boost_cinema_details.token == "jwt-token"
-        assert boost_cinema_details.tokenExpirationDate == datetime.datetime(2022, 10, 13, 17, 9, 25)
-        flash_mock.assert_called_once_with("Connexion à l'API OK.")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_create_boost_information_api_ko(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="admin@example.fr")
+#         venue = offerers_factories.VenueFactory()
+#         requests_mock.post(
+#             "https://test.com/api/vendors/login?ignore_device=True",
+#             status_code=401,
+#             json={"message": "Login fail"},
+#         )
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_update_password_api_ok(self, flask_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        cinema_id = "cinema_test"
-        cinema_provider_pivot = providers_factories.BoostCinemaProviderPivotFactory(venue=venue, idAtProvider=cinema_id)
-        username = "cinema_test"
-        boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot,
-            cinemaUrl="https://example.com/",
-            username=username,
-            password="password_test",
-        )
-        requests_mock.post(
-            "https://example.com/api/vendors/login?ignore_device=True",
-            json={"message": "Login successful", "token": "jwt-token"},
-        )
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": "12",
+#             "username": "username_test",
+#             "password": "password_test",
+#             "cinema_url": "https://test.com",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/boost/new", form=data)
 
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": cinema_id,
-            "username": username,
-            "password": "toto",
-            "cinema_url": "https://example.com/",
-        }
+#         assert response.status_code == 302
+#         cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
+#             providers_models.CinemaProviderPivot.venueId == venue.id
+#         ).one()
+#         assert cinema_provider_pivot.idAtProvider == "12"
+#         boost_cinema_details = providers_models.BoostCinemaDetails.query.filter(
+#             providers_models.BoostCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
+#         ).one()
+#         assert boost_cinema_details.username == "username_test"
+#         assert boost_cinema_details.password == "password_test"
+#         assert boost_cinema_details.cinemaUrl == "https://test.com/"
+#         flash_mock.assert_called_once_with("Connexion à l'API KO.", "error")
 
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/boost/edit/?id={boost_cinema_details.id}", form=data)
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_id_at_provider_unicity(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
+#         _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=boost_provider, idAtProvider="cinema_test"
+#         )
+#         venue_2 = offerers_factories.VenueFactory()
 
-        assert cinema_provider_pivot.idAtProvider == cinema_id
-        assert boost_cinema_details.cinemaUrl == "https://example.com/"
-        assert boost_cinema_details.username == username
-        assert boost_cinema_details.password == "toto"
-        assert response.status_code == 302
-        flask_mock.assert_called_once_with("Connexion à l'API OK.")
+#         data = {
+#             "venue_id": venue_2.id,
+#             "account_id": "account_test",
+#             "cinema_id": "cinema_test",
+#             "api_token": "token_test",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/boost/new", form=data)
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_update_password_api_ko(self, flask_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        cinema_id = "cinema_test"
-        cinema_provider_pivot = providers_factories.BoostCinemaProviderPivotFactory(venue=venue, idAtProvider=cinema_id)
-        username = "cinema_test"
-        boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot,
-            cinemaUrl="https://example.com/",
-            username=username,
-            password="password_test",
-        )
-        requests_mock.post(
-            "https://example.com/api/vendors/login?ignore_device=True",
-            status_code=401,
-            json={"message": "Login fail"},
-        )
+#         assert response.status_code == 200
+#         assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+#         assert providers_models.CinemaProviderPivot.query.count() == 1
 
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": cinema_id,
-            "username": username,
-            "password": "toto",
-            "cinema_url": "https://example.com/",
-        }
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_boost_information_when_venue_already_has_cinema_provider(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
+#         _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=boost_provider, idAtProvider="cinema1_test"
+#         )
 
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/boost/edit/?id={boost_cinema_details.id}", form=data)
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": "cinema2_test",
+#             "username": "username_test",
+#             "password": "password_test",
+#             "cinema_url": "https://test.com",
+#         }
 
-        assert cinema_provider_pivot.idAtProvider == cinema_id
-        assert boost_cinema_details.cinemaUrl == "https://example.com/"
-        assert boost_cinema_details.username == username
-        assert boost_cinema_details.password == "toto"
-        assert response.status_code == 302
-        flask_mock.assert_called_once_with("Connexion à l'API KO.", "error")
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_cannot_reuse_cinema_id_at_provider(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
-
-        venue_1 = offerers_factories.VenueFactory()
-        cinema_id_1 = "cinema_1"
-        cinema_provider_pivot_1 = providers_factories.BoostCinemaProviderPivotFactory(
-            venue=venue_1, provider=boost_provider, idAtProvider=cinema_id_1
-        )
-        username_1 = "cinema_test"
-        _boost_cinema_details_1 = providers_factories.BoostCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot_1,
-            cinemaUrl="https://example.com/",
-            username=username_1,
-            password="password_test",
-        )
-        venue_2 = offerers_factories.VenueFactory()
-        cinema_id_2 = "cinema_2"
-        cinema_provider_pivot_2 = providers_factories.CinemaProviderPivotFactory(
-            venue=venue_2, provider=boost_provider, idAtProvider=cinema_id_2
-        )
-        username_2 = "cinema_2"
-        boost_cinema_details_2 = providers_factories.BoostCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot_2,
-            cinemaUrl="https://another-example.com/",
-            username=username_2,
-            password="another_password",
-        )
-
-        data = {
-            "venue_id": venue_2.id,
-            "cinema_id": cinema_id_1,
-            "username": username_2,
-            "password": "another_password",
-            "cinema_url": "https://another-example.com/",
-        }
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/boost/edit/?id={boost_cinema_details_2.id}", form=data)
-
-        # no changes
-        assert cinema_provider_pivot_2.idAtProvider == cinema_id_2
-        assert boost_cinema_details_2.cinemaUrl == "https://another-example.com/"
-        assert boost_cinema_details_2.username == username_2
-        assert boost_cinema_details_2.password == "another_password"
-        assert response.status_code == 200  # no redirect
-        assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/boost/new", form=data)
+#         assert response.status_code == 200
+#         assert "Des identifiants cinéma existent déjà pour ce lieu id=" in response.data.decode("utf8")
+#         assert providers_models.CinemaProviderPivot.query.count() == 1
 
 
-class DeleteBoostPivotTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_boost_information(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="admin@example.fr")
-        boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
-        venue = offerers_factories.VenueFactory()
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=boost_provider, idAtProvider="12"
-        )
-        boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot,
-            cinemaUrl="https://test.com/",
-            username="username_test",
-            password="password_test",
-        )
+# class EditBoostPivotTest:
+#     @clean_database
+#     @freeze_time("2022-10-12 17:09:25")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_update_boost_information(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="admin@example.fr")
+#         boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=boost_provider, idAtProvider="12"
+#         )
+#         boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot,
+#             cinemaUrl="https://test.com/",
+#             username="username_test",
+#             password="password_test",
+#             token=None,
+#         )
+#         requests_mock.post(
+#             "https://new-url.com/api/vendors/login?ignore_device=True",
+#             json={"message": "Login successful", "token": "jwt-token"},
+#         )
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/boost/delete", form={"id": boost_cinema_details.id})
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": "13",
+#             "username": "new_username",
+#             "password": "new_password",
+#             "cinema_url": "https://new-url.com/",
+#         }
 
-        assert response.status_code == 302
-        assert providers_models.BoostCinemaDetails.query.count() == 0
-        assert providers_models.CinemaProviderPivot.query.count() == 0
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post(f"/pc/back-office/boost/edit/?id={boost_cinema_details.id}", form=data)
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_should_not_delete_boost_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="admin@example.fr")
-        boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
-        venue = offerers_factories.VenueFactory()
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=boost_provider, idAtProvider="12"
-        )
-        boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot,
-            cinemaUrl="https://test.com/",
-            username="username_test",
-            password="password_test",
-        )
-        providers_factories.VenueProviderFactory(venue=venue, provider=boost_provider)
+#         assert response.status_code == 302
+#         assert cinema_provider_pivot.idAtProvider == "13"
+#         assert boost_cinema_details.username == "new_username"
+#         assert boost_cinema_details.password == "new_password"
+#         assert boost_cinema_details.cinemaUrl == "https://new-url.com/"
+#         assert boost_cinema_details.token == "jwt-token"
+#         assert boost_cinema_details.tokenExpirationDate == datetime.datetime(2022, 10, 13, 17, 9, 25)
+#         flash_mock.assert_called_once_with("Connexion à l'API OK.")
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/boost/delete", form={"id": boost_cinema_details.id})
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_update_password_api_ok(self, flask_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_id = "cinema_test"
+#         cinema_provider_pivot = providers_factories.BoostCinemaProviderPivotFactory(venue=venue, idAtProvider=cinema_id)
+#         username = "cinema_test"
+#         boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot,
+#             cinemaUrl="https://example.com/",
+#             username=username,
+#             password="password_test",
+#         )
+#         requests_mock.post(
+#             "https://example.com/api/vendors/login?ignore_device=True",
+#             json={"message": "Login successful", "token": "jwt-token"},
+#         )
 
-        assert response.status_code == 302
-        assert providers_models.BoostCinemaDetails.query.count() == 1
-        assert providers_models.CinemaProviderPivot.query.count() == 1
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": cinema_id,
+#             "username": username,
+#             "password": "toto",
+#             "cinema_url": "https://example.com/",
+#         }
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/boost/edit/?id={boost_cinema_details.id}", form=data)
+
+#         assert cinema_provider_pivot.idAtProvider == cinema_id
+#         assert boost_cinema_details.cinemaUrl == "https://example.com/"
+#         assert boost_cinema_details.username == username
+#         assert boost_cinema_details.password == "toto"
+#         assert response.status_code == 302
+#         flask_mock.assert_called_once_with("Connexion à l'API OK.")
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_update_password_api_ko(self, flask_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_id = "cinema_test"
+#         cinema_provider_pivot = providers_factories.BoostCinemaProviderPivotFactory(venue=venue, idAtProvider=cinema_id)
+#         username = "cinema_test"
+#         boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot,
+#             cinemaUrl="https://example.com/",
+#             username=username,
+#             password="password_test",
+#         )
+#         requests_mock.post(
+#             "https://example.com/api/vendors/login?ignore_device=True",
+#             status_code=401,
+#             json={"message": "Login fail"},
+#         )
+
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": cinema_id,
+#             "username": username,
+#             "password": "toto",
+#             "cinema_url": "https://example.com/",
+#         }
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/boost/edit/?id={boost_cinema_details.id}", form=data)
+
+#         assert cinema_provider_pivot.idAtProvider == cinema_id
+#         assert boost_cinema_details.cinemaUrl == "https://example.com/"
+#         assert boost_cinema_details.username == username
+#         assert boost_cinema_details.password == "toto"
+#         assert response.status_code == 302
+#         flask_mock.assert_called_once_with("Connexion à l'API KO.", "error")
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_cannot_reuse_cinema_id_at_provider(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
+
+#         venue_1 = offerers_factories.VenueFactory()
+#         cinema_id_1 = "cinema_1"
+#         cinema_provider_pivot_1 = providers_factories.BoostCinemaProviderPivotFactory(
+#             venue=venue_1, provider=boost_provider, idAtProvider=cinema_id_1
+#         )
+#         username_1 = "cinema_test"
+#         _boost_cinema_details_1 = providers_factories.BoostCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot_1,
+#             cinemaUrl="https://example.com/",
+#             username=username_1,
+#             password="password_test",
+#         )
+#         venue_2 = offerers_factories.VenueFactory()
+#         cinema_id_2 = "cinema_2"
+#         cinema_provider_pivot_2 = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue_2, provider=boost_provider, idAtProvider=cinema_id_2
+#         )
+#         username_2 = "cinema_2"
+#         boost_cinema_details_2 = providers_factories.BoostCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot_2,
+#             cinemaUrl="https://another-example.com/",
+#             username=username_2,
+#             password="another_password",
+#         )
+
+#         data = {
+#             "venue_id": venue_2.id,
+#             "cinema_id": cinema_id_1,
+#             "username": username_2,
+#             "password": "another_password",
+#             "cinema_url": "https://another-example.com/",
+#         }
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/boost/edit/?id={boost_cinema_details_2.id}", form=data)
+
+#         # no changes
+#         assert cinema_provider_pivot_2.idAtProvider == cinema_id_2
+#         assert boost_cinema_details_2.cinemaUrl == "https://another-example.com/"
+#         assert boost_cinema_details_2.username == username_2
+#         assert boost_cinema_details_2.password == "another_password"
+#         assert response.status_code == 200  # no redirect
+#         assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+
+
+# class DeleteBoostPivotTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_boost_information(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="admin@example.fr")
+#         boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=boost_provider, idAtProvider="12"
+#         )
+#         boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot,
+#             cinemaUrl="https://test.com/",
+#             username="username_test",
+#             password="password_test",
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/boost/delete", form={"id": boost_cinema_details.id})
+
+#         assert response.status_code == 302
+#         assert providers_models.BoostCinemaDetails.query.count() == 0
+#         assert providers_models.CinemaProviderPivot.query.count() == 0
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_should_not_delete_boost_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="admin@example.fr")
+#         boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=boost_provider, idAtProvider="12"
+#         )
+#         boost_cinema_details = providers_factories.BoostCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot,
+#             cinemaUrl="https://test.com/",
+#             username="username_test",
+#             password="password_test",
+#         )
+#         providers_factories.VenueProviderFactory(venue=venue, provider=boost_provider)
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/boost/delete", form={"id": boost_cinema_details.id})
+
+#         assert response.status_code == 302
+#         assert providers_models.BoostCinemaDetails.query.count() == 1
+#         assert providers_models.CinemaProviderPivot.query.count() == 1

--- a/api/tests/admin/custom_views/category_view_test.py
+++ b/api/tests/admin/custom_views/category_view_test.py
@@ -1,25 +1,25 @@
-from pcapi.core.categories import categories
-from pcapi.core.categories import subcategories
-import pcapi.core.users.factories as users_factories
+# from pcapi.core.categories import categories
+# from pcapi.core.categories import subcategories
+# import pcapi.core.users.factories as users_factories
 
 
-class CategoryViewTest:
-    def test_authorized_user(self, app, db_session, client):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        client.with_session_auth(admin.email)
+# class CategoryViewTest:
+#     def test_authorized_user(self, app, db_session, client):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         client.with_session_auth(admin.email)
 
-        response = client.get("/pc/back-office/categories")
+#         response = client.get("/pc/back-office/categories")
 
-        assert response.status_code == 200
-        assert any(c.id in response.data.decode("utf-8") for c in categories.ALL_CATEGORIES)
+#         assert response.status_code == 200
+#         assert any(c.id in response.data.decode("utf-8") for c in categories.ALL_CATEGORIES)
 
 
-class SubcategoryViewTest:
-    def test_authorized_user(self, app, db_session, client):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        client.with_session_auth(admin.email)
+# class SubcategoryViewTest:
+#     def test_authorized_user(self, app, db_session, client):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         client.with_session_auth(admin.email)
 
-        response = client.get("/pc/back-office/subcategories")
+#         response = client.get("/pc/back-office/subcategories")
 
-        assert response.status_code == 200
-        assert any(s.id in response.data.decode("utf-8") for s in subcategories.ALL_SUBCATEGORIES)
+#         assert response.status_code == 200
+#         assert any(s.id in response.data.decode("utf-8") for s in subcategories.ALL_SUBCATEGORIES)

--- a/api/tests/admin/custom_views/cgr_pivot_view_test.py
+++ b/api/tests/admin/custom_views/cgr_pivot_view_test.py
@@ -1,247 +1,247 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-from freezegun import freeze_time
+# from freezegun import freeze_time
 
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.providers.factories as providers_factories
-import pcapi.core.providers.models as providers_models
-import pcapi.core.providers.repository as providers_repository
-from pcapi.core.users.factories import AdminFactory
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.providers.factories as providers_factories
+# import pcapi.core.providers.models as providers_models
+# import pcapi.core.providers.repository as providers_repository
+# from pcapi.core.users.factories import AdminFactory
 
-from tests.conftest import TestClient
-from tests.conftest import clean_database
-from tests.connectors.cgr import soap_definitions
-from tests.local_providers.cinema_providers.cgr import fixtures
-
-
-class CreateCGRPivotTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_create_cgr_information_api_ok(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="admin@example.fr")
-        venue = offerers_factories.VenueFactory()
-        requests_mock.get("https://example.com/web_service?wsdl", text=soap_definitions.WEB_SERVICE_DEFINITION)
-        requests_mock.post(
-            "https://example.com/web_service", text=fixtures.cgr_response_template([fixtures.FILM_138473])
-        )
-
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": "12",
-            "cinema_url": "https://example.com/web_service/",  # with trailing slash
-            "cinema_password": "strongPassword",
-        }
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/cgr/new", form=data)
-
-        assert response.status_code == 302
-        cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
-            providers_models.CinemaProviderPivot.venueId == venue.id
-        ).one()
-        assert cinema_provider_pivot.idAtProvider == "12"
-        cgr_cinema_details = providers_models.CGRCinemaDetails.query.filter(
-            providers_models.CGRCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
-        ).one()
-        assert cgr_cinema_details.cinemaUrl == "https://example.com/web_service"
-        assert cgr_cinema_details.numCinema == 999
-        assert cgr_cinema_details.password == "strongPassword"
-        flash_mock.assert_called_once_with("Connexion à l'API CGR OK.")
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_create_cgr_information_api_ko(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="admin@example.fr")
-        venue = offerers_factories.VenueFactory()
-
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": "12",
-            "cinema_url": "https://example.com/wrong/ws",
-            "cinema_password": "strongPassword",
-        }
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/cgr/new", form=data)
-
-        assert response.status_code == 302
-        cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
-            providers_models.CinemaProviderPivot.venueId == venue.id
-        ).one()
-        assert cinema_provider_pivot.idAtProvider == "12"
-        cgr_cinema_details = providers_models.CGRCinemaDetails.query.filter(
-            providers_models.CGRCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
-        ).one()
-        assert cgr_cinema_details.cinemaUrl == "https://example.com/wrong/ws"
-        assert cgr_cinema_details.password == "strongPassword"
-        flash_mock.assert_called_once_with("Connexion à l'API CGR KO.", "error")
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_id_at_provider_unicity(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
-        _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cgr_provider, idAtProvider="cinema_test"
-        )
-        venue_2 = offerers_factories.VenueFactory()
-
-        data = {
-            "venue_id": venue_2.id,
-            "account_id": "account_test",
-            "cinema_id": "cinema_test",
-            "cinema_password": "password_test",
-        }
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/cgr/new", form=data)
-
-        assert response.status_code == 200
-        assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
-        assert providers_models.CinemaProviderPivot.query.count() == 1
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_cgr_information_when_venue_already_has_cinema_provider(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
-        _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cgr_provider, idAtProvider="cinema1_test"
-        )
-
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": "cinema2_test",
-            "cinema_url": "https://example.com",
-            "cinema_password": "strongPassword",
-        }
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/cgr/new", form=data)
-        assert response.status_code == 200
-        assert "Des identifiants cinéma existent déjà pour ce lieu id=" in response.data.decode("utf8")
-        assert providers_models.CinemaProviderPivot.query.count() == 1
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
+# from tests.connectors.cgr import soap_definitions
+# from tests.local_providers.cinema_providers.cgr import fixtures
 
 
-class EditCGRPivotTest:
-    @clean_database
-    @freeze_time("2022-10-12 17:09:25")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_update_cgr_information(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="admin@example.fr")
-        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
-        venue = offerers_factories.VenueFactory()
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cgr_provider, idAtProvider="12"
-        )
-        cgr_cinema_details = providers_factories.CGRCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot, cinemaUrl="https://example.com", password="weakPassword"
-        )
-        requests_mock.get("https://new-url.com/web_service?wsdl", text=soap_definitions.WEB_SERVICE_DEFINITION)
-        requests_mock.post(
-            "https://new-url.com/web_service", text=fixtures.cgr_response_template([fixtures.FILM_138473])
-        )
+# class CreateCGRPivotTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_create_cgr_information_api_ok(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="admin@example.fr")
+#         venue = offerers_factories.VenueFactory()
+#         requests_mock.get("https://example.com/web_service?wsdl", text=soap_definitions.WEB_SERVICE_DEFINITION)
+#         requests_mock.post(
+#             "https://example.com/web_service", text=fixtures.cgr_response_template([fixtures.FILM_138473])
+#         )
 
-        data = {
-            "venue_id": venue.id,
-            "cinema_id": "13",
-            "cinema_url": "https://new-url.com/web_service",
-            "cinema_password": "strongPassword",
-        }
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": "12",
+#             "cinema_url": "https://example.com/web_service/",  # with trailing slash
+#             "cinema_password": "strongPassword",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/cgr/new", form=data)
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post(f"/pc/back-office/cgr/edit/?id={cgr_cinema_details.id}", form=data)
+#         assert response.status_code == 302
+#         cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
+#             providers_models.CinemaProviderPivot.venueId == venue.id
+#         ).one()
+#         assert cinema_provider_pivot.idAtProvider == "12"
+#         cgr_cinema_details = providers_models.CGRCinemaDetails.query.filter(
+#             providers_models.CGRCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
+#         ).one()
+#         assert cgr_cinema_details.cinemaUrl == "https://example.com/web_service"
+#         assert cgr_cinema_details.numCinema == 999
+#         assert cgr_cinema_details.password == "strongPassword"
+#         flash_mock.assert_called_once_with("Connexion à l'API CGR OK.")
 
-        assert response.status_code == 302
-        assert cinema_provider_pivot.idAtProvider == "13"
-        assert cgr_cinema_details.cinemaUrl == "https://new-url.com/web_service"
-        assert cgr_cinema_details.numCinema == 999
-        assert cgr_cinema_details.password == "strongPassword"
-        flash_mock.assert_called_once_with("Connexion à l'API CGR OK.")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_create_cgr_information_api_ko(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="admin@example.fr")
+#         venue = offerers_factories.VenueFactory()
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_cannot_reuse_cinema_id_at_provider(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": "12",
+#             "cinema_url": "https://example.com/wrong/ws",
+#             "cinema_password": "strongPassword",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/cgr/new", form=data)
 
-        venue_1 = offerers_factories.VenueFactory()
-        cinema_id_1 = "cinema_1"
-        cinema_provider_pivot_1 = providers_factories.CGRCinemaProviderPivotFactory(
-            venue=venue_1, provider=cgr_provider, idAtProvider=cinema_id_1
-        )
-        _cgr_cinema_details_1 = providers_factories.CGRCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot_1,
-            cinemaUrl="https://example.com/",
-        )
-        venue_2 = offerers_factories.VenueFactory()
-        cinema_id_2 = "cinema_2"
-        cinema_provider_pivot_2 = providers_factories.CinemaProviderPivotFactory(
-            venue=venue_2, provider=cgr_provider, idAtProvider=cinema_id_2
-        )
-        cgr_cinema_details_2 = providers_factories.CGRCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot_2,
-            cinemaUrl="https://another-example.com/",
-        )
+#         assert response.status_code == 302
+#         cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
+#             providers_models.CinemaProviderPivot.venueId == venue.id
+#         ).one()
+#         assert cinema_provider_pivot.idAtProvider == "12"
+#         cgr_cinema_details = providers_models.CGRCinemaDetails.query.filter(
+#             providers_models.CGRCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
+#         ).one()
+#         assert cgr_cinema_details.cinemaUrl == "https://example.com/wrong/ws"
+#         assert cgr_cinema_details.password == "strongPassword"
+#         flash_mock.assert_called_once_with("Connexion à l'API CGR KO.", "error")
 
-        data = {
-            "venue_id": venue_2.id,
-            "cinema_id": cinema_id_1,
-            "cinema_url": "https://another-example.com/",
-        }
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_id_at_provider_unicity(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+#         _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cgr_provider, idAtProvider="cinema_test"
+#         )
+#         venue_2 = offerers_factories.VenueFactory()
 
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/cgr/edit/?id={cgr_cinema_details_2.id}", form=data)
+#         data = {
+#             "venue_id": venue_2.id,
+#             "account_id": "account_test",
+#             "cinema_id": "cinema_test",
+#             "cinema_password": "password_test",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/cgr/new", form=data)
 
-        # no changes
-        assert cinema_provider_pivot_2.idAtProvider == cinema_id_2
-        assert cgr_cinema_details_2.cinemaUrl == "https://another-example.com/"
-        assert response.status_code == 200  # no redirect
-        assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+#         assert response.status_code == 200
+#         assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+#         assert providers_models.CinemaProviderPivot.query.count() == 1
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_cgr_information_when_venue_already_has_cinema_provider(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+#         _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cgr_provider, idAtProvider="cinema1_test"
+#         )
+
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": "cinema2_test",
+#             "cinema_url": "https://example.com",
+#             "cinema_password": "strongPassword",
+#         }
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/cgr/new", form=data)
+#         assert response.status_code == 200
+#         assert "Des identifiants cinéma existent déjà pour ce lieu id=" in response.data.decode("utf8")
+#         assert providers_models.CinemaProviderPivot.query.count() == 1
 
 
-class DeleteCGRPivotTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_cgr_information(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="admin@example.fr")
-        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
-        venue = offerers_factories.VenueFactory()
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cgr_provider, idAtProvider="12"
-        )
-        cgr_cinema_details = providers_factories.CGRCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot,
-            cinemaUrl="https://example.com/",
-        )
+# class EditCGRPivotTest:
+#     @clean_database
+#     @freeze_time("2022-10-12 17:09:25")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_update_cgr_information(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="admin@example.fr")
+#         cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cgr_provider, idAtProvider="12"
+#         )
+#         cgr_cinema_details = providers_factories.CGRCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot, cinemaUrl="https://example.com", password="weakPassword"
+#         )
+#         requests_mock.get("https://new-url.com/web_service?wsdl", text=soap_definitions.WEB_SERVICE_DEFINITION)
+#         requests_mock.post(
+#             "https://new-url.com/web_service", text=fixtures.cgr_response_template([fixtures.FILM_138473])
+#         )
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/cgr/delete", form={"id": cgr_cinema_details.id})
+#         data = {
+#             "venue_id": venue.id,
+#             "cinema_id": "13",
+#             "cinema_url": "https://new-url.com/web_service",
+#             "cinema_password": "strongPassword",
+#         }
 
-        assert response.status_code == 302
-        assert providers_models.CGRCinemaDetails.query.count() == 0
-        assert providers_models.CinemaProviderPivot.query.count() == 0
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post(f"/pc/back-office/cgr/edit/?id={cgr_cinema_details.id}", form=data)
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_should_not_delete_cgr_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="admin@example.fr")
-        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
-        venue = offerers_factories.VenueFactory()
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cgr_provider, idAtProvider="12"
-        )
-        cgr_cinema_details = providers_factories.CGRCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot,
-            cinemaUrl="https://example.com/",
-        )
-        providers_factories.VenueProviderFactory(venue=venue, provider=cgr_provider)
+#         assert response.status_code == 302
+#         assert cinema_provider_pivot.idAtProvider == "13"
+#         assert cgr_cinema_details.cinemaUrl == "https://new-url.com/web_service"
+#         assert cgr_cinema_details.numCinema == 999
+#         assert cgr_cinema_details.password == "strongPassword"
+#         flash_mock.assert_called_once_with("Connexion à l'API CGR OK.")
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/cgr/delete", form={"id": cgr_cinema_details.id})
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_cannot_reuse_cinema_id_at_provider(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
 
-        assert response.status_code == 302
-        assert providers_models.CGRCinemaDetails.query.count() == 1
-        assert providers_models.CinemaProviderPivot.query.count() == 1
+#         venue_1 = offerers_factories.VenueFactory()
+#         cinema_id_1 = "cinema_1"
+#         cinema_provider_pivot_1 = providers_factories.CGRCinemaProviderPivotFactory(
+#             venue=venue_1, provider=cgr_provider, idAtProvider=cinema_id_1
+#         )
+#         _cgr_cinema_details_1 = providers_factories.CGRCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot_1,
+#             cinemaUrl="https://example.com/",
+#         )
+#         venue_2 = offerers_factories.VenueFactory()
+#         cinema_id_2 = "cinema_2"
+#         cinema_provider_pivot_2 = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue_2, provider=cgr_provider, idAtProvider=cinema_id_2
+#         )
+#         cgr_cinema_details_2 = providers_factories.CGRCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot_2,
+#             cinemaUrl="https://another-example.com/",
+#         )
+
+#         data = {
+#             "venue_id": venue_2.id,
+#             "cinema_id": cinema_id_1,
+#             "cinema_url": "https://another-example.com/",
+#         }
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/cgr/edit/?id={cgr_cinema_details_2.id}", form=data)
+
+#         # no changes
+#         assert cinema_provider_pivot_2.idAtProvider == cinema_id_2
+#         assert cgr_cinema_details_2.cinemaUrl == "https://another-example.com/"
+#         assert response.status_code == 200  # no redirect
+#         assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+
+
+# class DeleteCGRPivotTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_cgr_information(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="admin@example.fr")
+#         cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cgr_provider, idAtProvider="12"
+#         )
+#         cgr_cinema_details = providers_factories.CGRCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot,
+#             cinemaUrl="https://example.com/",
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/cgr/delete", form={"id": cgr_cinema_details.id})
+
+#         assert response.status_code == 302
+#         assert providers_models.CGRCinemaDetails.query.count() == 0
+#         assert providers_models.CinemaProviderPivot.query.count() == 0
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_should_not_delete_cgr_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="admin@example.fr")
+#         cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cgr_provider, idAtProvider="12"
+#         )
+#         cgr_cinema_details = providers_factories.CGRCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot,
+#             cinemaUrl="https://example.com/",
+#         )
+#         providers_factories.VenueProviderFactory(venue=venue, provider=cgr_provider)
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/cgr/delete", form={"id": cgr_cinema_details.id})
+
+#         assert response.status_code == 302
+#         assert providers_models.CGRCinemaDetails.query.count() == 1
+#         assert providers_models.CinemaProviderPivot.query.count() == 1

--- a/api/tests/admin/custom_views/cine_office_pivot_view_test.py
+++ b/api/tests/admin/custom_views/cine_office_pivot_view_test.py
@@ -1,315 +1,315 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.providers.factories as providers_factories
-import pcapi.core.providers.models as providers_models
-from pcapi.core.providers.repository import get_provider_by_local_class
-from pcapi.core.users.factories import AdminFactory
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.providers.factories as providers_factories
+# import pcapi.core.providers.models as providers_models
+# from pcapi.core.providers.repository import get_provider_by_local_class
+# from pcapi.core.users.factories import AdminFactory
 
-from tests.conftest import TestClient
-from tests.conftest import clean_database
-
-
-class CreateCineOfficePivotTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_create_cine_office_information_api_ok(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        requests_mock.get("https://account_test.test_cds_url/vad/rating?api_token=token_test", json=[])
-
-        data = {
-            "venue_id": venue.id,
-            "account_id": "account_test",
-            "cinema_id": "cinema_test",
-            "api_token": "token_test",
-        }
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/cine-office/new", form=data)
-
-        assert response.status_code == 302
-        cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
-            providers_models.CinemaProviderPivot.venueId == venue.id
-        ).one()
-        assert cinema_provider_pivot.idAtProvider == "cinema_test"
-        cds_cinema_details = providers_models.CDSCinemaDetails.query.filter(
-            providers_models.CDSCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
-        ).one()
-        assert cds_cinema_details.accountId == "account_test"
-        assert cds_cinema_details.cinemaApiToken == "token_test"
-        assert requests_mock.call_count == 1
-        flash_mock.assert_called_once_with("Connexion à l'API OK.")
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_create_cine_office_information_api_ko(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        requests_mock.get(
-            "https://account_test.test_cds_url/vad/rating?api_token=token_test",
-            status_code=401,
-            reason="CONNECTION_ERROR : AUTHENTIFICATION_FAILED",
-        )
-
-        data = {
-            "venue_id": venue.id,
-            "account_id": "account_test",
-            "cinema_id": "cinema_test",
-            "api_token": "token_test",
-        }
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/cine-office/new", form=data)
-
-        assert response.status_code == 302
-        cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
-            providers_models.CinemaProviderPivot.venueId == venue.id
-        ).one()
-        assert cinema_provider_pivot.idAtProvider == "cinema_test"
-        cds_cinema_details = providers_models.CDSCinemaDetails.query.filter(
-            providers_models.CDSCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
-        ).one()
-        assert cds_cinema_details.accountId == "account_test"
-        assert cds_cinema_details.cinemaApiToken == "token_test"
-        assert requests_mock.call_count == 1
-        flash_mock.assert_called_once_with("Connexion à l'API KO.", "error")
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_id_at_provider_unicity(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue_1 = offerers_factories.VenueFactory()
-        cds_provider = get_provider_by_local_class("CDSStocks")
-        _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue_1, provider=cds_provider, idAtProvider="cinema_test"
-        )
-
-        venue_2 = offerers_factories.VenueFactory()
-
-        data = {
-            "venue_id": venue_2.id,
-            "account_id": "account_test",
-            "cinema_id": "cinema_test",
-            "api_token": "token_test",
-        }
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/cine-office/new", form=data)
-
-        assert response.status_code == 200
-        assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
-        assert providers_models.CinemaProviderPivot.query.count() == 1
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_cine_office_information_when_venue_already_has_cinema_provider(
-        self, _mocked_validate_csrf_token, app
-    ):
-        AdminFactory(email="user@example.com")
-        venue_1 = offerers_factories.VenueFactory()
-        cds_provider = get_provider_by_local_class("CDSStocks")
-        _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue_1, provider=cds_provider, idAtProvider="cinema1_test"
-        )
-
-        data = {
-            "venue_id": venue_1.id,
-            "account_id": "account2_test",
-            "cinema_id": "cinema2_test",
-            "api_token": "token2_test",
-        }
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/pc/back-office/cine-office/new", form=data)
-
-        assert response.status_code == 200
-        assert "Des identifiants cinéma existent déjà pour ce lieu id=" in response.data.decode("utf8")
-        assert providers_models.CinemaProviderPivot.query.count() == 1
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
 
 
-class EditCineOfficePivotTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_update_editable_attributes_api_ok(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        cds_provider = get_provider_by_local_class("CDSStocks")
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cds_provider, idAtProvider="cinema_test"
-        )
-        cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot, accountId="cinema_test", cinemaApiToken="token_test"
-        )
-        requests_mock.get("https://new_account_id.test_cds_url/vad/rating?api_token=new_token_id", json=[])
+# class CreateCineOfficePivotTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_create_cine_office_information_api_ok(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         requests_mock.get("https://account_test.test_cds_url/vad/rating?api_token=token_test", json=[])
 
-        data = {
-            "venue_id": venue.id,
-            "account_id": "new_account_id",
-            "cinema_id": "new_cinema_id",
-            "api_token": "new_token_id",
-        }
+#         data = {
+#             "venue_id": venue.id,
+#             "account_id": "account_test",
+#             "cinema_id": "cinema_test",
+#             "api_token": "token_test",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/cine-office/new", form=data)
 
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/cine-office/edit/?id={cds_cinema_details.id}", form=data)
+#         assert response.status_code == 302
+#         cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
+#             providers_models.CinemaProviderPivot.venueId == venue.id
+#         ).one()
+#         assert cinema_provider_pivot.idAtProvider == "cinema_test"
+#         cds_cinema_details = providers_models.CDSCinemaDetails.query.filter(
+#             providers_models.CDSCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
+#         ).one()
+#         assert cds_cinema_details.accountId == "account_test"
+#         assert cds_cinema_details.cinemaApiToken == "token_test"
+#         assert requests_mock.call_count == 1
+#         flash_mock.assert_called_once_with("Connexion à l'API OK.")
 
-        assert response.status_code == 302
-        assert cinema_provider_pivot.idAtProvider == "new_cinema_id"
-        assert cds_cinema_details.accountId == "new_account_id"
-        assert cds_cinema_details.cinemaApiToken == "new_token_id"
-        assert requests_mock.call_count == 1
-        flash_mock.assert_called_once_with("Connexion à l'API OK.")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_create_cine_office_information_api_ko(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         requests_mock.get(
+#             "https://account_test.test_cds_url/vad/rating?api_token=token_test",
+#             status_code=401,
+#             reason="CONNECTION_ERROR : AUTHENTIFICATION_FAILED",
+#         )
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_update_editable_attributes_api_ko(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        cds_provider = get_provider_by_local_class("CDSStocks")
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cds_provider, idAtProvider="cinema_test"
-        )
-        cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot, accountId="cinema_test", cinemaApiToken="token_test"
-        )
-        requests_mock.get(
-            "https://new_account_id.test_cds_url/vad/rating?api_token=new_token_id",
-            status_code=401,
-            reason="CONNECTION_ERROR : AUTHENTIFICATION_FAILED",
-        )
+#         data = {
+#             "venue_id": venue.id,
+#             "account_id": "account_test",
+#             "cinema_id": "cinema_test",
+#             "api_token": "token_test",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/cine-office/new", form=data)
 
-        data = {
-            "venue_id": venue.id,
-            "account_id": "new_account_id",
-            "cinema_id": "new_cinema_id",
-            "api_token": "new_token_id",
-        }
+#         assert response.status_code == 302
+#         cinema_provider_pivot = providers_models.CinemaProviderPivot.query.filter(
+#             providers_models.CinemaProviderPivot.venueId == venue.id
+#         ).one()
+#         assert cinema_provider_pivot.idAtProvider == "cinema_test"
+#         cds_cinema_details = providers_models.CDSCinemaDetails.query.filter(
+#             providers_models.CDSCinemaDetails.cinemaProviderPivotId == cinema_provider_pivot.id
+#         ).one()
+#         assert cds_cinema_details.accountId == "account_test"
+#         assert cds_cinema_details.cinemaApiToken == "token_test"
+#         assert requests_mock.call_count == 1
+#         flash_mock.assert_called_once_with("Connexion à l'API KO.", "error")
 
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/cine-office/edit/?id={cds_cinema_details.id}", form=data)
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_id_at_provider_unicity(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue_1 = offerers_factories.VenueFactory()
+#         cds_provider = get_provider_by_local_class("CDSStocks")
+#         _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue_1, provider=cds_provider, idAtProvider="cinema_test"
+#         )
 
-        assert response.status_code == 302
-        assert cinema_provider_pivot.idAtProvider == "new_cinema_id"
-        assert cds_cinema_details.accountId == "new_account_id"
-        assert cds_cinema_details.cinemaApiToken == "new_token_id"
-        assert requests_mock.call_count == 1
-        flash_mock.assert_called_once_with("Connexion à l'API KO.", "error")
+#         venue_2 = offerers_factories.VenueFactory()
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("flask.flash")
-    def test_update_token(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        cds_provider = get_provider_by_local_class("CDSStocks")
-        cinema_id = "cinema_test"
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cds_provider, idAtProvider=cinema_id
-        )
-        account_id = "cinema_test"
-        cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot, accountId=account_id, cinemaApiToken="token_test"
-        )
-        requests_mock.get("https://cinema_test.test_cds_url/vad/rating?api_token=new_token_id", json=[])
+#         data = {
+#             "venue_id": venue_2.id,
+#             "account_id": "account_test",
+#             "cinema_id": "cinema_test",
+#             "api_token": "token_test",
+#         }
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/cine-office/new", form=data)
 
-        data = {
-            "venue_id": venue.id,
-            "account_id": account_id,
-            "cinema_id": cinema_id,
-            "api_token": "new_token_id",
-        }
+#         assert response.status_code == 200
+#         assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+#         assert providers_models.CinemaProviderPivot.query.count() == 1
 
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/cine-office/edit/?id={cds_cinema_details.id}", form=data)
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_cine_office_information_when_venue_already_has_cinema_provider(
+#         self, _mocked_validate_csrf_token, app
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue_1 = offerers_factories.VenueFactory()
+#         cds_provider = get_provider_by_local_class("CDSStocks")
+#         _cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue_1, provider=cds_provider, idAtProvider="cinema1_test"
+#         )
 
-        assert cinema_provider_pivot.idAtProvider == cinema_id
-        assert cds_cinema_details.accountId == account_id
-        assert cds_cinema_details.cinemaApiToken == "new_token_id"
-        assert response.status_code == 302
-        assert requests_mock.call_count == 1
-        flash_mock.assert_called_once_with("Connexion à l'API OK.")
+#         data = {
+#             "venue_id": venue_1.id,
+#             "account_id": "account2_test",
+#             "cinema_id": "cinema2_test",
+#             "api_token": "token2_test",
+#         }
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_cannot_reuse_cinema_id_at_provider(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue_1 = offerers_factories.VenueFactory()
-        cds_provider = get_provider_by_local_class("CDSStocks")
-        cinema_id_1 = "cinema_1"
-        cinema_provider_pivot_1 = providers_factories.CinemaProviderPivotFactory(
-            venue=venue_1, provider=cds_provider, idAtProvider=cinema_id_1
-        )
-        account_id_1 = "cinema_1"
-        _cds_cinema_details_1 = providers_factories.CDSCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot_1, accountId=account_id_1, cinemaApiToken="token_test_1"
-        )
-        venue_2 = offerers_factories.VenueFactory()
-        cinema_id_2 = "cinema_2"
-        cinema_provider_pivot_2 = providers_factories.CinemaProviderPivotFactory(
-            venue=venue_2, provider=cds_provider, idAtProvider=cinema_id_2
-        )
-        account_id_2 = "cinema_2"
-        cds_cinema_details_2 = providers_factories.CDSCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot_2, accountId=account_id_2, cinemaApiToken="token_test_2"
-        )
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post("/pc/back-office/cine-office/new", form=data)
 
-        data = {
-            "venue_id": venue_2.id,
-            "account_id": account_id_2,
-            "cinema_id": cinema_id_1,
-            "api_token": "token_test_2",
-        }
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/cine-office/edit/?id={cds_cinema_details_2.id}", form=data)
-
-        # no changes
-        assert cinema_provider_pivot_2.idAtProvider == cinema_id_2
-        assert cds_cinema_details_2.accountId == account_id_2
-        assert cds_cinema_details_2.cinemaApiToken == "token_test_2"
-        assert response.status_code == 200  # no redirect
-        assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+#         assert response.status_code == 200
+#         assert "Des identifiants cinéma existent déjà pour ce lieu id=" in response.data.decode("utf8")
+#         assert providers_models.CinemaProviderPivot.query.count() == 1
 
 
-class DeleteCineOfficePivotTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_cine_office_information(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="admin@example.fr")
-        cds_provider = get_provider_by_local_class("CDSStocks")
-        venue = offerers_factories.VenueFactory()
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cds_provider, idAtProvider="cinema_test"
-        )
-        cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot, accountId="cinema_test", cinemaApiToken="token_test"
-        )
+# class EditCineOfficePivotTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_update_editable_attributes_api_ok(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         cds_provider = get_provider_by_local_class("CDSStocks")
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cds_provider, idAtProvider="cinema_test"
+#         )
+#         cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot, accountId="cinema_test", cinemaApiToken="token_test"
+#         )
+#         requests_mock.get("https://new_account_id.test_cds_url/vad/rating?api_token=new_token_id", json=[])
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/cine-office/delete", form={"id": cds_cinema_details.id})
+#         data = {
+#             "venue_id": venue.id,
+#             "account_id": "new_account_id",
+#             "cinema_id": "new_cinema_id",
+#             "api_token": "new_token_id",
+#         }
 
-        assert response.status_code == 302
-        assert providers_models.CDSCinemaDetails.query.count() == 0
-        assert providers_models.CinemaProviderPivot.query.count() == 0
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/cine-office/edit/?id={cds_cinema_details.id}", form=data)
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_should_not_delete_cine_office_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
-        AdminFactory(email="admin@example.fr")
-        cds_provider = get_provider_by_local_class("CDSStocks")
-        venue = offerers_factories.VenueFactory()
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=cds_provider, idAtProvider="cinema_test"
-        )
-        cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
-            cinemaProviderPivot=cinema_provider_pivot, accountId="cinema_test", cinemaApiToken="token_test"
-        )
-        providers_factories.VenueProviderFactory(venue=venue, provider=cds_provider)
+#         assert response.status_code == 302
+#         assert cinema_provider_pivot.idAtProvider == "new_cinema_id"
+#         assert cds_cinema_details.accountId == "new_account_id"
+#         assert cds_cinema_details.cinemaApiToken == "new_token_id"
+#         assert requests_mock.call_count == 1
+#         flash_mock.assert_called_once_with("Connexion à l'API OK.")
 
-        client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
-        response = client.post("/pc/back-office/cine-office/delete", form={"id": cds_cinema_details.id})
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_update_editable_attributes_api_ko(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         cds_provider = get_provider_by_local_class("CDSStocks")
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cds_provider, idAtProvider="cinema_test"
+#         )
+#         cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot, accountId="cinema_test", cinemaApiToken="token_test"
+#         )
+#         requests_mock.get(
+#             "https://new_account_id.test_cds_url/vad/rating?api_token=new_token_id",
+#             status_code=401,
+#             reason="CONNECTION_ERROR : AUTHENTIFICATION_FAILED",
+#         )
 
-        assert response.status_code == 302
-        assert providers_models.CDSCinemaDetails.query.count() == 1
-        assert providers_models.CinemaProviderPivot.query.count() == 1
+#         data = {
+#             "venue_id": venue.id,
+#             "account_id": "new_account_id",
+#             "cinema_id": "new_cinema_id",
+#             "api_token": "new_token_id",
+#         }
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/cine-office/edit/?id={cds_cinema_details.id}", form=data)
+
+#         assert response.status_code == 302
+#         assert cinema_provider_pivot.idAtProvider == "new_cinema_id"
+#         assert cds_cinema_details.accountId == "new_account_id"
+#         assert cds_cinema_details.cinemaApiToken == "new_token_id"
+#         assert requests_mock.call_count == 1
+#         flash_mock.assert_called_once_with("Connexion à l'API KO.", "error")
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("flask.flash")
+#     def test_update_token(self, flash_mock, _mocked_validate_csrf_token, requests_mock, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         cds_provider = get_provider_by_local_class("CDSStocks")
+#         cinema_id = "cinema_test"
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cds_provider, idAtProvider=cinema_id
+#         )
+#         account_id = "cinema_test"
+#         cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot, accountId=account_id, cinemaApiToken="token_test"
+#         )
+#         requests_mock.get("https://cinema_test.test_cds_url/vad/rating?api_token=new_token_id", json=[])
+
+#         data = {
+#             "venue_id": venue.id,
+#             "account_id": account_id,
+#             "cinema_id": cinema_id,
+#             "api_token": "new_token_id",
+#         }
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/cine-office/edit/?id={cds_cinema_details.id}", form=data)
+
+#         assert cinema_provider_pivot.idAtProvider == cinema_id
+#         assert cds_cinema_details.accountId == account_id
+#         assert cds_cinema_details.cinemaApiToken == "new_token_id"
+#         assert response.status_code == 302
+#         assert requests_mock.call_count == 1
+#         flash_mock.assert_called_once_with("Connexion à l'API OK.")
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_cannot_reuse_cinema_id_at_provider(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue_1 = offerers_factories.VenueFactory()
+#         cds_provider = get_provider_by_local_class("CDSStocks")
+#         cinema_id_1 = "cinema_1"
+#         cinema_provider_pivot_1 = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue_1, provider=cds_provider, idAtProvider=cinema_id_1
+#         )
+#         account_id_1 = "cinema_1"
+#         _cds_cinema_details_1 = providers_factories.CDSCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot_1, accountId=account_id_1, cinemaApiToken="token_test_1"
+#         )
+#         venue_2 = offerers_factories.VenueFactory()
+#         cinema_id_2 = "cinema_2"
+#         cinema_provider_pivot_2 = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue_2, provider=cds_provider, idAtProvider=cinema_id_2
+#         )
+#         account_id_2 = "cinema_2"
+#         cds_cinema_details_2 = providers_factories.CDSCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot_2, accountId=account_id_2, cinemaApiToken="token_test_2"
+#         )
+
+#         data = {
+#             "venue_id": venue_2.id,
+#             "account_id": account_id_2,
+#             "cinema_id": cinema_id_1,
+#             "api_token": "token_test_2",
+#         }
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/cine-office/edit/?id={cds_cinema_details_2.id}", form=data)
+
+#         # no changes
+#         assert cinema_provider_pivot_2.idAtProvider == cinema_id_2
+#         assert cds_cinema_details_2.accountId == account_id_2
+#         assert cds_cinema_details_2.cinemaApiToken == "token_test_2"
+#         assert response.status_code == 200  # no redirect
+#         assert "Cet identifiant cinéma existe déjà pour un autre lieu" in response.data.decode("utf8")
+
+
+# class DeleteCineOfficePivotTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_cine_office_information(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="admin@example.fr")
+#         cds_provider = get_provider_by_local_class("CDSStocks")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cds_provider, idAtProvider="cinema_test"
+#         )
+#         cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot, accountId="cinema_test", cinemaApiToken="token_test"
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/cine-office/delete", form={"id": cds_cinema_details.id})
+
+#         assert response.status_code == 302
+#         assert providers_models.CDSCinemaDetails.query.count() == 0
+#         assert providers_models.CinemaProviderPivot.query.count() == 0
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_should_not_delete_cine_office_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="admin@example.fr")
+#         cds_provider = get_provider_by_local_class("CDSStocks")
+#         venue = offerers_factories.VenueFactory()
+#         cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+#             venue=venue, provider=cds_provider, idAtProvider="cinema_test"
+#         )
+#         cds_cinema_details = providers_factories.CDSCinemaDetailsFactory(
+#             cinemaProviderPivot=cinema_provider_pivot, accountId="cinema_test", cinemaApiToken="token_test"
+#         )
+#         providers_factories.VenueProviderFactory(venue=venue, provider=cds_provider)
+
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.fr")
+#         response = client.post("/pc/back-office/cine-office/delete", form={"id": cds_cinema_details.id})
+
+#         assert response.status_code == 302
+#         assert providers_models.CDSCinemaDetails.query.count() == 1
+#         assert providers_models.CinemaProviderPivot.query.count() == 1

--- a/api/tests/admin/custom_views/criteria_view_test.py
+++ b/api/tests/admin/custom_views/criteria_view_test.py
@@ -1,84 +1,84 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-import pytest
+# import pytest
 
-import pcapi.core.criteria.factories as criteria_factories
-import pcapi.core.criteria.models as criteria_models
-import pcapi.core.offers.factories as offers_factories
-import pcapi.core.users.factories as users_factories
+# import pcapi.core.criteria.factories as criteria_factories
+# import pcapi.core.criteria.models as criteria_models
+# import pcapi.core.offers.factories as offers_factories
+# import pcapi.core.users.factories as users_factories
 
-from tests.conftest import clean_database
+# from tests.conftest import clean_database
 
 
-class CriteriaViewTest:
-    @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_criterion(self, mocked_validate_csrf_token, client, name):
-        users_factories.AdminFactory(email="admin@example.com")
+# class CriteriaViewTest:
+#     @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_criterion(self, mocked_validate_csrf_token, client, name):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post(
-            "/pc/back-office/criterion/new/",
-            form={"name": name, "description": "My description", "startDateTime": None, "endDateTime": None},
-        )
+#         response = api_client.post(
+#             "/pc/back-office/criterion/new/",
+#             form={"name": name, "description": "My description", "startDateTime": None, "endDateTime": None},
+#         )
 
-        assert response.status_code == 302
-        assert criteria_models.Criterion.query.count() == 1
-        criterion = criteria_models.Criterion.query.first()
-        assert criterion.name == name
-        assert criterion.description == "My description"
+#         assert response.status_code == 302
+#         assert criteria_models.Criterion.query.count() == 1
+#         criterion = criteria_models.Criterion.query.first()
+#         assert criterion.name == name
+#         assert criterion.description == "My description"
 
-    @pytest.mark.parametrize(
-        "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
-    )
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_criterion_with_whitespace(self, mocked_validate_csrf_token, client, name):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @pytest.mark.parametrize(
+#         "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
+#     )
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_criterion_with_whitespace(self, mocked_validate_csrf_token, client, name):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post(
-            "/pc/back-office/criterion/new/",
-            form={"name": name, "description": "My description", "startDateTime": None, "endDateTime": None},
-        )
+#         response = api_client.post(
+#             "/pc/back-office/criterion/new/",
+#             form={"name": name, "description": "My description", "startDateTime": None, "endDateTime": None},
+#         )
 
-        assert response.status_code == 200
-        assert "Le nom ne doit contenir aucun caractère d&#39;espacement" in response.data.decode("utf8")
-        assert criteria_models.Criterion.query.count() == 0
+#         assert response.status_code == 200
+#         assert "Le nom ne doit contenir aucun caractère d&#39;espacement" in response.data.decode("utf8")
+#         assert criteria_models.Criterion.query.count() == 0
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_criterion_too_long(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_criterion_too_long(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post(
-            "/pc/back-office/criterion/new/",
-            form={"name": "x" * 141, "description": "My description", "startDateTime": None, "endDateTime": None},
-        )
+#         response = api_client.post(
+#             "/pc/back-office/criterion/new/",
+#             form={"name": "x" * 141, "description": "My description", "startDateTime": None, "endDateTime": None},
+#         )
 
-        assert response.status_code == 200
-        assert "Le nom d&#39;un tag ne peut excéder 140 caractères" in response.data.decode("utf8")
-        assert criteria_models.Criterion.query.count() == 0
+#         assert response.status_code == 200
+#         assert "Le nom d&#39;un tag ne peut excéder 140 caractères" in response.data.decode("utf8")
+#         assert criteria_models.Criterion.query.count() == 0
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_criterion(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_criterion(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        criterion = criteria_factories.CriterionFactory(name="test_delete_criterion")
-        offer = offers_factories.OfferFactory(criteria=[criterion])
+#         criterion = criteria_factories.CriterionFactory(name="test_delete_criterion")
+#         offer = offers_factories.OfferFactory(criteria=[criterion])
 
-        assert len(offer.criteria) == 1
+#         assert len(offer.criteria) == 1
 
-        data = dict(id=criterion.id)
-        api_client = client.with_session_auth("admin@example.com")
+#         data = dict(id=criterion.id)
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post("/pc/back-office/criterion/delete/", form=data)
+#         response = api_client.post("/pc/back-office/criterion/delete/", form=data)
 
-        assert response.status_code == 302
-        assert len(offer.criteria) == 0
+#         assert response.status_code == 302
+#         assert len(offer.criteria) == 0

--- a/api/tests/admin/custom_views/cultural_survey_view_test.py
+++ b/api/tests/admin/custom_views/cultural_survey_view_test.py
@@ -1,19 +1,19 @@
-import pcapi.core.users.factories as users_factories
+# import pcapi.core.users.factories as users_factories
 
 
-class CulturalSurveyViewTest:
-    def test_authorized_user(self, app, db_session, client):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        client.with_session_auth(admin.email)
+# class CulturalSurveyViewTest:
+#     def test_authorized_user(self, app, db_session, client):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         client.with_session_auth(admin.email)
 
-        response = client.get("/pc/back-office/cultural_survey_answers")
+#         response = client.get("/pc/back-office/cultural_survey_answers")
 
-        assert response.status_code == 200
+#         assert response.status_code == 200
 
-    def test_unauthorized_user(self, app, db_session, client):
-        user = users_factories.UserFactory(email="admin@example.com")
-        client.with_session_auth(user.email)
+#     def test_unauthorized_user(self, app, db_session, client):
+#         user = users_factories.UserFactory(email="admin@example.com")
+#         client.with_session_auth(user.email)
 
-        response = client.get("/pc/back-office/cultural_survey_answers")
+#         response = client.get("/pc/back-office/cultural_survey_answers")
 
-        assert response.status_code == 403
+#         assert response.status_code == 403

--- a/api/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
+++ b/api/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
@@ -1,52 +1,52 @@
-import datetime
-import decimal
-from unittest import mock
+# import datetime
+# import decimal
+# from unittest import mock
 
-import pcapi.core.finance.factories as finance_factories
-import pcapi.core.finance.models as finance_models
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.users.factories as users_factories
+# import pcapi.core.finance.factories as finance_factories
+# import pcapi.core.finance.models as finance_models
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.users.factories as users_factories
 
-from tests.conftest import clean_database
-
-
-@clean_database
-@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-def test_create_rule(mocked_validate_csrf_token, client, app):
-    admin = users_factories.AdminFactory()
-    offerer = offerers_factories.OffererFactory()
-
-    data = dict(
-        offerer=offerer.id,
-        subcategories=[],
-        rate="80,25",
-        start_date="2030-10-01",
-        end_date="",
-    )
-    client = client.with_session_auth(admin.email)
-    response = client.post("/pc/back-office/customreimbursementrule/new/", form=data)
-
-    assert response.status_code == 302
-    rule = finance_models.CustomReimbursementRule.query.one()
-    assert rule.offerer == offerer
-    assert rule.rate == decimal.Decimal("0.8025")
-    assert rule.subcategories == []
-    assert rule.timespan.lower == datetime.datetime(2030, 9, 30, 22, 0)  # UTC
-    assert rule.timespan.upper is None
+# from tests.conftest import clean_database
 
 
-@clean_database
-@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-def test_edit_rule(mocked_validate_csrf_token, client, app):
-    admin = users_factories.AdminFactory()
-    timespan = (datetime.datetime.today() + datetime.timedelta(days=10), None)
-    rule = finance_factories.CustomReimbursementRuleFactory(timespan=timespan)
+# @clean_database
+# @mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+# def test_create_rule(mocked_validate_csrf_token, client, app):
+#     admin = users_factories.AdminFactory()
+#     offerer = offerers_factories.OffererFactory()
 
-    client = client.with_session_auth(admin.email)
-    data = {"end_date": "2030-10-01"}
-    response = client.post(f"/pc/back-office/customreimbursementrule/edit/?id={rule.id}", form=data)
+#     data = dict(
+#         offerer=offerer.id,
+#         subcategories=[],
+#         rate="80,25",
+#         start_date="2030-10-01",
+#         end_date="",
+#     )
+#     client = client.with_session_auth(admin.email)
+#     response = client.post("/pc/back-office/customreimbursementrule/new/", form=data)
 
-    assert response.status_code == 302
-    rule = finance_models.CustomReimbursementRule.query.one()
-    assert rule.timespan.lower == timespan[0]  # unchanged
-    assert rule.timespan.upper == datetime.datetime(2030, 9, 30, 22, 0)  # UTC
+#     assert response.status_code == 302
+#     rule = finance_models.CustomReimbursementRule.query.one()
+#     assert rule.offerer == offerer
+#     assert rule.rate == decimal.Decimal("0.8025")
+#     assert rule.subcategories == []
+#     assert rule.timespan.lower == datetime.datetime(2030, 9, 30, 22, 0)  # UTC
+#     assert rule.timespan.upper is None
+
+
+# @clean_database
+# @mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+# def test_edit_rule(mocked_validate_csrf_token, client, app):
+#     admin = users_factories.AdminFactory()
+#     timespan = (datetime.datetime.today() + datetime.timedelta(days=10), None)
+#     rule = finance_factories.CustomReimbursementRuleFactory(timespan=timespan)
+
+#     client = client.with_session_auth(admin.email)
+#     data = {"end_date": "2030-10-01"}
+#     response = client.post(f"/pc/back-office/customreimbursementrule/edit/?id={rule.id}", form=data)
+
+#     assert response.status_code == 302
+#     rule = finance_models.CustomReimbursementRule.query.one()
+#     assert rule.timespan.lower == timespan[0]  # unchanged
+#     assert rule.timespan.upper == datetime.datetime(2030, 9, 30, 22, 0)  # UTC

--- a/api/tests/admin/custom_views/feature_view_test.py
+++ b/api/tests/admin/custom_views/feature_view_test.py
@@ -1,32 +1,32 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-import pcapi.core.users.factories as users_factories
-from pcapi.models.feature import Feature
-from pcapi.notifications.internal import testing as internal_notification_testing
+# import pcapi.core.users.factories as users_factories
+# from pcapi.models.feature import Feature
+# from pcapi.notifications.internal import testing as internal_notification_testing
 
-from tests.conftest import clean_database
+# from tests.conftest import clean_database
 
 
-class FeatureViewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_feature_edition(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        inactive_feature = Feature.query.filter_by(isActive=False).first()
-        active_feature = Feature.query.filter_by(isActive=True).first()
+# class FeatureViewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_feature_edition(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         inactive_feature = Feature.query.filter_by(isActive=False).first()
+#         active_feature = Feature.query.filter_by(isActive=True).first()
 
-        data = {"isActive": "true"}
-        response = client.with_session_auth("admin@example.com").post(
-            f"/pc/back-office/feature/edit?id={inactive_feature.id}", form=data
-        )
-        assert response.status_code == 302
-        assert Feature.query.get(inactive_feature.id).isActive
-        assert len(internal_notification_testing.requests) == 1
+#         data = {"isActive": "true"}
+#         response = client.with_session_auth("admin@example.com").post(
+#             f"/pc/back-office/feature/edit?id={inactive_feature.id}", form=data
+#         )
+#         assert response.status_code == 302
+#         assert Feature.query.get(inactive_feature.id).isActive
+#         assert len(internal_notification_testing.requests) == 1
 
-        data = {"isActive": "false"}
-        response = client.with_session_auth("admin@example.com").post(
-            f"/pc/back-office/feature/edit?id={active_feature.id}", form=data
-        )
-        assert response.status_code == 302
-        assert not Feature.query.get(active_feature.id).isActive
-        assert len(internal_notification_testing.requests) == 2
+#         data = {"isActive": "false"}
+#         response = client.with_session_auth("admin@example.com").post(
+#             f"/pc/back-office/feature/edit?id={active_feature.id}", form=data
+#         )
+#         assert response.status_code == 302
+#         assert not Feature.query.get(active_feature.id).isActive
+#         assert len(internal_notification_testing.requests) == 2

--- a/api/tests/admin/custom_views/many_offers_operations_view_test.py
+++ b/api/tests/admin/custom_views/many_offers_operations_view_test.py
@@ -1,286 +1,286 @@
-from datetime import datetime
-from datetime import timedelta
-from unittest.mock import patch
+# from datetime import datetime
+# from datetime import timedelta
+# from unittest.mock import patch
 
-import pytest
+# import pytest
 
-from pcapi.admin.custom_views.many_offers_operations_view import _get_current_criteria_on_active_offers
-from pcapi.admin.custom_views.many_offers_operations_view import _get_products_compatible_status
-from pcapi.core.categories import subcategories
-import pcapi.core.criteria.factories as criteria_factories
-import pcapi.core.criteria.models as criteria_models
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.offers.factories as offers_factories
-import pcapi.core.offers.models as offers_models
-from pcapi.core.offers.models import Offer
-import pcapi.core.users.factories as users_factories
-from pcapi.models.offer_mixin import OfferValidationStatus
-from pcapi.models.offer_mixin import OfferValidationType
+# from pcapi.admin.custom_views.many_offers_operations_view import _get_current_criteria_on_active_offers
+# from pcapi.admin.custom_views.many_offers_operations_view import _get_products_compatible_status
+# from pcapi.core.categories import subcategories
+# import pcapi.core.criteria.factories as criteria_factories
+# import pcapi.core.criteria.models as criteria_models
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.offers.factories as offers_factories
+# import pcapi.core.offers.models as offers_models
+# from pcapi.core.offers.models import Offer
+# import pcapi.core.users.factories as users_factories
+# from pcapi.models.offer_mixin import OfferValidationStatus
+# from pcapi.models.offer_mixin import OfferValidationType
 
-from tests.conftest import TestClient
+# from tests.conftest import TestClient
 
 
-@pytest.mark.usefixtures("db_session")
-class ManyOffersOperationsViewTest:
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_search_product_from_ean(self, mocked_validate_csrf_token, app):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
-        product = offers_factories.ProductFactory(
-            extraData={"ean": "9783161484100"}, subcategoryId=subcategories.LIVRE_PAPIER.id
-        )
-        offers_factories.OfferFactory(product=product, extraData={"ean": "9783161484100"})
+# @pytest.mark.usefixtures("db_session")
+# class ManyOffersOperationsViewTest:
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_search_product_from_ean(self, mocked_validate_csrf_token, app):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
+#         product = offers_factories.ProductFactory(
+#             extraData={"ean": "9783161484100"}, subcategoryId=subcategories.LIVRE_PAPIER.id
+#         )
+#         offers_factories.OfferFactory(product=product, extraData={"ean": "9783161484100"})
 
-        data = dict(ean="978-3-16-148410-0")
+#         data = dict(ean="978-3-16-148410-0")
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/many_offers_operations/", form=data)
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/many_offers_operations/", form=data)
 
-        # Then
-        assert response.status_code == 302
-        assert (
-            response.headers["location"]
-            == "http://localhost/pc/back-office/many_offers_operations/edit?ean=9783161484100"
-        )
+#         # Then
+#         assert response.status_code == 302
+#         assert (
+#             response.headers["location"]
+#             == "http://localhost/pc/back-office/many_offers_operations/edit?ean=9783161484100"
+#         )
 
-        # Check that redirected page is rendered without error
-        get_response = client.get(response.headers["location"])
-        assert get_response.status_code == 200
+#         # Check that redirected page is rendered without error
+#         get_response = client.get(response.headers["location"])
+#         assert get_response.status_code == 200
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_search_product_from_visa(self, mocked_validate_csrf_token, app):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_search_product_from_visa(self, mocked_validate_csrf_token, app):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        data = dict(visa="978148")
+#         data = dict(visa="978148")
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/many_offers_operations/", form=data)
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/many_offers_operations/", form=data)
 
-        # Then
-        assert response.status_code == 302
-        assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/edit?visa=978148"
+#         # Then
+#         assert response.status_code == 302
+#         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/edit?visa=978148"
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_search_product_from_ean_with_invalid_ean(self, mocked_validate_csrf_token, app):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_search_product_from_ean_with_invalid_ean(self, mocked_validate_csrf_token, app):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        data = dict(
-            ean="978-3-16-14840-0",
-        )
+#         data = dict(
+#             ean="978-3-16-14840-0",
+#         )
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/many_offers_operations/", form=data)
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/many_offers_operations/", form=data)
 
-        # Then
-        assert response.status_code == 200
+#         # Then
+#         assert response.status_code == 200
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_search_product_with_no_ean_nor_visa(self, mocked_validate_csrf_token, app):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_search_product_with_no_ean_nor_visa(self, mocked_validate_csrf_token, app):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/many_offers_operations/", form={})
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/many_offers_operations/", form={})
 
-        # Then
-        assert response.status_code == 200
+#         # Then
+#         assert response.status_code == 200
 
-    @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_product_offers_criteria_from_ean(self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
-        product = offers_factories.ProductFactory(extraData={"ean": "9783161484100"})
-        offer1 = offers_factories.OfferFactory(product=product, extraData={"ean": "9783161484100"})
-        offer2 = offers_factories.OfferFactory(product=product, extraData={"ean": "9783161484100"})
-        inactive_offer = offers_factories.OfferFactory(
-            product=product, extraData={"ean": "9783161484100"}, isActive=False
-        )
-        unmatched_offer = offers_factories.OfferFactory()
-        criterion1 = criteria_factories.CriterionFactory(name="Pretty good books")
-        criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
+#     @patch("pcapi.core.search.async_index_offer_ids")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_product_offers_criteria_from_ean(self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
+#         product = offers_factories.ProductFactory(extraData={"ean": "9783161484100"})
+#         offer1 = offers_factories.OfferFactory(product=product, extraData={"ean": "9783161484100"})
+#         offer2 = offers_factories.OfferFactory(product=product, extraData={"ean": "9783161484100"})
+#         inactive_offer = offers_factories.OfferFactory(
+#             product=product, extraData={"ean": "9783161484100"}, isActive=False
+#         )
+#         unmatched_offer = offers_factories.OfferFactory()
+#         criterion1 = criteria_factories.CriterionFactory(name="Pretty good books")
+#         criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
 
-        data = dict(
-            criteria=[criterion1.id, criterion2.id],
-        )
+#         data = dict(
+#             criteria=[criterion1.id, criterion2.id],
+#         )
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post(
-            "/pc/back-office/many_offers_operations/add_criteria_to_offers?ean=9783161484100", form=data
-        )
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post(
+#             "/pc/back-office/many_offers_operations/add_criteria_to_offers?ean=9783161484100", form=data
+#         )
 
-        # Then
-        assert response.status_code == 302
-        assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
-        assert offer1.criteria == [criterion1, criterion2]
-        assert offer2.criteria == [criterion1, criterion2]
-        assert not inactive_offer.criteria
-        assert not unmatched_offer.criteria
-        mocked_async_index_offer_ids.assert_called_once_with([offer1.id, offer2.id])
+#         # Then
+#         assert response.status_code == 302
+#         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
+#         assert offer1.criteria == [criterion1, criterion2]
+#         assert offer2.criteria == [criterion1, criterion2]
+#         assert not inactive_offer.criteria
+#         assert not unmatched_offer.criteria
+#         mocked_async_index_offer_ids.assert_called_once_with([offer1.id, offer2.id])
 
-    @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_product_offers_criteria_from_visa(
-        self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app
-    ):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
-        product = offers_factories.ProductFactory(extraData={"visa": "9783161484100"})
-        offer1 = offers_factories.OfferFactory(product=product, extraData={"visa": "9783161484100"})
-        offer2 = offers_factories.OfferFactory(product=product, extraData={"visa": "9783161484100"})
-        inactive_offer = offers_factories.OfferFactory(
-            product=product, extraData={"visa": "9783161484100"}, isActive=False
-        )
-        unmatched_offer = offers_factories.OfferFactory()
-        criterion1 = criteria_factories.CriterionFactory(name="Pretty good books")
-        criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
+#     @patch("pcapi.core.search.async_index_offer_ids")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_product_offers_criteria_from_visa(
+#         self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app
+#     ):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
+#         product = offers_factories.ProductFactory(extraData={"visa": "9783161484100"})
+#         offer1 = offers_factories.OfferFactory(product=product, extraData={"visa": "9783161484100"})
+#         offer2 = offers_factories.OfferFactory(product=product, extraData={"visa": "9783161484100"})
+#         inactive_offer = offers_factories.OfferFactory(
+#             product=product, extraData={"visa": "9783161484100"}, isActive=False
+#         )
+#         unmatched_offer = offers_factories.OfferFactory()
+#         criterion1 = criteria_factories.CriterionFactory(name="Pretty good books")
+#         criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
 
-        data = dict(
-            criteria=[criterion1.id, criterion2.id],
-        )
+#         data = dict(
+#             criteria=[criterion1.id, criterion2.id],
+#         )
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post(
-            "/pc/back-office/many_offers_operations/add_criteria_to_offers?visa=9783161484100", form=data
-        )
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post(
+#             "/pc/back-office/many_offers_operations/add_criteria_to_offers?visa=9783161484100", form=data
+#         )
 
-        # Then
-        assert response.status_code == 302
-        assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
-        assert offer1.criteria == [criterion1, criterion2]
-        assert offer2.criteria == [criterion1, criterion2]
-        assert not inactive_offer.criteria
-        assert not unmatched_offer.criteria
-        mocked_async_index_offer_ids.called_once_with([offer1.id, offer2.id])
+#         # Then
+#         assert response.status_code == 302
+#         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
+#         assert offer1.criteria == [criterion1, criterion2]
+#         assert offer2.criteria == [criterion1, criterion2]
+#         assert not inactive_offer.criteria
+#         assert not unmatched_offer.criteria
+#         mocked_async_index_offer_ids.called_once_with([offer1.id, offer2.id])
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_product_offers_criteria_from_ean_without_offers(self, mocked_validate_csrf_token, app):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_product_offers_criteria_from_ean_without_offers(self, mocked_validate_csrf_token, app):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.get("/pc/back-office/many_offers_operations/edit?ean=9783161484100")
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.get("/pc/back-office/many_offers_operations/edit?ean=9783161484100")
 
-        # Then
-        assert response.status_code == 302
-        assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
+#         # Then
+#         assert response.status_code == 302
+#         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_product_offers_criteria_from_visa_without_offers(self, mocked_validate_csrf_token, app):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_product_offers_criteria_from_visa_without_offers(self, mocked_validate_csrf_token, app):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.get("/pc/back-office/many_offers_operations/edit?visa=9783161484100")
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.get("/pc/back-office/many_offers_operations/edit?visa=9783161484100")
 
-        # Then
-        assert response.status_code == 302
-        assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
+#         # Then
+#         assert response.status_code == 302
+#         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
 
-    def test_get_current_criteria_on_active_offers(self):
-        # Given
-        criterion1 = criteria_models.Criterion(name="One criterion")
-        criterion2 = criteria_models.Criterion(name="Another criterion")
-        offer1 = Offer(criteria=[criterion1], isActive=True)
-        offer2 = Offer(criteria=[criterion1, criterion2], isActive=True)
-        offer3 = Offer(criteria=[], isActive=True)
-        offer4 = Offer(criteria=[criterion1, criterion2], isActive=False)
-        expected_result = {
-            "One criterion": {"count": 2, "criterion": criterion1},
-            "Another criterion": {"count": 1, "criterion": criterion2},
-        }
+#     def test_get_current_criteria_on_active_offers(self):
+#         # Given
+#         criterion1 = criteria_models.Criterion(name="One criterion")
+#         criterion2 = criteria_models.Criterion(name="Another criterion")
+#         offer1 = Offer(criteria=[criterion1], isActive=True)
+#         offer2 = Offer(criteria=[criterion1, criterion2], isActive=True)
+#         offer3 = Offer(criteria=[], isActive=True)
+#         offer4 = Offer(criteria=[criterion1, criterion2], isActive=False)
+#         expected_result = {
+#             "One criterion": {"count": 2, "criterion": criterion1},
+#             "Another criterion": {"count": 1, "criterion": criterion2},
+#         }
 
-        # When
-        result = _get_current_criteria_on_active_offers([offer1, offer2, offer3, offer4])
+#         # When
+#         result = _get_current_criteria_on_active_offers([offer1, offer2, offer3, offer4])
 
-        # Then
-        assert result == expected_result
+#         # Then
+#         assert result == expected_result
 
-    @pytest.mark.parametrize(
-        "validation_status",
-        [
-            OfferValidationStatus.DRAFT,
-            OfferValidationStatus.PENDING,
-            OfferValidationStatus.REJECTED,
-            OfferValidationStatus.APPROVED,
-        ],
-    )
-    @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_product_gcu_compatibility(
-        self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app, db_session, validation_status
-    ):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
-        offerer = offerers_factories.OffererFactory()
-        product_1 = offers_factories.ThingProductFactory(
-            description="premier produit inapproprié",
-            extraData={"ean": "ean-de-test"},
-            isGcuCompatible=not validation_status == OfferValidationStatus.REJECTED,
-        )
-        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
-        offers_factories.OfferFactory(product=product_1, venue=venue, validation=validation_status)
-        offers_factories.OfferFactory(product=product_1, venue=venue)
+#     @pytest.mark.parametrize(
+#         "validation_status",
+#         [
+#             OfferValidationStatus.DRAFT,
+#             OfferValidationStatus.PENDING,
+#             OfferValidationStatus.REJECTED,
+#             OfferValidationStatus.APPROVED,
+#         ],
+#     )
+#     @patch("pcapi.core.search.async_index_offer_ids")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_product_gcu_compatibility(
+#         self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app, db_session, validation_status
+#     ):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
+#         offerer = offerers_factories.OffererFactory()
+#         product_1 = offers_factories.ThingProductFactory(
+#             description="premier produit inapproprié",
+#             extraData={"ean": "ean-de-test"},
+#             isGcuCompatible=not validation_status == OfferValidationStatus.REJECTED,
+#         )
+#         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+#         offers_factories.OfferFactory(product=product_1, venue=venue, validation=validation_status)
+#         offers_factories.OfferFactory(product=product_1, venue=venue)
 
-        initially_rejected = {
-            offer.id: {"type": offer.lastValidationType, "date": offer.lastValidationDate}
-            for offer in Offer.query.filter(Offer.validation == OfferValidationStatus.REJECTED)
-        }
+#         initially_rejected = {
+#             offer.id: {"type": offer.lastValidationType, "date": offer.lastValidationDate}
+#             for offer in Offer.query.filter(Offer.validation == OfferValidationStatus.REJECTED)
+#         }
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/many_offers_operations/product_gcu_compatibility?ean=ean-de-test")
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
+#         response = client.post("/pc/back-office/many_offers_operations/product_gcu_compatibility?ean=ean-de-test")
 
-        # Then
-        assert response.status_code == 302
-        assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
-        products = offers_models.Product.query.all()
-        offers = Offer.query.order_by("id").all()
-        first_product = products[0]
+#         # Then
+#         assert response.status_code == 302
+#         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
+#         products = offers_models.Product.query.all()
+#         offers = Offer.query.order_by("id").all()
+#         first_product = products[0]
 
-        assert not first_product.isGcuCompatible
-        for offer in offers:
-            assert offer.validation == offers_models.OfferValidationStatus.REJECTED
-            if offer.id in initially_rejected:
-                assert offer.lastValidationType == initially_rejected[offer.id]["type"]
-                assert offer.lastValidationDate == initially_rejected[offer.id]["date"]
-            else:
-                assert offer.lastValidationType == OfferValidationType.CGU_INCOMPATIBLE_PRODUCT
-                assert datetime.utcnow() - offer.lastValidationDate < timedelta(seconds=5)
-        mocked_async_index_offer_ids.assert_called_once_with(
-            [offer.id for offer in offers if offer.id not in initially_rejected]
-        )
+#         assert not first_product.isGcuCompatible
+#         for offer in offers:
+#             assert offer.validation == offers_models.OfferValidationStatus.REJECTED
+#             if offer.id in initially_rejected:
+#                 assert offer.lastValidationType == initially_rejected[offer.id]["type"]
+#                 assert offer.lastValidationDate == initially_rejected[offer.id]["date"]
+#             else:
+#                 assert offer.lastValidationType == OfferValidationType.CGU_INCOMPATIBLE_PRODUCT
+#                 assert datetime.utcnow() - offer.lastValidationDate < timedelta(seconds=5)
+#         mocked_async_index_offer_ids.assert_called_once_with(
+#             [offer.id for offer in offers if offer.id not in initially_rejected]
+#         )
 
-    def test_get_products_compatible_status(self):
-        # Given
-        products = []
-        products.append(offers_models.Product(isGcuCompatible=True))
-        products.append(offers_models.Product(isGcuCompatible=True))
+#     def test_get_products_compatible_status(self):
+#         # Given
+#         products = []
+#         products.append(offers_models.Product(isGcuCompatible=True))
+#         products.append(offers_models.Product(isGcuCompatible=True))
 
-        # Then
-        assert _get_products_compatible_status(products) == {
-            "status": "compatible_products",
-            "text": "Oui",
-        }
+#         # Then
+#         assert _get_products_compatible_status(products) == {
+#             "status": "compatible_products",
+#             "text": "Oui",
+#         }
 
-        products[0].isGcuCompatible = False
-        assert _get_products_compatible_status(products) == {
-            "status": "partially_incompatible_products",
-            "text": "Partiellement",
-        }
+#         products[0].isGcuCompatible = False
+#         assert _get_products_compatible_status(products) == {
+#             "status": "partially_incompatible_products",
+#             "text": "Partiellement",
+#         }
 
-        products[1].isGcuCompatible = False
-        assert _get_products_compatible_status(products) == {
-            "status": "incompatible_products",
-            "text": "Non",
-        }
+#         products[1].isGcuCompatible = False
+#         assert _get_products_compatible_status(products) == {
+#             "status": "incompatible_products",
+#             "text": "Non",
+#         }

--- a/api/tests/admin/custom_views/offer_view_test.py
+++ b/api/tests/admin/custom_views/offer_view_test.py
@@ -3,32 +3,38 @@ from unittest.mock import patch
 
 from flask import url_for
 from freezegun import freeze_time
-import pytest
 
 from pcapi.admin.custom_views.offer_view import OfferView
-from pcapi.admin.custom_views.offer_view import ValidationCollectiveOfferTemplateView
-from pcapi.admin.custom_views.offer_view import ValidationCollectiveOfferView
-from pcapi.admin.custom_views.offer_view import ValidationOfferView
-from pcapi.core import testing
+
+# from pcapi.admin.custom_views.offer_view import ValidationCollectiveOfferTemplateView
+# from pcapi.admin.custom_views.offer_view import ValidationCollectiveOfferView
+# from pcapi.admin.custom_views.offer_view import ValidationOfferView
+# from pcapi.core import testing
 import pcapi.core.bookings.factories as booking_factories
 from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.criteria.factories as criteria_factories
-from pcapi.core.educational import factories as educational_factories
-from pcapi.core.educational import models as educational_models
-from pcapi.core.educational.adage_backends.serialize import serialize_collective_offer
-import pcapi.core.educational.testing as adage_api_testing
-import pcapi.core.offerers.factories as offerers_factories
-from pcapi.core.offers.api import import_offer_validation_config
+
+# from pcapi.core.educational import factories as educational_factories
+# from pcapi.core.educational import models as educational_models
+# from pcapi.core.educational.adage_backends.serialize import serialize_collective_offer
+# import pcapi.core.educational.testing as adage_api_testing
+# import pcapi.core.offerers.factories as offerers_factories
+# from pcapi.core.offers.api import import_offer_validation_config
 import pcapi.core.offers.factories as offers_factories
+
+# from pcapi.core.offers.models import OfferValidationConfig
 from pcapi.core.offers.models import Offer
-from pcapi.core.offers.models import OfferValidationConfig
 from pcapi.core.offers.models import OfferValidationStatus
-from pcapi.core.testing import override_settings
+
+# from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
 from pcapi.models.offer_mixin import OfferValidationType
 
 from tests.conftest import TestClient
 from tests.conftest import clean_database
+
+
+# import pytest
 
 
 class BeneficiaryUserViewTest:
@@ -40,995 +46,995 @@ class BeneficiaryUserViewTest:
         assert offer_view.column_searchable_list is None or len(offer_view.column_searchable_list) == 0
 
 
-@pytest.mark.usefixtures("db_session")
-class OfferValidationViewTest:
-    @pytest.mark.parametrize("view_name", ("fraud_rules_configuration.index_view",))
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_super_admin_views_are_not_accessible_for_admins(self, client, view_name):
-        # given
-        users_factories.AdminFactory(email="admin@example.com")
-
-        # when
-        response = client.with_session_auth("admin@example.com").get(url_for(view_name))
-
-        # then
-        # redirection to admin.index due to inaccessibilty
-        assert response.status_code == 302
-        assert url_for("admin.index") in response.location
-
-    @pytest.mark.parametrize(
-        "view_name",
-        (
-            "suspend_fraud_users_by_email_providers.search",
-            "suspend_fraud_users_by_user_ids.search",
-        ),
-    )
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_super_admin_custom_views_are_not_accessible_for_admins(self, client, view_name):
-        # given
-        users_factories.AdminFactory(email="admin@example.com")
-
-        # when
-        response = client.with_session_auth("admin@example.com").get(url_for(view_name))
-
-        # then
-        assert response.status_code == 403
-
-    @pytest.mark.parametrize(
-        "view_name",
-        (
-            "fraud_rules_configuration.index_view",
-            "suspend_fraud_users_by_email_providers.search",
-            "suspend_fraud_users_by_user_ids.search",
-        ),
-    )
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_super_admin_views_are_accessible_for_super_admins(self, client, view_name):
-        # given
-        users_factories.AdminFactory(email="super_admin@example.com")
-
-        # when
-        response = client.with_session_auth("super_admin@example.com").get(url_for(view_name))
-
-        # then
-        assert response.status_code == 200
-
-    @pytest.mark.parametrize(
-        "view_name",
-        (
-            "fraud_rules_configuration.index_view",
-            "suspend_fraud_users_by_email_providers.search",
-            "suspend_fraud_users_by_user_ids.search",
-        ),
-    )
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_super_admin_menu_items_are_not_present_for_admins(self, client, view_name):
-        # given
-        users_factories.AdminFactory(email="admin@example.com")
-
-        # when
-        response = client.with_session_auth("admin@example.com").get(url_for("admin.index"))
-
-        # then
-        assert url_for(view_name) not in response.data.decode("utf-8")
-
-    @pytest.mark.parametrize(
-        "view_name",
-        (
-            "fraud_rules_configuration.index_view",
-            "suspend_fraud_users_by_email_providers.search",
-            "suspend_fraud_users_by_user_ids.search",
-        ),
-    )
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_super_admin_menu_items_are_present_for_super_admins(self, client, view_name):
-        # given
-        users_factories.AdminFactory(email="super_admin@example.com")
-
-        # when
-        response = client.with_session_auth("super_admin@example.com").get(url_for("admin.index"))
-
-        # then
-        assert url_for(view_name) in response.data.decode("utf-8")
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_approve_offer_and_go_to_next_offer(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-        # newest offer
-        offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-            id=3,
-        )
-        currently_displayed_offer = offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-            id=2,
-        )
-        oldest_offer = offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email2@example.com",
-            venue=venue,
-            id=1,
-        )
-
-        data = dict(validation=OfferValidationStatus.APPROVED.value, action="save-and-go-next")
-        response = client.with_session_auth("admin@example.com").post(
-            url_for("validation.edit", id=currently_displayed_offer.id), form=data
-        )
-
-        currently_displayed_offer = Offer.query.get(currently_displayed_offer.id)
-        assert currently_displayed_offer.validation == OfferValidationStatus.APPROVED
-        assert response.status_code == 302
-        assert url_for("validation.edit", id=oldest_offer.id) in response.location
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_approve_last_pending_offer_and_go_to_the_next_offer_redirect_to_validation_page(
-        self, mocked_validate_csrf_token, client
-    ):
-        users_factories.AdminFactory(email="admin@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-
-        offer = offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email@example.com",
-            venue=venue,
-        )
-
-        data = dict(validation=OfferValidationStatus.APPROVED.value, action="save-and-go-next")
-        response = client.with_session_auth("admin@example.com").post(
-            url_for("validation.edit", id=offer.id), form=data
-        )
-
-        assert offer.validation == OfferValidationStatus.APPROVED
-        assert response.status_code == 302
-        assert url_for("validation.index_view") in response.location
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
-    def test_approve_virtual_offer_and_send_mail_to_managing_offerer(
-        self,
-        mocked_send_offer_validation_status_update_email,
-        mocked_validate_csrf_token,
-        client,
-    ):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
-
-        venue = offerers_factories.VenueFactory(bookingEmail=None)
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-
-        offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING, isActive=True, venue=venue)
-
-        data = dict(validation=OfferValidationStatus.APPROVED.value, action="save-and-go-next")
-
-        # When
-        client.with_session_auth("admin@example.com").post(url_for("validation.edit", id=offer.id), form=data)
-
-        # Then
-        mocked_send_offer_validation_status_update_email.assert_called_once_with(
-            offer, OfferValidationStatus.APPROVED, ["pro@example.com"]
-        )
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
-    def test_approve_physical_offer_and_send_mail_to_venue_booking_email(
-        self,
-        mocked_send_offer_validation_status_update_email,
-        mocked_validate_csrf_token,
-        client,
-    ):
-        # Given
-        users_factories.AdminFactory(email="admin@example.com")
-
-        venue = offerers_factories.VenueFactory(bookingEmail="venue@example.com")
-
-        offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING, isActive=True, venue=venue)
-
-        data = dict(validation=OfferValidationStatus.APPROVED.value, action="save-and-go-next")
-
-        # When
-        client.with_session_auth("admin@example.com").post(url_for("validation.edit", id=offer.id), form=data)
-
-        # Then
-        mocked_send_offer_validation_status_update_email.assert_called_once_with(
-            offer, OfferValidationStatus.APPROVED, ["venue@example.com"]
-        )
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_import_validation_config(self, mocked_validate_csrf_token, client):
-        # Given
-        users_factories.AdminFactory(email="super_admin@example.com")
-        config_yaml = """
-                    minimum_score: 0.6
-                    rules:
-                       - name: "check offer name"
-                         factor: 0
-                         conditions:
-                           - model: "Offer"
-                             attribute: "name"
-                             condition:
-                                operator: "not in"
-                                comparated: "REJECTED"
-                       - name: "check offer max price"
-                         factor: 0.7
-                         conditions:
-                           - model: "Offer"
-                             attribute: "max_price"
-                             condition:
-                                operator: ">"
-                                comparated: 100
-                    """
-
-        data = dict(specs=config_yaml, action="save")
-
-        # When
-        response = client.with_session_auth("super_admin@example.com").post(
-            url_for("fraud_rules_configuration.create_view"), form=data
-        )
-        saved_config = OfferValidationConfig.query.one()
-
-        # Then
-        assert response.status_code == 302
-        assert saved_config.user.email == "super_admin@example.com"
-        assert saved_config.dateCreated.timestamp() == pytest.approx(datetime.datetime.utcnow().timestamp(), rel=1)
-        assert saved_config.specs == {
-            "minimum_score": 0.6,
-            "rules": [
-                {
-                    "name": "check offer name",
-                    "factor": 0,
-                    "conditions": [
-                        {
-                            "model": "Offer",
-                            "attribute": "name",
-                            "condition": {"operator": "not in", "comparated": "REJECTED"},
-                        }
-                    ],
-                },
-                {
-                    "name": "check offer max price",
-                    "factor": 0.7,
-                    "conditions": [
-                        {
-                            "model": "Offer",
-                            "attribute": "max_price",
-                            "condition": {"comparated": 100, "operator": ">"},
-                        }
-                    ],
-                },
-            ],
-        }
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_import_validation_config_fail_with_wrong_value(self, mocked_validate_csrf_token, client):
-        # Given
-        users_factories.AdminFactory(email="super_admin@example.com")
-        config_yaml = """
-                    minimum_score: 0.6
-                    parameters:
-                        name:
-                            model: "Offer"
-                            attribute: "name"
-                            condition:
-                                operator: "wrong value"
-                                comparated: "REJECTED"
-                            factor: 0
-                        price_all_types:
-                            model: "Offer"
-                            attribute: "max_price"
-                            condition:
-                                operator: ">"
-                                comparated: 100
-                            factor: 0.7
-                    """
-
-        data = dict(specs=config_yaml, action="save")
-
-        # When
-        response = client.with_session_auth("super_admin@example.com").post(
-            url_for("fraud_rules_configuration.create_view"), form=data
-        )
-
-        # Then
-        assert response.status_code == 400
-
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_import_validation_config_inaccessible_when_user_is_not_super_admin(
-        self, mocked_validate_csrf_token, client
-    ):
-        # Given
-        users_factories.AdminFactory(email="not_super_admin@example.com")
-        config_yaml = """
-                    minimum_score: 0.6
-                    parameters:
-                        name:
-                            model: "Offer"
-                            attribute: "name"
-                            condition:
-                                operator: "not in"
-                                comparated: "REJECTED"
-                            factor: 0
-                        price_all_types:
-                            model: "Offer"
-                            attribute: "max_price"
-                            condition:
-                                operator: ">"
-                                comparated: 100
-                            factor: 0.7
-                    """
-
-        data = dict(specs=config_yaml, action="save")
-
-        # When
-        response = client.with_session_auth("not_super_admin@example.com").post(
-            url_for("fraud_rules_configuration.create_view"), form=data
-        )
-
-        # Then
-        # redirection to admin.index due to inaccessibilty
-        assert response.status_code == 302
-        assert url_for("admin.index") in response.location
-
-    @freeze_time("2032-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_approve_offer(self, mocked_validate_csrf_token, client):
-        # Given
-        config_yaml = """
-                    minimum_score: 0.6
-                    rules:
-                       - name: "check offer name"
-                         factor: 0
-                         conditions:
-                           - model: "Offer"
-                             attribute: "name"
-                             condition:
-                                operator: "not in"
-                                comparated: "REJECTED"
-                    """
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        import_offer_validation_config(config_yaml, admin)
-        offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING, isActive=True)
-
-        # When
-        data = dict(validation=OfferValidationStatus.APPROVED.value, action="save")
-        client = client.with_session_auth("admin@example.com")
-        response = client.post(url_for("validation.edit", id=offer.id), form=data)
-
-        # Then
-        assert response.status_code == 302
-        assert url_for("validation.index_view") in response.location
-        assert offer.validation == OfferValidationStatus.APPROVED
-        assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
-        assert offer.lastValidationType == OfferValidationType.MANUAL
-
-    @freeze_time("2032-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_reject_offer(self, mocked_validate_csrf_token, client):
-        # Given
-        config_yaml = """
-                    minimum_score: 0.6
-                    rules:
-                       - name: "check offer name"
-                         factor: 0
-                         conditions:
-                           - model: "Offer"
-                             attribute: "name"
-                             condition:
-                                operator: "not in"
-                                comparated: "REJECTED"
-                    """
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        import_offer_validation_config(config_yaml, admin)
-        offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING)
-
-        # When
-        data = dict(validation=OfferValidationStatus.REJECTED.value, action="save")
-        client = client.with_session_auth("admin@example.com")
-        response = client.post(url_for("validation.edit", id=offer.id), form=data)
-
-        # Then
-        assert response.status_code == 302
-        assert url_for("validation.index_view") in response.location
-        assert offer.validation == OfferValidationStatus.REJECTED
-        assert offer.isActive is False
-        assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
-        assert offer.lastValidationType == OfferValidationType.MANUAL
-
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_access_to_validation_page_with_super_admin_user_on_prod_env(self, client):
-        users_factories.AdminFactory(email="super_admin@example.com")
-
-        response = client.with_session_auth("super_admin@example.com").get(url_for("validation.index_view"))
-
-        assert response.status_code == 200
-
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_access_to_validation_page_with_none_super_admin_user_on_prod_env(self, client):
-        users_factories.AdminFactory(email="simple_admin@example.com")
-
-        response = client.with_session_auth("simple_admin@example.com").get(url_for("validation.index_view"))
-
-        assert response.status_code == 302
-        assert url_for("admin.index") in response.location
-
-    def test_get_query_and_count(self, db_session):
-        offer_view = ValidationOfferView(model=Offer, session=db_session)
-        validated_offerer = offerers_factories.OffererFactory()
-        non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
-        offer_1 = offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            venue__managingOfferer=validated_offerer,
-        )
-        offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            venue__managingOfferer=non_validated_offerer,
-        )
-
-        get_query_offers_list = offer_view.get_query().all()
-        get_count_query_scalar = offer_view.get_count_query().scalar()
-
-        assert get_query_offers_list == [offer_1]
-        assert get_count_query_scalar == 1
-
-    @clean_database
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    def test_number_of_queries_for_offer_list(self, client):
-        admin = users_factories.AdminFactory(email="superadmin@example.com")
-
-        offers_factories.OfferValidationConfigFactory(
-            specs={
-                "minimum_score": 0.1,
-                "rules": [
-                    {
-                        "conditions": [
-                            {
-                                "attribute": "max_price",
-                                "condition": {"comparated": 1, "operator": ">"},
-                                "model": "Offer",
-                            },
-                        ],
-                        "factor": 0.8,
-                        "name": "Vérification",
-                    },
-                ],
-            }
-        )
-        for _ in range(5):
-            offers_factories.StockFactory(offer__validation=OfferValidationStatus.PENDING)
-
-        client = client.with_session_auth(admin.email)
-
-        with testing.assert_no_duplicated_queries():
-            response = client.get(url_for("validation.index_view"))
-
-        assert response.status_code == 200
-        assert b"<h2>Validation des offres</h2>" in response.data
-
-    @pytest.mark.parametrize(
-        "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
-    )
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_batch_approve_offers(self, mocked_validate_csrf_token, action, expected, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-        offer1 = offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-        )
-        offer2 = offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-        )
-
-        data = dict(rowid=[offer1.id, offer2.id], action=action)
-        client.with_session_auth("admin@example.com")
-        response = client.post(url_for("validation.action_view"), form=data)
-
-        assert response.status_code == 302
-        assert url_for("validation.index_view") in response.location
-
-        assert Offer.query.get(offer1.id).validation == expected
-        assert Offer.query.get(offer2.id).validation == expected
-
-        # There is no status returned by the action, check flash message
-        get_response = client.get(response.location)
-        assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
-
-    @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.offers.api.update_pending_offer_validation")
-    def test_batch_approve_reject_offers_not_updated(
-        self,
-        mocked_update_pending_offer_validation,
-        mocked_validate_csrf_token,
-        action,
-        client,
-    ):
-        users_factories.AdminFactory(email="admin@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-        offer = offers_factories.OfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-        )
-        offers_factories.OfferValidationConfigFactory()
-
-        mocked_update_pending_offer_validation.return_value = False
-
-        data = dict(rowid=[offer.id], action=action)
-        client.with_session_auth("admin@example.com")
-        response = client.post(url_for("validation.action_view"), form=data)
-
-        assert response.status_code == 302
-        assert url_for("validation.index_view") in response.location
-
-        assert Offer.query.get(offer.id).validation == OfferValidationStatus.PENDING
-
-        # There is no status returned by the action, check flash message
-        get_response = client.get(response.location)
-        assert (
-            "Une erreur s&#39;est produite lors de la mise à jour du statut de validation des offres"
-            in get_response.data.decode("utf8")
-        )
-
-    @freeze_time("2032-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_approve_collective_offer_template(self, mocked_validate_csrf_token, client):
-        # Given
-        config_yaml = """
-                    minimum_score: 0.6
-                    rules:
-                       - name: "check offer name"
-                         factor: 0
-                         conditions:
-                           - model: "Offer"
-                             attribute: "name"
-                             condition:
-                                operator: "not in"
-                                comparated: "REJECTED"
-                    """
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        import_offer_validation_config(config_yaml, admin)
-        offer = educational_factories.CollectiveOfferTemplateFactory(
-            validation=OfferValidationStatus.PENDING, isActive=True
-        )
-
-        # When
-        data = dict(validation=OfferValidationStatus.APPROVED.value, action="save")
-        response = client.with_session_auth("admin@example.com").post(
-            url_for("validation-collective-offer-template.edit", id=offer.id), form=data
-        )
-
-        # Then
-        assert response.status_code == 302
-        assert url_for("validation-collective-offer-template.index_view") in response.location
-        assert offer.validation == OfferValidationStatus.APPROVED
-        assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
-        assert offer.lastValidationType == OfferValidationType.MANUAL
-
-    @freeze_time("2032-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_reject_collective_offer_template(self, mocked_validate_csrf_token, client):
-        # Given
-        config_yaml = """
-                    minimum_score: 0.6
-                    rules:
-                       - name: "check offer name"
-                         factor: 0
-                         conditions:
-                           - model: "Offer"
-                             attribute: "name"
-                             condition:
-                                operator: "not in"
-                                comparated: "REJECTED"
-                    """
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        import_offer_validation_config(config_yaml, admin)
-        offer = educational_factories.CollectiveOfferTemplateFactory(validation=OfferValidationStatus.PENDING)
-
-        # When
-        data = dict(validation=OfferValidationStatus.REJECTED.value, action="save")
-        response = client.with_session_auth("admin@example.com").post(
-            url_for("validation-collective-offer-template.edit", id=offer.id), form=data
-        )
-
-        # Then
-        assert response.status_code == 302
-        assert url_for("validation-collective-offer-template.index_view") in response.location
-        assert offer.validation == OfferValidationStatus.REJECTED
-        assert offer.isActive is False
-        assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
-        assert offer.lastValidationType == OfferValidationType.MANUAL
-
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_access_to_collective_offer_template_validation_page_with_super_admin_user_on_prod_env(self, client):
-        users_factories.AdminFactory(email="super_admin@example.com")
-
-        response = client.with_session_auth("super_admin@example.com").get(
-            url_for("validation-collective-offer-template.index_view")
-        )
-
-        assert response.status_code == 200
-
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_access_to_collective_offer_templayte_validation_page_with_none_super_admin_user_on_prod_env(self, client):
-        users_factories.AdminFactory(email="simple_admin@example.com")
-
-        response = client.with_session_auth("simple_admin@example.com").get(
-            url_for("validation-collective-offer-template.index_view")
-        )
-
-        assert response.status_code == 302
-        assert url_for("admin.index") in response.location
-
-    def test_get_collective_offer_template_query_and_count(self, db_session):
-        offer_view = ValidationCollectiveOfferTemplateView(
-            model=educational_models.CollectiveOfferTemplate, session=db_session
-        )
-        validated_offerer = offerers_factories.OffererFactory()
-        non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
-        offer_1 = educational_factories.CollectiveOfferTemplateFactory(
-            validation=OfferValidationStatus.PENDING,
-            venue__managingOfferer=validated_offerer,
-        )
-        educational_factories.CollectiveOfferTemplateFactory(
-            validation=OfferValidationStatus.PENDING,
-            venue__managingOfferer=non_validated_offerer,
-        )
-
-        get_query_offers_list = offer_view.get_query().all()
-        get_count_query_scalar = offer_view.get_count_query().scalar()
-
-        assert get_query_offers_list == [offer_1]
-        assert get_count_query_scalar == 1
-
-    @pytest.mark.parametrize(
-        "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
-    )
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_batch_approve_collective_offers_template(self, mocked_validate_csrf_token, action, expected, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-        offer1 = educational_factories.CollectiveOfferTemplateFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-        )
-        offer2 = educational_factories.CollectiveOfferTemplateFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-        )
-
-        data = dict(rowid=[offer1.id, offer2.id], action=action)
-        client.with_session_auth("admin@example.com")
-        response = client.post(url_for("validation-collective-offer-template.action_view"), form=data)
-
-        assert response.status_code == 302
-        assert url_for("validation-collective-offer-template.index_view") in response.location
-
-        assert educational_models.CollectiveOfferTemplate.query.get(offer1.id).validation == expected
-        assert educational_models.CollectiveOfferTemplate.query.get(offer2.id).validation == expected
-
-        # There is no status returned by the action, check flash message
-        get_response = client.get(response.location)
-        assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
-
-    @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.offers.api.update_pending_offer_validation")
-    def test_batch_approve_reject_collective_offers_template_not_updated(
-        self,
-        mocked_update_pending_offer_validation,
-        mocked_validate_csrf_token,
-        action,
-        client,
-    ):
-        users_factories.AdminFactory(email="admin@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-        offer = educational_factories.CollectiveOfferTemplateFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-        )
-        offers_factories.OfferValidationConfigFactory()
-
-        mocked_update_pending_offer_validation.return_value = False
-
-        data = dict(rowid=[offer.id], action=action)
-        client.with_session_auth("admin@example.com")
-        response = client.post(url_for("validation-collective-offer-template.action_view"), form=data)
-
-        assert response.status_code == 302
-        assert url_for("validation-collective-offer-template.index_view") in response.location
-
-        assert (
-            educational_models.CollectiveOfferTemplate.query.get(offer.id).validation == OfferValidationStatus.PENDING
-        )
-
-        # There is no status returned by the action, check flash message
-        get_response = client.get(response.location)
-        assert (
-            "Une erreur s&#39;est produite lors de la mise à jour du statut de validation des offres"
-            in get_response.data.decode("utf8")
-        )
-
-    @freeze_time("2032-11-17 15:00:00")
-    @override_settings(ADAGE_API_URL="https://adage_base_url")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_approve_collective_offer_and_notify_adage(self, mocked_validate_csrf_token, client):
-        # Given
-        config_yaml = """
-                    minimum_score: 0.6
-                    rules:
-                       - name: "check offer name"
-                         factor: 0
-                         conditions:
-                           - model: "CollectiveOffer"
-                             attribute: "name"
-                             condition:
-                                operator: "not in"
-                                comparated: "REJECTED"
-                    """
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        import_offer_validation_config(config_yaml, admin)
-        educational_institution = educational_factories.EducationalInstitutionFactory()
-        offer = educational_factories.CollectiveStockFactory(
-            collectiveOffer__validation=OfferValidationStatus.PENDING,
-            collectiveOffer__isActive=True,
-            collectiveOffer__institution=educational_institution,
-        ).collectiveOffer
-
-        # When
-        data = dict(validation=OfferValidationStatus.APPROVED.value, action="save")
-        response = client.with_session_auth("admin@example.com").post(
-            url_for("validation-collective-offer.edit", id=offer.id), form=data
-        )
-
-        # Then
-        assert response.status_code == 302
-        assert url_for("validation-collective-offer.index_view") in response.location
-        assert offer.validation == OfferValidationStatus.APPROVED
-        assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
-        assert offer.lastValidationType == OfferValidationType.MANUAL
-
-        expected_payload = serialize_collective_offer(offer)
-        assert adage_api_testing.adage_requests[0]["sent_data"] == expected_payload
-        assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/offre-assoc"
-
-    @freeze_time("2032-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_reject_collective_offer_and_send_mail_to_administration(self, mocked_validate_csrf_token, client):
-        # Given
-        config_yaml = """
-                    minimum_score: 0.6
-                    rules:
-                       - name: "check offer name"
-                         factor: 0
-                         conditions:
-                           - model: "Offer"
-                             attribute: "name"
-                             condition:
-                                operator: "not in"
-                                comparated: "REJECTED"
-                    """
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        import_offer_validation_config(config_yaml, admin)
-        offer = educational_factories.CollectiveOfferFactory(validation=OfferValidationStatus.PENDING)
-
-        # When
-        data = dict(validation=OfferValidationStatus.REJECTED.value, action="save")
-        response = client.with_session_auth("admin@example.com").post(
-            url_for("validation-collective-offer.edit", id=offer.id), form=data
-        )
-
-        # Then
-        assert response.status_code == 302
-        assert url_for("validation-collective-offer.index_view") in response.location
-        assert offer.validation == OfferValidationStatus.REJECTED
-        assert offer.isActive is False
-        assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
-        assert offer.lastValidationType == OfferValidationType.MANUAL
-
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_access_to_collective_offer_validation_page_with_super_admin_user_on_prod_env(self, client):
-        users_factories.AdminFactory(email="super_admin@example.com")
-
-        response = client.with_session_auth("super_admin@example.com").get(
-            url_for("validation-collective-offer.index_view")
-        )
-
-        assert response.status_code == 200
-
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
-    def test_access_to_collectve_offer_validation_page_with_none_super_admin_user_on_prod_env(self, client):
-        users_factories.AdminFactory(email="simple_admin@example.com")
-
-        response = client.with_session_auth("simple_admin@example.com").get(
-            url_for("validation-collective-offer.index_view")
-        )
-
-        assert response.status_code == 302
-        assert url_for("admin.index") in response.location
-
-    def test_get_query_and_count_on_collective_offer(self, db_session):
-        offer_view = ValidationCollectiveOfferView(model=educational_models.CollectiveOffer, session=db_session)
-        validated_offerer = offerers_factories.OffererFactory()
-        non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
-        offer_1 = educational_factories.CollectiveOfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            venue__managingOfferer=validated_offerer,
-        )
-        educational_factories.CollectiveOfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            venue__managingOfferer=non_validated_offerer,
-        )
-
-        get_query_offers_list = offer_view.get_query().all()
-        get_count_query_scalar = offer_view.get_count_query().scalar()
-
-        assert get_query_offers_list == [offer_1]
-        assert get_count_query_scalar == 1
-
-    @clean_database
-    @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    def test_number_of_queries_for_collective_offer_list(self, client):
-        admin = users_factories.AdminFactory(email="superadmin@example.com")
-
-        offers_factories.OfferValidationConfigFactory(
-            specs={
-                "minimum_score": 0.1,
-                "rules": [
-                    {
-                        "conditions": [
-                            {
-                                "attribute": "max_price",
-                                "condition": {"comparated": 1, "operator": ">"},
-                                "model": "Offer",
-                            },
-                        ],
-                        "factor": 0.8,
-                        "name": "Vérification",
-                    },
-                ],
-            }
-        )
-        for _ in range(5):
-            educational_factories.CollectiveStockFactory(collectiveOffer__validation=OfferValidationStatus.PENDING)
-
-        client = client.with_session_auth(admin.email)
-
-        with testing.assert_no_duplicated_queries():
-            response = client.get(url_for("validation-collective-offer.index_view"))
-
-        assert response.status_code == 200
-        assert b"<h2>Validation des offres</h2>" in response.data
-
-    @pytest.mark.parametrize(
-        "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
-    )
-    @override_settings(ADAGE_API_URL="https://adage_base_url")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_batch_approve_collective_offers(self, mocked_validate_csrf_token, action, expected, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-        educational_institution = educational_factories.EducationalInstitutionFactory()
-        offer1 = educational_factories.CollectiveStockFactory(
-            collectiveOffer__validation=OfferValidationStatus.PENDING,
-            collectiveOffer__isActive=True,
-            collectiveOffer__venue__bookingEmail="email1@example.com",
-            collectiveOffer__venue=venue,
-            collectiveOffer__institution=educational_institution,
-        ).collectiveOffer
-        offer2 = educational_factories.CollectiveStockFactory(
-            collectiveOffer__validation=OfferValidationStatus.PENDING,
-            collectiveOffer__isActive=True,
-            collectiveOffer__venue__bookingEmail="email1@example.com",
-            collectiveOffer__venue=venue,
-        ).collectiveOffer
-
-        data = dict(rowid=[offer1.id, offer2.id], action=action)
-        client.with_session_auth("admin@example.com")
-        response = client.post(url_for("validation-collective-offer.action_view"), form=data)
-
-        assert response.status_code == 302
-        assert url_for("validation-collective-offer.index_view") in response.location
-
-        assert educational_models.CollectiveOffer.query.get(offer1.id).validation == expected
-        assert educational_models.CollectiveOffer.query.get(offer2.id).validation == expected
-
-        # There is no status returned by the action, check flash message
-        get_response = client.get(response.location)
-        assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
-
-        expected_payload_1 = serialize_collective_offer(offer1)
-        assert len(adage_api_testing.adage_requests) == 1
-        assert adage_api_testing.adage_requests[0]["sent_data"] == expected_payload_1
-        assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/offre-assoc"
-
-    @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.offers.api.update_pending_offer_validation")
-    def test_batch_approve_reject_collective_offers_not_updated(
-        self,
-        mocked_update_pending_offer_validation,
-        mocked_validate_csrf_token,
-        action,
-        client,
-    ):
-        users_factories.AdminFactory(email="admin@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory(email="pro@example.com")
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-        offer = educational_factories.CollectiveOfferFactory(
-            validation=OfferValidationStatus.PENDING,
-            isActive=True,
-            venue__bookingEmail="email1@example.com",
-            venue=venue,
-        )
-        offers_factories.OfferValidationConfigFactory()
-
-        mocked_update_pending_offer_validation.return_value = False
-
-        data = dict(rowid=[offer.id], action=action)
-        client.with_session_auth("admin@example.com")
-        response = client.post(url_for("validation-collective-offer.action_view"), form=data)
-
-        assert response.status_code == 302
-        assert url_for("validation-collective-offer.index_view") in response.location
-
-        assert educational_models.CollectiveOffer.query.get(offer.id).validation == OfferValidationStatus.PENDING
-
-        # There is no status returned by the action, check flash message
-        get_response = client.get(response.location)
-        assert (
-            "Une erreur s&#39;est produite lors de la mise à jour du statut de validation des offres"
-            in get_response.data.decode("utf8")
-        )
+# @pytest.mark.usefixtures("db_session")
+# class OfferValidationViewTest:
+#     @pytest.mark.parametrize("view_name", ("fraud_rules_configuration.index_view",))
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_super_admin_views_are_not_accessible_for_admins(self, client, view_name):
+#         # given
+#         users_factories.AdminFactory(email="admin@example.com")
+
+#         # when
+#         response = client.with_session_auth("admin@example.com").get(url_for(view_name))
+
+#         # then
+#         # redirection to admin.index due to inaccessibilty
+#         assert response.status_code == 302
+#         assert url_for("admin.index") in response.location
+
+#     @pytest.mark.parametrize(
+#         "view_name",
+#         (
+#             "suspend_fraud_users_by_email_providers.search",
+#             "suspend_fraud_users_by_user_ids.search",
+#         ),
+#     )
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_super_admin_custom_views_are_not_accessible_for_admins(self, client, view_name):
+#         # given
+#         users_factories.AdminFactory(email="admin@example.com")
+
+#         # when
+#         response = client.with_session_auth("admin@example.com").get(url_for(view_name))
+
+#         # then
+#         assert response.status_code == 403
+
+#     @pytest.mark.parametrize(
+#         "view_name",
+#         (
+#             "fraud_rules_configuration.index_view",
+#             "suspend_fraud_users_by_email_providers.search",
+#             "suspend_fraud_users_by_user_ids.search",
+#         ),
+#     )
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_super_admin_views_are_accessible_for_super_admins(self, client, view_name):
+#         # given
+#         users_factories.AdminFactory(email="super_admin@example.com")
+
+#         # when
+#         response = client.with_session_auth("super_admin@example.com").get(url_for(view_name))
+
+#         # then
+#         assert response.status_code == 200
+
+#     @pytest.mark.parametrize(
+#         "view_name",
+#         (
+#             "fraud_rules_configuration.index_view",
+#             "suspend_fraud_users_by_email_providers.search",
+#             "suspend_fraud_users_by_user_ids.search",
+#         ),
+#     )
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_super_admin_menu_items_are_not_present_for_admins(self, client, view_name):
+#         # given
+#         users_factories.AdminFactory(email="admin@example.com")
+
+#         # when
+#         response = client.with_session_auth("admin@example.com").get(url_for("admin.index"))
+
+#         # then
+#         assert url_for(view_name) not in response.data.decode("utf-8")
+
+#     @pytest.mark.parametrize(
+#         "view_name",
+#         (
+#             "fraud_rules_configuration.index_view",
+#             "suspend_fraud_users_by_email_providers.search",
+#             "suspend_fraud_users_by_user_ids.search",
+#         ),
+#     )
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_super_admin_menu_items_are_present_for_super_admins(self, client, view_name):
+#         # given
+#         users_factories.AdminFactory(email="super_admin@example.com")
+
+#         # when
+#         response = client.with_session_auth("super_admin@example.com").get(url_for("admin.index"))
+
+#         # then
+#         assert url_for(view_name) in response.data.decode("utf-8")
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_approve_offer_and_go_to_next_offer(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#         # newest offer
+#         offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#             id=3,
+#         )
+#         currently_displayed_offer = offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#             id=2,
+#         )
+#         oldest_offer = offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email2@example.com",
+#             venue=venue,
+#             id=1,
+#         )
+
+#         data = dict(validation=OfferValidationStatus.APPROVED.value, action="save-and-go-next")
+#         response = client.with_session_auth("admin@example.com").post(
+#             url_for("validation.edit", id=currently_displayed_offer.id), form=data
+#         )
+
+#         currently_displayed_offer = Offer.query.get(currently_displayed_offer.id)
+#         assert currently_displayed_offer.validation == OfferValidationStatus.APPROVED
+#         assert response.status_code == 302
+#         assert url_for("validation.edit", id=oldest_offer.id) in response.location
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_approve_last_pending_offer_and_go_to_the_next_offer_redirect_to_validation_page(
+#         self, mocked_validate_csrf_token, client
+#     ):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+
+#         offer = offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email@example.com",
+#             venue=venue,
+#         )
+
+#         data = dict(validation=OfferValidationStatus.APPROVED.value, action="save-and-go-next")
+#         response = client.with_session_auth("admin@example.com").post(
+#             url_for("validation.edit", id=offer.id), form=data
+#         )
+
+#         assert offer.validation == OfferValidationStatus.APPROVED
+#         assert response.status_code == 302
+#         assert url_for("validation.index_view") in response.location
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
+#     def test_approve_virtual_offer_and_send_mail_to_managing_offerer(
+#         self,
+#         mocked_send_offer_validation_status_update_email,
+#         mocked_validate_csrf_token,
+#         client,
+#     ):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
+
+#         venue = offerers_factories.VenueFactory(bookingEmail=None)
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+
+#         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING, isActive=True, venue=venue)
+
+#         data = dict(validation=OfferValidationStatus.APPROVED.value, action="save-and-go-next")
+
+#         # When
+#         client.with_session_auth("admin@example.com").post(url_for("validation.edit", id=offer.id), form=data)
+
+#         # Then
+#         mocked_send_offer_validation_status_update_email.assert_called_once_with(
+#             offer, OfferValidationStatus.APPROVED, ["pro@example.com"]
+#         )
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
+#     def test_approve_physical_offer_and_send_mail_to_venue_booking_email(
+#         self,
+#         mocked_send_offer_validation_status_update_email,
+#         mocked_validate_csrf_token,
+#         client,
+#     ):
+#         # Given
+#         users_factories.AdminFactory(email="admin@example.com")
+
+#         venue = offerers_factories.VenueFactory(bookingEmail="venue@example.com")
+
+#         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING, isActive=True, venue=venue)
+
+#         data = dict(validation=OfferValidationStatus.APPROVED.value, action="save-and-go-next")
+
+#         # When
+#         client.with_session_auth("admin@example.com").post(url_for("validation.edit", id=offer.id), form=data)
+
+#         # Then
+#         mocked_send_offer_validation_status_update_email.assert_called_once_with(
+#             offer, OfferValidationStatus.APPROVED, ["venue@example.com"]
+#         )
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_import_validation_config(self, mocked_validate_csrf_token, client):
+#         # Given
+#         users_factories.AdminFactory(email="super_admin@example.com")
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     rules:
+#                        - name: "check offer name"
+#                          factor: 0
+#                          conditions:
+#                            - model: "Offer"
+#                              attribute: "name"
+#                              condition:
+#                                 operator: "not in"
+#                                 comparated: "REJECTED"
+#                        - name: "check offer max price"
+#                          factor: 0.7
+#                          conditions:
+#                            - model: "Offer"
+#                              attribute: "max_price"
+#                              condition:
+#                                 operator: ">"
+#                                 comparated: 100
+#                     """
+
+#         data = dict(specs=config_yaml, action="save")
+
+#         # When
+#         response = client.with_session_auth("super_admin@example.com").post(
+#             url_for("fraud_rules_configuration.create_view"), form=data
+#         )
+#         saved_config = OfferValidationConfig.query.one()
+
+#         # Then
+#         assert response.status_code == 302
+#         assert saved_config.user.email == "super_admin@example.com"
+#         assert saved_config.dateCreated.timestamp() == pytest.approx(datetime.datetime.utcnow().timestamp(), rel=1)
+#         assert saved_config.specs == {
+#             "minimum_score": 0.6,
+#             "rules": [
+#                 {
+#                     "name": "check offer name",
+#                     "factor": 0,
+#                     "conditions": [
+#                         {
+#                             "model": "Offer",
+#                             "attribute": "name",
+#                             "condition": {"operator": "not in", "comparated": "REJECTED"},
+#                         }
+#                     ],
+#                 },
+#                 {
+#                     "name": "check offer max price",
+#                     "factor": 0.7,
+#                     "conditions": [
+#                         {
+#                             "model": "Offer",
+#                             "attribute": "max_price",
+#                             "condition": {"comparated": 100, "operator": ">"},
+#                         }
+#                     ],
+#                 },
+#             ],
+#         }
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_import_validation_config_fail_with_wrong_value(self, mocked_validate_csrf_token, client):
+#         # Given
+#         users_factories.AdminFactory(email="super_admin@example.com")
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     parameters:
+#                         name:
+#                             model: "Offer"
+#                             attribute: "name"
+#                             condition:
+#                                 operator: "wrong value"
+#                                 comparated: "REJECTED"
+#                             factor: 0
+#                         price_all_types:
+#                             model: "Offer"
+#                             attribute: "max_price"
+#                             condition:
+#                                 operator: ">"
+#                                 comparated: 100
+#                             factor: 0.7
+#                     """
+
+#         data = dict(specs=config_yaml, action="save")
+
+#         # When
+#         response = client.with_session_auth("super_admin@example.com").post(
+#             url_for("fraud_rules_configuration.create_view"), form=data
+#         )
+
+#         # Then
+#         assert response.status_code == 400
+
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_import_validation_config_inaccessible_when_user_is_not_super_admin(
+#         self, mocked_validate_csrf_token, client
+#     ):
+#         # Given
+#         users_factories.AdminFactory(email="not_super_admin@example.com")
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     parameters:
+#                         name:
+#                             model: "Offer"
+#                             attribute: "name"
+#                             condition:
+#                                 operator: "not in"
+#                                 comparated: "REJECTED"
+#                             factor: 0
+#                         price_all_types:
+#                             model: "Offer"
+#                             attribute: "max_price"
+#                             condition:
+#                                 operator: ">"
+#                                 comparated: 100
+#                             factor: 0.7
+#                     """
+
+#         data = dict(specs=config_yaml, action="save")
+
+#         # When
+#         response = client.with_session_auth("not_super_admin@example.com").post(
+#             url_for("fraud_rules_configuration.create_view"), form=data
+#         )
+
+#         # Then
+#         # redirection to admin.index due to inaccessibilty
+#         assert response.status_code == 302
+#         assert url_for("admin.index") in response.location
+
+#     @freeze_time("2032-11-17 15:00:00")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_approve_offer(self, mocked_validate_csrf_token, client):
+#         # Given
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     rules:
+#                        - name: "check offer name"
+#                          factor: 0
+#                          conditions:
+#                            - model: "Offer"
+#                              attribute: "name"
+#                              condition:
+#                                 operator: "not in"
+#                                 comparated: "REJECTED"
+#                     """
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         import_offer_validation_config(config_yaml, admin)
+#         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING, isActive=True)
+
+#         # When
+#         data = dict(validation=OfferValidationStatus.APPROVED.value, action="save")
+#         client = client.with_session_auth("admin@example.com")
+#         response = client.post(url_for("validation.edit", id=offer.id), form=data)
+
+#         # Then
+#         assert response.status_code == 302
+#         assert url_for("validation.index_view") in response.location
+#         assert offer.validation == OfferValidationStatus.APPROVED
+#         assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
+#         assert offer.lastValidationType == OfferValidationType.MANUAL
+
+#     @freeze_time("2032-11-17 15:00:00")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_reject_offer(self, mocked_validate_csrf_token, client):
+#         # Given
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     rules:
+#                        - name: "check offer name"
+#                          factor: 0
+#                          conditions:
+#                            - model: "Offer"
+#                              attribute: "name"
+#                              condition:
+#                                 operator: "not in"
+#                                 comparated: "REJECTED"
+#                     """
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         import_offer_validation_config(config_yaml, admin)
+#         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING)
+
+#         # When
+#         data = dict(validation=OfferValidationStatus.REJECTED.value, action="save")
+#         client = client.with_session_auth("admin@example.com")
+#         response = client.post(url_for("validation.edit", id=offer.id), form=data)
+
+#         # Then
+#         assert response.status_code == 302
+#         assert url_for("validation.index_view") in response.location
+#         assert offer.validation == OfferValidationStatus.REJECTED
+#         assert offer.isActive is False
+#         assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
+#         assert offer.lastValidationType == OfferValidationType.MANUAL
+
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_access_to_validation_page_with_super_admin_user_on_prod_env(self, client):
+#         users_factories.AdminFactory(email="super_admin@example.com")
+
+#         response = client.with_session_auth("super_admin@example.com").get(url_for("validation.index_view"))
+
+#         assert response.status_code == 200
+
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_access_to_validation_page_with_none_super_admin_user_on_prod_env(self, client):
+#         users_factories.AdminFactory(email="simple_admin@example.com")
+
+#         response = client.with_session_auth("simple_admin@example.com").get(url_for("validation.index_view"))
+
+#         assert response.status_code == 302
+#         assert url_for("admin.index") in response.location
+
+#     def test_get_query_and_count(self, db_session):
+#         offer_view = ValidationOfferView(model=Offer, session=db_session)
+#         validated_offerer = offerers_factories.OffererFactory()
+#         non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
+#         offer_1 = offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             venue__managingOfferer=validated_offerer,
+#         )
+#         offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             venue__managingOfferer=non_validated_offerer,
+#         )
+
+#         get_query_offers_list = offer_view.get_query().all()
+#         get_count_query_scalar = offer_view.get_count_query().scalar()
+
+#         assert get_query_offers_list == [offer_1]
+#         assert get_count_query_scalar == 1
+
+#     @clean_database
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
+#     def test_number_of_queries_for_offer_list(self, client):
+#         admin = users_factories.AdminFactory(email="superadmin@example.com")
+
+#         offers_factories.OfferValidationConfigFactory(
+#             specs={
+#                 "minimum_score": 0.1,
+#                 "rules": [
+#                     {
+#                         "conditions": [
+#                             {
+#                                 "attribute": "max_price",
+#                                 "condition": {"comparated": 1, "operator": ">"},
+#                                 "model": "Offer",
+#                             },
+#                         ],
+#                         "factor": 0.8,
+#                         "name": "Vérification",
+#                     },
+#                 ],
+#             }
+#         )
+#         for _ in range(5):
+#             offers_factories.StockFactory(offer__validation=OfferValidationStatus.PENDING)
+
+#         client = client.with_session_auth(admin.email)
+
+#         with testing.assert_no_duplicated_queries():
+#             response = client.get(url_for("validation.index_view"))
+
+#         assert response.status_code == 200
+#         assert b"<h2>Validation des offres</h2>" in response.data
+
+#     @pytest.mark.parametrize(
+#         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
+#     )
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_batch_approve_offers(self, mocked_validate_csrf_token, action, expected, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#         offer1 = offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#         )
+#         offer2 = offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#         )
+
+#         data = dict(rowid=[offer1.id, offer2.id], action=action)
+#         client.with_session_auth("admin@example.com")
+#         response = client.post(url_for("validation.action_view"), form=data)
+
+#         assert response.status_code == 302
+#         assert url_for("validation.index_view") in response.location
+
+#         assert Offer.query.get(offer1.id).validation == expected
+#         assert Offer.query.get(offer2.id).validation == expected
+
+#         # There is no status returned by the action, check flash message
+#         get_response = client.get(response.location)
+#         assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
+
+#     @pytest.mark.parametrize("action", ["approve", "reject"])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.offers.api.update_pending_offer_validation")
+#     def test_batch_approve_reject_offers_not_updated(
+#         self,
+#         mocked_update_pending_offer_validation,
+#         mocked_validate_csrf_token,
+#         action,
+#         client,
+#     ):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#         offer = offers_factories.OfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#         )
+#         offers_factories.OfferValidationConfigFactory()
+
+#         mocked_update_pending_offer_validation.return_value = False
+
+#         data = dict(rowid=[offer.id], action=action)
+#         client.with_session_auth("admin@example.com")
+#         response = client.post(url_for("validation.action_view"), form=data)
+
+#         assert response.status_code == 302
+#         assert url_for("validation.index_view") in response.location
+
+#         assert Offer.query.get(offer.id).validation == OfferValidationStatus.PENDING
+
+#         # There is no status returned by the action, check flash message
+#         get_response = client.get(response.location)
+#         assert (
+#             "Une erreur s&#39;est produite lors de la mise à jour du statut de validation des offres"
+#             in get_response.data.decode("utf8")
+#         )
+
+#     @freeze_time("2032-11-17 15:00:00")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_approve_collective_offer_template(self, mocked_validate_csrf_token, client):
+#         # Given
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     rules:
+#                        - name: "check offer name"
+#                          factor: 0
+#                          conditions:
+#                            - model: "Offer"
+#                              attribute: "name"
+#                              condition:
+#                                 operator: "not in"
+#                                 comparated: "REJECTED"
+#                     """
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         import_offer_validation_config(config_yaml, admin)
+#         offer = educational_factories.CollectiveOfferTemplateFactory(
+#             validation=OfferValidationStatus.PENDING, isActive=True
+#         )
+
+#         # When
+#         data = dict(validation=OfferValidationStatus.APPROVED.value, action="save")
+#         response = client.with_session_auth("admin@example.com").post(
+#             url_for("validation-collective-offer-template.edit", id=offer.id), form=data
+#         )
+
+#         # Then
+#         assert response.status_code == 302
+#         assert url_for("validation-collective-offer-template.index_view") in response.location
+#         assert offer.validation == OfferValidationStatus.APPROVED
+#         assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
+#         assert offer.lastValidationType == OfferValidationType.MANUAL
+
+#     @freeze_time("2032-11-17 15:00:00")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_reject_collective_offer_template(self, mocked_validate_csrf_token, client):
+#         # Given
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     rules:
+#                        - name: "check offer name"
+#                          factor: 0
+#                          conditions:
+#                            - model: "Offer"
+#                              attribute: "name"
+#                              condition:
+#                                 operator: "not in"
+#                                 comparated: "REJECTED"
+#                     """
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         import_offer_validation_config(config_yaml, admin)
+#         offer = educational_factories.CollectiveOfferTemplateFactory(validation=OfferValidationStatus.PENDING)
+
+#         # When
+#         data = dict(validation=OfferValidationStatus.REJECTED.value, action="save")
+#         response = client.with_session_auth("admin@example.com").post(
+#             url_for("validation-collective-offer-template.edit", id=offer.id), form=data
+#         )
+
+#         # Then
+#         assert response.status_code == 302
+#         assert url_for("validation-collective-offer-template.index_view") in response.location
+#         assert offer.validation == OfferValidationStatus.REJECTED
+#         assert offer.isActive is False
+#         assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
+#         assert offer.lastValidationType == OfferValidationType.MANUAL
+
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_access_to_collective_offer_template_validation_page_with_super_admin_user_on_prod_env(self, client):
+#         users_factories.AdminFactory(email="super_admin@example.com")
+
+#         response = client.with_session_auth("super_admin@example.com").get(
+#             url_for("validation-collective-offer-template.index_view")
+#         )
+
+#         assert response.status_code == 200
+
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_access_to_collective_offer_templayte_validation_page_with_none_super_admin_user_on_prod_env(self, client):
+#         users_factories.AdminFactory(email="simple_admin@example.com")
+
+#         response = client.with_session_auth("simple_admin@example.com").get(
+#             url_for("validation-collective-offer-template.index_view")
+#         )
+
+#         assert response.status_code == 302
+#         assert url_for("admin.index") in response.location
+
+#     def test_get_collective_offer_template_query_and_count(self, db_session):
+#         offer_view = ValidationCollectiveOfferTemplateView(
+#             model=educational_models.CollectiveOfferTemplate, session=db_session
+#         )
+#         validated_offerer = offerers_factories.OffererFactory()
+#         non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
+#         offer_1 = educational_factories.CollectiveOfferTemplateFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             venue__managingOfferer=validated_offerer,
+#         )
+#         educational_factories.CollectiveOfferTemplateFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             venue__managingOfferer=non_validated_offerer,
+#         )
+
+#         get_query_offers_list = offer_view.get_query().all()
+#         get_count_query_scalar = offer_view.get_count_query().scalar()
+
+#         assert get_query_offers_list == [offer_1]
+#         assert get_count_query_scalar == 1
+
+#     @pytest.mark.parametrize(
+#         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
+#     )
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_batch_approve_collective_offers_template(self, mocked_validate_csrf_token, action, expected, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#         offer1 = educational_factories.CollectiveOfferTemplateFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#         )
+#         offer2 = educational_factories.CollectiveOfferTemplateFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#         )
+
+#         data = dict(rowid=[offer1.id, offer2.id], action=action)
+#         client.with_session_auth("admin@example.com")
+#         response = client.post(url_for("validation-collective-offer-template.action_view"), form=data)
+
+#         assert response.status_code == 302
+#         assert url_for("validation-collective-offer-template.index_view") in response.location
+
+#         assert educational_models.CollectiveOfferTemplate.query.get(offer1.id).validation == expected
+#         assert educational_models.CollectiveOfferTemplate.query.get(offer2.id).validation == expected
+
+#         # There is no status returned by the action, check flash message
+#         get_response = client.get(response.location)
+#         assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
+
+#     @pytest.mark.parametrize("action", ["approve", "reject"])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.offers.api.update_pending_offer_validation")
+#     def test_batch_approve_reject_collective_offers_template_not_updated(
+#         self,
+#         mocked_update_pending_offer_validation,
+#         mocked_validate_csrf_token,
+#         action,
+#         client,
+#     ):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#         offer = educational_factories.CollectiveOfferTemplateFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#         )
+#         offers_factories.OfferValidationConfigFactory()
+
+#         mocked_update_pending_offer_validation.return_value = False
+
+#         data = dict(rowid=[offer.id], action=action)
+#         client.with_session_auth("admin@example.com")
+#         response = client.post(url_for("validation-collective-offer-template.action_view"), form=data)
+
+#         assert response.status_code == 302
+#         assert url_for("validation-collective-offer-template.index_view") in response.location
+
+#         assert (
+#             educational_models.CollectiveOfferTemplate.query.get(offer.id).validation == OfferValidationStatus.PENDING
+#         )
+
+#         # There is no status returned by the action, check flash message
+#         get_response = client.get(response.location)
+#         assert (
+#             "Une erreur s&#39;est produite lors de la mise à jour du statut de validation des offres"
+#             in get_response.data.decode("utf8")
+#         )
+
+#     @freeze_time("2032-11-17 15:00:00")
+#     @override_settings(ADAGE_API_URL="https://adage_base_url")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_approve_collective_offer_and_notify_adage(self, mocked_validate_csrf_token, client):
+#         # Given
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     rules:
+#                        - name: "check offer name"
+#                          factor: 0
+#                          conditions:
+#                            - model: "CollectiveOffer"
+#                              attribute: "name"
+#                              condition:
+#                                 operator: "not in"
+#                                 comparated: "REJECTED"
+#                     """
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         import_offer_validation_config(config_yaml, admin)
+#         educational_institution = educational_factories.EducationalInstitutionFactory()
+#         offer = educational_factories.CollectiveStockFactory(
+#             collectiveOffer__validation=OfferValidationStatus.PENDING,
+#             collectiveOffer__isActive=True,
+#             collectiveOffer__institution=educational_institution,
+#         ).collectiveOffer
+
+#         # When
+#         data = dict(validation=OfferValidationStatus.APPROVED.value, action="save")
+#         response = client.with_session_auth("admin@example.com").post(
+#             url_for("validation-collective-offer.edit", id=offer.id), form=data
+#         )
+
+#         # Then
+#         assert response.status_code == 302
+#         assert url_for("validation-collective-offer.index_view") in response.location
+#         assert offer.validation == OfferValidationStatus.APPROVED
+#         assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
+#         assert offer.lastValidationType == OfferValidationType.MANUAL
+
+#         expected_payload = serialize_collective_offer(offer)
+#         assert adage_api_testing.adage_requests[0]["sent_data"] == expected_payload
+#         assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/offre-assoc"
+
+#     @freeze_time("2032-11-17 15:00:00")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_reject_collective_offer_and_send_mail_to_administration(self, mocked_validate_csrf_token, client):
+#         # Given
+#         config_yaml = """
+#                     minimum_score: 0.6
+#                     rules:
+#                        - name: "check offer name"
+#                          factor: 0
+#                          conditions:
+#                            - model: "Offer"
+#                              attribute: "name"
+#                              condition:
+#                                 operator: "not in"
+#                                 comparated: "REJECTED"
+#                     """
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         import_offer_validation_config(config_yaml, admin)
+#         offer = educational_factories.CollectiveOfferFactory(validation=OfferValidationStatus.PENDING)
+
+#         # When
+#         data = dict(validation=OfferValidationStatus.REJECTED.value, action="save")
+#         response = client.with_session_auth("admin@example.com").post(
+#             url_for("validation-collective-offer.edit", id=offer.id), form=data
+#         )
+
+#         # Then
+#         assert response.status_code == 302
+#         assert url_for("validation-collective-offer.index_view") in response.location
+#         assert offer.validation == OfferValidationStatus.REJECTED
+#         assert offer.isActive is False
+#         assert offer.lastValidationDate == datetime.datetime(2032, 11, 17, 15)
+#         assert offer.lastValidationType == OfferValidationType.MANUAL
+
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_access_to_collective_offer_validation_page_with_super_admin_user_on_prod_env(self, client):
+#         users_factories.AdminFactory(email="super_admin@example.com")
+
+#         response = client.with_session_auth("super_admin@example.com").get(
+#             url_for("validation-collective-offer.index_view")
+#         )
+
+#         assert response.status_code == 200
+
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
+#     def test_access_to_collectve_offer_validation_page_with_none_super_admin_user_on_prod_env(self, client):
+#         users_factories.AdminFactory(email="simple_admin@example.com")
+
+#         response = client.with_session_auth("simple_admin@example.com").get(
+#             url_for("validation-collective-offer.index_view")
+#         )
+
+#         assert response.status_code == 302
+#         assert url_for("admin.index") in response.location
+
+#     def test_get_query_and_count_on_collective_offer(self, db_session):
+#         offer_view = ValidationCollectiveOfferView(model=educational_models.CollectiveOffer, session=db_session)
+#         validated_offerer = offerers_factories.OffererFactory()
+#         non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
+#         offer_1 = educational_factories.CollectiveOfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             venue__managingOfferer=validated_offerer,
+#         )
+#         educational_factories.CollectiveOfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             venue__managingOfferer=non_validated_offerer,
+#         )
+
+#         get_query_offers_list = offer_view.get_query().all()
+#         get_count_query_scalar = offer_view.get_count_query().scalar()
+
+#         assert get_query_offers_list == [offer_1]
+#         assert get_count_query_scalar == 1
+
+#     @clean_database
+#     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
+#     def test_number_of_queries_for_collective_offer_list(self, client):
+#         admin = users_factories.AdminFactory(email="superadmin@example.com")
+
+#         offers_factories.OfferValidationConfigFactory(
+#             specs={
+#                 "minimum_score": 0.1,
+#                 "rules": [
+#                     {
+#                         "conditions": [
+#                             {
+#                                 "attribute": "max_price",
+#                                 "condition": {"comparated": 1, "operator": ">"},
+#                                 "model": "Offer",
+#                             },
+#                         ],
+#                         "factor": 0.8,
+#                         "name": "Vérification",
+#                     },
+#                 ],
+#             }
+#         )
+#         for _ in range(5):
+#             educational_factories.CollectiveStockFactory(collectiveOffer__validation=OfferValidationStatus.PENDING)
+
+#         client = client.with_session_auth(admin.email)
+
+#         with testing.assert_no_duplicated_queries():
+#             response = client.get(url_for("validation-collective-offer.index_view"))
+
+#         assert response.status_code == 200
+#         assert b"<h2>Validation des offres</h2>" in response.data
+
+#     @pytest.mark.parametrize(
+#         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
+#     )
+#     @override_settings(ADAGE_API_URL="https://adage_base_url")
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_batch_approve_collective_offers(self, mocked_validate_csrf_token, action, expected, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#         educational_institution = educational_factories.EducationalInstitutionFactory()
+#         offer1 = educational_factories.CollectiveStockFactory(
+#             collectiveOffer__validation=OfferValidationStatus.PENDING,
+#             collectiveOffer__isActive=True,
+#             collectiveOffer__venue__bookingEmail="email1@example.com",
+#             collectiveOffer__venue=venue,
+#             collectiveOffer__institution=educational_institution,
+#         ).collectiveOffer
+#         offer2 = educational_factories.CollectiveStockFactory(
+#             collectiveOffer__validation=OfferValidationStatus.PENDING,
+#             collectiveOffer__isActive=True,
+#             collectiveOffer__venue__bookingEmail="email1@example.com",
+#             collectiveOffer__venue=venue,
+#         ).collectiveOffer
+
+#         data = dict(rowid=[offer1.id, offer2.id], action=action)
+#         client.with_session_auth("admin@example.com")
+#         response = client.post(url_for("validation-collective-offer.action_view"), form=data)
+
+#         assert response.status_code == 302
+#         assert url_for("validation-collective-offer.index_view") in response.location
+
+#         assert educational_models.CollectiveOffer.query.get(offer1.id).validation == expected
+#         assert educational_models.CollectiveOffer.query.get(offer2.id).validation == expected
+
+#         # There is no status returned by the action, check flash message
+#         get_response = client.get(response.location)
+#         assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
+
+#         expected_payload_1 = serialize_collective_offer(offer1)
+#         assert len(adage_api_testing.adage_requests) == 1
+#         assert adage_api_testing.adage_requests[0]["sent_data"] == expected_payload_1
+#         assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/offre-assoc"
+
+#     @pytest.mark.parametrize("action", ["approve", "reject"])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.offers.api.update_pending_offer_validation")
+#     def test_batch_approve_reject_collective_offers_not_updated(
+#         self,
+#         mocked_update_pending_offer_validation,
+#         mocked_validate_csrf_token,
+#         action,
+#         client,
+#     ):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory(email="pro@example.com")
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#         offer = educational_factories.CollectiveOfferFactory(
+#             validation=OfferValidationStatus.PENDING,
+#             isActive=True,
+#             venue__bookingEmail="email1@example.com",
+#             venue=venue,
+#         )
+#         offers_factories.OfferValidationConfigFactory()
+
+#         mocked_update_pending_offer_validation.return_value = False
+
+#         data = dict(rowid=[offer.id], action=action)
+#         client.with_session_auth("admin@example.com")
+#         response = client.post(url_for("validation-collective-offer.action_view"), form=data)
+
+#         assert response.status_code == 302
+#         assert url_for("validation-collective-offer.index_view") in response.location
+
+#         assert educational_models.CollectiveOffer.query.get(offer.id).validation == OfferValidationStatus.PENDING
+
+#         # There is no status returned by the action, check flash message
+#         get_response = client.get(response.location)
+#         assert (
+#             "Une erreur s&#39;est produite lors de la mise à jour du statut de validation des offres"
+#             in get_response.data.decode("utf8")
+#         )
 
 
 class OfferViewTest:
@@ -1152,13 +1158,13 @@ class OfferViewTest:
         assert offer.lastValidationType == OfferValidationType.AUTO  # unchanged
 
 
-class OfferForVenueSubviewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
-        admin = users_factories.AdminFactory(email="user@example.com")
-        client = client.with_session_auth(admin.email)
+# class OfferForVenueSubviewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
+#         admin = users_factories.AdminFactory(email="user@example.com")
+#         client = client.with_session_auth(admin.email)
 
-        response = client.get(url_for("offer_for_venue.index", id=42))
+#         response = client.get(url_for("offer_for_venue.index", id=42))
 
-        assert response.status_code == 404
+#         assert response.status_code == 404

--- a/api/tests/admin/custom_views/offerer_tag_category_view_test.py
+++ b/api/tests/admin/custom_views/offerer_tag_category_view_test.py
@@ -1,53 +1,53 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.offerers.models as offerers_models
-import pcapi.core.users.factories as users_factories
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.offerers.models as offerers_models
+# import pcapi.core.users.factories as users_factories
 
-from tests.conftest import clean_database
+# from tests.conftest import clean_database
 
 
-class OffererTagCategoryViewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_tag_category(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+# class OffererTagCategoryViewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_tag_category(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post("/pc/back-office/offerertagcategory/new/", form={"name": "test-category"})
+#         response = api_client.post("/pc/back-office/offerertagcategory/new/", form={"name": "test-category"})
 
-        assert response.status_code == 302
-        assert offerers_models.OffererTagCategory.query.count() == 1
-        category = offerers_models.OffererTagCategory.query.first()
-        assert category.name == "test-category"
+#         assert response.status_code == 302
+#         assert offerers_models.OffererTagCategory.query.count() == 1
+#         category = offerers_models.OffererTagCategory.query.first()
+#         assert category.name == "test-category"
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_tag_category(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        category = offerers_factories.OffererTagCategoryFactory()
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_tag_category(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         category = offerers_factories.OffererTagCategoryFactory()
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post(
-            f"/pc/back-office/offerertagcategory/edit/?id={category.id}",
-            form={"name": "updated-category", "label": "Catégorie de test"},
-        )
+#         response = api_client.post(
+#             f"/pc/back-office/offerertagcategory/edit/?id={category.id}",
+#             form={"name": "updated-category", "label": "Catégorie de test"},
+#         )
 
-        assert response.status_code == 302
-        assert category.name == "updated-category"
-        assert category.label == "Catégorie de test"
+#         assert response.status_code == 302
+#         assert category.name == "updated-category"
+#         assert category.label == "Catégorie de test"
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_tag_category(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
-        category = offerers_factories.OffererTagCategoryFactory()
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_tag_category(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         category = offerers_factories.OffererTagCategoryFactory()
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post("/pc/back-office/offerertagcategory/delete/", form={"id": category.id})
+#         response = api_client.post("/pc/back-office/offerertagcategory/delete/", form={"id": category.id})
 
-        assert response.status_code == 302
-        assert offerers_models.OffererTagCategory.query.count() == 0
+#         assert response.status_code == 302
+#         assert offerers_models.OffererTagCategory.query.count() == 0

--- a/api/tests/admin/custom_views/offerer_tag_view_test.py
+++ b/api/tests/admin/custom_views/offerer_tag_view_test.py
@@ -1,93 +1,93 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-import pytest
+# import pytest
 
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.offerers.models as offerers_models
-import pcapi.core.users.factories as users_factories
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.offerers.models as offerers_models
+# import pcapi.core.users.factories as users_factories
 
-from tests.conftest import clean_database
+# from tests.conftest import clean_database
 
 
-class OffererTagViewTest:
-    @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_tag(self, mocked_validate_csrf_token, client, name):
-        users_factories.AdminFactory(email="admin@example.com")
-        category = offerers_factories.OffererTagCategoryFactory()
+# class OffererTagViewTest:
+#     @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_tag(self, mocked_validate_csrf_token, client, name):
+#         users_factories.AdminFactory(email="admin@example.com")
+#         category = offerers_factories.OffererTagCategoryFactory()
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post("/pc/back-office/offerertag/new/", form={"name": name, "categories": [category.id]})
+#         response = api_client.post("/pc/back-office/offerertag/new/", form={"name": name, "categories": [category.id]})
 
-        assert response.status_code == 302
-        assert offerers_models.OffererTag.query.count() == 1
-        tag = offerers_models.OffererTag.query.first()
-        assert tag.name == name
-        assert tag.categories == [category]
+#         assert response.status_code == 302
+#         assert offerers_models.OffererTag.query.count() == 1
+#         tag = offerers_models.OffererTag.query.first()
+#         assert tag.name == name
+#         assert tag.categories == [category]
 
-    @pytest.mark.parametrize(
-        "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
-    )
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_tag_with_whitespace(self, mocked_validate_csrf_token, client, name):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @pytest.mark.parametrize(
+#         "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
+#     )
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_tag_with_whitespace(self, mocked_validate_csrf_token, client, name):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post("/pc/back-office/offerertag/new/", form={"name": name})
+#         response = api_client.post("/pc/back-office/offerertag/new/", form={"name": name})
 
-        assert response.status_code == 200
-        assert "Le nom ne doit contenir aucun caractère d&#39;espacement" in response.data.decode("utf8")
-        assert offerers_models.OffererTag.query.count() == 0
+#         assert response.status_code == 200
+#         assert "Le nom ne doit contenir aucun caractère d&#39;espacement" in response.data.decode("utf8")
+#         assert offerers_models.OffererTag.query.count() == 0
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_create_tag_too_long(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_create_tag_too_long(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post("/pc/back-office/offerertag/new/", form={"name": "x" * 141})
+#         response = api_client.post("/pc/back-office/offerertag/new/", form={"name": "x" * 141})
 
-        assert response.status_code == 200
-        assert "Le nom ne peut excéder 140 caractères" in response.data.decode("utf8")
-        assert offerers_models.OffererTag.query.count() == 0
+#         assert response.status_code == 200
+#         assert "Le nom ne peut excéder 140 caractères" in response.data.decode("utf8")
+#         assert offerers_models.OffererTag.query.count() == 0
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_tag(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_tag(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        category1 = offerers_factories.OffererTagCategoryFactory(name="comptage")
-        category2 = offerers_factories.OffererTagCategoryFactory(name="homologation")
-        tag = offerers_factories.OffererTagFactory(name="test_edit_tag", categories=[category1])
-        offerer = offerers_factories.OffererFactory(tags=[tag])
+#         category1 = offerers_factories.OffererTagCategoryFactory(name="comptage")
+#         category2 = offerers_factories.OffererTagCategoryFactory(name="homologation")
+#         tag = offerers_factories.OffererTagFactory(name="test_edit_tag", categories=[category1])
+#         offerer = offerers_factories.OffererFactory(tags=[tag])
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post(
-            f"/pc/back-office/offerertag/edit/?id={offerer.tags[0].id}",
-            form={"name": "test_edit_tag", "categories": [category2.id]},
-        )
+#         response = api_client.post(
+#             f"/pc/back-office/offerertag/edit/?id={offerer.tags[0].id}",
+#             form={"name": "test_edit_tag", "categories": [category2.id]},
+#         )
 
-        assert response.status_code == 302
-        assert len(offerer.tags) == 1
-        assert offerer.tags[0].name == "test_edit_tag"
-        assert offerer.tags[0].categories == [category2]
+#         assert response.status_code == 302
+#         assert len(offerer.tags) == 1
+#         assert offerer.tags[0].name == "test_edit_tag"
+#         assert offerer.tags[0].categories == [category2]
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_tag(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_tag(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        offerer = offerers_factories.OffererFactory(tags=[offerers_factories.OffererTagFactory(name="test_delete_tag")])
+#         offerer = offerers_factories.OffererFactory(tags=[offerers_factories.OffererTagFactory(name="test_delete_tag")])
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post("/pc/back-office/offerertag/delete/", form={"id": offerer.tags[0].id})
+#         response = api_client.post("/pc/back-office/offerertag/delete/", form={"id": offerer.tags[0].id})
 
-        assert response.status_code == 302
-        assert len(offerer.tags) == 0
+#         assert response.status_code == 302
+#         assert len(offerer.tags) == 0

--- a/api/tests/admin/custom_views/offerer_view_test.py
+++ b/api/tests/admin/custom_views/offerer_view_test.py
@@ -1,259 +1,259 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-import pytest
+# import pytest
 
-import pcapi.core.bookings.factories as booking_factories
-from pcapi.core.bookings.models import BookingStatus
-import pcapi.core.history.models as history_models
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.offerers.models as offerers_models
-from pcapi.core.users import testing as external_testing
-import pcapi.core.users.factories as users_factories
-from pcapi.models import db
+# import pcapi.core.bookings.factories as booking_factories
+# from pcapi.core.bookings.models import BookingStatus
+# import pcapi.core.history.models as history_models
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.offerers.models as offerers_models
+# from pcapi.core.users import testing as external_testing
+# import pcapi.core.users.factories as users_factories
+# from pcapi.models import db
 
-from tests.conftest import clean_database
+# from tests.conftest import clean_database
 
 
-class OffererViewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_offerer_add_tags(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+# class OffererViewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_offerer_add_tags(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        offerer = offerers_factories.OffererFactory()
-        tag1 = offerers_factories.OffererTagFactory(name="test_tag_1")
-        tag2 = offerers_factories.OffererTagFactory(name="test_tag_2")
+#         offerer = offerers_factories.OffererFactory()
+#         tag1 = offerers_factories.OffererTagFactory(name="test_tag_1")
+#         tag2 = offerers_factories.OffererTagFactory(name="test_tag_2")
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post(
-            f"/pc/back-office/offerer/edit/?id={offerer.id}",
-            form={
-                "name": "Updated offerer",
-                "siren": offerer.siren,
-                "city": offerer.city,
-                "postalCode": offerer.postalCode,
-                "address": offerer.address,
-                "tags": [tag1.id, tag2.id],  # Add both tags
-                "isActive": offerer.isActive,
-            },
-        )
+#         response = api_client.post(
+#             f"/pc/back-office/offerer/edit/?id={offerer.id}",
+#             form={
+#                 "name": "Updated offerer",
+#                 "siren": offerer.siren,
+#                 "city": offerer.city,
+#                 "postalCode": offerer.postalCode,
+#                 "address": offerer.address,
+#                 "tags": [tag1.id, tag2.id],  # Add both tags
+#                 "isActive": offerer.isActive,
+#             },
+#         )
 
-        assert response.status_code == 302
-        db.session.refresh(offerer)
-        assert offerer.name == "Updated offerer"
-        assert {tag.name for tag in offerer.tags} == {tag1.name, tag2.name}
+#         assert response.status_code == 302
+#         db.session.refresh(offerer)
+#         assert offerer.name == "Updated offerer"
+#         assert {tag.name for tag in offerer.tags} == {tag1.name, tag2.name}
 
-        assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Offerer", "id": offerer.id}]
+#         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Offerer", "id": offerer.id}]
 
-        assert history_models.ActionHistory.query.count() == 0
+#         assert history_models.ActionHistory.query.count() == 0
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_offerer_remove_tags(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_edit_offerer_remove_tags(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        offerer = offerers_factories.OffererFactory(
-            tags=[
-                offerers_factories.OffererTagFactory(),
-                offerers_factories.OffererTagFactory(),
-            ]
-        )
-        api_client = client.with_session_auth("admin@example.com")
+#         offerer = offerers_factories.OffererFactory(
+#             tags=[
+#                 offerers_factories.OffererTagFactory(),
+#                 offerers_factories.OffererTagFactory(),
+#             ]
+#         )
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post(
-            f"/pc/back-office/offerer/edit/?id={offerer.id}",
-            form={
-                "name": "Updated offerer",
-                "siren": offerer.siren,
-                "city": offerer.city,
-                "postalCode": offerer.postalCode,
-                "address": offerer.address,
-                "tags": [],  # Remove both tags
-                "isActive": offerer.isActive,
-            },
-        )
+#         response = api_client.post(
+#             f"/pc/back-office/offerer/edit/?id={offerer.id}",
+#             form={
+#                 "name": "Updated offerer",
+#                 "siren": offerer.siren,
+#                 "city": offerer.city,
+#                 "postalCode": offerer.postalCode,
+#                 "address": offerer.address,
+#                 "tags": [],  # Remove both tags
+#                 "isActive": offerer.isActive,
+#             },
+#         )
 
-        assert response.status_code == 302
-        db.session.refresh(offerer)
-        assert offerer.name == "Updated offerer"
-        assert len(offerer.tags) == 0
+#         assert response.status_code == 302
+#         db.session.refresh(offerer)
+#         assert offerer.name == "Updated offerer"
+#         assert len(offerer.tags) == 0
 
-        assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Offerer", "id": offerer.id}]
+#         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Offerer", "id": offerer.id}]
 
-        assert history_models.ActionHistory.query.count() == 0
+#         assert history_models.ActionHistory.query.count() == 0
 
-    @pytest.mark.parametrize(
-        "booking_status", [None, BookingStatus.USED, BookingStatus.CANCELLED, BookingStatus.REIMBURSED]
-    )
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_deactivate_offerer(self, mocked_validate_csrf_token, client, booking_status):
-        admin = users_factories.AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        pro_user = users_factories.ProFactory()
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-        if booking_status is not None:
-            booking_factories.BookingFactory(stock__offer__venue=venue, status=booking_status)
+#     @pytest.mark.parametrize(
+#         "booking_status", [None, BookingStatus.USED, BookingStatus.CANCELLED, BookingStatus.REIMBURSED]
+#     )
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_deactivate_offerer(self, mocked_validate_csrf_token, client, booking_status):
+#         admin = users_factories.AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         pro_user = users_factories.ProFactory()
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#         if booking_status is not None:
+#             booking_factories.BookingFactory(stock__offer__venue=venue, status=booking_status)
 
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            f"/pc/back-office/offerer/edit/?id={offerer.id}",
-            form={
-                "name": offerer.name,
-                "siren": offerer.siren,
-                "city": offerer.city,
-                "postalCode": offerer.postalCode,
-                "address": offerer.address,
-                # "isActive" is not sent in request when unchecked
-            },
-        )
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             f"/pc/back-office/offerer/edit/?id={offerer.id}",
+#             form={
+#                 "name": offerer.name,
+#                 "siren": offerer.siren,
+#                 "city": offerer.city,
+#                 "postalCode": offerer.postalCode,
+#                 "address": offerer.address,
+#                 # "isActive" is not sent in request when unchecked
+#             },
+#         )
 
-        assert response.status_code == 302
+#         assert response.status_code == 302
 
-        db.session.refresh(offerer)
-        db.session.refresh(venue)
+#         db.session.refresh(offerer)
+#         db.session.refresh(venue)
 
-        assert not offerer.isActive
-        assert len(external_testing.sendinblue_requests) == 2
-        assert {req["email"] for req in external_testing.sendinblue_requests} == {pro_user.email, venue.bookingEmail}
-        assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Offerer", "id": offerer.id}]
+#         assert not offerer.isActive
+#         assert len(external_testing.sendinblue_requests) == 2
+#         assert {req["email"] for req in external_testing.sendinblue_requests} == {pro_user.email, venue.bookingEmail}
+#         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Offerer", "id": offerer.id}]
 
-        assert history_models.ActionHistory.query.count() == 1
-        actions_list = history_models.ActionHistory.query.all()
-        assert len(actions_list) == 1
-        assert actions_list[0].actionType == history_models.ActionType.OFFERER_SUSPENDED
-        assert actions_list[0].authorUser == admin
-        assert actions_list[0].user is None
-        assert actions_list[0].offerer == offerer
+#         assert history_models.ActionHistory.query.count() == 1
+#         actions_list = history_models.ActionHistory.query.all()
+#         assert len(actions_list) == 1
+#         assert actions_list[0].actionType == history_models.ActionType.OFFERER_SUSPENDED
+#         assert actions_list[0].authorUser == admin
+#         assert actions_list[0].user is None
+#         assert actions_list[0].offerer == offerer
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_deactivate_offerer_rejected(self, mocked_validate_csrf_token, client):
-        admin = users_factories.AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer)
-        booking_factories.BookingFactory(stock__offer__venue=venue)
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_deactivate_offerer_rejected(self, mocked_validate_csrf_token, client):
+#         admin = users_factories.AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerer = venue.managingOfferer
+#         offerers_factories.UserOffererFactory(offerer=offerer)
+#         booking_factories.BookingFactory(stock__offer__venue=venue)
 
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            f"/pc/back-office/offerer/edit/?id={offerer.id}",
-            form={
-                "name": offerer.name,
-                "siren": offerer.siren,
-                "city": offerer.city,
-                "postalCode": offerer.postalCode,
-                "address": offerer.address,
-                # "isActive" is not sent in request when unchecked
-            },
-        )
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             f"/pc/back-office/offerer/edit/?id={offerer.id}",
+#             form={
+#                 "name": offerer.name,
+#                 "siren": offerer.siren,
+#                 "city": offerer.city,
+#                 "postalCode": offerer.postalCode,
+#                 "address": offerer.address,
+#                 # "isActive" is not sent in request when unchecked
+#             },
+#         )
 
-        assert response.status_code == 200
-        assert (
-            "Impossible de désactiver une structure juridique pour laquelle des réservations sont en cours."
-            in response.data.decode("utf8")
-        )
+#         assert response.status_code == 200
+#         assert (
+#             "Impossible de désactiver une structure juridique pour laquelle des réservations sont en cours."
+#             in response.data.decode("utf8")
+#         )
 
-        db.session.refresh(offerer)
-        db.session.refresh(venue)
+#         db.session.refresh(offerer)
+#         db.session.refresh(venue)
 
-        assert offerer.isActive
-        assert len(external_testing.sendinblue_requests) == 0
-        assert history_models.ActionHistory.query.count() == 0
+#         assert offerer.isActive
+#         assert len(external_testing.sendinblue_requests) == 0
+#         assert history_models.ActionHistory.query.count() == 0
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_reactivate_offerer(self, mocked_validate_csrf_token, client):
-        admin = users_factories.AdminFactory(email="user@example.com")
-        offerer = offerers_factories.OffererFactory(isActive=False)
-        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
-        pro_user = users_factories.ProFactory()
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_reactivate_offerer(self, mocked_validate_csrf_token, client):
+#         admin = users_factories.AdminFactory(email="user@example.com")
+#         offerer = offerers_factories.OffererFactory(isActive=False)
+#         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+#         pro_user = users_factories.ProFactory()
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
 
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            f"/pc/back-office/offerer/edit/?id={offerer.id}",
-            form={
-                "name": offerer.name,
-                "siren": offerer.siren,
-                "city": offerer.city,
-                "postalCode": offerer.postalCode,
-                "address": offerer.address,
-                "isActive": "y",
-            },
-        )
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             f"/pc/back-office/offerer/edit/?id={offerer.id}",
+#             form={
+#                 "name": offerer.name,
+#                 "siren": offerer.siren,
+#                 "city": offerer.city,
+#                 "postalCode": offerer.postalCode,
+#                 "address": offerer.address,
+#                 "isActive": "y",
+#             },
+#         )
 
-        assert response.status_code == 302
+#         assert response.status_code == 302
 
-        db.session.refresh(offerer)
-        db.session.refresh(venue)
+#         db.session.refresh(offerer)
+#         db.session.refresh(venue)
 
-        assert offerer.isActive
-        assert len(external_testing.sendinblue_requests) == 2
-        assert {req["email"] for req in external_testing.sendinblue_requests} == {pro_user.email, venue.bookingEmail}
-        assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Offerer", "id": offerer.id}]
+#         assert offerer.isActive
+#         assert len(external_testing.sendinblue_requests) == 2
+#         assert {req["email"] for req in external_testing.sendinblue_requests} == {pro_user.email, venue.bookingEmail}
+#         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Offerer", "id": offerer.id}]
 
-        assert history_models.ActionHistory.query.count() == 1
-        actions_list = history_models.ActionHistory.query.all()
-        assert len(actions_list) == 1
-        assert actions_list[0].actionType == history_models.ActionType.OFFERER_UNSUSPENDED
-        assert actions_list[0].authorUser == admin
-        assert actions_list[0].user is None
-        assert actions_list[0].offerer == offerer
+#         assert history_models.ActionHistory.query.count() == 1
+#         actions_list = history_models.ActionHistory.query.all()
+#         assert len(actions_list) == 1
+#         assert actions_list[0].actionType == history_models.ActionType.OFFERER_UNSUSPENDED
+#         assert actions_list[0].authorUser == admin
+#         assert actions_list[0].user is None
+#         assert actions_list[0].offerer == offerer
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_offerer(self, mocked_validate_csrf_token, client):
-        # Can delete offerer because there is no booking
-        admin = users_factories.AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(bookingEmail="booking@example.com")
-        pro_user = users_factories.ProFactory()
-        offerers_factories.UserOffererFactory(user=pro_user, offerer=venue.managingOfferer)
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_offerer(self, mocked_validate_csrf_token, client):
+#         # Can delete offerer because there is no booking
+#         admin = users_factories.AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(bookingEmail="booking@example.com")
+#         pro_user = users_factories.ProFactory()
+#         offerers_factories.UserOffererFactory(user=pro_user, offerer=venue.managingOfferer)
 
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            "/pc/back-office/offerer/delete/", form={"id": venue.managingOfferer.id, "url": "/pc/back-office/offerer/"}
-        )
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             "/pc/back-office/offerer/delete/", form={"id": venue.managingOfferer.id, "url": "/pc/back-office/offerer/"}
+#         )
 
-        assert response.status_code == 302
-        assert len(offerers_models.Offerer.query.all()) == 0
-        assert len(external_testing.sendinblue_requests) == 2
-        assert {req["email"] for req in external_testing.sendinblue_requests} == {
-            pro_user.email,
-            "booking@example.com",
-        }
+#         assert response.status_code == 302
+#         assert len(offerers_models.Offerer.query.all()) == 0
+#         assert len(external_testing.sendinblue_requests) == 2
+#         assert {req["email"] for req in external_testing.sendinblue_requests} == {
+#             pro_user.email,
+#             "booking@example.com",
+#         }
 
-    @pytest.mark.parametrize(
-        "booking_status",
-        [
-            BookingStatus.USED,
-            BookingStatus.CONFIRMED,
-            BookingStatus.CANCELLED,
-            BookingStatus.REIMBURSED,
-        ],
-    )
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_offerer_rejected(self, mocked_validate_csrf_token, client, booking_status):
-        admin = users_factories.AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        booking_factories.BookingFactory(stock__offer__venue=venue, status=booking_status)
-        offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
+#     @pytest.mark.parametrize(
+#         "booking_status",
+#         [
+#             BookingStatus.USED,
+#             BookingStatus.CONFIRMED,
+#             BookingStatus.CANCELLED,
+#             BookingStatus.REIMBURSED,
+#         ],
+#     )
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_offerer_rejected(self, mocked_validate_csrf_token, client, booking_status):
+#         admin = users_factories.AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         booking_factories.BookingFactory(stock__offer__venue=venue, status=booking_status)
+#         offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
 
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            "/pc/back-office/offerer/delete/", form={"id": venue.managingOfferer.id, "url": "/pc/back-office/offerer/"}
-        )
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             "/pc/back-office/offerer/delete/", form={"id": venue.managingOfferer.id, "url": "/pc/back-office/offerer/"}
+#         )
 
-        assert response.status_code == 302
+#         assert response.status_code == 302
 
-        list_response = api_client.get(response.headers["location"])
-        assert (
-            "Impossible d&#39;effacer une structure juridique pour laquelle il existe des réservations."
-            in list_response.data.decode("utf8")
-        )
+#         list_response = api_client.get(response.headers["location"])
+#         assert (
+#             "Impossible d&#39;effacer une structure juridique pour laquelle il existe des réservations."
+#             in list_response.data.decode("utf8")
+#         )
 
-        assert len(offerers_models.Offerer.query.all()) == 1
-        assert len(external_testing.sendinblue_requests) == 0
+#         assert len(offerers_models.Offerer.query.all()) == 1
+#         assert len(external_testing.sendinblue_requests) == 0

--- a/api/tests/admin/custom_views/partner_user_view_test.py
+++ b/api/tests/admin/custom_views/partner_user_view_test.py
@@ -1,190 +1,190 @@
-from datetime import datetime
-from unittest.mock import patch
+# from datetime import datetime
+# from unittest.mock import patch
 
-from dateutil.relativedelta import relativedelta
-from wtforms import Form
+# from dateutil.relativedelta import relativedelta
+# from wtforms import Form
 
-from pcapi.admin.custom_views.partner_user_view import PartnerUserView
-import pcapi.core.subscription.api as subscription_api
-import pcapi.core.subscription.models as subscription_models
-from pcapi.core.testing import override_settings
-from pcapi.core.users import models as users_models
-import pcapi.core.users.factories as users_factories
-from pcapi.core.users.models import User
+# from pcapi.admin.custom_views.partner_user_view import PartnerUserView
+# import pcapi.core.subscription.api as subscription_api
+# import pcapi.core.subscription.models as subscription_models
+# from pcapi.core.testing import override_settings
+# from pcapi.core.users import models as users_models
+# import pcapi.core.users.factories as users_factories
+# from pcapi.core.users.models import User
 
-from tests.conftest import TestClient
-from tests.conftest import clean_database
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
 
 
-class PartnerUserViewTest:
-    def test_should_generate_a_random_password_on_creation(self, app, db_session):
-        # given
-        user = User()
-        user.password = None
-        view = PartnerUserView(model=User, session=db_session)
+# class PartnerUserViewTest:
+#     def test_should_generate_a_random_password_on_creation(self, app, db_session):
+#         # given
+#         user = User()
+#         user.password = None
+#         view = PartnerUserView(model=User, session=db_session)
 
-        # when
-        view.on_model_change(Form(), model=user, is_created=True)
+#         # when
+#         view.on_model_change(Form(), model=user, is_created=True)
 
-        # then
-        assert user.password is not None
+#         # then
+#         assert user.password is not None
 
-    def test_should_preserve_password_on_edition(self, app, db_session):
-        # given
-        user = User()
-        user.password = "OriginalPassword"
-        view = PartnerUserView(model=User, session=db_session)
+#     def test_should_preserve_password_on_edition(self, app, db_session):
+#         # given
+#         user = User()
+#         user.password = "OriginalPassword"
+#         view = PartnerUserView(model=User, session=db_session)
 
-        # when
-        view.on_model_change(Form(), model=user, is_created=False)
+#         # when
+#         view.on_model_change(Form(), model=user, is_created=False)
 
-        # then
-        assert user.password == "OriginalPassword"
+#         # then
+#         assert user.password == "OriginalPassword"
 
-    def test_a_partner_should_never_be_a_beneficiary(self, app, db_session):
-        # given
-        user = User()
-        user.add_beneficiary_role()
-        view = PartnerUserView(model=User, session=db_session)
+#     def test_a_partner_should_never_be_a_beneficiary(self, app, db_session):
+#         # given
+#         user = User()
+#         user.add_beneficiary_role()
+#         view = PartnerUserView(model=User, session=db_session)
 
-        # when
-        view.on_model_change(Form(), model=user, is_created=False)
+#         # when
+#         view.on_model_change(Form(), model=user, is_created=False)
 
-        # then
-        assert not user.has_beneficiary_role
+#         # then
+#         assert not user.has_beneficiary_role
 
-    def test_a_partner_should_never_be_an_admin(self, app, db_session):
-        # given
-        user = User()
-        user.add_admin_role()
-        view = PartnerUserView(model=User, session=db_session)
+#     def test_a_partner_should_never_be_an_admin(self, app, db_session):
+#         # given
+#         user = User()
+#         user.add_admin_role()
+#         view = PartnerUserView(model=User, session=db_session)
 
-        # when
-        view.on_model_change(Form(), model=user, is_created=False)
+#         # when
+#         view.on_model_change(Form(), model=user, is_created=False)
 
-        # then
-        assert not user.has_admin_role
+#         # then
+#         assert not user.has_admin_role
 
-    def test_a_partner_should_not_need_to_fill_cultural_survey(self, app, db_session):
-        # given
-        user = User()
-        view = PartnerUserView(model=User, session=db_session)
+#     def test_a_partner_should_not_need_to_fill_cultural_survey(self, app, db_session):
+#         # given
+#         user = User()
+#         view = PartnerUserView(model=User, session=db_session)
 
-        # when
-        view.on_model_change(Form(), model=user, is_created=True)
+#         # when
+#         view.on_model_change(Form(), model=user, is_created=True)
 
-        # then
-        assert user.needsToFillCulturalSurvey is False
+#         # then
+#         assert user.needsToFillCulturalSurvey is False
 
-    @clean_database
-    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_super_admin_can_suspend_then_unsuspend_partner(self, mocked_validate_csrf_token, app):
-        super_admin = users_factories.AdminFactory(email="superadmin@example.com")
-        partner = users_factories.UserFactory(email="partner@example.com")
-        client = TestClient(app.test_client()).with_session_auth(super_admin.email)
+#     @clean_database
+#     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_super_admin_can_suspend_then_unsuspend_partner(self, mocked_validate_csrf_token, app):
+#         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
+#         partner = users_factories.UserFactory(email="partner@example.com")
+#         client = TestClient(app.test_client()).with_session_auth(super_admin.email)
 
-        # Super admin suspends partner
-        url = f"/pc/back-office/partner_users/suspend?user_id={partner.id}"
-        suspend_response = client.post(url, form={"reason": "fraud suspicion", "csrf_token": "token"})
-        assert suspend_response.status_code == 302
-        assert not partner.isActive
+#         # Super admin suspends partner
+#         url = f"/pc/back-office/partner_users/suspend?user_id={partner.id}"
+#         suspend_response = client.post(url, form={"reason": "fraud suspicion", "csrf_token": "token"})
+#         assert suspend_response.status_code == 302
+#         assert not partner.isActive
 
-        # Super admin unsuspends partner
-        url = f"/pc/back-office/partner_users/unsuspend?user_id={partner.id}"
-        unsuspend_response = client.post(url, form={"reason": "fraud suspicion", "csrf_token": "token"})
-        assert unsuspend_response.status_code == 302
-        assert partner.isActive
+#         # Super admin unsuspends partner
+#         url = f"/pc/back-office/partner_users/unsuspend?user_id={partner.id}"
+#         unsuspend_response = client.post(url, form={"reason": "fraud suspicion", "csrf_token": "token"})
+#         assert unsuspend_response.status_code == 302
+#         assert partner.isActive
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
-    def test_resend_validation_email_to_partner(
-        self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
-    ):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        partner = users_factories.UserFactory(email="partner@example.com", isEmailValidated=False)
-        client = TestClient(app.test_client()).with_session_auth(admin.email)
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
+#     def test_resend_validation_email_to_partner(
+#         self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
+#     ):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         partner = users_factories.UserFactory(email="partner@example.com", isEmailValidated=False)
+#         client = TestClient(app.test_client()).with_session_auth(admin.email)
 
-        url = f"/pc/back-office/partner_users/resend-validation-email?user_id={partner.id}"
-        resend_validation_email_response = client.post(url, form={"csrf_token": "token"})
-        assert resend_validation_email_response.status_code == 302
-        mocked_request_email_confirmation.assert_called_once_with(partner)
+#         url = f"/pc/back-office/partner_users/resend-validation-email?user_id={partner.id}"
+#         resend_validation_email_response = client.post(url, form={"csrf_token": "token"})
+#         assert resend_validation_email_response.status_code == 302
+#         mocked_request_email_confirmation.assert_called_once_with(partner)
 
-    @clean_database
-    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_clear_profile(self, mocked_validate_csrf_token, client):
-        admin = users_factories.AdminFactory()
-        user = users_factories.UserFactory(
-            dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=1),
-            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            activity=users_models.ActivityEnum.STUDENT.value,
-            email="user@example.com",
-            firstName="Partner",
-            lastName="Example",
-            departementCode="06",
-            postalCode="06000",
-            city="Nice",
-            idPieceNumber="123123123",
-        )
+#     @clean_database
+#     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_clear_profile(self, mocked_validate_csrf_token, client):
+#         admin = users_factories.AdminFactory()
+#         user = users_factories.UserFactory(
+#             dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=1),
+#             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+#             activity=users_models.ActivityEnum.STUDENT.value,
+#             email="user@example.com",
+#             firstName="Partner",
+#             lastName="Example",
+#             departementCode="06",
+#             postalCode="06000",
+#             city="Nice",
+#             idPieceNumber="123123123",
+#         )
 
-        client.with_session_auth(admin.email)
+#         client.with_session_auth(admin.email)
 
-        client.post(
-            f"/pc/back-office/partner_users/edit/?id={user.id}",
-            form={
-                "csrf_token": "token",
-                "email": user.email,
-                "firstName": "",
-                "lastName": "",
-                "departementCode": user.departementCode,
-                "postalCode": "",
-                "city": "",
-                "idPieceNumber": "",
-            },
-        )
+#         client.post(
+#             f"/pc/back-office/partner_users/edit/?id={user.id}",
+#             form={
+#                 "csrf_token": "token",
+#                 "email": user.email,
+#                 "firstName": "",
+#                 "lastName": "",
+#                 "departementCode": user.departementCode,
+#                 "postalCode": "",
+#                 "city": "",
+#                 "idPieceNumber": "",
+#             },
+#         )
 
-        assert user.firstName is None
-        assert user.lastName is None
-        assert user.postalCode is None
-        assert user.city is None
-        assert user.idPieceNumber == "123123123"  # admin is not superadmin
+#         assert user.firstName is None
+#         assert user.lastName is None
+#         assert user.postalCode is None
+#         assert user.city is None
+#         assert user.idPieceNumber == "123123123"  # admin is not superadmin
 
-        # next step was IDENTITY_CHECK before update action clears profile
-        assert (
-            subscription_api.get_user_subscription_state(user).next_step
-            == subscription_models.SubscriptionStep.PROFILE_COMPLETION
-        )
+#         # next step was IDENTITY_CHECK before update action clears profile
+#         assert (
+#             subscription_api.get_user_subscription_state(user).next_step
+#             == subscription_models.SubscriptionStep.PROFILE_COMPLETION
+#         )
 
-    @clean_database
-    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_clear_idpiecenumber(self, mocked_validate_csrf_token, client):
-        admin = users_factories.AdminFactory(email="superadmin@example.com")
-        user = users_factories.UserFactory(
-            email="user@example.com",
-            firstName="Partner",
-            lastName="Example",
-            departementCode="06",
-            postalCode="06000",
-            city="Nice",
-            idPieceNumber="123123123",
-        )
-        client.with_session_auth(admin.email)
+#     @clean_database
+#     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_clear_idpiecenumber(self, mocked_validate_csrf_token, client):
+#         admin = users_factories.AdminFactory(email="superadmin@example.com")
+#         user = users_factories.UserFactory(
+#             email="user@example.com",
+#             firstName="Partner",
+#             lastName="Example",
+#             departementCode="06",
+#             postalCode="06000",
+#             city="Nice",
+#             idPieceNumber="123123123",
+#         )
+#         client.with_session_auth(admin.email)
 
-        client.post(
-            f"/pc/back-office/partner_users/edit/?id={user.id}",
-            form={
-                "csrf_token": "token",
-                "email": user.email,
-                "firstName": user.firstName,
-                "lastName": user.lastName,
-                "departementCode": user.departementCode,
-                "postalCode": user.postalCode,
-                "city": user.city,
-                "idPieceNumber": "",
-            },
-        )
+#         client.post(
+#             f"/pc/back-office/partner_users/edit/?id={user.id}",
+#             form={
+#                 "csrf_token": "token",
+#                 "email": user.email,
+#                 "firstName": user.firstName,
+#                 "lastName": user.lastName,
+#                 "departementCode": user.departementCode,
+#                 "postalCode": user.postalCode,
+#                 "city": user.city,
+#                 "idPieceNumber": "",
+#             },
+#         )
 
-        assert user.idPieceNumber is None
+#         assert user.idPieceNumber is None

--- a/api/tests/admin/custom_views/pro_user_view_test.py
+++ b/api/tests/admin/custom_views/pro_user_view_test.py
@@ -1,119 +1,119 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-from pcapi.admin.custom_views.pro_user_view import ProUserView
-import pcapi.core.users.factories as users_factories
-from pcapi.core.users.models import User
+# from pcapi.admin.custom_views.pro_user_view import ProUserView
+# import pcapi.core.users.factories as users_factories
+# from pcapi.core.users.models import User
 
-from tests.conftest import TestClient
-from tests.conftest import clean_database
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
 
 
-class ProUserViewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_pro_user_edition(self, mocked_validate_csrf_token, app):
-        # Given
-        admin_user = users_factories.AdminFactory()
-        pro_user = users_factories.ProFactory()
+# class ProUserViewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_pro_user_edition(self, mocked_validate_csrf_token, app):
+#         # Given
+#         admin_user = users_factories.AdminFactory()
+#         pro_user = users_factories.ProFactory()
 
-        data = dict(
-            csrf_token="token",
-            firstName=pro_user.firstName,
-            lastName=pro_user.lastName,
-            dateOfBirth="",
-            departementCode="06",
-            postalCode="06000",
-            comment="",
-            email=pro_user.email,
-            phoneNumber="0601020304",
-        )
+#         data = dict(
+#             csrf_token="token",
+#             firstName=pro_user.firstName,
+#             lastName=pro_user.lastName,
+#             dateOfBirth="",
+#             departementCode="06",
+#             postalCode="06000",
+#             comment="",
+#             email=pro_user.email,
+#             phoneNumber="0601020304",
+#         )
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth(admin_user.email)
-        response = client.post(f"/pc/back-office/pro_users/edit?id={pro_user.id}", form=data)
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth(admin_user.email)
+#         response = client.post(f"/pc/back-office/pro_users/edit?id={pro_user.id}", form=data)
 
-        # Then
-        assert response.status_code == 302
+#         # Then
+#         assert response.status_code == 302
 
-        updated_user = User.query.filter_by(email=pro_user.email).first()
-        assert updated_user.firstName == pro_user.firstName
-        assert updated_user.lastName == pro_user.lastName
-        assert updated_user.dateOfBirth is None
-        assert updated_user.departementCode == "06"
-        assert updated_user.postalCode == "06000"
-        assert updated_user.phoneNumber == "+33601020304"
+#         updated_user = User.query.filter_by(email=pro_user.email).first()
+#         assert updated_user.firstName == pro_user.firstName
+#         assert updated_user.lastName == pro_user.lastName
+#         assert updated_user.dateOfBirth is None
+#         assert updated_user.departementCode == "06"
+#         assert updated_user.postalCode == "06000"
+#         assert updated_user.phoneNumber == "+33601020304"
 
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_pro_user_edition_phone_number_error(self, mocked_validate_csrf_token, app):
-        # Given
-        admin_user = users_factories.AdminFactory()
-        pro_user = users_factories.ProFactory()
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_pro_user_edition_phone_number_error(self, mocked_validate_csrf_token, app):
+#         # Given
+#         admin_user = users_factories.AdminFactory()
+#         pro_user = users_factories.ProFactory()
 
-        data = dict(
-            csrf_token="token",
-            firstName=pro_user.firstName,
-            lastName=pro_user.lastName,
-            dateOfBirth="",
-            departementCode="06",
-            postalCode="06000",
-            comment="",
-            email=pro_user.email,
-            phoneNumber="+++123",
-        )
+#         data = dict(
+#             csrf_token="token",
+#             firstName=pro_user.firstName,
+#             lastName=pro_user.lastName,
+#             dateOfBirth="",
+#             departementCode="06",
+#             postalCode="06000",
+#             comment="",
+#             email=pro_user.email,
+#             phoneNumber="+++123",
+#         )
 
-        # When
-        client = TestClient(app.test_client()).with_session_auth(admin_user.email)
-        response = client.post(f"/pc/back-office/pro_users/edit?id={pro_user.id}", form=data)
+#         # When
+#         client = TestClient(app.test_client()).with_session_auth(admin_user.email)
+#         response = client.post(f"/pc/back-office/pro_users/edit?id={pro_user.id}", form=data)
 
-        # Then
-        assert response.status_code == 200
+#         # Then
+#         assert response.status_code == 200
 
-        assert "Numéro de téléphone invalide" in response.data.decode("utf8")
+#         assert "Numéro de téléphone invalide" in response.data.decode("utf8")
 
-        updated_user = User.query.filter_by(email=pro_user.email).first()
-        assert updated_user.departementCode == pro_user.departementCode
-        assert updated_user.postalCode == pro_user.postalCode
-        assert updated_user.phoneNumber == pro_user.phoneNumber
+#         updated_user = User.query.filter_by(email=pro_user.email).first()
+#         assert updated_user.departementCode == pro_user.departementCode
+#         assert updated_user.postalCode == pro_user.postalCode
+#         assert updated_user.phoneNumber == pro_user.phoneNumber
 
-    def test_order_by_works(self, app, db_session):
-        view = ProUserView(model=User, session=db_session)
-        view.get_list(page=1, sort_column="email", sort_desc="", search="", filters="")
+#     def test_order_by_works(self, app, db_session):
+#         view = ProUserView(model=User, session=db_session)
+#         view.get_list(page=1, sort_column="email", sort_desc="", search="", filters="")
 
-    @clean_database
-    # FIXME (dbaty, 2020-12-16): I could not find a quick way to
-    # generate a valid CSRF token in tests. This should be fixed.
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_suspend_pro(self, mocked_validate_csrf_token, app):
-        admin = users_factories.AdminFactory(email="admin15@example.com")
-        pro = users_factories.ProFactory(email="user15@example.com")
+#     @clean_database
+#     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
+#     # generate a valid CSRF token in tests. This should be fixed.
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_suspend_pro(self, mocked_validate_csrf_token, app):
+#         admin = users_factories.AdminFactory(email="admin15@example.com")
+#         pro = users_factories.ProFactory(email="user15@example.com")
 
-        client = TestClient(app.test_client()).with_session_auth(admin.email)
-        url = f"/pc/back-office/pro_users/suspend?user_id={pro.id}"
-        data = {
-            "reason": "fraud suspicion",
-            "csrf_token": "token",
-        }
-        response = client.post(url, form=data)
+#         client = TestClient(app.test_client()).with_session_auth(admin.email)
+#         url = f"/pc/back-office/pro_users/suspend?user_id={pro.id}"
+#         data = {
+#             "reason": "fraud suspicion",
+#             "csrf_token": "token",
+#         }
+#         response = client.post(url, form=data)
 
-        assert response.status_code == 302
-        assert not pro.isActive
+#         assert response.status_code == 302
+#         assert not pro.isActive
 
-    @clean_database
-    # FIXME (dbaty, 2020-12-16): I could not find a quick way to
-    # generate a valid CSRF token in tests. This should be fixed.
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_unsuspend_pro(self, mocked_validate_csrf_token, app):
-        admin = users_factories.AdminFactory(email="admin15@example.com")
-        pro = users_factories.ProFactory(email="user15@example.com", isActive=False)
+#     @clean_database
+#     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
+#     # generate a valid CSRF token in tests. This should be fixed.
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_unsuspend_pro(self, mocked_validate_csrf_token, app):
+#         admin = users_factories.AdminFactory(email="admin15@example.com")
+#         pro = users_factories.ProFactory(email="user15@example.com", isActive=False)
 
-        client = TestClient(app.test_client()).with_session_auth(admin.email)
-        url = f"/pc/back-office/pro_users/unsuspend?user_id={pro.id}"
-        data = {
-            "reason": "fraud",
-            "csrf_token": "token",
-        }
-        response = client.post(url, form=data)
+#         client = TestClient(app.test_client()).with_session_auth(admin.email)
+#         url = f"/pc/back-office/pro_users/unsuspend?user_id={pro.id}"
+#         data = {
+#             "reason": "fraud",
+#             "csrf_token": "token",
+#         }
+#         response = client.post(url, form=data)
 
-        assert response.status_code == 302
-        assert pro.isActive
+#         assert response.status_code == 302
+#         assert pro.isActive

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -1,416 +1,416 @@
-from datetime import datetime
-import logging
-from unittest.mock import patch
+# from datetime import datetime
+# import logging
+# from unittest.mock import patch
 
-from dateutil.relativedelta import relativedelta
-import freezegun
-import pytest
+# from dateutil.relativedelta import relativedelta
+# import freezegun
+# import pytest
 
-from pcapi.admin.custom_views.support_view.api import BeneficiaryActivationStatus
-from pcapi.admin.custom_views.support_view.api import get_beneficiary_activation_status
-import pcapi.core.fraud.factories as fraud_factories
-import pcapi.core.fraud.models as fraud_models
-from pcapi.core.testing import override_features
-from pcapi.core.testing import override_settings
-import pcapi.core.users.factories as users_factories
-import pcapi.core.users.models as users_models
-
-
-AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
+# from pcapi.admin.custom_views.support_view.api import BeneficiaryActivationStatus
+# from pcapi.admin.custom_views.support_view.api import get_beneficiary_activation_status
+# import pcapi.core.fraud.factories as fraud_factories
+# import pcapi.core.fraud.models as fraud_models
+# from pcapi.core.testing import override_features
+# from pcapi.core.testing import override_settings
+# import pcapi.core.users.factories as users_factories
+# import pcapi.core.users.models as users_models
 
 
-@pytest.mark.usefixtures("db_session")
-class BeneficiaryListViewTest:
-    def test_list_view(self, client):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        client.with_session_auth(admin.email)
-
-        for review_status in fraud_models.FraudReviewStatus:
-            user = users_factories.UserFactory(civility="M.")
-            fraud_factories.BeneficiaryFraudCheckFactory(user=user)
-            fraud_factories.BeneficiaryFraudReviewFactory(user=user, review=review_status)
-        response = client.get(f"/pc/back-office/support_beneficiary/?search={user.id}")
-        assert response.status_code == 200
+# AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
 
 
-@pytest.mark.usefixtures("db_session")
-class BeneficiaryDetailViewTest:
-    def test_detail_view(self, client):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        user = users_factories.UserFactory()
-        fraud_factories.BeneficiaryFraudCheckFactory(user=user)
-        client.with_session_auth(admin.email)
-        response = client.get("/pc/back-office/support_beneficiary/?id={user.id}")
-        assert response.status_code == 200
+# @pytest.mark.usefixtures("db_session")
+# class BeneficiaryListViewTest:
+#     def test_list_view(self, client):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         client.with_session_auth(admin.email)
 
-    def test_detail_view_with_new_fraud_error_reason_codes(self, client):
-        admin = users_factories.AdminFactory(email="admin@example.com")
-        user = users_factories.UserFactory()
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user,
-            reasonCodes=[
-                fraud_models.FraudReasonCode.DUPLICATE_ID_PIECE_NUMBER,
-                fraud_models.FraudReasonCode.DUPLICATE_INE,
-            ],
-        )
-        client.with_session_auth(admin.email)
-        response = client.get("/pc/back-office/support_beneficiary/?id={user.id}")
-        assert response.status_code == 200
+#         for review_status in fraud_models.FraudReviewStatus:
+#             user = users_factories.UserFactory(civility="M.")
+#             fraud_factories.BeneficiaryFraudCheckFactory(user=user)
+#             fraud_factories.BeneficiaryFraudReviewFactory(user=user, review=review_status)
+#         response = client.get(f"/pc/back-office/support_beneficiary/?search={user.id}")
+#         assert response.status_code == 200
 
 
-@pytest.mark.usefixtures("db_session")
-class BeneficiaryValidationViewTest:
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_auth_required(self, client):
-        user = users_factories.UserFactory()
-        response = client.post(f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}")
-        assert response.status_code == 302
-        assert response.headers["Location"] == "http://localhost/pc/back-office/"
+# @pytest.mark.usefixtures("db_session")
+# class BeneficiaryDetailViewTest:
+#     def test_detail_view(self, client):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         user = users_factories.UserFactory()
+#         fraud_factories.BeneficiaryFraudCheckFactory(user=user)
+#         client.with_session_auth(admin.email)
+#         response = client.get("/pc/back-office/support_beneficiary/?id={user.id}")
+#         assert response.status_code == 200
 
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_override_validation_for_fraud_check_is_ko(self, client):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
-        check = fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.DMS, status=fraud_models.FraudCheckStatus.KO
-        )
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-        )
-        assert response.status_code == 302
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).first()
-        assert review.review == fraud_models.FraudReviewStatus.OK
-        assert review.reason == "User is granted"
-        user = users_models.User.query.get(user.id)
-        assert user.has_beneficiary_role is True
-
-        dms_content = fraud_models.DMSContent(**check.resultContent)
-        assert user.firstName == dms_content.first_name
-        assert user.lastName == dms_content.last_name
-        assert user.idPieceNumber == dms_content.id_piece_number
-
-        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).first()
-        assert fraud_check.status == check.status
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_validate_user_from_dms_data_staging(self, client):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
-        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-        )
-        assert response.status_code == 302
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).first()
-        assert review.review == fraud_models.FraudReviewStatus.OK
-        assert review.reason == "User is granted"
-        user = users_models.User.query.get(user.id)
-        assert user.has_beneficiary_role is True
-        assert len(user.deposits) == 1
-
-        dms_content = fraud_models.DMSContent(**check.resultContent)
-        assert user.firstName == dms_content.first_name
-        assert user.lastName == dms_content.last_name
-        assert user.idPieceNumber == dms_content.id_piece_number
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_validate_user_from_educonnect(self, client):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
-        check = fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user,
-            type=fraud_models.FraudCheckType.EDUCONNECT,
-            eligibilityType=users_models.EligibilityType.UNDERAGE,
-        )
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-        )
-        assert response.status_code == 302
-
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
-        assert review.review == fraud_models.FraudReviewStatus.OK
-        assert review.reason == "User is granted"
-        user = users_models.User.query.get(user.id)
-        assert user.has_underage_beneficiary_role
-        assert len(user.deposits) == 1
-
-        educonnect_content = fraud_models.EduconnectContent(**check.resultContent)
-        assert user.firstName == educonnect_content.get_first_name()
-        assert user.lastName == educonnect_content.get_last_name()
-        assert user.idPieceNumber == educonnect_content.get_id_piece_number()
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_validate_user_from_ubble(self, client):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
-        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-        )
-        assert response.status_code == 302
-
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
-        assert review.review == fraud_models.FraudReviewStatus.OK
-        assert review.reason == "User is granted"
-        user = users_models.User.query.get(user.id)
-        assert user.has_beneficiary_role
-        assert len(user.deposits) == 1
-
-        ubble_content = fraud_models.UbbleContent(**check.resultContent)
-        assert user.firstName == ubble_content.get_first_name()
-        assert user.lastName == ubble_content.get_last_name()
-        assert user.idPieceNumber == ubble_content.get_id_piece_number()
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    @patch("flask.flash")
-    def test_ine_hash_duplicate(self, flash_mock, client):
-        other_user_with_same_ine = users_factories.UserFactory(ineHash="shotgun")
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user,
-            type=fraud_models.FraudCheckType.EDUCONNECT,
-            eligibilityType=users_models.EligibilityType.UNDERAGE,
-            resultContent=fraud_factories.EduconnectContentFactory(ine_hash="shotgun"),
-        )
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-        )
-        assert response.status_code == 302
-
-        assert not user.has_underage_beneficiary_role
-        assert len(user.deposits) == 0
-        flash_mock.assert_called_once_with(
-            f"Le numéro INE shotgun est déjà utilisé par l'utilisateur {other_user_with_same_ine.id}", "error"
-        )
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    @patch("flask.flash")
-    def test_id_piece_number_duplicate(self, flash_mock, client):
-        other_user_with_same_id = users_factories.UserFactory(idPieceNumber="123456")
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user,
-            type=fraud_models.FraudCheckType.DMS,
-            eligibilityType=users_models.EligibilityType.UNDERAGE,
-            resultContent=fraud_factories.DMSContentFactory(id_piece_number="123456"),
-        )
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-        )
-        assert response.status_code == 302
-
-        assert not user.has_underage_beneficiary_role
-        assert len(user.deposits) == 0
-        flash_mock.assert_called_once_with(
-            f"Le numéro de CNI 123456 est déjà utilisé par l'utilisateur {other_user_with_same_id.id}", "error"
-        )
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_validate_user_wrong_args(self, client):
-        user = users_factories.UserFactory()
-        admin = users_factories.AdminFactory()
-
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "badkey": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-        )
-        assert response.status_code == 302
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
-        assert review is None
-
-        user = users_models.User.query.get(user.id)
-        assert user.has_beneficiary_role is False
-        assert user.deposits == []
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_validate_user_already_reviewed(self, client):
-        user = users_factories.UserFactory()
-        admin = users_factories.AdminFactory()
-        expected_review = fraud_factories.BeneficiaryFraudReviewFactory(user=user, author=admin)
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
-        )
-        assert response.status_code == 302
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
-        assert review.reason == expected_review.reason
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_validate_not_super_user_fails(self, client):
-        user = users_factories.UserFactory()
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        with override_settings(IS_PROD=True):
-            response = client.post(
-                f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-                form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-            )
-        assert response.status_code == 302
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
-        assert review is None
-        assert user.has_beneficiary_role is False
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_prod_requires_super_admin(self, client):
-        user = users_factories.UserFactory()
-        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        with override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[admin.email]):
-            response = client.post(
-                f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-                form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
-            )
-        assert response.status_code == 302
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
-        assert review is not None
-        assert review.author == admin
-        assert user.has_beneficiary_role is True
-
-        ubble_content = fraud_models.UbbleContent(**check.resultContent)
-        assert user.firstName == ubble_content.get_first_name()
-        assert user.lastName == ubble_content.get_last_name()
-
-    def test_review_ko_does_not_activate_the_beneficiary(self, client):
-        user = users_factories.UserFactory()
-        fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        with override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[admin.email]):
-            response = client.post(
-                f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-                form={"user_id": user.id, "reason": "User is denied", "review": "KO", "eligibility": "Par défaut"},
-            )
-        assert response.status_code == 302
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
-        assert review is not None
-        assert review.author == admin
-        assert review.review == fraud_models.FraudReviewStatus.KO
-        assert user.has_beneficiary_role is False
-
-    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_validate_user_with_non_default_eligibility(self, client):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
-        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
-        admin = users_factories.AdminFactory()
-        client.with_session_auth(admin.email)
-
-        response = client.post(
-            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "AGE18"},
-        )
-        assert response.status_code == 302
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).first()
-        assert review.review == fraud_models.FraudReviewStatus.OK
-        assert review.reason == "User is granted"
-        user = users_models.User.query.get(user.id)
-        assert user.has_beneficiary_role is True
-        assert len(user.deposits) == 1
-
-        dms_content = fraud_models.DMSContent(**check.resultContent)
-        assert user.firstName == dms_content.first_name
-        assert user.lastName == dms_content.last_name
-        assert user.idPieceNumber == dms_content.id_piece_number
+#     def test_detail_view_with_new_fraud_error_reason_codes(self, client):
+#         admin = users_factories.AdminFactory(email="admin@example.com")
+#         user = users_factories.UserFactory()
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user,
+#             reasonCodes=[
+#                 fraud_models.FraudReasonCode.DUPLICATE_ID_PIECE_NUMBER,
+#                 fraud_models.FraudReasonCode.DUPLICATE_INE,
+#             ],
+#         )
+#         client.with_session_auth(admin.email)
+#         response = client.get("/pc/back-office/support_beneficiary/?id={user.id}")
+#         assert response.status_code == 200
 
 
-@pytest.mark.usefixtures("db_session")
-class ValidatePhoneNumberTest:
-    def test_phone_validation(self, client, caplog):
-        admin = users_factories.AdminFactory()
-        user = users_factories.UserFactory(phoneValidationStatus=None)
-        client.with_session_auth(admin.email)
-        with caplog.at_level(logging.INFO):
-            response = client.post(f"/pc/back-office/support_beneficiary/validate/beneficiary/phone_number/{user.id}")
-        assert response.status_code == 302
-        assert (
-            response.headers["Location"] == f"http://localhost/pc/back-office/support_beneficiary/details/?id={user.id}"
-        )
+# @pytest.mark.usefixtures("db_session")
+# class BeneficiaryValidationViewTest:
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_view_auth_required(self, client):
+#         user = users_factories.UserFactory()
+#         response = client.post(f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}")
+#         assert response.status_code == 302
+#         assert response.headers["Location"] == "http://localhost/pc/back-office/"
 
-        assert user.phoneValidationStatus == users_models.PhoneValidationStatusType.VALIDATED
-        assert "flask-admin: Manual phone validation" in caplog.messages
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_override_validation_for_fraud_check_is_ko(self, client):
+#         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+#         check = fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user, type=fraud_models.FraudCheckType.DMS, status=fraud_models.FraudCheckStatus.KO
+#         )
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
 
-    def should_activate_user_if_phone_validation_is_the_last_step(self, client):
-        admin = users_factories.AdminFactory()
-        user = users_factories.UserFactory(
-            phoneValidationStatus=None,
-            isEmailValidated=True,
-            dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2),
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.UBBLE, status=fraud_models.FraudCheckStatus.OK
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.PROFILE_COMPLETION, status=fraud_models.FraudCheckStatus.OK
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
-        )
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#         )
+#         assert response.status_code == 302
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).first()
+#         assert review.review == fraud_models.FraudReviewStatus.OK
+#         assert review.reason == "User is granted"
+#         user = users_models.User.query.get(user.id)
+#         assert user.has_beneficiary_role is True
 
-        client.with_session_auth(admin.email)
-        response = client.post(f"/pc/back-office/support_beneficiary/validate/beneficiary/phone_number/{user.id}")
-        assert response.status_code == 302
-        assert user.has_beneficiary_role is True
+#         dms_content = fraud_models.DMSContent(**check.resultContent)
+#         assert user.firstName == dms_content.first_name
+#         assert user.lastName == dms_content.last_name
+#         assert user.idPieceNumber == dms_content.id_piece_number
+
+#         fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).first()
+#         assert fraud_check.status == check.status
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_view_validate_user_from_dms_data_staging(self, client):
+#         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+#         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#         )
+#         assert response.status_code == 302
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).first()
+#         assert review.review == fraud_models.FraudReviewStatus.OK
+#         assert review.reason == "User is granted"
+#         user = users_models.User.query.get(user.id)
+#         assert user.has_beneficiary_role is True
+#         assert len(user.deposits) == 1
+
+#         dms_content = fraud_models.DMSContent(**check.resultContent)
+#         assert user.firstName == dms_content.first_name
+#         assert user.lastName == dms_content.last_name
+#         assert user.idPieceNumber == dms_content.id_piece_number
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_view_validate_user_from_educonnect(self, client):
+#         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
+#         check = fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user,
+#             type=fraud_models.FraudCheckType.EDUCONNECT,
+#             eligibilityType=users_models.EligibilityType.UNDERAGE,
+#         )
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#         )
+#         assert response.status_code == 302
+
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
+#         assert review.review == fraud_models.FraudReviewStatus.OK
+#         assert review.reason == "User is granted"
+#         user = users_models.User.query.get(user.id)
+#         assert user.has_underage_beneficiary_role
+#         assert len(user.deposits) == 1
+
+#         educonnect_content = fraud_models.EduconnectContent(**check.resultContent)
+#         assert user.firstName == educonnect_content.get_first_name()
+#         assert user.lastName == educonnect_content.get_last_name()
+#         assert user.idPieceNumber == educonnect_content.get_id_piece_number()
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_view_validate_user_from_ubble(self, client):
+#         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+#         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#         )
+#         assert response.status_code == 302
+
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
+#         assert review.review == fraud_models.FraudReviewStatus.OK
+#         assert review.reason == "User is granted"
+#         user = users_models.User.query.get(user.id)
+#         assert user.has_beneficiary_role
+#         assert len(user.deposits) == 1
+
+#         ubble_content = fraud_models.UbbleContent(**check.resultContent)
+#         assert user.firstName == ubble_content.get_first_name()
+#         assert user.lastName == ubble_content.get_last_name()
+#         assert user.idPieceNumber == ubble_content.get_id_piece_number()
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     @patch("flask.flash")
+#     def test_ine_hash_duplicate(self, flash_mock, client):
+#         other_user_with_same_ine = users_factories.UserFactory(ineHash="shotgun")
+#         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user,
+#             type=fraud_models.FraudCheckType.EDUCONNECT,
+#             eligibilityType=users_models.EligibilityType.UNDERAGE,
+#             resultContent=fraud_factories.EduconnectContentFactory(ine_hash="shotgun"),
+#         )
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#         )
+#         assert response.status_code == 302
+
+#         assert not user.has_underage_beneficiary_role
+#         assert len(user.deposits) == 0
+#         flash_mock.assert_called_once_with(
+#             f"Le numéro INE shotgun est déjà utilisé par l'utilisateur {other_user_with_same_ine.id}", "error"
+#         )
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     @patch("flask.flash")
+#     def test_id_piece_number_duplicate(self, flash_mock, client):
+#         other_user_with_same_id = users_factories.UserFactory(idPieceNumber="123456")
+#         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user,
+#             type=fraud_models.FraudCheckType.DMS,
+#             eligibilityType=users_models.EligibilityType.UNDERAGE,
+#             resultContent=fraud_factories.DMSContentFactory(id_piece_number="123456"),
+#         )
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#         )
+#         assert response.status_code == 302
+
+#         assert not user.has_underage_beneficiary_role
+#         assert len(user.deposits) == 0
+#         flash_mock.assert_called_once_with(
+#             f"Le numéro de CNI 123456 est déjà utilisé par l'utilisateur {other_user_with_same_id.id}", "error"
+#         )
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_view_validate_user_wrong_args(self, client):
+#         user = users_factories.UserFactory()
+#         admin = users_factories.AdminFactory()
+
+#         client.with_session_auth(admin.email)
+
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "badkey": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#         )
+#         assert response.status_code == 302
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
+#         assert review is None
+
+#         user = users_models.User.query.get(user.id)
+#         assert user.has_beneficiary_role is False
+#         assert user.deposits == []
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_view_validate_user_already_reviewed(self, client):
+#         user = users_factories.UserFactory()
+#         admin = users_factories.AdminFactory()
+#         expected_review = fraud_factories.BeneficiaryFraudReviewFactory(user=user, author=admin)
+#         client.with_session_auth(admin.email)
+
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+#         )
+#         assert response.status_code == 302
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
+#         assert review.reason == expected_review.reason
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_view_validate_not_super_user_fails(self, client):
+#         user = users_factories.UserFactory()
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         with override_settings(IS_PROD=True):
+#             response = client.post(
+#                 f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#                 form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#             )
+#         assert response.status_code == 302
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
+#         assert review is None
+#         assert user.has_beneficiary_role is False
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_prod_requires_super_admin(self, client):
+#         user = users_factories.UserFactory()
+#         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         with override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[admin.email]):
+#             response = client.post(
+#                 f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#                 form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
+#             )
+#         assert response.status_code == 302
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
+#         assert review is not None
+#         assert review.author == admin
+#         assert user.has_beneficiary_role is True
+
+#         ubble_content = fraud_models.UbbleContent(**check.resultContent)
+#         assert user.firstName == ubble_content.get_first_name()
+#         assert user.lastName == ubble_content.get_last_name()
+
+#     def test_review_ko_does_not_activate_the_beneficiary(self, client):
+#         user = users_factories.UserFactory()
+#         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         with override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[admin.email]):
+#             response = client.post(
+#                 f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#                 form={"user_id": user.id, "reason": "User is denied", "review": "KO", "eligibility": "Par défaut"},
+#             )
+#         assert response.status_code == 302
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
+#         assert review is not None
+#         assert review.author == admin
+#         assert review.review == fraud_models.FraudReviewStatus.KO
+#         assert user.has_beneficiary_role is False
+
+#     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+#     def test_validation_view_validate_user_with_non_default_eligibility(self, client):
+#         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+#         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
+#         admin = users_factories.AdminFactory()
+#         client.with_session_auth(admin.email)
+
+#         response = client.post(
+#             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+#             form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "AGE18"},
+#         )
+#         assert response.status_code == 302
+#         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).first()
+#         assert review.review == fraud_models.FraudReviewStatus.OK
+#         assert review.reason == "User is granted"
+#         user = users_models.User.query.get(user.id)
+#         assert user.has_beneficiary_role is True
+#         assert len(user.deposits) == 1
+
+#         dms_content = fraud_models.DMSContent(**check.resultContent)
+#         assert user.firstName == dms_content.first_name
+#         assert user.lastName == dms_content.last_name
+#         assert user.idPieceNumber == dms_content.id_piece_number
 
 
-@pytest.mark.usefixtures("db_session")
-class BeneficiaryActivationStatusTest:
-    def test_not_eligible(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=25))
-        assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.NOT_APPLICABLE
+# @pytest.mark.usefixtures("db_session")
+# class ValidatePhoneNumberTest:
+#     def test_phone_validation(self, client, caplog):
+#         admin = users_factories.AdminFactory()
+#         user = users_factories.UserFactory(phoneValidationStatus=None)
+#         client.with_session_auth(admin.email)
+#         with caplog.at_level(logging.INFO):
+#             response = client.post(f"/pc/back-office/support_beneficiary/validate/beneficiary/phone_number/{user.id}")
+#         assert response.status_code == 302
+#         assert (
+#             response.headers["Location"] == f"http://localhost/pc/back-office/support_beneficiary/details/?id={user.id}"
+#         )
 
-    def test_beneficiary(self):
-        user = users_factories.BeneficiaryGrant18Factory()
-        # even if there was a passed fraud_check ko
-        fraud_factories.BeneficiaryFraudCheckFactory(user=user, status=fraud_models.FraudCheckStatus.KO)
-        assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.OK
+#         assert user.phoneValidationStatus == users_models.PhoneValidationStatusType.VALIDATED
+#         assert "flask-admin: Manual phone validation" in caplog.messages
 
-    def test_ex_underage(self):
-        with freezegun.freeze_time(datetime.utcnow() - relativedelta(years=3)):
-            user = users_factories.UnderageBeneficiaryFactory(
-                dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=5),
-            )
-        assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.INCOMPLETE
+#     def should_activate_user_if_phone_validation_is_the_last_step(self, client):
+#         admin = users_factories.AdminFactory()
+#         user = users_factories.UserFactory(
+#             phoneValidationStatus=None,
+#             isEmailValidated=True,
+#             dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2),
+#         )
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user, type=fraud_models.FraudCheckType.UBBLE, status=fraud_models.FraudCheckStatus.OK
+#         )
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user, type=fraud_models.FraudCheckType.PROFILE_COMPLETION, status=fraud_models.FraudCheckStatus.OK
+#         )
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+#         )
 
-    def test_ex_underage_with_some_fraud_check_ko(self):
-        with freezegun.freeze_time(datetime.utcnow() - relativedelta(years=3)):
-            user = users_factories.UnderageBeneficiaryFactory(
-                dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=5),
-                phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.PROFILE_COMPLETION, status=fraud_models.FraudCheckStatus.OK
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.UBBLE, status=fraud_models.FraudCheckStatus.KO
-        )
-        assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.KO
+#         client.with_session_auth(admin.email)
+#         response = client.post(f"/pc/back-office/support_beneficiary/validate/beneficiary/phone_number/{user.id}")
+#         assert response.status_code == 302
+#         assert user.has_beneficiary_role is True
+
+
+# @pytest.mark.usefixtures("db_session")
+# class BeneficiaryActivationStatusTest:
+#     def test_not_eligible(self):
+#         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=25))
+#         assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.NOT_APPLICABLE
+
+#     def test_beneficiary(self):
+#         user = users_factories.BeneficiaryGrant18Factory()
+#         # even if there was a passed fraud_check ko
+#         fraud_factories.BeneficiaryFraudCheckFactory(user=user, status=fraud_models.FraudCheckStatus.KO)
+#         assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.OK
+
+#     def test_ex_underage(self):
+#         with freezegun.freeze_time(datetime.utcnow() - relativedelta(years=3)):
+#             user = users_factories.UnderageBeneficiaryFactory(
+#                 dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=5),
+#             )
+#         assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.INCOMPLETE
+
+#     def test_ex_underage_with_some_fraud_check_ko(self):
+#         with freezegun.freeze_time(datetime.utcnow() - relativedelta(years=3)):
+#             user = users_factories.UnderageBeneficiaryFactory(
+#                 dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=5),
+#                 phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+#             )
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user, type=fraud_models.FraudCheckType.PROFILE_COMPLETION, status=fraud_models.FraudCheckStatus.OK
+#         )
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+#         )
+#         fraud_factories.BeneficiaryFraudCheckFactory(
+#             user=user, type=fraud_models.FraudCheckType.UBBLE, status=fraud_models.FraudCheckStatus.KO
+#         )
+#         assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.KO

--- a/api/tests/admin/custom_views/suspend_fraudulent_users_by_ids_test.py
+++ b/api/tests/admin/custom_views/suspend_fraudulent_users_by_ids_test.py
@@ -1,32 +1,32 @@
-import io
-from unittest.mock import patch
+# import io
+# from unittest.mock import patch
 
-import pytest
+# import pytest
 
-from pcapi.core.bookings import factories as booking_factories
-from pcapi.core.users.factories import AdminFactory
-from pcapi.core.users.factories import BeneficiaryGrant18Factory
+# from pcapi.core.bookings import factories as booking_factories
+# from pcapi.core.users.factories import AdminFactory
+# from pcapi.core.users.factories import BeneficiaryGrant18Factory
 
 
-@pytest.mark.usefixtures("db_session")
-class SuspendFraudulentUsersByIdsTest:
-    @patch(
-        "pcapi.admin.custom_views.suspend_fraudulent_users_by_ids.suspend_fraudulent_beneficiary_users_by_ids_job.delay"
-    )
-    def test_suspend_users_by_ids(self, mocked_suspend_fraudulent_beneficiary_users_by_ids_job, client):
-        admin_user = AdminFactory(email="admin@example.com")
-        fraudulent_user_1 = BeneficiaryGrant18Factory(id=5)
-        fraudulent_user_2 = BeneficiaryGrant18Factory(id=16)
-        booking_factories.BookingFactory(user=fraudulent_user_1)
-        booking_factories.UsedBookingFactory(user=fraudulent_user_2)
-        user_ids_csv = (io.BytesIO(b"user_id\n5\n16"), "user_ids.csv")
-        files = {"user_ids_csv": user_ids_csv}
-        headers = {"content-type": "multipart/form-data"}
+# @pytest.mark.usefixtures("db_session")
+# class SuspendFraudulentUsersByIdsTest:
+#     @patch(
+#         "pcapi.admin.custom_views.suspend_fraudulent_users_by_ids.suspend_fraudulent_beneficiary_users_by_ids_job.delay"
+#     )
+#     def test_suspend_users_by_ids(self, mocked_suspend_fraudulent_beneficiary_users_by_ids_job, client):
+#         admin_user = AdminFactory(email="admin@example.com")
+#         fraudulent_user_1 = BeneficiaryGrant18Factory(id=5)
+#         fraudulent_user_2 = BeneficiaryGrant18Factory(id=16)
+#         booking_factories.BookingFactory(user=fraudulent_user_1)
+#         booking_factories.UsedBookingFactory(user=fraudulent_user_2)
+#         user_ids_csv = (io.BytesIO(b"user_id\n5\n16"), "user_ids.csv")
+#         files = {"user_ids_csv": user_ids_csv}
+#         headers = {"content-type": "multipart/form-data"}
 
-        client = client.with_session_auth(admin_user.email)
-        response = client.post("/pc/back-office/suspend_fraud_users_by_user_ids", files=files, headers=headers)
+#         client = client.with_session_auth(admin_user.email)
+#         response = client.post("/pc/back-office/suspend_fraud_users_by_user_ids", files=files, headers=headers)
 
-        mocked_suspend_fraudulent_beneficiary_users_by_ids_job.assert_called_once_with([5, 16], admin_user)
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert "La suspension des utilisateurs via ids a bien été lancée" in content
+#         mocked_suspend_fraudulent_beneficiary_users_by_ids_job.assert_called_once_with([5, 16], admin_user)
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert "La suspension des utilisateurs via ids a bien été lancée" in content

--- a/api/tests/admin/custom_views/user_email_history_view_test.py
+++ b/api/tests/admin/custom_views/user_email_history_view_test.py
@@ -1,97 +1,97 @@
-from flask import url_for
-import pytest
+# from flask import url_for
+# import pytest
 
-from pcapi.core.testing import assert_model_count_delta
-from pcapi.core.testing import override_settings
-import pcapi.core.users.factories as users_factories
-import pcapi.core.users.models as users_models
-
-
-@pytest.fixture(name="admin_client", scope="function")
-def admin_client_fixture(client):
-    users_factories.AdminFactory(email="admin@example.com")
-    return client.with_session_auth("admin@example.com")
+# from pcapi.core.testing import assert_model_count_delta
+# from pcapi.core.testing import override_settings
+# import pcapi.core.users.factories as users_factories
+# import pcapi.core.users.models as users_models
 
 
-VALIDATE_EMAIL_PATH = "user_email_history.validate_user_email"
-INDEX_PATH = "user_email_history.index_view"
-BENEFICIARY_DETAILS_PATH = "support_beneficiary.details_view"
+# @pytest.fixture(name="admin_client", scope="function")
+# def admin_client_fixture(client):
+#     users_factories.AdminFactory(email="admin@example.com")
+#     return client.with_session_auth("admin@example.com")
 
 
-@pytest.mark.usefixtures("db_session")
-class UserEmailHistoryViewTest:
-    def test_admin_validation(self, admin_client):
-        user = users_factories.BeneficiaryGrant18Factory()
-        entry = users_factories.EmailUpdateEntryFactory(user=user)
+# VALIDATE_EMAIL_PATH = "user_email_history.validate_user_email"
+# INDEX_PATH = "user_email_history.index_view"
+# BENEFICIARY_DETAILS_PATH = "support_beneficiary.details_view"
 
-        with assert_model_count_delta(users_models.UserEmailHistory, 1):
-            url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id)
-            response = admin_client.post(url)
 
-            assert response.status_code == 302
-            assert response.location == url_for(INDEX_PATH, _external=True)
+# @pytest.mark.usefixtures("db_session")
+# class UserEmailHistoryViewTest:
+#     def test_admin_validation(self, admin_client):
+#         user = users_factories.BeneficiaryGrant18Factory()
+#         entry = users_factories.EmailUpdateEntryFactory(user=user)
 
-    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
-    def test_only_super_admins_can_validate(self, admin_client):
-        """
-        Test that a regular admin cannot validate a user's new email
-        address.
+#         with assert_model_count_delta(users_models.UserEmailHistory, 1):
+#             url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id)
+#             response = admin_client.post(url)
 
-        Note: outside of production env, all admins are super admins.
-        """
-        user = users_factories.BeneficiaryGrant18Factory()
-        entry = users_factories.EmailUpdateEntryFactory(user=user)
+#             assert response.status_code == 302
+#             assert response.location == url_for(INDEX_PATH, _external=True)
 
-        with assert_model_count_delta(users_models.UserEmailHistory, 0):
-            url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id)
-            response = admin_client.post(url)
+#     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
+#     def test_only_super_admins_can_validate(self, admin_client):
+#         """
+#         Test that a regular admin cannot validate a user's new email
+#         address.
 
-            assert response.status_code == 302
-            assert response.location == url_for(INDEX_PATH, _external=True)
+#         Note: outside of production env, all admins are super admins.
+#         """
+#         user = users_factories.BeneficiaryGrant18Factory()
+#         entry = users_factories.EmailUpdateEntryFactory(user=user)
 
-    @pytest.mark.parametrize(
-        "validation_factory",
-        [
-            users_factories.EmailValidationEntryFactory,
-            users_factories.EmailAdminValidationEntryFactory,
-        ],
-    )
-    def test_already_validated(self, admin_client, validation_factory):
-        user = users_factories.BeneficiaryGrant18Factory()
-        update_entry = users_factories.EmailUpdateEntryFactory(user=user)
-        validation_factory(user=user)
+#         with assert_model_count_delta(users_models.UserEmailHistory, 0):
+#             url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id)
+#             response = admin_client.post(url)
 
-        with assert_model_count_delta(users_models.UserEmailHistory, 0):
-            url = url_for(VALIDATE_EMAIL_PATH, entry_id=update_entry.id)
-            response = admin_client.post(url)
+#             assert response.status_code == 302
+#             assert response.location == url_for(INDEX_PATH, _external=True)
 
-            assert response.status_code == 302
-            assert response.location == url_for(INDEX_PATH, _external=True)
+#     @pytest.mark.parametrize(
+#         "validation_factory",
+#         [
+#             users_factories.EmailValidationEntryFactory,
+#             users_factories.EmailAdminValidationEntryFactory,
+#         ],
+#     )
+#     def test_already_validated(self, admin_client, validation_factory):
+#         user = users_factories.BeneficiaryGrant18Factory()
+#         update_entry = users_factories.EmailUpdateEntryFactory(user=user)
+#         validation_factory(user=user)
 
-    def test_next_url(self, admin_client):
-        """
-        Test that the expected redirect happens when valid query
-        parameters are passed.
-        """
-        user = users_factories.BeneficiaryGrant18Factory()
-        entry = users_factories.EmailUpdateEntryFactory(user=user)
+#         with assert_model_count_delta(users_models.UserEmailHistory, 0):
+#             url = url_for(VALIDATE_EMAIL_PATH, entry_id=update_entry.id)
+#             response = admin_client.post(url)
 
-        url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id, next=BENEFICIARY_DETAILS_PATH, id=user.id)
-        response = admin_client.post(url)
+#             assert response.status_code == 302
+#             assert response.location == url_for(INDEX_PATH, _external=True)
 
-        assert response.status_code == 302
-        assert response.location == url_for(BENEFICIARY_DETAILS_PATH, id=user.id, _external=True)
+#     def test_next_url(self, admin_client):
+#         """
+#         Test that the expected redirect happens when valid query
+#         parameters are passed.
+#         """
+#         user = users_factories.BeneficiaryGrant18Factory()
+#         entry = users_factories.EmailUpdateEntryFactory(user=user)
 
-    def test_next_url_broken(self, admin_client):
-        """
-        Test that the default redirect is used when the query parameters
-        are not valid.
-        """
-        user = users_factories.BeneficiaryGrant18Factory()
-        entry = users_factories.EmailUpdateEntryFactory(user=user)
+#         url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id, next=BENEFICIARY_DETAILS_PATH, id=user.id)
+#         response = admin_client.post(url)
 
-        url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id, next="nope")
-        response = admin_client.post(url)
+#         assert response.status_code == 302
+#         assert response.location == url_for(BENEFICIARY_DETAILS_PATH, id=user.id, _external=True)
 
-        assert response.status_code == 302
-        assert response.location == url_for(INDEX_PATH, _external=True)
+#     def test_next_url_broken(self, admin_client):
+#         """
+#         Test that the default redirect is used when the query parameters
+#         are not valid.
+#         """
+#         user = users_factories.BeneficiaryGrant18Factory()
+#         entry = users_factories.EmailUpdateEntryFactory(user=user)
+
+#         url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id, next="nope")
+#         response = admin_client.post(url)
+
+#         assert response.status_code == 302
+#         assert response.location == url_for(INDEX_PATH, _external=True)

--- a/api/tests/admin/custom_views/user_offerer_view_test.py
+++ b/api/tests/admin/custom_views/user_offerer_view_test.py
@@ -1,29 +1,29 @@
-from unittest.mock import patch
+# from unittest.mock import patch
 
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.offerers.models as offerers_models
-import pcapi.core.users.factories as users_factories
-import pcapi.core.users.models as users_models
+# import pcapi.core.offerers.factories as offerers_factories
+# import pcapi.core.offerers.models as offerers_models
+# import pcapi.core.users.factories as users_factories
+# import pcapi.core.users.models as users_models
 
-from tests.conftest import clean_database
+# from tests.conftest import clean_database
 
 
-class UserOffererViewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_user_offerer(self, mocked_validate_csrf_token, client):
-        users_factories.AdminFactory(email="admin@example.com")
+# class UserOffererViewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_user_offerer(self, mocked_validate_csrf_token, client):
+#         users_factories.AdminFactory(email="admin@example.com")
 
-        user_offerer = offerers_factories.UserOffererFactory()
+#         user_offerer = offerers_factories.UserOffererFactory()
 
-        api_client = client.with_session_auth("admin@example.com")
+#         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post(
-            "/pc/back-office/userofferer/delete/",
-            form={"id": f"{user_offerer.id},{user_offerer.userId},{user_offerer.offererId}"},
-        )
+#         response = api_client.post(
+#             "/pc/back-office/userofferer/delete/",
+#             form={"id": f"{user_offerer.id},{user_offerer.userId},{user_offerer.offererId}"},
+#         )
 
-        assert response.status_code == 302
-        assert offerers_models.UserOfferer.query.count() == 0
-        assert users_models.User.query.count() == 2
-        assert offerers_models.Offerer.query.count() == 1
+#         assert response.status_code == 302
+#         assert offerers_models.UserOfferer.query.count() == 0
+#         assert users_models.User.query.count() == 2
+#         assert offerers_models.Offerer.query.count() == 1

--- a/api/tests/admin/custom_views/venue_view_test.py
+++ b/api/tests/admin/custom_views/venue_view_test.py
@@ -1,742 +1,742 @@
-from dataclasses import asdict
-import logging
-import re
-from unittest.mock import patch
-
-from flask import url_for
-import pytest
-
-from pcapi.admin.custom_views.venue_view import _format_venue_provider
-from pcapi.connectors import sirene
-from pcapi.core.bookings.factories import BookingFactory
-from pcapi.core.bookings.models import BookingStatus
-import pcapi.core.criteria.factories as criteria_factories
-import pcapi.core.mails.testing as mails_testing
-from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
-import pcapi.core.offerers.factories as offerers_factories
-from pcapi.core.offerers.models import Venue
-import pcapi.core.offers.factories as offers_factories
-import pcapi.core.offers.models as offers_models
-import pcapi.core.providers.factories as providers_factories
-from pcapi.core.users.factories import AdminFactory
-import pcapi.core.users.testing as external_testing
-from pcapi.utils.urls import build_pc_pro_venue_link
-
-from tests.conftest import TestClient
-from tests.conftest import clean_database
-
-
-def base_form_data(venue: Venue) -> dict:
-    return dict(
-        name=venue.name,
-        siret=venue.siret,
-        city=venue.city,
-        postalCode=venue.postalCode,
-        address=venue.address,
-        publicName=venue.publicName,
-        latitude=venue.latitude,
-        longitude=venue.longitude,
-        isPermanent=venue.isPermanent,
-        adageId=venue.adageId,
-    )
-
-
-class EditVenueTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    def test_add_siret_to_venue_without_pricing_point(
-        self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
-    ):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueWithoutSiretFactory()
-        data = base_form_data(venue) | dict(siret="88888888888888", comment=None)
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        with caplog.at_level(logging.INFO):
-            response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 302
-        venue_edited = Venue.query.get(venue.id)
-        assert venue_edited.siret == "88888888888888"
-        assert venue_edited.current_pricing_point_id == venue_edited.id
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-        # A log from after_model_change() is written first
-        assert caplog.records[1].message == "[ADMIN] The SIRET of a Venue has been modified"
-        assert caplog.records[1].extra == {
-            "venue_id": venue.id,
-            "previous_siret": None,
-            "new_siret": "88888888888888",
-            "user_email": "user@example.com",
-        }
-
-        assert len(venue.action_history) == 1
-        update_snapshot = venue.action_history[0].extraData["modified_info"]
-        assert update_snapshot["siret"]["new_info"] == "88888888888888"
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    def test_edit_siret_with_self_pricing_point(
-        self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
-    ):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(siret="12345678901234", pricing_point="self")
-        data = base_form_data(venue) | dict(siret="88888888888888")
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        with caplog.at_level(logging.INFO):
-            response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 302
-        venue_edited = Venue.query.get(venue.id)
-        assert venue_edited.siret == "88888888888888"
-        assert venue_edited.current_pricing_point_id == venue_edited.id
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-        # A log from after_model_change() is written first
-        assert caplog.records[1].message == "[ADMIN] The SIRET of a Venue has been modified"
-        assert caplog.records[1].extra == {
-            "venue_id": venue.id,
-            "previous_siret": "12345678901234",
-            "new_siret": "88888888888888",
-            "user_email": "user@example.com",
-        }
-
-        assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.SireneApiException)
-    def test_unavailable_sirene_api_warning(
-        self, _mocked_sirene_get_siret, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
-    ):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueWithoutSiretFactory()
-        data = base_form_data(venue) | dict(siret="88888888888888", comment=None)
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        with caplog.at_level(logging.INFO):
-            response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data, follow_redirects=True)
-
-        assert response.history[0].status_code == 302
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert "Ce SIRET n&#39;a pas pu être vérifié, mais la modification a néanmoins été effectuée" in content
-        venue_edited = Venue.query.get(venue.id)
-        assert venue_edited.siret == "88888888888888"
-        assert venue_edited.current_pricing_point_id == venue_edited.id
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-        # A log from after_model_change() is written first
-        assert caplog.records[1].message == "[ADMIN] The SIRET of a Venue has been modified"
-        assert caplog.records[1].extra == {
-            "venue_id": venue.id,
-            "previous_siret": None,
-            "new_siret": "88888888888888",
-            "user_email": "user@example.com",
-        }
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    def test_cannot_remove_siret(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(siret="12345678901234")
-        data = base_form_data(venue) | dict(siret="")
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert "Le champ SIRET ne peut pas être vide si ce lieu avait déjà un SIRET." in content
-        refreshed_venue = Venue.query.get(venue.id)
-        assert refreshed_venue.siret == "12345678901234"
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-        assert len(external_testing.zendesk_sell_requests) == 0
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    def test_cannot_set_not_all_digits_siret(
-        self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
-    ):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(siret="12345678901234")
-
-        data = base_form_data(venue) | dict(siret="123456780ABCD")
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert "Le SIRET doit être une série d&#39;exactement 14 chiffres." in content
-        refreshed_venue = Venue.query.get(venue.id)
-        assert refreshed_venue.siret == "12345678901234"
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    def test_cannot_use_inactive_siret(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(siret="12345678901234")
-
-        data = base_form_data(venue) | dict(siret="22222222222222")
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        with patch("pcapi.connectors.sirene.get_siret") as mock_get_siret:
-            mock_get_siret.return_value.active = False
-            response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert "Ce SIRET n&#39;est plus actif, on ne peut pas l&#39;attribuer à ce lieu" in content
-        venue_edited = Venue.query.get(venue.id)
-        assert venue_edited.siret == "12345678901234"
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    def test_cannot_set_already_used_siret(
-        self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
-    ):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(siret="12345678901234")
-        offerers_factories.VenueFactory(siret="22222222222222")
-
-        data = base_form_data(venue) | dict(siret="22222222222222")
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(
-            f"/pc/back-office/venue/edit/?id={venue.id}",
-            form=data,
-        )
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        # This is returned by the FA Unique validator
-        assert "Already exists." in content
-        refreshed_venue = Venue.query.get(venue.id)
-        assert refreshed_venue.siret == "12345678901234"
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    def test_cannot_add_siret_if_exisiting_pricing_point(
-        self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
-    ):
-        AdminFactory(email="user@example.com")
-        offerer = offerers_factories.OffererFactory()
-        pricing_point = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
-        venue = offerers_factories.VenueWithoutSiretFactory(managingOfferer=offerer, pricing_point=pricing_point)
-
-        data = base_form_data(venue) | dict(siret="22222222222222")
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 200
-        content = response.data.decode(response.charset)
-        assert "Ce lieu a déjà un point de valorisation" in content
-        refreshed_venue = Venue.query.get(venue.id)
-        assert refreshed_venue.siret is None
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-
-        assert len(external_testing.zendesk_sell_requests) == 0
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_update_venue_other_offer_id_at_provider(self, mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(siret="22222222222222")
-        id_at_providers = "id_at_provider_ne_contenant_pas_le_siret"
-        stock = offers_factories.StockFactory(
-            offer__venue=venue, idAtProviders=id_at_providers, offer__idAtProvider=id_at_providers
-        )
-
-        data = dict(
-            name=venue.name,
-            siret="88888888888888",
-            city=venue.city,
-            postalCode=venue.postalCode,
-            address=venue.address,
-            publicName=venue.publicName,
-            latitude=venue.latitude,
-            longitude=venue.longitude,
-            isPermanent=venue.isPermanent,
-            adageId=venue.adageId,
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 302
-
-        venue_edited = Venue.query.get(venue.id)
-        stock = offers_models.Stock.query.get(stock.id)
-        offer = offers_models.Offer.query.get(stock.offer.id)
-
-        assert venue_edited.siret == "88888888888888"
-        assert stock.idAtProviders == "id_at_provider_ne_contenant_pas_le_siret"
-        assert offer.idAtProvider == "id_at_provider_ne_contenant_pas_le_siret"
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_update_venue_without_siret(self, mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueWithoutSiretFactory()
-
-        data = dict(
-            name=venue.name,
-            siret="88888888888888",
-            city=venue.city,
-            postalCode=venue.postalCode,
-            address=venue.address,
-            publicName=venue.publicName,
-            latitude=venue.latitude,
-            longitude=venue.longitude,
-            isPermanent=venue.isPermanent,
-            adageId=venue.adageId,
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 302
-
-        assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    def test_update_venue_reindex_all(self, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(isPermanent=False)
-
-        new_name = venue.name + "(updated)"
-        data = dict(
-            name=new_name,
-            siret=venue.siret,
-            city=venue.city,
-            postalCode=venue.postalCode,
-            address=venue.address,
-            publicName=venue.publicName,
-            latitude="42.01",
-            longitude=venue.longitude,
-            isPermanent=True,
-            adageId=venue.adageId,
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 302
-
-        venue = Venue.query.get(venue.id)
-        assert venue.isPermanent
-        assert venue.name == new_name
-
-        mocked_async_index_offers_of_venue_ids.assert_called_once_with([venue.id])
-
-        assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    @patch("pcapi.core.search.async_index_venue_ids")
-    def test_update_venue_reindex_venue_only(
-        self, mocked_async_index_venue_ids, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app
-    ):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(isPermanent=False)
-
-        data = dict(
-            name=venue.name,
-            siret=venue.siret,
-            city=venue.city,
-            postalCode=venue.postalCode,
-            address=venue.address,
-            publicName=venue.publicName,
-            latitude=venue.latitude,
-            longitude=venue.longitude,
-            isPermanent=True,
-            adageId=venue.adageId,
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 302
-
-        venue = Venue.query.get(venue.id)
-        assert venue.isPermanent
-
-        mocked_async_index_venue_ids.assert_called_once_with([venue.id])
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-
-        assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_offers_of_venue_ids")
-    @patch("pcapi.core.search.async_index_venue_ids")
-    @patch("pcapi.core.search.reindex_venue_ids")
-    def test_reindex_when_tags_updated(
-        self,
-        mocked_reindex_venue_ids,
-        mocked_async_index_venue_ids,
-        mocked_async_index_offers_of_venue_ids,
-        mocked_validate_csrf_token,
-        client,
-    ):
-        admin = AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(isPermanent=True)
-        tag = criteria_factories.CriterionFactory()
-        data = {
-            "criteria": [tag.id],
-            "name": venue.name,
-            "siret": venue.siret,
-            "city": venue.city,
-            "postalCode": venue.postalCode,
-            "address": venue.address,
-            "publicName": venue.publicName,
-            "latitude": venue.latitude,
-            "longitude": venue.longitude,
-            "isPermanent": True,
-            "adageId": venue.adageId,
-        }
-
-        client = client.with_session_auth(admin.email)
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 302
-
-        mocked_reindex_venue_ids.assert_called_once_with([venue.id])
-        mocked_async_index_venue_ids.assert_not_called()
-        mocked_async_index_offers_of_venue_ids.assert_not_called()
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_venue_user_receives_permanent_venue_email(self, mocked_validate_csrf_token, app):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(isPermanent=False)
-
-        data = dict(
-            name=venue.name,
-            siret=venue.siret,
-            city=venue.city,
-            postalCode=venue.postalCode,
-            address=venue.address,
-            publicName=venue.publicName,
-            latitude=venue.latitude,
-            longitude=venue.longitude,
-            isPermanent=True,
-            adageId=venue.adageId,
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        assert response.status_code == 302
-
-        venue = Venue.query.get(venue.id)
-        assert venue.isPermanent
-        assert len(mails_testing.outbox) == 1
-        assert mails_testing.outbox[0].sent_data["params"] == {
-            "VENUE_FORM_URL": build_pc_pro_venue_link(venue),
-            "VENUE_NAME": venue.publicName or venue.name,
-        }
-        assert mails_testing.outbox[0].sent_data["template"] == asdict(TransactionalEmail.VENUE_NEEDS_PICTURE.value)
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @pytest.mark.parametrize("prev_is_permanent, new_is_permanent", [(True, True), (False, False), (True, False)])
-    def test_venue_user_does_not_receives_permanent_venue_email_if_disabled_or_not_changed(
-        self, mocked_validate_csrf_token, app, prev_is_permanent, new_is_permanent
-    ):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(isPermanent=prev_is_permanent)
-
-        data = dict(
-            name=venue.name,
-            siret=venue.siret,
-            city=venue.city,
-            postalCode=venue.postalCode,
-            address=venue.address,
-            publicName=venue.publicName,
-            latitude=venue.latitude,
-            longitude=venue.longitude,
-            adageId=venue.adageId,
-        )
-
-        if new_is_permanent:
-            data["isPermanent"] = new_is_permanent
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        venue = Venue.query.get(venue.id)
-        assert venue.isPermanent is new_is_permanent
-
-        assert response.status_code == 302
-
-        assert not mails_testing.outbox
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @pytest.mark.parametrize("booking_email_value", [None, ""])
-    def test_venue_user_does_not_receives_permanent_without_booking_email(
-        self, mocked_validate_csrf_token, app, booking_email_value
-    ):
-        AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(isPermanent=False, bookingEmail=None)
-
-        data = dict(
-            name=venue.name,
-            siret=venue.siret,
-            city=venue.city,
-            postalCode=venue.postalCode,
-            address=venue.address,
-            publicName=venue.publicName,
-            latitude=venue.latitude,
-            longitude=venue.longitude,
-            adageId=venue.adageId,
-            isPermanent=True,
-        )
-
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
-
-        venue = Venue.query.get(venue.id)
-
-        assert response.status_code == 302
-
-        assert not mails_testing.outbox
-
-
-class DeleteVenueTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_venue(self, mocked_validate_csrf_token, client):
-        admin = AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory(bookingEmail="booking@example.com")
-        user_offerer1 = offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
-        user_offerer2 = offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
-
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            "/pc/back-office/venue/delete/", form={"id": venue.id, "url": "/pc/back-office/venue/"}
-        )
-
-        assert response.status_code == 302
-        assert len(Venue.query.all()) == 0
-        assert len(external_testing.sendinblue_requests) == 3
-        assert {req["email"] for req in external_testing.sendinblue_requests} == {
-            user_offerer1.user.email,
-            user_offerer2.user.email,
-            "booking@example.com",
-        }
-
-    @pytest.mark.parametrize(
-        "booking_status",
-        [
-            BookingStatus.USED,
-            BookingStatus.CONFIRMED,
-            BookingStatus.CANCELLED,
-            BookingStatus.REIMBURSED,
-        ],
-    )
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_venue_rejected(self, mocked_validate_csrf_token, client, booking_status):
-        admin = AdminFactory(email="user@example.com")
-        venue = offerers_factories.VenueFactory()
-        offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
-        BookingFactory(stock__offer__venue=venue, status=booking_status)
-
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            "/pc/back-office/venue/delete/", form={"id": venue.id, "url": "/pc/back-office/venue/"}
-        )
-
-        assert response.status_code == 302
-
-        list_response = api_client.get(response.headers["location"])
-        assert "Impossible d&#39;effacer un lieu pour lequel il existe des réservations." in list_response.data.decode(
-            "utf8"
-        )
-
-        assert len(Venue.query.all()) == 1
-        assert len(external_testing.sendinblue_requests) == 0
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_venue_rejected_because_of_pricing_point(self, mocked_validate_csrf_token, client):
-        admin = AdminFactory()
-        venue = offerers_factories.VenueFactory(pricing_point="self")
-        offerers_factories.VenueFactory(pricing_point=venue, managingOfferer=venue.managingOfferer)
-
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            "/pc/back-office/venue/delete/", form={"id": venue.id, "url": "/pc/back-office/venue/"}
-        )
-
-        assert response.status_code == 302
-
-        list_response = api_client.get(response.headers["location"])
-        assert (
-            "Impossible d&#39;effacer un lieu utilisé comme point de valorisation d&#39;un autre lieu."
-            in list_response.data.decode("utf8")
-        )
-
-        assert len(Venue.query.all()) == 2
-        assert len(external_testing.sendinblue_requests) == 0
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_delete_venue_rejected_because_of_reimbursement_point(self, mocked_validate_csrf_token, client):
-        admin = AdminFactory()
-        venue = offerers_factories.VenueFactory(reimbursement_point="self")
-        offerers_factories.VenueFactory(reimbursement_point=venue, managingOfferer=venue.managingOfferer)
-
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.post(
-            "/pc/back-office/venue/delete/", form={"id": venue.id, "url": "/pc/back-office/venue/"}
-        )
-
-        assert response.status_code == 302
-
-        list_response = api_client.get(response.headers["location"])
-        assert (
-            "Impossible d&#39;effacer un lieu utilisé comme point de remboursement d&#39;un autre lieu."
-            in list_response.data.decode("utf8")
-        )
-
-        assert len(Venue.query.all()) == 2
-        assert len(external_testing.sendinblue_requests) == 0
-
-
-class GetVenueProviderLinkTest:
-    @pytest.mark.usefixtures("db_session")
-    def test_return_empty_link_when_no_venue_provider(self, app):
-        # Given
-        venue = offerers_factories.VenueFactory()
-
-        # When
-        link = _format_venue_provider(None, None, venue, None)
-
-        # Then
-        assert not link
-
-    @pytest.mark.usefixtures("db_session")
-    def test_return_link_to_venue_provider(self, app):
-        # Given
-        venue_provider = providers_factories.VenueProviderFactory()
-        venue = venue_provider.venue
-
-        # When
-        link = _format_venue_provider(None, None, venue, None)
-
-        # Then
-        assert str(venue.id) in link
-
-
-class VenueForOffererSubviewTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
-        admin = AdminFactory(email="user@example.com")
-        offerer = offerers_factories.OffererFactory()
-        venue1 = offerers_factories.VenueFactory(managingOfferer=offerer)
-        venue2 = offerers_factories.VenueFactory(managingOfferer=offerer)
-        offerers_factories.VenueFactory()  # not expected result
-
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.get(url_for("venue_for_offerer.index", id=offerer.id))
-
-        assert response.status_code == 200
-
-        # Check venues in html content
-        regex = r'<td class="col-id">\s+(\d+)\s+</td>'
-        venue_ids = re.findall(regex, response.data.decode("utf8"))
-
-        assert sorted(venue_ids) == sorted([str(venue1.id), str(venue2.id)])
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_list_venues_for_offerer_not_found(self, mocked_validate_csrf_token, client):
-        admin = AdminFactory(email="user@example.com")
-
-        api_client = client.with_session_auth(admin.email)
-        response = api_client.get(url_for("venue_for_offerer.index", id=42))
-
-        assert response.status_code == 404
-
-
-class UpdateVenuesTest:
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_venue_ids")
-    def test_reindexed_after_is_permanent_updated_to_true(
-        self, mock_async_index_venue_ids, _mocked_validate_csrf_token, client
-    ):
-        admin = AdminFactory(email="user@example.com")
-        venue_id = offerers_factories.VenueFactory(isPermanent=False).id
-
-        data = {"ids": [venue_id], "is_permanent": True}
-
-        client = client.with_session_auth(admin.email)
-        response = client.post("/pc/back-office/venue/update/", form=data)
-
-        assert response.status_code == 302
-
-        venue = Venue.query.get(venue_id)
-        assert venue.isPermanent
-
-        mock_async_index_venue_ids.assert_called_once()
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_venue_ids")
-    def test_unindexed_after_is_permanent_updated_to_false(
-        self, mock_async_index_venue_ids, _mocked_validate_csrf_token, client
-    ):
-        admin = AdminFactory(email="user@example.com")
-        venue_id = offerers_factories.VenueFactory(isPermanent=False).id
-
-        data = {"ids": [venue_id], "is_permanent": "false"}
-
-        client = client.with_session_auth(admin.email)
-        response = client.post("/pc/back-office/venue/update/", form=data)
-
-        assert response.status_code == 302
-
-        venue = Venue.query.get(venue_id)
-        assert not venue.isPermanent
-
-        mock_async_index_venue_ids.assert_called_once()
-
-    @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    @patch("pcapi.core.search.async_index_venue_ids")
-    def test_immediate_reindexation_on_tag_update(
-        self, mock_async_index_venue_ids, _mocked_validate_csrf_token, client
-    ):
-        admin = AdminFactory(email="user@example.com")
-        venue_id = offerers_factories.VenueFactory(isPermanent=False).id
-        criterion = criteria_factories.CriterionFactory()
-
-        data = {"ids": [venue_id], "is_permanent": True, "tags": [criterion.id]}
-
-        client = client.with_session_auth(admin.email)
-        response = client.post("/pc/back-office/venue/update/", form=data)
-
-        assert response.status_code == 302
-
-        venue = Venue.query.get(venue_id)
-        assert venue.isPermanent
-        assert {criterion.name for criterion in venue.criteria} == {criterion.name}
-
-        mock_async_index_venue_ids.assert_called_once()
+# from dataclasses import asdict
+# import logging
+# import re
+# from unittest.mock import patch
+
+# from flask import url_for
+# import pytest
+
+# from pcapi.admin.custom_views.venue_view import _format_venue_provider
+# from pcapi.connectors import sirene
+# from pcapi.core.bookings.factories import BookingFactory
+# from pcapi.core.bookings.models import BookingStatus
+# import pcapi.core.criteria.factories as criteria_factories
+# import pcapi.core.mails.testing as mails_testing
+# from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+# import pcapi.core.offerers.factories as offerers_factories
+# from pcapi.core.offerers.models import Venue
+# import pcapi.core.offers.factories as offers_factories
+# import pcapi.core.offers.models as offers_models
+# import pcapi.core.providers.factories as providers_factories
+# from pcapi.core.users.factories import AdminFactory
+# import pcapi.core.users.testing as external_testing
+# from pcapi.utils.urls import build_pc_pro_venue_link
+
+# from tests.conftest import TestClient
+# from tests.conftest import clean_database
+
+
+# def base_form_data(venue: Venue) -> dict:
+#     return dict(
+#         name=venue.name,
+#         siret=venue.siret,
+#         city=venue.city,
+#         postalCode=venue.postalCode,
+#         address=venue.address,
+#         publicName=venue.publicName,
+#         latitude=venue.latitude,
+#         longitude=venue.longitude,
+#         isPermanent=venue.isPermanent,
+#         adageId=venue.adageId,
+#     )
+
+
+# class EditVenueTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     def test_add_siret_to_venue_without_pricing_point(
+#         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueWithoutSiretFactory()
+#         data = base_form_data(venue) | dict(siret="88888888888888", comment=None)
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         with caplog.at_level(logging.INFO):
+#             response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 302
+#         venue_edited = Venue.query.get(venue.id)
+#         assert venue_edited.siret == "88888888888888"
+#         assert venue_edited.current_pricing_point_id == venue_edited.id
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+#         # A log from after_model_change() is written first
+#         assert caplog.records[1].message == "[ADMIN] The SIRET of a Venue has been modified"
+#         assert caplog.records[1].extra == {
+#             "venue_id": venue.id,
+#             "previous_siret": None,
+#             "new_siret": "88888888888888",
+#             "user_email": "user@example.com",
+#         }
+
+#         assert len(venue.action_history) == 1
+#         update_snapshot = venue.action_history[0].extraData["modified_info"]
+#         assert update_snapshot["siret"]["new_info"] == "88888888888888"
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     def test_edit_siret_with_self_pricing_point(
+#         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(siret="12345678901234", pricing_point="self")
+#         data = base_form_data(venue) | dict(siret="88888888888888")
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         with caplog.at_level(logging.INFO):
+#             response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 302
+#         venue_edited = Venue.query.get(venue.id)
+#         assert venue_edited.siret == "88888888888888"
+#         assert venue_edited.current_pricing_point_id == venue_edited.id
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+#         # A log from after_model_change() is written first
+#         assert caplog.records[1].message == "[ADMIN] The SIRET of a Venue has been modified"
+#         assert caplog.records[1].extra == {
+#             "venue_id": venue.id,
+#             "previous_siret": "12345678901234",
+#             "new_siret": "88888888888888",
+#             "user_email": "user@example.com",
+#         }
+
+#         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.SireneApiException)
+#     def test_unavailable_sirene_api_warning(
+#         self, _mocked_sirene_get_siret, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueWithoutSiretFactory()
+#         data = base_form_data(venue) | dict(siret="88888888888888", comment=None)
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         with caplog.at_level(logging.INFO):
+#             response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data, follow_redirects=True)
+
+#         assert response.history[0].status_code == 302
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert "Ce SIRET n&#39;a pas pu être vérifié, mais la modification a néanmoins été effectuée" in content
+#         venue_edited = Venue.query.get(venue.id)
+#         assert venue_edited.siret == "88888888888888"
+#         assert venue_edited.current_pricing_point_id == venue_edited.id
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+#         # A log from after_model_change() is written first
+#         assert caplog.records[1].message == "[ADMIN] The SIRET of a Venue has been modified"
+#         assert caplog.records[1].extra == {
+#             "venue_id": venue.id,
+#             "previous_siret": None,
+#             "new_siret": "88888888888888",
+#             "user_email": "user@example.com",
+#         }
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     def test_cannot_remove_siret(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(siret="12345678901234")
+#         data = base_form_data(venue) | dict(siret="")
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert "Le champ SIRET ne peut pas être vide si ce lieu avait déjà un SIRET." in content
+#         refreshed_venue = Venue.query.get(venue.id)
+#         assert refreshed_venue.siret == "12345678901234"
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+#         assert len(external_testing.zendesk_sell_requests) == 0
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     def test_cannot_set_not_all_digits_siret(
+#         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(siret="12345678901234")
+
+#         data = base_form_data(venue) | dict(siret="123456780ABCD")
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert "Le SIRET doit être une série d&#39;exactement 14 chiffres." in content
+#         refreshed_venue = Venue.query.get(venue.id)
+#         assert refreshed_venue.siret == "12345678901234"
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     def test_cannot_use_inactive_siret(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(siret="12345678901234")
+
+#         data = base_form_data(venue) | dict(siret="22222222222222")
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         with patch("pcapi.connectors.sirene.get_siret") as mock_get_siret:
+#             mock_get_siret.return_value.active = False
+#             response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert "Ce SIRET n&#39;est plus actif, on ne peut pas l&#39;attribuer à ce lieu" in content
+#         venue_edited = Venue.query.get(venue.id)
+#         assert venue_edited.siret == "12345678901234"
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     def test_cannot_set_already_used_siret(
+#         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(siret="12345678901234")
+#         offerers_factories.VenueFactory(siret="22222222222222")
+
+#         data = base_form_data(venue) | dict(siret="22222222222222")
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(
+#             f"/pc/back-office/venue/edit/?id={venue.id}",
+#             form=data,
+#         )
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         # This is returned by the FA Unique validator
+#         assert "Already exists." in content
+#         refreshed_venue = Venue.query.get(venue.id)
+#         assert refreshed_venue.siret == "12345678901234"
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     def test_cannot_add_siret_if_exisiting_pricing_point(
+#         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
+#     ):
+#         AdminFactory(email="user@example.com")
+#         offerer = offerers_factories.OffererFactory()
+#         pricing_point = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
+#         venue = offerers_factories.VenueWithoutSiretFactory(managingOfferer=offerer, pricing_point=pricing_point)
+
+#         data = base_form_data(venue) | dict(siret="22222222222222")
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 200
+#         content = response.data.decode(response.charset)
+#         assert "Ce lieu a déjà un point de valorisation" in content
+#         refreshed_venue = Venue.query.get(venue.id)
+#         assert refreshed_venue.siret is None
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+
+#         assert len(external_testing.zendesk_sell_requests) == 0
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_update_venue_other_offer_id_at_provider(self, mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(siret="22222222222222")
+#         id_at_providers = "id_at_provider_ne_contenant_pas_le_siret"
+#         stock = offers_factories.StockFactory(
+#             offer__venue=venue, idAtProviders=id_at_providers, offer__idAtProvider=id_at_providers
+#         )
+
+#         data = dict(
+#             name=venue.name,
+#             siret="88888888888888",
+#             city=venue.city,
+#             postalCode=venue.postalCode,
+#             address=venue.address,
+#             publicName=venue.publicName,
+#             latitude=venue.latitude,
+#             longitude=venue.longitude,
+#             isPermanent=venue.isPermanent,
+#             adageId=venue.adageId,
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 302
+
+#         venue_edited = Venue.query.get(venue.id)
+#         stock = offers_models.Stock.query.get(stock.id)
+#         offer = offers_models.Offer.query.get(stock.offer.id)
+
+#         assert venue_edited.siret == "88888888888888"
+#         assert stock.idAtProviders == "id_at_provider_ne_contenant_pas_le_siret"
+#         assert offer.idAtProvider == "id_at_provider_ne_contenant_pas_le_siret"
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_update_venue_without_siret(self, mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueWithoutSiretFactory()
+
+#         data = dict(
+#             name=venue.name,
+#             siret="88888888888888",
+#             city=venue.city,
+#             postalCode=venue.postalCode,
+#             address=venue.address,
+#             publicName=venue.publicName,
+#             latitude=venue.latitude,
+#             longitude=venue.longitude,
+#             isPermanent=venue.isPermanent,
+#             adageId=venue.adageId,
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 302
+
+#         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     def test_update_venue_reindex_all(self, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(isPermanent=False)
+
+#         new_name = venue.name + "(updated)"
+#         data = dict(
+#             name=new_name,
+#             siret=venue.siret,
+#             city=venue.city,
+#             postalCode=venue.postalCode,
+#             address=venue.address,
+#             publicName=venue.publicName,
+#             latitude="42.01",
+#             longitude=venue.longitude,
+#             isPermanent=True,
+#             adageId=venue.adageId,
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 302
+
+#         venue = Venue.query.get(venue.id)
+#         assert venue.isPermanent
+#         assert venue.name == new_name
+
+#         mocked_async_index_offers_of_venue_ids.assert_called_once_with([venue.id])
+
+#         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     @patch("pcapi.core.search.async_index_venue_ids")
+#     def test_update_venue_reindex_venue_only(
+#         self, mocked_async_index_venue_ids, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(isPermanent=False)
+
+#         data = dict(
+#             name=venue.name,
+#             siret=venue.siret,
+#             city=venue.city,
+#             postalCode=venue.postalCode,
+#             address=venue.address,
+#             publicName=venue.publicName,
+#             latitude=venue.latitude,
+#             longitude=venue.longitude,
+#             isPermanent=True,
+#             adageId=venue.adageId,
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 302
+
+#         venue = Venue.query.get(venue.id)
+#         assert venue.isPermanent
+
+#         mocked_async_index_venue_ids.assert_called_once_with([venue.id])
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+
+#         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
+#     @patch("pcapi.core.search.async_index_venue_ids")
+#     @patch("pcapi.core.search.reindex_venue_ids")
+#     def test_reindex_when_tags_updated(
+#         self,
+#         mocked_reindex_venue_ids,
+#         mocked_async_index_venue_ids,
+#         mocked_async_index_offers_of_venue_ids,
+#         mocked_validate_csrf_token,
+#         client,
+#     ):
+#         admin = AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(isPermanent=True)
+#         tag = criteria_factories.CriterionFactory()
+#         data = {
+#             "criteria": [tag.id],
+#             "name": venue.name,
+#             "siret": venue.siret,
+#             "city": venue.city,
+#             "postalCode": venue.postalCode,
+#             "address": venue.address,
+#             "publicName": venue.publicName,
+#             "latitude": venue.latitude,
+#             "longitude": venue.longitude,
+#             "isPermanent": True,
+#             "adageId": venue.adageId,
+#         }
+
+#         client = client.with_session_auth(admin.email)
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 302
+
+#         mocked_reindex_venue_ids.assert_called_once_with([venue.id])
+#         mocked_async_index_venue_ids.assert_not_called()
+#         mocked_async_index_offers_of_venue_ids.assert_not_called()
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_venue_user_receives_permanent_venue_email(self, mocked_validate_csrf_token, app):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(isPermanent=False)
+
+#         data = dict(
+#             name=venue.name,
+#             siret=venue.siret,
+#             city=venue.city,
+#             postalCode=venue.postalCode,
+#             address=venue.address,
+#             publicName=venue.publicName,
+#             latitude=venue.latitude,
+#             longitude=venue.longitude,
+#             isPermanent=True,
+#             adageId=venue.adageId,
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         assert response.status_code == 302
+
+#         venue = Venue.query.get(venue.id)
+#         assert venue.isPermanent
+#         assert len(mails_testing.outbox) == 1
+#         assert mails_testing.outbox[0].sent_data["params"] == {
+#             "VENUE_FORM_URL": build_pc_pro_venue_link(venue),
+#             "VENUE_NAME": venue.publicName or venue.name,
+#         }
+#         assert mails_testing.outbox[0].sent_data["template"] == asdict(TransactionalEmail.VENUE_NEEDS_PICTURE.value)
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @pytest.mark.parametrize("prev_is_permanent, new_is_permanent", [(True, True), (False, False), (True, False)])
+#     def test_venue_user_does_not_receives_permanent_venue_email_if_disabled_or_not_changed(
+#         self, mocked_validate_csrf_token, app, prev_is_permanent, new_is_permanent
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(isPermanent=prev_is_permanent)
+
+#         data = dict(
+#             name=venue.name,
+#             siret=venue.siret,
+#             city=venue.city,
+#             postalCode=venue.postalCode,
+#             address=venue.address,
+#             publicName=venue.publicName,
+#             latitude=venue.latitude,
+#             longitude=venue.longitude,
+#             adageId=venue.adageId,
+#         )
+
+#         if new_is_permanent:
+#             data["isPermanent"] = new_is_permanent
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         venue = Venue.query.get(venue.id)
+#         assert venue.isPermanent is new_is_permanent
+
+#         assert response.status_code == 302
+
+#         assert not mails_testing.outbox
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @pytest.mark.parametrize("booking_email_value", [None, ""])
+#     def test_venue_user_does_not_receives_permanent_without_booking_email(
+#         self, mocked_validate_csrf_token, app, booking_email_value
+#     ):
+#         AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(isPermanent=False, bookingEmail=None)
+
+#         data = dict(
+#             name=venue.name,
+#             siret=venue.siret,
+#             city=venue.city,
+#             postalCode=venue.postalCode,
+#             address=venue.address,
+#             publicName=venue.publicName,
+#             latitude=venue.latitude,
+#             longitude=venue.longitude,
+#             adageId=venue.adageId,
+#             isPermanent=True,
+#         )
+
+#         client = TestClient(app.test_client()).with_session_auth("user@example.com")
+#         response = client.post(f"/pc/back-office/venue/edit/?id={venue.id}", form=data)
+
+#         venue = Venue.query.get(venue.id)
+
+#         assert response.status_code == 302
+
+#         assert not mails_testing.outbox
+
+
+# class DeleteVenueTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_venue(self, mocked_validate_csrf_token, client):
+#         admin = AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory(bookingEmail="booking@example.com")
+#         user_offerer1 = offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
+#         user_offerer2 = offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
+
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             "/pc/back-office/venue/delete/", form={"id": venue.id, "url": "/pc/back-office/venue/"}
+#         )
+
+#         assert response.status_code == 302
+#         assert len(Venue.query.all()) == 0
+#         assert len(external_testing.sendinblue_requests) == 3
+#         assert {req["email"] for req in external_testing.sendinblue_requests} == {
+#             user_offerer1.user.email,
+#             user_offerer2.user.email,
+#             "booking@example.com",
+#         }
+
+#     @pytest.mark.parametrize(
+#         "booking_status",
+#         [
+#             BookingStatus.USED,
+#             BookingStatus.CONFIRMED,
+#             BookingStatus.CANCELLED,
+#             BookingStatus.REIMBURSED,
+#         ],
+#     )
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_venue_rejected(self, mocked_validate_csrf_token, client, booking_status):
+#         admin = AdminFactory(email="user@example.com")
+#         venue = offerers_factories.VenueFactory()
+#         offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
+#         BookingFactory(stock__offer__venue=venue, status=booking_status)
+
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             "/pc/back-office/venue/delete/", form={"id": venue.id, "url": "/pc/back-office/venue/"}
+#         )
+
+#         assert response.status_code == 302
+
+#         list_response = api_client.get(response.headers["location"])
+#         assert "Impossible d&#39;effacer un lieu pour lequel il existe des réservations." in list_response.data.decode(
+#             "utf8"
+#         )
+
+#         assert len(Venue.query.all()) == 1
+#         assert len(external_testing.sendinblue_requests) == 0
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_venue_rejected_because_of_pricing_point(self, mocked_validate_csrf_token, client):
+#         admin = AdminFactory()
+#         venue = offerers_factories.VenueFactory(pricing_point="self")
+#         offerers_factories.VenueFactory(pricing_point=venue, managingOfferer=venue.managingOfferer)
+
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             "/pc/back-office/venue/delete/", form={"id": venue.id, "url": "/pc/back-office/venue/"}
+#         )
+
+#         assert response.status_code == 302
+
+#         list_response = api_client.get(response.headers["location"])
+#         assert (
+#             "Impossible d&#39;effacer un lieu utilisé comme point de valorisation d&#39;un autre lieu."
+#             in list_response.data.decode("utf8")
+#         )
+
+#         assert len(Venue.query.all()) == 2
+#         assert len(external_testing.sendinblue_requests) == 0
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_delete_venue_rejected_because_of_reimbursement_point(self, mocked_validate_csrf_token, client):
+#         admin = AdminFactory()
+#         venue = offerers_factories.VenueFactory(reimbursement_point="self")
+#         offerers_factories.VenueFactory(reimbursement_point=venue, managingOfferer=venue.managingOfferer)
+
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.post(
+#             "/pc/back-office/venue/delete/", form={"id": venue.id, "url": "/pc/back-office/venue/"}
+#         )
+
+#         assert response.status_code == 302
+
+#         list_response = api_client.get(response.headers["location"])
+#         assert (
+#             "Impossible d&#39;effacer un lieu utilisé comme point de remboursement d&#39;un autre lieu."
+#             in list_response.data.decode("utf8")
+#         )
+
+#         assert len(Venue.query.all()) == 2
+#         assert len(external_testing.sendinblue_requests) == 0
+
+
+# class GetVenueProviderLinkTest:
+#     @pytest.mark.usefixtures("db_session")
+#     def test_return_empty_link_when_no_venue_provider(self, app):
+#         # Given
+#         venue = offerers_factories.VenueFactory()
+
+#         # When
+#         link = _format_venue_provider(None, None, venue, None)
+
+#         # Then
+#         assert not link
+
+#     @pytest.mark.usefixtures("db_session")
+#     def test_return_link_to_venue_provider(self, app):
+#         # Given
+#         venue_provider = providers_factories.VenueProviderFactory()
+#         venue = venue_provider.venue
+
+#         # When
+#         link = _format_venue_provider(None, None, venue, None)
+
+#         # Then
+#         assert str(venue.id) in link
+
+
+# class VenueForOffererSubviewTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
+#         admin = AdminFactory(email="user@example.com")
+#         offerer = offerers_factories.OffererFactory()
+#         venue1 = offerers_factories.VenueFactory(managingOfferer=offerer)
+#         venue2 = offerers_factories.VenueFactory(managingOfferer=offerer)
+#         offerers_factories.VenueFactory()  # not expected result
+
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.get(url_for("venue_for_offerer.index", id=offerer.id))
+
+#         assert response.status_code == 200
+
+#         # Check venues in html content
+#         regex = r'<td class="col-id">\s+(\d+)\s+</td>'
+#         venue_ids = re.findall(regex, response.data.decode("utf8"))
+
+#         assert sorted(venue_ids) == sorted([str(venue1.id), str(venue2.id)])
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     def test_list_venues_for_offerer_not_found(self, mocked_validate_csrf_token, client):
+#         admin = AdminFactory(email="user@example.com")
+
+#         api_client = client.with_session_auth(admin.email)
+#         response = api_client.get(url_for("venue_for_offerer.index", id=42))
+
+#         assert response.status_code == 404
+
+
+# class UpdateVenuesTest:
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_venue_ids")
+#     def test_reindexed_after_is_permanent_updated_to_true(
+#         self, mock_async_index_venue_ids, _mocked_validate_csrf_token, client
+#     ):
+#         admin = AdminFactory(email="user@example.com")
+#         venue_id = offerers_factories.VenueFactory(isPermanent=False).id
+
+#         data = {"ids": [venue_id], "is_permanent": True}
+
+#         client = client.with_session_auth(admin.email)
+#         response = client.post("/pc/back-office/venue/update/", form=data)
+
+#         assert response.status_code == 302
+
+#         venue = Venue.query.get(venue_id)
+#         assert venue.isPermanent
+
+#         mock_async_index_venue_ids.assert_called_once()
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_venue_ids")
+#     def test_unindexed_after_is_permanent_updated_to_false(
+#         self, mock_async_index_venue_ids, _mocked_validate_csrf_token, client
+#     ):
+#         admin = AdminFactory(email="user@example.com")
+#         venue_id = offerers_factories.VenueFactory(isPermanent=False).id
+
+#         data = {"ids": [venue_id], "is_permanent": "false"}
+
+#         client = client.with_session_auth(admin.email)
+#         response = client.post("/pc/back-office/venue/update/", form=data)
+
+#         assert response.status_code == 302
+
+#         venue = Venue.query.get(venue_id)
+#         assert not venue.isPermanent
+
+#         mock_async_index_venue_ids.assert_called_once()
+
+#     @clean_database
+#     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+#     @patch("pcapi.core.search.async_index_venue_ids")
+#     def test_immediate_reindexation_on_tag_update(
+#         self, mock_async_index_venue_ids, _mocked_validate_csrf_token, client
+#     ):
+#         admin = AdminFactory(email="user@example.com")
+#         venue_id = offerers_factories.VenueFactory(isPermanent=False).id
+#         criterion = criteria_factories.CriterionFactory()
+
+#         data = {"ids": [venue_id], "is_permanent": True, "tags": [criterion.id]}
+
+#         client = client.with_session_auth(admin.email)
+#         response = client.post("/pc/back-office/venue/update/", form=data)
+
+#         assert response.status_code == 302
+
+#         venue = Venue.query.get(venue_id)
+#         assert venue.isPermanent
+#         assert {criterion.name for criterion in venue.criteria} == {criterion.name}
+
+#         mock_async_index_venue_ids.assert_called_once()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22604

## But de la pull request

Décommission de Flask-admin, en commentant toutes les routes (sauf les offres et les règles de fraude)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
