### PR TITLE
(PC-23792)[BO] feat: redirect search results to details when a single result is found

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -130,6 +130,9 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY = "Activer le nouveau parcours de dépôt de coordonnées bancaires"
     WIP_CATEGORY_SELECTION = "Activer la nouvelle sélection de catégories"
     WIP_ENABLE_ADAGE_GEO_LOCATION = "Activer le filtre d'offres adage par géolocalisation"
+    WIP_BACKOFFICE_ENABLE_REDIRECT_SINGLE_RESULT = (
+        "Backoffice : Afficher directement les détails lorsque la recherche ne renvoie qu'un seul résultat"
+    )
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -205,6 +208,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY,
     FeatureToggle.WIP_CATEGORY_SELECTION,
     FeatureToggle.WIP_ENABLE_ADAGE_GEO_LOCATION,
+    FeatureToggle.WIP_BACKOFFICE_ENABLE_REDIRECT_SINGLE_RESULT,
 )
 
 if settings.IS_PROD or settings.IS_STAGING:

--- a/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
@@ -78,7 +78,7 @@ def render_offerer_details(
 
     return render_template(
         "offerer/get.html",
-        search_form=search_forms.ProSearchForm(pro_type=TypeOptions.OFFERER.value),
+        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.OFFERER.value),
         search_dst=url_for("backoffice_v3_web.search_pro"),
         offerer=offerer,
         region=regions_utils.get_region_name_from_postal_code(offerer.postalCode),

--- a/api/src/pcapi/routes/backoffice_v3/pro_users.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro_users.py
@@ -53,7 +53,7 @@ def get(user_id: int) -> utils.BackofficeResponse:
 
     return render_template(
         "pro_user/get.html",
-        search_form=search_forms.ProSearchForm(pro_type=TypeOptions.USER.value),
+        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.USER.value),
         search_dst=url_for("backoffice_v3_web.search_pro"),
         user=user,
         form=form,

--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -207,7 +207,7 @@ def render_venue_details(
 
     return render_template(
         "venue/get.html",
-        search_form=search_forms.ProSearchForm(pro_type=TypeOptions.VENUE.value),
+        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.VENUE.value),
         search_dst=url_for("backoffice_v3_web.search_pro"),
         venue=venue,
         edit_venue_form=edit_venue_form,


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-23792

Permettre d'aller directement à la page de détails d'un utilisateur, une structure ou un lieu lorsque la recherche ne renvoie qu'un seul résultat. C'est toujours le cas lors d'une recherche par id, email, siren, siret.
Conditionné à un FF pour faire tester ce comportement aux métiers.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques