### PR TITLE
(BSR)[API] test: Get rid of pytest_flask_sqlalchemy

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -174,7 +174,6 @@ python_files = ["*test.py", "test*.py"]
 python_classes = ["*Test"]
 python_functions = ["test_*", "when_*", "expect_*", "should_*"]
 env_files = ["local_test_env_file"]
-mocked-sessions = ["pcapi.models.db.session"]
 junit_family = "xunit1"
 markers = [
     "backoffice_v3"

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -51,7 +51,6 @@ pysaml2
 pytest
 pytest-cov
 pytest-flask
-pytest-flask-sqlalchemy
 pytest-mock
 pytest-dotenv
 pytest-socket

--- a/api/src/pcapi/core/testing.py
+++ b/api/src/pcapi/core/testing.py
@@ -17,7 +17,6 @@ import sqlalchemy.engine
 import sqlalchemy.event
 import sqlalchemy.orm
 
-from pcapi import models
 from pcapi import settings
 from pcapi.models import db
 from pcapi.models.feature import Feature
@@ -31,57 +30,8 @@ AUTHENTICATION_QUERIES = 2
 class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         abstract = True
-        # See comment in _save()
-        # sqlalchemy_session = pcapi.models.db.session
-        sqlalchemy_session = "ignored"  # see hack in `_save()`
-        sqlalchemy_session_persistence = "commit"
-
-    @classmethod
-    def _save(
-        cls,
-        model_class: typing.Type[models.Model],
-        session: typing.Any,
-        *args: typing.Any,
-        **kwargs: typing.Any,
-    ) -> models.Model:
-        # FIXME (dbaty, 2020-10-20): pytest-flask-sqlalchemy mocks
-        # (replaces) `db.session` to remove the session and rollback
-        # changes at the end of each test function (see `_session()`
-        # fixture in pytest-flask-sqlalchemy). As such, the session
-        # that is used in tests is not the session we defined in
-        # `Meta.sqlalchemy_session` above. Because of this, data added
-        # through a factory is not rollback'ed. To work around this,
-        # here is a hack.
-        # This issue is discussed here: https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/12
-        session = db.session
-
-        known_fields = {
-            prop.key
-            for prop in sqlalchemy.orm.class_mapper(model_class).iterate_properties
-            if isinstance(prop, (sqlalchemy.orm.ColumnProperty, sqlalchemy.orm.RelationshipProperty))
-        }
-        unknown_fields = set(kwargs.keys()) - known_fields
-        if unknown_fields:
-            raise ValueError(
-                f"{cls.__name__} received unexpected argument(s): "
-                f"{', '.join(sorted(unknown_fields))}. "
-                f"Possible arguments are: {', '.join(sorted(known_fields))}"
-            )
-
-        return super()._save(model_class, session, *args, **kwargs)
-
-    @classmethod
-    def _get_or_create(
-        cls,
-        model_class: typing.Type[models.Model],
-        session: typing.Any,
-        *args: typing.Any,
-        **kwargs: typing.Any,
-    ) -> models.Model:
-        # See comment in _save for the reason why we inject the
-        # session like this.
-        session = db.session
-        return super()._get_or_create(model_class, session, *args, **kwargs)
+        sqlalchemy_session = db.session
+        sqlalchemy_session_persistence = "flush"
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
pytest-flask-sqlalchemy mocks too much. It adds savepoints that are
not there when running the code outside tests. Because of these extra
savepoints, rollbacks performed by the implementation act differently
when tests are run. Finally, pytest-flask-sqlalchemy does not play
well with factory-boy.

Instead, we define a simple "db_session" fixture that holds everything
within a transaction, which is rolled back after each test. Nothing is
mocked.