### PR TITLE
(BSR)[API] fix: decrease sentry error level when ean is 404

### DIFF
--- a/api/src/pcapi/connectors/titelive.py
+++ b/api/src/pcapi/connectors/titelive.py
@@ -91,7 +91,7 @@ def get_by_ean13(ean13: str) -> dict[str, typing.Any]:
         if 400 <= response.status_code < 500:
             core_logging.log_for_supervision(
                 logger,
-                logging.ERROR,
+                logging.WARNING if response.status_code == 404 else logging.ERROR,
                 "Titelive get by ean 13: External error: %s",
                 response.status_code,
                 extra={


### PR DESCRIPTION
## But de la pull request

Si la recherche est 404, cela envoi une erreur sur sentry.

La 404 n'étant pas une erreur que nous souhaitons remonter sur sentry, nous la passons en warning

## Implémentation

NA

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
