### PR TITLE
(PC-23394) fix: allow modification only of venues tags

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -629,6 +629,7 @@ def batch_edit_venues() -> utils.BackofficeResponse:
     venues = offerers_models.Venue.query.filter(offerers_models.Venue.id.in_(form.object_ids_list)).all()
 
     updated_criteria_venues = _update_venues_criteria(venues=venues, criteria_ids=form.criteria.data)
+    updated_permanent_venues = []
     if form.all_permanent.data:
         updated_permanent_venues = _update_permanent_venues(venues=venues, is_permanent=True)
     elif form.all_not_permanent.data:

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -1372,3 +1372,21 @@ class BatchEditVenuesTest(PostEndpointHelper):
         assert venues[1].isPermanent is set_permanent
 
         mock_async_index_venue_ids.assert_called_once()
+
+    def test_batch_edit_venues_only_criteria(self, legit_user, authenticated_client, criteria):
+        new_criterion = criteria_factories.CriterionFactory()
+        venues = [
+            offerers_factories.VenueFactory(criteria=[criteria[0]]),
+        ]
+
+        form_data = {
+            "object_ids": ",".join(str(venue.id) for venue in venues),
+            "criteria": [criteria[0].id, new_criterion.id],
+            "all_permanent": "",
+            "all_not_permanent": "",
+        }
+
+        response = self.post_to_endpoint(authenticated_client, form=form_data)
+        assert response.status_code == 303
+
+        assert set(venues[0].criteria) == {criteria[0], new_criterion}


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-23394

Pouvoir : 
-     faire les modifications sur les lieux, en ne faisant uniquement les modifications sur les tags
-     faire des modifications sur les lieux en faisant tags + lieu permanent

Il y avait un bug si on ne choisissait uniquement les tags sans les notions de lieux permanents/non permanents

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [X] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques