### PR TITLE
(PC-22957)[API] feat: Create option in generator for user in 17-18 transition

### DIFF
--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -126,13 +126,6 @@ class PhoneValidatedUserFactory(EmailValidatedUserFactory):
     - phone number validation (if user is at least 18yo)
     """
 
-    phoneNumber = factory.LazyAttribute(
-        lambda o: "+33612345678" if o.age == users_constants.ELIGIBILITY_AGE_18 else None
-    )
-    phoneValidationStatus = factory.LazyAttribute(
-        lambda o: models.PhoneValidationStatusType.VALIDATED if o.age == users_constants.ELIGIBILITY_AGE_18 else None
-    )
-
     @classmethod
     def beneficiary_fraud_checks(
         cls, obj: models.User, **kwargs: typing.Any
@@ -141,6 +134,8 @@ class PhoneValidatedUserFactory(EmailValidatedUserFactory):
 
         fraud_checks = super().beneficiary_fraud_checks(obj, **kwargs)
         if obj.age == users_constants.ELIGIBILITY_AGE_18:
+            obj.phoneNumber = f"+336{obj.id:08}"  # type: ignore [assignment]
+            obj.phoneValidationStatus = models.PhoneValidationStatusType.VALIDATED
             fraud_checks.append(fraud_factories.PhoneValidationFraudCheckFactory(user=obj))
         return fraud_checks
 

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -223,13 +223,11 @@ class IdentityValidatedUserFactory(ProfileCompletedUserFactory):
     """
 
     validatedBirthDate = LazyAttribute(lambda o: datetime.utcnow().date() - relativedelta(years=o.age))
-    idPieceNumber = factory.Faker("ssn", locale="fr_FR")
 
     @classmethod
     def set_custom_attributes(cls, obj: models.User, **kwargs: typing.Any) -> None:
         super().set_custom_attributes(obj)
-        if obj.idPieceNumber:
-            obj.idPieceNumber = obj.idPieceNumber[:12]
+        obj.idPieceNumber = f"{obj.id:012}"
 
     @classmethod
     def beneficiary_fraud_checks(

--- a/api/src/pcapi/core/users/generator.py
+++ b/api/src/pcapi/core/users/generator.py
@@ -31,6 +31,7 @@ class GenerateUserData:
     age: int = users_constants.ELIGIBILITY_AGE_18
     id_provider: GeneratedIdProvider = GeneratedIdProvider.UBBLE
     step: GeneratedSubscriptionStep = GeneratedSubscriptionStep.EMAIL_VALIDATION
+    transition_17_18: bool = False
 
 
 def generate_user(user_data: GenerateUserData) -> users_models.User:
@@ -51,6 +52,10 @@ def generate_user(user_data: GenerateUserData) -> users_models.User:
             factory = users_factories.HonorStatementValidatedUserFactory
         case GeneratedSubscriptionStep.BENEFICIARY:
             factory = users_factories.BeneficiaryFactory
+
+    if user_data.transition_17_18:
+        user_data.age = 18
+        factory = users_factories.Transition1718Factory
 
     id_provider = user_data.id_provider.value
     return factory(age=user_data.age, beneficiaryFraudChecks__type=id_provider)

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/blueprint.py
@@ -54,7 +54,12 @@ def generate_user() -> utils.BackofficeResponse:
     # >18yo user cannot be identified with Educonnect
     age = form.age.data
     id_provider = form.id_provider.data
-    if age >= users_constants.ELIGIBILITY_AGE_18 and id_provider == users_generator.GeneratedIdProvider.EDUCONNECT.name:
+    transition_17_18 = form.transition_17_18.data
+    if (
+        not transition_17_18
+        and age >= users_constants.ELIGIBILITY_AGE_18
+        and id_provider == users_generator.GeneratedIdProvider.EDUCONNECT.name
+    ):
         flash("Un utilisateur de plus de 18 ans ne peut pas être identifié via Educonnect", "warning")
         return redirect(url_for("backoffice_v3_web.get_generated_user"), code=303)
 
@@ -72,6 +77,7 @@ def generate_user() -> utils.BackofficeResponse:
             age=form.age.data,
             id_provider=users_generator.GeneratedIdProvider[form.id_provider.data],
             step=users_generator.GeneratedSubscriptionStep[form.step.data],
+            transition_17_18=form.transition_17_18.data,
         )
         user = users_generator.generate_user(user_data=user_data)
     except users_exceptions.UserGenerationForbiddenException:

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
@@ -36,3 +36,4 @@ class UserGeneratorForm(utils.PCForm):
         ],
         default=GeneratedSubscriptionStep.EMAIL_VALIDATION.name,
     )
+    transition_17_18 = fields.PCCheckboxField("Transition 17-18")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-22957

Ajouter la possibilité de créer un utilisateur qui a été bénéficiaire 15-17 et qui a maintenant 18 ans.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques


https://github.com/pass-culture/pass-culture-main/assets/128476306/1f6e2f56-31f3-4a6c-967b-fa230968fcb1
