### PR TITLE
(PC-23484)[BO] Fix advanced search on offer status

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offers/blueprint.py
@@ -37,6 +37,7 @@ list_offers_blueprint = utils.child_backoffice_blueprint(
     permission=perm_models.Permissions.READ_OFFERS,
 )
 
+aliased_stock = sa.orm.aliased(offers_models.Stock)
 
 SEARCH_FIELD_TO_PYTHON = {
     "CATEGORY": {
@@ -63,13 +64,13 @@ SEARCH_FIELD_TO_PYTHON = {
     },
     "EVENT_DATE": {
         "field": "date",
-        "column": offers_models.Stock.beginningDatetime,
+        "column": aliased_stock.beginningDatetime,
         "special": partial(date_utils.date_to_localized_datetime, time_=datetime.datetime.min.time()),
         "inner_join": "stock",
     },
     "BOOKING_LIMIT_DATE": {
         "field": "date",
-        "column": offers_models.Stock.bookingLimitDatetime,
+        "column": aliased_stock.bookingLimitDatetime,
         "special": partial(date_utils.date_to_localized_datetime, time_=datetime.datetime.min.time()),
         "inner_join": "stock",
     },
@@ -130,10 +131,10 @@ JOIN_DICT: dict[str, list[dict[str, typing.Any]]] = {
         {
             "name": "stock",
             "args": (
-                offers_models.Stock,
+                aliased_stock,
                 sa.and_(
-                    offers_models.Stock.offerId == offers_models.Offer.id,
-                    offers_models.Stock.isSoftDeleted.is_(False),
+                    aliased_stock.offerId == offers_models.Offer.id,
+                    aliased_stock.isSoftDeleted.is_(False),
                 ),
             ),
         }

--- a/api/tests/routes/backoffice_v3/offers_test.py
+++ b/api/tests/routes/backoffice_v3/offers_test.py
@@ -109,6 +109,22 @@ class ListOffersTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data)
         assert set(int(row["ID"]) for row in rows) == {offers[2].id}
 
+    def test_list_offers_by_status_and_event_date(self, authenticated_client, offers):
+        query_args = {
+            "search-0-search_field": "STATUS",
+            "search-0-operator": "IN",
+            "search-0-status": offers_models.OfferStatus.ACTIVE.value,
+            "search-2-search_field": "EVENT_DATE",
+            "search-2-operator": "LESS_THAN",
+            "search-2-date": datetime.date.today().isoformat(),
+        }
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, **query_args))
+
+        # assert there is no problem joining stock table twice (for status and event date)
+        assert response.status_code == 200
+
     def test_list_offers_without_sort_should_not_have_created_date_sort_link(self, authenticated_client):
         # given
         query_args = {}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23484

Le filtre sur le statut de l'offre impliquait une jointure caché (property). Donc à l'ajout d'un filtre supplémentaire lui aussi incluant une jointure sur le stock, une erreur survenait

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques