### PR TITLE
(PC-23192)[PRO] fix: do not partially reset filters on stocks deletion

### DIFF
--- a/pro/src/screens/OfferIndividual/StocksEventEdition/StockFormList/StockFormList.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/StockFormList/StockFormList.tsx
@@ -30,7 +30,7 @@ import {
   StocksEventFormSortingColumn,
 } from './stocksFiltering'
 
-import { StockEventFormValues, STOCK_EVENT_FORM_DEFAULT_VALUES } from './'
+import { StockEventFormValues } from './'
 
 interface StockFormListProps {
   offer: OfferIndividual
@@ -367,10 +367,6 @@ const StockFormList = ({
                           }
                         } else {
                           arrayHelpers.remove(index)
-                          /* istanbul ignore next: DEBT, TO FIX */
-                          if (values.stocks.length === 1) {
-                            arrayHelpers.push(STOCK_EVENT_FORM_DEFAULT_VALUES)
-                          }
                         }
                       },
                       label: 'Supprimer le stock',

--- a/pro/src/screens/OfferIndividual/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/StocksEventEdition.tsx
@@ -294,25 +294,23 @@ const StocksEventEdition = ({
         setOffer && setOffer(response.payload)
       }
 
-      const formStocks = [...formik.values.stocks, ...hiddenStocksRef.current]
+      const formStocks = [...formik.values.stocks]
 
       // When we delete a stock we must remove it from the initial values
       // otherwise it will trigger the routeLeavingGuard
-      const initalStocks = [...formik.initialValues.stocks]
-      initalStocks.splice(stockIndex, 1)
+      const initialStocks = [...formik.initialValues.stocks]
+      initialStocks.splice(stockIndex, 1)
       formik.resetForm({
-        values: { stocks: initalStocks },
+        values: { stocks: initialStocks },
       })
 
       // Set back possible user change.
       /* istanbul ignore next: DEBT, TO FIX */
       formStocks.splice(stockIndex, 1)
       /* istanbul ignore next: DEBT, TO FIX */
-      formStocks.length
-        ? formik.setValues({ stocks: formStocks })
-        : formik.resetForm({
-            values: { stocks: [STOCK_EVENT_FORM_DEFAULT_VALUES] },
-          })
+      if (formStocks.length) {
+        formik.setValues({ stocks: formStocks })
+      }
       notify.success('Le stock a été supprimé.')
     } catch {
       notify.error('Une erreur est survenue lors de la suppression du stock.')


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23192

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques