### PR TITLE
(PC-21533)[PRO] feat: add has upload image tracker for venue

### DIFF
--- a/pro/src/components/ImageUploader/ButtonImageEdit/index.ts
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/index.ts
@@ -1,5 +1,5 @@
 export { default as ButtonImageEdit } from './ButtonImageEdit'
 export type {
-  UploadImageValues as IUploadImageValues,
-  CropParams as ICropParams,
+  UploadImageValues as UploadImageValues,
+  CropParams as CropParams,
 } from './types'

--- a/pro/src/components/ImageUploader/ImageUploader.tsx
+++ b/pro/src/components/ImageUploader/ImageUploader.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { ButtonAppPreview } from './ButtonAppPreview'
 import { ButtonImageDelete } from './ButtonImageDelete'
-import { ButtonImageEdit, IUploadImageValues } from './ButtonImageEdit'
+import { ButtonImageEdit, UploadImageValues } from './ButtonImageEdit'
 import { OnImageUploadArgs } from './ButtonImageEdit/ModalImageEdit/ModalImageEdit'
 import { ImagePreview } from './ImagePreview'
 import styles from './ImageUploader.module.scss'
@@ -11,7 +11,7 @@ import { UploaderModeEnum } from './types'
 export interface ImageUploaderProps {
   onImageUpload: (values: OnImageUploadArgs) => Promise<void>
   onImageDelete: () => Promise<void>
-  initialValues?: IUploadImageValues
+  initialValues?: UploadImageValues
   mode: UploaderModeEnum
   onClickButtonImageAdd?: () => void
 }

--- a/pro/src/components/ImageUploader/index.ts
+++ b/pro/src/components/ImageUploader/index.ts
@@ -1,2 +1,2 @@
 export { default as ImageUploader } from './ImageUploader'
-export type { IUploadImageValues, ICropParams } from './ButtonImageEdit'
+export type { UploadImageValues, CropParams } from './ButtonImageEdit'

--- a/pro/src/components/OfferIndividualForm/ImageUploaderOffer/ImageUploaderOffer.tsx
+++ b/pro/src/components/OfferIndividualForm/ImageUploaderOffer/ImageUploaderOffer.tsx
@@ -6,7 +6,7 @@ import { OnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/Moda
 import { UploaderModeEnum } from 'components/ImageUploader/types'
 import { useOfferIndividualContext } from 'context/OfferIndividualContext'
 import { Events } from 'core/FirebaseEvents/constants'
-import { OFFER_WIZARD_MODE } from 'core/Offers'
+import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { OfferIndividualImage } from 'core/Offers/types'
 import { useOfferWizardMode } from 'hooks'
 import useAnalytics from 'hooks/useAnalytics'

--- a/pro/src/components/OfferIndividualForm/ImageUploaderOffer/utils/buildInitialValues.ts
+++ b/pro/src/components/OfferIndividualForm/ImageUploaderOffer/utils/buildInitialValues.ts
@@ -1,9 +1,9 @@
-import { IUploadImageValues } from 'components/ImageUploader/ButtonImageEdit'
+import { UploadImageValues } from 'components/ImageUploader/ButtonImageEdit'
 import { OfferIndividualImage } from 'core/Offers/types'
 
 export const buildInitialValues = (
   imageOffer?: OfferIndividualImage
-): IUploadImageValues => {
+): UploadImageValues => {
   return {
     imageUrl: imageOffer?.url || '',
     originalImageUrl: imageOffer?.originalUrl || '',

--- a/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
+++ b/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
@@ -4,10 +4,10 @@ import React from 'react'
 import { api } from 'apiClient/api'
 import FormLayout from 'components/FormLayout'
 import { ImageUploader } from 'components/ImageUploader'
-import { IUploadImageValues } from 'components/ImageUploader/ButtonImageEdit'
+import { UploadImageValues } from 'components/ImageUploader/ButtonImageEdit'
 import { OnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageEdit'
 import { UploaderModeEnum } from 'components/ImageUploader/types'
-import { Events } from 'core/FirebaseEvents/constants'
+import { Events, VenueEvents } from 'core/FirebaseEvents/constants'
 import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
 import { postImageToVenue } from 'repository/pcapi/pcapi'
@@ -31,7 +31,7 @@ export interface VenueBannerMetaProps {
 const buildInitialValues = (
   bannerUrl?: string,
   bannerMeta?: VenueBannerMetaProps
-): IUploadImageValues => {
+): UploadImageValues => {
   let cropParams
   if (bannerMeta !== undefined) {
     cropParams = {
@@ -56,12 +56,12 @@ interface ImageUploaderProps {
 
 /* istanbul ignore next: DEBT, TO FIX */
 const ImageUploaderVenue = ({ isCreatingVenue }: ImageUploaderProps) => {
-  const { logEvent } = useAnalytics()
   const notify = useNotification()
   const {
     setFieldValue,
     values: { id: venueId, bannerUrl, bannerMeta },
   } = useFormikContext<VenueFormValues>()
+  const { logEvent } = useAnalytics()
 
   const handleOnImageUpload = async ({
     imageFile,
@@ -81,6 +81,10 @@ const ImageUploaderVenue = ({ isCreatingVenue }: ImageUploaderProps) => {
 
       setFieldValue('bannerUrl', editedVenue.bannerUrl)
       setFieldValue('bannerMeta', editedVenue.bannerMeta)
+      logEvent?.(VenueEvents.UPLOAD_IMAGE, {
+        from: location.pathname,
+        venueId: venueId,
+      })
       notify.success('Vos modifications ont bien été prises en compte')
       return Promise.resolve()
     } catch {

--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -68,6 +68,7 @@ export enum VenueEvents {
   CLICKED_VENUE_VALIDATED_RESERVATIONS_LINK = 'hasClickedVenueValidatedReservationsLink',
   CLICKED_VENUE_EMPTY_STOCK_LINK = 'hasClickedVenueEmptyStockLink',
   CLICKED_BANK_DETAILS_RECORD_FOLLOW_UP = 'HasClickedBankDetailsRecordFollowUp',
+  UPLOAD_IMAGE = 'HasUploadedImage',
 }
 
 export enum CollectiveBookingsEvents {

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -5,7 +5,7 @@ import {
   CollectiveOffersBookingResponseModel,
   PriceCategoryResponseModel,
 } from 'apiClient/v1'
-import { ICropParams } from 'components/ImageUploader'
+import { CropParams } from 'components/ImageUploader'
 import { CollectiveOfferStatus } from 'core/OfferEducational'
 import { AccessibiltyFormValues } from 'core/shared'
 
@@ -154,7 +154,7 @@ export interface OfferIndividualImage {
   originalUrl: string
   url: string
   credit: string | null
-  cropParams?: ICropParams
+  cropParams?: CropParams
 }
 
 export interface OfferIndividual {

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormImageUploader/FormImageUploader.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormImageUploader/FormImageUploader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import FormLayout from 'components/FormLayout'
-import { ImageUploader, IUploadImageValues } from 'components/ImageUploader'
+import { ImageUploader, UploadImageValues } from 'components/ImageUploader'
 import { OnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageEdit'
 import { UploaderModeEnum } from 'components/ImageUploader/types'
 import { OfferCollectiveImage } from 'core/Offers/types'
@@ -14,7 +14,7 @@ export interface ImageUploaderOfferProps {
 
 const buildInitialValues = (
   imageOffer: OfferCollectiveImage | null
-): IUploadImageValues => ({
+): UploadImageValues => ({
   imageUrl: imageOffer?.url || '',
   originalImageUrl: imageOffer?.url || '',
   credit: imageOffer?.credit || '',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-21533

L’event HasUploadedImage est déclenché à l’upload de l’image (image de lieu car le tracker hasClickedOfferFormNavigation permet de tracker l'événement côté offre)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques