### PR TITLE
(PC-23054)[API] feat: add minor feats to offer validation rules

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -788,8 +788,24 @@ class OfferValidationSubRuleField(enum.Enum):
         "model": OfferValidationModel.OFFER,
         "attribute": OfferValidationAttribute.SUBCATEGORY_ID,
     }
+    SUBCATEGORY_COLLECTIVE_OFFER = {
+        "model": OfferValidationModel.COLLECTIVE_OFFER,
+        "attribute": OfferValidationAttribute.SUBCATEGORY_ID,
+    }
+    SUBCATEGORY_COLLECTIVE_OFFER_TEMPLATE = {
+        "model": OfferValidationModel.COLLECTIVE_OFFER_TEMPLATE,
+        "attribute": OfferValidationAttribute.SUBCATEGORY_ID,
+    }
     CATEGORY_OFFER = {
         "model": OfferValidationModel.OFFER,
+        "attribute": OfferValidationAttribute.CATEGORY,
+    }
+    CATEGORY_COLLECTIVE_OFFER = {
+        "model": OfferValidationModel.COLLECTIVE_OFFER,
+        "attribute": OfferValidationAttribute.CATEGORY,
+    }
+    CATEGORY_COLLECTIVE_OFFER_TEMPLATE = {
+        "model": OfferValidationModel.COLLECTIVE_OFFER_TEMPLATE,
         "attribute": OfferValidationAttribute.CATEGORY,
     }
     SHOW_SUB_TYPE_OFFER = {

--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -361,8 +361,16 @@ def format_offer_validation_sub_rule_field(sub_rule_field: offers_models.OfferVa
             return "La description de l'offre collective vitrine"
         case offers_models.OfferValidationSubRuleField.SUBCATEGORY_OFFER:
             return "La sous-catégorie de l'offre individuelle"
+        case offers_models.OfferValidationSubRuleField.SUBCATEGORY_COLLECTIVE_OFFER:
+            return "La sous-catégorie de l'offre collective"
+        case offers_models.OfferValidationSubRuleField.SUBCATEGORY_COLLECTIVE_OFFER_TEMPLATE:
+            return "La sous-catégorie de l'offre collective vitrine"
         case offers_models.OfferValidationSubRuleField.CATEGORY_OFFER:
             return "La catégorie de l'offre individuelle"
+        case offers_models.OfferValidationSubRuleField.CATEGORY_COLLECTIVE_OFFER:
+            return "La catégorie de l'offre collective"
+        case offers_models.OfferValidationSubRuleField.CATEGORY_COLLECTIVE_OFFER_TEMPLATE:
+            return "La catégorie de l'offre collective vitrine"
         case offers_models.OfferValidationSubRuleField.SHOW_SUB_TYPE_OFFER:
             return "Le sous-type de spectacle de l'offre individuelle"
         case offers_models.OfferValidationSubRuleField.ID_OFFERER:

--- a/api/src/pcapi/routes/backoffice_v3/offer_validation_rules/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offer_validation_rules/blueprint.py
@@ -57,10 +57,14 @@ def _get_offerers_data_for_rules(rules: list[offers_models.OfferValidationRule])
 def list_rules() -> utils.BackofficeResponse:
     form = forms.SearchRuleForm(formdata=utils.get_query_params())
 
-    base_query = offers_models.OfferValidationRule.query.outerjoin(offers_models.OfferValidationSubRule).options(
-        sa.orm.joinedload(offers_models.OfferValidationRule.latestAuthor).load_only(
-            users_models.User.firstName, users_models.User.lastName, users_models.User.email
+    base_query = (
+        offers_models.OfferValidationRule.query.outerjoin(offers_models.OfferValidationSubRule)
+        .options(
+            sa.orm.joinedload(offers_models.OfferValidationRule.latestAuthor).load_only(
+                users_models.User.firstName, users_models.User.lastName, users_models.User.email
+            )
         )
+        .order_by(offers_models.OfferValidationRule.name)
     )
 
     if not form.validate():

--- a/api/tests/routes/backoffice_v3/offer_validation_rules_test.py
+++ b/api/tests/routes/backoffice_v3/offer_validation_rules_test.py
@@ -47,7 +47,7 @@ class ListRulesTest(GetEndpointHelper):
             model=offers_models.OfferValidationModel.OFFER,
             attribute=offers_models.OfferValidationAttribute.NAME,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
 
         response = authenticated_client.get(url_for(self.endpoint))
@@ -120,13 +120,13 @@ class CreateOfferValidationRuleTest(PostEndpointHelper):
                 {
                     "sub_rules-0-sub_rule_type": "DESCRIPTION_OFFER",
                     "sub_rules-0-operator": "CONTAINS_EXACTLY",
-                    "sub_rules-0-list_field": "suspicious, verboten, interdit",
+                    "sub_rules-0-list_field": "interdit, suspicious, verboten",
                 },
                 {
                     "model": offers_models.OfferValidationModel.OFFER,
                     "attribute": offers_models.OfferValidationAttribute.DESCRIPTION,
                     "operator": offers_models.OfferValidationRuleOperator.CONTAINS_EXACTLY,
-                    "comparated": {"comparated": ["suspicious", "verboten", "interdit"]},
+                    "comparated": {"comparated": ["interdit", "suspicious", "verboten"]},
                 },
             ),
             (
@@ -146,7 +146,7 @@ class CreateOfferValidationRuleTest(PostEndpointHelper):
                 {
                     "sub_rules-0-sub_rule_type": "OFFER_TYPE",
                     "sub_rules-0-operator": "NOT_IN",
-                    "sub_rules-0-offer_type": ["COLLECTIVE_OFFER_TEMPLATE"],
+                    "sub_rules-0-offer_type": ["CollectiveOfferTemplate"],
                 },
                 {
                     "model": None,
@@ -280,7 +280,7 @@ class CreateOfferValidationRuleTest(PostEndpointHelper):
         sub_rule_data = get_empty_sub_rule_data() | {
             "sub_rules-0-sub_rule_type": "DESCRIPTION_OFFER",
             "sub_rules-0-operator": "CONTAINS_EXACTLY",
-            "sub_rules-0-list_field": "suspicious, verboten, interdit",
+            "sub_rules-0-list_field": "interdit, suspicious, verboten",
         }
         form = {"name": ""} | sub_rule_data
 
@@ -311,7 +311,7 @@ class CreateOfferValidationRuleTest(PostEndpointHelper):
     def test_create_offer_validation_rule_without_operator(self, authenticated_client):
         sub_rule_data = get_empty_sub_rule_data() | {
             "sub_rules-0-sub_rule_type": "DESCRIPTION_OFFER",
-            "sub_rules-0-list_field": "suspicious, verboten, interdit",
+            "sub_rules-0-list_field": "interdit, suspicious, verboten",
         }
         form = {"name": "First rule of robotics"} | sub_rule_data
 
@@ -347,7 +347,7 @@ class CreateOfferValidationRuleTest(PostEndpointHelper):
         sub_rule_data = get_empty_sub_rule_data() | {
             "sub_rules-0-sub_rule_type": "DESCRIPTION_OFFER",
             "sub_rules-0-operator": "EQUALS",
-            "sub_rules-0-list_field": "suspicious, verboten, interdit",
+            "sub_rules-0-list_field": "interdit, suspicious, verboten",
         }
         form = {"name": ""} | sub_rule_data
 
@@ -374,7 +374,7 @@ class GetDeleteOfferValidationRuleFormTest(GetEndpointHelper):
             model=offers_models.OfferValidationModel.OFFER,
             attribute=offers_models.OfferValidationAttribute.NAME,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
         form_url = url_for(self.endpoint, rule_id=rule.id)
 
@@ -395,14 +395,14 @@ class DeleteOfferValidationRuleTest(PostEndpointHelper):
             model=offers_models.OfferValidationModel.OFFER,
             attribute=offers_models.OfferValidationAttribute.NAME,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
         sub_rule_2 = offers_factories.OfferValidationSubRuleFactory(
             validationRule=rule,
             model=offers_models.OfferValidationModel.OFFER,
             attribute=offers_models.OfferValidationAttribute.DESCRIPTION,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS_EXACTLY,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
 
         response = self.post_to_endpoint(authenticated_client, rule_id=rule.id)
@@ -429,7 +429,7 @@ class GetEditOfferValidationRuleFormTest(GetEndpointHelper):
             model=offers_models.OfferValidationModel.OFFER,
             attribute=offers_models.OfferValidationAttribute.NAME,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
         form_url = url_for(self.endpoint, rule_id=rule.id)
 
@@ -443,14 +443,6 @@ class EditOfferValidationRuleTest(PostEndpointHelper):
     endpoint_kwargs = {"rule_id": 1}
     needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
-    ## edit one rule to one rule
-    # modify only comparated
-    # modify operator
-    # modify sub_rule_type
-    # modify only name
-    ## edit one rule to two rule
-    ## edit two rule to one rule
-
     def test_edit_offer_validation_rule(self, legit_user, authenticated_client):
         rule = offers_factories.OfferValidationRuleFactory(
             name="First rule of robotics", dateModified=datetime.datetime.utcnow() - datetime.timedelta(days=1)
@@ -460,13 +452,13 @@ class EditOfferValidationRuleTest(PostEndpointHelper):
             model=offers_models.OfferValidationModel.OFFER,
             attribute=offers_models.OfferValidationAttribute.NAME,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
         sub_rule_data = get_empty_sub_rule_data() | {
             "sub_rules-0-id": str(sub_rule.id),
             "sub_rules-0-sub_rule_type": "DESCRIPTION_OFFER",
             "sub_rules-0-operator": "CONTAINS",
-            "sub_rules-0-list_field": "suspicious, verboten, interdit, pifpafpouf",
+            "sub_rules-0-list_field": "interdit, suspicious, verboten, ajout",
         }
         form = {"name": "Second rule of robotics"} | sub_rule_data
 
@@ -485,7 +477,7 @@ class EditOfferValidationRuleTest(PostEndpointHelper):
         assert rule.subRules[0].model == offers_models.OfferValidationModel.OFFER
         assert rule.subRules[0].attribute == offers_models.OfferValidationAttribute.DESCRIPTION
         assert rule.subRules[0].operator == offers_models.OfferValidationRuleOperator.CONTAINS
-        assert rule.subRules[0].comparated == {"comparated": ["suspicious", "verboten", "interdit", "pifpafpouf"]}
+        assert rule.subRules[0].comparated == {"comparated": ["ajout", "interdit", "suspicious", "verboten"]}
 
     def test_edit_offer_validation_rule_add_sub_rule(self, legit_user, authenticated_client):
         rule = offers_factories.OfferValidationRuleFactory(
@@ -496,19 +488,20 @@ class EditOfferValidationRuleTest(PostEndpointHelper):
             model=offers_models.OfferValidationModel.OFFER,
             attribute=offers_models.OfferValidationAttribute.NAME,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
+        old_sub_rule_id = sub_rule.id
         sub_rule_data_0 = get_empty_sub_rule_data(0) | {
-            "sub_rules-0-id": str(sub_rule.id),
+            "sub_rules-0-id": str(old_sub_rule_id),
             "sub_rules-0-sub_rule_type": "DESCRIPTION_OFFER",
             "sub_rules-0-operator": "CONTAINS",
-            "sub_rules-0-list_field": "suspicious, verboten, interdit, pifpafpouf",
+            "sub_rules-0-list_field": "interdit, suspicious, verboten, ajout",
         }
         sub_rule_data_1 = get_empty_sub_rule_data(1) | {
             "sub_rules-1-id": None,
             "sub_rules-1-sub_rule_type": "DESCRIPTION_COLLECTIVE_OFFER",
             "sub_rules-1-operator": "CONTAINS_EXACTLY",
-            "sub_rules-1-list_field": "suspicious, verboten, interdit",
+            "sub_rules-1-list_field": "interdit, suspicious, verboten",
         }
         form = {"name": "Second rule of robotics"} | sub_rule_data_0 | sub_rule_data_1
 
@@ -523,16 +516,16 @@ class EditOfferValidationRuleTest(PostEndpointHelper):
         assert rule.name == "Second rule of robotics"
         assert rule.latestAuthor == legit_user
         assert rule.dateModified.date() == datetime.date.today()
-        assert rule.subRules[0].id == sub_rule.id
+        assert rule.subRules[0].id == old_sub_rule_id
         assert rule.subRules[0].model == offers_models.OfferValidationModel.OFFER
         assert rule.subRules[0].attribute == offers_models.OfferValidationAttribute.DESCRIPTION
         assert rule.subRules[0].operator == offers_models.OfferValidationRuleOperator.CONTAINS
-        assert rule.subRules[0].comparated == {"comparated": ["suspicious", "verboten", "interdit", "pifpafpouf"]}
-        assert rule.subRules[1].id != sub_rule.id
+        assert rule.subRules[0].comparated == {"comparated": ["ajout", "interdit", "suspicious", "verboten"]}
+        assert rule.subRules[1].id != old_sub_rule_id
         assert rule.subRules[1].model == offers_models.OfferValidationModel.COLLECTIVE_OFFER
         assert rule.subRules[1].attribute == offers_models.OfferValidationAttribute.DESCRIPTION
         assert rule.subRules[1].operator == offers_models.OfferValidationRuleOperator.CONTAINS_EXACTLY
-        assert rule.subRules[1].comparated == {"comparated": ["suspicious", "verboten", "interdit"]}
+        assert rule.subRules[1].comparated == {"comparated": ["interdit", "suspicious", "verboten"]}
 
     def test_edit_offer_validation_rule_delete_sub_rule(self, legit_user, authenticated_client):
         rule = offers_factories.OfferValidationRuleFactory(
@@ -543,14 +536,14 @@ class EditOfferValidationRuleTest(PostEndpointHelper):
             model=offers_models.OfferValidationModel.OFFER,
             attribute=offers_models.OfferValidationAttribute.NAME,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
         sub_rule_2 = offers_factories.OfferValidationSubRuleFactory(
             validationRule=rule,
             model=offers_models.OfferValidationModel.COLLECTIVE_OFFER,
             attribute=offers_models.OfferValidationAttribute.NAME,
             operator=offers_models.OfferValidationRuleOperator.CONTAINS_EXACTLY,
-            comparated={"comparated": ["suspicious", "verboten", "interdit"]},
+            comparated={"comparated": ["interdit", "suspicious", "verboten"]},
         )
         sub_rule_data_0 = get_empty_sub_rule_data(0) | {
             "sub_rules-0-id": None,
@@ -587,6 +580,6 @@ class EditOfferValidationRuleTest(PostEndpointHelper):
         assert rule.subRules[1].model == offers_models.OfferValidationModel.OFFER
         assert rule.subRules[1].attribute == offers_models.OfferValidationAttribute.DESCRIPTION
         assert rule.subRules[1].operator == offers_models.OfferValidationRuleOperator.CONTAINS
-        assert rule.subRules[1].comparated == {"comparated": ["Riri", "Fifi", "Loulou"]}
+        assert rule.subRules[1].comparated == {"comparated": ["Fifi", "Loulou", "Riri"]}
 
         assert not offers_models.OfferValidationRule.query.filter_by(id=sub_rule_2.id).one_or_none()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23054

## But de la pull request

- Correction d’un bug d’affichage lors de la modification de sous-règle type d’offre, où la liste des types n'était pas remplie.
- Trier les mots-clés par ordre alphabétique
- Trier les règles par ordre alphabétique
- Permettre d'écrire des noms de règle plus longs (256 max)

- Rajouter 4 types de sous-règles:
Sous-catégorie de l’offre collective
Sous-catégorie de l’offre collective vitrine
Catégorie de l’offre collective
Catégorie de l’offre collective vitrine

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
