### PR TITLE
(PC-23129)[API] fix: updateVenueProviderPayload body

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/ToggleVenueProviderStatusButton/ToggleVenueProviderStatusButton.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/ToggleVenueProviderStatusButton/ToggleVenueProviderStatusButton.tsx
@@ -29,10 +29,13 @@ const ToggleVenueProviderStatusButton = ({
     setIsLoading(true)
     const payload = {
       ...venueProvider,
+      // Price is a number in VenueProviderResponse but PostVenueProviderBody expects a string
+      // We should probably fix this at some point
+      price: venueProvider.price?.toString(),
+      providerId: venueProvider.provider.id,
       isActive: !venueProvider.isActive,
     }
     api
-      // @ts-expect-error boolean | null is not assignable to boolean | undefined
       .updateVenueProvider(payload)
       .then(editedVenueProvider => {
         afterEdit(editedVenueProvider)


### PR DESCRIPTION
the ts-expect-error hide 2 errors, price is not a string and providerId missing.
The second one was the bug

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-23129
