### PR TITLE
PC-22706 Parse DMS registration_datetime

### DIFF
--- a/api/src/pcapi/connectors/dms/models.py
+++ b/api/src/pcapi/connectors/dms/models.py
@@ -132,6 +132,7 @@ class DmsApplicationResponse(pydantic.BaseModel):
     profile: Profile = pydantic.Field(alias="usager")
     state: GraphQLApplicationStates
 
+    _format_draft_date = pydantic.validator("draft_date", allow_reuse=True)(parse_dms_datetime)
     _format_processed_datetime = pydantic.validator("processed_datetime", allow_reuse=True)(parse_dms_datetime)
     _format_filing_date = pydantic.validator("filing_date", allow_reuse=True)(parse_dms_datetime)
     _format_latest_modification_datetime = pydantic.validator("latest_modification_datetime", allow_reuse=True)(

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -10,7 +10,6 @@ import uuid
 from dateutil.relativedelta import relativedelta
 from factory.declarations import LazyAttribute
 import factory.fuzzy
-import pytz
 
 from pcapi import settings
 from pcapi.core import testing
@@ -87,9 +86,7 @@ class DMSContentFactory(factory.Factory):
     phone = factory.Sequence("+33612{:06}".format)
     postal_code = "75008"
     procedure_number = factory.Faker("pyint")
-    registration_datetime = LazyAttribute(
-        lambda _: datetime.utcnow().replace(tzinfo=pytz.utc).strftime("%Y-%m-%dT%H:%M:%S%z")
-    )
+    registration_datetime = LazyAttribute(lambda _: datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"))
 
 
 class UbbleContentFactory(factory.Factory):

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -325,7 +325,7 @@ class DMSContent(common_models.IdentityCheckContent):
         return self.postal_code
 
     def get_registration_datetime(self) -> datetime.datetime | None:
-        return dms_models.parse_dms_datetime(self.registration_datetime) if self.registration_datetime else None
+        return dms_models.parse_dms_datetime(self.registration_datetime)
 
 
 UBBLE_REASON_CODE_MAPPING = {

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -363,9 +363,7 @@ class HandleDmsApplicationTest:
         result_content = fraud_check.source_data()
         assert result_content.application_number == 1
         assert result_content.birth_date == AGE18_ELIGIBLE_BIRTH_DATE
-        assert result_content.registration_datetime == datetime.datetime(
-            2020, 5, 13, 9, 9, 46, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))
-        )
+        assert result_content.registration_datetime == datetime.datetime(2020, 5, 13, 7, 9, 46)
         assert result_content.first_name == ""
         assert result_content.field_errors == [
             fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.first_name, value=""),

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -317,9 +317,7 @@ class DmsWebhookApplicationTest:
         assert content.postal_code == "06000"
         assert content.procedure_number == 45678
         assert content.state == "accepte"
-        assert content.registration_datetime == datetime.datetime(
-            2022, 3, 17, 12, 19, 37, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600))
-        )
+        assert content.registration_datetime == datetime.datetime(2022, 3, 17, 11, 19, 37)
 
         db.session.refresh(user)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-22706

Le but est de
- formater dans la BDD les valeurs de `registration_datetime` dans les dossiers DMS (on passe en UTC).
- faire le formatage à l'écriture dans la BDD à partir de maintenant

Un petit [ticket](https://passculture.atlassian.net/browse/PC-23703) suivra pour changer la fonction `get_registration_datetime`qui n'aura plus de raison de parser la valeur.


Le script ne sera pas mergé.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques