### PR TITLE
(PC-23753)[API] feat: make @transaction() transactional

### DIFF
--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -12,6 +12,7 @@ from sentry_sdk import set_tag
 from pcapi import settings
 from pcapi.flask_app import app
 from pcapi.flask_app import setup_metrics
+from pcapi.repository import mark_transaction_as_invalid
 from pcapi.routes.backoffice.scss import preprocess_scss
 
 
@@ -31,6 +32,7 @@ csrf.init_app(app)
 
 @app.errorhandler(CSRFError)
 def handle_csrf_error(error: typing.Any) -> tuple[str, int]:
+    mark_transaction_as_invalid()
     return render_template("errors/csrf.html"), 400
 
 

--- a/api/src/pcapi/core/permissions/api.py
+++ b/api/src/pcapi/core/permissions/api.py
@@ -6,7 +6,6 @@ from pcapi.core.history import api as history_api
 from pcapi.core.history import models as history_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
-from pcapi.repository import transaction
 
 
 def raise_error_on_empty_role_name(name: str) -> None:
@@ -43,16 +42,15 @@ def update_role(
     for permission in removed_roles:
         modified_info[permission.name] = {"old_info": True, "new_info": False}
 
-    with transaction():
-        role.name = name
-        role.permissions = permissions
+    role.name = name
+    role.permissions = permissions
 
-        history_api.add_action(
-            action_type=history_models.ActionType.ROLE_PERMISSIONS_CHANGED,
-            author=author,
-            role_name=role.name,
-            modified_info=modified_info,
-        )
+    history_api.add_action(
+        action_type=history_models.ActionType.ROLE_PERMISSIONS_CHANGED,
+        author=author,
+        role_name=role.name,
+        modified_info=modified_info,
+    )
 
     return role
 

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -241,9 +241,7 @@ def get_shell_extra_context() -> dict:
 
 
 @app.teardown_request
-def remove_db_session(
-    exc: BaseException | None = None,  # pylint: disable=unused-argument
-) -> None:
+def remove_db_session(exc: BaseException | None = None) -> None:
     try:
         db.session.remove()
     except AttributeError:

--- a/api/src/pcapi/repository/__init__.py
+++ b/api/src/pcapi/repository/__init__.py
@@ -1,14 +1,135 @@
 from contextlib import contextmanager
-from typing import Iterator
+from dataclasses import dataclass
+import functools
+from types import TracebackType
+import typing
 
+from flask import g
+
+from pcapi import settings
 from pcapi.models import db
 
 
+# FIXME: cue for queries count in tests to remove when all routes will be atomics
+if settings.IS_RUNNING_TESTS:
+    _test_is_session_managed: bool = False
+
+
+# DEPRECATED in favor of @atomic() because @transaction() is not reentrant
 @contextmanager
-def transaction() -> Iterator[None]:
+def transaction() -> typing.Iterator[None]:
     try:
         yield
         db.session.commit()
     except Exception:
         db.session.rollback()
         raise
+
+
+@dataclass
+class AtomicContext:
+    autoflush: bool
+    invalid_transaction: bool
+
+
+class atomic:
+    def __enter__(self) -> "atomic":
+        # In that context g is local to the thread
+        # use a list to make the context manager/decorator reentrant
+        g._atomic_contexts = getattr(g, "_atomic_contexts", [])
+        g._atomic_contexts.append(
+            AtomicContext(
+                autoflush=db.session.autoflush,
+                invalid_transaction=False,
+            )
+        )
+        db.session.begin_nested()
+        db.session.autoflush = False
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type | None = None,
+        exc_value: Exception | None = None,
+        traceback: TracebackType | None = None,
+        /,
+    ) -> typing.Literal[False]:
+        context: AtomicContext = g._atomic_contexts.pop()
+
+        db.session.autoflush = context.autoflush
+
+        if context.invalid_transaction or exc_value is not None:
+            db.session.rollback()
+        else:
+            db.session.commit()
+
+        # do not supress the exception
+        return False
+
+    # decorator part
+    def __call__(self, func: typing.Callable) -> typing.Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):  # type: ignore [no-untyped-def]
+            if _is_managed_session():
+                # use the context manager part to make the decorator reeantrant.
+                with type(self):
+                    return func(*args, **kwargs)
+            else:
+                _mark_session_management()
+                with db.session.no_autoflush:
+                    try:
+                        return func(*args, **kwargs)
+                    except Exception as exp:
+                        mark_transaction_as_invalid()
+                        raise exp
+                    finally:
+                        _manage_session()
+
+        return wrapper
+
+
+def mark_transaction_as_invalid() -> None:
+    """Mark the transaction as to be rolled back by the `atomic_view` decorator or context manager"""
+    atomic_contexts = getattr(g, "_atomic_contexts", [])
+    if atomic_contexts:
+        atomic_contexts[-1].invalid_transaction = True
+    else:
+        if _is_managed_session():
+            g._session_to_commit = False
+
+
+def _mark_session_management() -> None:
+    g._session_to_commit = True
+    g._managed_session = True
+    if settings.IS_RUNNING_TESTS:
+        global _test_is_session_managed  # pylint: disable=global-statement
+        _test_is_session_managed = True
+
+
+def _is_managed_session() -> bool:
+    return getattr(g, "_managed_session", False)
+
+
+def _manage_session() -> None:
+    if _is_managed_session():
+        if g._session_to_commit:
+            db.session.commit()
+        else:
+            db.session.rollback()
+
+        del g._session_to_commit
+        del g._managed_session
+
+
+def _test_helper_get_is_session_managed() -> bool:
+    if settings.IS_RUNNING_TESTS:
+        return _test_is_session_managed
+    raise RuntimeError("This global variable is only available for test purpose")
+
+
+def _test_helper_reset_is_session_managed() -> None:
+    if settings.IS_RUNNING_TESTS:
+        global _test_is_session_managed  # pylint: disable=global-statement
+        _test_is_session_managed = False
+    else:
+        raise RuntimeError("This global variable is only available for test purpose")

--- a/api/src/pcapi/repository/repository.py
+++ b/api/src/pcapi/repository/repository.py
@@ -14,12 +14,16 @@ from pcapi.validation.models import entity_validator
 logger = logging.getLogger(__name__)
 
 
+# DEPRECATED in favor of @atomic() and db.session.delete because committing or
+# rollbacking should be done by a transaction context manager, not manually
 def delete(*models: Model) -> None:
     for model in models:
         db.session.delete(model)
     db.session.commit()
 
 
+# DEPRECATED in favor of @atomic() and db.session.add because committing or
+# rollbacking should be done by a transaction context manager, not manually
 def add_to_session(*models: Model) -> None:
     """Validate models and add them to session."""
     if not models:
@@ -39,6 +43,8 @@ def add_to_session(*models: Model) -> None:
         raise api_errors
 
 
+# DEPRECATED in favor of @atomic() and db.session.add because committing or
+# rollbacking should be done by a transaction context manager, not manually
 def save(*models: Model, commit: bool = True) -> None:
     add_to_session(*models)
 

--- a/api/src/pcapi/routes/backoffice/admin/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/blueprint.py
@@ -12,6 +12,7 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
 from pcapi.models import feature as feature_models
 from pcapi.notifications.internal.transactional import change_feature_flip as change_feature_flip_internal_message
+from pcapi.repository import atomic
 from pcapi.repository import repository
 
 from . import forms
@@ -21,6 +22,7 @@ from ..forms import empty as empty_forms
 
 
 @blueprint.backoffice_web.route("/admin/roles", methods=["GET"])
+@atomic()
 @utils.permission_required(perm_models.Permissions.MANAGE_PERMISSIONS)
 def get_roles() -> utils.BackofficeResponse:
     roles = perm_api.list_roles()
@@ -58,6 +60,7 @@ def get_roles_history() -> utils.BackofficeResponse:
 
 
 @blueprint.backoffice_web.route("/admin/roles/<int:role_id>", methods=["POST"])
+@atomic()
 @utils.permission_required(perm_models.Permissions.MANAGE_PERMISSIONS)
 def update_role(role_id: int) -> utils.BackofficeResponse:
     permissions = perm_api.list_permissions()

--- a/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
@@ -4,6 +4,7 @@ from flask import current_app as app
 from pcapi.core.bookings import exceptions
 from pcapi.domain.client_exceptions import ClientError
 from pcapi.models import api_errors
+from pcapi.repository import mark_transaction_as_invalid
 
 
 JsonResponse = tuple[Response, int]
@@ -19,27 +20,32 @@ JsonResponse = tuple[Response, int]
 @app.errorhandler(exceptions.DigitalExpenseLimitHasBeenReached)
 @app.errorhandler(exceptions.OfferCategoryNotBookableByUser)
 def handle_book_an_offer(exception: ClientError) -> JsonResponse:
+    mark_transaction_as_invalid()
     return app.generate_error_response(exception.errors), 400
 
 
 @app.errorhandler(exceptions.CannotCancelConfirmedBooking)
 def handle_cancel_a_booking(exception: ClientError) -> JsonResponse:
+    mark_transaction_as_invalid()
     return app.generate_error_response(exception.errors), 400
 
 
 @app.errorhandler(exceptions.BookingDoesntExist)
 def handle_cancel_a_booking_not_found(exception: exceptions.BookingDoesntExist) -> JsonResponse:
+    mark_transaction_as_invalid()
     return app.generate_error_response(exception.errors), 404
 
 
 @app.errorhandler(exceptions.BookingIsAlreadyRefunded)
 def handle_booking_is_already_refunded(exception: exceptions.BookingIsAlreadyRefunded) -> JsonResponse:
+    mark_transaction_as_invalid()
     error = {"payment": ["Cette réservation a été remboursée"]}
     return app.generate_error_response(error), api_errors.ForbiddenError.status_code
 
 
 @app.errorhandler(exceptions.BookingRefused)
 def handle_booking_refused(exception: exceptions.BookingRefused) -> JsonResponse:
+    mark_transaction_as_invalid()
     error = {
         "educationalBooking": (
             "Cette réservation pour une offre éducationnelle a été refusée par le chef d'établissement"
@@ -50,17 +56,20 @@ def handle_booking_refused(exception: exceptions.BookingRefused) -> JsonResponse
 
 @app.errorhandler(exceptions.BookingIsNotConfirmed)
 def handle_booking_is_not_confirmed(exception: exceptions.BookingIsNotConfirmed) -> JsonResponse:
+    mark_transaction_as_invalid()
     error = {"booking": [str(exception)]}
     return app.generate_error_response(error), api_errors.ForbiddenError.status_code
 
 
 @app.errorhandler(exceptions.BookingIsAlreadyUsed)
 def handle_booking_is_already_used(exception: exceptions.BookingIsAlreadyUsed) -> JsonResponse:
+    mark_transaction_as_invalid()
     error = {"booking": ["Cette réservation a déjà été validée"]}
     return app.generate_error_response(error), api_errors.ResourceGoneError.status_code
 
 
 @app.errorhandler(exceptions.BookingIsAlreadyCancelled)
 def handle_booking_is_already_cancelled(exception: exceptions.BookingIsAlreadyCancelled) -> JsonResponse:
+    mark_transaction_as_invalid()
     error = {"booking_cancelled": ["Cette réservation a été annulée"]}
     return app.generate_error_response(error), api_errors.ResourceGoneError.status_code

--- a/api/src/pcapi/routes/error_handlers/thumbnails_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/thumbnails_error_handlers.py
@@ -4,6 +4,7 @@ from flask import Response
 from flask import current_app as app
 
 from pcapi.core.offers import exceptions as offers_exceptions
+from pcapi.repository import mark_transaction_as_invalid
 
 
 logger = logging.getLogger(__name__)
@@ -11,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 @app.errorhandler(offers_exceptions.ImageValidationError)
 def handle_create_a_thumbnail(exception: Exception) -> tuple[Response, int]:
+    mark_transaction_as_invalid()
     error_message = exception.args[0] if exception.args else "L'image n'est pas valide"
     logger.error(
         "When creating the offer thumbnail, this error was encountered: %s: %s",

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -21,6 +21,7 @@ from requests.auth import _basic_auth_str
 from requests.exceptions import ConnectionError as RequestConnectionError
 import requests_mock
 
+from pcapi import repository
 from pcapi import settings
 from pcapi.analytics.amplitude import testing as amplitude_testing
 import pcapi.core.educational.testing as adage_api_testing
@@ -373,6 +374,11 @@ if os.environ.get("CHECK_DATA_LEAKS"):
         counts_after = {model: model.query.count() for model in models}
         leaked_models = ", ".join([model.__name__ for model in models if counts_after[model] != counts_before[model]])
         assert not leaked_models, f"LEAK: {request.function} leaks {leaked_models}"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clean_global_test_cue():
+    repository._test_helper_reset_is_session_managed()
 
 
 @pytest.fixture(name="cloud_task_client")

--- a/api/tests/repository/test_transaction.py
+++ b/api/tests/repository/test_transaction.py
@@ -1,0 +1,90 @@
+import uuid
+
+import pytest
+
+from pcapi.core.users.models import UserSession
+from pcapi.models import db
+from pcapi.repository import _manage_session
+from pcapi.repository import atomic
+from pcapi.repository import mark_transaction_as_invalid
+
+from tests.conftest import clean_database
+
+
+class AtomicTest:
+    @clean_database
+    def test_atomic_commits_on_success(self):
+        user_session = UserSession(userId=1, uuid=uuid.uuid4())
+
+        with atomic():
+            db.session.add(user_session)
+
+        assert UserSession.query.count() == 1
+
+    @clean_database
+    def test_atomic_rolls_back_on_raise(self):
+        user_session = UserSession(userId=1, uuid=uuid.uuid4())
+
+        with pytest.raises(ValueError):
+            with atomic():
+                db.session.add(user_session)
+                raise ValueError()
+
+        assert UserSession.query.count() == 0
+
+    @clean_database
+    def test_atomic_is_reentrant(self):
+        user_session = UserSession(userId=1, uuid=uuid.uuid4())
+
+        with pytest.raises(ValueError):
+            with atomic():
+                with atomic():
+                    db.session.add(user_session)
+
+                assert UserSession.query.count() == 1
+
+                raise ValueError()
+
+        assert UserSession.query.count() == 0
+
+    @clean_database
+    def test_atomic_disables_autoflush(self):
+        user_session = UserSession(userId=1, uuid=uuid.uuid4())
+
+        with atomic():
+            db.session.add(user_session)
+            assert UserSession.query.count() == 0
+
+    @clean_database
+    def test_atomic_decorator_commits_on_success(self):
+        @atomic()
+        def view():
+            user_session = UserSession(userId=1, uuid=uuid.uuid4())
+            db.session.add(user_session)
+
+        view()
+        _manage_session()
+        assert UserSession.query.count() == 1
+
+    @clean_database
+    def test_atomic_decorator_rollsback_on_exception(self):
+        @atomic()
+        def view():
+            user_session = UserSession(userId=1, uuid=uuid.uuid4())
+            db.session.add(user_session)
+            raise ValueError()
+
+        with pytest.raises(ValueError):
+            view()
+        assert UserSession.query.count() == 0
+
+    @clean_database
+    def test_atomic_decorator_rollback_invalid_transaction(self):
+        @atomic()
+        def view():
+            user_session = UserSession(userId=1, uuid=uuid.uuid4())
+            db.session.add(user_session)
+            mark_transaction_as_invalid()
+
+        view()
+        assert UserSession.query.count() == 0


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23753

Le but est d'avoir un système de gestion des transactions pour faire correspondre au cycle de vie d'une requête http.

```python
@public_api.route("/check/transactions", methods=["POST"])
@repository.transaction()
def check_transactions():
    import uuid
    from flask import request
    from pcapi.core.users.models import UserSession
    from pcapi.repository import repository

    s = UserSession()
    s.userId = 1
    s.uuid = uuid.uuid4()
    # The code typically calls `repository.save()` for every addition or update and commits
    repository.save(s, commit=False)

    # If an error is raised, we should not commit the transaction. And yet we do...
    if "raise" in request.args:
        raise ValueError("an horrible error occurs, let's rollback, shall we?")

    return "OK", 200
```
Actuellement, un appel `POST /check/transaction?raise=3` commit quand même le `UserSession` alors qu'il devrait rollback

## Proposition

Réecrire le context manager `repository.transaction()` pour utiliser la syntaxe `with db.session.begin_nested(): yield` plutôt que gérer manuellement le commit. Il est possible de déplacer la validation de `repository.save()` dans le context manager et ainsi déprécier la fonction.

Avantages : 
- le context manager s'occupe pour nous de commit ou rollback automatiquement
- la migration de `repository.save()` en `repository.add_to_session()` est simple puisqu'ils partagent la même signature
- la syntaxe décorateur est pratique pour décorer rapidement toutes les routes et appels de cron qui en ont besoin

Désavantage : 
- `db.session.commit()` commit toute la transaction, il n'est donc pas possible d'imbriquer les `@transaction()`
  imbriquer les transactions n'est [pas recommandé par SQLAlchemy](https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#migrating-from-the-subtransaction-pattern)
- puisqu'on ne peut pas commit "manuellement", on doit attendre de sortir de la transaction pour que les modèles dans la session obtiennent un `id`. Cet identifiant est parfois nécessaire comme pour upload la miniature d'une offre.