### PR TITLE
(BSR)[API] fix: Fix Amplitude configuration on integration

### DIFF
--- a/api/.env.integration
+++ b/api/.env.integration
@@ -5,6 +5,8 @@ ALGOLIA_VENUES_INDEX_NAME=integration-venues
 ALGOLIA_COLLECTIVE_OFFERS_INDEX_NAME=integration-collective-offers
 ALGOLIA_OFFERS_BY_VENUE_CHUNK_SIZE=10000
 ALGOLIA_TRIGGER_INDEXATION=0
+AMPLITUDE_BACKEND=pcapi.analytics.amplitude.backends.logger.LoggerBackend
+AMPLITUDE_QUEUE_NAME=amplitude-queue-integration
 API_URL=https://backend.integration.passculture.app
 BACKOFFICE_SEARCH_SIMILARITY_MINIMAL_SCORE=0.2
 # Batch keys below are public keys:


### PR DESCRIPTION
We should not send events to Amplitude on that environment. The logger
backend will thus be enough. But we need to customize the name of the
queue for Google Task (it defaults to "amplitude-queue-development",
which does not exist on the "integration" environment).