### PR TITLE
(PC-23295)[API] refactor: Remove WIP_ENABLE_NEW_FRAUD_RULES feature flag

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 60d5208fd945 (pre) (head)
-48013aa5a395 (post) (head)
+4fb121d642ef (post) (head)

--- a/api/src/pcapi/alembic/versions/20230801T165116_4fb121d642ef_remove_feature_flag_enable_new_fraud_rules.py
+++ b/api/src/pcapi/alembic/versions/20230801T165116_4fb121d642ef_remove_feature_flag_enable_new_fraud_rules.py
@@ -1,0 +1,32 @@
+"""
+Remove feature flag WIP_ENABLE_NEW_FRAUD_RULES always at true
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4fb121d642ef"
+down_revision = "48013aa5a395"
+branch_labels = None
+depends_on = None
+
+
+def get_flag():  # type: ignore [no-untyped-def]
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="WIP_ENABLE_NEW_FRAUD_RULES",
+        isActive=True,
+        description="Active la nouvelle gestion des règles de validation d'offre",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -108,7 +108,6 @@ class FeatureToggle(enum.Enum):
     WIP_ADD_CLG_6_5_COLLECTIVE_OFFER = "Ouverture des offres collectives au 6ème et 5ème"
     WIP_ENABLE_LIKE_IN_ADAGE = "Active la possibilité de liker une offre sur adage"
     WIP_ENABLE_NEW_ONBOARDING = "Active le nouvel onboarding sans SIREN"
-    WIP_ENABLE_NEW_FRAUD_RULES = "Active la nouvelle gestion des règles de validation d'offre"
     WIP_ENABLE_COLLECTIVE_DMS_TRACKING = "Active le suivi du référencement DMS pour les acteurs EAC"
     WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY = "Changer le template d'email de confirmation de réservation"
     WIP_ENABLE_TRUSTED_DEVICE = "Active la fonctionnalité d'appareil de confiance"
@@ -181,7 +180,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ADD_CLG_6_5_COLLECTIVE_OFFER,
     FeatureToggle.WIP_ENABLE_LIKE_IN_ADAGE,
     FeatureToggle.WIP_ENABLE_NEW_ONBOARDING,
-    FeatureToggle.WIP_ENABLE_NEW_FRAUD_RULES,
     FeatureToggle.WIP_ENABLE_COLLECTIVE_DMS_TRACKING,
     FeatureToggle.WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY,
     FeatureToggle.WIP_ENABLE_TRUSTED_DEVICE,

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1383,20 +1383,6 @@ class DeactivatePermanentlyUnavailableProductTest:
 
 
 @pytest.mark.usefixtures("db_session")
-class ComputeOfferValidationTest:
-    def test_approve_if_no_offer_validation_config(self):
-        offer = models.Offer(name="Maybe we should reject this offer")
-
-        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.APPROVED
-
-    def test_matching_keyword_in_name(self):
-        offer = factories.OfferFactory(name="A suspicious offer")
-        factories.StockFactory(price=10, offer=offer)
-        api.import_offer_validation_config(SIMPLE_OFFER_VALIDATION_CONFIG, users_factories.UserFactory())
-        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.PENDING
-
-
-@pytest.mark.usefixtures("db_session")
 class UpdateOfferValidationStatusTest:
     def test_update_pending_offer_validation_status_to_approved(self):
         offer = factories.OfferFactory(validation=models.OfferValidationStatus.PENDING)
@@ -1810,7 +1796,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": ["REJECTED"]},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.PENDING
         assert models.ValidationRuleOfferLink.query.count() == 1
 
     def test_offer_validation_with_unrelated_rule(self):
@@ -1822,9 +1808,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": ["REJECTED"]},
         )
 
-        assert (
-            api.set_offer_status_based_on_fraud_criteria_v2(collective_offer) == models.OfferValidationStatus.APPROVED
-        )
+        assert api.set_offer_status_based_on_fraud_criteria(collective_offer) == models.OfferValidationStatus.APPROVED
         assert models.ValidationRuleOfferLink.query.count() == 0
 
     @pytest.mark.parametrize(
@@ -1845,7 +1829,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": 10},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == expected_status
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == expected_status
 
     @pytest.mark.parametrize(
         "price, expected_status",
@@ -1865,7 +1849,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": 10},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == expected_status
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == expected_status
 
     @pytest.mark.parametrize(
         "price, expected_status",
@@ -1885,7 +1869,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": 10},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == expected_status
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == expected_status
 
     @pytest.mark.parametrize(
         "price, expected_status",
@@ -1905,7 +1889,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": 10},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == expected_status
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == expected_status
 
     @pytest.mark.parametrize(
         "subcategoryId, expected_status",
@@ -1924,7 +1908,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": ["ESCAPE_GAME"]},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == expected_status
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == expected_status
 
     def test_offer_validation_with_one_rule_with_not_in(self):
         offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
@@ -1935,7 +1919,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": ["MUSEE", "LIVRE", "CINEMA"]},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.APPROVED
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.APPROVED
 
     def test_offer_validation_with_one_rule_with_categories(self):
         offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
@@ -1946,7 +1930,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": ["JEU"]},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.PENDING
 
     def test_offer_validation_with_contains_exact_rule(self):
         offer_to_approve = factories.OfferFactory(name="La blanquette est bonne")
@@ -1960,10 +1944,8 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": ["bon", "lot"]},
         )
 
-        assert (
-            api.set_offer_status_based_on_fraud_criteria_v2(offer_to_approve) == models.OfferValidationStatus.APPROVED
-        )
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer_to_flag) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_approve) == models.OfferValidationStatus.APPROVED
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_flag) == models.OfferValidationStatus.PENDING
 
     def test_offer_validation_with_contains_rule(self):
         offer_to_flag = factories.OfferFactory(name="Sapristi, un lot interdit")
@@ -1977,10 +1959,8 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": ["bon", "lot"]},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer_to_flag) == models.OfferValidationStatus.PENDING
-        assert (
-            api.set_offer_status_based_on_fraud_criteria_v2(offer_to_flag_too) == models.OfferValidationStatus.PENDING
-        )
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_flag) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_flag_too) == models.OfferValidationStatus.PENDING
         assert models.ValidationRuleOfferLink.query.count() == 2
 
     def test_offer_validation_rule_with_offer_type(self):
@@ -1994,8 +1974,8 @@ class ResolveOfferValidationRuleTest:
             operator=models.OfferValidationRuleOperator.IN,
             comparated={"comparated": ["CollectiveOffer"]},
         )
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.APPROVED
-        assert api.set_offer_status_based_on_fraud_criteria_v2(collective_offer) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.APPROVED
+        assert api.set_offer_status_based_on_fraud_criteria(collective_offer) == models.OfferValidationStatus.PENDING
         assert models.ValidationRuleOfferLink.query.count() == 0
         assert educational_models.ValidationRuleCollectiveOfferLink.query.count() == 1
 
@@ -2013,8 +1993,8 @@ class ResolveOfferValidationRuleTest:
             operator=models.OfferValidationRuleOperator.IN,
             comparated={"comparated": [offerer.id]},
         )
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.PENDING
-        assert api.set_offer_status_based_on_fraud_criteria_v2(collective_offer) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(collective_offer) == models.OfferValidationStatus.PENDING
         assert models.ValidationRuleOfferLink.query.count() == 1
         assert educational_models.ValidationRuleCollectiveOfferLink.query.count() == 1
 
@@ -2036,7 +2016,7 @@ class ResolveOfferValidationRuleTest:
             operator=models.OfferValidationRuleOperator.CONTAINS_EXACTLY,
             comparated={"comparated": ["dark"]},
         )
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == expected_status
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == expected_status
 
     @pytest.mark.parametrize(
         "offer_kwargs, expected_status",
@@ -2060,7 +2040,7 @@ class ResolveOfferValidationRuleTest:
             operator=models.OfferValidationRuleOperator.CONTAINS_EXACTLY,
             comparated={"comparated": ["dark"]},
         )
-        assert api.set_offer_status_based_on_fraud_criteria_v2(stock.collectiveOffer) == expected_status
+        assert api.set_offer_status_based_on_fraud_criteria(stock.collectiveOffer) == expected_status
 
     @pytest.mark.parametrize(
         "offer_kwargs, expected_status",
@@ -2081,7 +2061,7 @@ class ResolveOfferValidationRuleTest:
             operator=models.OfferValidationRuleOperator.CONTAINS_EXACTLY,
             comparated={"comparated": ["dark"]},
         )
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == expected_status
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == expected_status
 
     def test_offer_validation_with_multiple_rules(self):
         offer = factories.OfferFactory(name="offer with a verboten name")
@@ -2103,7 +2083,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": 100},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.PENDING
         assert models.ValidationRuleOfferLink.query.count() == 1
 
     def test_offer_validation_rule_with_multiple_sub_rules(self):
@@ -2126,10 +2106,8 @@ class ResolveOfferValidationRuleTest:
             operator=models.OfferValidationRuleOperator.GREATER_THAN,
             comparated={"comparated": 100},
         )
-        assert (
-            api.set_offer_status_based_on_fraud_criteria_v2(offer_to_approve) == models.OfferValidationStatus.APPROVED
-        )
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer_to_flag) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_approve) == models.OfferValidationStatus.APPROVED
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_flag) == models.OfferValidationStatus.PENDING
         assert models.ValidationRuleOfferLink.query.count() == 1
 
     def test_offer_validation_rule_with_unrelated_rules(self):
@@ -2155,9 +2133,9 @@ class ResolveOfferValidationRuleTest:
             operator=models.OfferValidationRuleOperator.GREATER_THAN,
             comparated={"comparated": 100},
         )
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer_to_flag) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_flag) == models.OfferValidationStatus.PENDING
         assert (
-            api.set_offer_status_based_on_fraud_criteria_v2(collective_offer_to_flag)
+            api.set_offer_status_based_on_fraud_criteria(collective_offer_to_flag)
             == models.OfferValidationStatus.PENDING
         )
         assert models.ValidationRuleOfferLink.query.count() == 1
@@ -2172,7 +2150,7 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": ["forbidden", "words"]},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer) == models.OfferValidationStatus.APPROVED
+        assert api.set_offer_status_based_on_fraud_criteria(offer) == models.OfferValidationStatus.APPROVED
 
     def test_validation_rule_offer_link_data(self):
         offer_to_flag = factories.OfferFactory(name="Sapristi, un lot interdit")
@@ -2196,10 +2174,8 @@ class ResolveOfferValidationRuleTest:
             comparated={"comparated": 250},
         )
 
-        assert api.set_offer_status_based_on_fraud_criteria_v2(offer_to_flag) == models.OfferValidationStatus.PENDING
-        assert (
-            api.set_offer_status_based_on_fraud_criteria_v2(offer_to_flag_too) == models.OfferValidationStatus.PENDING
-        )
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_flag) == models.OfferValidationStatus.PENDING
+        assert api.set_offer_status_based_on_fraud_criteria(offer_to_flag_too) == models.OfferValidationStatus.PENDING
 
         assert models.ValidationRuleOfferLink.query.filter_by(offerId=offer_to_flag.id).count() == 2
         assert models.ValidationRuleOfferLink.query.filter_by(offerId=offer_to_flag_too.id).count() == 1

--- a/api/tests/routes/pro/patch_collective_offer_publication_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_publication_test.py
@@ -3,24 +3,10 @@ import pytest
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import factories as offerers_factories
-from pcapi.core.offers import api as offers_api
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers import models as offers_models
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
-
-
-SIMPLE_OFFER_VALIDATION_CONFIG = """
-        minimum_score: 0.6
-        rules:
-            - name: "check offer name"
-              factor: 0
-              conditions:
-               - model: "CollectiveOffer"
-                 attribute: "name"
-                 condition:
-                    operator: "contains"
-                    comparated:
-                      - "suspicious"
-        """
 
 
 @pytest.mark.usefixtures("db_session")
@@ -47,7 +33,15 @@ class Returns204Test:
         user_offerer = offerers_factories.UserOffererFactory(offerer=offer.venue.managingOfferer)
 
         url = f"/collective/offers/{offer.id}/publish"
-        offers_api.import_offer_validation_config(SIMPLE_OFFER_VALIDATION_CONFIG, user_offerer.user)
+
+        offer_name_rule = offers_factories.OfferValidationRuleFactory(name="Règle sur les noms d'offres")
+        offers_factories.OfferValidationSubRuleFactory(
+            validationRule=offer_name_rule,
+            model=offers_models.OfferValidationModel.COLLECTIVE_OFFER,
+            attribute=offers_models.OfferValidationAttribute.NAME,
+            operator=offers_models.OfferValidationRuleOperator.CONTAINS,
+            comparated={"comparated": ["suspicious"]},
+        )
 
         response = client.with_session_auth(user_offerer.user.email).patch(url)
 

--- a/api/tests/routes/pro/patch_collective_offer_template_publication_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_publication_test.py
@@ -3,24 +3,10 @@ import pytest
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import factories as offerers_factories
-from pcapi.core.offers import api as offers_api
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers import models as offers_models
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
-
-
-SIMPLE_OFFER_VALIDATION_CONFIG = """
-        minimum_score: 0.6
-        rules:
-            - name: "check offer name"
-              factor: 0
-              conditions:
-               - model: "CollectiveOfferTemplate"
-                 attribute: "name"
-                 condition:
-                    operator: "contains"
-                    comparated:
-                      - "suspicious"
-        """
 
 
 @pytest.mark.usefixtures("db_session")
@@ -43,7 +29,15 @@ class Returns204Test:
         user_offerer = offerers_factories.UserOffererFactory(offerer=offer.venue.managingOfferer)
 
         url = f"/collective/offers-template/{offer.id}/publish"
-        offers_api.import_offer_validation_config(SIMPLE_OFFER_VALIDATION_CONFIG, user_offerer.user)
+
+        offer_name_rule = offers_factories.OfferValidationRuleFactory(name="Règle sur les noms d'offres")
+        offers_factories.OfferValidationSubRuleFactory(
+            validationRule=offer_name_rule,
+            model=offers_models.OfferValidationModel.COLLECTIVE_OFFER_TEMPLATE,
+            attribute=offers_models.OfferValidationAttribute.NAME,
+            operator=offers_models.OfferValidationRuleOperator.CONTAINS,
+            comparated={"comparated": ["suspicious"]},
+        )
 
         response = client.with_session_auth(user_offerer.user.email).patch(url)
 


### PR DESCRIPTION
## But de la pull request

Retire le FF WIP_ENABLE_NEW_FRAUD_RULES qui est toujours à true depuis le démantèlement de Flask Admin

Suppresion sur les environnements : https://www.notion.so/passcultureapp/Manip-faire-pour-les-MES-MEP-MEI-1e3c8bc00b224ca18852be1d717c52e5

Ticket Jira: https://passculture.atlassian.net/browse/PC-23295

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques