### PR TITLE
(BSR)[API] fix: Avoid flask_limiter error log with email_rate_limiter when email is empty

### DIFF
--- a/api/src/pcapi/utils/rate_limiting.py
+++ b/api/src/pcapi/utils/rate_limiting.py
@@ -55,6 +55,7 @@ def ip_rate_limiter(**kwargs: typing.Any) -> typing.Callable:
 def email_rate_limiter(**kwargs: typing.Any) -> typing.Callable:
     base_kwargs = {
         "key_func": get_email_from_request,
+        "exempt_when": lambda: not get_email_from_request(),
         "scope": "rate_limiter",
         "error_message": "rate limit by email exceeded",
     }


### PR DESCRIPTION
flask_limiter logs an error each time we get a request that has an
empty identifier:

    Skipping limit: 10 per 1 minute. Empty value found in parameters.

This is logged from `flask_limiter.Limiter.__evaluate_limits()`. To
avoid that, we can provide a non-empty value. Since we don't really
need to rate-limit requests that don't provide any identifier, we
can use a UUID.

---

Erreur Sentry qu'on cherche à faire taire : https://sentry.passculture.team/organizations/sentry/issues/394199/