### PR TITLE
(PC-23282)[PRO] make priceDetail mandatory in collective offer form

### DIFF
--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -205,7 +205,6 @@ const OfferEducationalStock = <
                   className={styles['price-details']}
                   countCharacters
                   disabled={mode === Mode.READ_ONLY}
-                  isOptional
                   label={DETAILS_PRICE_LABEL}
                   maxLength={MAX_DETAILS_LENGTH}
                   name="priceDetail"

--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -34,6 +34,7 @@ const initialValuesNotEmpty = {
   bookingLimitDatetime: '2023-03-30',
   numberOfPlaces: 10,
   totalPrice: 100,
+  priceDetail: 'Détail du prix',
 }
 
 const mockedUsedNavigate = jest.fn()

--- a/pro/src/screens/OfferEducationalStock/validationSchema.ts
+++ b/pro/src/screens/OfferEducationalStock/validationSchema.ts
@@ -87,7 +87,7 @@ export const generateValidationSchema = (
         test: (value, context) => isBeforeEventDate(value, context),
       })
       .nullable(),
-    priceDetail: yup.string().nullable().max(MAX_DETAILS_LENGTH),
+    priceDetail: yup.string().required('Champ requis').max(MAX_DETAILS_LENGTH),
   })
 }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23282

<img width="956" alt="Capture d’écran 2023-07-26 à 14 35 33" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/33fd7166-647d-4852-8421-c00e9216a3a4">

A noter que lors de l'édition d'un offre qui n'avait pas de `priceDetail`, le bouton "Enregistrer" ne trigger la validation du formulaire (et donc le message d'erreur) que quand on est sur l'onglet Date & prix.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques