### PR TITLE
(PC-23415)[BO] feat: user search by email, with or without email history

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -940,7 +940,12 @@ def comment_public_account(user_id: int) -> utils.BackofficeResponse:
 
 
 def fetch_rows(search_model: search.SearchUserModel) -> Pagination:
-    return search_utils.fetch_paginated_rows(users_api.search_public_account, search_model)
+    rows = search_utils.fetch_paginated_rows(users_api.search_public_account, search_model)
+
+    if rows.total == 0 and email_utils.is_valid_email_or_email_domain(email_utils.sanitize_email(search_model.terms)):
+        return search_utils.fetch_paginated_rows(users_api.search_public_account_in_history_email, search_model)
+
+    return rows
 
 
 def get_public_account_link(user_id: int, **kwargs: typing.Any) -> str:

--- a/api/src/pcapi/utils/email.py
+++ b/api/src/pcapi/utils/email.py
@@ -6,6 +6,10 @@ def sanitize_email(email: str) -> str:
     return email.strip().lower()
 
 
+def is_valid_email_or_email_domain(content: str) -> bool:
+    return is_valid_email(content) or is_valid_email_domain(content)
+
+
 def is_valid_email(content: str) -> bool:
     try:
         email_validator.validate_email(content, check_deliverability=False)

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -396,6 +396,20 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
         assert len(cards_text) == 1
         assert_user_equals(cards_text[0], event.user)
 
+    def test_can_search_old_domain(self, authenticated_client):
+        # given
+        event = users_factories.EmailValidationEntryFactory()
+        event.user.email = event.newEmail
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=f"@{event.oldDomainEmail}"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], event.user)
+
 
 class GetPublicAccountTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.public_accounts.get_public_account"


### PR DESCRIPTION
## But de la pull request

Pour améliorer la rapidité de la recherche de bénéficiaire par adresse email. Nous regardons dans un premier temps s'il y a des utilisateurs avec l'email recherché. Si aucun résultat, nous recherchons dans la table d'historique des adresses emails. 

Ticket Jira : https://passculture.atlassian.net/browse/PC-23415

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [X] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [] J'ai ajouté des screenshots pour d'éventuels changements graphiques