### PR TITLE
Pc 21648 add categories tags offres lieux

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-405f222670b2 (pre) (head)
-96e489262a9a (post) (head)
+08dfd555fca2 (pre) (head)
+9f5e01a79b73 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230712T150744_08dfd555fca2_add_categories_tags_offre_lieux.py
+++ b/api/src/pcapi/alembic/versions/20230712T150744_08dfd555fca2_add_categories_tags_offre_lieux.py
@@ -1,0 +1,49 @@
+"""
+add categories to offer and venue tags
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "08dfd555fca2"
+down_revision = "405f222670b2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "criterion_category",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("label", sa.String(length=140), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("label"),
+    )
+    op.create_table(
+        "criterion_category_mapping",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("criterionId", sa.BigInteger(), nullable=False),
+        sa.Column("categoryId", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["categoryId"], ["criterion_category.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["criterionId"], ["criterion.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("criterionId", "categoryId", name="unique_criterion_category"),
+    )
+    op.create_index(
+        op.f("ix_criterion_category_mapping_categoryId"),
+        "criterion_category_mapping",
+        ["categoryId"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_criterion_category_mapping_criterionId"), "criterion_category_mapping", ["criterionId"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_criterion_category_mapping_criterionId"), table_name="criterion_category_mapping")
+    op.drop_index(op.f("ix_criterion_category_mapping_categoryId"), table_name="criterion_category_mapping")
+    op.drop_table("criterion_category_mapping")
+    op.drop_table("criterion_category")

--- a/api/src/pcapi/alembic/versions/20230713T111742_9f5e01a79b73_init_categories_tags_offre_lieux.py
+++ b/api/src/pcapi/alembic/versions/20230713T111742_9f5e01a79b73_init_categories_tags_offre_lieux.py
@@ -1,0 +1,33 @@
+"""init default categories on offer/venue tags
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "9f5e01a79b73"
+down_revision = "96e489262a9a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("INSERT INTO criterion_category (label) VALUES ('Comptage partenaire label et appellation du MC')")
+    op.execute("INSERT INTO criterion_category (label) VALUES ('Comptage partenaire EPN')")
+    op.execute("INSERT INTO criterion_category (label) VALUES ('Playlist lieux et offres')")
+    op.execute(
+        'INSERT INTO criterion_category_mapping ("criterionId", "categoryId") '
+        "SELECT c.id, ct.id "
+        "FROM criterion c, (SELECT id FROM criterion_category WHERE label = "
+        "'Playlist lieux et offres') ct"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        'DELETE FROM criterion_category_mapping where "categoryId" = (SELECT id FROM criterion_category '
+        "WHERE label = 'playlist-lieux-offres')"
+    )
+    op.execute("DELETE FROM criterion_category WHERE label = 'Comptage partenaire label et appellation du MC'")
+    op.execute("DELETE FROM criterion_category WHERE label = 'Comptage partenaire EPN'")
+    op.execute("DELETE FROM criterion_category WHERE label = 'Playlist lieux et offres'")

--- a/api/src/pcapi/core/criteria/models.py
+++ b/api/src/pcapi/core/criteria/models.py
@@ -11,6 +11,10 @@ class Criterion(PcObject, Base, Model):
     startDateTime = sqla.Column(sqla.DateTime, nullable=True)
     endDateTime = sqla.Column(sqla.DateTime, nullable=True)
 
+    categories: list["CriterionCategory"] = sqla.orm.relationship(
+        "CriterionCategory", secondary="criterion_category_mapping"
+    )
+
     def __str__(self) -> str:
         return self.name
 
@@ -46,3 +50,29 @@ class OfferCriterion(PcObject, Base, Model):
             name="unique_offer_criterion",
         ),
     )
+
+
+class CriterionCategory(PcObject, Base, Model):
+    """
+    Criterion categories used for partners counting, reporting, etc.
+    """
+
+    __tablename__ = "criterion_category"
+
+    label: str = sqla.Column(sqla.String(140), nullable=False, unique=True)
+
+    def __str__(self) -> str:
+        return self.label
+
+
+class CriterionCategoryMapping(PcObject, Base, Model):
+    __tablename__ = "criterion_category_mapping"
+
+    criterionId: int = sqla.Column(
+        sqla.BigInteger, sqla.ForeignKey("criterion.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    categoryId: int = sqla.Column(
+        sqla.BigInteger, sqla.ForeignKey("criterion_category.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+
+    __table_args__ = (sqla.UniqueConstraint("criterionId", "categoryId", name="unique_criterion_category"),)

--- a/api/src/pcapi/routes/backoffice_v3/forms/tags.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/tags.py
@@ -22,6 +22,7 @@ class EditTagForm(FlaskForm):
 
     start_date = fields.PCDateField("Date de début", validators=(wtforms.validators.Optional(),))
     end_date = fields.PCDateField("Date de fin", validators=(wtforms.validators.Optional(),))
+    categories = fields.PCSelectMultipleField("Catégories", coerce=int)
 
     def validate_start_date(self, start_date: fields.PCDateField) -> fields.PCDateField:
         end_date = self._fields["end_date"]

--- a/api/src/pcapi/routes/backoffice_v3/templates/tags/list_tags.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/tags/list_tags.html
@@ -34,6 +34,7 @@
             <th scope="col">ID</th>
             <th scope="col">Nom</th>
             <th scope="col" class="col-5">Description</th>
+            <th scope="col">Catégories</th>
             <th scope="col">Date de début</th>
             <th scope="col">Date de fin</th>
           </tr>
@@ -72,6 +73,7 @@
               <td>{{ tag.id }}</td>
               <td>{{ tag.name }}</td>
               <td>{{ tag.description | empty_string_if_null }}</td>
+              <td>{{ tag.categories | format_tag_object_list }}</td>
               <td>{{ tag.startDateTime | format_date }}</td>
               <td>{{ tag.endDateTime | format_date }}</td>
             </tr>

--- a/api/tests/routes/backoffice_v3/tags_test.py
+++ b/api/tests/routes/backoffice_v3/tags_test.py
@@ -41,6 +41,23 @@ class CreateTagTest(PostEndpointHelper):
         assert not tag.startDateTime
         assert not tag.endDateTime
 
+    def test_create_tag_with_categories(self, authenticated_client):
+        form = {"name": "my-tag", "description": "description", "categories": [2]}
+
+        response = self.post_to_endpoint(authenticated_client, form=form)
+
+        assert response.status_code == 303
+        assert response.location == url_for("backoffice_v3_web.tags.list_tags", _external=True)
+
+        tag = criteria_models.Criterion.query.first()
+
+        assert tag.name == "my-tag"
+        assert tag.description == "description"
+        assert not tag.startDateTime
+        assert not tag.endDateTime
+        assert len(tag.categories) == 1
+        assert tag.categories[0].label == "Comptage partenaire EPN"
+
 
 class DeleteTagTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.tags.delete_tag"
@@ -78,6 +95,7 @@ class UpdateTagTest(PostEndpointHelper):
             "description": new_tag_description,
             "start_date": new_start_date,
             "end_date": new_end_date,
+            "categories": [2, 3],
         }
 
         response = self.post_to_endpoint(authenticated_client, tag_id=tag.id, form=form)
@@ -91,6 +109,9 @@ class UpdateTagTest(PostEndpointHelper):
         assert tag.description == new_tag_description
         assert tag.startDateTime.date() == new_start_date
         assert tag.endDateTime.date() == new_end_date
+        assert len(tag.categories) == 2
+        assert tag.categories[0].label == "Comptage partenaire EPN"
+        assert tag.categories[1].label == "Playlist lieux et offres"
 
 
 class ListTagsTest(GetEndpointHelper):


### PR DESCRIPTION
## But de la pull request

Permettre l'ajout de catégories sur les tags offres et lieux à des fins de reporting.

https://passculture.atlassian.net/browse/PC-21648

Liste :
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/a3351ed9-b7d8-492c-9e32-34ba769bfa9d)

Édition :
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/c99ff7a4-784c-4344-80f3-db38c8c0b90b)


## Vérifications

- [X] J'ai écrit les tests nécessaires
- [X] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques