### PR TITLE
(PC-23285)[PRO] fix display publier sur adage button when pending

### DIFF
--- a/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
+++ b/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
@@ -103,11 +103,23 @@ const OfferEducationalActions = ({
   const shouldShowOfferActions =
     mode === Mode.EDITION || mode === Mode.READ_ONLY
 
+  const shouldDisplayAdagePublicationButton =
+    !isBooked &&
+    ![OfferStatus.EXPIRED, OfferStatus.PENDING].includes(offer.status)
+
+  const shouldDisplayBookingLink =
+    lastBookingId &&
+    (lastBookingStatus != CollectiveBookingStatus.CANCELLED ||
+      offer.status == OfferStatus.EXPIRED)
+
+  const shouldDisplayStatusSeparator =
+    shouldDisplayAdagePublicationButton || shouldDisplayBookingLink
+
   return (
     <>
       {shouldShowOfferActions && (
         <div className={cn(style['actions'], className)}>
-          {!isBooked && offer.status != OfferStatus.EXPIRED && (
+          {shouldDisplayAdagePublicationButton && (
             <Button
               icon={offer.isActive ? fullHideIcon : strokeCheckIcon}
               onClick={activateOffer}
@@ -121,33 +133,31 @@ const OfferEducationalActions = ({
             </Button>
           )}
 
-          {lastBookingId &&
-            (lastBookingStatus != CollectiveBookingStatus.CANCELLED ||
-              offer.status == OfferStatus.EXPIRED) && (
-              <ButtonLink
-                variant={ButtonVariant.TERNARY}
-                className={style['button-link']}
-                link={{ isExternal: false, to: getBookingLink() }}
-                icon={fullNextIcon}
-                iconPosition={IconPositionEnum.LEFT}
-                onClick={() =>
-                  logEvent?.(
-                    CollectiveBookingsEvents.CLICKED_SEE_COLLECTIVE_BOOKING,
-                    {
-                      from: '/offre/collectif/recapitulatif',
-                    }
-                  )
-                }
-              >
-                Voir la{' '}
-                {lastBookingStatus == 'PENDING'
-                  ? 'préréservation'
-                  : 'réservation'}
-              </ButtonLink>
-            )}
+          {shouldDisplayBookingLink && (
+            <ButtonLink
+              variant={ButtonVariant.TERNARY}
+              className={style['button-link']}
+              link={{ isExternal: false, to: getBookingLink() }}
+              icon={fullNextIcon}
+              iconPosition={IconPositionEnum.LEFT}
+              onClick={() =>
+                logEvent?.(
+                  CollectiveBookingsEvents.CLICKED_SEE_COLLECTIVE_BOOKING,
+                  {
+                    from: '/offre/collectif/recapitulatif',
+                  }
+                )
+              }
+            >
+              Voir la{' '}
+              {lastBookingStatus == 'PENDING'
+                ? 'préréservation'
+                : 'réservation'}
+            </ButtonLink>
+          )}
           {offer.status && (
             <>
-              {offer.status != OfferStatus.EXPIRED && (
+              {shouldDisplayStatusSeparator && (
                 <>
                   <div className={style.separator} />{' '}
                 </>

--- a/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
+++ b/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
@@ -109,8 +109,8 @@ const OfferEducationalActions = ({
 
   const shouldDisplayBookingLink =
     lastBookingId &&
-    (lastBookingStatus != CollectiveBookingStatus.CANCELLED ||
-      offer.status == OfferStatus.EXPIRED)
+    (lastBookingStatus !== CollectiveBookingStatus.CANCELLED ||
+      offer.status === OfferStatus.EXPIRED)
 
   const shouldDisplayStatusSeparator =
     shouldDisplayAdagePublicationButton || shouldDisplayBookingLink
@@ -150,7 +150,7 @@ const OfferEducationalActions = ({
               }
             >
               Voir la{' '}
-              {lastBookingStatus == 'PENDING'
+              {lastBookingStatus === 'PENDING'
                 ? 'préréservation'
                 : 'réservation'}
             </ButtonLink>

--- a/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
+++ b/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
@@ -228,4 +228,19 @@ describe('OfferEducationalActions', () => {
       isActive: true,
     })
   })
+
+  it('should not display adage publish button when offer is pending', () => {
+    renderOfferEducationalActions({
+      ...defaultValues,
+      offer: collectiveOfferFactory({
+        status: OfferStatus.PENDING,
+      }),
+    })
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Publier sur Adage',
+      })
+    ).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23285

Screen 
<img width="899" alt="Capture d’écran 2023-07-21 à 16 11 42" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/d48b36bc-9fb2-4588-b2ec-3dbba44159e1">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques