### PR TITLE
(PC-23361)[PRO] test: add e2e for signup journey

### DIFF
--- a/pro/cypress/e2e/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/signupJourneyCreateOfferer.cy.ts
@@ -1,0 +1,75 @@
+describe('Signup journey', () => {
+  it('should create offerer', () => {
+    cy.login('pctest.admin93.0@example.com', 'user@AZERTY123')
+
+    // Welcome page
+    cy.visit({ method: 'GET', url: '/parcours-inscription' })
+    cy.contains('Commencer').click()
+
+    // Offerer page
+    cy.intercept({
+      method: 'GET',
+      url: 'http://localhost:5001/sirene/siret/11111111111111',
+    }).as('getSiret')
+
+    cy.get('#siret').type('11111111111111')
+    cy.wait('@getSiret')
+    cy.contains('Continuer').click()
+    cy.wait('@getSiret')
+
+    // Authentication page
+    cy.get('#publicName').type('First Offerer')
+    cy.contains('Étape suivante').click()
+
+    // Activity page
+    cy.get('#venueTypeCode').select('Spectacle vivant')
+    cy.get('[name="socialUrls[0]"]').type('https://exemple.com')
+    cy.contains('Ajouter un lien').click()
+    cy.get('[name="socialUrls[1]"]').type('https://exemple2.com')
+    cy.get('[name="targetCustomer.individual"]').check()
+    cy.contains('Étape suivante').click()
+
+    // Validation page
+    cy.contains('Valider et créer ma structure').click()
+    cy.url().should('be.equal', 'http://localhost:3001/accueil')
+  })
+
+  it('should ask offerer attachment to a user and create new offerer', () => {
+    cy.login('pctest.pro93.0@example.com', 'user@AZERTY123')
+
+    // Welcome page
+    cy.visit({ method: 'GET', url: '/parcours-inscription' })
+    cy.contains('Commencer').click()
+
+    // Offerer page
+    cy.intercept({
+      method: 'GET',
+      url: 'http://localhost:5001/sirene/siret/11111111111111',
+    }).as('getSiret')
+
+    cy.get('#siret').type('11111111111111')
+    cy.wait('@getSiret')
+    cy.contains('Continuer').click()
+    cy.wait('@getSiret')
+
+    // Offerer attachment
+    cy.contains('Ajouter une nouvelle structure').click()
+
+    // Authentication page
+    cy.get('#search-addressAutocomplete').clear()
+    cy.get('#search-addressAutocomplete').type('89 Rue la Boétie 75008 Paris')
+    cy.get('#list-addressAutocomplete').first().click()
+    cy.contains('89 Rue la Boétie 75008 Paris')
+    cy.contains('Étape suivante').click()
+
+    // Activity page
+    cy.get('#venueTypeCode').select('Spectacle vivant')
+    cy.get('[name="socialUrls[0]"]').type('https://exempleAttachement.com')
+    cy.get('[name="targetCustomer.individual"]').check()
+    cy.contains('Étape suivante').click()
+
+    // Validation page
+    cy.contains('Valider et créer ma structure').click()
+    cy.url().should('be.equal', 'http://localhost:3001/accueil')
+  })
+})

--- a/pro/cypress/e2e/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/signupJourneyCreateOfferer.cy.ts
@@ -1,5 +1,41 @@
 describe('Signup journey', () => {
   const siret = Math.random().toString().substring(2, 16)
+
+  const welcomeStep = () => {
+    // Welcome page
+    cy.visit({ method: 'GET', url: '/parcours-inscription' })
+    cy.contains('Commencer').click()
+  }
+
+  const offererStep = () => {
+    // Offerer page
+    cy.intercept({
+      method: 'GET',
+      url: `http://localhost:5001/sirene/siret/${siret}`,
+    }).as('getSiret')
+
+    cy.get('#siret').type(siret)
+    cy.contains('Continuer').click()
+    cy.wait('@getSiret')
+  }
+
+  const activityStep = () => {
+    // Activity page
+    cy.get('#venueTypeCode').select('Spectacle vivant')
+    cy.get('[name="socialUrls[0]"]').type('https://exemple.com')
+    cy.contains('Ajouter un lien').click()
+    cy.get('[name="socialUrls[1]"]').type('https://exemple2.com')
+
+    cy.get('[name="targetCustomer.individual"]').check()
+    cy.contains('Étape suivante').click()
+  }
+
+  const validationStep = () => {
+    // Validation page
+    cy.contains('Valider et créer ma structure').click()
+    cy.url().should('be.equal', 'http://localhost:3001/accueil')
+  }
+
   before(() => {
     cy.setFeatureFlags([{ name: 'WIP_ENABLE_NEW_ONBOARDING', isActive: true }])
   })
@@ -7,55 +43,24 @@ describe('Signup journey', () => {
   it('should create offerer', () => {
     cy.login('pctest.pro93.0@example.com', 'user@AZERTY123')
 
-    // Welcome page
-    cy.visit({ method: 'GET', url: '/parcours-inscription' })
-    cy.contains('Commencer').click()
-
-    // Offerer page
-    cy.intercept({
-      method: 'GET',
-      url: `http://localhost:5001/sirene/siret/${siret}`,
-    }).as('getSiret')
-
-    cy.get('#siret').type(siret)
-    cy.wait('@getSiret')
-    cy.contains('Continuer').click()
-    cy.wait('@getSiret')
+    welcomeStep()
+    offererStep()
 
     // Authentication page
     cy.get('#publicName').type('First Offerer')
     cy.contains('Étape suivante').click()
 
-    // Activity page
-    cy.get('#venueTypeCode').select('Spectacle vivant')
-    cy.get('[name="socialUrls[0]"]').type('https://exemple.com')
-    cy.contains('Ajouter un lien').click()
-    cy.get('[name="socialUrls[1]"]').type('https://exemple2.com')
-    cy.get('[name="targetCustomer.individual"]').check()
-    cy.contains('Étape suivante').click()
+    activityStep()
+    validationStep()
 
-    // Validation page
-    cy.contains('Valider et créer ma structure').click()
-    cy.url().should('be.equal', 'http://localhost:3001/accueil')
+    cy.logout()
   })
 
   it('should ask offerer attachment to a user and create new offerer', () => {
     cy.login('pctest.pro97.0@example.com', 'user@AZERTY123')
 
-    // Welcome page
-    cy.visit({ method: 'GET', url: '/parcours-inscription' })
-    cy.contains('Commencer').click()
-
-    // Offerer page
-    cy.intercept({
-      method: 'GET',
-      url: `http://localhost:5001/sirene/siret/${siret}`,
-    }).as('getSiret')
-
-    cy.get('#siret').type(siret)
-    cy.wait('@getSiret')
-    cy.contains('Continuer').click()
-    cy.wait('@getSiret')
+    welcomeStep()
+    offererStep()
 
     // Offerer attachment
     cy.contains('Ajouter une nouvelle structure').click()
@@ -66,15 +71,10 @@ describe('Signup journey', () => {
     cy.get('#list-addressAutocomplete li').first().click()
     cy.contains('Étape suivante').click()
 
-    // Activity page
-    cy.get('#venueTypeCode').select('Spectacle vivant')
-    cy.get('[name="socialUrls[0]"]').type('https://exempleAttachement.com')
-    cy.get('[name="targetCustomer.individual"]').check()
-    cy.contains('Étape suivante').click()
+    activityStep()
+    validationStep()
 
-    // Validation page
-    cy.contains('Valider et créer ma structure').click()
-    cy.url().should('be.equal', 'http://localhost:3001/accueil')
+    cy.logout()
   })
 
   after(() => {

--- a/pro/cypress/e2e/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/signupJourneyCreateOfferer.cy.ts
@@ -1,6 +1,11 @@
 describe('Signup journey', () => {
+  const siret = Math.random().toString().substring(2, 16)
+  before(() => {
+    cy.setFeatureFlags([{ name: 'WIP_ENABLE_NEW_ONBOARDING', isActive: true }])
+  })
+
   it('should create offerer', () => {
-    cy.login('pctest.admin93.0@example.com', 'user@AZERTY123')
+    cy.login('pctest.pro93.0@example.com', 'user@AZERTY123')
 
     // Welcome page
     cy.visit({ method: 'GET', url: '/parcours-inscription' })
@@ -9,10 +14,10 @@ describe('Signup journey', () => {
     // Offerer page
     cy.intercept({
       method: 'GET',
-      url: 'http://localhost:5001/sirene/siret/11111111111111',
+      url: `http://localhost:5001/sirene/siret/${siret}`,
     }).as('getSiret')
 
-    cy.get('#siret').type('11111111111111')
+    cy.get('#siret').type(siret)
     cy.wait('@getSiret')
     cy.contains('Continuer').click()
     cy.wait('@getSiret')
@@ -35,7 +40,7 @@ describe('Signup journey', () => {
   })
 
   it('should ask offerer attachment to a user and create new offerer', () => {
-    cy.login('pctest.pro93.0@example.com', 'user@AZERTY123')
+    cy.login('pctest.pro97.0@example.com', 'user@AZERTY123')
 
     // Welcome page
     cy.visit({ method: 'GET', url: '/parcours-inscription' })
@@ -44,10 +49,10 @@ describe('Signup journey', () => {
     // Offerer page
     cy.intercept({
       method: 'GET',
-      url: 'http://localhost:5001/sirene/siret/11111111111111',
+      url: `http://localhost:5001/sirene/siret/${siret}`,
     }).as('getSiret')
 
-    cy.get('#siret').type('11111111111111')
+    cy.get('#siret').type(siret)
     cy.wait('@getSiret')
     cy.contains('Continuer').click()
     cy.wait('@getSiret')
@@ -58,8 +63,7 @@ describe('Signup journey', () => {
     // Authentication page
     cy.get('#search-addressAutocomplete').clear()
     cy.get('#search-addressAutocomplete').type('89 Rue la Boétie 75008 Paris')
-    cy.get('#list-addressAutocomplete').first().click()
-    cy.contains('89 Rue la Boétie 75008 Paris')
+    cy.get('#list-addressAutocomplete li').first().click()
     cy.contains('Étape suivante').click()
 
     // Activity page
@@ -71,5 +75,9 @@ describe('Signup journey', () => {
     // Validation page
     cy.contains('Valider et créer ma structure').click()
     cy.url().should('be.equal', 'http://localhost:3001/accueil')
+  })
+
+  after(() => {
+    cy.setFeatureFlags([{ name: 'WIP_ENABLE_NEW_ONBOARDING', isActive: false }])
   })
 })

--- a/pro/cypress/support/commands.ts
+++ b/pro/cypress/support/commands.ts
@@ -56,6 +56,15 @@ Cypress.Commands.add('login', (email: string, password: string) => {
   cy.url().should('be.equal', 'http://localhost:3001/accueil')
 })
 
+Cypress.Commands.add('logout', () => {
+  cy.intercept({ method: 'GET', url: '/users/signout' }).as('signoutUser')
+
+  cy.get('[aria-label="Déconnexion"]').click()
+  cy.wait('@signoutUser')
+
+  cy.url().should('be.equal', 'http://localhost:3001/connexion')
+})
+
 Cypress.Commands.add('setFeatureFlags', (features: Feature[]) => {
   cy.request({
     method: 'PATCH',

--- a/pro/cypress/support/index.d.ts
+++ b/pro/cypress/support/index.d.ts
@@ -1,5 +1,6 @@
 declare namespace Cypress {
   interface Chainable {
+    logout(): Chainable
     login(email: string, password: string): Chainable
     setFeatureFlags(features: Feature[]): Chainable
   }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23361

Ajout des tests e2e pour le parcours d'inscription

[Capture vidéo du 02-08-2023 17:14:26.webm](https://github.com/pass-culture/pass-culture-main/assets/106379750/71ee7c62-a379-4472-bffa-f7e68f37c5af)

Il y a 2 tests qui se suivent:
- La création d'une structure avec un compte
- Un autre utilisateur qui renseigne le même SIRET, qui est redirigé vers la page de rattachement, mais qui choisit de créer sa structure.
- Le cas où l'utilisateur se rattache n'est pas pris en compte, car cette partie sera bientôt supprimée.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques