### PR TITLE
Revert "(BSR) fix: always deploy both app on testing"

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -88,12 +88,8 @@ jobs:
       teleport_version: 11.1.1
       teleport_proxy: teleport.ehp.passculture.team:443
       teleport_kubernetes_cluster: passculture-metier-ehp
-      # We sould not always deploy both apps, we do it for now until we
-      # have a better way to know which app have modifications in a pull request
-      # Today only the front is deployed if the PR has 2 commits, the first one with
-      # modification on the api and the second one with modification on the front
-      deploy_api: true
-      deploy_pro: true
+      deploy_api: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
+      deploy_pro: ${{ needs.check-pro-folder-changes.outputs.folder_changed == 'true' }}
     secrets: inherit
 
   notification:


### PR DESCRIPTION
This reverts commit befb3d5e0d415e34c036599705e2dcd4d1f16b7c.

This didn't work because deploy-api needs "build api docker image on master" needs test-api to run. 
We will have to be smarter but i don't have time now