### PR TITLE
(PC-21255)[API] fix: use correct api error codes when token is expired

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -114,12 +114,8 @@ def get_email_update_status(user: users_models.User) -> serializers.EmailUpdateS
 
 
 @blueprint.native_v1.route("/profile/email_update/confirm", methods=["POST"])
-@spectree_serialize(
-    on_success_status=204,
-    api=blueprint.api,
-)
-@authenticated_and_active_user_required
-def confirm_email_update(user: users_models.User, body: serializers.ChangeBeneficiaryEmailBody) -> None:
+@spectree_serialize(on_success_status=204, api=blueprint.api)
+def confirm_email_update(body: serializers.ChangeBeneficiaryEmailBody) -> None:
     try:
         email_api.update.confirm_email_update_request(body.token)
     except pydantic.ValidationError:

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -126,14 +126,14 @@ def confirm_email_update(body: serializers.ChangeBeneficiaryEmailBody) -> None:
     except exceptions.InvalidToken:
         raise api_errors.ApiErrors(
             {"code": "INVALID_TOKEN", "message": "aucune demande de changement d'email en cours"},
-            status_code=404,
+            status_code=401,
         )
     except exceptions.EmailExistsError:
         # Returning an error message might help the end client find
         # existing email addresses.
         raise api_errors.ApiErrors(
             {"message": "Token invalide"},
-            status_code=400,
+            status_code=401,
         )
 
 
@@ -148,7 +148,7 @@ def cancel_email_update(body: serializers.ChangeBeneficiaryEmailBody) -> None:
     except exceptions.InvalidToken:
         raise api_errors.ApiErrors(
             {"code": "INVALID_TOKEN", "message": "aucune demande de changement d'email en cours"},
-            status_code=404,
+            status_code=401,
         )
 
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -692,7 +692,7 @@ class ConfirmUpdateUserEmailTest:
         )
         client.with_token(user.email)
         response = client.post("/native/v1/profile/email_update/confirm", json={"token": token})
-        assert response.status_code == 404
+        assert response.status_code == 401
         assert response.json["message"] == "aucune demande de changement d'email en cours"
 
     def test_cannot_confirm_if_no_pending_email_update(self, client, app):
@@ -702,7 +702,7 @@ class ConfirmUpdateUserEmailTest:
         client.with_token(user.email)
         response = client.post("/native/v1/profile/email_update/confirm", json={"token": token})
 
-        assert response.status_code == 404
+        assert response.status_code == 401
         assert response.json["message"] == "aucune demande de changement d'email en cours"
 
 
@@ -1163,7 +1163,7 @@ class CancelEmailChangeTest:
         )
         app.redis_client.expireat(email_update.get_token_key(user, email_update.TokenType.CONFIRMATION), datetime.utcnow() - timedelta(days=1))  # type: ignore [attr-defined]
         response = client.post("/native/v1/profile/email_update/cancel", json={"token": token})
-        assert response.status_code == 404
+        assert response.status_code == 401
 
 
 class GetTokenExpirationTest:

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -2856,7 +2856,6 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
-                    "security": [{"JWTAuth": []}],
                     "summary": "confirm_email_update <POST>",
                     "tags": [],
                 }


### PR DESCRIPTION
## But de la pull request
Retourner des 401 (au lieu de 404) pour faciliter la gestion des erreurs pour le front

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-21255

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques