### PR TITLE
Pc 23343 old tokens support email change

### DIFF
--- a/api/src/pcapi/core/token/__init__.py
+++ b/api/src/pcapi/core/token/__init__.py
@@ -64,7 +64,7 @@ class Token:
         app.redis_client.delete(Token._get_redis_key(self.type_, self.user_id))  # type: ignore [attr-defined]
 
     @classmethod
-    def load_and_check(cls, encoded_token: str, type_: TokenType, user_id: int) -> "Token":
+    def load_and_check(cls, encoded_token: str, type_: TokenType, user_id: int | None = None) -> "Token":
         token = Token.load_without_checking(encoded_token)
         token.check(type_, user_id)
         return token

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -123,16 +123,9 @@ def confirm_email_update(body: serializers.ChangeBeneficiaryEmailBody) -> None:
             {"code": "INVALID_EMAIL", "message": "Adresse email invalide"},
             status_code=400,
         )
-    except exceptions.InvalidToken:
+    except (exceptions.InvalidToken, exceptions.EmailExistsError):
         raise api_errors.ApiErrors(
             {"code": "INVALID_TOKEN", "message": "aucune demande de changement d'email en cours"},
-            status_code=401,
-        )
-    except exceptions.EmailExistsError:
-        # Returning an error message might help the end client find
-        # existing email addresses.
-        raise api_errors.ApiErrors(
-            {"message": "Token invalide"},
             status_code=401,
         )
 

--- a/api/tests/core/users/email/test_update.py
+++ b/api/tests/core/users/email/test_update.py
@@ -1,8 +1,6 @@
 import dataclasses
-import datetime
 from unittest.mock import patch
 
-from freezegun import freeze_time
 import pytest
 from sqlalchemy.exc import IntegrityError
 
@@ -15,22 +13,10 @@ import pcapi.core.users.email.update as email_update
 import pcapi.core.users.exceptions as users_exceptions
 from pcapi.core.users.models import EmailHistoryEventTypeEnum
 from pcapi.core.users.models import User
-from pcapi.core.users.utils import decode_jwt_token
 from pcapi.core.users.utils import encode_jwt_payload
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
-
-
-def _initialize_token_old(user, new_email, app):  # delete after migration
-    expiration_date = datetime.datetime.utcnow() + users_constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
-    token = encode_jwt_payload({"current_email": user.email, "new_email": new_email}, expiration_date)
-    app.redis_client.set(
-        email_update.get_token_key(user, email_update.TokenType.CONFIRMATION),
-        token,
-        ex=users_constants.EMAIL_CHANGE_TOKEN_LIFE_TIME,
-    )
-    return token
 
 
 def _initialize_token(user, new_email, app=None):
@@ -62,15 +48,11 @@ class RequestEmailUpdateTest:
 
 
 class EmailUpdateConfirmationTest:
-    @pytest.mark.parametrize(
-        "token_init",
-        [(_initialize_token), (_initialize_token_old)],
-    )
-    def test_email_update_confirmation(self, app, token_init):
+    def test_email_update_confirmation(self, app):
         # Given
         user = users_factories.UserFactory()
         email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
-        token = token_init(user, email_update_request.newEmail, app)
+        token = _initialize_token(user, email_update_request.newEmail, app)
 
         # When
         email_update.confirm_email_update_request(token)
@@ -91,17 +73,13 @@ class EmailUpdateConfirmationTest:
         )
 
         # Token is deleted
-        assert app.redis_client.get(email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)) is None
+        assert not token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
 
-    @pytest.mark.parametrize(
-        "token_init",
-        [(_initialize_token), (_initialize_token_old)],
-    )
-    def test_update_email_confirmation_with_invalid_token(self, app, token_init):
+    def test_update_email_confirmation_with_invalid_token(self, app):
         # Given
         user = users_factories.UserFactory()
         email_update_request = users_factories.EmailUpdateEntryFactory(user=user)  # existing confirmation token
-        token_init(user, email_update_request.newEmail, app)
+        _initialize_token(user, email_update_request.newEmail, app)
         invalid_token = encode_jwt_payload({"current_email": user.email, "new_email": "new@e.mail"})
 
         # When
@@ -118,19 +96,13 @@ class EmailUpdateConfirmationTest:
         assert len(mails_testing.outbox) == 0
 
         # Token is not deleted
-        assert app.redis_client.get(
-            email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)
-        ) is not None or token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
+        assert token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
 
-    @pytest.mark.parametrize(
-        "token_init",
-        [(_initialize_token), (_initialize_token_old)],
-    )
-    def test_update_email_confirmation_email_already_exists(self, app, token_init):
+    def test_update_email_confirmation_email_already_exists(self, app):
         # Given
         user = users_factories.UserFactory()
         email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
-        token = token_init(user, email_update_request.newEmail, app)
+        token = _initialize_token(user, email_update_request.newEmail, app)
         users_factories.UserFactory(email=email_update_request.newEmail)
 
         # When
@@ -147,19 +119,13 @@ class EmailUpdateConfirmationTest:
         assert len(mails_testing.outbox) == 0
 
         # Token is not deleted
-        assert app.redis_client.get(
-            email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)
-        ) is not None or token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
+        assert token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
 
-    @pytest.mark.parametrize(
-        "token_init",
-        [(_initialize_token), (_initialize_token_old)],
-    )
-    def test_update_email_confirmation_update_history_failed(self, app, token_init):
+    def test_update_email_confirmation_update_history_failed(self, app):
         # Given
         user = users_factories.UserFactory()
         email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
-        token = token_init(user, email_update_request.newEmail, app)
+        token = _initialize_token(user, email_update_request.newEmail, app)
 
         with pytest.raises(Exception):
             with patch(
@@ -177,21 +143,15 @@ class EmailUpdateConfirmationTest:
         assert len(mails_testing.outbox) == 1
 
         # Token is not deleted
-        assert app.redis_client.get(
-            email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)
-        ) is not None or token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
+        assert token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
 
 
 class EmailUpdateCancellationTest:
-    @pytest.mark.parametrize(
-        "token_init",
-        [(_initialize_token), (_initialize_token_old)],
-    )
-    def test_email_update_cancellation(self, app, token_init):
+    def test_email_update_cancellation(self, app):
         # Given
         user = users_factories.UserFactory()
         email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
-        token = token_init(user, email_update_request.newEmail, app)
+        token = _initialize_token(user, email_update_request.newEmail, app)
 
         # When
         email_update.cancel_email_update_request(token)
@@ -207,18 +167,14 @@ class EmailUpdateCancellationTest:
         assert user.is_active is False
 
         # Token is deleted
-        assert app.redis_client.get(email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)) is None
+        assert not token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
 
-    @pytest.mark.parametrize(
-        "token_init",
-        [(_initialize_token), (_initialize_token_old)],
-    )
-    def test_email_update_cancellation_with_invalid_token(self, app, token_init):
+    def test_email_update_cancellation_with_invalid_token(self, app):
         # Given
         user = users_factories.UserFactory()
         email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
 
-        token_init(user, email_update_request.newEmail, app)
+        _initialize_token(user, email_update_request.newEmail, app)
 
         invalid_token = encode_jwt_payload({"current_email": user.email, "new_email": "new@e.mail"})
 
@@ -236,19 +192,13 @@ class EmailUpdateCancellationTest:
         assert user.is_active is True
 
         # Token is not deleted
-        assert app.redis_client.get(
-            email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)
-        ) is not None or token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
+        assert token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
 
-    @pytest.mark.parametrize(
-        "token_init",
-        [(_initialize_token), (_initialize_token_old)],
-    )
-    def test_email_update_cancellation_suspend_account_failed(self, app, token_init):
+    def test_email_update_cancellation_suspend_account_failed(self, app):
         # Given
         user = users_factories.UserFactory()
         email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
-        token = token_init(user, email_update_request.newEmail, app)
+        token = _initialize_token(user, email_update_request.newEmail, app)
 
         with pytest.raises(Exception):
             with patch(
@@ -266,136 +216,4 @@ class EmailUpdateCancellationTest:
         assert user.is_active is True
 
         # Token is not deleted
-        assert app.redis_client.get(
-            email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)
-        ) is not None or token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)
-
-
-class EmailUpdateTokenTest:
-    @pytest.mark.parametrize(
-        "token_type",
-        [
-            (email_update.TokenType.CONFIRMATION),
-            (email_update.TokenType.VALIDATION),
-        ],
-    )
-    def test_generate_email_change_token(self, app, token_type):
-        # Given
-        user = users_factories.UserFactory()
-        new_email = "Updated_" + user.email
-        expiration_date = email_update.generate_email_change_token_expiration_date()
-
-        # When
-        token = email_update.generate_email_change_token(
-            user, new_email, expiration_date=expiration_date, token_type=token_type
-        )
-
-        # Then
-        decoded_token = decode_jwt_token(token)
-        assert app.redis_client.get(email_update.get_token_key(user, token_type)) == token
-        assert decoded_token["current_email"] == user.email
-        assert decoded_token["new_email"] == new_email
-        assert decoded_token["exp"] == int(expiration_date.timestamp())
-
-    @pytest.mark.parametrize(
-        "token_type",
-        [
-            (email_update.TokenType.CONFIRMATION),
-            (email_update.TokenType.VALIDATION),
-        ],
-    )
-    def test_check_token_nominal(self, app, token_type):
-        # Given
-        user = users_factories.UserFactory()
-        new_email = "Updated_" + user.email
-        expiration_date = email_update.generate_email_change_token_expiration_date()
-        token = email_update.generate_email_change_token(
-            user, new_email, expiration_date=expiration_date, token_type=token_type
-        )
-
-        # should not raise
-        email_update._check_token(user, token, token_type)
-
-    @pytest.mark.parametrize(
-        "token_type",
-        [
-            (email_update.TokenType.CONFIRMATION),
-            (email_update.TokenType.VALIDATION),
-        ],
-    )
-    def test_check_token_wrong_type(self, app, token_type):
-        # Given
-        user = users_factories.UserFactory()
-        new_email = "Updated_" + user.email
-        expiration_date = email_update.generate_email_change_token_expiration_date()
-        token = email_update.generate_email_change_token(
-            user, new_email, expiration_date=expiration_date, token_type=token_type
-        )
-
-        # When
-        with pytest.raises(users_exceptions.InvalidToken):
-            email_update._check_token(
-                user,
-                token,
-                email_update.TokenType.CONFIRMATION
-                if token_type == email_update.TokenType.VALIDATION
-                else email_update.TokenType.VALIDATION,
-            )
-
-    @pytest.mark.parametrize(
-        "token_type",
-        [
-            (email_update.TokenType.CONFIRMATION),
-            (email_update.TokenType.VALIDATION),
-        ],
-    )
-    def test_expire_token(self, app, token_type):
-        # Given
-        user = users_factories.UserFactory()
-        new_email = "Updated_" + user.email
-        expiration_date = email_update.generate_email_change_token_expiration_date()
-        token = email_update.generate_email_change_token(
-            user, new_email, expiration_date=expiration_date, token_type=token_type
-        )
-
-        # When
-        email_update._expire_token(user, token_type)
-
-        # Then
-        assert app.redis_client.get(email_update.get_token_key(user, token_type)) is None
-
-        with pytest.raises(users_exceptions.InvalidToken):
-            email_update._check_token(user, token, token_type)
-
-    @pytest.mark.parametrize(
-        "token_type",
-        [
-            (email_update.TokenType.CONFIRMATION),
-            (email_update.TokenType.VALIDATION),
-        ],
-    )
-    @freeze_time("2021-01-01 00:00:00")
-    def test_get_active_token_expiration(self, app, token_type):
-        # Given
-        user = users_factories.UserFactory()
-        new_email = "Updated_" + user.email
-        expiration_date = email_update.generate_email_change_token_expiration_date()
-        email_update.generate_email_change_token(
-            user, new_email, expiration_date=expiration_date, token_type=token_type
-        )
-
-        # When
-        expiration = email_update.get_active_token_expiration(user)
-
-        # Then
-        assert expiration == expiration_date
-
-    def test_get_active_token_expiration_no_token(self, app):
-        # Given
-        user = users_factories.UserFactory()
-
-        # When
-        expiration = email_update.get_active_token_expiration(user)
-
-        # Then
-        assert expiration is None
+        assert token_utils.Token.token_exists(token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION, user.id)


### PR DESCRIPTION
## But de la pull request

- nettoyer le code pour supprimer le support des anciens tokens. 
- Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23343

contexte:
doit être merger au plutôt 24 heures après la mise en production  le temps que les anciens tokens disparaissent
- https://passculture.atlassian.net/browse/PC-23312
- https://passculture.atlassian.net/browse/PC-23344

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques