### PR TITLE
(PC-21669)[API] feat: Extend refresh token lifetime when logging in from trusted device

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1258,17 +1258,16 @@ def should_save_login_device_as_trusted_device(
     ).scalar()
 
 
-def is_suspicious_login(device_info: "account_serialization.TrustedDevice | None", user: models.User) -> bool:
+def is_login_device_a_trusted_device(
+    device_info: "account_serialization.TrustedDevice | None", user: models.User
+) -> bool:
     if device_info is None or not device_info.device_id:
-        return True
-
-    if not user.trusted_devices:
-        return True
-
-    if any(device.deviceId == device_info.device_id for device in user.trusted_devices):
         return False
 
-    return True
+    if any(device.deviceId == device_info.device_id for device in user.trusted_devices):
+        return True
+
+    return False
 
 
 def create_suspicious_login_email_token(login_info: users_models.LoginDeviceHistory | None, user_id: int) -> str:

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -73,7 +73,7 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
     users_api.update_last_connection_date(user)
     return authentication.SigninResponse(
         access_token=users_api.create_user_access_token(user),
-        refresh_token=create_refresh_token(identity=user.email),
+        refresh_token=users_api.create_user_refresh_token(user, body.device_info),
         account_state=user.account_state,
     )
 

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -64,7 +64,7 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
             login_history = users_api.update_login_device_history(body.device_info, user)
 
         if (
-            users_api.is_suspicious_login(body.device_info, user)
+            not users_api.is_login_device_a_trusted_device(body.device_info, user)
             and FeatureToggle.WIP_ENABLE_SUSPICIOUS_EMAIL_SEND.is_active()
         ):
             token = users_api.create_suspicious_login_email_token(login_history, user.id)

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -1,6 +1,5 @@
 import logging
 
-from flask_jwt_extended import create_refresh_token
 from flask_jwt_extended import get_jwt_identity
 from flask_jwt_extended import jwt_required
 
@@ -177,7 +176,7 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
 
     response = ValidateEmailResponse(
         access_token=users_api.create_user_access_token(user),
-        refresh_token=create_refresh_token(identity=user.email),
+        refresh_token=users_api.create_user_refresh_token(user, body.device_info),
     )
 
     return response

--- a/api/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/api/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -55,6 +55,7 @@ class ChangePasswordRequest(BaseModel):
 
 class ValidateEmailRequest(BaseModel):
     email_validation_token: str
+    device_info: TrustedDevice | None = None
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -191,6 +191,10 @@ JWT_SECRET_KEY = secrets_utils.get("JWT_SECRET_KEY")
 # default is 15 minutes
 # https://flask-jwt-extended.readthedocs.io/en/stable/options/#JWT_ACCESS_TOKEN_EXPIRES
 JWT_ACCESS_TOKEN_EXPIRES = int(os.environ.get("JWT_ACCESS_TOKEN_EXPIRES", 60 * 15))
+# default is 1 month
+JWT_REFRESH_TOKEN_EXPIRES = int(os.environ.get("JWT_REFRESH_TOKEN_EXPIRES", 31 * 24 * 60 * 60))
+# default is 1 year
+JWT_REFRESH_TOKEN_EXTENDED_EXPIRES = int(os.environ.get("JWT_REFRESH_TOKEN_EXTENDED_EXPIRES", 366 * 24 * 60 * 60))
 
 
 # TITELIVE

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1416,28 +1416,28 @@ class ShouldSaveLoginDeviceAsTrustedDeviceTest:
         assert users_api.should_save_login_device_as_trusted_device(device_info=self.device_info, user=user) is False
 
 
-class IsSuspiciousLoginTest:
-    def test_is_suspicious_when_user_has_no_trusted_device(self):
+class isLoginDeviceTrustedDeviceTest:
+    def should_not_be_trusted_when_user_has_no_trusted_device(self):
         user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="2E429592-2446-425F-9A62-D6983F375B3B", os="iOS", source="iPhone 13"
         )
 
         assert user.trusted_devices == []
-        assert users_api.is_suspicious_login(device_info=device_info, user=user) is True
+        assert users_api.is_login_device_a_trusted_device(device_info=device_info, user=user) is False
 
-    def test_is_suspicious_when_no_device_info(self):
+    def should_not_be_trusted_when_no_device_info(self):
         user = users_factories.UserFactory()
 
-        assert users_api.is_suspicious_login(device_info=None, user=user) is True
+        assert users_api.is_login_device_a_trusted_device(device_info=None, user=user) is False
 
-    def test_is_suspicious_when_no_device_id(self):
+    def should_not_be_trusted_when_no_device_id(self):
         user = users_factories.UserFactory()
         device_without_id = account_serialization.TrustedDevice(deviceId="", os="iOS", source="iPhone 13")
 
-        assert users_api.is_suspicious_login(device_info=device_without_id, user=user) is True
+        assert users_api.is_login_device_a_trusted_device(device_info=device_without_id, user=user) is False
 
-    def test_is_not_suspicious_when_device_is_a_trusted_device(self):
+    def should_be_trusted_when_device_is_a_trusted_device(self):
         user = users_factories.UserFactory()
         trusted_device = users_factories.TrustedDeviceFactory(user=user)
         users_factories.TrustedDeviceFactory(deviceId="3A44812-5776-235D-8E31-G4361H987A1A", user=user)
@@ -1445,14 +1445,14 @@ class IsSuspiciousLoginTest:
             deviceId=trusted_device.deviceId, os="iOS", source="iPhone 13"
         )
 
-        assert users_api.is_suspicious_login(device_info=device_info, user=user) is False
+        assert users_api.is_login_device_a_trusted_device(device_info=device_info, user=user) is True
 
-    def test_is_suspicious_when_device_is_not_a_trusted_device(self):
+    def should_not_be_trusted_when_device_is_not_a_trusted_device(self):
         user = users_factories.UserFactory()
         users_factories.TrustedDeviceFactory(user=user)
         device_info = account_serialization.TrustedDevice(deviceId="other-device-id", os="iOS", source="iPhone 13")
 
-        assert users_api.is_suspicious_login(device_info=device_info, user=user) is True
+        assert users_api.is_login_device_a_trusted_device(device_info=device_info, user=user) is False
 
 
 class CreateSuspiciousLoginEmailTokenTest:

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1810,7 +1810,14 @@ def test_public_api(client):
                     "type": "object",
                 },
                 "ValidateEmailRequest": {
-                    "properties": {"emailValidationToken": {"title": "Emailvalidationtoken", "type": "string"}},
+                    "properties": {
+                        "deviceInfo": {
+                            "anyOf": [{"$ref": "#/components/schemas/TrustedDevice"}],
+                            "nullable": True,
+                            "title": "TrustedDevice",
+                        },
+                        "emailValidationToken": {"title": "Emailvalidationtoken", "type": "string"},
+                    },
                     "required": ["emailValidationToken"],
                     "title": "ValidateEmailRequest",
                     "type": "object",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-21669

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques