### PR TITLE
(PC-23323)[BO] feat: Enable reimbursement rule end date adding if not…

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -2344,8 +2344,8 @@ def edit_reimbursement_rule(
     rule: models.CustomReimbursementRule,
     end_date: datetime.datetime,
 ) -> models.CustomReimbursementRule:
-    if rule.timespan.lower <= datetime.datetime.utcnow():
-        error = "Il n'est pas possible de modifier la date de fin lorsque la date de début est dépassée."
+    if end_date.date() <= datetime.datetime.utcnow().date():
+        error = "La date de fin doit être postérieure à la date du jour."
         raise exceptions.WrongDateForReimbursementRule(error)
     # To avoid complexity, we do not allow to edit the end date of a
     # rule that already has one.

--- a/api/src/pcapi/routes/backoffice_v3/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/custom_reimbursement_rules/list.html
@@ -51,7 +51,7 @@
             {% for reimbursement_rule in rows %}
               <tr>
                 <td>
-                  {% if reimbursement_rule.timespan.lower > now and not reimbursement_rule.timespan.upper %}
+                  {% if not reimbursement_rule.timespan.upper %}
                     <div class="dropdown">
                       <button type="button"
                               data-bs-toggle="dropdown"
@@ -90,7 +90,7 @@
           </tbody>
         </table>
         {% for reimbursement_rule in rows %}
-          {% if reimbursement_rule.timespan.lower > now and not reimbursement_rule.timespan.upper %}
+          {% if not reimbursement_rule.timespan.upper %}
             {{ build_lazy_modal(
             url_for("backoffice_v3_web.reimbursement_rules.get_edit_custom_reimbursement_rule_form", reimbursement_rule_id=reimbursement_rule.id),
             "edit-custom-reimbursement-rule-" + reimbursement_rule.id|string) }}

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -2593,15 +2593,6 @@ class EditReimbursementRuleTest:
         assert rule.timespan.lower == datetime.datetime(today.year + 1, 1, 1, 0, 0)  # unchanged
         assert rule.timespan.upper == datetime.datetime(today.year + 2, 10, 3, 0, 0)
 
-    def test_cannot_change_end_date_when_start_date_is_reached(self):
-        today = datetime.date.today()
-        timespan = (pytz.utc.localize(datetime.datetime(today.year, 1, 1)), None)
-        rule = factories.CustomReimbursementRuleFactory(timespan=timespan)
-        end = pytz.utc.localize(datetime.datetime(today.year + 1, 10, 3, 0, 0))
-
-        with pytest.raises(exceptions.WrongDateForReimbursementRule):
-            api.edit_reimbursement_rule(rule, end_date=end)
-
     def test_cannot_change_existing_end_date(self):
         today = datetime.datetime.today()
         timespan = (today - datetime.timedelta(days=10), today)


### PR DESCRIPTION
… exists

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23323

Rendre possible l'ajout d'une date de fin peu importe si la date de début est passée ou non.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques