### PR TITLE
(PC-23311)[PRO] fix: ui returns and add display all members button

### DIFF
--- a/pro/src/pages/Offerers/Offerer/OffererDetails/AttachmentInvitations/AttachmentInvitations.module.scss
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/AttachmentInvitations/AttachmentInvitations.module.scss
@@ -11,7 +11,7 @@
     @include fonts.title4;
 
     border-bottom: thin solid colors.$grey-medium;
-    margin: rem.torem(12px) 0 rem.torem(32px) 0;
+    margin: rem.torem(12px) 0 rem.torem(16px) 0;
     padding-bottom: rem.torem(8px);
 
     .main-list-title-text {
@@ -22,11 +22,11 @@
   .subtitle {
     @include fonts.button;
 
-    margin-bottom: rem.torem(16px);
+    margin-bottom: rem.torem(8px);
   }
 
   .description {
-    margin-bottom: rem.torem(16px);
+    margin-bottom: rem.torem(24px);
   }
 
   .invitation-form {
@@ -51,9 +51,12 @@
     margin-bottom: rem.torem(24px);
   }
 
+  .members-container {
+    margin-bottom: rem.torem(24px);
+  }
+
   .members-list {
     width: 100%;
-    margin-bottom: rem.torem(16px);
 
     th {
       @include fonts.caption;
@@ -66,9 +69,16 @@
     td {
       @include fonts.body;
 
-      padding-bottom: rem.torem(12px);
       vertical-align: middle;
       text-align: left;
     }
+
+    tr:not(:last-child) td {
+      padding-bottom: rem.torem(12px);
+    }
   }
+}
+
+.display-all-members-button {
+  margin-top: rem.torem(20px);
 }

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/AttachmentInvitations/AttachmentInvitations.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/AttachmentInvitations/AttachmentInvitations.tsx
@@ -6,6 +6,8 @@ import { api } from 'apiClient/api'
 import { GetOffererMemberResponseModel } from 'apiClient/v1'
 import FormLayout from 'components/FormLayout/FormLayout'
 import useNotification from 'hooks/useNotification'
+import fullDownIcon from 'icons/full-down.svg'
+import fullUpIcon from 'icons/full-up.svg'
 import { Button, SubmitButton } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import EmailSpellCheckInput from 'ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput'
@@ -25,6 +27,7 @@ const AttachmentInvitations = ({ offererId }: AttachmentInvitationsProps) => {
   const location = useLocation()
   const notify = useNotification()
   const [isLoading, setIsLoading] = useState(false)
+  const [displayAllMembers, setDisplayAllMembers] = useState(false)
   const [members, setMembers] = useState<Array<GetOffererMemberResponseModel>>(
     []
   )
@@ -79,22 +82,39 @@ const AttachmentInvitations = ({ offererId }: AttachmentInvitationsProps) => {
       </div>
 
       {!!members && (
-        <table className={styles['members-list']}>
-          <thead>
-            <tr>
-              <th scope="col">Email</th>
-              <th scope="col">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {members.map(({ email }) => (
-              <tr key={email}>
-                <td>{email}</td>
-                <td>Validé (à récupérer du back)</td>
+        <div className={styles['members-container']}>
+          <table className={styles['members-list']}>
+            <thead>
+              <tr>
+                <th scope="col">Email</th>
+                <th scope="col">Statut</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {members.map(
+                ({ email }, index) =>
+                  !(!displayAllMembers && index > 4) && (
+                    <tr key={email}>
+                      <td>{email}</td>
+                      <td>Validé (à récupérer du back)</td>
+                    </tr>
+                  )
+              )}
+            </tbody>
+          </table>
+          {members.length > 5 && (
+            <Button
+              onClick={() => setDisplayAllMembers(!displayAllMembers)}
+              variant={ButtonVariant.TERNARY}
+              icon={displayAllMembers ? fullUpIcon : fullDownIcon}
+              className={styles['display-all-members-button']}
+            >
+              {displayAllMembers
+                ? 'Voir moins de collaborateurs'
+                : 'Voir plus de collaborateurs'}
+            </Button>
+          )}
+        </div>
       )}
 
       {!showInvitationForm ? (


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23311

Il faut le FF **`WIP_ENABLE_NEW_USER_OFFERER_LINK`**

    Status -> Statut

    Espacement entre le séparateur de la section et “email” : 24px → 16px

    Espacement entre titre “Ajout de collaborateurs” et texte : 16px → 8px

    Espacement entre texte “Vous pouvez ajouter…” et composant Adresse email : 16px → 24px

    Plus de 5 lignes de collaborateurs → le CTA “Voir plus” n’apparait pas


![Capture d’écran du 2023-08-17 17-04-59](https://github.com/pass-culture/pass-culture-main/assets/106379750/17e43a26-c949-4402-8de0-76ab5aa93939)
![Capture d’écran du 2023-08-17 17-04-42](https://github.com/pass-culture/pass-culture-main/assets/106379750/f94d7a10-a61d-4ed0-b06e-b580a63f8fa2)
![Capture d’écran du 2023-08-17 17-04-17](https://github.com/pass-culture/pass-culture-main/assets/106379750/80cd7f17-99ce-43ce-9d32-2369ad8cbe31)
![Capture d’écran du 2023-08-17 17-03-39](https://github.com/pass-culture/pass-culture-main/assets/106379750/985c7feb-d019-4cac-b922-512ee26d86d6)


## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ X] J'ai ajouté des screenshots pour d'éventuels changements graphiques