### PR TITLE
(PC-23051)[API] fix: hide soft deleted stocks from offer response

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -190,6 +190,8 @@ class OfferResponse(BaseModel):
         offer.expense_domains = get_expense_domains(offer)
         offer.isExpired = offer.hasBookingLimitDatetimesPassed
         offer.metadata = offer_metadata.get_metadata_from_offer(offer)
+        if offer.stocks:
+            offer.stocks = offer.activeStocks
 
         result = super().from_orm(offer)
 

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -261,10 +261,10 @@ class GetOfferStockResponseModel(BaseModel):
         # here we have N+1 requests (for each stock we query an activation code)
         # but it should be more efficient than loading all activationCodes of all stocks
         if stock.canHaveActivationCodes:
-            availble_activation_code = offers_repository.get_available_activation_code(stock)
-            stock.hasActivationCode = availble_activation_code is not None
+            available_activation_code = offers_repository.get_available_activation_code(stock)
+            stock.hasActivationCode = available_activation_code is not None
             stock.activationCodesExpirationDatetime = (
-                availble_activation_code.expirationDate if availble_activation_code else None
+                available_activation_code.expirationDate if available_activation_code else None
             )
         else:
             stock.hasActivationCode = False

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -478,6 +478,17 @@ class OffersTest:
         assert isinstance(response.json["metadata"], dict)
         assert response.json["metadata"]["@type"] == "Product"
 
+    def should_not_return_soft_deleted_offer(self, client):
+        offer = offers_factories.OfferFactory()
+        offers_factories.StockFactory(offer=offer, quantity=1, isSoftDeleted=True)
+        non_deleted_stock = offers_factories.StockFactory(offer=offer, quantity=1)
+
+        response = client.get(f"/native/v1/offer/{offer.id}")
+
+        assert response.status_code == 200
+        assert len(response.json["stocks"]) == 1
+        assert response.json["stocks"][0]["id"] == non_deleted_stock.id
+
 
 class SendOfferWebAppLinkTest:
     def test_sendinblue_send_offer_webapp_link_by_email(self, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23051

## But de la pull request

Ne plus remonter les stocks soft deleted dans la réponse de GET /offer/ID

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
