### PR TITLE
(PC-23524)[API] feat: Cinema Syncho use str as return type for get film id from uuid insted of int

### DIFF
--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -28,7 +28,7 @@ def get_shows_stock(venue_id: int, shows_id: list[int]) -> dict[int, int]:
     return client.get_shows_remaining_places(shows_id)
 
 
-def get_movie_stocks(venue_id: int, movie_id: int) -> dict[int, int]:
+def get_movie_stocks(venue_id: int, movie_id: str) -> dict[int, int]:
     client = _get_external_bookings_client_api(venue_id)
     return client.get_film_showtimes_stocks(movie_id)
 

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -63,8 +63,8 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
     def get_shows_remaining_places(self, shows_id: list[int]) -> dict[int, int]:  # type: ignore [empty-body]
         pass
 
-    def get_film_showtimes_stocks(self, film_id: int) -> dict[int, int]:
-        showtimes = self.get_showtimes(film=film_id)
+    def get_film_showtimes_stocks(self, film_id: str) -> dict[int, int]:
+        showtimes = self.get_showtimes(film=int(film_id))
         return {showtime.id: showtime.numberSeatsRemaining for showtime in showtimes}
 
     def cancel_booking(self, barcodes: list[str]) -> None:

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -35,7 +35,7 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
         self.account_id = account_id
         super()
 
-    def get_film_showtimes_stocks(self, film_id: int) -> dict[int, int]:  # type: ignore [empty-body]
+    def get_film_showtimes_stocks(self, film_id: str) -> dict[int, int]:  # type: ignore [empty-body]
         pass
 
     @lru_cache

--- a/api/src/pcapi/core/external_bookings/cgr/client.py
+++ b/api/src/pcapi/core/external_bookings/cgr/client.py
@@ -25,8 +25,8 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
         response = get_seances_pass_culture(self.cgr_cinema_details)
         return response.ObjetRetour.Films
 
-    def get_film_showtimes_stocks(self, film_id: int) -> dict[int, int]:
-        response = get_seances_pass_culture(self.cgr_cinema_details, allocine_film_id=film_id)
+    def get_film_showtimes_stocks(self, film_id: str) -> dict[int, int]:
+        response = get_seances_pass_culture(self.cgr_cinema_details, allocine_film_id=int(film_id))
         return {show.IDSeance: show.NbPlacesRestantes for show in response.ObjetRetour.Films[0].Seances}
 
     def book_ticket(

--- a/api/src/pcapi/core/external_bookings/ems/client.py
+++ b/api/src/pcapi/core/external_bookings/ems/client.py
@@ -39,8 +39,8 @@ class EMSClientAPI(external_bookings_models.ExternalBookingsClientAPI):
     def get_shows_remaining_places(self, shows_id: list[int]) -> dict[int, int]:
         raise NotImplementedError()
 
-    def get_film_showtimes_stocks(self, film_id: int) -> dict[int, int]:
-        payload = ems_serializers.AvailableShowsRequest(num_cine=self.cinema_id, id_film=str(film_id))
+    def get_film_showtimes_stocks(self, film_id: str) -> dict[int, int]:
+        payload = ems_serializers.AvailableShowsRequest(num_cine=self.cinema_id, id_film=film_id)
         response = self.connector.do_request(self.connector.shows_availability_endpoint, payload.dict())
         self.connector.raise_for_status(response)
 

--- a/api/src/pcapi/core/external_bookings/models.py
+++ b/api/src/pcapi/core/external_bookings/models.py
@@ -27,7 +27,7 @@ class ExternalBookingsClientAPI:
     def get_shows_remaining_places(self, shows_id: list[int]) -> dict[int, int]:
         raise NotImplementedError("Should be implemented in subclass (abstract method)")
 
-    def get_film_showtimes_stocks(self, film_id: int) -> dict[int, int]:
+    def get_film_showtimes_stocks(self, film_id: str) -> dict[int, int]:
         raise NotImplementedError("Should be implemented in subclass (abstract method)")
 
     def cancel_booking(self, barcodes: list[str]) -> None:

--- a/api/src/pcapi/utils/cinema_providers.py
+++ b/api/src/pcapi/utils/cinema_providers.py
@@ -63,13 +63,13 @@ def get_showtime_id_from_uuid(stock_uuid: str | None, provider_name: str) -> int
             return None
 
 
-def get_boost_or_cgr_or_ems_film_id_from_uuid(offer_uuid: str | None) -> int | None:
+def get_boost_or_cgr_or_ems_film_id_from_uuid(offer_uuid: str | None) -> str | None:
     """
     Parses the uuid with this pattern: uuid pattern: <film_id>%<venue.id>%<Boost|CGR|EMS>
     and returns the film_id as int, or None if it cannot
     """
     if offer_uuid:
         match = re_search(r"(.*?)%", offer_uuid)
-        if match and match.group(1).isdigit():
-            return int(match.group(1))
+        if match and match.group(1).isalnum():
+            return match.group(1)
     return None

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2210,7 +2210,7 @@ class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
             provider=venue_provider.provider,
             idAtProvider=venue_provider.venueIdAtOfferProvider,
         )
-        movie_id = 523
+        movie_id = "52F3G"
         offer_id_at_provider = f"{movie_id}%{venue_provider.venueId}%EMS"
         offer = factories.EventOfferFactory(
             venue=venue_provider.venue, idAtProvider=offer_id_at_provider, lastProviderId=ems_provider.id

--- a/api/tests/utils/cinema_providers_test.py
+++ b/api/tests/utils/cinema_providers_test.py
@@ -77,11 +77,12 @@ def test_get_showtime_id_from_uuid(stock_uuid, provider_name, result):
 @pytest.mark.parametrize(
     "offer_uuid,result",
     [
-        ("123%45%Boost", 123),
-        ("369%45%CGR", 369),
+        ("123%45%Boost", "123"),
+        ("369%45%CGR", "369"),
+        ("X8OSR%1097%EMS", "X8OSR"),
         ("123445+43423", None),
         (None, None),
-        ("movie_id%%venue_id%Boost", None),
+        ("%venue_id%Boost", None),
     ],
 )
 def test_get_boost_film_id_from_uuid(offer_uuid, result):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23524

Utiliser `str` pour  `film_id` récupérer à partir de `Offer.idAtProvider` pour supporter les ids alphanumériques.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques