### PR TITLE
(BSR)[API] fix: remove deactivate_permanently_unavailable_products

### DIFF
--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -8,7 +8,6 @@ from pcapi.connectors.ftp_titelive import get_files_to_process_from_titelive_ftp
 from pcapi.core.categories import subcategories
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.offers.api as offers_api
-from pcapi.core.offers.api import deactivate_permanently_unavailable_products
 import pcapi.core.offers.exceptions as offers_exceptions
 import pcapi.core.offers.models as offers_models
 import pcapi.core.providers.models as providers_models
@@ -245,20 +244,10 @@ class TiteLiveThings(LocalProvider):
                 return []
 
         if is_unreleased_book(self.product_infos):
-            products = offers_models.Product.query.filter(
-                offers_models.Product.extraData["ean"].astext == book_unique_identifier
-            ).all()
-            if len(products) > 0:
-                deactivate_permanently_unavailable_products(book_unique_identifier)
-                logger.info(
-                    "deactivating products and offers with ean=%s because it has 'xxx' in 'titre' and 'auteurs' fields, which means it is not yet released",
-                    book_unique_identifier,
-                )
-            else:
-                logger.info(
-                    "Ignoring ean=%s because it has 'xxx' in 'titre' and 'auteurs' fields, which means it is not yet released",
-                    book_unique_identifier,
-                )
+            logger.info(
+                "Ignoring ean=%s because it has 'xxx' in 'titre' and 'auteurs' fields, which means it is not yet released",
+                book_unique_identifier,
+            )
             return []
 
         book_information_last_update = read_things_date(self.product_infos[INFO_KEYS["DATE_UPDATED"]])

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1310,35 +1310,6 @@ class DeactivateInappropriateProductTest:
 
 
 @pytest.mark.usefixtures("db_session")
-class DeactivatePermanentlyUnavailableProductTest:
-    @mock.patch("pcapi.core.search.async_index_offer_ids")
-    def test_should_deactivate_permanently_unavailable_product(self, mocked_async_index_offer_ids):
-        # Given
-        product1 = factories.ThingProductFactory(
-            subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"ean": "ean-de-test"}
-        )
-        product2 = factories.ThingProductFactory(
-            subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"ean": "ean-de-test"}
-        )
-        factories.OfferFactory(product=product1)
-        factories.OfferFactory(product=product1)
-        factories.OfferFactory(product=product2)
-
-        # When
-        api.deactivate_permanently_unavailable_products("ean-de-test")
-
-        # Then
-        products = models.Product.query.all()
-        offers = models.Offer.query.all()
-
-        assert any(product.name == "xxx" for product in products)
-        assert not any(offer.isActive for offer in offers)
-        assert any(offer.name == "xxx" for offer in offers)
-        mocked_async_index_offer_ids.assert_called_once()
-        assert set(mocked_async_index_offer_ids.call_args[0][0]) == {o.id for o in offers}
-
-
-@pytest.mark.usefixtures("db_session")
 class ComputeOfferValidationTest:
     def test_approve_if_no_offer_validation_config(self):
         offer = models.Offer(name="Maybe we should reject this offer")


### PR DESCRIPTION
## But de la pull request

Nous retrouvons dans le stock du pass des livres en `xxx`, ceci car on désactive les livres et on modifie le titre, alors que des librairies ont du stock : 

![image](https://github.com/pass-culture/pass-culture-main/assets/77674046/df5d01ee-84c9-4b7a-888f-32f36b373695)

Ex : https://passculture.app/recherche?date=null&hitsPerPage=20&locationFilter=%7B%22loca[%E2%80%A6]esults%22&searchId=%22ff41768c-c219-47e9-ad0b-80fcdc10dc4d%22

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques