### PR TITLE
(PC-23031)[PRO] feat: add offerer id and venue id to new request mail

### DIFF
--- a/api/src/pcapi/core/mails/transactional/educational/eac_new_request_made_by_redactor_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/educational/eac_new_request_made_by_redactor_to_pro.py
@@ -34,5 +34,7 @@ def get_data_request_made_by_redactor_to_pro(
             "REDACTOR_EMAIL": request.educationalRedactor.email,
             "REDACTOR_PHONE_NUMBER": request.phoneNumber,
             "OFFER_CREATION_URL": f"{settings.PRO_URL}/offre/collectif/creation/{request.collectiveOfferTemplateId}/requete/{request.id}",
+            "OFFERER_ID": request.collectiveOfferTemplate.venue.managingOffererId,
+            "VENUE_ID": request.collectiveOfferTemplate.venue.id,
         },
     )

--- a/api/tests/core/mails/transactional/educational/eac_new_request_made_by_redactor_to_pro_test.py
+++ b/api/tests/core/mails/transactional/educational/eac_new_request_made_by_redactor_to_pro_test.py
@@ -47,4 +47,6 @@ class SendEacNewBookingEmailToProTest:
             "REDACTOR_EMAIL": request.educationalRedactor.email,
             "REDACTOR_PHONE_NUMBER": None,
             "OFFER_CREATION_URL": f"{settings.PRO_URL}/offre/collectif/creation/{request.collectiveOfferTemplateId}/requete/{request.id}",
+            "OFFERER_ID": request.collectiveOfferTemplate.venue.managingOffererId,
+            "VENUE_ID": request.collectiveOfferTemplate.venue.id,
         }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23031

## But de la pull request

Ajouter les paramètres `OFFERER_ID` et `VENUE_ID` lors de l'envoie du mail indiquant une nouvelle demande d'offre réservable. 
