### PR TITLE
(PC-23217)[API] perf: up individual offer rate_limit value to 200/minute

### DIFF
--- a/api/.env.integration
+++ b/api/.env.integration
@@ -46,6 +46,7 @@ OBJECT_STORAGE_URL=https://storage.googleapis.com/passculture-metier-ehp-integra
 OUTSCALE_SECNUM_BUCKET_NAME=passculture-metier-ehp-integration-idpictures
 PRO_URL=https://integration.passculture.pro
 PUSH_NOTIFICATION_BACKEND=pcapi.notifications.push.backends.batch.BatchBackend
+RATE_LIMIT_BY_API_KEY=200/minute
 RECAPTCHA_RESET_PASSWORD_MINIMAL_SCORE=0.5
 REDIS_OFFER_IDS_CHUNK_SIZE=10000
 SEARCH_BACKEND=pcapi.core.search.backends.algolia.AlgoliaBackend

--- a/api/.env.production
+++ b/api/.env.production
@@ -66,6 +66,7 @@ OBJECT_STORAGE_URL=https://storage.googleapis.com/passculture-metier-prod-produc
 OUTSCALE_SECNUM_BUCKET_NAME=passculture-metier-prod-production-idpictures
 PRO_URL=https://passculture.pro
 PUSH_NOTIFICATION_BACKEND=pcapi.notifications.push.backends.batch.BatchBackend
+RATE_LIMIT_BY_API_KEY=200/minute
 REDIS_OFFER_IDS_CHUNK_SIZE=1000
 REDIS_VENUE_IDS_FOR_OFFERS_CHUNK_SIZE=1
 REDIS_VENUE_IDS_CHUNK_SIZE=10000


### PR DESCRIPTION
50/minute is too low for event offers which requires at least 3 calls. 
We should split the rate_limit between asynchronous routes and synchronous route or between events and products.
However for now only the event API is public.
I will keep track of perfs to see if we could bring it up

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23217
