### PR TITLE
(PC-23782)[PRO] fix: add scroll and focus to first error in signup

### DIFF
--- a/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { BannerRGS } from 'components/Banner'
 import FormLayout from 'components/FormLayout'
 import LegalInfos from 'components/LegalInfos/LegalInfos'
+import { useScrollToFirstErrorAfterSubmit } from 'hooks'
 import CookiesFooter from 'pages/CookiesFooter/CookiesFooter'
 import MaybeAppUserDialog from 'pages/Signup/SignupContainer/MaybeAppUserDialog'
 import {
@@ -22,6 +23,7 @@ import styles from './SignupContainer.module.scss'
 import { SignupFormValues } from './types'
 
 const SignupForm = (): JSX.Element => {
+  useScrollToFirstErrorAfterSubmit()
   const navigate = useNavigate()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { isSubmitting } = useFormikContext<SignupFormValues>()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23782

Nous avions oublié d'ajouter le hook à la page d'inscription pour focus l'utilisateur sur le premier champ avec une erreur.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques