### PR TITLE
(PC-23048)[API] fix: typo in retry decorator+tests

### DIFF
--- a/api/src/pcapi/utils/decorators.py
+++ b/api/src/pcapi/utils/decorators.py
@@ -34,8 +34,8 @@ def retry(
                         exception_handler(*args, **kwargs)
                     if logger:
                         logger.info(
-                            "Caught exception, retriyng",
-                            extra={"exception": exception.__class__.__name__, "remaining_attempts": inner_max_attempts},
+                            "Caught exception, retrying",
+                            extra={"exception": exception.__name__, "remaining_attempts": inner_max_attempts},
                         )
             return func(*args, **kwargs)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques