### PR TITLE
(PC-23566)[BO] feat: Add history to finance incident detailed page

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-117312f339eb (pre) (head)
+72fa9c444b5a (pre) (head)
 38d84c4d6248 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230810T101608_72fa9c444b5a_add_finance_incident_to_action_history.py
+++ b/api/src/pcapi/alembic/versions/20230810T101608_72fa9c444b5a_add_finance_incident_to_action_history.py
@@ -1,0 +1,41 @@
+"""Add finance incident to ActionHistory table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "72fa9c444b5a"
+down_revision = "117312f339eb"
+branch_labels = None
+depends_on = None
+
+fk_constaint_name = "action_history_incident_fkey"
+
+
+def upgrade() -> None:
+    op.add_column("action_history", sa.Column("financeIncidentId", sa.BigInteger(), nullable=True))
+    op.create_index(op.f("ix_action_history_financeIncidentId"), "action_history", ["financeIncidentId"], unique=False)
+    op.create_foreign_key(
+        fk_constaint_name, "action_history", "finance_incident", ["financeIncidentId"], ["id"], ondelete="CASCADE"
+    )
+
+    op.drop_constraint("check_at_least_one_resource_or_is_fraud_action", "action_history")
+    op.create_check_constraint(
+        "check_at_least_one_resource_or_is_fraud_action",
+        "action_history",
+        'num_nonnulls("userId", "offererId", "venueId", "financeIncidentId") >= 1 OR "actionType" = \'BLACKLIST_DOMAIN_NAME\' OR "actionType" = \'REMOVE_BLACKLISTED_DOMAIN_NAME\'',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("check_at_least_one_resource_or_is_fraud_action", "action_history")
+    op.drop_constraint(fk_constaint_name, "action_history", type_="foreignkey")
+    op.drop_index(op.f("ix_action_history_financeIncidentId"), table_name="action_history")
+    op.drop_column("action_history", "financeIncidentId")
+    op.create_check_constraint(
+        "check_at_least_one_resource_or_is_fraud_action",
+        "action_history",
+        'num_nonnulls("userId", "offererId", "venueId") >= 1 OR "actionType" = \'BLACKLIST_DOMAIN_NAME\' OR "actionType" = \'REMOVE_BLACKLISTED_DOMAIN_NAME\'',
+    )

--- a/api/src/pcapi/core/history/api.py
+++ b/api/src/pcapi/core/history/api.py
@@ -4,6 +4,7 @@ import typing
 
 from sqlalchemy.ext.mutable import MutableDict
 
+from pcapi.core.finance import models as finance_models
 from pcapi.core.history import models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import models as users_models
@@ -17,6 +18,7 @@ def log_action(
     user: users_models.User | None = None,
     offerer: offerers_models.Offerer | None = None,
     venue: offerers_models.Venue | None = None,
+    finance_incident: finance_models.FinanceIncident | None = None,
     comment: str | None = None,
     save: bool = True,
     **extra_data: typing.Any,
@@ -29,8 +31,8 @@ def log_action(
     new resources in parameters; when such an exception is raised, it shows a bug in our code.
     """
     legit_actions = (models.ActionType.BLACKLIST_DOMAIN_NAME, models.ActionType.REMOVE_BLACKLISTED_DOMAIN_NAME)
-    if (not user and not offerer and not venue) and (action_type not in legit_actions):
-        raise ValueError("No resource (user, offerer, venue)")
+    if (not user and not offerer and not venue and not finance_incident) and (action_type not in legit_actions):
+        raise ValueError("No resource (user, offerer, venue, finance incident)")
 
     if save:
         if user is not None and user.id is None:
@@ -54,6 +56,7 @@ def log_action(
         # FIXME remove type ignores when upgrading to sqlalchemy 2.0
         offerer=offerer,  # type: ignore
         venue=venue,  # type: ignore
+        financeIncident=finance_incident,  # type: ignore
         comment=comment or None,  # do not store empty string
         extraData=extra_data,
     )

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -987,6 +987,7 @@ def set_offerer_pending(
         offerer=offerer,
         venue=None,  # otherwise mypy does not accept extra_data dict
         user=None,  # otherwise mypy does not accept extra_data dict
+        finance_incident=None,  # otherwise mypy does not accept extra_data dict
         comment=comment,
         save=False,
         **extra_data,

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -7,9 +7,7 @@
         <div class="d-flex flex-row justify-content-start">
           <h5 class="card-title">
             {{ user.firstName | empty_string_if_null }} {{ user.lastName | empty_string_if_null | upper }}
-            {% for role in user.roles %}
-              <span class="me-2 badge rounded-pill text-bg-primary align-middle">{{ role | format_role }}</span>
-            {% endfor %}
+            {% for role in user.roles %}<span class="me-2 badge rounded-pill text-bg-primary align-middle">{{ role | format_role }}</span>{% endfor %}
             {% if not user.isActive %}
               <span class="badge rounded-pill text-bg-secondary align-middle">{{ user.isActive | format_state }}</span>
             {% endif %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/finance/incident/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/finance/incident/get/details.html
@@ -2,11 +2,18 @@
 {% from "components/presentation/details/tabs.html" import build_details_tabs_wrapper %}
 {% from "components/presentation/details/tabs.html" import build_details_tab_content %}
 {% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
+{% from "components/turbo/spinner.html" import build_loading_spinner with context %}
 {% call build_details_tabs_wrapper() %}
   {{ build_details_tab("bookings", "Réservations", active_tab == "bookings") }}
+  {{ build_details_tab("history", "Historique", active_tab == "history") }}
 {% endcall %}
 {% call build_details_tabs_content_wrapper() %}
   {% call build_details_tab_content("bookings", active_tab == 'bookings') %}
     {% include "finance/incident/get/details/bookings.html" %}
+  {% endcall %}
+  {% call build_details_tab_content("history", active_tab == 'history') %}
+    <turbo-frame data-turbo="false" id="incident_history_frame" loading="lazy" src="{{ url_for('backoffice_v3_web.finance_incident.get_history', finance_incident_id=incident.id) }}">
+    {{ build_loading_spinner() }}
+    </turbo-frame>
   {% endcall %}
 {% endcall %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/finance/incident/get/details/history.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/finance/incident/get/details/history.html
@@ -1,0 +1,6 @@
+{% from "components/history/view.html" import build_history_view with context %}
+<turbo-frame id="incident_history_frame">
+{% call build_history_view(dst, form, actions, true) %}
+  Ajouter un commentaire
+{% endcall %}
+</turbo-frame>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23566

Ajout de l'historique dans la page incident
- Deux types d'actions ajoutées : création et annulation d'incident
- A la création de l'incident, le commentaire dans l'historique est l'origine de la demande

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/508009a5-a441-4be2-aa6c-1ef22a761f2a)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques