### PR TITLE
(PC-23651)[PRO] feat: add queryId to adage tracking events

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
@@ -38,6 +38,7 @@ const ContactButton = ({
     apiAdage.logContactModalButtonClick({
       iframeFrom: removeParamsFromUrl(location.pathname),
       offerId,
+      queryId: queryId,
     })
     logClickOnOffer(offerId.toString(), position, queryId)
   }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -50,10 +50,12 @@ const Offer = ({ offer, queryId, position }: OfferProps): JSX.Element => {
         ? apiAdage.logOfferDetailsButtonClick({
             iframeFrom: removeParamsFromUrl(location.pathname),
             stockId: offer.stock.id,
+            queryId: queryId,
           })
         : apiAdage.logOfferTemplateDetailsButtonClick({
             iframeFrom: removeParamsFromUrl(location.pathname),
             offerId: offer.id,
+            queryId: queryId,
           })
     }
     setDisplayDetails(!displayDetails)
@@ -63,6 +65,7 @@ const Offer = ({ offer, queryId, position }: OfferProps): JSX.Element => {
     apiAdage.logFavOfferButtonClick({
       iframeFrom: removeParamsFromUrl(location.pathname),
       offerId: offer.id,
+      queryId: queryId,
     })
     setIsModalLikeOpen(true)
   }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
@@ -41,6 +41,7 @@ const PrebookingButton = ({
       apiAdage.logBookingModalButtonClick({
         iframeFrom: removeParamsFromUrl(location.pathname),
         stockId,
+        queryId: queryId,
       })
     }
     setIsModalOpen(true)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23651

Ajouter le queryId pour les différentes routes de tracking Adage : 

- Evénement de pré-réservation
- Evénement de contact
- Evénement de like
- Evénement de click sur le détail d'une offre 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques