### PR TITLE
(PC-23844)[PRO] fix: MultiSelectAutocomplete stack trace

### DIFF
--- a/pro/src/ui-kit/form/MultiSelectAutoComplete/MultiSelectAutocomplete.tsx
+++ b/pro/src/ui-kit/form/MultiSelectAutoComplete/MultiSelectAutocomplete.tsx
@@ -77,10 +77,13 @@ const MultiSelectAutocomplete = ({
   }, [containerRef])
 
   useEffect(() => {
-    const regExp = new RegExp(searchField.value, 'i')
     setFilteredOptions(
       options.filter(
-        option => searchField.value === '' || option.label.match(regExp)
+        option =>
+          searchField.value === '' ||
+          option.label
+            .toLocaleLowerCase()
+            .includes(searchField.value.toLocaleLowerCase())
       )
     )
   }, [searchField.value])


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23844

- Corriger le problème affichant une Stack Trace à l'utilisateur si celui-ci écris un caractère qui spécial utilisé par les regex.

Le problème à été corrigé pour le le SelectAutocomplete avec ce ticket PC-23636.
En revanche, il a été déplacé sur le MultiSelectAutocomplete.


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques