### PR TITLE
PC-22931: Anonymise Ubble staging data

### DIFF
--- a/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
+++ b/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
@@ -213,9 +213,17 @@ SET "resultContent" = CASE
     THEN "resultContent" || (
         '{"email": "user' || "userId" || '@anonymized.email", "phone": "' || pg_temp.fake_phone_number_from_id("userId") || '", "address": "42 rue de la ville 44000 Nantes", "last_name": "' || pg_temp.fake_last_name("userId") || '", "first_name": "' || pg_temp.fake_first_name("userId") || '", "id_piece_number": "00000000 1 ZZ0"}'
       )::text::jsonb
+  WHEN ("type" = 'UBBLE' AND "status" = 'OK')
+    THEN "resultContent" || (
+        '{"identification_id": "11111111-1111-1111-1111-111111111111"}'
+      )::text::jsonb
+  WHEN ("type" = 'UBBLE' AND "status" = 'KO')
+    THEN "resultContent" || (
+        '{"identification_id": "00000000-0000-0000-0000-000000000000"}'
+      )::text::jsonb
   WHEN "type" = 'UBBLE'
     THEN "resultContent" || (
-      '{"last_name": "' || pg_temp.fake_last_name("userId") || '", "first_name": "' || pg_temp.fake_first_name("userId") || '", "married_name": "marriedName", "id_document_number": null, "identification_url": null}'
+      '{"last_name": "' || pg_temp.fake_last_name("userId") || '", "first_name": "' || pg_temp.fake_first_name("userId") || '", "married_name": "marriedName", "id_document_number": null, "identification_id": "22222222-2222-2222-2222-222222222222", "identification_url": null}'
     )::text::jsonb
   WHEN "type" = 'INTERNAL_REVIEW'
     THEN "resultContent" || (


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22931

## But de la pull request

Anonymiser les données du dossier Ubble des utilisateurs lors de la recopie de la BDD en staging.

## Implémentation

Ajout de 2 instructions dans le script anonymise.sql.

La [doc](https://ubbleai.github.io/developer-documentation/#internationalization) Ubble nous dit d'utiliser les codes suivants :
- 11111111-1111-1111-1111-111111111111 pour un identification valide,
- 00000000-0000-0000-0000-000000000000 pour une identification invalide,
- 22222222-2222-2222-2222-222222222222 si non décidé.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
