### PR TITLE
(BSR)[API] bump: Bump requests to 2.31.0

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -57,7 +57,7 @@ pytest-dotenv
 pytest-socket
 python-dotenv==0.21.1
 pyyaml==6.0
-requests==2.28.2
+requests==2.31.0
 requests_mock
 rq==1.12.0
 schwifty==2022.9.0


### PR DESCRIPTION
See https://github.com/psf/requests/releases for the changelog.
Nothing notable, except:
    
- a security fix about `Proxy-Authorization` HTTP header (we were not
  affected);
    
- an update of `urllib3`, whose changelog [1] does not contain anything
  notable either.
    
[1] https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#what-are-the-important-changes