### PR TITLE
(PC-22144)[API] feat: Include price info in offers metadata

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -639,12 +639,12 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return image.url if image else None  # type: ignore [return-value]
 
     @property
-    def min_price(self) -> float:
+    def min_price(self) -> float | None:
         available_stocks = [stock.price for stock in self.stocks if not stock.isSoftDeleted]
         if len(available_stocks) > 0:
             return min(available_stocks)
 
-        return 0
+        return None
 
     @property
     def max_price(self) -> float:  # used in validation rule, do not remove

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -639,6 +639,14 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return image.url if image else None  # type: ignore [return-value]
 
     @property
+    def min_price(self) -> float:
+        available_stocks = [stock.price for stock in self.stocks if not stock.isSoftDeleted]
+        if len(available_stocks) > 0:
+            return min(available_stocks)
+
+        return 0
+
+    @property
     def max_price(self) -> float:  # used in validation rule, do not remove
         try:
             return max(stock.price for stock in self.stocks if not stock.isSoftDeleted)

--- a/api/src/pcapi/core/offers/offer_metadata.py
+++ b/api/src/pcapi/core/offers/offer_metadata.py
@@ -2,7 +2,7 @@ import datetime
 import typing
 
 from pcapi.core.offerers.models import Venue
-from pcapi.core.offers.models import Offer
+import pcapi.core.offers.models as offers_models
 
 
 Metadata = dict[str, typing.Any]
@@ -26,8 +26,8 @@ def _get_metadata_from_venue(venue: Venue) -> Metadata:
     }
 
 
-def _get_common_metadata_from_offer(offer: Offer) -> Metadata:
-    metadata = {
+def _get_common_metadata_from_offer(offer: offers_models.Offer) -> Metadata:
+    metadata: Metadata = {
         "@type": "Product",
         "name": offer.name,
     }
@@ -35,10 +35,17 @@ def _get_common_metadata_from_offer(offer: Offer) -> Metadata:
     if offer.image:
         metadata["image"] = offer.image.url
 
+    if offer.stocks:
+        metadata["offers"] = {
+            "@type": "AggregateOffer",
+            "priceCurrency": "EUR",
+            "lowPrice": str(offer.min_price),
+        }
+
     return metadata
 
 
-def _get_event_metadata_from_offer(offer: Offer) -> Metadata:
+def _get_event_metadata_from_offer(offer: offers_models.Offer) -> Metadata:
     common_metadata = _get_common_metadata_from_offer(offer)
 
     event_metadata = {
@@ -53,7 +60,7 @@ def _get_event_metadata_from_offer(offer: Offer) -> Metadata:
     return common_metadata | event_metadata
 
 
-def get_metadata_from_offer(offer: Offer) -> Metadata:
+def get_metadata_from_offer(offer: offers_models.Offer) -> Metadata:
     context = {
         "@context": "https://schema.org",
     }

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -620,10 +620,10 @@ class OfferMinPriceTest:
     def should_be_zero_when_no_stocks(self):
         offer = factories.OfferFactory()
 
-        assert offer.min_price == 0
+        assert offer.min_price is None
 
     def should_be_zero_when_all_stocks_are_soft_deleted(self):
         offer = factories.OfferFactory()
         factories.StockFactory(offer=offer, isSoftDeleted=True, price=10)
 
-        assert offer.min_price == 0
+        assert offer.min_price is None

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -607,3 +607,23 @@ class StockIsEventDeletableTest:
         dt = datetime.datetime.utcnow() - bookings_constants.AUTO_USE_AFTER_EVENT_TIME_DELAY
         stock = factories.EventStockFactory(beginningDatetime=dt, offer__validation=models.OfferValidationStatus.DRAFT)
         assert stock.isEventDeletable
+
+
+class OfferMinPriceTest:
+    def should_be_smallest_stock_price(self):
+        offer = factories.OfferFactory()
+        factories.StockFactory(offer=offer, price=5)
+        factories.StockFactory(offer=offer, price=10)
+
+        assert offer.min_price == 5
+
+    def should_be_zero_when_no_stocks(self):
+        offer = factories.OfferFactory()
+
+        assert offer.min_price == 0
+
+    def should_be_zero_when_all_stocks_are_soft_deleted(self):
+        offer = factories.OfferFactory()
+        factories.StockFactory(offer=offer, isSoftDeleted=True, price=10)
+
+        assert offer.min_price == 0

--- a/api/tests/core/offers/test_offer_metadata.py
+++ b/api/tests/core/offers/test_offer_metadata.py
@@ -42,6 +42,32 @@ class OfferMetadataTest:
 
         assert "image" not in metadata
 
+    class OfferTest:
+        def should_have_an_offer(self):
+            offer = offers_factories.OfferFactory()
+            offers_factories.StockFactory(offer=offer, price=5.10)
+
+            metadata = get_metadata_from_offer(offer)
+
+            assert "AggregateOffer" == metadata["offers"]["@type"]
+
+        def should_have_a_low_price(self):
+            offer = offers_factories.OfferFactory()
+            offers_factories.StockFactory(offer=offer, price=5.10)
+            offers_factories.StockFactory(offer=offer, price=2)
+
+            metadata = get_metadata_from_offer(offer)
+
+            assert "2.00" == metadata["offers"]["lowPrice"]
+
+        def should_have_a_price_currency(self):
+            offer = offers_factories.OfferFactory()
+            offers_factories.StockFactory(offer=offer, price=5.10)
+
+            metadata = get_metadata_from_offer(offer)
+
+            assert "EUR" == metadata["offers"]["priceCurrency"]
+
     class GivenAnEventTest:
         def should_describe_an_event(self):
             offer = offers_factories.EventOfferFactory()

--- a/api/tests/core/offers/test_offer_metadata.py
+++ b/api/tests/core/offers/test_offer_metadata.py
@@ -49,7 +49,7 @@ class OfferMetadataTest:
 
             metadata = get_metadata_from_offer(offer)
 
-            assert "AggregateOffer" == metadata["offers"]["@type"]
+            assert metadata["offers"]["@type"] == "AggregateOffer"
 
         def should_have_a_low_price(self):
             offer = offers_factories.OfferFactory()
@@ -58,7 +58,7 @@ class OfferMetadataTest:
 
             metadata = get_metadata_from_offer(offer)
 
-            assert "2.00" == metadata["offers"]["lowPrice"]
+            assert metadata["offers"]["lowPrice"] == "2.00"
 
         def should_have_a_price_currency(self):
             offer = offers_factories.OfferFactory()
@@ -66,7 +66,7 @@ class OfferMetadataTest:
 
             metadata = get_metadata_from_offer(offer)
 
-            assert "EUR" == metadata["offers"]["priceCurrency"]
+            assert metadata["offers"]["priceCurrency"] == "EUR"
 
     class GivenAnEventTest:
         def should_describe_an_event(self):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-22144

Pour la structure, on est parti sur :

- Un produit ou événement
    - Qui contient une offre [AggregateOffer](https://schema.org/AggregateOffer), avec un prix minimal, parce que c'est la seule information accessible depuis la webapp en mode déconnecté.
    

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques