### PR TITLE
(PC-23129)[API] fix create multiple ean on workers

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -190,7 +190,6 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
                 created_offer = _create_offer_from_product(
                     venue,
                     product_by_ean[ean],
-                    stock_data["id_at_provider"],
                     provider,
                 )
                 created_offers.append(created_offer)
@@ -278,7 +277,6 @@ def _serialize_products_from_body(
             "quantity": product.stock.quantity,
             "price": product.stock.price,
             "booking_limit_datetime": product.stock.booking_limit_datetime,
-            "id_at_provider": product.id_at_provider,
         }
     return stock_details
 
@@ -286,13 +284,14 @@ def _serialize_products_from_body(
 def _create_offer_from_product(
     venue: offerers_models.Venue,
     product: offers_models.Product,
-    id_at_provider: str | None,
     provider: providers_models.Provider,
 ) -> offers_models.Offer:
+    ean = None
     if product.extraData:
-        offers_validation.check_ean_does_not_exist(product.extraData.get("ean"), venue)
+        ean = product.extraData.get("ean")
+        offers_validation.check_ean_does_not_exist(ean, venue)
 
-    offer = offers_api.build_new_offer_from_product(venue, product, id_at_provider, provider.id)
+    offer = offers_api.build_new_offer_from_product(venue, product, ean, provider.id)
 
     offer.audioDisabilityCompliant = venue.audioDisabilityCompliant
     offer.mentalDisabilityCompliant = venue.mentalDisabilityCompliant

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -191,7 +191,7 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
                     venue,
                     product_by_ean[ean],
                     stock_data["id_at_provider"],
-                    current_api_key.provider,
+                    provider,
                 )
                 created_offers.append(created_offer)
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -129,9 +129,6 @@ EXTERNAL_TICKET_OFFICE_URL_FIELD = pydantic.Field(
     description="Link displayed to users wishing to book the offer but who do not have (anymore) credit.",
     example="https://example.com",
 )
-ID_AT_PROVIDER_FIELD = pydantic.Field(
-    description="The ID of the offer in your database. May be used to assert proper synchronization."
-)
 IMAGE_CREDIT_FIELD = pydantic.Field(None, description="Image owner or author.", example="Jane Doe")
 WITHDRAWAL_DETAILS_FIELD = pydantic.Field(
     None,
@@ -466,7 +463,6 @@ class ProductOfferByEanCreation(serialization.ConfiguredBaseModel):
         ean: str = EAN_FIELD
     else:
         ean: pydantic.constr(min_length=13, max_length=13) = EAN_FIELD
-    id_at_provider: str | None = ID_AT_PROVIDER_FIELD
     stock: StockCreation
 
     class Config:

--- a/api/tests/routes/public/individual_offers/v1/endpoints_test.py
+++ b/api/tests/routes/public/individual_offers/v1/endpoints_test.py
@@ -1025,7 +1025,6 @@ class PostProductByEanTest:
                 "products": [
                     {
                         "ean": product.extraData["ean"],
-                        "idAtProvider": "id",
                         "stock": {
                             "bookingLimitDatetime": "2022-01-01T16:00:00+04:00",
                             "price": 1234,
@@ -1050,7 +1049,6 @@ class PostProductByEanTest:
         assert created_offer.bookingEmail == venue.bookingEmail
         assert created_offer.description == product.description
         assert created_offer.extraData == product.extraData
-        assert created_offer.idAtProvider == "id"
         assert created_offer.lastProvider.name == "Technical provider"
         assert created_offer.name == product.name
         assert created_offer.product == product
@@ -1087,7 +1085,6 @@ class PostProductByEanTest:
                 "products": [
                     {
                         "ean": product.extraData["ean"],
-                        "idAtProvider": "id",
                         "stock": {
                             "bookingLimitDatetime": "2022-01-01T16:00:00+04:00",
                             "price": 1234,
@@ -1115,7 +1112,6 @@ class PostProductByEanTest:
                 "products": [
                     {
                         "ean": product.extraData["ean"],
-                        "idAtProvider": "id",
                         "stock": {
                             "price": 1234,
                             "quantity": 3,
@@ -1138,7 +1134,6 @@ class PostProductByEanTest:
                 "products": [
                     {
                         "ean": product.extraData["ean"],
-                        "idAtProvider": "id",
                         "stock": {
                             "price": 1234,
                             "quantity": 3,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23129

Workers cannot access request contexted current_api_key.
https://sentry.passculture.team/organizations/sentry/issues/419621/?project=5&referrer=slack

Remove an unused field that we thought once was a good idea