### PR TITLE
(PC-23304)[API] fix: allow stocks quantity to be 0

### DIFF
--- a/api/src/pcapi/routes/public/books_stocks/serialization.py
+++ b/api/src/pcapi/routes/public/books_stocks/serialization.py
@@ -65,7 +65,7 @@ class StockCreationBodyModel(BaseModel):
     booking_limit_datetime: datetime | None
     price: decimal.Decimal | None
     price_category_id: int | None
-    quantity: int | None = Field(None, ge=1, le=models.Stock.MAX_STOCK_QUANTITY)
+    quantity: int | None = Field(None, ge=0, le=models.Stock.MAX_STOCK_QUANTITY)
 
     class Config:
         alias_generator = to_camel
@@ -78,7 +78,7 @@ class StockEditionBodyModel(BaseModel):
     id: int
     price: decimal.Decimal | None
     price_category_id: int | None
-    quantity: int | None = Field(None, ge=1, le=models.Stock.MAX_STOCK_QUANTITY)
+    quantity: int | None = Field(None, ge=0, le=models.Stock.MAX_STOCK_QUANTITY)
 
     class Config:
         alias_generator = to_camel

--- a/api/tests/routes/pro/post_stocks_test.py
+++ b/api/tests/routes/pro/post_stocks_test.py
@@ -328,7 +328,7 @@ class Returns201Test:
                 },
                 {
                     "price": 40,
-                    "quantity": None,
+                    "quantity": 0,
                     "bookingLimitDatetime": serialize(booking_limit_datetime),
                 },
             ],
@@ -567,8 +567,8 @@ class Returns400Test:
             "offerId": ["Ce champ est obligatoire"],
             "stocks.0.id": ["Ce champ est obligatoire"],
             "stocks.0.quantity": [
-                "Saisissez un nombre supérieur ou égal à 1",
-                "Saisissez un nombre supérieur ou égal à 1",
+                "Saisissez un nombre supérieur ou égal à 0",
+                "Saisissez un nombre supérieur ou égal à 0",
             ],
         }
 


### PR DESCRIPTION
This bug appeared in this commit https://github.com/pass-culture/pass-culture-main/commit/0b1fdf116ce735cbce743f2b8615ec27adb22aad
quantity=0 means remaining_quantity=0 .

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23304
