### PR TITLE
(PC-23858)[PRO] hide all participants checkbox in bookable offer

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
@@ -16,13 +16,14 @@ import useParticipantsOptions from './useParticipantsOptions'
 const FormParticipants = ({
   disableForm,
   offerStock,
+  isTemplate,
 }: {
   disableForm: boolean
   offerStock?: GetCollectiveOfferCollectiveStockResponseModel | null
+  isTemplate: boolean
 }): JSX.Element => {
   const { values, setFieldValue } =
     useFormikContext<OfferEducationalFormValues>()
-
   const isCLG6Active = useActiveFeature('WIP_ADD_CLG_6_5_COLLECTIVE_OFFER')
   const isBeforeSeptembre1st =
     offerStock?.beginningDatetime &&
@@ -32,7 +33,8 @@ const FormParticipants = ({
     )
   const defaultPartipantsOptions = useParticipantsOptions(
     values.participants,
-    setFieldValue
+    setFieldValue,
+    isTemplate
   )
   const filteredParticipantsOptions =
     isCLG6Active && !isBeforeSeptembre1st

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
@@ -25,7 +25,8 @@ const filteredParticipants = Object.values(StudentLevels).filter(
 const renderFormParticipants = (
   participants: Record<string, boolean>,
   storeOverride?: Partial<RootState>,
-  offerStock?: GetCollectiveOfferCollectiveStockResponseModel | null
+  offerStock?: GetCollectiveOfferCollectiveStockResponseModel | null,
+  isTemplate: boolean = true
 ) => {
   const storeOverrides = {
     features: {
@@ -41,7 +42,11 @@ const renderFormParticipants = (
   }
   return renderWithProviders(
     <Formik initialValues={{ participants }} onSubmit={() => {}}>
-      <FormParticipants disableForm={false} offerStock={offerStock} />
+      <FormParticipants
+        disableForm={false}
+        offerStock={offerStock}
+        isTemplate={isTemplate}
+      />
     </Formik>,
     { storeOverrides }
   )
@@ -229,5 +234,23 @@ describe('FormParticipants', () => {
         screen.queryByLabelText(StudentLevels.COLL_GE_5E)
       ).not.toBeInTheDocument()
     })
+  })
+
+  it('should not display the all participants option when the collective offer is bookable', () => {
+    const storeOverride = {
+      features: {
+        initialized: true,
+        list: [
+          {
+            isActive: true,
+            nameKey: 'WIP_ADD_CLG_6_5_COLLECTIVE_OFFER',
+          } as FeatureResponseModel,
+        ],
+      },
+    }
+    const offerStock = collectiveStockFactory()
+    renderFormParticipants(participants, storeOverride, offerStock, false)
+
+    expect(screen.queryByLabelText(ALL_STUDENTS_LABEL)).not.toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/useParticipantsOptions.ts
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/useParticipantsOptions.ts
@@ -19,8 +19,11 @@ const useParticipantsOptions = (
     field: string,
     value: any,
     shouldValidate?: boolean | undefined
-  ) => void
+  ) => void,
+  isTemplate: boolean = false
 ) => {
+  const canToggleAllParticipants = isTemplate
+
   const handleParticipantsAllChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -39,16 +42,21 @@ const useParticipantsOptions = (
   const handleParticipantsChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    if (!event.target.checked) {
+    if (!event.target.checked && canToggleAllParticipants) {
       setFieldValue('participants.all', false)
     }
   }
+
   return [
-    {
-      label: ALL_STUDENTS_LABEL,
-      name: 'participants.all',
-      onChange: handleParticipantsAllChange,
-    },
+    ...(canToggleAllParticipants
+      ? [
+          {
+            label: ALL_STUDENTS_LABEL,
+            name: 'participants.all',
+            onChange: handleParticipantsAllChange,
+          },
+        ]
+      : []),
     ...Object.values(StudentLevels).map(studentLevel => ({
       label: getStudentLevelLabel(studentLevel),
       name: `participants.${studentLevel}`,

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -187,6 +187,7 @@ const OfferEducationalForm = ({
           <FormParticipants
             disableForm={mode === Mode.READ_ONLY}
             offerStock={isCollectiveOffer(offer) ? offer.collectiveStock : null}
+            isTemplate={isTemplate}
           />
           <FormAccessibility disableForm={mode === Mode.READ_ONLY} />
           <FormContact disableForm={mode === Mode.READ_ONLY} />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23858

Pour reproduire : 
- Créer une offre collective réservable -> la checkbox "Tous les niveaux" ne devrait pas apparaître
- La checkbox devrait toujours apparaître sur les offres vitrines


<img width="490" alt="Capture d’écran 2023-08-17 à 17 00 47" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/1635935c-6120-43d1-be6f-bd8af25f3da9">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques