### PR TITLE
PC-22956 Make fraud checks consistent with user

### DIFF
--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -11,6 +11,7 @@ from factory.declarations import LazyAttribute
 import factory.fuzzy
 import pytz
 
+from pcapi import settings
 from pcapi.core import testing
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
@@ -133,12 +134,12 @@ class ProfileCompletionContentFactory(factory.Factory):
         model = models.ProfileCompletionContent
 
     activity = "Lycéen"
-    address = factory.Faker("address")
+    address = factory.Faker("address", locale="fr_FR")
     city = factory.Faker("city")
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     origin = "In app"
-    postal_code = factory.Faker("postcode")
+    postal_code = factory.Faker("postcode", locale="fr_FR")
     school_type = None
 
 

--- a/api/tests/core/users/test_generator.py
+++ b/api/tests/core/users/test_generator.py
@@ -144,3 +144,16 @@ class UserGeneratorTest:
 
         assert user.age == age
         self.assert_user_is_beneficiary(user)
+
+    def test_profile_completion_is_consistent_with_user_data(self):
+        user_data = users_generator.GenerateUserData(
+            age=users_constants.ELIGIBILITY_AGE_18,
+            step=users_generator.GeneratedSubscriptionStep.PROFILE_COMPLETION,
+        )
+        user = users_generator.generate_user(user_data)
+        profile_completion = user.beneficiaryFraudChecks[-1]
+        assert profile_completion.resultContent["address"] == user.address
+        assert profile_completion.resultContent["city"] == user.city
+        assert profile_completion.resultContent["firstName"] == user.firstName
+        assert profile_completion.resultContent["lastName"] == user.lastName
+        assert profile_completion.resultContent["postalCode"] == user.postalCode

--- a/api/tests/core/users/test_generator.py
+++ b/api/tests/core/users/test_generator.py
@@ -157,3 +157,14 @@ class UserGeneratorTest:
         assert profile_completion.resultContent["firstName"] == user.firstName
         assert profile_completion.resultContent["lastName"] == user.lastName
         assert profile_completion.resultContent["postalCode"] == user.postalCode
+
+    def test_identity_check_is_consistent_with_user_data(self):
+        user_data = users_generator.GenerateUserData(
+            age=users_constants.ELIGIBILITY_AGE_18,
+            step=users_generator.GeneratedSubscriptionStep.IDENTITY_CHECK,
+        )
+        user = users_generator.generate_user(user_data)
+        identity_check = user.beneficiaryFraudChecks[-1]
+        assert identity_check.resultContent["first_name"] == user.firstName
+        assert identity_check.resultContent["last_name"] == user.lastName
+        assert identity_check.resultContent["birth_date"] == str(user.birth_date)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22956

## But de la pull request

Faire en sorte que les données générées aléatoirement pour les attributs de l'utilisateur soient aussi celles utilisées pour ses `beneficiaryFraudChecks` `PROFILE_COMPLETION` et `IDENTITY_CHECK`.

## Implémentation

- Passer les attributs en paramètre des factories avec le deep context.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
