### PR TITLE
(BSR)[API] fix: Fix `_cancel_booking()` when booking is already used

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -186,6 +186,7 @@ def add_event(
 def cancel_latest_event(
     booking: bookings_models.Booking | educational_models.CollectiveBooking,
     motive: models.FinanceEventMotive,
+    commit: bool = False,
 ) -> models.FinanceEvent | None:
     event = models.FinanceEvent.query.filter(
         (models.FinanceEvent.booking == booking)
@@ -207,7 +208,7 @@ def cancel_latest_event(
             extra={"booking": booking.id},
         )
         return None
-    pricing = _cancel_event_pricing(event, models.PricingLogReason.MARK_AS_UNUSED)
+    pricing = _cancel_event_pricing(event, models.PricingLogReason.MARK_AS_UNUSED, commit=commit)
     event.status = models.FinanceEventStatus.CANCELLED
     db.session.flush()
     logger.info(

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -195,10 +195,10 @@ def cancel_latest_event(
         models.FinanceEvent.status.in_(models.CANCELLABLE_FINANCE_EVENT_STATUSES),
     ).one_or_none()
     if not event:
-        # Once the feature flag is on, there MUST be an event. If no
+        # Once we have switched to event pricing, there MUST be an event. If no
         # event can be found, something is wrong somewhere (probably a
         # bug).
-        if feature.FeatureToggle.PRICE_FINANCE_EVENTS.is_active():
+        if not feature.FeatureToggle.PRICE_BOOKINGS.is_active():
             log = logger.error
         else:
             log = logger.info

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -637,8 +637,6 @@ class CancelLatestEventTest:
 
         api.cancel_latest_event(event1.booking, motive=event1.motive)
 
-        db.session.refresh(event1)
-        db.session.refresh(event2)
         assert event1.status == models.FinanceEventStatus.CANCELLED
         assert event1.pricings[0].status == models.PricingStatus.CANCELLED
 
@@ -666,8 +664,6 @@ class CancelLatestEventTest:
             api.cancel_latest_event(event1.booking, motive=event1.motive)
 
         # No changes!
-        db.session.refresh(event1)
-        db.session.refresh(event2)
         assert event1.status == models.FinanceEventStatus.PRICED
         assert event1.pricings[0].status == models.PricingStatus.VALIDATED
         assert event2.status == models.FinanceEventStatus.PRICED
@@ -676,10 +672,8 @@ class CancelLatestEventTest:
         with override_settings(FINANCE_OVERRIDE_PRICING_ORDERING_ON_PRICING_POINTS=[ppoint.id]):
             api.cancel_latest_event(event1.booking, motive=event1.motive)
 
-        # This time, event1 and its pricing was cancelled. event2 and
+        # This time, event1 and its pricing were cancelled. event2 and
         # its pricing were left untouched.
-        db.session.refresh(event1)
-        db.session.refresh(event2)
         assert event1.status == models.FinanceEventStatus.CANCELLED
         assert event1.pricings[0].status == models.PricingStatus.CANCELLED
         assert event2.status == models.FinanceEventStatus.PRICED  # unchanged

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -545,7 +545,7 @@ class DeleteStockTest:
 
         # cancellation can trigger more than one request to Batch
         assert len(push_testing.requests) >= 1
-
+        db.session.expunge_all()
         stock = models.Stock.query.one()
         assert stock.isSoftDeleted
         booking1 = bookings_models.Booking.query.get(booking1.id)
@@ -559,6 +559,7 @@ class DeleteStockTest:
         assert booking3.cancellationReason == bookings_models.BookingCancellationReasons.OFFERER
         booking4 = bookings_models.Booking.query.get(booking4.id)
         assert booking4.status == bookings_models.BookingStatus.USED  # unchanged
+        assert booking4.cancellationDate is None
         assert booking4.pricings[0].status == finance_models.PricingStatus.PROCESSED  # unchanged
 
         assert len(mails_testing.outbox) == 3


### PR DESCRIPTION
Commits à relire séparément.

Le 3ème commit a un test qui échoue (et que j'ai donc commenté). C'est un problème dû à `pytest_flask_sqlalchemy` : il introduit plein de SAVEPOINT (qui n'existe pas hors des tests), donc le ROLLBACK revient au dernier SAVEPOINT (surnuméraire), au lieu de revenir au premier BEGIN. Concrètement, dans ce test, on ne rollbacke pas jusqu'au bon endroit. En réalité, quand j'exécute le code du test dans une session Python hors des tests, tout fonctionne : le ROLLBACK se fait correctement.