### PR TITLE
(PC-23045)[API] feat: Preserve user-offerer link when user is rejected

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-f2f67d2fb7f3 (pre) (head)
+1f3334d5aee5 (pre) (head)
 c21c9c622d05 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230803T154405_1f3334d5aee5_add_new_validation_status_user_offerer.py
+++ b/api/src/pcapi/alembic/versions/20230803T154405_1f3334d5aee5_add_new_validation_status_user_offerer.py
@@ -1,0 +1,37 @@
+"""add new validation status DELETED for relation user-offerer
+"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "1f3334d5aee5"
+down_revision = "f2f67d2fb7f3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE validationstatus ADD VALUE 'DELETED'")
+    op.execute(
+        'ALTER TABLE user_offerer ALTER COLUMN "validationStatus" TYPE validationstatus USING '
+        '"validationStatus"::text::validationstatus'
+    )
+    op.execute(
+        'ALTER TABLE offerer ALTER COLUMN "validationStatus" TYPE validationstatus USING '
+        '"validationStatus"::text::validationstatus'
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TYPE validationstatus RENAME TO validationstatus_old")
+    op.execute("CREATE TYPE validationstatus AS ENUM ('NEW', 'PENDING', 'VALIDATED', 'REJECTED')")
+    op.execute(
+        'ALTER TABLE user_offerer ALTER COLUMN "validationStatus" TYPE validationstatus USING '
+        '"validationStatus"::text::validationstatus'
+    )
+    op.execute(
+        'ALTER TABLE offerer ALTER COLUMN "validationStatus" TYPE validationstatus USING '
+        '"validationStatus"::text::validationstatus'
+    )
+    op.execute("DROP TYPE validationstatus_old")

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -662,7 +662,16 @@ def create_offerer(
     if offerer is not None:
         # The user can have his attachment rejected or deleted to the structure,
         # in this case it is passed to NEW if the structure is not rejected
-        user_offerer = offerers_models.UserOfferer.query.filter_by(userId=user.id, offererId=offerer.id).first()
+        user_offerer = (
+            offerers_models.UserOfferer.query.filter_by(userId=user.id, offererId=offerer.id)
+            .filter(
+                sa.or_(
+                    offerers_models.UserOfferer.validationStatus == ValidationStatus.REJECTED,
+                    offerers_models.UserOfferer.validationStatus == ValidationStatus.DELETED,
+                )
+            )
+            .first()
+        )
         if user_offerer:
             user_offerer.validationStatus = ValidationStatus.VALIDATED
         else:
@@ -1051,7 +1060,9 @@ def rm_previous_venue_thumbs(venue: models.Venue) -> None:
         return
 
     # handle old banner urls that did not have a timestamp
-    timestamp = get_timestamp_from_url(venue.bannerUrl) if "_" in venue.bannerUrl else ""  # type: ignore [arg-type, operator]
+    timestamp = (
+        get_timestamp_from_url(venue.bannerUrl) if "_" in venue.bannerUrl else ""
+    )  # type: ignore [arg-type, operator]
     storage.remove_thumb(venue, storage_id_suffix=str(timestamp), ignore_thumb_count=True)
 
     # some older venues might have a banner but not the original file

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -666,8 +666,8 @@ def create_offerer(
             offerers_models.UserOfferer.query.filter_by(userId=user.id, offererId=offerer.id)
             .filter(
                 sa.or_(
-                    offerers_models.UserOfferer.validationStatus == ValidationStatus.REJECTED,
-                    offerers_models.UserOfferer.validationStatus == ValidationStatus.DELETED,
+                    offerers_models.UserOfferer.isRejected,
+                    offerers_models.UserOfferer.isDeleted,
                 )
             )
             .first()

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -188,6 +188,14 @@ class NotValidatedUserOffererFactory(UserOffererFactory):
     validationStatus = ValidationStatus.NEW
 
 
+class RejectedUserOffererFactory(UserOffererFactory):
+    validationStatus = ValidationStatus.REJECTED
+
+
+class DeletedUserOffererFactory(UserOffererFactory):
+    validationStatus = ValidationStatus.DELETED
+
+
 class UserNotValidatedOffererFactory(BaseFactory):
     class Meta:
         model = models.UserOfferer

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -48,7 +48,10 @@ def get_all_offerers_for_user(
     query = models.Offerer.query.filter(models.Offerer.isActive.is_(True))
 
     if not user.has_admin_role:
-        user_offerer_filters = [models.UserOfferer.userId == user.id]
+        user_offerer_filters = [
+            models.UserOfferer.userId == user.id,
+            sqla.not_(models.UserOfferer.isRejected) & sqla.not_(models.UserOfferer.isDeleted),
+        ]
         if not include_non_validated_user_offerers:
             user_offerer_filters.append(models.UserOfferer.isValidated)
         query = query.join(models.Offerer.UserOfferers).filter(*user_offerer_filters)

--- a/api/src/pcapi/models/validation_status_mixin.py
+++ b/api/src/pcapi/models/validation_status_mixin.py
@@ -11,6 +11,7 @@ class ValidationStatus(enum.Enum):
     PENDING = "PENDING"
     VALIDATED = "VALIDATED"
     REJECTED = "REJECTED"
+    DELETED = "DELETED"
 
 
 @declarative_mixin
@@ -59,3 +60,12 @@ class ValidationStatusMixin:
     def isRejected(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         # sqla.not_(isRejected) works only if we check None separately.
         return cls.validationStatus == ValidationStatus.REJECTED
+
+    @sqla_hybrid.hybrid_property
+    def isDeleted(self) -> bool:
+        return self.validationStatus == ValidationStatus.DELETED
+
+    @isDeleted.expression  # type: ignore [no-redef]
+    def isDeleted(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+        # sqla.not_(isDeleted) works only if we check None separately.
+        return cls.validationStatus == ValidationStatus.DELETED

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -252,6 +252,8 @@ def format_validation_status(status: validation_status_mixin.ValidationStatus) -
             return "Validé"
         case validation_status_mixin.ValidationStatus.REJECTED:
             return "Rejeté"
+        case validation_status_mixin.ValidationStatus.DELETED:
+            return "Supprimé"
         case _:
             return status.value
 

--- a/api/src/pcapi/routes/backoffice/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/badges.html
@@ -1,4 +1,4 @@
-{% macro build_status_badge(object, new, pending, validated, rejected) %}
+{% macro build_status_badge(object, new, pending, validated, rejected, deleted) %}
   {% if object.isNew %}
     <span class="me-1 pb-1 badge rounded-pill text-bg-info">{{ new }}</span>
   {% elif object.isPending %}
@@ -7,6 +7,8 @@
     <span class="me-1 pb-1 badge rounded-pill text-bg-success">{{ validated }}</span>
   {% elif object.isRejected %}
     <span class="me-1 pb-1 badge rounded-pill text-bg-danger">{{ rejected }}</span>
+  {% elif object.isDeleted %}
+    <span class="me-1 pb-1 badge rounded-pill text-bg-danger">{{ deleted }}</span>
   {% endif %}
 {% endmacro %}
 {% macro build_venue_badges(venue) %}
@@ -25,7 +27,7 @@
   {% endif %}
 {% endmacro %}
 {% macro build_offerer_status_badge(offerer) %}
-  {{ build_status_badge(offerer, "Nouvelle", "En attente", "Validée", "Rejetée") }}
+  {{ build_status_badge(offerer, "Nouvelle", "En attente", "Validée", "Rejetée", "Supprimée") }}
 {% endmacro %}
 {% macro build_offerer_badges(offerer) %}
   <span class="me-1 pb-1 badge rounded-pill text-bg-secondary">Structure</span>
@@ -38,7 +40,7 @@
   {% endif %}
 {% endmacro %}
 {% macro build_user_offerer_status_badge(user_offerer) %}
-  {{ build_status_badge(user_offerer, "Nouveau", "En attente", "Validé", "Rejeté") }}
+  {{ build_status_badge(user_offerer, "Nouveau", "En attente", "Validé", "Rejeté", "Supprimé") }}
 {% endmacro %}
 {% macro build_pro_user_status_badge(pro_user) %}
   {% if pro_user.proValidationStatus.value == "VALIDATED" %}

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -357,6 +357,34 @@ class OffererFirstUserPropertyTest:
 
         assert offerer.first_user == first.user
 
+    def test_first_user_when_only_user_is_rejected(self):
+        offerer = factories.OffererFactory()
+        factories.RejectedUserOffererFactory(offerer=offerer)
+
+        assert offerer.first_user is None
+
+    def test_first_user_when_only_user_is_deleted(self):
+        offerer = factories.OffererFactory()
+        factories.DeletedUserOffererFactory(offerer=offerer)
+
+        assert offerer.first_user is None
+
+    def test_first_user_when_first_user_is_rejected_and_other_users(self):
+        offerer = factories.OffererFactory()
+        rejected_user_offerer = factories.RejectedUserOffererFactory(offerer=offerer)
+        factories.UserOffererFactory.create_batch(3, offerer=offerer)
+
+        assert offerer.first_user is not None
+        assert offerer.first_user != rejected_user_offerer.user
+
+    def test_first_user_when_first_user_is_deleted_and_other_users(self):
+        offerer = factories.OffererFactory()
+        deleted_user_offerer = factories.DeletedUserOffererFactory(offerer=offerer)
+        factories.UserOffererFactory.create_batch(3, offerer=offerer)
+
+        assert offerer.first_user is not None
+        assert offerer.first_user != deleted_user_offerer.user
+
 
 class VenueDmsAdageStatusTest:
     def test_dms_adage_status_when_no_dms_application(self):

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -5,7 +5,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import UserOfferer
-from pcapi.core.users.factories import ProFactory
+from pcapi.core.users import factories as users_factories
 from pcapi.core.users.models import User
 from pcapi.models.validation_status_mixin import ValidationStatus
 
@@ -100,7 +100,7 @@ class Returns204Test:
     def when_successful_and_existing_offerer_creates_editor_user_offerer_and_does_not_log_in(self, client):
         # Given
         offerer = offerers_factories.NotValidatedOffererFactory(siren="349974931")
-        pro = ProFactory(email="bobby@test.com")
+        pro = users_factories.ProFactory(email="bobby@test.com")
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
 
         data = BASE_DATA_PRO.copy()


### PR DESCRIPTION
## But de la pull request

Lors d'un rejet ou la suppression d'un compte pro rattaché à une structure, on garde dorénavant en base de données la relation afin d'afficher ce rejet dans la liste des comptes Pro. 
Le statut de relation passe à REJECTED ou DELETED. 
Un log d'action de rejet ou suppression est rattaché sur le compte pro.
Changement validé par la Data.

Ticket Jira : https://passculture.atlassian.net/browse/PC-23045

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/f556c440-2262-43ce-a7c8-3956ecb306df)


## Vérifications

- [X] J'ai écrit les tests nécessaires
- [X] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques