### PR TITLE
(PC-23823)[PRO] fix: error in timezone for stockEvents serialization

### DIFF
--- a/pro/src/core/OfferEducational/utils/buildDatetimesForStockPayload.ts
+++ b/pro/src/core/OfferEducational/utils/buildDatetimesForStockPayload.ts
@@ -32,12 +32,9 @@ export const buildBeginningDatetimeForStockPayload = (
   eventTime: string,
   departmentCode: string
 ): string => {
-  const beginningDateTimeInDepartmentTimezone = buildDateTime(
-    eventDate,
-    eventTime
-  )
+  const beginningDateTimeInUserTimezone = buildDateTime(eventDate, eventTime)
   const beginningDateTimeInUTCTimezone = getUtcDateTimeFromLocalDepartement(
-    beginningDateTimeInDepartmentTimezone,
+    beginningDateTimeInUserTimezone,
     departmentCode
   )
   return toISOStringWithoutMilliseconds(beginningDateTimeInUTCTimezone)
@@ -49,14 +46,11 @@ export const buildBookingLimitDatetimeForStockPayload = (
   bookingLimitDatetime: string,
   departmentCode: string
 ): string => {
-  const beginningDateTimeInDepartmentTimezone = buildDateTime(
-    eventDate,
-    eventTime
-  )
+  const beginningDateTimeInUserTimezone = buildDateTime(eventDate, eventTime)
   const bookingLimitDatetimeUtc = getUtcDateTimeFromLocalDepartement(
     getBookingLimitDatetime(
       bookingLimitDatetime,
-      beginningDateTimeInDepartmentTimezone
+      beginningDateTimeInUserTimezone
     ),
     departmentCode
   )

--- a/pro/src/screens/OfferIndividual/StocksEventCreation/form/onSubmit.ts
+++ b/pro/src/screens/OfferIndividual/StocksEventCreation/form/onSubmit.ts
@@ -21,18 +21,28 @@ export const onSubmit = (
   departmentCode: string
 ): StocksEvent[] => {
   const dates = getRecurrenceDates(values)
-
   return generateStocksForDates(values, dates, departmentCode)
+}
+
+const getYearMonthDay = (date: string) => {
+  const [year, month, day] = date.split('-')
+  return {
+    year: parseInt(year),
+    month: parseInt(month) - 1,
+    day: parseInt(day),
+  }
 }
 
 const getRecurrenceDates = (values: RecurrenceFormValues): Date[] => {
   switch (values.recurrenceType) {
-    case RecurrenceType.UNIQUE:
+    case RecurrenceType.UNIQUE: {
       /* istanbul ignore next: should be already validated by yup */
       if (!isDateValid(values.startingDate)) {
         throw new Error('Starting date is empty')
       }
-      return [new Date(values.startingDate)]
+      const { year, month, day } = getYearMonthDay(values.startingDate)
+      return [new Date(year, month, day)]
+    }
 
     case RecurrenceType.DAILY: {
       /* istanbul ignore next: should be already validated by yup */
@@ -42,10 +52,20 @@ const getRecurrenceDates = (values: RecurrenceFormValues): Date[] => {
       ) {
         throw new Error('Starting or ending date is empty')
       }
+      const {
+        year: startYear,
+        month: startMonth,
+        day: startDay,
+      } = getYearMonthDay(values.startingDate)
+      const {
+        year: endYear,
+        month: endMonth,
+        day: endDay,
+      } = getYearMonthDay(values.endingDate)
 
       return getDatesInInterval(
-        new Date(values.startingDate),
-        new Date(values.endingDate)
+        new Date(startYear, startMonth, startDay),
+        new Date(endYear, endMonth, endDay)
       )
     }
 
@@ -58,10 +78,20 @@ const getRecurrenceDates = (values: RecurrenceFormValues): Date[] => {
       ) {
         throw new Error('Starting, ending date or days is empty')
       }
+      const {
+        year: startYear,
+        month: startMonth,
+        day: startDay,
+      } = getYearMonthDay(values.startingDate)
+      const {
+        year: endYear,
+        month: endMonth,
+        day: endDay,
+      } = getYearMonthDay(values.endingDate)
 
       return getDatesInInterval(
-        new Date(values.startingDate),
-        new Date(values.endingDate),
+        new Date(startYear, startMonth, startDay),
+        new Date(endYear, endMonth, endDay),
         values.days
       )
     }
@@ -76,10 +106,20 @@ const getRecurrenceDates = (values: RecurrenceFormValues): Date[] => {
       if (values.monthlyOption === null) {
         throw new Error('Monthly option is empty')
       }
+      const {
+        year: startYear,
+        month: startMonth,
+        day: startDay,
+      } = getYearMonthDay(values.startingDate)
+      const {
+        year: endYear,
+        month: endMonth,
+        day: endDay,
+      } = getYearMonthDay(values.endingDate)
 
       return getDatesWithMonthlyOption(
-        new Date(values.startingDate),
-        new Date(values.endingDate),
+        new Date(startYear, startMonth, startDay),
+        new Date(endYear, endMonth, endDay),
         values.monthlyOption
       )
     }

--- a/pro/src/screens/OfferIndividual/StocksEventEdition/StockFormList/StockFormList.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/StockFormList/StockFormList.tsx
@@ -1,7 +1,6 @@
 import cn from 'classnames'
-import { isAfter } from 'date-fns'
 import { FieldArray, useFormikContext } from 'formik'
-import React, { ChangeEvent, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { StockFormActions } from 'components/StockFormActions'
 import { FilterResultsRow } from 'components/StocksEventList/FilterResultsRow'
@@ -57,7 +56,7 @@ const StockFormList = ({
     deletingStock: StockEventFormValues
     deletingIndex: number
   } | null>(null)
-  const { values, setFieldValue, setTouched } = useFormikContext<{
+  const { values, setFieldValue } = useFormikContext<{
     stocks: StockEventFormValues[]
   }>()
   const today = getLocalDepartementDateTimeFromUtc(
@@ -327,35 +326,6 @@ const StockFormList = ({
                   }
                   const { readOnlyFields } = stockFormValues
 
-                  const onChangeBeginningDate = (
-                    event: ChangeEvent<HTMLInputElement>
-                  ) => {
-                    const date = event.target.value
-                    const stockBookingLimitDatetime =
-                      stockFormValues.bookingLimitDatetime
-                    /* istanbul ignore next: DEBT to fix */
-                    if (stockBookingLimitDatetime === null) {
-                      return
-                    }
-                    // tested but coverage don't see it.
-                    /* istanbul ignore next */
-                    if (
-                      date !== '' &&
-                      isAfter(
-                        new Date(stockBookingLimitDatetime),
-                        new Date(date)
-                      )
-                    ) {
-                      setTouched({
-                        [`stocks[${index}]bookingLimitDatetime`]: true,
-                      })
-                      setFieldValue(
-                        `stocks[${index}]bookingLimitDatetime`,
-                        date
-                      )
-                    }
-                  }
-
                   const beginningDate = stockFormValues.beginningDate
                   const actions = [
                     {
@@ -395,7 +365,6 @@ const StockFormList = ({
                           isLabelHidden
                           minDate={today}
                           disabled={readOnlyFields.includes('beginningDate')}
-                          onChange={onChangeBeginningDate}
                           hideFooter
                         />
                       </td>

--- a/pro/src/screens/OfferIndividual/StocksEventEdition/adapters/serializers.ts
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/adapters/serializers.ts
@@ -1,4 +1,3 @@
-import { set } from 'date-fns'
 import endOfDay from 'date-fns/endOfDay'
 
 import { StockCreationBodyModel, StockEditionBodyModel } from 'apiClient/v1'
@@ -41,11 +40,25 @@ export const buildDateTime = (date: string, time: string) => {
   if (!isDateValid(date) || hours === undefined || minutes === undefined) {
     throw Error('La date ou l’heure est invalide')
   }
+  const [year, month, day] = date.split('-')
 
-  return set(new Date(date), {
-    hours: parseInt(hours),
-    minutes: parseInt(minutes),
-  })
+  // previously method with :
+  // set(new Date(date), {
+  //   hours: parseInt(hours),
+  //   minutes: parseInt(minutes),
+  // })
+  // introduced a bug on western timezone,
+  // indeed new Date(date) return a date at 00h00 from user local timezone
+  // once set it was the day before
+
+  // new Date(year, month, day, hours, minutes)
+  return new Date(
+    parseInt(year),
+    parseInt(month) - 1,
+    parseInt(day),
+    parseInt(hours),
+    parseInt(minutes)
+  )
 }
 
 export const serializeBeginningDateTime = (
@@ -53,14 +66,16 @@ export const serializeBeginningDateTime = (
   beginningTime: string,
   departementCode: string
 ): string => {
-  const beginningDateTimeInDepartementTimezone = buildDateTime(
+  const beginningDateTimeInUserTimezone = buildDateTime(
     beginningDate,
     beginningTime
   )
+
   const beginningDateTimeInUTCTimezone = getUtcDateTimeFromLocalDepartement(
-    beginningDateTimeInDepartementTimezone,
+    beginningDateTimeInUserTimezone,
     departementCode
   )
+
   return toISOStringWithoutMilliseconds(beginningDateTimeInUTCTimezone)
 }
 

--- a/pro/src/screens/OfferIndividual/StocksEventEdition/adapters/serializers.ts
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/adapters/serializers.ts
@@ -42,15 +42,6 @@ export const buildDateTime = (date: string, time: string) => {
   }
   const [year, month, day] = date.split('-')
 
-  // previously method with :
-  // set(new Date(date), {
-  //   hours: parseInt(hours),
-  //   minutes: parseInt(minutes),
-  // })
-  // introduced a bug on western timezone,
-  // indeed new Date(date) return a date at 00h00 from user local timezone
-  // once set it was the day before
-
   // new Date(year, month, day, hours, minutes)
   return new Date(
     parseInt(year),


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23823

_ Fixer un bug sur l'enregistrement pour les timzone à l'ouest, la date était fixée un jour avant

Pour tous les fuseaux à l'ouest une journée était décrémentée 
on faisait un new Date('2023-11-12') interprété par Date comme une date à minuit -> avec le décalage horaire elle était fixé à un jour avant
en envoyant tous les paramètres new Date(year, month, day) -> new Date nous renvoit bien le jour qu'on veut

pour tester : mettre sa machine sur un fuseau horaire en moins une ou plus d'heure, essayer de modifier un stock event, la date du jour ne change pas



_ onChange date de début : enlever une feature cassé (aucune idée de comment la réparer) 
en gros quand on tape 1, 2 ou 3 dans le champ date la date dans le event.target.value est les 01 02 ou 03 du mois,
il peut arriver (souvent) que cela fasse passer la date limite de réservation après la date de l'event et dans ce cas elle était ramenée au 01 / 02 ou 03 
sans que l'utilisateur ne s'en rende compte
-> on préfère enlever la feature qui n'apportait pas grand chose et laisser la main à l'utilisateur
le message d'erreur lui donnant l'indication nécessaire



## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques