### PR TITLE
(PC-22637)[PRO] feat: survey satisfaction close iwth api call

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersInstitutionList/OffersInstitutionList.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersInstitutionList/OffersInstitutionList.tsx
@@ -15,13 +15,6 @@ const OffersInstitutionList = ({
   venueFilter,
 }: OffersInstitutionListProps): JSX.Element => {
   const adageUser = useAdageUser()
-  return (
-    <Offers
-      setIsLoading={() => {}}
-      userRole={adageUser.role}
-      userEmail={adageUser.email}
-      displayStats={false}
-    />
-  )
+  return <Offers setIsLoading={() => {}} displayStats={false} />
 }
 export default OffersInstitutionList

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -10,6 +10,7 @@ import fullUpIcon from 'icons/full-up.svg'
 import strokeLikeIcon from 'icons/stroke-like.svg'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
 import strokePassIcon from 'icons/stroke-pass.svg'
+import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import {
   HydratedCollectiveOffer,
   HydratedCollectiveOfferTemplate,
@@ -33,20 +34,13 @@ export interface OfferProps {
   offer: HydratedCollectiveOffer | HydratedCollectiveOfferTemplate
   queryId: string
   position: number
-  userEmail?: string | null
-  userRole: AdageFrontRoles
 }
 
-const Offer = ({
-  offer,
-  queryId,
-  position,
-  userEmail,
-  userRole,
-}: OfferProps): JSX.Element => {
+const Offer = ({ offer, queryId, position }: OfferProps): JSX.Element => {
   const [displayDetails, setDisplayDetails] = useState(false)
   const [isModalLikeOpen, setIsModalLikeOpen] = useState(false)
   const isLikeActive = useActiveFeature('WIP_ENABLE_LIKE_IN_ADAGE')
+  const adageUser = useAdageUser()
 
   const openOfferDetails = (
     offer: HydratedCollectiveOffer | HydratedCollectiveOfferTemplate
@@ -111,12 +105,12 @@ const Offer = ({
               offerId={offer.id}
               position={position}
               queryId={queryId}
-              userEmail={userEmail}
-              userRole={userRole}
+              userEmail={adageUser.email}
+              userRole={adageUser.role}
             />
           ) : (
             <PrebookingButton
-              canPrebookOffers={userRole == AdageFrontRoles.REDACTOR}
+              canPrebookOffers={adageUser.role == AdageFrontRoles.REDACTOR}
               className={style['offer-prebooking-button']}
               offerId={offer.id}
               queryId={queryId}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -10,12 +10,12 @@ import { connectInfiniteHits, connectStats } from 'react-instantsearch-dom'
 import {
   CollectiveOfferResponseModel,
   CollectiveOfferTemplateResponseModel,
-  AdageFrontRoles,
 } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
 import useActiveFeature from 'hooks/useActiveFeature'
 import { getCollectiveOfferAdapter } from 'pages/AdageIframe/app/adapters/getCollectiveOfferAdapter'
 import { getCollectiveOfferTemplateAdapter } from 'pages/AdageIframe/app/adapters/getCollectiveOfferTemplateAdapter'
+import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { AnalyticsContext } from 'pages/AdageIframe/app/providers/AnalyticsContextProvider'
 import {
   HydratedCollectiveOffer,
@@ -43,8 +43,6 @@ export interface OffersComponentProps
 
 interface OffersComponentPropsWithHits
   extends InfiniteHitsProvided<ResultType> {
-  userRole: AdageFrontRoles
-  userEmail?: string | null
   setIsLoading: (isLoading: boolean) => void
   handleResetFiltersAndLaunchSearch?: () => void
   displayStats?: boolean
@@ -59,8 +57,6 @@ type OfferMap = Map<
 >
 
 export const OffersComponent = ({
-  userRole,
-  userEmail,
   setIsLoading,
   handleResetFiltersAndLaunchSearch,
   hits,
@@ -95,6 +91,11 @@ export const OffersComponent = ({
       setIsCookieEnabled(false)
     }
   }, [])
+
+  const adageUser = useAdageUser()
+
+  const showSurveySatisfaction =
+    isSatisfactionSurveyActive && !adageUser.preferences?.feedback_form_closed
 
   const { filtersKeys, hasClickedSearch, setHasClickedSearch } =
     useContext(AnalyticsContext)
@@ -187,13 +188,7 @@ export const OffersComponent = ({
       <ul className={styles['offers-list']}>
         {offers.map((offer, index) => (
           <div key={`${offer.isTemplate ? 'T' : ''}${offer.id}`}>
-            <Offer
-              offer={offer}
-              position={index}
-              queryId={queryId}
-              userEmail={userEmail}
-              userRole={userRole}
-            />
+            <Offer offer={offer} position={index} queryId={queryId} />
             {index === 0 && showDiffuseHelp && (
               <DiffuseHelp
                 description={
@@ -201,9 +196,7 @@ export const OffersComponent = ({
                 }
               />
             )}
-            {index === 1 && isSatisfactionSurveyActive && isCookieEnabled && (
-              <SurveySatisfaction />
-            )}
+            {index === 1 && showSurveySatisfaction && <SurveySatisfaction />}
           </div>
         ))}
         <div className={styles['offers-load-more']}>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -7,6 +7,7 @@ import {
   OfferAddressType,
   StudentLevels,
 } from 'apiClient/adage'
+import { AdageUserContext } from 'pages/AdageIframe/app/providers/AdageUserContext'
 import { HydratedCollectiveOffer } from 'pages/AdageIframe/app/types/offers'
 import { defaultCollectiveTemplateOffer } from 'utils/adageFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -39,18 +40,28 @@ vi.mock('react-instantsearch-dom', () => {
   }
 })
 
+const user = {
+  role: AdageFrontRoles.REDACTOR,
+  email: 'test@example.com',
+}
+
 const renderOffers = (
   props: OfferProps,
   featuresOverride?: { nameKey: string; isActive: boolean }[]
 ) => {
-  renderWithProviders(<Offer {...props} />, {
-    storeOverrides: {
-      features: {
-        list: featuresOverride,
-        initialized: true,
+  renderWithProviders(
+    <AdageUserContext.Provider value={{ adageUser: user }}>
+      <Offer {...props} />
+    </AdageUserContext.Provider>,
+    {
+      storeOverrides: {
+        features: {
+          list: featuresOverride,
+          initialized: true,
+        },
       },
-    },
-  })
+    }
+  )
 }
 
 describe('offer', () => {
@@ -159,7 +170,6 @@ describe('offer', () => {
       offer: offerInParis,
       queryId: '1',
       position: 1,
-      userRole: AdageFrontRoles.REDACTOR,
     }
   })
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -170,8 +170,6 @@ export const OffersSearchComponent = ({
         <div className="search-results">
           <Offers
             setIsLoading={setIsLoading}
-            userRole={adageUser.role}
-            userEmail={adageUser.email}
             resetForm={resetForm}
             logFiltersOnSearch={logFiltersOnSearch}
             submitCount={formik.submitCount}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OldOffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OldOffersSearch.tsx
@@ -143,8 +143,6 @@ export const OldOffersSearchComponent = ({
         <Offers
           handleResetFiltersAndLaunchSearch={handleResetFiltersAndLaunchSearch}
           setIsLoading={setIsLoading}
-          userRole={adageUser.role}
-          userEmail={adageUser.email}
         />
       </div>
     </>

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
@@ -1,6 +1,8 @@
 import cn from 'classnames'
 import React, { useState } from 'react'
 
+import { apiAdage } from 'apiClient/api'
+import useNotification from 'hooks/useNotification'
 import strokeCloseIcon from 'icons/stroke-close.svg'
 import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -8,17 +10,21 @@ import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './SurveySatisfaction.module.scss'
 
-const LOCAL_STORAGE_HAS_SEEN_SATISFACTION_KEY = 'SURVEY_SATISFACTION_ADAGE_SEEN'
-
 export const SurveySatisfaction = (): JSX.Element => {
   const [shouldHideSurveySatisfaction, setShouldHideSurveySatisfaction] =
-    useState(
-      Boolean(localStorage.getItem(LOCAL_STORAGE_HAS_SEEN_SATISFACTION_KEY))
-    )
+    useState(false)
 
-  const onCloseSurvey = () => {
-    localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_SATISFACTION_KEY, 'true')
-    setShouldHideSurveySatisfaction(true)
+  const notify = useNotification()
+
+  const onCloseSurvey = async () => {
+    try {
+      await apiAdage.saveRedactorPreferences({
+        feedback_form_closed: true,
+      })
+      setShouldHideSurveySatisfaction(true)
+    } catch {
+      notify.error('Une erreur est survenue. Merci de réessayer plus tard')
+    }
   }
 
   return !shouldHideSurveySatisfaction ? (

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
@@ -2,9 +2,17 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
+import { apiAdage } from 'apiClient/api'
+import * as useNotification from 'hooks/useNotification'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { SurveySatisfaction } from '../SurveySatisfaction'
+
+vi.mock('apiClient/api', () => ({
+  apiAdage: {
+    saveRedactorPreferences: jest.fn(() => Promise.resolve({})),
+  },
+}))
 
 describe('SurveySatisfaction', () => {
   it('should close survey satisfaction', async () => {
@@ -21,5 +29,27 @@ describe('SurveySatisfaction', () => {
         screen.queryByText('Enquête de satisfaction')
       ).not.toBeInTheDocument()
     })
+  })
+
+  it('should fail close survey satisfaction', async () => {
+    const notifyError = vi.fn()
+    // @ts-expect-error
+    vi.spyOn(useNotification, 'default').mockImplementation(() => ({
+      error: notifyError,
+    }))
+
+    vi.spyOn(apiAdage, 'saveRedactorPreferences').mockRejectedValue({
+      isOk: false,
+    })
+
+    renderWithProviders(<SurveySatisfaction />)
+
+    screen.getByText('Enquête de satisfaction')
+
+    const closeButton = screen.getByTitle('Masquer le bandeau')
+
+    userEvent.click(closeButton)
+
+    await waitFor(() => expect(notifyError).toHaveBeenCalledTimes(1))
   })
 })


### PR DESCRIPTION
…or each env

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-22637

Ticket sur adage : SOUS FF `WIP_ENABLE_SATISFACTION_SURVEY`

sauvegarder l'information en back lorsque l'utilisateur ferme l'enquête de satisfaction afin de qu'il ne l'a voit plus jamais

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques