### PR TITLE
(PC-23956)[API] fix: venue name and siret should not be editable from pro account

### DIFF
--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -73,14 +73,17 @@ def check_venue_edition(modifications: dict[str, typing.Any], venue: models.Venu
 
     if managing_offerer_id:
         raise ApiErrors(errors={"managingOffererId": ["Vous ne pouvez pas changer la structure d'un lieu"]})
-    if siret and venue.siret and siret != venue.siret:
+    # modifications.get("siret") may be False if there is no change (ok) OR if it has been cleared (forbidden!)
+    if "siret" in modifications and venue.siret and siret != venue.siret:
         raise ApiErrors(errors={"siret": ["Vous ne pouvez pas modifier le siret d'un lieu"]})
     if siret:
         venue_with_same_siret = models.Venue.query.filter_by(siret=siret).one_or_none()
         if venue_with_same_siret:
             raise ApiErrors(errors={"siret": ["Un lieu avec le même siret existe déjà"]})
+    if "name" in modifications and modifications["name"] != venue.name:
+        raise ApiErrors(errors={"name": ["Vous ne pouvez pas modifier la raison sociale d'un lieu"]})
     if not venue.isVirtual and None in venue_disability_compliance and None in modifications_disability_compliance:
-        raise ApiErrors(errors={"global": ["L'accessibilité du lieu doit etre définie."]})
+        raise ApiErrors(errors={"global": ["L'accessibilité du lieu doit être définie."]})
 
     if reimbursement_point_id:
         check_venue_can_be_linked_to_reimbursement_point(venue, reimbursement_point_id)

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -48,7 +48,7 @@ class Returns200Test:
         # when
         venue_data = populate_missing_data_from_venue(
             {
-                "name": "Ma librairie",
+                "publicName": "Ma librairie",
                 "venueTypeCode": "BOOKSTORE",
                 "venueLabelId": venue_label.id,
             },
@@ -60,7 +60,7 @@ class Returns200Test:
         # then
         assert response.status_code == 200
         venue = offerers_models.Venue.query.get(venue_id)
-        assert venue.name == "Ma librairie"
+        assert venue.publicName == "Ma librairie"
         assert venue.venueTypeCode == offerers_models.VenueTypeCode.BOOKSTORE
         assert len(external_testing.sendinblue_requests) == 1
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
@@ -76,7 +76,7 @@ class Returns200Test:
 
         venue_data = populate_missing_data_from_venue(
             {
-                "name": "new name",
+                "publicName": "new public name",
                 "bookingEmail": "no.update@email.com",
                 "isEmailAppliedOnAllOffers": False,
             },
@@ -90,7 +90,7 @@ class Returns200Test:
 
         venue_data = populate_missing_data_from_venue(
             {
-                "name": "new name",
+                "publicName": "new public name",
                 "bookingEmail": "new.venue@email.com",
                 "isEmailAppliedOnAllOffers": True,
             },
@@ -131,7 +131,7 @@ class Returns200Test:
 
         venue_data = populate_missing_data_from_venue(
             {
-                "name": "new name",
+                "publicName": "new public name",
                 "withdrawalDetails": "Ceci est un texte de modalités de retrait",
                 "isWithdrawalAppliedOnAllOffers": True,
                 "shouldSendMail": True,
@@ -164,7 +164,7 @@ class Returns200Test:
 
         venue_data = populate_missing_data_from_venue(
             {
-                "name": "new name",
+                "publicName": "new public name",
                 "withdrawalDetails": "Ceci est un texte de modalités de retrait",
                 "isWithdrawalAppliedOnAllOffers": True,
                 "shouldSendMail": False,
@@ -194,7 +194,7 @@ class Returns200Test:
 
         venue_data = populate_missing_data_from_venue(
             {
-                "name": "new name",
+                "publicName": "new public name",
                 "audioDisabilityCompliant": True,
                 "isAccessibilityAppliedOnAllOffers": True,
             },
@@ -218,7 +218,7 @@ class Returns200Test:
 
         assert len(venue.action_history) == 1
         update_snapshot = venue.action_history[0].extraData["modified_info"]
-        assert update_snapshot["name"]["new_info"] == venue_data["name"]
+        assert update_snapshot["publicName"]["new_info"] == venue_data["publicName"]
 
     def when_siret_does_not_change(self, app) -> None:
         # Given


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-23956

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques