### PR TITLE
PC-23703 no more parsing in get registration datetime

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -13,7 +13,6 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 import sqlalchemy.orm as sa_orm
 
-from pcapi.connectors.dms import models as dms_models
 from pcapi.core.users import models as users_models
 from pcapi.models import Base
 from pcapi.models import Model
@@ -326,7 +325,7 @@ class DMSContent(common_models.IdentityCheckContent):
         return self.postal_code
 
     def get_registration_datetime(self) -> datetime.datetime | None:
-        return dms_models.parse_dms_datetime(self.registration_datetime)
+        return self.registration_datetime
 
 
 # https://ubbleai.github.io/developer-documentation/#reason-codes


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23703

Suite de cette [PR](https://github.com/pass-culture/pass-culture-main/pull/7619).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques