### PR TITLE
(BSR)[API] build: Use latest version of the Helm chart (Prometheus)

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -33,4 +33,4 @@ environments:
       - chartVersion: 0.21.7
   perf:
     values:
-      - chartVersion: 0.21.8
+      - chartVersion: 0.21.9


### PR DESCRIPTION
Version 0.21.9 has the latest fixes to export metrics with Prometheus.