### PR TITLE
(PC-23584)[API] fix: Cancel and re-do HONOR_STATEMENT when eligibility difference detected

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -708,6 +708,15 @@ def handle_eligibility_difference_between_declaration_and_identity_provider(
     if profile_completion_fraud_check:
         _update_fraud_check_eligibility_with_history(profile_completion_fraud_check, id_provider_detected_eligibility)
 
+    # Handle eligibility update for HONOR_STATEMENT fraud check, if it exists
+    honor_statement_fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter(
+        fraud_models.BeneficiaryFraudCheck.user == user,
+        fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.HONOR_STATEMENT,
+        fraud_models.BeneficiaryFraudCheck.eligibilityType == declared_eligibility,
+    ).first()
+    if honor_statement_fraud_check:
+        _update_fraud_check_eligibility_with_history(honor_statement_fraud_check, id_provider_detected_eligibility)
+
     return new_fraud_check
 
 

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -664,6 +664,14 @@ class CommonSubscritpionTest:
             eligibilityType=users_models.EligibilityType.UNDERAGE,
             resultContent=fraud_factories.ProfileCompletionContentFactory(),
         )
+        # Honor statement fraud check
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.HONOR_STATEMENT,
+            status=fraud_models.FraudCheckStatus.OK,
+            eligibilityType=users_models.EligibilityType.UNDERAGE,
+            resultContent=fraud_factories.ProfileCompletionContentFactory(),
+        )
         assert (
             subscription_api.handle_eligibility_difference_between_declaration_and_identity_provider(user, fraud_check)
             != fraud_check
@@ -672,7 +680,7 @@ class CommonSubscritpionTest:
         user_fraud_checks = sorted(
             fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).all(), key=lambda x: x.id
         )
-        assert len(user_fraud_checks) == 4
+        assert len(user_fraud_checks) == 6
         assert user_fraud_checks[0].eligibilityType == users_models.EligibilityType.UNDERAGE
         assert user_fraud_checks[0].type == fraud_models.FraudCheckType.UBBLE
         assert user_fraud_checks[0].reason == "Eligibility type changed by the identity provider"
@@ -683,13 +691,22 @@ class CommonSubscritpionTest:
         assert user_fraud_checks[1].reason == "Eligibility type changed by the identity provider"
         assert user_fraud_checks[1].status == fraud_models.FraudCheckStatus.CANCELED
 
-        assert user_fraud_checks[2].eligibilityType == users_models.EligibilityType.AGE18
-        assert user_fraud_checks[2].type == fraud_models.FraudCheckType.UBBLE
-        assert user_fraud_checks[2].status == fraud_models.FraudCheckStatus.PENDING
+        assert user_fraud_checks[2].eligibilityType == users_models.EligibilityType.UNDERAGE
+        assert user_fraud_checks[2].type == fraud_models.FraudCheckType.HONOR_STATEMENT
+        assert user_fraud_checks[2].reason == "Eligibility type changed by the identity provider"
+        assert user_fraud_checks[2].status == fraud_models.FraudCheckStatus.CANCELED
 
         assert user_fraud_checks[3].eligibilityType == users_models.EligibilityType.AGE18
-        assert user_fraud_checks[3].type == fraud_models.FraudCheckType.PROFILE_COMPLETION
-        assert user_fraud_checks[3].status == fraud_models.FraudCheckStatus.OK
+        assert user_fraud_checks[3].type == fraud_models.FraudCheckType.UBBLE
+        assert user_fraud_checks[3].status == fraud_models.FraudCheckStatus.PENDING
+
+        assert user_fraud_checks[4].eligibilityType == users_models.EligibilityType.AGE18
+        assert user_fraud_checks[4].type == fraud_models.FraudCheckType.PROFILE_COMPLETION
+        assert user_fraud_checks[4].status == fraud_models.FraudCheckStatus.OK
+
+        assert user_fraud_checks[5].eligibilityType == users_models.EligibilityType.AGE18
+        assert user_fraud_checks[5].type == fraud_models.FraudCheckType.HONOR_STATEMENT
+        assert user_fraud_checks[5].status == fraud_models.FraudCheckStatus.OK
 
     def test_handle_eligibility_difference_between_declaration_and_identity_provider_unreadable_document(self):
         user = users_factories.UserFactory()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23584

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques