### PR TITLE
(BSR)[BO] fix: use sequence not faker's domain_name

### DIFF
--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -259,7 +259,7 @@ class BlacklistedDomainNameFactory(testing.BaseFactory):
     class Meta:
         model = models.BlacklistedDomainName
 
-    domain = factory.Faker("domain_name")
+    domain = factory.Sequence("my-domain-{}.com".format)
 
 
 class ProductWhitelistFactory(testing.BaseFactory):


### PR DESCRIPTION
## But de la pull request

**Bug** test flaky à cause de la génération de noms de domaine. Deux objets de la table blacklisted_domain_name peuvent se retrouver avec le même nom, ce qui fait planter le test.

**Fix** utiliser une séquence afin d'éviter tout doublon.