### PR TITLE
(PC-21880)[BO] fix incident amount on creation

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/finance/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/finance/forms.py
@@ -26,7 +26,9 @@ class IncidentCreationForm(FlaskForm):
 
     origin = fields.PCStringField("Origine de la demande")
 
-    total_amount = fields.PCDecimalField("Montant total de l'incident", validators=[Optional()])
+    total_amount = fields.PCDecimalField(
+        "Montant total de l'incident (à récupérer à la structure)", validators=[Optional()]
+    )
 
 
 class BookingIncidentForm(empty_forms.BatchForm, IncidentCreationForm):

--- a/api/src/pcapi/routes/backoffice_v3/templates/finance/incident/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/finance/incident/list.html
@@ -7,7 +7,7 @@
     <h2 class="fw-light">Incidents sur les réservations individuelles</h2>
     <div>
       {% if rows %}
-        <div class="d-flex justify-content-around">
+        <div class="d-flex flex-column">
           <p class="lead num-results">
             {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
             résultat{{ "s" if rows | length > 1 else "" }}
@@ -49,7 +49,7 @@
                   <td>{{ links.build_offerer_name_to_details_link(incident.venue.managingOfferer) }}</td>
                   <td>{{ links.build_venue_name_to_details_link(venue) }}</td>
                   <td>
-                    {{ incident.details }}
+                    {{ incident.details['origin'] }}
                   </tr>
                 {% endfor %}
               </tbody>

--- a/api/tests/routes/backoffice_v3/finance_test.py
+++ b/api/tests/routes/backoffice_v3/finance_test.py
@@ -118,7 +118,8 @@ class CreateIncidentTest(PostEndpointHelper):
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
     def test_create_incident_from_one_booking(self, authenticated_client):
-        booking = bookings_factories.ReimbursedBookingFactory()
+        pricing = finance_factories.PricingFactory(status=finance_models.PricingStatus.INVOICED)
+        booking = bookings_factories.ReimbursedBookingFactory(pricings=[pricing])
 
         object_ids = str(booking.id)
 
@@ -163,9 +164,12 @@ class CreateIncidentTest(PostEndpointHelper):
         offer = offers_factories.OfferFactory(venue=venue)
         stock = offers_factories.StockFactory(offer=offer)
         selected_bookings = [
-            bookings_factories.ReimbursedBookingFactory(stock=stock),
-            bookings_factories.ReimbursedBookingFactory(stock=stock),
-            bookings_factories.ReimbursedBookingFactory(stock=stock),
+            bookings_factories.ReimbursedBookingFactory(
+                stock=stock, pricings=[finance_factories.PricingFactory(status=finance_models.PricingStatus.INVOICED)]
+            ),
+            bookings_factories.ReimbursedBookingFactory(
+                stock=stock, pricings=[finance_factories.PricingFactory(status=finance_models.PricingStatus.INVOICED)]
+            ),
         ]
         object_ids = ",".join([str(booking.id) for booking in selected_bookings])
         total_booking_amount = sum(booking.amount for booking in selected_bookings)
@@ -184,4 +188,4 @@ class CreateIncidentTest(PostEndpointHelper):
         assert finance_models.FinanceIncident.query.count() == 1
         finance_incident = finance_models.FinanceIncident.query.first()
         assert finance_incident.details["origin"] == "Origine de la demande"
-        assert finance_models.BookingFinanceIncident.query.count() == 3
+        assert finance_models.BookingFinanceIncident.query.count() == 2


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-21880

Apport de quelques fix sur la création d'incident, dont :
- Le montant final de l'incident (directement basé sur le montant du dernier `Pricing` facturé)
- Alignement du compteur d'incidents affichés sur la page globale
- Le wording du label sur le montant de l'incident
- Afficher uniquement l'origine de l'incident au lieu de tous les détails de l'incident dans la page globale

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/45124f64-dfec-4f94-8443-2cdfa80ea4c6)
![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/92dc965a-2797-4792-8427-a83692ac22a2)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques