### PR TITLE
(PC-23106)[API] fix: fix category offer validation rule

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-3eb1ca346ea8 (pre) (head)
+05de9b01bf9b (pre) (head)
 ccd0fadcfff1 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230704T102119_05de9b01bf9b_rename_category_validation_attribute.py
+++ b/api/src/pcapi/alembic/versions/20230704T102119_05de9b01bf9b_rename_category_validation_attribute.py
@@ -1,0 +1,19 @@
+"""Rename OfferValidationAttribute Category to CategoryId
+"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "05de9b01bf9b"
+down_revision = "3eb1ca346ea8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE offer_validation_attribute RENAME VALUE 'CATEGORY' TO 'CATEGORY_ID'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TYPE offer_validation_attribute RENAME VALUE 'CATEGORY_ID' TO 'CATEGORY'")

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -443,6 +443,10 @@ class CollectiveOffer(
     def category(self) -> categories.Category:
         return self.subcategory.category
 
+    @property
+    def categoryId(self) -> str:  # used in validation rule, do not remove
+        return self.subcategory.category.id
+
     @hybrid_property
     def isEvent(self) -> bool:
         return self.subcategory.is_event

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -602,6 +602,10 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return self.subcategory.category
 
     @property
+    def categoryId(self) -> str:  # used in validation rule, do not remove
+        return self.subcategory.category.id
+
+    @property
     def image(self) -> OfferImage | None:
         activeMediation = self.activeMediation
         if activeMediation:
@@ -726,7 +730,7 @@ class OfferValidationAttribute(enum.Enum):
     NAME = "name"
     DESCRIPTION = "description"
     ID = "id"
-    CATEGORY = "category"
+    CATEGORY_ID = "categoryId"
     SUBCATEGORY_ID = "subcategoryId"
     WITHDRAWAL_DETAILS = "withdrawalDetails"
     MAX_PRICE = "max_price"
@@ -798,15 +802,15 @@ class OfferValidationSubRuleField(enum.Enum):
     }
     CATEGORY_OFFER = {
         "model": OfferValidationModel.OFFER,
-        "attribute": OfferValidationAttribute.CATEGORY,
+        "attribute": OfferValidationAttribute.CATEGORY_ID,
     }
     CATEGORY_COLLECTIVE_OFFER = {
         "model": OfferValidationModel.COLLECTIVE_OFFER,
-        "attribute": OfferValidationAttribute.CATEGORY,
+        "attribute": OfferValidationAttribute.CATEGORY_ID,
     }
     CATEGORY_COLLECTIVE_OFFER_TEMPLATE = {
         "model": OfferValidationModel.COLLECTIVE_OFFER_TEMPLATE,
-        "attribute": OfferValidationAttribute.CATEGORY,
+        "attribute": OfferValidationAttribute.CATEGORY_ID,
     }
     SHOW_SUB_TYPE_OFFER = {
         "model": OfferValidationModel.OFFER,

--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -431,7 +431,7 @@ def get_comparated_format_function(
             and sub_rule.model == offers_models.OfferValidationModel.OFFERER
         ):
             return lambda offerer_id: offerer_dict[offerer_id]
-        if sub_rule.attribute == offers_models.OfferValidationAttribute.CATEGORY:
+        if sub_rule.attribute == offers_models.OfferValidationAttribute.CATEGORY_ID:
             return lambda category_id: categories.ALL_CATEGORIES_DICT[category_id].pro_label
         if sub_rule.attribute == offers_models.OfferValidationAttribute.SUBCATEGORY_ID:
             return lambda subcategory_id: subcategories_v2.ALL_SUBCATEGORIES_DICT[subcategory_id].pro_label

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1878,9 +1878,20 @@ class ResolveOfferValidationRuleTest:
         offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
         factories.OfferValidationSubRuleFactory(
             model=models.OfferValidationModel.OFFER,
-            attribute=models.OfferValidationAttribute.CATEGORY,
-            operator=models.OfferValidationRuleOperator.NOT_IN,
+            attribute=models.OfferValidationAttribute.CATEGORY_ID,
+            operator=models.OfferValidationRuleOperator.IN,
             comparated={"comparated": ["MUSEE", "LIVRE", "CINEMA"]},
+        )
+
+        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.APPROVED
+
+    def test_offer_validation_with_one_rule_with_categories(self):
+        offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
+        factories.OfferValidationSubRuleFactory(
+            model=models.OfferValidationModel.OFFER,
+            attribute=models.OfferValidationAttribute.CATEGORY_ID,
+            operator=models.OfferValidationRuleOperator.IN,
+            comparated={"comparated": ["JEU"]},
         )
 
         assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.PENDING

--- a/api/tests/routes/backoffice_v3/offer_validation_rules_test.py
+++ b/api/tests/routes/backoffice_v3/offer_validation_rules_test.py
@@ -163,7 +163,7 @@ class CreateOfferValidationRuleTest(PostEndpointHelper):
                 },
                 {
                     "model": offers_models.OfferValidationModel.OFFER,
-                    "attribute": offers_models.OfferValidationAttribute.CATEGORY,
+                    "attribute": offers_models.OfferValidationAttribute.CATEGORY_ID,
                     "operator": offers_models.OfferValidationRuleOperator.IN,
                     "comparated": {"comparated": ["FILM", "CINEMA"]},
                 },
@@ -272,7 +272,7 @@ class CreateOfferValidationRuleTest(PostEndpointHelper):
         assert rule.subRules[0].operator == offers_models.OfferValidationRuleOperator.GREATER_THAN
         assert rule.subRules[0].comparated == {"comparated": 200}
         assert rule.subRules[1].model == offers_models.OfferValidationModel.OFFER
-        assert rule.subRules[1].attribute == offers_models.OfferValidationAttribute.CATEGORY
+        assert rule.subRules[1].attribute == offers_models.OfferValidationAttribute.CATEGORY_ID
         assert rule.subRules[1].operator == offers_models.OfferValidationRuleOperator.NOT_IN
         assert rule.subRules[1].comparated == {"comparated": ["INSTRUMENT"]}
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23106

## But de la pull request

Fix les sous-règles impliquant les catégories d'offre

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
