### PR TITLE
(PC-23435)[PRO] feat: hide ReimbursementPoint component if FF is active

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
@@ -4,6 +4,7 @@ import { GetOffererResponseModel } from 'apiClient/v1'
 import FormLayout from 'components/FormLayout'
 import ReimbursementPoint from 'components/VenueForm/ReimbursementPoint/ReimbursementPoint'
 import { Venue } from 'core/Venue/types'
+import useActiveFeature from 'hooks/useActiveFeature'
 import fullLinkIcon from 'icons/full-link.svg'
 import InternalBanner from 'ui-kit/Banners/InternalBanner'
 
@@ -22,6 +23,9 @@ const ReimbursementFields = ({
   scrollToSection,
   venue,
 }: ReimbursementFieldsProps) => {
+  const isNewBankDetailsJourneyEnable = useActiveFeature(
+    'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
+  )
   const venueHaveSiret = !!venue.siret
   const offererHaveVenueWithSiret = offerer.hasAvailablePricingPoints
   const createVenuePath = `/structures/${offerer.id}/lieux/creation`
@@ -60,12 +64,15 @@ const ReimbursementFields = ({
                   setVenueHasPricingPoint={setVenueHasPricingPoint}
                 />
               )}
-              <ReimbursementPoint
-                offerer={offerer}
-                readOnly={readOnly}
-                initialVenue={venue}
-                venueHasPricingPoint={venueHasPricingPoint}
-              />
+
+              {!isNewBankDetailsJourneyEnable && (
+                <ReimbursementPoint
+                  offerer={offerer}
+                  readOnly={readOnly}
+                  initialVenue={venue}
+                  venueHasPricingPoint={venueHasPricingPoint}
+                />
+              )}
             </>
           )}
         </FormLayout.Section>

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.tsx
@@ -14,7 +14,17 @@ import ReimbursementFields, {
   ReimbursementFieldsProps,
 } from '../ReimbursementFields'
 
-const renderReimbursementFields = async (props: ReimbursementFieldsProps) => {
+const renderReimbursementFields = async (
+  props: ReimbursementFieldsProps,
+  featuresOverride?: { nameKey: string; isActive: boolean }[]
+) => {
+  const storeOverrides = {
+    features: {
+      list: featuresOverride,
+      initialized: true,
+    },
+  }
+
   const rtlReturn = renderWithProviders(
     <Formik onSubmit={() => {}} initialValues={{}}>
       {({ handleSubmit }) => (
@@ -22,7 +32,8 @@ const renderReimbursementFields = async (props: ReimbursementFieldsProps) => {
           <ReimbursementFields {...props} />
         </Form>
       )}
-    </Formik>
+    </Formik>,
+    { storeOverrides }
   )
 
   const loadingMessage = screen.queryByText('Chargement en cours ...')
@@ -94,6 +105,32 @@ describe('ReimbursementFields', () => {
 
     await renderReimbursementFields(props)
 
-    expect(screen.queryByText('Barème de remboursement')).toBeInTheDocument()
+    expect(screen.getByText('Barème de remboursement')).toBeInTheDocument()
+
+    expect(screen.getByText('Coordonnées bancaires')).toBeInTheDocument()
+  })
+
+  it('should not display bank details section if ff is active', async () => {
+    const featuresOverride = [
+      {
+        nameKey: 'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY',
+        isActive: true,
+      },
+    ]
+    const venueWithoutSiret = {
+      ...venue,
+      siret: '',
+    }
+    props.venue = venueWithoutSiret
+
+    await renderReimbursementFields(props, featuresOverride)
+
+    expect(screen.getByText('Barème de remboursement')).toBeInTheDocument()
+
+    await expect(
+      screen.queryByText('Chargement en cours ...')
+    ).not.toBeInTheDocument()
+
+    expect(screen.queryByText('Coordonnées bancaires')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23435

- Ne pas afficher la section "Coordonées bancaires" si le FF WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY est activé.
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/89e5b37e-2242-454d-bf2e-c234502e096e)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques