### PR TITLE
(PC-23283)[PRO] feat: add has clicked add image tracker

### DIFF
--- a/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageAdd/ButtonImageAdd.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageAdd/ButtonImageAdd.tsx
@@ -25,7 +25,6 @@ const ButtonImageAdd = ({
     })}
     onClick={onClick}
     type="button"
-    data-testid="add-image-button"
   >
     <SvgIcon src={strokeMoreIcon} alt="" className={style['icon']} />
     <span className={style['label']}>

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageAdd/ButtonImageAdd.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageAdd/ButtonImageAdd.tsx
@@ -25,6 +25,7 @@ const ButtonImageAdd = ({
     })}
     onClick={onClick}
     type="button"
+    data-testid="add-image-button"
   >
     <SvgIcon src={strokeMoreIcon} alt="" className={style['icon']} />
     <span className={style['label']}>

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageEdit.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageEdit.tsx
@@ -15,21 +15,28 @@ export interface ButtonImageEditProps {
   onImageUpload: (values: OnImageUploadArgs) => Promise<void>
   initialValues?: UploadImageValues
   mode: UploaderModeEnum
+  onClickButtonImage?: () => void
 }
 
 const ButtonImageEdit = ({
   mode,
   initialValues = {},
   onImageUpload,
+  onClickButtonImage,
 }: ButtonImageEditProps): JSX.Element => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { imageUrl, originalImageUrl } = initialValues
+
+  const onClickButtonImageAdd = () => {
+    onClickButtonImage && onClickButtonImage()
+    setIsModalOpen(true)
+  }
 
   return (
     <>
       {imageUrl || originalImageUrl ? (
         <Button
-          onClick={() => setIsModalOpen(true)}
+          onClick={onClickButtonImageAdd}
           variant={ButtonVariant.TERNARY}
           alt="Modifier l’image"
           icon={fullEditIcon}
@@ -37,7 +44,7 @@ const ButtonImageEdit = ({
           Modifier
         </Button>
       ) : (
-        <ButtonImageAdd mode={mode} onClick={() => setIsModalOpen(true)} />
+        <ButtonImageAdd mode={mode} onClick={onClickButtonImageAdd} />
       )}
 
       {isModalOpen && (

--- a/pro/src/components/ImageUploader/ImageUploader.tsx
+++ b/pro/src/components/ImageUploader/ImageUploader.tsx
@@ -13,6 +13,7 @@ export interface ImageUploaderProps {
   onImageDelete: () => Promise<void>
   initialValues?: IUploadImageValues
   mode: UploaderModeEnum
+  onClickButtonImageAdd?: () => void
 }
 
 const ImageUploader = ({
@@ -20,6 +21,7 @@ const ImageUploader = ({
   onImageDelete,
   initialValues = {},
   mode,
+  onClickButtonImageAdd,
 }: ImageUploaderProps) => {
   const { imageUrl, originalImageUrl, credit, cropParams } = initialValues
 
@@ -43,6 +45,7 @@ const ImageUploader = ({
                   cropParams,
                 }}
                 onImageUpload={onImageUpload}
+                onClickButtonImage={onClickButtonImageAdd}
               />
               {mode != UploaderModeEnum.OFFER_COLLECTIVE && (
                 <ButtonAppPreview imageUrl={imageUrl} mode={mode} />
@@ -52,7 +55,11 @@ const ImageUploader = ({
           </div>
         </>
       ) : (
-        <ButtonImageEdit mode={mode} onImageUpload={onImageUpload} />
+        <ButtonImageEdit
+          mode={mode}
+          onImageUpload={onImageUpload}
+          onClickButtonImage={onClickButtonImageAdd}
+        />
       )}
     </div>
   )

--- a/pro/src/components/OfferIndividualForm/ImageUploaderOffer/ImageUploaderOffer.tsx
+++ b/pro/src/components/OfferIndividualForm/ImageUploaderOffer/ImageUploaderOffer.tsx
@@ -4,7 +4,10 @@ import FormLayout from 'components/FormLayout'
 import { ImageUploader } from 'components/ImageUploader'
 import { OnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageEdit'
 import { UploaderModeEnum } from 'components/ImageUploader/types'
+import { useOfferIndividualContext } from 'context/OfferIndividualContext'
+import { Events } from 'core/FirebaseEvents/constants'
 import { OfferIndividualImage } from 'core/Offers/types'
+import useAnalytics from 'hooks/useAnalytics'
 import { InfoBox } from 'ui-kit'
 
 import { buildInitialValues } from './utils'
@@ -19,24 +22,38 @@ const ImageUploaderOffer = ({
   onImageUpload,
   onImageDelete,
   imageOffer,
-}: ImageUploaderOfferProps) => (
-  <FormLayout.Section title="Image de l’offre">
-    <FormLayout.Row
-      sideComponent={
-        <InfoBox>
-          Les offres avec une image ont 4 fois plus de chance d’être consultées
-          que celles qui n’en ont pas.
-        </InfoBox>
-      }
-    >
-      <ImageUploader
-        onImageUpload={onImageUpload}
-        onImageDelete={onImageDelete}
-        initialValues={buildInitialValues(imageOffer)}
-        mode={UploaderModeEnum.OFFER}
-      />
-    </FormLayout.Row>
-  </FormLayout.Section>
-)
+}: ImageUploaderOfferProps) => {
+  const { offer } = useOfferIndividualContext()
+
+  const { logEvent } = useAnalytics()
+
+  const logButtonAddClick = () => {
+    logEvent?.(Events.CLICKED_ADD_IMAGE, {
+      offerId: offer?.id,
+      imageType: UploaderModeEnum.OFFER,
+    })
+  }
+
+  return (
+    <FormLayout.Section title="Image de l’offre">
+      <FormLayout.Row
+        sideComponent={
+          <InfoBox>
+            Les offres avec une image ont 4 fois plus de chance d’être
+            consultées que celles qui n’en ont pas.
+          </InfoBox>
+        }
+      >
+        <ImageUploader
+          onImageUpload={onImageUpload}
+          onImageDelete={onImageDelete}
+          initialValues={buildInitialValues(imageOffer)}
+          mode={UploaderModeEnum.OFFER}
+          onClickButtonImageAdd={logButtonAddClick}
+        />
+      </FormLayout.Row>
+    </FormLayout.Section>
+  )
+}
 
 export default ImageUploaderOffer

--- a/pro/src/components/OfferIndividualForm/ImageUploaderOffer/ImageUploaderOffer.tsx
+++ b/pro/src/components/OfferIndividualForm/ImageUploaderOffer/ImageUploaderOffer.tsx
@@ -6,7 +6,9 @@ import { OnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/Moda
 import { UploaderModeEnum } from 'components/ImageUploader/types'
 import { useOfferIndividualContext } from 'context/OfferIndividualContext'
 import { Events } from 'core/FirebaseEvents/constants'
+import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { OfferIndividualImage } from 'core/Offers/types'
+import { useOfferWizardMode } from 'hooks'
 import useAnalytics from 'hooks/useAnalytics'
 import { InfoBox } from 'ui-kit'
 
@@ -24,6 +26,7 @@ const ImageUploaderOffer = ({
   imageOffer,
 }: ImageUploaderOfferProps) => {
   const { offer } = useOfferIndividualContext()
+  const mode = useOfferWizardMode()
 
   const { logEvent } = useAnalytics()
 
@@ -31,6 +34,7 @@ const ImageUploaderOffer = ({
     logEvent?.(Events.CLICKED_ADD_IMAGE, {
       offerId: offer?.id,
       imageType: UploaderModeEnum.OFFER,
+      isEdition: mode === OFFER_WIZARD_MODE.EDITION,
     })
   }
 

--- a/pro/src/components/OfferIndividualForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.tracker.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.tracker.spec.tsx
@@ -1,0 +1,89 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Form, Formik } from 'formik'
+import React from 'react'
+
+import { UploaderModeEnum } from 'components/ImageUploader/types'
+import {
+  IOfferIndividualContext,
+  OfferIndividualContext,
+} from 'context/OfferIndividualContext'
+import { Events } from 'core/FirebaseEvents/constants'
+import * as useAnalytics from 'hooks/useAnalytics'
+import { individualOfferFactory } from 'utils/individualApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import ImageUploaderOffer, {
+  IImageUploaderOfferProps,
+} from '../ImageUploaderOffer'
+
+const mockLogEvent = jest.fn()
+
+const renderImageUploaderVenue = (
+  props: IImageUploaderOfferProps,
+  contextOverride?: Partial<IOfferIndividualContext>
+) => {
+  const contextValue: IOfferIndividualContext = {
+    offerId: 'OFFER_ID',
+    offer: individualOfferFactory({ id: 'OFFER_ID' }),
+    venueList: [],
+    offererNames: [],
+    categories: [],
+    subCategories: [],
+    setOffer: () => {},
+    shouldTrack: true,
+    setShouldTrack: () => {},
+    showVenuePopin: {},
+    ...contextOverride,
+  }
+
+  return renderWithProviders(
+    <OfferIndividualContext.Provider value={contextValue}>
+      <Formik
+        initialValues={{
+          imageUrl: 'noimage.jpg',
+          originalImageUrl: 'noimage.jpg',
+          credit: 'John Do',
+          cropParams: {
+            xCropPercent: 100,
+            yCropPercent: 100,
+            heightCropPercent: 1,
+            widthCropPercent: 1,
+          },
+        }}
+        onSubmit={jest.fn()}
+      >
+        <Form>
+          <ImageUploaderOffer {...props} />
+        </Form>
+      </Formik>
+    </OfferIndividualContext.Provider>
+  )
+}
+
+describe('ImageUploaderOffer::tracker', () => {
+  let props: IImageUploaderOfferProps
+
+  beforeEach(() => {
+    props = {
+      onImageUpload: jest.fn().mockResolvedValue(undefined),
+      onImageDelete: jest.fn().mockResolvedValue(undefined),
+    }
+
+    jest.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+      logEvent: mockLogEvent,
+      setLogEvent: null,
+    }))
+  })
+
+  it('should log add image event on click', async () => {
+    renderImageUploaderVenue(props)
+
+    await userEvent.click(screen.getByTestId('add-image-button'))
+
+    expect(mockLogEvent).toHaveBeenNthCalledWith(1, Events.CLICKED_ADD_IMAGE, {
+      offerId: 'OFFER_ID',
+      imageType: UploaderModeEnum.OFFER,
+    })
+  })
+})

--- a/pro/src/components/OfferIndividualForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.tracker.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.tracker.spec.tsx
@@ -5,8 +5,8 @@ import React from 'react'
 
 import { UploaderModeEnum } from 'components/ImageUploader/types'
 import {
-  IOfferIndividualContext,
   OfferIndividualContext,
+  OfferIndividualContextValues,
 } from 'context/OfferIndividualContext'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
@@ -14,18 +14,18 @@ import { individualOfferFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ImageUploaderOffer, {
-  IImageUploaderOfferProps,
+  ImageUploaderOfferProps,
 } from '../ImageUploaderOffer'
 
 const mockLogEvent = jest.fn()
 
-const renderImageUploaderVenue = (
-  props: IImageUploaderOfferProps,
-  contextOverride?: Partial<IOfferIndividualContext>
+const renderImageUploaderOffer = (
+  props: ImageUploaderOfferProps,
+  contextOverride?: Partial<OfferIndividualContextValues>
 ) => {
-  const contextValue: IOfferIndividualContext = {
-    offerId: 'OFFER_ID',
-    offer: individualOfferFactory({ id: 'OFFER_ID' }),
+  const contextValue: OfferIndividualContextValues = {
+    offerId: 12,
+    offer: individualOfferFactory({ id: 12 }),
     venueList: [],
     offererNames: [],
     categories: [],
@@ -62,7 +62,7 @@ const renderImageUploaderVenue = (
 }
 
 describe('ImageUploaderOffer::tracker', () => {
-  let props: IImageUploaderOfferProps
+  let props: ImageUploaderOfferProps
 
   beforeEach(() => {
     props = {
@@ -77,13 +77,16 @@ describe('ImageUploaderOffer::tracker', () => {
   })
 
   it('should log add image event on click', async () => {
-    renderImageUploaderVenue(props)
+    renderImageUploaderOffer(props)
 
-    await userEvent.click(screen.getByTestId('add-image-button'))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Ajouter une image' })
+    )
 
     expect(mockLogEvent).toHaveBeenNthCalledWith(1, Events.CLICKED_ADD_IMAGE, {
-      offerId: 'OFFER_ID',
+      offerId: 12,
       imageType: UploaderModeEnum.OFFER,
+      isEdition: true,
     })
   })
 })

--- a/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
+++ b/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
@@ -7,6 +7,8 @@ import { ImageUploader } from 'components/ImageUploader'
 import { IUploadImageValues } from 'components/ImageUploader/ButtonImageEdit'
 import { OnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageEdit'
 import { UploaderModeEnum } from 'components/ImageUploader/types'
+import { Events } from 'core/FirebaseEvents/constants'
+import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
 import { postImageToVenue } from 'repository/pcapi/pcapi'
 
@@ -50,6 +52,7 @@ const buildInitialValues = (
 
 /* istanbul ignore next: DEBT, TO FIX */
 const ImageUploaderVenue = () => {
+  const { logEvent } = useAnalytics()
   const notify = useNotification()
   const {
     setFieldValue,
@@ -98,6 +101,13 @@ const ImageUploaderVenue = () => {
     }
   }
 
+  const logButtonAddClick = () => {
+    logEvent?.(Events.CLICKED_ADD_IMAGE, {
+      venueId: venueId,
+      imageType: UploaderModeEnum.VENUE,
+    })
+  }
+
   return (
     <FormLayout.Section
       title="Ajouter une image"
@@ -110,6 +120,7 @@ const ImageUploaderVenue = () => {
           onImageDelete={handleOnImageDelete}
           initialValues={buildInitialValues(bannerUrl, bannerMeta || undefined)}
           mode={UploaderModeEnum.VENUE}
+          onClickButtonImageAdd={logButtonAddClick}
         />
       </FormLayout.Row>
     </FormLayout.Section>

--- a/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
+++ b/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
@@ -50,8 +50,12 @@ const buildInitialValues = (
   }
 }
 
+interface ImageUploaderProps {
+  isCreatingVenue: boolean
+}
+
 /* istanbul ignore next: DEBT, TO FIX */
-const ImageUploaderVenue = () => {
+const ImageUploaderVenue = ({ isCreatingVenue }: ImageUploaderProps) => {
   const { logEvent } = useAnalytics()
   const notify = useNotification()
   const {
@@ -105,6 +109,7 @@ const ImageUploaderVenue = () => {
     logEvent?.(Events.CLICKED_ADD_IMAGE, {
       venueId: venueId,
       imageType: UploaderModeEnum.VENUE,
+      isEdition: !isCreatingVenue,
     })
   }
 

--- a/pro/src/components/VenueForm/ImageUploaderVenue/__specs__/ImageUploaderVenue.tracker.spec.tsx
+++ b/pro/src/components/VenueForm/ImageUploaderVenue/__specs__/ImageUploaderVenue.tracker.spec.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Form, Formik } from 'formik'
+import React from 'react'
+
+import { UploaderModeEnum } from 'components/ImageUploader/types'
+import { Events } from 'core/FirebaseEvents/constants'
+import * as useAnalytics from 'hooks/useAnalytics'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import ImageUploaderVenue from '../ImageUploaderVenue'
+
+const mockLogEvent = jest.fn()
+
+const renderImageUploaderVenue = () =>
+  renderWithProviders(
+    <Formik
+      initialValues={{
+        id: 1,
+        imageUrl: 'noimage.jpg',
+        originalImageUrl: 'noimage.jpg',
+        credit: 'John Do',
+        cropParams: {
+          xCropPercent: 100,
+          yCropPercent: 100,
+          heightCropPercent: 1,
+          widthCropPercent: 1,
+        },
+      }}
+      onSubmit={jest.fn()}
+    >
+      <Form>
+        <ImageUploaderVenue />
+      </Form>
+    </Formik>
+  )
+
+describe('ImageUploaderVenue::tracker', () => {
+  beforeEach(() => {
+    jest.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+      logEvent: mockLogEvent,
+      setLogEvent: null,
+    }))
+  })
+
+  it('should log add image event on click', async () => {
+    renderImageUploaderVenue()
+
+    await userEvent.click(screen.getByTestId('add-image-button'))
+
+    expect(mockLogEvent).toHaveBeenNthCalledWith(1, Events.CLICKED_ADD_IMAGE, {
+      venueId: 1,
+      imageType: UploaderModeEnum.VENUE,
+    })
+  })
+})

--- a/pro/src/components/VenueForm/ImageUploaderVenue/__specs__/ImageUploaderVenue.tracker.spec.tsx
+++ b/pro/src/components/VenueForm/ImageUploaderVenue/__specs__/ImageUploaderVenue.tracker.spec.tsx
@@ -30,7 +30,7 @@ const renderImageUploaderVenue = () =>
       onSubmit={jest.fn()}
     >
       <Form>
-        <ImageUploaderVenue />
+        <ImageUploaderVenue isCreatingVenue={false} />
       </Form>
     </Formik>
   )
@@ -46,11 +46,14 @@ describe('ImageUploaderVenue::tracker', () => {
   it('should log add image event on click', async () => {
     renderImageUploaderVenue()
 
-    await userEvent.click(screen.getByTestId('add-image-button'))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Ajouter une image' })
+    )
 
     expect(mockLogEvent).toHaveBeenNthCalledWith(1, Events.CLICKED_ADD_IMAGE, {
       venueId: 1,
       imageType: UploaderModeEnum.VENUE,
+      isEdition: true,
     })
   })
 })

--- a/pro/src/components/VenueForm/VenueForm.tsx
+++ b/pro/src/components/VenueForm/VenueForm.tsx
@@ -135,7 +135,9 @@ const VenueForm = ({
         />
         {
           /* istanbul ignore next: DEBT, TO FIX */
-          !!shouldDisplayImageVenueUploaderSection && <ImageUploaderVenue />
+          !!shouldDisplayImageVenueUploaderSection && (
+            <ImageUploaderVenue isCreatingVenue={isCreatingVenue} />
+          )
         }
         {!initialIsVirtual && (
           <FormLayout.Section

--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -57,9 +57,8 @@ export enum Events {
   CLICKED_EAC_DMS_TIMELINE = 'hasClickedEacDmsTimeline',
   CLICKED_EAC_DMS_LINK = 'hasClickedEacDmsLink',
   EAC_WRONG_STUDENTS_MODAL_OPEN = 'hasOpenedEacWrongStudentsModal',
-
   CLICKED_CREATE_OFFER_FROM_REQUEST = 'hasClickedCreateOfferFromRequest',
-  CLICKED_ADD_IMAGE = 'CLICKED_ADD_IMAGE',
+  CLICKED_ADD_IMAGE = 'hasClickedAddImage',
 }
 export enum VenueEvents {
   CLICKED_VENUE_ACCORDION_BUTTON = 'hasClickedVenueAccordionButton',

--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -57,7 +57,9 @@ export enum Events {
   CLICKED_EAC_DMS_TIMELINE = 'hasClickedEacDmsTimeline',
   CLICKED_EAC_DMS_LINK = 'hasClickedEacDmsLink',
   EAC_WRONG_STUDENTS_MODAL_OPEN = 'hasOpenedEacWrongStudentsModal',
+
   CLICKED_CREATE_OFFER_FROM_REQUEST = 'hasClickedCreateOfferFromRequest',
+  CLICKED_ADD_IMAGE = 'CLICKED_ADD_IMAGE',
 }
 export enum VenueEvents {
   CLICKED_VENUE_ACCORDION_BUTTON = 'hasClickedVenueAccordionButton',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23283

- Ajouter le tracker hasClickedAddImage lorsque l'utilisateur clique sur "Ajouter une image"

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques