### PR TITLE
PC 23530 national program

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-b5652ab2625c (pre) (head)
+397f1d7e7dcc (pre) (head)
 38d84c4d6248 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230803T034843_397f1d7e7dcc_create_national_program_table_with_history.py
+++ b/api/src/pcapi/alembic/versions/20230803T034843_397f1d7e7dcc_create_national_program_table_with_history.py
@@ -1,0 +1,74 @@
+"""create national program table (with history)
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "397f1d7e7dcc"
+down_revision = "b5652ab2625c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create national program
+    op.create_table(
+        "national_program",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column("dateCreated", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    # Create collective offer template links history
+    op.create_table(
+        "national_program_offer_template_link_history",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("dateCreated", sa.DateTime(), nullable=False),
+        sa.Column("collectiveOfferTemplateId", sa.BigInteger(), nullable=False),
+        sa.Column("nationalProgramId", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["collectiveOfferTemplateId"], ["collective_offer_template.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["nationalProgramId"], ["national_program.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Create collective offer links history
+    op.create_table(
+        "national_program_offer_link_history",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("dateCreated", sa.DateTime(), nullable=False),
+        sa.Column("collectiveOfferId", sa.BigInteger(), nullable=False),
+        sa.Column("nationalProgramId", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["collectiveOfferId"], ["collective_offer.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["nationalProgramId"], ["national_program.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # New column (collective offer): nationalProgramId
+    op.add_column("collective_offer", sa.Column("nationalProgramId", sa.BigInteger(), nullable=True))
+    op.create_index(
+        op.f("ix_collective_offer_nationalProgramId"), "collective_offer", ["nationalProgramId"], unique=False
+    )
+    op.create_foreign_key(None, "collective_offer", "national_program", ["nationalProgramId"], ["id"])
+
+    # New column (collective offer template): nationalProgramId
+    op.add_column("collective_offer_template", sa.Column("nationalProgramId", sa.BigInteger(), nullable=True))
+    op.create_index(
+        op.f("ix_collective_offer_template_nationalProgramId"),
+        "collective_offer_template",
+        ["nationalProgramId"],
+        unique=False,
+    )
+    op.create_foreign_key(None, "collective_offer_template", "national_program", ["nationalProgramId"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_column("collective_offer", "nationalProgramId")
+    op.drop_column("collective_offer_template", "nationalProgramId")
+
+    op.drop_table("national_program_offer_link_history")
+    op.drop_table("national_program_offer_template_link_history")
+    op.drop_table("national_program")

--- a/api/src/pcapi/core/educational/api/national_program.py
+++ b/api/src/pcapi/core/educational/api/national_program.py
@@ -1,0 +1,39 @@
+from pcapi.core.educational import exceptions
+from pcapi.core.educational import models
+from pcapi.models import db
+from pcapi.repository import repository
+
+
+AnyCollectiveOffer = models.CollectiveOffer | models.CollectiveOfferTemplate
+
+
+def create_national_program(name: str) -> models.NationalProgram:
+    program = models.NationalProgram(name=name)
+    repository.save(program)
+    return program
+
+
+def link_collective_offer_to_program(
+    program: models.NationalProgram, offer: AnyCollectiveOffer, commit: bool = True
+) -> None:
+    offer.nationalProgramId = program.id
+
+    if isinstance(offer, models.CollectiveOffer):
+        history_event = models.NationalProgramOfferLinkHistory(nationalProgramId=program.id, collectiveOfferId=offer.id)
+    else:
+        history_event = models.NationalProgramOfferTemplateLinkHistory(
+            nationalProgramId=program.id, collectiveOfferTemplateId=offer.id
+        )
+
+    if commit:
+        repository.save(offer, history_event)
+    else:
+        db.session.add_all([offer, history_event])
+
+
+def link_offer_to_program(program_id: int, offer: AnyCollectiveOffer, commit: bool = True) -> None:
+    program = models.NationalProgram.query.get(program_id)
+    if not program:
+        raise exceptions.NationalProgramNotFound()
+
+    link_collective_offer_to_program(program, offer, commit)

--- a/api/src/pcapi/core/educational/exceptions.py
+++ b/api/src/pcapi/core/educational/exceptions.py
@@ -183,3 +183,7 @@ class OffererNotAllowedToDuplicate(Exception):
 
 class CantGetImageFromUrl(Exception):
     pass
+
+
+class NationalProgramNotFound(Exception):
+    pass

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -295,3 +295,10 @@ class CollectiveOfferRequestFactory(BaseFactory):
     educationalRedactor = factory.SubFactory(EducationalRedactorFactory)
     educationalInstitution = factory.SubFactory(EducationalInstitutionFactory)
     collectiveOfferTemplate = factory.SubFactory(CollectiveOfferTemplateFactory)
+
+
+class NationalProgramFactory(BaseFactory):
+    class Meta:
+        model = models.NationalProgram
+
+    name = factory.Sequence("Dispositif national {}".format)

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -357,6 +357,16 @@ class CollectiveOffer(
     def isPublicApi(self) -> bool:
         return self.providerId is not None
 
+    # does the collective offer belongs to a national program
+    nationalProgramId: int | None = sa.Column(
+        sa.BigInteger,
+        sa.ForeignKey("national_program.id"),
+        nullable=True,
+        index=True,
+    )
+
+    nationalProgram: sa_orm.Mapped["NationalProgram"] = relationship("NationalProgram", foreign_keys=nationalProgramId)
+
     @property
     def isEducational(self) -> bool:
         # FIXME (rpaoloni, 2022-03-7): Remove legacy support layer
@@ -575,6 +585,16 @@ class CollectiveOfferTemplate(
         back_populates="collectiveOfferTemplates",
     )
 
+    # does the collective offer belongs to a national program
+    nationalProgramId: int | None = sa.Column(
+        sa.BigInteger,
+        sa.ForeignKey("national_program.id"),
+        nullable=True,
+        index=True,
+    )
+
+    nationalProgram: sa_orm.Mapped["NationalProgram"] = relationship("NationalProgram", foreign_keys=nationalProgramId)
+
     @property
     def isEducational(self) -> bool:
         # FIXME (rpaoloni, 2022-05-09): Remove legacy support layer
@@ -677,6 +697,7 @@ class CollectiveOfferTemplate(
             "offerVenue",
             "students",
             "interventionArea",
+            "nationalProgramId",
         ]
         collective_offer_mapping = {x: getattr(collective_offer, x) for x in list_of_common_attributes}
         return cls(
@@ -1281,4 +1302,46 @@ class ValidationRuleCollectiveOfferTemplateLink(PcObject, Base, Model):
     )
     collectiveOfferTemplateId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("collective_offer_template.id", ondelete="CASCADE"), nullable=False
+    )
+
+
+class NationalProgram(PcObject, Base, Model):
+    """
+    Keep a track of existing national program that are used to highlight
+    collective offers (templates) within a coherent frame.
+    """
+
+    name: str = sa.Column(sa.Text, unique=True)
+    dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
+
+
+class NationalProgramOfferLinkHistory(PcObject, Base, Model):
+    """
+    Keep a track on national program and collective offer links.
+    It might be useful to find if an offer has been part of a given
+    program or not.
+    """
+
+    dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    collectiveOfferId: int = sa.Column(
+        sa.BigInteger, sa.ForeignKey("collective_offer.id", ondelete="CASCADE"), nullable=False
+    )
+    nationalProgramId: int = sa.Column(
+        sa.BigInteger, sa.ForeignKey("national_program.id", ondelete="CASCADE"), nullable=False
+    )
+
+
+class NationalProgramOfferTemplateLinkHistory(PcObject, Base, Model):
+    """
+    Keep a track on national program and collective offer template links.
+    It might be useful to find if an offer has been part of a given
+    program or not.
+    """
+
+    dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    collectiveOfferTemplateId: int = sa.Column(
+        sa.BigInteger, sa.ForeignKey("collective_offer_template.id", ondelete="CASCADE"), nullable=False
+    )
+    nationalProgramId: int = sa.Column(
+        sa.BigInteger, sa.ForeignKey("national_program.id", ondelete="CASCADE"), nullable=False
     )

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -29,6 +29,7 @@ from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import validation as educational_validation
 from pcapi.core.educational.api import offer as educational_api_offer
+import pcapi.core.educational.api.national_program as national_program_api
 from pcapi.core.external.attributes.api import update_external_pro
 import pcapi.core.external_bookings.api as external_bookings_api
 import pcapi.core.finance.conf as finance_conf
@@ -351,6 +352,9 @@ def update_collective_offer(
             raise educational_exceptions.VenueIdDontExist()
         if new_venue.managingOffererId != offerer.id:
             raise educational_exceptions.OffererOfVenueDontMatchOfferer()
+
+    if nationalProgramId := new_values.pop("nationalProgramId", None):
+        national_program_api.link_offer_to_program(nationalProgramId, offer_to_update)
     updated_fields = _update_collective_offer(offer=offer_to_update, new_values=new_values)
 
     search.async_index_collective_offer_ids([offer_to_update.id])
@@ -373,6 +377,10 @@ def update_collective_offer_template(offer_id: int, new_values: dict) -> None:
         offerer = offerers_repository.get_by_collective_offer_template_id(offer_to_update.id)
         if new_venue.managingOffererId != offerer.id:
             raise educational_exceptions.OffererOfVenueDontMatchOfferer()
+
+    if nationalProgramId := new_values.pop("nationalProgramId", None):
+        national_program_api.link_offer_to_program(nationalProgramId, offer_to_update)
+
     _update_collective_offer(offer=offer_to_update, new_values=new_values)
     search.async_index_collective_offer_template_ids([offer_to_update.id])
 

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -165,6 +165,7 @@ class CollectiveOfferResponseModel(BaseModel, common_models.AccessibilityComplia
     imageCredit: str | None
     imageUrl: str | None
     teacher: EducationalRedactorResponseModel | None
+    nationalProgramId: int | None
 
     @classmethod
     def from_orm(
@@ -218,6 +219,7 @@ class CollectiveOfferTemplateResponseModel(BaseModel, common_models.Accessibilit
     interventionArea: list[str]
     imageCredit: str | None
     imageUrl: str | None
+    nationalProgramId: int | None
 
     @classmethod
     def from_orm(

--- a/api/src/pcapi/routes/pro/__init__.py
+++ b/api/src/pcapi/routes/pro/__init__.py
@@ -10,6 +10,7 @@ def install_routes(app: Flask) -> None:
     from . import collective_stocks
     from . import features
     from . import finance
+    from . import national_programs
     from . import offerers
     from . import offers
     from . import providers

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -219,6 +219,15 @@ def create_collective_offer(
             {"code": "COLLECTIVE_OFFER_TEMPLATE_NOT_FOUND"},
             status_code=404,
         )
+    except educational_exceptions.NationalProgramNotFound:
+        logger.info(
+            "Could not create offer: national program not found",
+            extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
+        )
+        raise ApiErrors(
+            {"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_NOT_FOUND"},
+            status_code=400,
+        )
 
     return collective_offers_serialize.CollectiveOfferResponseIdModel.from_orm(offer)
 
@@ -259,6 +268,8 @@ def edit_collective_offer(
         raise ApiErrors({"venueId": "The venue does not exist."}, 404)
     except educational_exceptions.CollectiveOfferIsPublicApi:
         raise ApiErrors({"global": ["Collective offer created by public API is not editable."]}, 403)
+    except educational_exceptions.NationalProgramNotFound:
+        raise ApiErrors({"global": ["National program not found"]}, 400)
     except educational_exceptions.EducationalDomainsNotFound:
         logger.info(
             "Could not update offer: educational domains not found.",
@@ -342,6 +353,8 @@ def edit_collective_offer_template(
         raise ApiErrors({"venueId": "New venue needs to have the same offerer"}, 403)
     except offers_exceptions.SubcategoryNotEligibleForEducationalOffer:
         raise ApiErrors({"subcategoryId": "this subcategory is not educational"}, 400)
+    except educational_exceptions.NationalProgramNotFound:
+        raise ApiErrors({"global": ["National program not found"]}, 400)
     except educational_exceptions.EducationalDomainsNotFound:
         logger.info(
             "Could not update offer: educational domains not found.",
@@ -591,6 +604,15 @@ def create_collective_offer_template(
         raise ApiErrors(
             {"code": "COLLECTIVE_OFFER_TEMPLATE_NOT_FOUND"},
             status_code=404,
+        )
+    except educational_exceptions.NationalProgramNotFound:
+        logger.info(
+            "Could not create offer: national program not found",
+            extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
+        )
+        raise ApiErrors(
+            {"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_NOT_FOUND"},
+            status_code=400,
         )
 
     return collective_offers_serialize.CollectiveOfferResponseIdModel.from_orm(offer)

--- a/api/src/pcapi/routes/pro/national_programs.py
+++ b/api/src/pcapi/routes/pro/national_programs.py
@@ -1,0 +1,21 @@
+from flask_login import login_required
+
+import pcapi.core.educational.models as educational_models
+from pcapi.routes.apis import private_api
+from pcapi.routes.serialization import national_programs as serialization
+from pcapi.serialization.decorator import spectree_serialize
+
+from . import blueprint
+
+
+@private_api.route("/national-programs", methods=["GET"])
+@login_required
+@spectree_serialize(
+    response_model=serialization.ListNationalProgramsResponseModel,
+    api=blueprint.pro_private_schema,
+)
+def get_national_programs() -> serialization.ListNationalProgramsResponseModel:
+    query = educational_models.NationalProgram.query
+    return serialization.ListNationalProgramsResponseModel(
+        __root__=[serialization.NationalProgramModel(id=program.id, name=program.name) for program in query]
+    )

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -101,6 +101,10 @@ class CollectiveOfferResponseModel(BaseModel):
     imageCredit: str | None
     imageUrl: str | None
     isPublicApi: bool
+    nationalProgramId: int | None
+
+    class Config:
+        alias_generator = to_camel
 
 
 class ListCollectiveOffersResponseModel(BaseModel):
@@ -148,6 +152,7 @@ def _serialize_offer_paginated(offer: CollectiveOffer | CollectiveOfferTemplate)
         imageCredit=offer.imageCredit,
         imageUrl=offer.imageUrl,
         isPublicApi=offer.isPublicApi if not is_offer_template else False,
+        nationalProgramId=offer.nationalProgramId,
     )
 
 
@@ -272,6 +277,7 @@ class GetCollectiveOfferBaseResponseModel(BaseModel, AccessibilityComplianceMixi
     is_cancellable_from_offerer: bool = Field(alias="isCancellable")
     imageCredit: str | None
     imageUrl: str | None
+    nationalProgramId: int | None
 
     class Config:
         allow_population_by_field_name = True
@@ -391,6 +397,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
     intervention_area: list[str] | None
     template_id: int | None
     offerer_id: str | None  # FIXME (MathildeDuboille - 24/10/22) prevent bug in production where offererId is sent in params
+    nationalProgramId: int | None
 
     @validator("name", pre=True)
     def validate_name(cls, name: str) -> str:
@@ -491,6 +498,7 @@ class PatchCollectiveOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     domains: list[int] | None
     interventionArea: list[str] | None
     venueId: int | None
+    nationalProgramId: int | None
 
     @validator("name", allow_reuse=True)
     def validate_name(cls, name: str | None) -> str | None:

--- a/api/src/pcapi/routes/serialization/national_programs.py
+++ b/api/src/pcapi/routes/serialization/national_programs.py
@@ -1,0 +1,10 @@
+from pcapi.routes.serialization import BaseModel
+
+
+class NationalProgramModel(BaseModel):
+    id: int
+    name: str
+
+
+class ListNationalProgramsResponseModel(BaseModel):
+    __root__: list[NationalProgramModel]

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -22,11 +22,13 @@ educational_year_dates = {"start": datetime(2020, 9, 1), "end": datetime(2021, 8
 class CollectiveOfferTemplateTest:
     def test_get_collective_offer_template(self, client):
         # Given
+        national_program = educational_factories.NationalProgramFactory()
         offer = educational_factories.CollectiveOfferTemplateFactory(
             name="offer name",
             description="offer description",
             priceDetail="détail du prix",
             students=[StudentLevels.GENERAL2],
+            nationalProgramId=national_program.id,
         )
         offer_id = offer.id
 
@@ -80,11 +82,13 @@ class CollectiveOfferTemplateTest:
             "domains": [{"id": offer.domains[0].id, "name": offer.domains[0].name}],
             "imageUrl": None,
             "imageCredit": None,
+            "nationalProgramId": national_program.id,
         }
 
     def test_get_collective_offer_template_with_offer_venue(self, client):
         # Given
         venue = offerers_factories.VenueFactory()
+        national_program = educational_factories.NationalProgramFactory()
         offer = educational_factories.CollectiveOfferTemplateFactory(
             name="offer name",
             description="offer description",
@@ -95,6 +99,7 @@ class CollectiveOfferTemplateTest:
                 "addressType": "offererVenue",
                 "otherAddress": "",
             },
+            nationalProgramId=national_program.id,
         )
         offer_id = offer.id
 
@@ -148,6 +153,7 @@ class CollectiveOfferTemplateTest:
             "domains": [{"id": offer.domains[0].id, "name": offer.domains[0].name}],
             "imageUrl": None,
             "imageCredit": None,
+            "nationalProgramId": national_program.id,
         }
 
     def test_should_return_404_when_no_collective_offer_template(self, client):

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -23,6 +23,7 @@ class CollectiveOfferTest:
     def test_get_collective_offer(self, client):
         # Given
         institution = educational_factories.EducationalInstitutionFactory(institutionId="12890AI")
+        national_program = educational_factories.NationalProgramFactory()
         stock = educational_factories.CollectiveStockFactory(
             beginningDatetime=datetime(2021, 5, 15),
             collectiveOffer__name="offer name",
@@ -32,6 +33,7 @@ class CollectiveOfferTest:
             collectiveOffer__educational_domains=[educational_factories.EducationalDomainFactory()],
             collectiveOffer__institution=institution,
             collectiveOffer__teacher=educational_factories.EducationalRedactorFactory(),
+            collectiveOffer__nationalProgramId=national_program.id,
         )
 
         adage_jwt_fake_valid_token = create_adage_valid_token_with_email(
@@ -110,12 +112,14 @@ class CollectiveOfferTest:
                 "lastName": stock.collectiveOffer.teacher.lastName,
                 "civility": stock.collectiveOffer.teacher.civility,
             },
+            "nationalProgramId": national_program.id,
         }
 
     def test_get_collective_offer_with_offer_venue(self, client):
         # Given
         institution = educational_factories.EducationalInstitutionFactory(institutionId="pouet")
         venue = offerers_factories.VenueFactory()
+        national_program = educational_factories.NationalProgramFactory()
         stock = educational_factories.CollectiveStockFactory(
             beginningDatetime=datetime(2021, 5, 15),
             collectiveOffer__name="offer name",
@@ -129,6 +133,7 @@ class CollectiveOfferTest:
                 "addressType": "offererVenue",
                 "otherAddress": "",
             },
+            collectiveOffer__nationalProgramId=national_program.id,
         )
 
         adage_jwt_fake_valid_token = create_adage_valid_token_with_email(
@@ -202,6 +207,7 @@ class CollectiveOfferTest:
             "imageCredit": None,
             "imageUrl": None,
             "teacher": None,
+            "nationalProgramId": national_program.id,
         }
 
     def test_should_return_404_when_no_collective_offer(self, client):

--- a/api/tests/routes/pro/get_all_collective_offers_test.py
+++ b/api/tests/routes/pro/get_all_collective_offers_test.py
@@ -24,7 +24,10 @@ class Returns200Test:
         offerer_factories.UserOffererFactory(user=user, offerer=offerer)
         venue = offerer_factories.VenueFactory(managingOfferer=offerer)
         institution = educational_factories.EducationalInstitutionFactory()
-        offer = educational_factories.CollectiveOfferFactory(venue=venue, offerId=1, institution=institution)
+        national_program = educational_factories.NationalProgramFactory()
+        offer = educational_factories.CollectiveOfferFactory(
+            venue=venue, offerId=1, institution=institution, nationalProgramId=national_program.id
+        )
         educational_factories.CollectiveStockFactory(collectiveOffer=offer, stockId=1)
 
         # When
@@ -43,6 +46,7 @@ class Returns200Test:
         assert response_json[0]["educationalInstitution"]["name"] == institution.name
         assert response_json[0]["imageCredit"] is None
         assert response_json[0]["imageUrl"] is None
+        assert response_json[0]["nationalProgramId"] == national_program.id
 
     def test_one_inactive_offer(self, client):
         # Given

--- a/api/tests/routes/pro/get_collective_offer_template_test.py
+++ b/api/tests/routes/pro/get_collective_offer_template_test.py
@@ -11,7 +11,8 @@ from pcapi.utils.human_ids import humanize
 class Returns200Test:
     def test_access_by_beneficiary(self, client):
         # Given
-        offer = educational_factories.CollectiveOfferTemplateFactory()
+        national_program = educational_factories.NationalProgramFactory()
+        offer = educational_factories.CollectiveOfferTemplateFactory(nationalProgramId=national_program.id)
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
 
         # When
@@ -33,6 +34,7 @@ class Returns200Test:
         assert response_json["imageUrl"] is None
         assert response_json["name"] == offer.name
         assert response_json["id"] == offer.id
+        assert response_json["nationalProgramId"] == national_program.id
 
     def test_performance(self, client):
         # Given

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -18,8 +18,12 @@ class Returns200Test:
         # Given
         template = educational_factories.CollectiveOfferTemplateFactory()
         stock = educational_factories.CollectiveStockFactory()
+        national_program = educational_factories.NationalProgramFactory()
         offer = educational_factories.CollectiveOfferFactory(
-            collectiveStock=stock, teacher=educational_factories.EducationalRedactorFactory(), templateId=template.id
+            collectiveStock=stock,
+            teacher=educational_factories.EducationalRedactorFactory(),
+            templateId=template.id,
+            nationalProgramId=national_program.id,
         )
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
 
@@ -50,6 +54,7 @@ class Returns200Test:
             "civility": offer.teacher.civility,
         }
         assert response_json["templateId"] == template.id
+        assert response_json["nationalProgramId"] == national_program.id
 
     def test_sold_out(self, client):
         # Given

--- a/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
+++ b/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
@@ -65,6 +65,7 @@ class Returns200Test:
         offer = educational_factories.CollectiveOfferFactory(
             venue=venue,
             institution=institution,
+            nationalProgram=educational_factories.NationalProgramFactory(),
         )
         offer_id = offer.id
         educational_factories.CollectiveStockFactory(collectiveOffer=offer)
@@ -142,6 +143,7 @@ class Returns200Test:
             "lastBookingStatus": None,
             "lastBookingId": None,
             "teacher": None,
+            "nationalProgramId": offer.nationalProgramId,
         }
 
     def test_duplicate_collective_offer_draft_offer(self, client):

--- a/api/tests/routes/pro/test_national_programs.py
+++ b/api/tests/routes/pro/test_national_programs.py
@@ -1,0 +1,20 @@
+from flask import url_for
+import pytest
+
+import pcapi.core.educational.factories as educational_factories
+import pcapi.core.users.factories as users_factories
+
+
+@pytest.mark.usefixtures("db_session")
+class GetNationalProgramsTest:
+    def test_get_national_programs(self, client):
+        pro = users_factories.ProFactory()
+        programs = educational_factories.NationalProgramFactory.create_batch(2)
+
+        client = client.with_session_auth(email=pro.email)
+        response = client.get(url_for("Private API.get_national_programs"))
+
+        assert response.status_code == 200
+
+        program_names = {program["name"] for program in response.json}
+        assert program_names == {program.name for program in programs}

--- a/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
@@ -29,6 +29,7 @@ export type CollectiveOfferResponseModel = {
   mentalDisabilityCompliant: boolean;
   motorDisabilityCompliant: boolean;
   name: string;
+  nationalProgramId?: number | null;
   offerId?: string | null;
   offerVenue: CollectiveOfferOfferVenue;
   stock: OfferStockResponse;

--- a/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
@@ -25,6 +25,7 @@ export type CollectiveOfferTemplateResponseModel = {
   mentalDisabilityCompliant: boolean;
   motorDisabilityCompliant: boolean;
   name: string;
+  nationalProgramId?: number | null;
   offerId?: string | null;
   offerVenue: CollectiveOfferOfferVenue;
   students: Array<StudentLevels>;

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -116,6 +116,7 @@ export type { ListCollectiveBookingsResponseModel } from './models/ListCollectiv
 export type { ListCollectiveOffersQueryModel } from './models/ListCollectiveOffersQueryModel';
 export type { ListCollectiveOffersResponseModel } from './models/ListCollectiveOffersResponseModel';
 export type { ListFeatureResponseModel } from './models/ListFeatureResponseModel';
+export type { ListNationalProgramsResponseModel } from './models/ListNationalProgramsResponseModel';
 export type { ListOffersOfferResponseModel } from './models/ListOffersOfferResponseModel';
 export type { ListOffersQueryModel } from './models/ListOffersQueryModel';
 export type { ListOffersResponseModel } from './models/ListOffersResponseModel';
@@ -125,6 +126,7 @@ export type { ListProviderResponse } from './models/ListProviderResponse';
 export type { ListVenueProviderQuery } from './models/ListVenueProviderQuery';
 export type { ListVenueProviderResponse } from './models/ListVenueProviderResponse';
 export type { LoginUserBodyModel } from './models/LoginUserBodyModel';
+export type { NationalProgramModel } from './models/NationalProgramModel';
 export type { NewPasswordBodyModel } from './models/NewPasswordBodyModel';
 export { OfferAddressType } from './models/OfferAddressType';
 export type { OfferDomain } from './models/OfferDomain';

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
@@ -23,6 +23,7 @@ export type CollectiveOfferResponseModel = {
   isPublicApi: boolean;
   isShowcase: boolean;
   name: string;
+  nationalProgramId?: number | null;
   status: string;
   stocks: Array<CollectiveOffersStockResponseModel>;
   subcategoryId: SubcategoryIdEnum;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -41,6 +41,7 @@ export type GetCollectiveOfferResponseModel = {
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name: string;
+  nationalProgramId?: number | null;
   offerId?: number | null;
   offerVenue: CollectiveOfferOfferVenueResponseModel;
   status: OfferStatus;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
@@ -31,6 +31,7 @@ export type GetCollectiveOfferTemplateResponseModel = {
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name: string;
+  nationalProgramId?: number | null;
   offerId?: number | null;
   offerVenue: CollectiveOfferOfferVenueResponseModel;
   status: OfferStatus;

--- a/pro/src/apiClient/v1/models/ListNationalProgramsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListNationalProgramsResponseModel.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { NationalProgramModel } from './NationalProgramModel';
+
+export type ListNationalProgramsResponseModel = Array<NationalProgramModel>;

--- a/pro/src/apiClient/v1/models/NationalProgramModel.ts
+++ b/pro/src/apiClient/v1/models/NationalProgramModel.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type NationalProgramModel = {
+  id: number;
+  name: string;
+};
+

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferBodyModel.ts
@@ -19,6 +19,7 @@ export type PatchCollectiveOfferBodyModel = {
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name?: string | null;
+  nationalProgramId?: number | null;
   offerVenue?: CollectiveOfferVenueBodyModel | null;
   students?: Array<StudentLevels> | null;
   subcategoryId?: SubcategoryIdEnum | null;

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
@@ -19,6 +19,7 @@ export type PatchCollectiveOfferTemplateBodyModel = {
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name?: string | null;
+  nationalProgramId?: number | null;
   offerVenue?: CollectiveOfferVenueBodyModel | null;
   priceDetail?: string | null;
   students?: Array<StudentLevels> | null;

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
@@ -18,6 +18,7 @@ export type PostCollectiveOfferBodyModel = {
   mentalDisabilityCompliant?: boolean;
   motorDisabilityCompliant?: boolean;
   name: string;
+  nationalProgramId?: number | null;
   offerVenue: CollectiveOfferVenueBodyModel;
   offererId?: string | null;
   students: Array<StudentLevels>;

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
@@ -18,6 +18,7 @@ export type PostCollectiveOfferTemplateBodyModel = {
   mentalDisabilityCompliant?: boolean;
   motorDisabilityCompliant?: boolean;
   name: string;
+  nationalProgramId?: number | null;
   offerVenue: CollectiveOfferVenueBodyModel;
   offererId?: string | null;
   priceDetail?: string | null;

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -47,6 +47,7 @@ import type { ListBookingsResponseModel } from '../models/ListBookingsResponseMo
 import type { ListCollectiveBookingsResponseModel } from '../models/ListCollectiveBookingsResponseModel';
 import type { ListCollectiveOffersResponseModel } from '../models/ListCollectiveOffersResponseModel';
 import type { ListFeatureResponseModel } from '../models/ListFeatureResponseModel';
+import type { ListNationalProgramsResponseModel } from '../models/ListNationalProgramsResponseModel';
 import type { ListOffersResponseModel } from '../models/ListOffersResponseModel';
 import type { ListVenueProviderResponse } from '../models/ListVenueProviderResponse';
 import type { LoginUserBodyModel } from '../models/LoginUserBodyModel';
@@ -957,6 +958,22 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'GET',
       url: '/finance/reimbursement-points',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * get_national_programs <GET>
+   * @returns ListNationalProgramsResponseModel OK
+   * @throws ApiError
+   */
+  public getNationalPrograms(): CancelablePromise<ListNationalProgramsResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/national-programs',
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Entity`,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23530

:arrow_right: avoir la possibilité de rattacher des offres collectives (et vitrines) à des dispositifs nationaux. Nous n'avons besoin que du nom du dispositif, pas besoin de plus d'informations pour le moment.

Cette PR ajoute et modifie des routes afin de : 

1. renseigner ce dispositif lors de la création d'offres collectives et d'offres vitrines ;
2. renseigner ce dispositif lors de l'édition d'offres collectives et d'offres vitrines ;
3. connaître tous les dispositifs nationaux connus (en base de données) ;
4. remonter cette information côté portail pro et adage (iframe).

# Discussion technique : modèle de données

Afin d'avoir un peu plus de souplesse, les dispositifs nationaux sont enregistrés dans une table et non dans un enum.

Une table d'historique a été ajoutée même si elle n'était pas demandée initialement : cela ne devrait pas coûter grand chose et nous permettra de se dire dans six mois qu'il aurait été intéressant de savoir comment et pourquoi telle offre collective est marquée comme faisant partie de tel dispositif, etc. C'est très discutable ; je retirer cette table si besoin.

On pourrait enregistrer ces changements dans les logs mais j'ai peu que la rechercher devienne vite compliquée, à voir, cela pourrait être un meilleur compromis.