### PR TITLE
(BSR)[PRO] fix: reimbursementField test

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.tsx
@@ -114,9 +114,9 @@ describe('ReimbursementFields', () => {
 
     expect(screen.getByText('Barème de remboursement')).toBeInTheDocument()
 
-    await expect(
-      screen.queryByText('Chargement en cours ...')
-    ).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(api.getAvailableReimbursementPoints).toHaveBeenCalledTimes(1)
+    })
 
     expect(screen.getByText('Coordonnées bancaires')).toBeInTheDocument()
   })
@@ -137,10 +137,6 @@ describe('ReimbursementFields', () => {
     await renderReimbursementFields(props, featuresOverride)
 
     expect(screen.getByText('Barème de remboursement')).toBeInTheDocument()
-
-    await expect(
-      screen.queryByText('Chargement en cours ...')
-    ).not.toBeInTheDocument()
 
     expect(screen.queryByText('Coordonnées bancaires')).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## But de la pull request

Corriger le test "should display pricing point section when venue has no siret" de ReimbursementFields.spec.tsx

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques