### PR TITLE
(PC-23318)[PRO] fix: display required message for allocine price field 

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.tsx
@@ -92,6 +92,12 @@ const AllocineProviderForm = ({
         pristine: formProps.pristine,
       })
 
+      const required = (value: number | undefined) => {
+        return typeof value === 'number'
+          ? undefined
+          : 'Ce champ est obligatoire'
+      }
+
       return (
         <form className="allocine-provider-form">
           {!isLoading && (
@@ -131,6 +137,7 @@ const AllocineProviderForm = ({
                   placeholder="Ex : 12€"
                   step={0.01}
                   required
+                  validate={required}
                 />
               </div>
               <div className="apf-quantity-section">


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23318

Afficher un message d'erreur lorsque le champ "prix" est vide. (rollback de ce qui était présent avant modification)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques