### PR TITLE
(PC-23320)[BO] fix: preserve date created sort during offer search

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offers/blueprint.py
@@ -270,7 +270,7 @@ def list_offers() -> utils.BackofficeResponse:
         "offer/list.html",
         rows=offers,
         form=display_form,
-        date_created_sort_url=display_form.get_sort_link(".list_offers") if form.sort.data else None,
+        date_created_sort_url=form.get_sort_link_with_search_data(".list_offers") if form.sort.data else None,
         get_initial_stock=_get_initial_stock,
         get_remaining_stock=_get_remaining_stock,
         advanced_query=advanced_query,

--- a/api/src/pcapi/routes/backoffice_v3/offers/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/offers/forms.py
@@ -2,6 +2,7 @@ import enum
 from functools import partial
 import json
 import typing
+from urllib.parse import urlencode
 
 from flask import url_for
 from flask_wtf import FlaskForm
@@ -255,6 +256,20 @@ class GetOfferAdvancedSearchForm(GetOffersBaseFields):
                 if field_data:
                     return False
         return empty
+
+    def get_sort_link_with_search_data(self, endpoint: str) -> str:
+        search_data = {}
+        for i, sub_form in enumerate(self.search):
+            prefix = f"search-{i}-"
+            for field_name, field_value in sub_form.data.items():
+                if field_value:
+                    search_data[f"{prefix}{field_name}"] = field_value
+
+        encoded_search_data = urlencode(search_data, doseq=True)
+
+        base_url = self.get_sort_link(endpoint)
+
+        return f"{base_url}&{encoded_search_data}" if encoded_search_data else f"{base_url}"
 
 
 class GetOffersSearchForm(GetOffersBaseFields):


### PR DESCRIPTION
## But de la pull request

Mettre la possibilité de trier par date de création sur l'écran Backoffice Offres individuelles quand on vient d'une recherche pré-filtrée (page d'accueil) :

Ticket Jira : https://passculture.atlassian.net/browse/PC-23320

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/588233bd-ff74-417c-9521-0e7f3a77a8f7)

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/5fa14760-ab0d-4f2f-8894-d448252e56e8)

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques