### PR TITLE
(PC-23189)[PRO] feat: rename AdageHeaderFrom to iframe_from for data

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -20,7 +20,7 @@ def log_catalog_view(
         event_name="CatalogView",
         extra_data={
             "source": body.source,
-            "AdageHeaderFrom": body.AdageHeaderFrom,
+            "from": body.iframeFrom,
         },
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -37,10 +37,12 @@ def log_search_button_click(
     body: serialization.SearchBody,
 ) -> None:
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
+    extra_data = body.dict()
+    extra_data["from"] = extra_data.pop("iframeFrom")
     educational_utils.log_information_for_data_purpose(
         event_name="SearchButtonClicked",
         user_email=authenticated_information.email,
-        extra_data=body.dict(),
+        extra_data=extra_data,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
     )
@@ -57,7 +59,7 @@ def log_offer_details_button_click(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
     educational_utils.log_information_for_data_purpose(
         event_name="OfferDetailButtonClick",
-        extra_data={"stockId": body.stockId, "AdageHeaderFrom": body.AdageHeaderFrom},
+        extra_data={"stockId": body.stockId, "from": body.iframeFrom},
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -75,7 +77,7 @@ def log_offer_template_details_button_click(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
     educational_utils.log_information_for_data_purpose(
         event_name="TemplateOfferDetailButtonClick",
-        extra_data={"offerId": body.offerId, "AdageHeaderFrom": body.AdageHeaderFrom},
+        extra_data={"offerId": body.offerId, "from": body.iframeFrom},
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -93,7 +95,7 @@ def log_booking_modal_button_click(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
     educational_utils.log_information_for_data_purpose(
         event_name="BookingModalButtonClick",
-        extra_data={"stockId": body.stockId, "AdageHeaderFrom": body.AdageHeaderFrom},
+        extra_data={"stockId": body.stockId, "from": body.iframeFrom},
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -111,7 +113,7 @@ def log_contact_modal_button_click(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
     educational_utils.log_information_for_data_purpose(
         event_name="ContactModalButtonClick",
-        extra_data={"offerId": body.offerId, "AdageHeaderFrom": body.AdageHeaderFrom},
+        extra_data={"offerId": body.offerId, "from": body.iframeFrom},
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -129,7 +131,7 @@ def log_fav_offer_button_click(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
     educational_utils.log_information_for_data_purpose(
         event_name="FavOfferButtonClick",
-        extra_data={"offerId": body.offerId, "AdageHeaderFrom": body.AdageHeaderFrom},
+        extra_data={"offerId": body.offerId, "from": body.iframeFrom},
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -147,7 +149,7 @@ def log_header_link_click(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
     educational_utils.log_information_for_data_purpose(
         event_name="HeaderLinkClick",
-        extra_data={"header_link_name": body.header_link_name.value, "AdageHeaderFrom": body.AdageHeaderFrom},
+        extra_data={"header_link_name": body.header_link_name.value, "from": body.iframeFrom},
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -162,9 +164,11 @@ def log_request_form_popin_dismiss(
     body: serialization.CollectiveRequestBody,
 ) -> None:
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
+    extra_data = body.dict()
+    extra_data["from"] = extra_data.pop("iframeFrom")
     educational_utils.log_information_for_data_purpose(
         event_name="RequestPopinDismiss",
-        extra_data=body.dict(),
+        extra_data=extra_data,
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -4,7 +4,7 @@ from pcapi.routes.serialization import BaseModel
 
 
 class AdageBaseModel(BaseModel):
-    AdageHeaderFrom: str
+    iframeFrom: str
 
 
 class CatalogViewBody(AdageBaseModel):

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -15,7 +15,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = client.post(
                 "/adage-iframe/logs/catalog-view",
-                json={"source": "partnersMap", "AdageHeaderFrom": "for_my_institution"},
+                json={"source": "partnersMap", "iframeFrom": "for_my_institution"},
             )
 
         # then
@@ -24,7 +24,7 @@ class LogsTest:
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
             "source": "partnersMap",
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "uai": "EAU123",
             "user_role": AdageFrontRoles.READONLY,
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
@@ -44,7 +44,7 @@ class LogsTest:
                         "departments",
                         "institutionId",
                     ],
-                    "AdageHeaderFrom": "for_my_institution",
+                    "iframeFrom": "for_my_institution",
                     "resultsCount": 0,
                 },
             )
@@ -54,7 +54,7 @@ class LogsTest:
         assert caplog.records[0].message == "SearchButtonClicked"
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "filters": ["departments", "institutionId"],
             "resultsCount": 0,
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
@@ -71,7 +71,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = client.post(
                 "/adage-iframe/logs/offer-detail",
-                json={"stockId": 1, "AdageHeaderFrom": "for_my_institution"},
+                json={"stockId": 1, "iframeFrom": "for_my_institution"},
             )
 
         # then
@@ -80,7 +80,7 @@ class LogsTest:
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
             "stockId": 1,
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
             "uai": "EAU123",
             "user_role": AdageFrontRoles.READONLY,
@@ -95,7 +95,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = client.post(
                 "/adage-iframe/logs/offer-template-detail",
-                json={"offerId": 1, "AdageHeaderFrom": "for_my_institution"},
+                json={"offerId": 1, "iframeFrom": "for_my_institution"},
             )
 
         # then
@@ -104,7 +104,7 @@ class LogsTest:
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
             "offerId": 1,
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
             "uai": "EAU123",
             "user_role": AdageFrontRoles.READONLY,
@@ -119,7 +119,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = client.post(
                 "/adage-iframe/logs/booking-modal-button",
-                json={"stockId": 1, "AdageHeaderFrom": "for_my_institution"},
+                json={"stockId": 1, "iframeFrom": "for_my_institution"},
             )
 
         # then
@@ -128,7 +128,7 @@ class LogsTest:
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
             "stockId": 1,
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
             "uai": "EAU123",
             "user_role": AdageFrontRoles.READONLY,
@@ -143,7 +143,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = client.post(
                 "/adage-iframe/logs/offer-template-detail",
-                json={"offerId": 1, "AdageHeaderFrom": "for_my_institution"},
+                json={"offerId": 1, "iframeFrom": "for_my_institution"},
             )
 
         # then
@@ -152,7 +152,7 @@ class LogsTest:
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
             "offerId": 1,
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
             "uai": "EAU123",
             "user_role": AdageFrontRoles.READONLY,
@@ -167,7 +167,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = client.post(
                 "/adage-iframe/logs/fav-offer",
-                json={"offerId": 1, "AdageHeaderFrom": "for_my_institution"},
+                json={"offerId": 1, "iframeFrom": "for_my_institution"},
             )
 
         # then
@@ -176,7 +176,7 @@ class LogsTest:
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
             "offerId": 1,
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
             "uai": "EAU123",
             "user_role": AdageFrontRoles.READONLY,
@@ -190,7 +190,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = test_client.post(
                 "/adage-iframe/logs/header-link-click",
-                json={"header_link_name": "search", "AdageHeaderFrom": "for_my_institution"},
+                json={"header_link_name": "search", "iframeFrom": "for_my_institution"},
             )
 
         # then
@@ -201,7 +201,7 @@ class LogsTest:
         assert record.extra == {
             "analyticsSource": "adage",
             "header_link_name": "search",
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
             "uai": "123456",
             "user_role": AdageFrontRoles.READONLY,
@@ -222,7 +222,7 @@ class LogsTest:
                     "totalStudents": 30,
                     "totalTeachers": 2,
                     "comment": "La première règle du Fight Club est: il est interdit de parler du Fight Club",
-                    "AdageHeaderFrom": "for_my_institution",
+                    "iframeFrom": "for_my_institution",
                 },
             )
 
@@ -231,7 +231,7 @@ class LogsTest:
         record = [record for record in caplog.records if record.message == "RequestPopinDismiss"][0]
         assert record.extra == {
             "analyticsSource": "adage",
-            "AdageHeaderFrom": "for_my_institution",
+            "from": "for_my_institution",
             "collectiveOfferTemplateId": 1,
             "phoneNumber": "0601020304",
             "requestedDate": "2022-12-02",

--- a/pro/src/apiClient/adage/models/AdageHeaderLogBody.ts
+++ b/pro/src/apiClient/adage/models/AdageHeaderLogBody.ts
@@ -6,7 +6,7 @@
 import type { AdageHeaderLink } from './AdageHeaderLink';
 
 export type AdageHeaderLogBody = {
-  AdageHeaderFrom: string;
   header_link_name: AdageHeaderLink;
+  iframeFrom: string;
 };
 

--- a/pro/src/apiClient/adage/models/CatalogViewBody.ts
+++ b/pro/src/apiClient/adage/models/CatalogViewBody.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 
 export type CatalogViewBody = {
-  AdageHeaderFrom: string;
+  iframeFrom: string;
   source: string;
 };
 

--- a/pro/src/apiClient/adage/models/CollectiveRequestBody.ts
+++ b/pro/src/apiClient/adage/models/CollectiveRequestBody.ts
@@ -4,9 +4,9 @@
 /* eslint-disable */
 
 export type CollectiveRequestBody = {
-  AdageHeaderFrom: string;
   collectiveOfferTemplateId: number;
   comment: string;
+  iframeFrom: string;
   phoneNumber?: string | null;
   requestedDate?: string | null;
   totalStudents?: number | null;

--- a/pro/src/apiClient/adage/models/OfferIdBody.ts
+++ b/pro/src/apiClient/adage/models/OfferIdBody.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 
 export type OfferIdBody = {
-  AdageHeaderFrom: string;
+  iframeFrom: string;
   offerId: number;
 };
 

--- a/pro/src/apiClient/adage/models/SearchBody.ts
+++ b/pro/src/apiClient/adage/models/SearchBody.ts
@@ -4,8 +4,8 @@
 /* eslint-disable */
 
 export type SearchBody = {
-  AdageHeaderFrom: string;
   filters: Array<string>;
+  iframeFrom: string;
   resultsCount: number;
 };
 

--- a/pro/src/apiClient/adage/models/StockIdBody.ts
+++ b/pro/src/apiClient/adage/models/StockIdBody.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 
 export type StockIdBody = {
-  AdageHeaderFrom: string;
+  iframeFrom: string;
   stockId: number;
 };
 

--- a/pro/src/pages/AdageIframe/app/App.tsx
+++ b/pro/src/pages/AdageIframe/app/App.tsx
@@ -77,7 +77,7 @@ export const App = (): JSX.Element => {
         setIsLoading(false)
         if (LOGS_DATA) {
           apiAdage.logCatalogView({
-            AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+            iframeFrom: removeParamsFromUrl(location.pathname),
             source: siret || venueId ? 'partnersMap' : 'homepage',
           })
         }

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -54,7 +54,7 @@ export const AdageHeaderComponent = ({ hits }: HitsProvided<ResultType>) => {
 
   const logAdageLinkClick = (headerLinkName: AdageHeaderLink) => {
     apiAdage.logHeaderLinkClick({
-      AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+      iframeFrom: removeParamsFromUrl(location.pathname),
       header_link_name: headerLinkName,
     })
   }

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
@@ -130,7 +130,7 @@ describe('AdageHeader', () => {
       )
       expect(apiAdage.logHeaderLinkClick).toHaveBeenCalledTimes(1)
       expect(apiAdage.logHeaderLinkClick).toHaveBeenCalledWith({
-        AdageHeaderFrom: '/',
+        iframeFrom: '/',
         header_link_name: headerLink.headerLinkName,
       })
     }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
@@ -36,7 +36,7 @@ const ContactButton = ({
   const handleButtonClick = () => {
     setIsModalOpen(true)
     apiAdage.logContactModalButtonClick({
-      AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+      iframeFrom: removeParamsFromUrl(location.pathname),
       offerId,
     })
     logClickOnOffer(offerId.toString(), position, queryId)

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
@@ -55,7 +55,7 @@ const RequestFormDialog = ({
   }
   const closeRequestFormDialog = () => {
     apiAdage.logRequestFormPopinDismiss({
-      AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+      iframeFrom: removeParamsFromUrl(location.pathname),
       collectiveOfferTemplateId: offerId,
       comment: formik.values.description,
       phoneNumber: formik.values.teacherPhone,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/RequestFormDialog.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/RequestFormDialog.spec.tsx
@@ -158,7 +158,7 @@ describe('RequestFormDialog', () => {
     )
 
     expect(apiAdage.logRequestFormPopinDismiss).toHaveBeenCalledWith({
-      AdageHeaderFrom: '/',
+      iframeFrom: '/',
       collectiveOfferTemplateId: 1,
       comment: 'Test description',
       phoneNumber: undefined,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -54,11 +54,11 @@ const Offer = ({
     if (LOGS_DATA) {
       !offer.isTemplate
         ? apiAdage.logOfferDetailsButtonClick({
-            AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+            iframeFrom: removeParamsFromUrl(location.pathname),
             stockId: offer.stock.id,
           })
         : apiAdage.logOfferTemplateDetailsButtonClick({
-            AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+            iframeFrom: removeParamsFromUrl(location.pathname),
             offerId: offer.id,
           })
     }
@@ -67,7 +67,7 @@ const Offer = ({
 
   const handleLikeClick = () => {
     apiAdage.logFavOfferButtonClick({
-      AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+      iframeFrom: removeParamsFromUrl(location.pathname),
       offerId: offer.id,
     })
     setIsModalLikeOpen(true)

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -90,7 +90,7 @@ export const OffersComponent = ({
     // wait for nbHits to update before sending data results
     if (LOGS_DATA && hasClickedSearch) {
       apiAdage.logSearchButtonClick({
-        AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+        iframeFrom: removeParamsFromUrl(location.pathname),
         filters: filtersKeys,
         resultsCount: nbHits,
       })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
@@ -39,7 +39,7 @@ const PrebookingButton = ({
   const handleBookingModalButtonClick = (stockId: number) => {
     if (LOGS_DATA) {
       apiAdage.logBookingModalButtonClick({
-        AdageHeaderFrom: removeParamsFromUrl(location.pathname),
+        iframeFrom: removeParamsFromUrl(location.pathname),
         stockId,
       })
     }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23189

Renomme le champs `AdageHeaderFrom` pour `iframe_from` dans les logs adage par soucis d'homogénéité pour la data
