### PR TITLE
(PC-23070)[API] fix: unsync offer from algolia on delete unwanted product

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1265,6 +1265,8 @@ def delete_unwanted_existing_product(idAtProviders: str) -> None:
         product.isGcuCompatible = False
         product.isSynchronizationCompatible = False
         repository.save(product)
+        offer_ids = [id_ for id_, in offers.with_entities(models.Offer.id)]
+        search.async_index_offer_ids(offer_ids)
         raise exceptions.CannotDeleteProductWithBookings()
 
     objects_to_delete = []
@@ -1279,6 +1281,7 @@ def delete_unwanted_existing_product(idAtProviders: str) -> None:
     favorites = users_models.Favorite.query.filter(users_models.Favorite.offerId.in_(offer_ids)).all()
     objects_to_delete = objects_to_delete + favorites
     repository.delete(*objects_to_delete)
+    search.async_index_offer_ids(offer_ids)
 
 
 def batch_delete_draft_offers(query: BaseQuery) -> None:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23070

## But de la pull request

Actuellement, quand un produit existant passe en inéligible, nous ne resynchronisation pas aloglia pour ses offres.

Cette PR ajoute la re-synchro algolia

## Implémentation

- Ajout d'appel de `search.async_index_offer_ids` pour :
  - Quand le produit a au moins un booking 
  - Quand le produit n'as pas de booking

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
