### PR TITLE
(PC-23448)[PRO] fix: wording and DS link in ApplicationBanner component

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ApplicationBanner/ApplicationBanner.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ApplicationBanner/ApplicationBanner.tsx
@@ -10,7 +10,7 @@ const ApplicationBanner = ({ applicationId }: ApplicationBannerProps) => (
   <Banner
     links={[
       {
-        href: `https://www.demarches-simplifiees.fr/dossiers/${applicationId}`,
+        href: `https://www.demarches-simplifiees.fr/dossiers/${applicationId}/messagerie`,
         linkTitle: 'Voir le dossier en cours',
       },
     ]}
@@ -18,7 +18,7 @@ const ApplicationBanner = ({ applicationId }: ApplicationBannerProps) => (
   >
     Les coordonnées bancaires de votre lieu sont en cours de validation par
     notre service financier. <br /> Vos remboursements seront rétroactifs une
-    fois vos coordonnées bancaires ajoutées.
+    fois vos coordonnées bancaires validées.
   </Banner>
 )
 

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ApplicationBanner/__specs__/ApplicationBanner.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ApplicationBanner/__specs__/ApplicationBanner.spec.tsx
@@ -14,13 +14,13 @@ describe('when offerer has no bank informations', () => {
     render(<ApplicationBanner {...props} />)
     expect(
       await screen.findByText(
-        'Les coordonnées bancaires de votre lieu sont en cours de validation par notre service financier. Vos remboursements seront rétroactifs une fois vos coordonnées bancaires ajoutées.'
+        'Les coordonnées bancaires de votre lieu sont en cours de validation par notre service financier. Vos remboursements seront rétroactifs une fois vos coordonnées bancaires validées.'
       )
     ).toBeInTheDocument()
     const link = screen.getByRole('link')
     expect(link).toHaveAttribute(
       'href',
-      'https://www.demarches-simplifiees.fr/dossiers/12'
+      'https://www.demarches-simplifiees.fr/dossiers/12/messagerie'
     )
     expect(link).toHaveTextContent('Voir le dossier en cours')
   })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23448

Vos remboursements seront rétroactifs une fois vos coordonnées bancaires ajoutées.” → validées.

  Voir le dossier en cours” : 

- Lien de renvoi actuel : dossier DS
- Lien de renvoi souhaité : messagerie dossier DS (lien iso “Suivre mon dossier de CBs” situé dans le bloc prochaines étapes)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques