### PR TITLE
(PC-23129)[API] fix: again, i went too fast and forgot a fix

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -216,7 +216,7 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
                 price=finance_utils.to_euros(stock_data["price"]),
                 quantity=serialization.deserialize_quantity(stock_data["quantity"]),
                 booking_limit_datetime=stock_data["booking_limit_datetime"],
-                creating_provider=current_api_key.provider,
+                creating_provider=provider,
             )
     for offer in offers_to_update:
         try:


### PR DESCRIPTION
current_api_key is defined in a context of a request, not in workers

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23129

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques