### PR TITLE
(PC-23798)[API] fix: id check status in stepper

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -534,7 +534,7 @@ class BeneficiaryFraudCheck(PcObject, Base, Model):
         nullable=True,
     )
     resultContent: sa.orm.Mapped[dict | None] = sa.Column(sa.dialects.postgresql.JSONB(none_as_null=True))
-    status = sa.Column(sa.Enum(FraudCheckStatus, create_constraint=False), nullable=True)
+    status: FraudCheckStatus = sa.Column(sa.Enum(FraudCheckStatus, create_constraint=False), nullable=True)
     thirdPartyId: str = sa.Column(sa.TEXT(), index=True, nullable=False)
     type: FraudCheckType = sa.Column(sa.Enum(FraudCheckType, create_constraint=False), nullable=False)
     updatedAt: datetime.datetime = sa.Column(

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -319,10 +319,9 @@ def get_relevant_identity_fraud_check(
 def get_identity_check_subscription_item(
     user: users_models.User, eligibility: users_models.EligibilityType | None
 ) -> models.SubscriptionItem:
-    user_subscription_state = get_user_subscription_state(user)
-    return models.SubscriptionItem(
-        type=models.SubscriptionStep.IDENTITY_CHECK, status=user_subscription_state.fraud_status
-    )
+    id_check = get_relevant_identity_fraud_check(user, eligibility)
+    status = get_identity_check_fraud_status(user, eligibility, id_check)
+    return models.SubscriptionItem(type=models.SubscriptionStep.IDENTITY_CHECK, status=status)
 
 
 def get_honor_statement_subscription_item(

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/public_accounts/registration_steps.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/public_accounts/registration_steps.html
@@ -141,19 +141,19 @@
         {% endif %}
         <div class="icon-container position-absolute">
           {% if status_text == 'ok' %}
-            <i class="bi bi-check-circle-fill text-success me-5 fs-4"
+            <i class="bi bi-check-circle-fill text-success me-5 fs-4 pc-test-step-status"
                title="{{ status_text }}"></i>
           {% elif status_text == 'ko' %}
-            <i class="bi bi-exclamation-circle-fill text-danger me-5 fs-4"
+            <i class="bi bi-exclamation-circle-fill text-danger me-5 fs-4 pc-test-step-status"
                title="{{ status_text }}"></i>
           {% elif status_text == 'error' %}
-            <i class="bi bi-x-circle-fill text-danger me-5 fs-4"
+            <i class="bi bi-x-circle-fill text-danger me-5 fs-4 pc-test-step-status"
                title="{{ status_text }}"></i>
           {% elif status_text == 'canceled' %}
-            <i class="bi bi-trash3-fill text-danger me-5 fs-4"
+            <i class="bi bi-trash3-fill text-danger me-5 fs-4 pc-test-step-status"
                title="{{ status_text }}"></i>
           {% else %}
-            <i class="bi bi-exclamation-circle-fill text-warning me-5 fs-4"
+            <i class="bi bi-exclamation-circle-fill text-warning me-5 fs-4 pc-test-step-status"
                title="{{ status_text }}"></i>
           {% endif %}
         </div>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23798

Use `id_check.status` instead of `fraud_check.status` for stepper.

**avant**

![image](https://github.com/pass-culture/pass-culture-main/assets/77674046/209ffb49-614e-4721-aa99-82d19e415cb6)

**apres**

![image](https://github.com/pass-culture/pass-culture-main/assets/77674046/8350ad48-f592-4426-8802-87f664b8d545)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques