### PR TITLE
(PC-21161)[PRO] refactor: wording email errors

### DIFF
--- a/api/src/pcapi/domain/password.py
+++ b/api/src/pcapi/domain/password.py
@@ -42,12 +42,12 @@ def check_password_strength(key: str, password: str) -> None:
 
 def _ensure_new_password_is_different_from_old(user: User, new_password: str, errors: ApiErrors) -> None:
     if user.checkPassword(new_password):
-        errors.add_error("newPassword", "Ton nouveau mot de passe est identique à l’ancien.")
+        errors.add_error("newPassword", "Le nouveau mot de passe est identique à l’ancien.")
 
 
 def _ensure_given_old_password_is_correct(user: User, old_password: str, errors: ApiErrors) -> None:
     if not user.checkPassword(old_password):
-        errors.add_error("oldPassword", "Votre mot de passe actuel est incorrect")
+        errors.add_error("oldPassword", "Le mot de passe actuel est incorrect.")
 
 
 def _ensure_new_password_is_strong_enough(field_name: str, field_value: str, errors: ApiErrors) -> None:
@@ -64,7 +64,7 @@ def _ensure_new_password_is_strong_enough(field_name: str, field_value: str, err
     if not re.match(regex, field_value) or not at_least_one_special_char:
         errors.add_error(
             field_name,
-            "Ton mot de passe doit contenir au moins :\n"
+            "Le mot de passe doit contenir au moins :\n"
             "- 12 caractères\n"
             "- Un chiffre\n"
             "- Une majuscule et une minuscule\n"

--- a/api/tests/domain/password_test.py
+++ b/api/tests/domain/password_test.py
@@ -38,12 +38,12 @@ class CheckPasswordValidityTest:
 
         # then
         assert api_errors.value.errors["newPassword"] == [
-            "Ton mot de passe doit contenir au moins :\n"
+            "Le mot de passe doit contenir au moins :\n"
             "- 12 caractères\n"
             "- Un chiffre\n"
             "- Une majuscule et une minuscule\n"
             "- Un caractère spécial",
-            "Ton nouveau mot de passe est identique à l’ancien.",
+            "Le nouveau mot de passe est identique à l’ancien.",
         ]
 
         assert api_errors.value.errors["newConfirmationPassword"] == ["Les deux mots de passe ne sont pas identiques."]
@@ -119,7 +119,7 @@ class EnsureNewPasswordIsStrongEnoughTest:
 
         # then
         assert api_errors.errors["newPassword"] == [
-            "Ton mot de passe doit contenir au moins :\n"
+            "Le mot de passe doit contenir au moins :\n"
             "- 12 caractères\n"
             "- Un chiffre\n"
             "- Une majuscule et une minuscule\n"
@@ -163,7 +163,7 @@ class EnsureGivenOldPasswordIsCorrectTest:
         _ensure_given_old_password_is_correct(user, old_password, api_errors)
 
         # then
-        assert api_errors.errors["oldPassword"] == ["Votre mot de passe actuel est incorrect"]
+        assert api_errors.errors["oldPassword"] == ["Le mot de passe actuel est incorrect."]
 
 
 class EnsureNewPasswordIsDifertFromOldTest:
@@ -178,4 +178,4 @@ class EnsureNewPasswordIsDifertFromOldTest:
         _ensure_new_password_is_different_from_old(user, new_password, api_errors)
 
         # then
-        assert api_errors.errors["newPassword"] == ["Ton nouveau mot de passe est identique à l’ancien."]
+        assert api_errors.errors["newPassword"] == ["Le nouveau mot de passe est identique à l’ancien."]

--- a/api/tests/routes/pro/post_change_password_test.py
+++ b/api/tests/routes/pro/post_change_password_test.py
@@ -65,8 +65,8 @@ class Returns400Test:
         response = client.post("/users/password", json=data)
         # then
         assert response.status_code == 400
-        assert response.json["oldPassword"] == ["Votre mot de passe actuel est incorrect"]
-        assert "Ton mot de passe doit contenir au moins :" in response.json["newPassword"][0]
+        assert response.json["oldPassword"] == ["Le mot de passe actuel est incorrect."]
+        assert "Le mot de passe doit contenir au moins :" in response.json["newPassword"][0]
 
     def when_data_password_don_t_match_in_the_request_body(self, client):
         # given

--- a/api/tests/routes/pro/signup_pro_V2_test.py
+++ b/api/tests/routes/pro/signup_pro_V2_test.py
@@ -124,7 +124,7 @@ class Returns400Test:
         assert response.status_code == 400
         response = response.json
         assert response["password"] == [
-            "Ton mot de passe doit contenir au moins :\n"
+            "Le mot de passe doit contenir au moins :\n"
             "- 12 caractères\n"
             "- Un chiffre\n"
             "- Une majuscule et une minuscule\n"

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -271,7 +271,7 @@ class Returns400Test:
         assert response.status_code == 400
         response = response.json
         assert response["password"] == [
-            "Ton mot de passe doit contenir au moins :\n"
+            "Le mot de passe doit contenir au moins :\n"
             "- 12 caractères\n"
             "- Un chiffre\n"
             "- Une majuscule et une minuscule\n"

--- a/api/tests/routes/shared/post_new_password_test.py
+++ b/api/tests/routes/shared/post_new_password_test.py
@@ -103,7 +103,7 @@ def test_fail_if_new_password_is_not_strong_enough(client):
 
     assert response.status_code == 400
     assert response.json["newPassword"] == [
-        "Ton mot de passe doit contenir au moins :\n"
+        "Le mot de passe doit contenir au moins :\n"
         "- 12 caractères\n"
         "- Un chiffre\n"
         "- Une majuscule et une minuscule\n"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-21161

Modification des messages d'erreur liés au mot de passe :

```
"Ton nouveau mot de passe est identique à l’ancien." → “Le nouveau mot de passe est identique à l’ancien.”

"Votre mot de passe actuel est incorrect" → “Le mot de passe actuel est incorrect.”

"Ton mot de passe doit contenir au moins :\n" → “Le mot de passe doit contenir au moins”
```

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques