### PR TITLE
PC-23359 add users commands

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -323,6 +323,8 @@ et choisir le python précédemment installé en local (virtual env ou pyenv).
 
 ## Ecriture d'une tâche automatique (cron)
 
-Les commandes à lancer régulièrement (par example des synchro journalières) sont définies dans le fichier src/pcapi/scheduled_tasks/commands.py
+Les commandes à lancer régulièrement (par example des synchro journalières) sont définies dans les fichiers `src/pcapi/*/commands.py`
+Pour que les commandes soient enregistrées par Flask, il faut que le fichier `path/to/commands.py` soit référencé dans la fonction `install_commands` de `api/src/pcapi/scripts/install.py`
+
 Pour que les commandes soient exécutées, il faut ouvrir une PR sur le repo pass-culture/pass-culture-deployment
 Les infos sont dans le [README](https://github.com/pass-culture/pass-culture-deployment)

--- a/api/src/pcapi/scripts/install.py
+++ b/api/src/pcapi/scripts/install.py
@@ -13,6 +13,7 @@ def install_commands(app: flask.Flask) -> None:
         "pcapi.core.search.commands.indexation",
         "pcapi.core.search.commands.settings",
         "pcapi.core.subscription.commands",
+        "pcapi.core.users.commands",
         "pcapi.scheduled_tasks.commands",
         "pcapi.scheduled_tasks.titelive_commands",
         "pcapi.scripts.beneficiary.import_test_users",


### PR DESCRIPTION
## But de la pull request
Ajouter les commandes de pcapi/core/users/commands.py à Flask

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23359

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques