### PR TITLE
(PC-23883)[API] chore: Remove blurry_video from FraudReasonCodes

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -60,7 +60,6 @@ class FraudReasonCode(enum.Enum):
     # Specific to Ubble
     # Ubble native errors
     BLURRY_DOCUMENT_VIDEO = "blurry_video"
-    BLURRY_VIDEO = "blurry_video"
     DOCUMENT_DAMAGED = "document_damaged"
     ELIGIBILITY_CHANGED = "eligibility_changed"  # The user's eligibility detected by ubble is different from the eligibility declared by the user
     ID_CHECK_BLOCKED_OTHER = (

--- a/api/src/pcapi/core/fraud/ubble/constants.py
+++ b/api/src/pcapi/core/fraud/ubble/constants.py
@@ -4,7 +4,6 @@ from pcapi.core.fraud import models as fraud_models
 RESTARTABLE_FRAUD_CHECK_REASON_CODES = (
     # Reasons which allow user to retry ubble identification
     fraud_models.FraudReasonCode.BLURRY_DOCUMENT_VIDEO,
-    fraud_models.FraudReasonCode.BLURRY_VIDEO,
     fraud_models.FraudReasonCode.DOCUMENT_DAMAGED,
     fraud_models.FraudReasonCode.ID_CHECK_BLOCKED_OTHER,
     fraud_models.FraudReasonCode.ID_CHECK_EXPIRED,
@@ -19,7 +18,6 @@ RESTARTABLE_FRAUD_CHECK_REASON_CODES = (
 REASON_CODE_REQUIRING_EMAIL_UPDATE = (
     # Reasons which require an email to user when occuring
     fraud_models.FraudReasonCode.BLURRY_DOCUMENT_VIDEO,
-    fraud_models.FraudReasonCode.BLURRY_VIDEO,
     fraud_models.FraudReasonCode.DOCUMENT_DAMAGED,
     fraud_models.FraudReasonCode.ID_CHECK_BLOCKED_OTHER,
     fraud_models.FraudReasonCode.ID_CHECK_DATA_MATCH,

--- a/api/src/pcapi/core/subscription/ubble/models.py
+++ b/api/src/pcapi/core/subscription/ubble/models.py
@@ -35,14 +35,6 @@ UBBLE_CODE_ERROR_MAPPING = {
         retryable_user_message="Nous n'arrivons pas à lire ton document, les vidéos transmises sont floues. Réessaie la vérification d’identité en t’assurant de la netteté lors de l’envoi.",
         priority=30,
     ),
-    fraud_models.FraudReasonCode.BLURRY_VIDEO: UbbleError(
-        detail_message="La vidéo est floue",
-        not_retryable_user_message="Nous n'arrivons pas à lire ton document, les vidéos transmises sont floues. Rends-toi sur le site demarches-simplifiees.fr pour renouveler ta demande.",
-        retryable_action_hint="Réessaie avec ta pièce d'identité en t'assurant qu'elle soit lisible",
-        retryable_message_summary=f"Le document que tu as présenté est illisible{u_nbsp}: les vidéos sont floues.",
-        retryable_user_message="Nous n'arrivons pas à lire ton document, les vidéos transmises sont floues. Réessaie la vérification d’identité en t’assurant de la netteté lors de l’envoi.",
-        priority=30,
-    ),
     fraud_models.FraudReasonCode.DOCUMENT_DAMAGED: UbbleError(
         detail_message="Le document est endommagé",
         not_retryable_user_message="Nous n'arrivons pas à lire ton document. Rends-toi sur le site demarches-simplifiees.fr pour renouveler ta demande.",

--- a/api/src/pcapi/routes/internal/e2e_ubble.py
+++ b/api/src/pcapi/routes/internal/e2e_ubble.py
@@ -18,7 +18,7 @@ from pcapi.serialization.decorator import spectree_serialize
 
 class UbbleError(enum.Enum):
     NETWORK_CONNECTION_ISSUE = 1201
-    BLURRY_VIDEO = 1310
+    BLURRY_DOCUMENT_VIDEO = 1301
     LACK_OF_LUMINOSITY = 1320
     ID_CHECK_EXPIRED = 2101
     ID_CHECK_NOT_SUPPORTED = 2102

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1687,7 +1687,7 @@ def test_public_api(client):
                 },
                 "UbbleError": {
                     "description": "An enumeration.",
-                    "enum": [1201, 1310, 1320, 2101, 2102, 2103, 2201],
+                    "enum": [1201, 1301, 1320, 2101, 2102, 2103, 2201],
                     "title": "UbbleError",
                 },
                 "UpdateEmailTokenExpiration": {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23883

Supprimer `BLURRY_VIDEO` qui est maintenant remplacé par `BLURRY_DOCUMENT_VIDEO` suite à l'exécution du [script de transition](https://github.com/pass-culture/pass-culture-main/pull/7756).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques