### PR TITLE
(BSR)[API] fix: Fix `_delete_dependent_event_pricings` functions

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1030,7 +1030,10 @@ def _delete_dependent_event_pricings(event: models.FinanceEvent, log_message: st
     logs.delete(synchronize_session=False)
     pricings = models.Pricing.query.filter(models.Pricing.id.in_(pricing_ids))
     pricings.delete(synchronize_session=False)
-    models.FinanceEvent.query.filter(models.FinanceEvent.id.in_(events_already_priced)).update(
+    models.FinanceEvent.query.filter(
+        models.FinanceEvent.id.in_(events_already_priced),
+        models.FinanceEvent.status == models.FinanceEventStatus.PRICED,
+    ).update(
         {"status": models.FinanceEventStatus.READY},
         synchronize_session=False,
     )
@@ -1165,7 +1168,8 @@ def _delete_dependent_pricings(
     models.FinanceEvent.query.filter(
         models.FinanceEvent.id.in_(
             models.Pricing.query.filter(models.Pricing.id.in_(pricing_ids)).with_entities(models.Pricing.eventId)
-        )
+        ),
+        models.FinanceEvent.status == models.FinanceEventStatus.PRICED,
     ).update(
         {"status": models.FinanceEventStatus.READY},
         synchronize_session=False,


### PR DESCRIPTION
The dependent pricing that we would like to delete could already have
been cancelled. In that case, its event has been cancelled, too. If
so, we should not change the event status to `READY`. This can happen
when the booking has been marked as unused.