### PR TITLE
(BSR) use self hosted runner in ci

### DIFF
--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    runs-on: docker-cache
+    runs-on: [self-hosted, linux, x64]
     steps:
     - name: Output variables
       id: vars

--- a/.github/workflows/build-on-tags.yaml
+++ b/.github/workflows/build-on-tags.yaml
@@ -30,7 +30,7 @@ jobs:
 
   build-docker:
     name: 'Build and push Docker images'
-    runs-on: docker-cache
+    runs-on: [self-hosted, linux, x64]
     needs:
       - find-hotfix-tag-number
     permissions:

--- a/.github/workflows/reusable--build-and-tag.yml
+++ b/.github/workflows/reusable--build-and-tag.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   build-and-tag-version:
-    runs-on: docker-cache
+    runs-on: [self-hosted, linux, x64]
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## But de la pull request

Utiliser les runners self-hosted afin de contourner un souci sur les runners docker-cache.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques