### PR TITLE
(PC-18004)[PRO] fix: spacing between section and profile title

### DIFF
--- a/pro/src/pages/Home/Homepage.scss
+++ b/pro/src/pages/Home/Homepage.scss
@@ -9,6 +9,8 @@
   }
 
   .h-description-list {
+    margin-top: rem.torem(16px);
+
     .h-dl-row {
       display: flex;
       flex-direction: row;
@@ -124,7 +126,7 @@
   }
 
   .h-section {
-    margin-top: rem.torem(40px);
+    margin-top: rem.torem(32px);
 
     &:first-child {
       margin-top: 0;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18004

## But de la pull request

- 16px entre 'profil' et les informations
- 40px --> 32px entre le titre des sections

## Implémentation

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/6741242e-e1d6-444e-8db9-551065ba5206)

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
