### PR TITLE
(BSR)[PRO] fix: send prod sourcemaps for prod Sentry issues

### DIFF
--- a/.github/workflows/release--build.yml
+++ b/.github/workflows/release--build.yml
@@ -61,6 +61,7 @@ jobs:
       CHANNEL: "${{ github.event.inputs.releaseNumber }}.0.0"
       EXPIRES: "30d"
       REF: v${{ github.event.inputs.releaseNumber }}.0.0
+      PUSH_RELEASE_TO_SENTRY: true
 
   create-maintenance-branch:
     name: Create maintenance branch


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : 

- dans [la PR précédente](https://github.com/pass-culture/pass-culture-main/pull/6584) on s'était dit de n'envoyer que les sourcemaps en staging vu que la même version serait déployée plus tard en prod
- malheureusement ce n'est pas encore le cas, l'app est rebuild pour la prod avec un hash différent dans le nom de fichier donc le sourcemap doit être différent
- cette PR active l'envoi des sourcemaps en prod pour corriger ça en attendant que les fichiers statiques déployés sur staging+prod soient strictement les mêmes