### PR TITLE
(PC-23013)[API] feat: force reset when dms eac import is stuck

### DIFF
--- a/api/src/pcapi/connectors/dms/models.py
+++ b/api/src/pcapi/connectors/dms/models.py
@@ -13,7 +13,7 @@ from pcapi.models.pc_object import PcObject
 
 class LatestDmsImport(PcObject, Base, Model):
     procedureId = sa.Column(sa.Integer, nullable=False)
-    latestImportDatetime = sa.Column(sa.DateTime, nullable=False)
+    latestImportDatetime: datetime.datetime = sa.Column(sa.DateTime, nullable=False)
     isProcessing = sa.Column(sa.Boolean, nullable=False)
     processedApplications: list[int] = sa.Column(postgresql.ARRAY(sa.Integer), nullable=False, default=[])
 

--- a/api/tests/core/educational/api/test_update_dms_status.py
+++ b/api/tests/core/educational/api/test_update_dms_status.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -64,12 +64,12 @@ class UpdateDmsStatusTest:
         assert venue1.collectiveDmsApplications[0].procedure == 123
         assert venue1.collectiveDmsApplications[0].application == 1
         assert venue1.collectiveDmsApplications[0].siret == venue1.siret
-        assert venue1.collectiveDmsApplications[0].lastChangeDate == datetime(2023, 4, 9, 15, 17, 38)
-        assert venue1.collectiveDmsApplications[0].depositDate == datetime(2023, 3, 6, 15, 17, 37)
-        assert venue1.collectiveDmsApplications[0].expirationDate == datetime(2024, 3, 6, 15, 17, 37)
-        assert venue1.collectiveDmsApplications[0].buildDate == datetime(2023, 3, 7, 15, 17, 37)
-        assert venue1.collectiveDmsApplications[0].instructionDate == datetime(2023, 4, 8, 15, 17, 37)
-        assert venue1.collectiveDmsApplications[0].processingDate == datetime(2023, 4, 9, 15, 19, 37)
+        assert venue1.collectiveDmsApplications[0].lastChangeDate == datetime.datetime(2023, 4, 9, 15, 17, 38)
+        assert venue1.collectiveDmsApplications[0].depositDate == datetime.datetime(2023, 3, 6, 15, 17, 37)
+        assert venue1.collectiveDmsApplications[0].expirationDate == datetime.datetime(2024, 3, 6, 15, 17, 37)
+        assert venue1.collectiveDmsApplications[0].buildDate == datetime.datetime(2023, 3, 7, 15, 17, 37)
+        assert venue1.collectiveDmsApplications[0].instructionDate == datetime.datetime(2023, 4, 8, 15, 17, 37)
+        assert venue1.collectiveDmsApplications[0].processingDate == datetime.datetime(2023, 4, 9, 15, 19, 37)
         assert venue1.collectiveDmsApplications[0].userDeletionDate is None
 
         assert len(venue2.collectiveDmsApplications) == 1
@@ -77,10 +77,10 @@ class UpdateDmsStatusTest:
         assert venue2.collectiveDmsApplications[0].procedure == 123
         assert venue2.collectiveDmsApplications[0].application == 2
         assert venue2.collectiveDmsApplications[0].siret == venue2.siret
-        assert venue2.collectiveDmsApplications[0].lastChangeDate == datetime(2023, 3, 6, 15, 17, 38)
-        assert venue2.collectiveDmsApplications[0].depositDate == datetime(2023, 3, 6, 15, 17, 37)
-        assert venue2.collectiveDmsApplications[0].expirationDate == datetime(2024, 3, 6, 15, 17, 37)
-        assert venue2.collectiveDmsApplications[0].buildDate == datetime(2023, 3, 6, 15, 17, 37)
+        assert venue2.collectiveDmsApplications[0].lastChangeDate == datetime.datetime(2023, 3, 6, 15, 17, 38)
+        assert venue2.collectiveDmsApplications[0].depositDate == datetime.datetime(2023, 3, 6, 15, 17, 37)
+        assert venue2.collectiveDmsApplications[0].expirationDate == datetime.datetime(2024, 3, 6, 15, 17, 37)
+        assert venue2.collectiveDmsApplications[0].buildDate == datetime.datetime(2023, 3, 6, 15, 17, 37)
         assert venue2.collectiveDmsApplications[0].instructionDate is None
         assert venue2.collectiveDmsApplications[0].processingDate is None
         assert venue2.collectiveDmsApplications[0].userDeletionDate is None
@@ -109,12 +109,12 @@ class UpdateDmsStatusTest:
         assert venue.collectiveDmsApplications[0].procedure == 123
         assert venue.collectiveDmsApplications[0].application == 1
         assert venue.collectiveDmsApplications[0].siret == venue.siret
-        assert venue.collectiveDmsApplications[0].lastChangeDate == datetime(2023, 4, 9, 15, 17, 38)
-        assert venue.collectiveDmsApplications[0].depositDate == datetime(2023, 3, 6, 15, 17, 37)
-        assert venue.collectiveDmsApplications[0].expirationDate == datetime(2024, 3, 6, 15, 17, 37)
-        assert venue.collectiveDmsApplications[0].buildDate == datetime(2023, 3, 7, 15, 17, 37)
-        assert venue.collectiveDmsApplications[0].instructionDate == datetime(2023, 4, 8, 15, 17, 37)
-        assert venue.collectiveDmsApplications[0].processingDate == datetime(2023, 4, 9, 15, 19, 37)
+        assert venue.collectiveDmsApplications[0].lastChangeDate == datetime.datetime(2023, 4, 9, 15, 17, 38)
+        assert venue.collectiveDmsApplications[0].depositDate == datetime.datetime(2023, 3, 6, 15, 17, 37)
+        assert venue.collectiveDmsApplications[0].expirationDate == datetime.datetime(2024, 3, 6, 15, 17, 37)
+        assert venue.collectiveDmsApplications[0].buildDate == datetime.datetime(2023, 3, 7, 15, 17, 37)
+        assert venue.collectiveDmsApplications[0].instructionDate == datetime.datetime(2023, 4, 8, 15, 17, 37)
+        assert venue.collectiveDmsApplications[0].processingDate == datetime.datetime(2023, 4, 9, 15, 19, 37)
         assert venue.collectiveDmsApplications[0].userDeletionDate is None
 
     def test_only_call_from_last_update(self):
@@ -142,3 +142,18 @@ class UpdateDmsStatusTest:
         with patch("pcapi.connectors.dms.api.DMSGraphQLClient", return_value=mock):
             import_dms_applications(procedure_number=123)
         mock.get_eac_nodes_siret_states.assert_not_called()
+
+    def test_reset_import_if_stuck(self):
+        mock = MagicMock()
+        mock.get_eac_nodes_siret_states = MagicMock(return_value=DEFAULT_API_RESULT)
+
+        latest_import = dms_factories.LatestDmsImportFactory(
+            procedureId=123,
+            isProcessing=True,
+            latestImportDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+        )
+
+        with patch("pcapi.connectors.dms.api.DMSGraphQLClient", return_value=mock):
+            import_dms_applications(procedure_number=123)
+        mock.get_eac_nodes_siret_states.assert_not_called()
+        assert not latest_import.isProcessing


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23013

## But de la pull request

Ajout d'un reset de l'import DMS EAC dans le cas où il se bloque

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
