### PR TITLE
(PC-22980] feat: Delete unused backoffice permission by using another.

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 05de9b01bf9b (pre) (head)
-ccd0fadcfff1 (post) (head)
+97cccec19d0e (post) (head)

--- a/api/src/pcapi/alembic/versions/20230703T131004_97cccec19d0e_remove_unused_backoffice_permission.py
+++ b/api/src/pcapi/alembic/versions/20230703T131004_97cccec19d0e_remove_unused_backoffice_permission.py
@@ -1,0 +1,20 @@
+"""
+Remove 'BATCH_SUSPEND_USERS' permission
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "97cccec19d0e"
+down_revision = "ccd0fadcfff1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DELETE FROM permission WHERE name = 'BATCH_SUSPEND_USERS'")
+
+
+def downgrade() -> None:
+    op.execute("INSERT INTO permission (name) VALUES ('BATCH_SUSPEND_USERS')")

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -35,7 +35,6 @@ class Permissions(enum.Enum):
 
     SUSPEND_USER = "suspendre un compte utilisateur"
     UNSUSPEND_USER = "réactiver un compte utilisateur"
-    BATCH_SUSPEND_USERS = "suspendre en masse des comptes bénéficiaires/grand public"
 
     READ_PRO_ENTITY = "visualiser une structure, un lieu ou un compte pro"
     MANAGE_PRO_ENTITY = "gérer une structure, un lieu ou un compte pro"

--- a/api/src/pcapi/routes/backoffice_v3/fraud.py
+++ b/api/src/pcapi/routes/backoffice_v3/fraud.py
@@ -27,7 +27,7 @@ fraud_blueprint = utils.child_backoffice_blueprint(
     "fraud",
     __name__,
     url_prefix="/fraud",
-    permission=perm_models.Permissions.BATCH_SUSPEND_USERS,
+    permission=perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS,
 )
 
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -124,13 +124,13 @@
                 </div>
                 <hr />
               {% endif %}
-              {% if has_permission("PRO_FRAUD_ACTIONS") or has_permission("BATCH_SUSPEND_USERS") %}
+              {% if has_permission("PRO_FRAUD_ACTIONS") or has_permission("BENEFICIARY_FRAUD_ACTIONS") %}
                 <div class="nav nav-pills flex-column">
                   {% call menu_section("Fraude et conformité") %}
                     {% if has_permission("PRO_FRAUD_ACTIONS") %}
                       {{ menu_section_item("Règles de validation d'offres", "backoffice_v3_web.offer_validation_rules.list_rules") }}
                     {% endif %}
-                    {% if has_permission("BATCH_SUSPEND_USERS") %}
+                    {% if has_permission("BENEFICIARY_FRAUD_ACTIONS") %}
                       {{ menu_section_item("Suspension de comptes jeunes", "backoffice_v3_web.fraud.list_blacklisted_domain_names") }}
                     {% endif %}
                   {% endcall %}

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -48,7 +48,6 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "fraude-jeunes": [
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS,
-        perm_models.Permissions.BATCH_SUSPEND_USERS,
         perm_models.Permissions.MANAGE_BOOKINGS,
         perm_models.Permissions.READ_BOOKINGS,
     ],

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -73,7 +73,6 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "fraude-jeunes": [
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS,
-        perm_models.Permissions.BATCH_SUSPEND_USERS,
         perm_models.Permissions.MANAGE_BOOKINGS,
         perm_models.Permissions.READ_BOOKINGS,
     ],

--- a/api/tests/routes/backoffice_v3/fraud_test.py
+++ b/api/tests/routes/backoffice_v3/fraud_test.py
@@ -26,7 +26,7 @@ pytestmark = [
 
 class ListBlacklistedDomainNamesTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.fraud.list_blacklisted_domain_names"
-    needed_permission = perm_models.Permissions.BATCH_SUSPEND_USERS
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_list_blacklisted_domain_names(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory(email="user@example.fr")
@@ -59,7 +59,7 @@ class ListBlacklistedDomainNamesTest(GetEndpointHelper):
 
 class PrepareBlacklistDomainNamesTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.fraud.prepare_blacklist_domain_name"
-    needed_permission = perm_models.Permissions.BATCH_SUSPEND_USERS
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_prepare_blacklist_domain_name(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory(email="user@example.fr")
@@ -84,7 +84,7 @@ class PrepareBlacklistDomainNamesTest(GetEndpointHelper):
 class BlacklistDomainNameTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.fraud.blacklist_domain_name"
     endpoint_kwargs = {"domain": "example.fr"}
-    needed_permission = perm_models.Permissions.BATCH_SUSPEND_USERS
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_blacklist_domain_name(self, authenticated_client):
         user = bookings_factories.BookingFactory(user__email="user@example.fr").user
@@ -125,7 +125,7 @@ class BlacklistDomainNameTest(PostEndpointHelper):
 class RemoveBlacklistedDomainNameTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.fraud.remove_blacklisted_domain_name"
     endpoint_kwargs = {"domain": "example.fr"}
-    needed_permission = perm_models.Permissions.BATCH_SUSPEND_USERS
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_remove_blacklisted_domain(self, authenticated_client):
         domain = fraud_factories.BlacklistedDomainNameFactory().domain


### PR DESCRIPTION
https://passculture.atlassian.net/browse/PC-22980

## But de la pull request

Suppression de la permission backoffice ""suspendre en masse des comptes bénéficiaires/grand public" remplacé par “actions exclusives à l'équipe Fraude (jeune)”

## Implémentation

- Remove permission
- Update référence

À mon sens, pas besoin d'écrire exceptionnellement de tests, ceux en place suffissent. Un contrôle de permission permet de vérifier que les routes fraudes ont obligatoirement et uniquement la permission "actions exclusives à l'équipe Fraude (jeune)"

Voir `UnauthorizedHelperBase` de `tests/routes/backoffice_v3/helpers/unauthorized.py`

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
