### PR TITLE
(BSR)[BO] fix: remove useless call to subquery

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
@@ -277,7 +277,6 @@ def get_pro_users(offerer_id: int) -> utils.BackofficeResponse:
             )
         )
         .distinct()
-        .subquery()
     )
 
     rows = (


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : pour supprimer ce warning de sqlalchemy
`src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py:300: SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques