### PR TITLE
Pc 23953 add test for desk invalidate button

### DIFF
--- a/pro/src/components/Dialog/ConfirmDialog/__specs__/ConfirmDialog.spec.tsx
+++ b/pro/src/components/Dialog/ConfirmDialog/__specs__/ConfirmDialog.spec.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import ConfirmDialog from '..'
+
+describe('ConfirmDialog', () => {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+
+  it('should call onConfirm on confirm button click', async () => {
+    render(
+      <ConfirmDialog
+        title="Dialog"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        confirmText="Valider"
+        cancelText="Annuler"
+      />
+    )
+
+    await userEvent.click(screen.getByText('Valider'))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onCancel on cancel button click', async () => {
+    render(
+      <ConfirmDialog
+        title="Dialog"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        confirmText="Valider"
+        cancelText="Annuler"
+      />
+    )
+
+    await userEvent.click(screen.getByText('Annuler'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/pro/src/screens/Desk/ButtonInvalidateToken/__specs__/ButtonInvalidateToken.spec.tsx
+++ b/pro/src/screens/Desk/ButtonInvalidateToken/__specs__/ButtonInvalidateToken.spec.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { ButtonInvalidateToken } from '..'
+
+describe('ButtonInvalidateToken', () => {
+  it('should open modal on invalidate button click', async () => {
+    render(<ButtonInvalidateToken onConfirm={vi.fn()} />)
+
+    await userEvent.click(screen.getByText('Invalider la contremarque'))
+
+    expect(
+      screen.getByText('Voulez-vous vraiment invalider cette contremarque ?')
+    ).toBeInTheDocument()
+  })
+
+  it('should close Dialog on cancel button click', async () => {
+    render(<ButtonInvalidateToken onConfirm={vi.fn()} />)
+
+    await userEvent.click(screen.getByText('Invalider la contremarque'))
+    await userEvent.click(screen.getByText('Annuler'))
+
+    expect(
+      screen.queryByText('Voulez-vous vraiment invalider cette contremarque ?')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should close Dialog on confirm button click', async () => {
+    render(<ButtonInvalidateToken onConfirm={vi.fn()} />)
+
+    await userEvent.click(screen.getByText('Invalider la contremarque'))
+    await userEvent.click(screen.getByText('Continuer'))
+
+    expect(
+      screen.queryByText('Voulez-vous vraiment invalider cette contremarque ?')
+    ).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23953

Ajouter les tests pour le bouton Invalider la contremarque de la page Guichet. 

![Capture d’écran 2023-08-21 à 12 22 47](https://github.com/pass-culture/pass-culture-main/assets/71768799/5dd01033-6a14-4402-857f-2c44109d06a0)
