### PR TITLE
(PC-22930)[BO] feat: Add link to app in user generator

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/admin/users_generator.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/admin/users_generator.html
@@ -29,6 +29,13 @@
                   <span class="fw-bold">User ID :</span> {{ user.id }}
                 </div>
               </a>
+              {% if link_to_app %}
+                <a href="{{ link_to_app }}">
+                  <div class="mb-1">
+                    <span class="fw-bold">Aller sur l'app en tant que {{ user.firstName or "User" }} {{ user.lastName or user.id }}</span>
+                  </div>
+                </a>
+              {% endif %}
               <div class="mb-1">
                 <span class="fw-bold">Email :</span> {{ user.email }}
               </div>

--- a/api/tests/routes/backoffice_v3/user_generation_test.py
+++ b/api/tests/routes/backoffice_v3/user_generation_test.py
@@ -22,12 +22,36 @@ class UserGenerationGetRouteTest:
     needed_permission = None
 
     def test_returns_user_data(self, authenticated_client):
-        generated_user = users_factories.UserFactory()
+        generated_user = users_factories.BaseUserFactory()
 
         response = authenticated_client.get(url_for(self.endpoint, userId=generated_user.id))
 
         assert response.status_code == 200
         assert generated_user.email in html_parser.content_as_text(response.data)
+
+    def test_contains_link_to_app_if_token_and_names(self, authenticated_client):
+        generated_user = users_factories.ProfileCompletedUserFactory()
+        response = authenticated_client.get(url_for(self.endpoint, userId=generated_user.id, accessToken="0"))
+
+        assert response.status_code == 200
+        assert (
+            f"Aller sur l'app en tant que {generated_user.firstName} {generated_user.lastName}"
+            in html_parser.content_as_text(response.data)
+        )
+
+    def test_contains_link_to_app_if_token_and_no_names(self, authenticated_client):
+        generated_user = users_factories.BaseUserFactory()
+        response = authenticated_client.get(url_for(self.endpoint, userId=generated_user.id, accessToken="0"))
+
+        assert response.status_code == 200
+        assert f"Aller sur l'app en tant que User {generated_user.id}" in html_parser.content_as_text(response.data)
+
+    def test_does_not_contain_link_to_app_if_no_token(self, authenticated_client):
+        generated_user = users_factories.ProfileCompletedUserFactory()
+        response = authenticated_client.get(url_for(self.endpoint, userId=generated_user.id, accessToken=""))
+
+        assert response.status_code == 200
+        assert "Aller sur l'app" not in html_parser.content_as_text(response.data)
 
 
 class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermissionHelper):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-22930

### Implémentation

Quand l'utilisateur est généré, on génère en même temps un token de type ```EMAIL_VALIDATION``` pour ensuite afficher un lien vers l'app et se connecter directement.

Le choix a été fait d'utiliser ce type de token pour faciliter l'implémentation backend et ne pas apporter de modification au front.
Cela permet un cas d'usage tout à fait fonctionnel.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques

https://github.com/pass-culture/pass-culture-main/assets/128476306/a911f7de-23b5-446a-ac1c-394747ef249c