### PR TITLE
(PC-23454)[API] feat: do not allow events with tickets

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -125,6 +125,7 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_NEW_USER_OFFERER_LINK = "Activer le nouvel ajout des collaborateurs"
     WIP_ENABLE_NATIONAL_SYSTEM = "Activer le dispositif national dans les offres collectives"
     WIP_ENABLE_DIFFUSE_HELP = "Activer l'affichage de l'aide diffuse adage"
+    WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API = "Activer la création événements avec tickets dans l'API publique"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -195,6 +196,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ENABLE_NEW_USER_OFFERER_LINK,
     FeatureToggle.WIP_ENABLE_NATIONAL_SYSTEM,
     FeatureToggle.WIP_ENABLE_DIFFUSE_HELP,
+    FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API,
 )
 
 if settings.IS_PROD or settings.IS_STAGING:

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -11,6 +11,7 @@ from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.core.offers import models as offers_models
 from pcapi.models import api_errors
 from pcapi.models import db
+from pcapi.models import feature
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils import rate_limiting
 from pcapi.validation.routes.users_authentifications import api_key_required
@@ -30,6 +31,11 @@ def _deserialize_ticket_collection(
         if subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id].can_be_withdrawable:
             return offers_models.WithdrawalTypeEnum.NO_TICKET, None
         return None, None
+
+    if not feature.FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API.is_active():
+        raise api_errors.ApiErrors(
+            {"global": "During this API Beta, it is only possible to create events without tickets."}, status_code=400
+        )
     if isinstance(ticket_collection, serialization.SentByEmailDetails):
         return offers_models.WithdrawalTypeEnum.BY_EMAIL, ticket_collection.daysBeforeEvent * 24 * 3600
     return offers_models.WithdrawalTypeEnum.ON_SITE, ticket_collection.minutesBeforeEvent * 60

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -3,6 +3,7 @@ import pytest
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
+from pcapi.core.testing import override_features
 
 from . import utils
 
@@ -126,6 +127,7 @@ class PatchEventTest:
             "stageDirector": "Robert",
         }
 
+    @override_features(WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API=True)
     def test_patch_all_fields(self, client):
         venue, api_key = utils.create_offerer_provider_linked_to_venue()
         event_offer = offers_factories.EventOfferFactory(
@@ -160,3 +162,32 @@ class PatchEventTest:
         assert event_offer.bookingContact == "test@myemail.com"
         assert event_offer.bookingEmail == "test@myemail.com"
         assert event_offer.withdrawalDetails == "Here !"
+
+    def test_cannot_edit_event_with_ticket_if_FF_not_active(self, client):
+        # This test can be deleted with FF WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API
+        venue, api_key = utils.create_offerer_provider_linked_to_venue()
+        event_offer = offers_factories.EventOfferFactory(
+            venue=venue,
+            bookingContact="contact@example.com",
+            bookingEmail="notify@passq.com",
+            subcategoryId="CONCERT",
+            durationMinutes=20,
+            isDuo=False,
+            lastProvider=api_key.provider,
+            withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
+            withdrawalDelay=86400,
+            withdrawalDetails="Around there",
+        )
+
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
+            f"/public/offers/v1/events/{event_offer.id}",
+            json={
+                "ticketCollection": {"way": "on_site", "minutesBeforeEvent": 60},
+                "bookingContact": "test@myemail.com",
+                "bookingEmail": "test@myemail.com",
+                "eventDuration": 40,
+                "enableDoubleBookings": "true",
+                "itemCollectionDetails": "Here !",
+            },
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
We don't want to allow partners to use the event api to create events with tickets, they will have to wait until our booking api is release. This is to avoid having a spike in support request. However we want to have beta testers, some are interested for free events
