### PR TITLE
(BSR)[API] test: add whitespace and NBSP to IBAN and BIC test data

### DIFF
--- a/api/src/pcapi/domain/demarches_simplifiees.py
+++ b/api/src/pcapi/domain/demarches_simplifiees.py
@@ -72,7 +72,7 @@ def parse_raw_bank_info_data(data: dict, procedure_version: int) -> dict:
         if field["id"] in ID_TO_NAME_MAPPING:
             result[ID_TO_NAME_MAPPING[field["id"]]] = field["value"]
         elif field["id"] == DMS_TOKEN_ID:
-            result["dms_token"] = _remove_dms_pro_prefix(field["value"])
+            result["dms_token"] = _remove_dms_pro_prefix(field["value"].strip("  "))
         elif field["id"] == "Q2hhbXAtNzgyODAw" and procedure_version in (2, 3):
             result["siret"] = field["etablissement"]["siret"]
             result["siren"] = field["etablissement"]["siret"][:9]

--- a/api/tests/connector_creators/demarches_simplifiees_creators.py
+++ b/api/tests/connector_creators/demarches_simplifiees_creators.py
@@ -26,10 +26,10 @@ def get_bank_info_response_procedure_v2(annotation: dict):
                 },
                 {"id": "Q2hhbXAtMzUyNzI3", "label": "BIC", "stringValue": "SOGEFRPP ", "value": "SOGEFRPP "},
                 {
-                    "id": "Q2hhbXAtNDA3ODk1",
+                    "id": "Q2hhbXAtMjY3NDMyMQ==",
                     "label": "N° d'identifiant du lieu",
-                    "stringValue": "60a7536a21c8",
-                    "value": "60a7536a21c8",
+                    "stringValue": " PRO-60a7536a21c8 ",
+                    "value": " PRO-60a7536a21c8 ",
                 },
             ],
             "dateDerniereModification": "2020-01-03T01:00:00+01:00",

--- a/api/tests/connector_creators/demarches_simplifiees_creators.py
+++ b/api/tests/connector_creators/demarches_simplifiees_creators.py
@@ -21,10 +21,10 @@ def get_bank_info_response_procedure_v2(annotation: dict):
                 {
                     "id": "Q2hhbXAtMzUyNzIy",
                     "label": "IBAN",
-                    "stringValue": "FR7630007000111234567890144",
-                    "value": "FR7630007000111234567890144",
+                    "stringValue": "FR7630007000111234567890144 ",
+                    "value": "FR7630007000111234567890144 ",
                 },
-                {"id": "Q2hhbXAtMzUyNzI3", "label": "BIC", "stringValue": "SOGEFRPP", "value": "SOGEFRPP"},
+                {"id": "Q2hhbXAtMzUyNzI3", "label": "BIC", "stringValue": "SOGEFRPP ", "value": "SOGEFRPP "},
                 {
                     "id": "Q2hhbXAtNDA3ODk1",
                     "label": "N° d'identifiant du lieu",


### PR DESCRIPTION
## But de la pull request

Tester que les espaces et espaces insécables sont nettoyés des champs IBAN et BIC lors du traitement des dossiers DS d'ajout de CB


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques