### PR TITLE
(BSR)[API] feat: Allow localhost in CORS_ALLOWED_ORIGINS for testing and perf environment

### DIFF
--- a/api/.env.testing
+++ b/api/.env.testing
@@ -17,10 +17,10 @@ BACKOFFICE_URL=https://backoffice.testing.passculture.team/
 # Batch keys below are public keys:
 BATCH_ANDROID_API_KEY=5F8E91B93C5C1EADFF860843D4616B # ggignore
 BATCH_IOS_API_KEY=5F8EF34DD5CF8B0662ADE77220FDDE     # ggignore
-CORS_ALLOWED_ORIGINS=https://web.testing.passculture.team,https://pro.testing.passculture.team,https://app.passculture-testing.beta.gouv.fr,https://pro.passculture-testing.beta.gouv.fr,https://pro-test.testing.passculture.team,https://.*.web.app
-CORS_ALLOWED_ORIGINS_BACKOFFICE=https://backoffice.testing.passculture.team,http://localhost:.*
-CORS_ALLOWED_ORIGINS_NATIVE=https://app.testing.passculture.team,https://adage.testing.passculture.team
-CORS_ALLOWED_ORIGINS_ADAGE_IFRAME=https://adage.testing.passculture.team,https://pro.testing.passculture.team,https://pro-test.testing.passculture.team,https://.*.web.app
+CORS_ALLOWED_ORIGINS=http://localhost:.*,https://web.testing.passculture.team,https://pro.testing.passculture.team,https://app.passculture-testing.beta.gouv.fr,https://pro.passculture-testing.beta.gouv.fr,https://pro-test.testing.passculture.team,https://.*.web.app
+CORS_ALLOWED_ORIGINS_BACKOFFICE=http://localhost:.*,https://backoffice.testing.passculture.team,http://localhost:.*
+CORS_ALLOWED_ORIGINS_NATIVE=http://localhost:.*,https://app.testing.passculture.team,https://adage.testing.passculture.team
+CORS_ALLOWED_ORIGINS_ADAGE_IFRAME=http://localhost:.*,https://adage.testing.passculture.team,https://pro.testing.passculture.team,https://pro-test.testing.passculture.team,https://.*.web.app
 DEMARCHES_SIMPLIFIEES_INACTIVITY_TOLERANCE_DELAY=2
 DEMARCHES_SIMPLIFIEES_ENROLLMENT_INSTRUCTOR=SW5zdHJ1Y3RldXItNTY5OTQ=
 DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_FR=48860


### PR DESCRIPTION
It makes easier to play with the "testing" or the "perf" [1] backend
from a local frontend.

[1] Yes, the "perf" environment actually uses the same settings as
    "testing".