### PR TITLE
(PC-23341)[API] feat: Add feature flag to activate/deactivate v1 of API Contremarque

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -124,6 +124,7 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_NEW_ADAGE_FILTERS = "Active les nouveaux filtres adage"
     WIP_MANDATORY_BOOKING_CONTACT = "Rend obligatoire offer.bookingContact pour les offres retirables"
     WIP_ENABLE_BOOST_PREFIXED_EXTERNAL_BOOKING = "Active les réservations externe boost avec préfix"
+    WIP_ENABLE_API_CONTREMARQUE_V1 = "Active l'API Contremarque v1"
 
     def is_active(self) -> bool:
         if flask.has_request_context():

--- a/api/tests/routes/public/booking_token/v1/get_booking_by_token_test.py
+++ b/api/tests/routes/public/booking_token/v1/get_booking_by_token_test.py
@@ -10,6 +10,7 @@ from pcapi.core.bookings.factories import UsedBookingFactory
 import pcapi.core.finance.factories as finance_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
+from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 from pcapi.routes.serialization import serialize
 from pcapi.utils.date import utc_datetime_to_department_timezone
@@ -296,3 +297,13 @@ class Returns410Test:
         # Then
         assert response.status_code == 410
         assert response.json["booking"] == ["Cette réservation a déjà été validée"]
+
+
+@pytest.mark.usefixtures("db_session")
+class GoodByeV1Test:
+    @override_features(WIP_ENABLE_API_CONTREMARQUE_V1=False)
+    def test_raise_404_if_api_is_deactivated(self, client):
+        admin = users_factories.AdminFactory()
+        client = client.with_session_auth(admin.email)
+        response = client.get("/bookings/token/TOKEN")
+        assert response.status_code == 404

--- a/api/tests/routes/public/booking_token/v1/patch_booking_by_token_test.py
+++ b/api/tests/routes/public/booking_token/v1/patch_booking_by_token_test.py
@@ -4,6 +4,7 @@ import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
 from pcapi.utils.human_ids import humanize
 
@@ -191,3 +192,13 @@ class Returns410Test:
         assert response.status_code == 410
         assert response.json["booking_cancelled"] == ["Cette réservation a été annulée"]
         assert Booking.query.get(booking.id).status is not BookingStatus.USED
+
+
+@pytest.mark.usefixtures("db_session")
+class GoodByeV1Test:
+    @override_features(WIP_ENABLE_API_CONTREMARQUE_V1=False)
+    def test_raise_404_if_api_is_deactivated(self, client):
+        admin = users_factories.AdminFactory()
+        client = client.with_session_auth(admin.email)
+        response = client.patch("/bookings/token/TOKEN")
+        assert response.status_code == 404


### PR DESCRIPTION
This API was planned to be deactivated on 2023-07-01. Here we add a
feature flag that can be used to deactivate the API for a few weeks
before we finally delete the code.