### PR TITLE
(PR-23065)[PRO] feat: wording de méthode de transmission

### DIFF
--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
@@ -53,7 +53,7 @@ const TicketWithdrawal = ({
       <FormLayout.Row>
         <RadioGroup
           group={ticketWithdrawalTypeRadios}
-          legend="Comment les billets, places seront-ils transmis ?"
+          legend="Précisez la façon dont vous distribuerez les billets :"
           name="withdrawalType"
           disabled={readOnlyFields.includes('withdrawalType')}
         />

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
@@ -56,7 +56,9 @@ describe('OfferIndividual section: TicketWithdrawal', () => {
     })
 
     // should contain sent date information when tickets are sent by mail
-    await userEvent.click(await screen.findByText('Envoi par email'))
+    await userEvent.click(
+      await screen.findByText('Les billets seront envoyés par email')
+    )
     expect(await screen.findByText('Date d’envoi')).toBeInTheDocument()
 
     // should contain withdrawal hour information when tickets are to withdraw on place
@@ -65,7 +67,9 @@ describe('OfferIndividual section: TicketWithdrawal', () => {
     )
     expect(await screen.findByText('Heure de retrait')).toBeInTheDocument()
 
-    await userEvent.click(await screen.findByText('Évènement sans billet'))
+    await userEvent.click(
+      await screen.findByText('Aucun billet n’est nécessaire')
+    )
     expect(await screen.queryByText('Date d’envoi')).not.toBeInTheDocument()
     expect(await screen.queryByText('Heure de retrait')).not.toBeInTheDocument()
   })
@@ -95,8 +99,12 @@ describe('OfferIndividual section: TicketWithdrawal', () => {
       onSubmit,
     })
 
-    expect(screen.getByLabelText('Envoi par email')).toBeDisabled()
-    expect(screen.getByLabelText('Évènement sans billet')).toBeDisabled()
+    expect(
+      screen.getByLabelText('Les billets seront envoyés par email')
+    ).toBeDisabled()
+    expect(
+      screen.getByLabelText('Aucun billet n’est nécessaire')
+    ).toBeDisabled()
     expect(
       screen.getByLabelText('Retrait sur place (guichet, comptoir...)')
     ).toBeDisabled()

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/constants.ts
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/constants.ts
@@ -9,11 +9,11 @@ export const TICKET_WITHDRAWAL_DEFAULT_VALUES = {
 
 export const ticketWithdrawalTypeRadios = [
   {
-    label: 'Évènement sans billet',
+    label: 'Aucun billet n’est nécessaire',
     value: WithdrawalTypeEnum.NO_TICKET,
   },
   {
-    label: 'Envoi par email',
+    label: 'Les billets seront envoyés par email',
     value: WithdrawalTypeEnum.BY_EMAIL,
   },
   {

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
@@ -157,7 +157,9 @@ describe('OfferIndividual section: UsefulInformations', () => {
     await userEvent.selectOptions(offererSelect, offererId.toString())
     const venueSelect = screen.getByLabelText('Lieu')
     await userEvent.selectOptions(venueSelect, venueList[0].id.toString())
-    const withEmail = screen.getByLabelText('Envoi par email')
+    const withEmail = screen.getByLabelText(
+      'Les billets seront envoyés par email'
+    )
     await userEvent.click(withEmail)
 
     const bookingContactField = screen.getByLabelText('Email de contact')
@@ -246,7 +248,7 @@ describe('OfferIndividual section: UsefulInformations', () => {
     })
 
     expect(
-      screen.getByText('Comment les billets, places seront-ils transmis ?')
+      screen.getByText('Précisez la façon dont vous distribuerez les billets :')
     ).toBeInTheDocument()
   })
 
@@ -259,7 +261,9 @@ describe('OfferIndividual section: UsefulInformations', () => {
     })
 
     expect(
-      screen.queryByText('Comment les billets, places seront-ils transmis ?')
+      screen.queryByText(
+        'Précisez la façon dont vous distribuerez les billets :'
+      )
     ).not.toBeInTheDocument()
   })
 

--- a/pro/src/core/Offers/constants.ts
+++ b/pro/src/core/Offers/constants.ts
@@ -46,8 +46,9 @@ export enum OFFER_WIZARD_MODE {
 export const OFFER_WITHDRAWAL_TYPE_LABELS = {
   [OFFER_WITHDRAWAL_TYPE_OPTIONS.ON_SITE]:
     'Retrait sur place (guichet, comptoir...)',
-  [OFFER_WITHDRAWAL_TYPE_OPTIONS.NO_TICKET]: 'Évènement sans billet',
-  [OFFER_WITHDRAWAL_TYPE_OPTIONS.BY_EMAIL]: 'Envoi par email',
+  [OFFER_WITHDRAWAL_TYPE_OPTIONS.NO_TICKET]: 'Aucun billet n’est nécessaire',
+  [OFFER_WITHDRAWAL_TYPE_OPTIONS.BY_EMAIL]:
+    'Les billets seront envoyés par email',
 }
 
 export const OFFER_STATUS_ACTIVE = OfferStatus.ACTIVE

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -926,7 +926,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
 
         if (withdrawalInformations.withdrawalType) {
           const withdrawalTypeField = await screen.findByLabelText(
-            'Envoi par email'
+            'Les billets seront envoyés par email'
           )
           await userEvent.click(withdrawalTypeField)
           expectedBody.withdrawalType = WithdrawalTypeEnum.BY_EMAIL

--- a/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
@@ -209,7 +209,7 @@ const OfferSummary = ({
           /* istanbul ignore next: DEBT, TO FIX */
           offerData.withdrawalType && (
             <SummaryLayout.Row
-              title="Comment les billets, places seront-ils transmis ?"
+              title="Précisez la façon dont vous distribuerez les billets :"
               description={
                 OFFER_WITHDRAWAL_TYPE_LABELS[offerData.withdrawalType]
               }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23065

## But de la pull request

Dans le parcours de création d’offre, pour les types d’offres qui affichent la partie suivante 

Remplacer “Comment les billets, places seront-ils transmis ?“ par “Précisez la façon dont vous distribuerez les billets :”

remplacer “Évènement sans billet“ par “Aucun billet n’est nécessaire”

remplacer “Envoi par email“ par “Les billets seront envoyés par email”

 remplacer “Retrait sur place (guichet, comptoir...)“ par “Les billets devront être retirés sur place (guichet, comptoir...)”

## Informations supplémentaires

<img width="975" alt="Capture d’écran 2023-07-04 à 14 28 28" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/000c8bdc-6ceb-4db0-b809-b4a2fb2c2f02">


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `PC-23065-wording-methode`
 
