### PR TITLE
(PC-23841)[API] feat: add venue academy in algolia facet filters

### DIFF
--- a/api/src/pcapi/algolia_settings_collective_offers.json
+++ b/api/src/pcapi/algolia_settings_collective_offers.json
@@ -20,7 +20,8 @@
     "filterOnly(offer.students)",
     "filterOnly(offer.subcategoryId)",
     "filterOnly(venue.departmentCode)",
-    "filterOnly(venue.id)"
+    "filterOnly(venue.id)",
+    "filterOnly(venue.academy)"
   ],
   "attributesToSnippet": null,
   "attributesToHighlight": null,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23841

Ajouter l'académie dans les filtres algolia (fichier de config)

