### PR TITLE
(PC-23030)[API] feat: Add provider url columns for new booking API

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-60d5208fd945 (pre) (head)
+b5652ab2625c (pre) (head)
 49e118a9dd48 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230804T143314_b5652ab2625c_add_provider_url_column.py
+++ b/api/src/pcapi/alembic/versions/20230804T143314_b5652ab2625c_add_provider_url_column.py
@@ -1,0 +1,21 @@
+"""add urls column to Provider"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "b5652ab2625c"
+down_revision = "60d5208fd945"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("provider", sa.Column("bookingExternalUrl", sa.Text(), nullable=True))
+    op.add_column("provider", sa.Column("cancelExternalUrl", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("provider", "cancelExternalUrl")
+    op.drop_column("provider", "bookingExternalUrl")

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -65,6 +65,8 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
     )
 
     logoUrl: str = Column(Text(), nullable=True)
+    bookingExternalUrl: str = Column(Text(), nullable=True)
+    cancelExternalUrl: str = Column(Text(), nullable=True)
     pricesInCents: bool = Column(Boolean, nullable=False, default=False, server_default=expression.false())
 
     collectiveOffers: sa_orm.Mapped["CollectiveOffer"] = relationship("CollectiveOffer", back_populates="provider")

--- a/api/src/pcapi/routes/backoffice_v3/providers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/blueprint.py
@@ -51,8 +51,8 @@ def get_create_provider_form() -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_v3_web.providers.create_provider"),
         div_id="create-provider",  # must be consistent with parameter passed to build_lazy_modal
-        title="Créer un prestataire qui se synchronisera avec le pass Culture",
-        button_text="Créer le prestataire",
+        title="Créer un partenaire technique qui se synchronisera avec le pass Culture",
+        button_text="Créer le partenaire",
     )
 
 
@@ -71,6 +71,8 @@ def create_provider() -> utils.BackofficeResponse:
             logoUrl=form.logo_url.data,
             enabledForPro=form.enabled_for_pro.data,
             isActive=form.is_active.data,
+            bookingExternalUrl=form.booking_external_url.data,
+            cancelExternalUrl=form.cancel_external_url.data,
         )
         offerer, is_offerer_new = _get_or_create_offerer(form)
         offerer_provider = offerers_models.OffererProvider(offerer=offerer, provider=provider)
@@ -121,6 +123,8 @@ def get_update_provider_form(provider_id: int) -> utils.BackofficeResponse:
         logo_url=provider.logoUrl,
         enabled_for_pro=provider.enabledForPro,
         is_active=provider.isActive,
+        booking_external_url=provider.bookingExternalUrl,
+        cancel_external_url=provider.cancelExternalUrl,
     )
 
     return render_template(
@@ -128,8 +132,8 @@ def get_update_provider_form(provider_id: int) -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_v3_web.providers.update_provider", provider_id=provider_id),
         div_id=f"update-provider-{provider_id}",  # must be consistent with parameter passed to build_lazy_modal
-        title="Modifier un prestataire synchronisé avec le pass Culture",
-        button_text="Modifier le prestataire",
+        title="Modifier un partenaire technique synchronisé avec le pass Culture",
+        button_text="Modifier le partenaire",
     )
 
 
@@ -147,6 +151,8 @@ def update_provider(provider_id: int) -> utils.BackofficeResponse:
     provider.logoUrl = form.logo_url.data
     provider.enabledForPro = form.enabled_for_pro.data
     provider.isActive = form.is_active.data
+    provider.bookingExternalUrl = form.booking_external_url.data
+    provider.cancelExternalUrl = form.cancel_external_url.data
 
     try:
         db.session.add(provider)

--- a/api/src/pcapi/routes/backoffice_v3/providers/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/forms.py
@@ -34,6 +34,20 @@ class CreateProviderForm(FlaskForm):
             wtforms.validators.Length(max=1024, message="Doit contenir moins de %(max)d caractères"),
         ),
     )
+    booking_external_url = fields.PCOptStringField(
+        "URL de la route de validation de reservation",
+        validators=(
+            wtforms.validators.Optional(""),
+            wtforms.validators.Length(max=1024, message="Doit contenir moins de %(max)d caractères"),
+        ),
+    )
+    cancel_external_url = fields.PCOptStringField(
+        "URL de la route d'annulation de reservation",
+        validators=(
+            wtforms.validators.Optional(""),
+            wtforms.validators.Length(max=1024, message="Doit contenir moins de %(max)d caractères"),
+        ),
+    )
     enabled_for_pro = fields.PCSwitchBooleanField("Actif pour les pros", default="checked")
     is_active = fields.PCSwitchBooleanField("Actif", default="checked")
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -106,7 +106,7 @@
                     {% if has_permission("MOVE_SIRET") %}{{ menu_section_item("Déplacer un SIRET", "backoffice_v3_web.move_siret.move_siret") }}{% endif %}
                     {% if has_permission("ADVANCED_PRO_SUPPORT") %}
                       {{ menu_section_item("Synchronisation Pivot", "backoffice_v3_web.pivots.get_pivots") }}
-                      {{ menu_section_item("Synchronisation Prestataires", "backoffice_v3_web.providers.get_providers") }}
+                      {{ menu_section_item("Synchronisation partenaires techniques", "backoffice_v3_web.providers.get_providers") }}
                     {% endif %}
                     {% if has_permission("READ_REIMBURSEMENT_RULES") %}
                       {{ menu_section_item("Tarifs dérogatoires", "backoffice_v3_web.reimbursement_rules.list_custom_reimbursement_rules") }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/providers/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/providers/get.html
@@ -2,7 +2,7 @@
 {% extends "layouts/connected.html" %}
 {% block page %}
   <div class="pt-3 px-5">
-    <h2 class="fw-light">Synchronisation Prestataires</h2>
+    <h2 class="fw-light">Synchronisation partenaires techniques</h2>
     <button class="btn btn-outline-primary lead fw-bold mt-2"
             data-bs-toggle="modal"
             data-bs-target="#create-provider"

--- a/api/tests/routes/backoffice_v3/providers_test.py
+++ b/api/tests/routes/backoffice_v3/providers_test.py
@@ -66,6 +66,8 @@ class CreateProviderTest(PostEndpointHelper):
             "postal_code": "75008",
             "siren": "123456789",
             "logo_url": "https://example.org/image.png",
+            "booking_external_url": "https://example.org/booking",
+            "cancel_external_url": "https://example.org/cancel",
             "enabled_for_pro": False,
             "is_active": True,
         }
@@ -83,6 +85,8 @@ class CreateProviderTest(PostEndpointHelper):
         assert created_provider.logoUrl == form_data["logo_url"]
         assert created_provider.enabledForPro == form_data["enabled_for_pro"]
         assert created_provider.isActive == form_data["is_active"]
+        assert created_provider.bookingExternalUrl == form_data["booking_external_url"]
+        assert created_provider.cancelExternalUrl == form_data["cancel_external_url"]
 
         assert created_provider.offererProvider is not None
         created_offerer = created_provider.offererProvider.offerer
@@ -104,6 +108,8 @@ class CreateProviderTest(PostEndpointHelper):
             "postal_code": "38000",
             "siren": offerer.siren,
             "logo_url": "https://example.org/image.png",
+            "booking_external_url": "https://example.org/booking",
+            "cancel_external_url": "https://example.org/cancel",
             "enabled_for_pro": False,
             "is_active": True,
         }
@@ -121,6 +127,8 @@ class CreateProviderTest(PostEndpointHelper):
         assert created_provider.logoUrl == form_data["logo_url"]
         assert created_provider.enabledForPro == form_data["enabled_for_pro"]
         assert created_provider.isActive == form_data["is_active"]
+        assert created_provider.bookingExternalUrl == form_data["booking_external_url"]
+        assert created_provider.cancelExternalUrl == form_data["cancel_external_url"]
 
         assert offerers_models.Offerer.query.count() == 1
         assert created_provider.offererProvider.offerer == offerer
@@ -145,6 +153,8 @@ class UpdateProviderTest(PostEndpointHelper):
         form_data = {
             "name": "Individual Offer API consumer",
             "logo_url": "https://example.org/image.png",
+            "booking_external_url": "https://example.org/booking",
+            "cancel_external_url": "https://example.org/cancel",
             "enabled_for_pro": False,
             "is_active": True,
         }
@@ -160,6 +170,8 @@ class UpdateProviderTest(PostEndpointHelper):
         assert updated_provider.logoUrl == form_data["logo_url"]
         assert updated_provider.enabledForPro == form_data["enabled_for_pro"]
         assert updated_provider.isActive == form_data["is_active"]
+        assert updated_provider.bookingExternalUrl == form_data["booking_external_url"]
+        assert updated_provider.cancelExternalUrl == form_data["cancel_external_url"]
         assert not updated_provider.apiKeys
 
         assert offerer.name != form_data["name"]


### PR DESCRIPTION
Add 2 columns to Provider table and to the create and edit form in backoffice_V3 "Synchronisation partenaires techniques"
bookingExternalUrl -> url to call when a booking is made 
cancelExternalUrl -> url to call to cancel a booking
![Screenshot 2023-08-03 at 14 53 00](https://github.com/pass-culture/pass-culture-main/assets/95358853/f02cb29d-99d5-44fa-b81d-3af38ae8f9fc)
![Screenshot 2023-08-03 at 14 53 13](https://github.com/pass-culture/pass-culture-main/assets/95358853/c54627be-412c-4e4f-97b2-c5b6b7484fd5)


Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23030
