### PR TITLE
(PC-23222)[API] feat: Set offerer's name as favorite's venue name for digital offers

### DIFF
--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -123,7 +123,7 @@ def get_favorites_for(user: User, favorite_id: int | None = None) -> list[Favori
             joinedload(Favorite.offer)
             .joinedload(Offer.venue)
             .joinedload(Venue.managingOfferer)
-            .load_only(Offerer.validationStatus, Offerer.isActive)
+            .load_only(Offerer.validationStatus, Offerer.isActive, Offerer.name)
         )
         .options(
             joinedload(Favorite.offer)

--- a/api/src/pcapi/routes/native/v1/serialization/favorites.py
+++ b/api/src/pcapi/routes/native/v1/serialization/favorites.py
@@ -51,7 +51,7 @@ class FavoriteOfferResponse(BaseModel):
     @classmethod
     def from_orm(cls, offer: Offer) -> "FavoriteOfferResponse":
         offer.coordinates = {"latitude": offer.venue.latitude, "longitude": offer.venue.longitude}
-        offer.venueName = offer.venue.common_name
+        offer.venueName = offer.venue.managingOfferer.name if offer.isDigital else offer.venue.common_name
         offer.expenseDomains = get_expense_domains(offer)
         return super().from_orm(offer)
 

--- a/api/tests/routes/native/v1/favorites_test.py
+++ b/api/tests/routes/native/v1/favorites_test.py
@@ -180,6 +180,30 @@ class GetTest:
             assert favorites[0]["offer"]["subcategoryId"] == "SEANCE_CINE"
             assert favorites[0]["offer"]["venueName"] == "Le Petit Rintintin"
 
+        def test_offer_venue_name_is_common_name_for_non_digital_offer(self, app):
+            user, test_client = utils.create_user_and_test_client(app)
+            offerer = offerers_factories.OffererFactory(name="Pathé Gaumont")
+            venue = offerers_factories.VenueFactory(managingOfferer=offerer, publicName="Ciné Pathé")
+            offer = offers_factories.EventOfferFactory(venue=venue)
+            users_factories.FavoriteFactory(offer=offer, user=user)
+
+            response = test_client.get(FAVORITES_URL)
+            favorites = response.json["favorites"]
+
+            assert favorites[0]["offer"]["venueName"] == "Ciné Pathé"
+
+        def test_offer_venue_name_is_offerer_name_for_digital_offer(self, app):
+            user, test_client = utils.create_user_and_test_client(app)
+            offerer = offerers_factories.OffererFactory(name="Pathé Gaumont")
+            venue = offerers_factories.VenueFactory(managingOfferer=offerer, publicName="Ciné Pathé")
+            offer = offers_factories.DigitalOfferFactory(venue=venue)
+            users_factories.FavoriteFactory(offer=offer, user=user)
+
+            response = test_client.get(FAVORITES_URL)
+            favorites = response.json["favorites"]
+
+            assert favorites[0]["offer"]["venueName"] == "Pathé Gaumont"
+
         def test_expired_offer(self, app):
             # Given
             today = datetime.utcnow() + timedelta(hours=3)  # offset a bit to make sure it's > now()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23222

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques