### PR TITLE
Pc 23356 add features to booking confirmation email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -105,5 +105,6 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "BOOKING_LINK": booking_app_link(booking),
             "OFFER_WITHDRAWAL_DELAY": bookings_common.get_offer_withdrawal_delay(booking),
             "OFFER_WITHDRAWAL_TYPE": bookings_common.get_offer_withdrawal_type(booking),
+            "FEATURES": ", ".join(stock.features),
         },
     )

--- a/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
@@ -93,6 +93,7 @@ def get_new_booking_to_pro_email_data(
             "WITHDRAWAL_PERIOD": booking_constants.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY.days
             if offer.subcategoryId == subcategories.LIVRE_PAPIER.id
             else booking_constants.BOOKINGS_AUTO_EXPIRY_DELAY.days,
+            "FEATURES": ", ".join(booking.stock.features),
         },
     )
 

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -186,7 +186,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     priceCategory: sa_orm.Mapped["PriceCategory | None"] = sa.orm.relationship("PriceCategory", back_populates="stocks")
     quantity = sa.Column(sa.Integer, nullable=True)
     rawProviderQuantity = sa.Column(sa.Integer, nullable=True)
-    features = sa.Column(postgresql.ARRAY(sa.Text), nullable=False, server_default=sa.text("'{}'::text[]"))
+    features: list[str] = sa.Column(postgresql.ARRAY(sa.Text), nullable=False, server_default=sa.text("'{}'::text[]"))
 
     @property
     def isBookable(self) -> bool:

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -77,6 +77,7 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
             "BOOKING_LINK": f"https://webapp-v2.example.com/reservation/{booking.id}/details",
             "OFFER_WITHDRAWAL_TYPE": None,
             "OFFER_WITHDRAWAL_DELAY": None,
+            "FEATURES": "",
         },
     )
     email_data.params.update(overrides)
@@ -95,7 +96,7 @@ def test_should_return_event_specific_data_for_email_when_offer_is_an_event_send
 
 @freeze_time("2021-10-15 12:48:00")
 def test_should_return_event_specific_data_for_email_when_offer_is_a_duo_event_sendinblue():
-    booking = booking = BookingFactory(
+    booking = BookingFactory(
         stock=offers_factories.EventStockFactory(price=23.99), dateCreated=datetime.utcnow(), quantity=2
     )
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
@@ -197,6 +198,36 @@ def test_should_return_offer_tags():
         mediation,
         OFFER_TAGS="Tagged_offer",
         **{key: value for key, value in email_data.params.items() if key != "OFFER_TAGS"},
+    )
+    assert email_data == expected
+
+
+@freeze_time("2021-10-15 12:48:00")
+def test_should_return_offer_features():
+    stock = offers_factories.ThingStockFactory(
+        features=["VO", "IMAX"],
+        price=23.99,
+    )
+    booking = BookingFactory(
+        dateCreated=datetime.utcnow(),
+        stock=stock,
+    )
+    mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
+
+    email_data = get_booking_confirmation_to_beneficiary_email_data(booking)
+
+    expected = get_expected_base_sendinblue_email_data(
+        booking,
+        mediation,
+        FEATURES="VO, IMAX",
+        ALL_THINGS_NOT_VIRTUAL_THING=True,
+        EVENT_DATE=None,
+        EVENT_HOUR=None,
+        IS_EVENT=False,
+        IS_SINGLE_EVENT=False,
+        CAN_EXPIRE=True,
+        EXPIRATION_DELAY=30,
+        BOOKING_LINK=f"https://webapp-v2.example.com/reservation/{booking.id}/details",
     )
     assert email_data == expected
 

--- a/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
@@ -64,6 +64,7 @@ def get_expected_base_email_data(booking, **overrides):
         "USER_PHONENUMBER": "",
         "VENUE_NAME": "Lieu de l'offreur",
         "WITHDRAWAL_PERIOD": 30,
+        "FEATURES": "",
     }
     email_data_params.update(overrides)
     return email_data_params
@@ -359,6 +360,15 @@ class OffererBookingRecapTest:
             email_data = get_new_booking_to_pro_email_data(booking)
 
         assert not email_data.params["NEEDS_BANK_INFORMATION_REMINDER"]
+
+    @pytest.mark.usefixtures("db_session")
+    def test_booking_with_features(self):
+        stock = offers_factories.StockFactory(features=["VO", "IMAX"])
+        booking = make_booking(stock=stock)
+
+        email_data = get_new_booking_to_pro_email_data(booking)
+
+        assert email_data.params["FEATURES"] == "VO, IMAX"
 
 
 class SendNewBookingEmailToProTest:


### PR DESCRIPTION
## But de la pull request

- ajouter les attribut (exemple: VO, Imax) à l'email de confirmation de réservation du côté jeune et du côté pro

- Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23356

## Vérifications

- [ ] J'ai écrit les tests nécessaires
