### PR TITLE
(PC-23628)[PRO] feat: fill search bar with venue filter when valued

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -38,11 +38,14 @@ export const OffersInstantSearch = ({
   const { facetFilters } = useContext(FacetFiltersContext)
 
   const newAdageFilters = useActiveFeature('WIP_ENABLE_NEW_ADAGE_FILTERS')
-
+  const initialQuery = newAdageFilters
+    ? venueFilter?.publicName || venueFilter?.name || ''
+    : ''
   return (
     <InstantSearch
       indexName={ALGOLIA_COLLECTIVE_OFFERS_INDEX}
       searchClient={searchClient}
+      searchState={{ query: initialQuery }}
     >
       <Configure
         attributesToHighlight={[]}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -109,7 +109,6 @@ export const OffersSearchComponent = ({
     })
 
     setFacetFilters(updatedFilters.queryFilters)
-
     refine(formik.values.query)
   }
 
@@ -120,7 +119,10 @@ export const OffersSearchComponent = ({
   }
 
   const formik = useFormik<SearchFormValues>({
-    initialValues: computeFiltersInitialValues(adageUser.departmentCode),
+    initialValues: computeFiltersInitialValues(
+      adageUser.departmentCode,
+      venueFilter
+    ),
     enableReinitialize: true,
     onSubmit: handleSubmit,
   })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
@@ -21,15 +21,15 @@ export const ADAGE_FILTERS_DEFAULT_VALUES: SearchFormValues = {
 }
 
 export const computeFiltersInitialValues = (
-  userDepartmentCode?: string | null
+  userDepartmentCode?: string | null,
+  venueFilter?: VenueResponse | null
 ) => {
-  if (!userDepartmentCode) {
-    return ADAGE_FILTERS_DEFAULT_VALUES
-  }
   return {
     ...ADAGE_FILTERS_DEFAULT_VALUES,
-    departments: [userDepartmentCode],
-    eventAddressType: OfferAddressType.OTHER,
+    departments: userDepartmentCode
+      ? [userDepartmentCode]
+      : ADAGE_FILTERS_DEFAULT_VALUES.departments,
+    query: venueFilter ? venueFilter.publicName || venueFilter.name : '',
   }
 }
 

--- a/pro/src/pages/AdageIframe/app/providers/FacetFiltersContextProvider.tsx
+++ b/pro/src/pages/AdageIframe/app/providers/FacetFiltersContextProvider.tsx
@@ -35,13 +35,6 @@ export const FacetFiltersContextProvider = ({
 }): JSX.Element => {
   const newAdageFilters = useActiveFeature('WIP_ENABLE_NEW_ADAGE_FILTERS')
 
-  const defaultFacetFilters = venueFilter
-    ? [
-        computeVenueFacetFilter(venueFilter),
-        ...getDefaultFacetFilterUAICodeValue(uai, departmentCode, venueFilter),
-      ]
-    : [...getDefaultFacetFilterUAICodeValue(uai, departmentCode, venueFilter)]
-
   const oldDefaultFacetFilters = venueFilter
     ? [
         computeVenueFacetFilter(venueFilter),
@@ -59,7 +52,9 @@ export const FacetFiltersContextProvider = ({
         ),
       ]
   const [facetFilters, setFacetFilters] = useState<Facets>(
-    newAdageFilters ? defaultFacetFilters : oldDefaultFacetFilters
+    newAdageFilters
+      ? [...getDefaultFacetFilterUAICodeValue(uai, departmentCode, venueFilter)]
+      : oldDefaultFacetFilters
   )
 
   const value = useMemo(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23628

Valoriser la barre de recherche avec le nom du lieu quand l'utilisateur adage arrive depuis la carto

En local : 
FF à activer : `WIP_ENABLE_NEW_ADAGE_FILTERS`
Ajouter à la fin de l'url : `venue=[ID du lieu]`
