### PR TITLE
Pc 23287 eac add tracker for satisfaction survey

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -204,15 +204,14 @@ def log_tracking_filter(
 @blueprint.adage_iframe.route("/logs/sat-survey", methods=["POST"])
 @spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
 @adage_jwt_required
-def log_closer_satisfaction_survey(
+def log_open_satisfaction_survey(
     authenticated_information: AuthenticatedInformation,
-    body: serialization.ClosedSatisfactionSurvey,
+    body: serialization.AdageBaseModel,
 ) -> None:
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)  # type: ignore [arg-type]
     educational_utils.log_information_for_data_purpose(
-        event_name="CloseSatisfactionSurvey",
+        event_name="OpenSatisfactionSurvey",
         extra_data={
-            "source": body.source,
             "from": body.iframeFrom,
             "queryId": body.queryId,
         },

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -12,10 +12,6 @@ class CatalogViewBody(AdageBaseModel):
     source: str
 
 
-class ClosedSatisfactionSurvey(AdageBaseModel):
-    source: str
-
-
 class StockIdBody(AdageBaseModel):
     stockId: int
 

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -310,10 +310,9 @@ class LogsTest:
 
         # then
         assert response.status_code == 204
-        assert caplog.records[0].message == "CloseSatisfactionSurvey"
+        assert caplog.records[0].message == "OpenSatisfactionSurvey"
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
-            "source": "Academic Octathalon",
             "queryId": "1234a",
             "from": "for_my_institution",
             "uai": "EAU123",

--- a/pro/src/apiClient/adage/index.ts
+++ b/pro/src/apiClient/adage/index.ts
@@ -11,6 +11,7 @@ export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
 export type { AcademiesResponseModel } from './models/AcademiesResponseModel';
+export type { AdageBaseModel } from './models/AdageBaseModel';
 export { AdageFrontRoles } from './models/AdageFrontRoles';
 export { AdageHeaderLink } from './models/AdageHeaderLink';
 export type { AdageHeaderLogBody } from './models/AdageHeaderLogBody';
@@ -20,7 +21,6 @@ export type { BookCollectiveOfferResponse } from './models/BookCollectiveOfferRe
 export type { CatalogViewBody } from './models/CatalogViewBody';
 export type { CategoriesResponseModel } from './models/CategoriesResponseModel';
 export type { CategoryResponseModel } from './models/CategoryResponseModel';
-export type { ClosedSatisfactionSurvey } from './models/ClosedSatisfactionSurvey';
 export type { CollectiveOfferOfferVenue } from './models/CollectiveOfferOfferVenue';
 export type { CollectiveOfferResponseModel } from './models/CollectiveOfferResponseModel';
 export type { CollectiveOfferTemplateResponseModel } from './models/CollectiveOfferTemplateResponseModel';

--- a/pro/src/apiClient/adage/models/AdageBaseModel.ts
+++ b/pro/src/apiClient/adage/models/AdageBaseModel.ts
@@ -3,9 +3,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type ClosedSatisfactionSurvey = {
+export type AdageBaseModel = {
   iframeFrom: string;
   queryId?: string | null;
-  source: string;
 };
 

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -3,13 +3,13 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { AcademiesResponseModel } from '../models/AcademiesResponseModel';
+import type { AdageBaseModel } from '../models/AdageBaseModel';
 import type { AdageHeaderLogBody } from '../models/AdageHeaderLogBody';
 import type { AuthenticatedResponse } from '../models/AuthenticatedResponse';
 import type { BookCollectiveOfferRequest } from '../models/BookCollectiveOfferRequest';
 import type { BookCollectiveOfferResponse } from '../models/BookCollectiveOfferResponse';
 import type { CatalogViewBody } from '../models/CatalogViewBody';
 import type { CategoriesResponseModel } from '../models/CategoriesResponseModel';
-import type { ClosedSatisfactionSurvey } from '../models/ClosedSatisfactionSurvey';
 import type { CollectiveOfferResponseModel } from '../models/CollectiveOfferResponseModel';
 import type { CollectiveOfferTemplateResponseModel } from '../models/CollectiveOfferTemplateResponseModel';
 import type { CollectiveRequestBody } from '../models/CollectiveRequestBody';
@@ -368,13 +368,13 @@ export class DefaultService {
   }
 
   /**
-   * log_closer_satisfaction_survey <POST>
+   * log_open_satisfaction_survey <POST>
    * @param requestBody
    * @returns void
    * @throws ApiError
    */
-  public logCloserSatisfactionSurvey(
-    requestBody?: ClosedSatisfactionSurvey,
+  public logOpenSatisfactionSurvey(
+    requestBody?: AdageBaseModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -196,7 +196,9 @@ export const OffersComponent = ({
                 }
               />
             )}
-            {index === 1 && showSurveySatisfaction && <SurveySatisfaction />}
+            {index === 1 && showSurveySatisfaction && (
+              <SurveySatisfaction queryId={queryId} />
+            )}
           </div>
         ))}
         <div className={styles['offers-load-more']}>

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
@@ -10,7 +10,13 @@ import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './SurveySatisfaction.module.scss'
 
-export const SurveySatisfaction = (): JSX.Element => {
+interface SurveySatisfactionProps {
+  queryId?: string
+}
+
+export const SurveySatisfaction = ({
+  queryId,
+}: SurveySatisfactionProps): JSX.Element => {
   const [shouldHideSurveySatisfaction, setShouldHideSurveySatisfaction] =
     useState(false)
 
@@ -25,6 +31,13 @@ export const SurveySatisfaction = (): JSX.Element => {
     } catch {
       notify.error('Une erreur est survenue. Merci de réessayer plus tard')
     }
+  }
+
+  const logOpenSatisfactionSurvey = async () => {
+    apiAdage.logOpenSatisfactionSurvey({
+      iframeFrom: location.pathname,
+      queryId: queryId,
+    })
   }
 
   return !shouldHideSurveySatisfaction ? (
@@ -73,6 +86,7 @@ export const SurveySatisfaction = (): JSX.Element => {
               target: '_blank',
             }}
             className={styles['survey-button']}
+            onClick={logOpenSatisfactionSurvey}
           >
             Je donne mon avis
           </ButtonLink>

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
@@ -10,13 +10,17 @@ import { SurveySatisfaction } from '../SurveySatisfaction'
 
 vi.mock('apiClient/api', () => ({
   apiAdage: {
-    saveRedactorPreferences: jest.fn(() => Promise.resolve({})),
+    saveRedactorPreferences: vi.fn(),
+    logOpenSatisfactionSurvey: vi.fn(),
   },
 }))
 
 describe('SurveySatisfaction', () => {
+  const defaultProps = {
+    queryId: '123',
+  }
   it('should close survey satisfaction', async () => {
-    renderWithProviders(<SurveySatisfaction />)
+    renderWithProviders(<SurveySatisfaction {...defaultProps} />)
 
     screen.getByText('Enquête de satisfaction')
 
@@ -42,7 +46,7 @@ describe('SurveySatisfaction', () => {
       isOk: false,
     })
 
-    renderWithProviders(<SurveySatisfaction />)
+    renderWithProviders(<SurveySatisfaction {...defaultProps} />)
 
     screen.getByText('Enquête de satisfaction')
 
@@ -51,5 +55,18 @@ describe('SurveySatisfaction', () => {
     userEvent.click(closeButton)
 
     await waitFor(() => expect(notifyError).toHaveBeenCalledTimes(1))
+  })
+
+  it('should log info when opening sastisfaction survey', async () => {
+    renderWithProviders(<SurveySatisfaction {...defaultProps} />)
+
+    const openButton = screen.getByRole('link', { name: 'Je donne mon avis' })
+
+    await userEvent.click(openButton)
+
+    expect(apiAdage.logOpenSatisfactionSurvey).toHaveBeenCalledWith({
+      iframeFrom: '/',
+      queryId: '123',
+    })
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23287

Logger l'information que l'utilisateur à ouvert le questionnaire de satisfaction sur Adage

FF à activer : WIP_ENABLE_SATISFACTION_SURVEY

