### PR TITLE
(PC-22592)[API] fix: add rayon + csr_id while transitionning

### DIFF
--- a/api/tests/local_providers/titelive_things_test.py
+++ b/api/tests/local_providers/titelive_things_test.py
@@ -17,10 +17,12 @@ import pcapi.core.providers.models as providers_models
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.local_providers import TiteLiveThings
 from pcapi.local_providers.titelive_things.titelive_things import COLUMN_INDICES
+from pcapi.utils.csr import get_closest_csr
 
 
 EAN_TEST = "9782809455069"
 EAN_TEST_TITLE = "Secret wars : marvel zombies n.1"
+GTL_ID_TEST = "3030400"
 BASE_DATA_LINE_PARTS = [
     EAN_TEST,
     EAN_TEST_TITLE,
@@ -79,7 +81,7 @@ BASE_DATA_LINE_PARTS = [
     "0",
     "1",
     "",
-    "3030400",
+    GTL_ID_TEST,
     "4300",
     "3012420280013",
     "0",
@@ -110,6 +112,10 @@ class TiteliveThingsTest:
         assert product.extraData.get("bookFormat") == offers_models.BookFormat.BEAUX_LIVRES.value
         assert product.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert product.extraData.get("ean") == EAN_TEST
+        assert product.extraData.get("gtl_id") == GTL_ID_TEST
+        closest_csr = get_closest_csr(GTL_ID_TEST)
+        assert product.extraData.get("csr_id") == closest_csr.get("csr_id")
+        assert product.extraData.get("rayon") == closest_csr.get("label")
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-22592

- On conserve dans `extraData` sous rayon (`csr_label`) et en plus son `csr_id` 
- On stock le nouvelle id rayon titelive `gtl_id` dans `extraData`

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques