### PR TITLE
(PC-23591)[BO] Fix remaining stock in offers table

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -194,11 +194,11 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
 
     @hybrid_property
     def _bookable(self) -> bool:
-        return not self.isExpired and not self.isSoldOut
+        return not self.isExpired and not self.isSoldOut and not self.isSoftDeleted
 
     @_bookable.expression  # type: ignore [no-redef]
     def _bookable(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
-        return sa.and_(sa.not_(cls.isExpired), sa.not_(cls.isSoldOut))
+        return sa.and_(sa.not_(cls.isExpired), sa.not_(cls.isSoldOut), sa.not_(cls.isSoftDeleted))
 
     @property
     def is_forbidden_to_underage(self) -> bool:

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -514,6 +514,10 @@ class StockQuantityTest:
 
 
 class StockIsBookableTest:
+    def test_not_bookable_if_stock_is_soft_deleted(self):
+        stock = factories.StockFactory(isSoftDeleted=True)
+        assert not stock.isBookable
+
     def test_not_bookable_if_booking_limit_datetime_has_passed(self):
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         stock = factories.StockFactory(bookingLimitDatetime=past)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23591

La propriété `isBookable` d'un stock incluait les stocks "soft deleted" (gardés en base à des fins d'historisation).
Cela impliquait notamment de fausses quantités de stock restant dans la table d'offres individuelles.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques