### PR TITLE
(PC-23706)[PRO] feat: display diffuse help after first submit

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -82,7 +82,7 @@ export const OffersComponent = ({
   const newAdageFilters = useActiveFeature('WIP_ENABLE_NEW_ADAGE_FILTERS')
 
   const showDiffuseHelp =
-    isDiffuseHelpActive && submitCount === 1 && isCookieEnabled
+    isDiffuseHelpActive && (submitCount ?? 0) > 0 && isCookieEnabled
 
   useEffect(() => {
     try {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
@@ -658,7 +658,7 @@ describe('offers', () => {
       expect(diffuseHelp).not.toBeInTheDocument()
     })
 
-    it('should not show diffuse help', async () => {
+    it('should not show diffuse help on first render', async () => {
       vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(
         offerInParis
       )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23706

Afficher l'aide diffuse **à partir** du premier submit du formulaire et non seulement la première fois
