### PR TITLE
(PC-23174)[PRO] fix: add default size for stroke icon in adage offer

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -169,6 +169,7 @@ const Offer = ({
                 className={cn(style['offer-see-more-icon'], {
                   [style['offer-see-more-icon-closed']]: !displayDetails,
                 })}
+                width="16"
               />
               en savoir plus
             </button>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23174

Fix l'icone à côté de "en savoir plus" dans adage 


![Capture d’écran 2023-07-07 à 08 26 04](https://github.com/pass-culture/pass-culture-main/assets/71768799/329e08eb-ea97-4a8b-a240-c2510521e1e4)


