### PR TITLE
(PC-22922)[API] fix: Barcode Error when cancel external booking

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -263,7 +263,9 @@ def _cancel_external_booking(booking: Booking, stock: Stock) -> None:
                 raise feature.DisabledFeatureError("ENABLE_CGR_INTEGRATION is inactive")
         case _:
             raise offers_exceptions.UnexpectedCinemaProvider(f"Unknown Provider: {venue_provider_name}")
-    barcodes = [external_booking.barcode for external_booking in booking.externalBookings]
+    barcodes = [
+        external_booking.barcode for external_booking in booking.externalBookings if external_booking.barcode.isdigit()
+    ]
     external_bookings_api.cancel_booking(stock.offer.venueId, barcodes)
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22922

## But de la pull request

- Erreur Sentry sur la validité d'un code barre pour les réservations externes. 


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
