### PR TITLE
(PC-23064)[BO] Fix different reimbursement points on venue page

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -294,7 +294,6 @@ def get_stats_data(venue_id: int) -> serialization.VenueStats:
 
 def get_venue_bank_information(venue: offerers_models.Venue) -> serialization.VenueBankInformation:
     now = datetime.utcnow()
-    has_bank_information = venue.bic and venue.iban
     reimbursement_point_name = None
     pricing_point_name = None
     bic = None
@@ -318,15 +317,13 @@ def get_venue_bank_information(venue: offerers_models.Venue) -> serialization.Ve
         None,
     )
 
-    if has_bank_information:
-        bic = venue.bic
-        iban = venue.iban
-        reimbursement_point_name = venue.name
-    elif current_reimbursement_point is not None:
+    if current_reimbursement_point:
         bic = current_reimbursement_point.bic
         iban = current_reimbursement_point.iban
         reimbursement_point_name = current_reimbursement_point.name
-        reimbursement_point_url = url_for("backoffice_v3_web.venue.get", venue_id=current_reimbursement_point.id)
+
+        if current_reimbursement_point.id != venue.id:
+            reimbursement_point_url = url_for("backoffice_v3_web.venue.get", venue_id=current_reimbursement_point.id)
 
     if venue.siret:
         pricing_point_name = venue.name


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23064

### Problématique
Pour les lieux ayant à la fois des coordonnées bancaires (`bankInformation`) ET un point de remboursement valide : le point de remboursement affiché dans l'onglet "Remboursements" et dans l'encadré à droite étaient différents.

### Constat
En me basant sur ce qu'affiche PC pro dans les coordonnées bancaires des lieux en question, j'ai conclu que même si un lieu est porteur d'informations bancaires (`bankInformation`), un point de remboursement valable (`reimbursementPoint`) sera toujours préféré pour le remboursement.

### Solution
J'ai donc modifié la façon de sélectionner le point de remboursement du lieu en me basant d'abord sur les `reimbursement_point_links` plutôt que sur ses `bankInformation`

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques