### PR TITLE
(BSR) fix: always deploy both app on testing

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -88,8 +88,12 @@ jobs:
       teleport_version: 11.1.1
       teleport_proxy: teleport.ehp.passculture.team:443
       teleport_kubernetes_cluster: passculture-metier-ehp
-      deploy_api: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
-      deploy_pro: ${{ needs.check-pro-folder-changes.outputs.folder_changed == 'true' }}
+      # We sould not always deploy both apps, we do it for now until we
+      # have a better way to know which app have modifications in a pull request
+      # Today only the front is deployed if the PR has 2 commits, the first one with
+      # modification on the api and the second one with modification on the front
+      deploy_api: true
+      deploy_pro: true
     secrets: inherit
 
   notification:


### PR DESCRIPTION
On a eu une plusieurs bug en testing, cela arrivait parcequ'une PR avec des commits méleangent de l'api et du pro et que le dernier commit comprends des modifs uniquement sur l'une des deux app est mergée. Seul le dernier commit est regardé pour savoir ce qu'on doit déployer -> Décalage de version entre le front et le back. 

Simple fix : toujours déployer les deux comme en staging/prod
