### PR TITLE
(PC-23759)[PRO] open dialog modals within screen

### DIFF
--- a/pro/src/components/AdageButtonFilter/AdageButtonFilter.tsx
+++ b/pro/src/components/AdageButtonFilter/AdageButtonFilter.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import fullDownIcon from 'icons/full-down.svg'
 import fullUpIcon from 'icons/full-up.svg'
@@ -29,7 +29,27 @@ const AdageButtonFilter = ({
   filterName,
   handleSubmit,
 }: AdageButtonFilterProps): JSX.Element => {
+  const [dialogLeftOffset, setDialogLeftOffset] = useState(0)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const dialogRef = useRef<HTMLDialogElement | null>(null)
+
+  useEffect(() => {
+    const containerElm = containerRef.current
+    const dialogElm = dialogRef.current
+
+    //  Only reposition when opening the dialog
+    if (!isOpen || !containerElm || !dialogElm) {
+      return
+    }
+
+    //  Part of the dialog width that goes beyond the body width on the right
+    const dialogOutOfScreenDistance =
+      containerElm.getBoundingClientRect().left +
+      dialogElm.getBoundingClientRect().width -
+      document.body.clientWidth
+
+    setDialogLeftOffset(Math.max(dialogOutOfScreenDistance, 0))
+  }, [isOpen])
 
   const handleClickOutside = useCallback(
     (e: MouseEvent): void => {
@@ -85,7 +105,12 @@ const AdageButtonFilter = ({
       </button>
 
       <div className={styles['adage-button-modal']}>
-        <dialog open={isOpen} className={styles['adage-button-children']}>
+        <dialog
+          open={isOpen}
+          className={styles['adage-button-children']}
+          style={{ left: `${-dialogLeftOffset}px` }}
+          ref={dialogRef}
+        >
           {children}
         </dialog>
       </div>

--- a/pro/src/components/AdageButtonFilter/__specs__/AdageButtonFilter.spec.tsx
+++ b/pro/src/components/AdageButtonFilter/__specs__/AdageButtonFilter.spec.tsx
@@ -117,4 +117,14 @@ describe('AdageButtonFilter', () => {
       })
     ).toBeInTheDocument()
   })
+
+  it('should not display the dialog when the button modal was not opened or was closed', async () => {
+    renderAdageButtonFilter({
+      ...props,
+      children: <div>Test adagebuttonfilter</div>,
+      isOpen: false,
+    })
+
+    expect(screen.getByRole('dialog', { hidden: true })).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23759

Affichage des dialogs en décalé pour rentrer à 100% dans l'écran. Par ex ici le dropdown lié au bouton Catégorie ne s'ouvre pas aligné à gauche du bouton mais décalé pour entrer à 100% dans la largeur du document.

<img width="1169" alt="Capture d’écran 2023-08-22 à 14 53 28" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/94022e20-ef0a-466d-bcba-db7a02384e2c">

A noter :
- On utilise la largeur du document et pas de la window parce qu'on est dans une iframe sur ADAGE
- J'ai choisi d'utiliser un state de décalage qui re-render le component quand la modal s'ouvre (donc double render à chaque ouverture), plutôt que mettre à jour l'attribut HTML de la modal directement dans le useEffect. Je trouve ça plus dans la logique React mais je peux me tromper.

Pour reproduire : 
- Activer le FF "WIP_ENABLE_NEW_ADAGE_FILTERS"
- Commenter le "max-width: 80%" dans OfferFilters.module.scss pour que les dialogs s'ouvrent sur la droite de l'écran
- Ouvrir le dialog du bouton de filtre le plus à droite


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques