### PR TITLE
(BSR)[API] fix: Don't check client version on our "/adage" endpoints

### DIFF
--- a/api/src/pcapi/routes/adage/v1/blueprint.py
+++ b/api/src/pcapi/routes/adage/v1/blueprint.py
@@ -2,12 +2,10 @@ from flask import Blueprint
 from spectree import SecurityScheme
 from spectree import SpecTree
 
-from pcapi.routes.native import utils
 from pcapi.serialization.utils import before_handler
 
 
 adage_v1 = Blueprint("adage_v1", __name__)
-adage_v1.before_request(utils.check_client_version)
 
 
 EAC_API_KEY_AUTH = "ApiKeyAuth"


### PR DESCRIPTION
Version check is only useful for endpoints that are used by the
beneficiary app.