### PR TITLE
(PC-23050) Fix duplicate fraud detection

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -614,10 +614,14 @@ class BeneficiaryFraudReview(PcObject, Base, Model):
 class FraudItem:
     detail: str
     status: FraudStatus
+    extra_data: dict = dataclasses.field(default_factory=dict)
     reason_codes: list[FraudReasonCode] = dataclasses.field(default_factory=list)
 
     def __bool__(self) -> bool:
         return self.status == FraudStatus.OK
+
+    def get_duplicate_beneficiary_id(self) -> int | None:
+        return self.extra_data.get("duplicate_id")
 
 
 class BlacklistedDomainName(PcObject, Base, Model):

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -636,7 +636,6 @@ def activate_beneficiary_if_no_missing_step(user: users_models.User) -> bool:
         fraud_api.invalidate_fraud_check_for_duplicate_user(
             subscription_state.identity_fraud_check, duplicate_beneficiary.id
         )
-        fraud_api.handle_fraud_suspicion(user, duplicate_beneficiary)
         return False
 
     source_data = typing.cast(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23050

Le ticket avait déjà été mergé mais l'implémentation était fausse : elle ne couvrait pas la user story décrite.
Cette PR enlève ce qui avait été fait pour le réimplémenter différemment : 

À la première PR on couvrait le cas d'un utilisateur doublement bénéficiaire dans `activate_beneficiary_if_no_missing_steps`, or cette fonction est appelée à de nombreux endroits et il est difficile de cerner son périmètre d'action. La preuve en est, la user story ne fonctionnait pas.

Ici on intègre ce cas de fraude à la validation des `FraudItems`, c'est-à-dire dès la réception des résultats de la vérification d'identité.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques