### PR TITLE
(BSR)ci: use docker-cache runner for docker build jobs

### DIFF
--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    runs-on: [self-hosted, linux, x64]
+    runs-on: docker-cache
     steps:
     - name: Output variables
       id: vars

--- a/.github/workflows/build-on-tags.yaml
+++ b/.github/workflows/build-on-tags.yaml
@@ -30,7 +30,7 @@ jobs:
 
   build-docker:
     name: 'Build and push Docker images'
-    runs-on: [self-hosted, linux, x64]
+    runs-on: docker-cache
     needs:
       - find-hotfix-tag-number
     permissions:

--- a/.github/workflows/reusable--build-and-tag.yml
+++ b/.github/workflows/reusable--build-and-tag.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   build-and-tag-version:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: docker-cache
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
La cause de nos soucis de stockage est identifiée, nous pouvons repasser sur ces runners plus malins.