### PR TITLE
(PC-22750)[API] feat: sandbox: eac: rm offers from eac_rejected offerer

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -71,14 +71,6 @@ def create_offers(
         reimbursed_booking=False,
     )
 
-    # eac_rejected
-    offerer = next(offerers_iterator)
-    create_offers_base_list(
-        offerer=offerer,
-        institutions=institutions,
-        domains=domains,
-    )
-
 
 def create_offers_base_list(
     offerer: offerers_models.Offerer,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22750

## But de la pull request

Supprimer les offres collectives liées au lieu "eac_rejected" : elles ne devraient pas exister et ne peuvent pas être dupliquées, ce qui créé de la confusion.