### PR TITLE
(BSR)[API] fix: add categoryid property to offer collective templates

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -609,6 +609,10 @@ class CollectiveOfferTemplate(
             raise ValueError(f"Unexpected subcategoryId '{self.subcategoryId}' for collective offer template {self.id}")
         return subcategories.ALL_SUBCATEGORIES_DICT[self.subcategoryId]
 
+    @property
+    def categoryId(self) -> str:  # used in validation rule, do not remove
+        return self.subcategory.category.id
+
     @hybrid_property
     def isEvent(self) -> bool:
         return self.subcategory.is_event


### PR DESCRIPTION
## But de la pull request

Rajouter une porperty aux CollectiveOfferTemplate qui est utilisée par les règles de fraude

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques