### PR TITLE
(PC-22377)[PRO] feat: log filters on new algolia search

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -48,6 +48,7 @@ interface OffersComponentPropsWithHits
   handleResetFiltersAndLaunchSearch?: () => void
   displayStats?: boolean
   resetForm?: () => void
+  logFiltersOnSearch?: (nbHits: number, queryId: string) => void
 }
 
 type OfferMap = Map<
@@ -66,6 +67,7 @@ export const OffersComponent = ({
   nbHits,
   displayStats = true,
   resetForm,
+  logFiltersOnSearch,
 }: OffersComponentProps): JSX.Element => {
   const [queriesAreLoading, setQueriesAreLoading] = useState(false)
   const [offers, setOffers] = useState<
@@ -106,6 +108,9 @@ export const OffersComponent = ({
     setQueriesAreLoading(true)
     if (hits.length != 0 && queryId != hits[0].__queryID) {
       setQueryId(hits[0].__queryID)
+      if (newAdageFilters && logFiltersOnSearch) {
+        logFiltersOnSearch(nbHits, hits[0].__queryID)
+      }
     }
     Promise.all(
       hits.map(async hit => {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -7,6 +7,7 @@ import type { SearchBoxProvided } from 'react-instantsearch-core'
 import { connectSearchBox } from 'react-instantsearch-dom'
 
 import { VenueResponse } from 'apiClient/adage'
+import { apiAdage } from 'apiClient/api'
 import useActiveFeature from 'hooks/useActiveFeature'
 import strokeOffersIcon from 'icons/stroke-offers.svg'
 import strokeVenueIcon from 'icons/stroke-venue.svg'
@@ -16,6 +17,7 @@ import {
   FiltersContext,
 } from 'pages/AdageIframe/app/providers'
 import Tabs from 'ui-kit/Tabs'
+import { removeParamsFromUrl } from 'utils/removeParamsFromUrl'
 
 import {
   ADAGE_FILTERS_DEFAULT_VALUES,
@@ -120,6 +122,16 @@ export const OffersSearchComponent = ({
     formik.handleSubmit()
   }
 
+  const logFiltersOnSearch = (nbHits: number, queryId: string) => {
+    /* istanbul ignore next: TO FIX the current structure make it hard to test, we probably should not mock Offers in OfferSearch tests */
+    apiAdage.logTrackingFilter({
+      iframeFrom: removeParamsFromUrl(location.pathname),
+      resultNumber: nbHits,
+      queryId: queryId,
+      filterValues: formik ? formik.values : {},
+    })
+  }
+
   const formik = useFormik<SearchFormValues>({
     initialValues: computeFiltersInitialValues(adageUser.departmentCode),
     enableReinitialize: true,
@@ -156,6 +168,7 @@ export const OffersSearchComponent = ({
             userRole={adageUser.role}
             userEmail={adageUser.email}
             resetForm={resetForm}
+            logFiltersOnSearch={logFiltersOnSearch}
           />
         </div>
       </FormikContext.Provider>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-22377


Ajout du tracking des filtres adage quand une nouvelle requête algolia est lancée 

FF : WIP_ENABLE_NEW_ADAGE_FILTERS
