### PR TITLE
(PC-23845)[API] fix: Return only name and siren when create offerer

### DIFF
--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -129,12 +129,12 @@ def delete_api_key(api_key_prefix: str) -> None:
 @private_api.route("/offerers", methods=["POST"])
 @login_required
 @spectree_serialize(
-    on_success_status=201, response_model=offerers_serialize.GetOffererResponseModel, api=blueprint.pro_private_schema
+    on_success_status=201, response_model=offerers_serialize.PostOffererResponseModel, api=blueprint.pro_private_schema
 )
-def create_offerer(body: offerers_serialize.CreateOffererQueryModel) -> offerers_serialize.GetOffererResponseModel:
+def create_offerer(body: offerers_serialize.CreateOffererQueryModel) -> offerers_serialize.PostOffererResponseModel:
     user_offerer = api.create_offerer(current_user, body)
 
-    return offerers_serialize.GetOffererResponseModel.from_orm(user_offerer.offerer)
+    return offerers_serialize.PostOffererResponseModel.from_orm(user_offerer.offerer)
 
 
 @private_api.route("/offerers/<int:offerer_id>/eac-eligibility", methods=["GET"])

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -67,6 +67,15 @@ class OffererApiKey(BaseModel):
     prefixes: list[str]
 
 
+class PostOffererResponseModel(BaseModel):
+    name: str
+    id: int
+    siren: str
+
+    class Config:
+        orm_mode = True
+
+
 class GetOffererResponseModel(BaseModel):
     address: str | None
     apiKey: OffererApiKey

--- a/api/tests/routes/pro/post_offerer_test.py
+++ b/api/tests/routes/pro/post_offerer_test.py
@@ -34,9 +34,31 @@ def test_create_virtual_venue(client):
     assert response.status_code == 201
     assert response.json["siren"] == "418166096"
     assert response.json["name"] == "Test Offerer"
-    virtual_venues = list(filter(lambda v: v["isVirtual"], response.json["managedVenues"]))
+    virtual_venues = offerers_models.Venue.query.filter(offerers_models.Venue.isVirtual == True).all()
     assert len(virtual_venues) == 1
     assert len(users_testing.sendinblue_requests) == 1
+
+
+def test_returned_data(client):
+    pro = users_factories.ProFactory()
+
+    body = {
+        "name": "Test Offerer",
+        "siren": "418166096",
+        "address": "123 rue de Paris",
+        "postalCode": "93100",
+        "city": "Montreuil",
+    }
+
+    client = client.with_session_auth(pro.email)
+    response = client.post("/offerers", json=body)
+
+    created_offerer = offerers_models.Offerer.query.one()
+    assert response.json == {
+        "id": created_offerer.id,
+        "siren": "418166096",
+        "name": "Test Offerer",
+    }
 
 
 def test_when_no_address_is_provided(client):

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -154,6 +154,7 @@ export { PhoneValidationStatusType } from './models/PhoneValidationStatusType';
 export type { PostCollectiveOfferBodyModel } from './models/PostCollectiveOfferBodyModel';
 export type { PostCollectiveOfferTemplateBodyModel } from './models/PostCollectiveOfferTemplateBodyModel';
 export type { PostOfferBodyModel } from './models/PostOfferBodyModel';
+export type { PostOffererResponseModel } from './models/PostOffererResponseModel';
 export type { PostVenueBodyModel } from './models/PostVenueBodyModel';
 export type { PostVenueProviderBody } from './models/PostVenueProviderBody';
 export type { PriceCategoryBody } from './models/PriceCategoryBody';

--- a/pro/src/apiClient/v1/models/PostOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/PostOffererResponseModel.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type PostOffererResponseModel = {
+  id: number;
+  name: string;
+  siren: string;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -71,6 +71,7 @@ import type { PatchOfferPublishBodyModel } from '../models/PatchOfferPublishBody
 import type { PostCollectiveOfferBodyModel } from '../models/PostCollectiveOfferBodyModel';
 import type { PostCollectiveOfferTemplateBodyModel } from '../models/PostCollectiveOfferTemplateBodyModel';
 import type { PostOfferBodyModel } from '../models/PostOfferBodyModel';
+import type { PostOffererResponseModel } from '../models/PostOffererResponseModel';
 import type { PostVenueBodyModel } from '../models/PostVenueBodyModel';
 import type { PostVenueProviderBody } from '../models/PostVenueProviderBody';
 import type { PriceCategoryBody } from '../models/PriceCategoryBody';
@@ -996,12 +997,12 @@ export class DefaultService {
   /**
    * create_offerer <POST>
    * @param requestBody
-   * @returns GetOffererResponseModel Created
+   * @returns PostOffererResponseModel Created
    * @throws ApiError
    */
   public createOfferer(
     requestBody?: CreateOffererQueryModel,
-  ): CancelablePromise<GetOffererResponseModel> {
+  ): CancelablePromise<PostOffererResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
       url: '/offerers',

--- a/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.tsx
+++ b/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import { ApiError, GetOffererResponseModel } from 'apiClient/v1'
+import { ApiError, PostOffererResponseModel } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import Notification from 'components/Notification/Notification'
@@ -90,7 +90,7 @@ describe('src | components | OffererCreation', () => {
     })
     const offerer = {
       id: 1,
-    } as GetOffererResponseModel
+    } as PostOffererResponseModel
     vi.spyOn(api, 'createOfferer').mockResolvedValue(offerer)
 
     renderOffererCreation({})


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23845

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques