### PR TITLE
(BSR)[PRO] fix: banner tips help icon viewbox

### DIFF
--- a/pro/src/ui-kit/Banners/BannerLayout/BannerLayout.tsx
+++ b/pro/src/ui-kit/Banners/BannerLayout/BannerLayout.tsx
@@ -45,13 +45,7 @@ const BannerLayout = ({
     >
       {type === 'notification-info' && showTitle && (
         <div className={styles['container']}>
-          <SvgIcon
-            src={shadowTipsHelpIcon}
-            alt=""
-            className={styles['icon']}
-            viewBox="0 0 22 26"
-            width="22"
-          />
+          <SvgIcon src={shadowTipsHelpIcon} alt="" className={styles['icon']} />
           <span className={styles['container-title']}>À SAVOIR</span>
         </div>
       )}


### PR DESCRIPTION
## But de la pull request

- Corriger l'affichage de l'icône shadowTipsHelp dans la bannière info

### Avant:

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/2b294e12-e706-437d-9f9c-21141f99281b)

### Après: 

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/22ff9ace-f5b1-475d-8e9c-e0db0697e9ec)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques