### PR TITLE
(BSR)[API] fix: permissions can be missing

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -209,4 +209,10 @@ class BackOfficeUserProfile(Base, Model):
 
     @property
     def permissions(self) -> typing.Collection[Permissions]:
-        return [Permissions[perm.name] for role in self.roles for perm in role.permissions]
+        permissions_members = Permissions.__members__
+        return [
+            Permissions[perm.name]
+            for role in self.roles
+            for perm in role.permissions
+            if perm.name in permissions_members
+        ]


### PR DESCRIPTION
## But de la pull request

Ceci évite les erreurs quand on bisect car le role en bdd n'existe pas dans notre enum

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques