### PR TITLE
(PC-23774)[API] feat: public api: cancel collective booking

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-72fa9c444b5a (pre) (head)
+1112f930c271 (pre) (head)
 f891eee42f86 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230822T181748_1112f930c271_add_new_value_to_collectivebookingcancellationreasons_enum.py
+++ b/api/src/pcapi/alembic/versions/20230822T181748_1112f930c271_add_new_value_to_collectivebookingcancellationreasons_enum.py
@@ -1,0 +1,20 @@
+"""
+add new value to CollectiveBookingCancellationReasons enum
+"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "1112f930c271"
+down_revision = "72fa9c444b5a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE bookingcancellationreasons ADD VALUE IF NOT EXISTS 'PUBLIC_API'")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -385,9 +385,10 @@ def _cancel_collective_booking_by_offerer(
     return booking_to_cancel
 
 
-def cancel_collective_booking_by_id_from_support(
+def cancel_collective_booking(
     collective_booking: educational_models.CollectiveBooking,
     reason: educational_models.CollectiveBookingCancellationReasons,
+    _from: str | None = None,
 ) -> None:
     with transaction():
         educational_repository.get_and_lock_collective_stock(stock_id=collective_booking.collectiveStock.id)
@@ -413,7 +414,9 @@ def cancel_collective_booking_by_id_from_support(
         db.session.commit()
     search.async_index_collective_offer_ids([collective_booking.collectiveStock.collectiveOfferId])
     logger.info(
-        "CollectiveBooking has been cancelled by support",
+        "CollectiveBooking has been cancelled by %s %s",
+        reason.value.lower(),
+        f"from {_from}" if _from else "",
         extra={
             "collective_booking": collective_booking.id,
             "reason": str(educational_models.CollectiveBookingCancellationReasons.OFFERER),
@@ -421,7 +424,7 @@ def cancel_collective_booking_by_id_from_support(
     )
 
 
-def uncancel_collective_booking_by_id_from_support(
+def uncancel_collective_booking(
     collective_booking: educational_models.CollectiveBooking,
 ) -> None:
     with transaction():

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -67,6 +67,7 @@ class CollectiveBookingCancellationReasons(enum.Enum):
     FRAUD = "FRAUD"
     REFUSED_BY_INSTITUTE = "REFUSED_BY_INSTITUTE"
     REFUSED_BY_HEADMASTER = "REFUSED_BY_HEADMASTER"
+    PUBLIC_API = "PUBLIC_API"
 
 
 class Ministry(enum.Enum):

--- a/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
@@ -233,7 +233,7 @@ def mark_booking_as_used(collective_booking_id: int) -> utils.BackofficeResponse
         return _redirect_after_collective_booking_action()
 
     try:
-        educational_api_booking.uncancel_collective_booking_by_id_from_support(collective_booking)
+        educational_api_booking.uncancel_collective_booking(collective_booking)
     except Exception as exc:  # pylint: disable=broad-except
         flash(f"Une erreur s'est produite : {str(exc)}", "warning")
     else:
@@ -253,8 +253,10 @@ def mark_booking_as_cancelled(collective_booking_id: int) -> utils.BackofficeRes
         return _redirect_after_collective_booking_action()
 
     try:
-        educational_api_booking.cancel_collective_booking_by_id_from_support(
-            collective_booking, educational_models.CollectiveBookingCancellationReasons(form.reason.data)
+        educational_api_booking.cancel_collective_booking(
+            collective_booking,
+            educational_models.CollectiveBookingCancellationReasons(form.reason.data),
+            _from="support",
         )
     except educational_exceptions.CollectiveBookingAlreadyCancelled:
         flash("Impossible d'annuler une réservation déjà annulée", "warning")

--- a/api/tests/routes/public/blueprint_v2_openapi_test.py
+++ b/api/tests/routes/public/blueprint_v2_openapi_test.py
@@ -185,7 +185,7 @@ def test_public_api(client, app):
                         "email": {"title": "Email", "type": "string"},
                         "formula": {
                             "allOf": [{"$ref": "#/components/schemas/BookingFormula"}],
-                            "description": "S'applique uniquement aux offres de cat\u00e9gorie Cin\u00e9ma. Abonnement (ABO) ou place (PLACE).",
+                            "description": "S'applique uniquement aux offres de catégorie Cinéma. Abonnement (ABO) ou place (PLACE).",
                             "nullable": True,
                         },
                         "isUsed": {"title": "Isused", "type": "boolean"},
@@ -198,7 +198,7 @@ def test_public_api(client, app):
                         "publicOfferId": {"title": "Publicofferid", "type": "string"},
                         "quantity": {"title": "Quantity", "type": "integer"},
                         "theater": {
-                            "description": "Identifiant du film et de la salle dans le cas d\u2019une offre synchronis\u00e9e par Allocin\u00e9.",
+                            "description": "Identifiant du film et de la salle dans le cas d’une offre synchronisée par Allociné.",
                             "example": {"film_id": "...", "salle_id": "..."},
                             "title": "Theater",
                             "type": "object",
@@ -598,7 +598,7 @@ def test_public_api(client, app):
                 "VenuePhysicalLocation": {
                     "properties": {
                         "address": {
-                            "example": "55 rue du Faubourg-Saint-Honor\u00e9",
+                            "example": "55 rue du Faubourg-Saint-Honoré",
                             "nullable": True,
                             "title": "Address",
                             "type": "string",
@@ -616,11 +616,7 @@ def test_public_api(client, app):
                         "activityDomain": {"$ref": "#/components/schemas/VenueTypeEnum"},
                         "createdDatetime": {"format": "date-time", "title": "Createddatetime", "type": "string"},
                         "id": {"title": "Id", "type": "integer"},
-                        "legalName": {
-                            "example": "Palais de l'\u00c9lys\u00e9e",
-                            "title": "Legalname",
-                            "type": "string",
-                        },
+                        "legalName": {"example": "Palais de l'Élysée", "title": "Legalname", "type": "string"},
                         "location": {
                             "description": "Location where the offers will be available or will take place. There is exactly one digital venue per offerer, which is listed although its id is not required to create a digital offer (see DigitalLocation model).",
                             "discriminator": {
@@ -638,7 +634,7 @@ def test_public_api(client, app):
                         },
                         "publicName": {
                             "description": "If null, legalName is used.",
-                            "example": "\u00c9lys\u00e9e",
+                            "example": "Élysée",
                             "nullable": True,
                             "title": "Publicname",
                             "type": "string",
@@ -709,7 +705,7 @@ def test_public_api(client, app):
         "paths": {
             "/v2/bookings/cancel/token/{token}": {
                 "patch": {
-                    "description": "Bien que, dans le cas d\u2019un \u00e9v\u00e8nement, l\u2019utilisateur ne peut plus annuler sa r\u00e9servation 72h avant le d\u00e9but de ce dernier, cette API permet d\u2019annuler la r\u00e9servation d\u2019un utilisateur si elle n\u2019a pas encore \u00e9t\u00e9 valid\u00e9.",
+                    "description": "Bien que, dans le cas d’un évènement, l’utilisateur ne peut plus annuler sa réservation 72h avant le début de ce dernier, cette API permet d’annuler la réservation d’un utilisateur si elle n’a pas encore été validé.",
                     "operationId": "PatchCancelBookingByToken",
                     "parameters": [
                         {
@@ -721,13 +717,13 @@ def test_public_api(client, app):
                         }
                     ],
                     "responses": {
-                        "204": {"description": "La contremarque a \u00e9t\u00e9 annul\u00e9e avec succ\u00e8s"},
-                        "401": {"description": "Authentification n\u00e9cessaire"},
+                        "204": {"description": "La contremarque a été annulée avec succès"},
+                        "401": {"description": "Authentification nécessaire"},
                         "403": {
-                            "description": "Vous n'avez pas les droits n\u00e9cessaires pour annuler cette contremarque ou la r\u00e9servation a d\u00e9j\u00e0 \u00e9t\u00e9 valid\u00e9e"
+                            "description": "Vous n'avez pas les droits nécessaires pour annuler cette contremarque ou la réservation a déjà été validée"
                         },
                         "404": {"description": "La contremarque n'existe pas"},
-                        "410": {"description": "La contremarque a d\u00e9j\u00e0 \u00e9t\u00e9 annul\u00e9e"},
+                        "410": {"description": "La contremarque a déjà été annulée"},
                         "422": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
@@ -736,7 +732,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
-                    "summary": "Annulation d'une r\u00e9servation.",
+                    "summary": "Annulation d'une réservation.",
                     "tags": ["API Contremarque"],
                 }
             },
@@ -754,16 +750,12 @@ def test_public_api(client, app):
                         }
                     ],
                     "responses": {
-                        "204": {
-                            "description": "L'annulation de la validation de la contremarque a bien \u00e9t\u00e9 effectu\u00e9e"
-                        },
-                        "401": {"description": "Authentification n\u00e9cessaire"},
-                        "403": {
-                            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette contremarque"
-                        },
+                        "204": {"description": "L'annulation de la validation de la contremarque a bien été effectuée"},
+                        "401": {"description": "Authentification nécessaire"},
+                        "403": {"description": "Vous n'avez pas les droits nécessaires pour voir cette contremarque"},
                         "404": {"description": "La contremarque n'existe pas"},
                         "410": {
-                            "description": "La requ\u00eate est refus\u00e9e car la contremarque n'a pas encore \u00e9t\u00e9 valid\u00e9e, a \u00e9t\u00e9 annul\u00e9e, ou son remboursement a \u00e9t\u00e9 initi\u00e9"
+                            "description": "La requête est refusée car la contremarque n'a pas encore été validée, a été annulée, ou son remboursement a été initié"
                         },
                         "422": {
                             "content": {
@@ -773,13 +765,13 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
-                    "summary": "Annulation de la validation d'une r\u00e9servation.",
+                    "summary": "Annulation de la validation d'une réservation.",
                     "tags": ["API Contremarque"],
                 }
             },
             "/v2/bookings/token/{token}": {
                 "get": {
-                    "description": "Le code \u201ccontremarque\u201d ou \"token\" est une cha\u00eene de caract\u00e8res permettant d\u2019identifier la r\u00e9servation et qui sert de preuve de r\u00e9servation. Ce code unique est g\u00e9n\u00e9r\u00e9 pour chaque r\u00e9servation d'un utilisateur sur l'application et lui est transmis \u00e0 cette occasion.",
+                    "description": "Le code “contremarque” ou \"token\" est une chaîne de caractères permettant d’identifier la réservation et qui sert de preuve de réservation. Ce code unique est généré pour chaque réservation d'un utilisateur sur l'application et lui est transmis à cette occasion.",
                     "operationId": "GetBookingByTokenV2",
                     "parameters": [
                         {
@@ -795,15 +787,13 @@ def test_public_api(client, app):
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/GetBookingResponse"}}
                             },
-                            "description": "La contremarque existe et n\u2019est pas valid\u00e9e",
+                            "description": "La contremarque existe et n’est pas validée",
                         },
-                        "401": {"description": "Authentification n\u00e9cessaire"},
-                        "403": {
-                            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette contremarque"
-                        },
+                        "401": {"description": "Authentification nécessaire"},
+                        "403": {"description": "Vous n'avez pas les droits nécessaires pour voir cette contremarque"},
                         "404": {"description": "La contremarque n'existe pas"},
                         "410": {
-                            "description": "Cette contremarque a \u00e9t\u00e9 valid\u00e9e.\n En l\u2019invalidant vous indiquez qu\u2019elle n\u2019a pas \u00e9t\u00e9 utilis\u00e9e et vous ne serez pas rembours\u00e9."
+                            "description": "Cette contremarque a été validée.\n En l’invalidant vous indiquez qu’elle n’a pas été utilisée et vous ne serez pas remboursé."
                         },
                         "422": {
                             "content": {
@@ -813,13 +803,13 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
-                    "summary": "Consultation d'une r\u00e9servation.",
+                    "summary": "Consultation d'une réservation.",
                     "tags": ["API Contremarque"],
                 }
             },
             "/v2/bookings/use/token/{token}": {
                 "patch": {
-                    "description": "Pour confirmer que la r\u00e9servation a bien \u00e9t\u00e9 utilis\u00e9e par le jeune.",
+                    "description": "Pour confirmer que la réservation a bien été utilisée par le jeune.",
                     "operationId": "PatchBookingUseByToken",
                     "parameters": [
                         {
@@ -831,14 +821,12 @@ def test_public_api(client, app):
                         }
                     ],
                     "responses": {
-                        "204": {"description": "La contremarque a bien \u00e9t\u00e9 valid\u00e9e"},
-                        "401": {"description": "Authentification n\u00e9cessaire"},
-                        "403": {
-                            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette contremarque"
-                        },
+                        "204": {"description": "La contremarque a bien été validée"},
+                        "401": {"description": "Authentification nécessaire"},
+                        "403": {"description": "Vous n'avez pas les droits nécessaires pour voir cette contremarque"},
                         "404": {"description": "La contremarque n'existe pas"},
                         "410": {
-                            "description": "Cette contremarque a \u00e9t\u00e9 valid\u00e9e.\n En l\u2019invalidant vous indiquez qu\u2019elle n\u2019a pas \u00e9t\u00e9 utilis\u00e9e et vous ne serez pas rembours\u00e9."
+                            "description": "Cette contremarque a été validée.\n En l’invalidant vous indiquez qu’elle n’a pas été utilisée et vous ne serez pas remboursé."
                         },
                         "422": {
                             "content": {
@@ -848,7 +836,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
-                    "summary": "Validation d'une r\u00e9servation.",
+                    "summary": "Validation d'une réservation.",
                     "tags": ["API Contremarque"],
                 }
             },
@@ -872,13 +860,13 @@ def test_public_api(client, app):
                                     "schema": {"$ref": "#/components/schemas/CollectiveBookingResponseModel"}
                                 }
                             },
-                            "description": "Les informations d'une r\u00e9servation collective",
+                            "description": "Les informations d'une réservation collective",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "422": {
                             "content": {
@@ -888,9 +876,40 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cup\u00e9ration les informations d'une r\u00e9servation collective",
+                    "summary": "Récupération les informations d'une réservation collective",
                     "tags": ["API offres collectives"],
-                }
+                },
+                "patch": {
+                    "description": "",
+                    "operationId": "CancelCollectiveBooking",
+                    "parameters": [
+                        {
+                            "description": "",
+                            "in": "path",
+                            "name": "booking_id",
+                            "required": True,
+                            "schema": {"format": "int32", "type": "integer"},
+                        }
+                    ],
+                    "responses": {
+                        "204": {"description": "Annuler une réservation collective"},
+                        "401": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
+                            },
+                            "description": "Authentification nécessaire",
+                        },
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable Entity",
+                        },
+                    },
+                    "security": [{"ApiKeyAuth": []}],
+                    "summary": "Annuler une réservation collective",
+                    "tags": ["API offres collectives"],
+                },
             },
             "/v2/collective/categories": {
                 "get": {
@@ -906,13 +925,13 @@ def test_public_api(client, app):
                                     }
                                 }
                             },
-                            "description": "La liste des cat\u00e9gories \u00e9ligibles existantes.",
+                            "description": "La liste des catégories éligibles existantes.",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "422": {
                             "content": {
@@ -922,7 +941,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cup\u00e9ration de la liste des cat\u00e9gories d'offres propos\u00e9es.",
+                    "summary": "Récupération de la liste des catégories d'offres proposées.",
                     "tags": ["API offres collectives"],
                 }
             },
@@ -938,13 +957,13 @@ def test_public_api(client, app):
                                     "schema": {"$ref": "#/components/schemas/CollectiveOffersListDomainsResponseModel"}
                                 }
                             },
-                            "description": "La liste des domaines d'\u00e9ducation.",
+                            "description": "La liste des domaines d'éducation.",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "422": {
                             "content": {
@@ -954,7 +973,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cup\u00e9ration de la liste des domaines d'\u00e9ducation pouvant \u00eatre associ\u00e9s aux offres collectives.",
+                    "summary": "Récupération de la liste des domaines d'éducation pouvant être associés aux offres collectives.",
                     "tags": ["API offres collectives"],
                 }
             },
@@ -1022,19 +1041,19 @@ def test_public_api(client, app):
                                     }
                                 }
                             },
-                            "description": "La liste des \u00e9tablissement scolaires \u00e9ligibles.",
+                            "description": "La liste des établissement scolaires éligibles.",
                         },
                         "400": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Requ\u00eate malform\u00e9e",
+                            "description": "Requête malformée",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "422": {
                             "content": {
@@ -1044,7 +1063,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cup\u00e9ration de la liste \u00e9tablissements scolaires.",
+                    "summary": "Récupération de la liste établissements scolaires.",
                     "tags": ["API offres collectives"],
                 }
             },
@@ -1095,13 +1114,13 @@ def test_public_api(client, app):
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "403": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette offre collective",
+                            "description": "Vous n'avez pas les droits nécessaires pour voir cette offre collective",
                         },
                         "404": {
                             "content": {
@@ -1117,7 +1136,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cuperation de l'offre collective avec l'identifiant offer_id. Cette api ignore les offre vitrines et les offres commenc\u00e9es sur l'interface web et non finalis\u00e9es.",
+                    "summary": "Récuperation de l'offre collective avec l'identifiant offer_id. Cette api ignore les offre vitrines et les offres commencées sur l'interface web et non finalisées.",
                     "tags": ["API offres collectives"],
                 },
                 "post": {
@@ -1138,31 +1157,31 @@ def test_public_api(client, app):
                                     "schema": {"$ref": "#/components/schemas/GetPublicCollectiveOfferResponseModel"}
                                 }
                             },
-                            "description": "L'offre collective \u00e0 \u00e9t\u00e9 cr\u00e9\u00e9e avec succes",
+                            "description": "L'offre collective à été créée avec succes",
                         },
                         "400": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Requ\u00eate malform\u00e9e",
+                            "description": "Requête malformée",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "403": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Non \u00e9ligible pour les offres collectives",
+                            "description": "Non éligible pour les offres collectives",
                         },
                         "404": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "L'une des resources pour la cr\u00e9ation de l'offre n'a pas \u00e9t\u00e9 trouv\u00e9e",
+                            "description": "L'une des resources pour la création de l'offre n'a pas été trouvée",
                         },
                         "422": {
                             "content": {
@@ -1172,7 +1191,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "Cr\u00e9ation d'une offre collective.",
+                    "summary": "Création d'une offre collective.",
                     "tags": ["API offres collectives"],
                 },
             },
@@ -1202,13 +1221,13 @@ def test_public_api(client, app):
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "403": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette offre collective",
+                            "description": "Vous n'avez pas les droits nécessaires pour voir cette offre collective",
                         },
                         "404": {
                             "content": {
@@ -1224,7 +1243,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cuperation de l'offre collective avec l'identifiant offer_id.",
+                    "summary": "Récuperation de l'offre collective avec l'identifiant offer_id.",
                     "tags": ["API offres collectives"],
                 },
                 "patch": {
@@ -1253,41 +1272,41 @@ def test_public_api(client, app):
                                     "schema": {"$ref": "#/components/schemas/GetPublicCollectiveOfferResponseModel"}
                                 }
                             },
-                            "description": "L'offre collective \u00e0 \u00e9t\u00e9 \u00e9dit\u00e9 avec succes",
+                            "description": "L'offre collective à été édité avec succes",
                         },
                         "400": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Requ\u00eate malform\u00e9e",
+                            "description": "Requête malformée",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "403": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Vous n'avez pas les droits n\u00e9cessaires pour \u00e9diter cette offre collective",
+                            "description": "Vous n'avez pas les droits nécessaires pour éditer cette offre collective",
                         },
                         "404": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "L'une des resources pour la cr\u00e9ation de l'offre n'a pas \u00e9t\u00e9 trouv\u00e9e",
+                            "description": "L'une des resources pour la création de l'offre n'a pas été trouvée",
                         },
                         "422": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Cetains champs ne peuvent pas \u00eatre \u00e9dit\u00e9s selon l'\u00e9tat de l'offre",
+                            "description": "Cetains champs ne peuvent pas être édités selon l'état de l'offre",
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "\u00c9dition d'une offre collective.",
+                    "summary": "Édition d'une offre collective.",
                     "tags": ["API offres collectives"],
                 },
             },
@@ -1305,13 +1324,13 @@ def test_public_api(client, app):
                                     }
                                 }
                             },
-                            "description": "La liste des domaines d'\u00e9ducation.",
+                            "description": "La liste des domaines d'éducation.",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "422": {
                             "content": {
@@ -1321,7 +1340,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cup\u00e9ration de la liste des publics cibles pour lesquelles des offres collectives peuvent \u00eatre propos\u00e9es.",
+                    "summary": "Récupération de la liste des publics cibles pour lesquelles des offres collectives peuvent être proposées.",
                     "tags": ["API offres collectives"],
                 }
             },
@@ -1339,13 +1358,13 @@ def test_public_api(client, app):
                                     }
                                 }
                             },
-                            "description": "La liste des sous-cat\u00e9gories \u00e9ligibles existantes.",
+                            "description": "La liste des sous-catégories éligibles existantes.",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "422": {
                             "content": {
@@ -1355,13 +1374,13 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cup\u00e9ration de la liste des sous-cat\u00e9gories d'offres propos\u00e9es a un public collectif.",
+                    "summary": "Récupération de la liste des sous-catégories d'offres proposées a un public collectif.",
                     "tags": ["API offres collectives"],
                 }
             },
             "/v2/collective/venues": {
                 "get": {
-                    "description": "Tous les lieux enregistr\u00e9s, sont list\u00e9s ici avec leurs coordonn\u00e9es.",
+                    "description": "Tous les lieux enregistrés, sont listés ici avec leurs coordonnées.",
                     "operationId": "ListVenues",
                     "parameters": [],
                     "responses": {
@@ -1371,13 +1390,13 @@ def test_public_api(client, app):
                                     "schema": {"$ref": "#/components/schemas/CollectiveOffersListVenuesResponseModel"}
                                 }
                             },
-                            "description": "La liste des lieux ou vous pouvez cr\u00e9er une offre.",
+                            "description": "La liste des lieux ou vous pouvez créer une offre.",
                         },
                         "401": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification n\u00e9cessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "422": {
                             "content": {
@@ -1387,7 +1406,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "R\u00e9cup\u00e9ration de la liste des lieux associ\u00e9s au fournisseur authentifi\u00e9e par le jeton d'API.",
+                    "summary": "Récupération de la liste des lieux associés au fournisseur authentifiée par le jeton d'API.",
                     "tags": ["API offres collectives"],
                 }
             },

--- a/api/tests/routes/public/collective/endpoints/bookings_test.py
+++ b/api/tests/routes/public/collective/endpoints/bookings_test.py
@@ -1,9 +1,14 @@
+from datetime import datetime
+
 from flask import url_for
+from freezegun import freeze_time
 import pytest
 
 import pcapi.core.educational.factories as educational_factories
+import pcapi.core.educational.models as educational_models
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.providers.factories as providers_factories
+from pcapi.models import db
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -52,3 +57,49 @@ class GetCollectiveBookingTest:
         response = client.get(url_for("pro_public_api_v2.get_collective_booking", booking_id=booking.id))
 
         assert response.status_code == 404
+
+
+@pytest.fixture(name="venue")
+def venue_fixture():
+    vp = providers_factories.VenueProviderFactory(isActive=True)
+    offerers_factories.ApiKeyFactory(provider=vp.provider, offerer=vp.venue.managingOfferer)
+    return vp.venue
+
+
+class CancelCollectiveBookingTest:
+    @freeze_time("2023-01-01 10:00:00")
+    def test_cancel_collective_booking(self, client, venue):
+        booking = educational_factories.CollectiveBookingFactory(collectiveStock__collectiveOffer__venue=venue)
+
+        response = self._send_request(client, booking.id)
+        assert response.status_code == 204
+
+        db.session.refresh(booking)
+
+        assert booking.cancellationReason == educational_models.CollectiveBookingCancellationReasons.PUBLIC_API
+        assert booking.cancellationDate == datetime(2023, 1, 1, 10)
+        assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
+
+    def test_cannot_cancel_reimbursed_booking(self, client, venue):
+        booking = educational_factories.ReimbursedCollectiveBookingFactory(
+            collectiveStock__collectiveOffer__venue=venue
+        )
+
+        response = self._send_request(client, booking.id)
+        assert response.status_code == 403
+
+        db.session.refresh(booking)
+        assert booking.status == educational_models.CollectiveBookingStatus.REIMBURSED
+
+    def test_cannot_cancel_already_cancelled_booking(self, client, venue):
+        booking = educational_factories.CancelledCollectiveBookingFactory(collectiveStock__collectiveOffer__venue=venue)
+
+        response = self._send_request(client, booking.id)
+        assert response.status_code == 403
+
+        db.session.refresh(booking)
+        assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
+
+    def _send_request(self, client, booking_id: int):
+        client = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY)
+        return client.patch(url_for("pro_public_api_v2.cancel_collective_booking", booking_id=booking_id))

--- a/pro/src/apiClient/v1/models/CollectiveBookingCancellationReasons.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingCancellationReasons.ts
@@ -13,4 +13,5 @@ export enum CollectiveBookingCancellationReasons {
   FRAUD = 'FRAUD',
   REFUSED_BY_INSTITUTE = 'REFUSED_BY_INSTITUTE',
   REFUSED_BY_HEADMASTER = 'REFUSED_BY_HEADMASTER',
+  PUBLIC_API = 'PUBLIC_API',
 }

--- a/pro/src/apiClient/v2/services/ApiOffresCollectivesService.ts
+++ b/pro/src/apiClient/v2/services/ApiOffresCollectivesService.ts
@@ -45,6 +45,28 @@ export class ApiOffresCollectivesService {
   }
 
   /**
+   * Annuler une réservation collective
+   * @param bookingId
+   * @returns void
+   * @throws ApiError
+   */
+  public cancelCollectiveBooking(
+    bookingId: number,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'PATCH',
+      url: '/v2/collective/bookings/{booking_id}',
+      path: {
+        'booking_id': bookingId,
+      },
+      errors: {
+        401: `Authentification nécessaire`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
    * Récupération de la liste des catégories d'offres proposées.
    * @returns CollectiveOffersListCategoriesResponseModel La liste des catégories éligibles existantes.
    * @throws ApiError


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23774

Nouvelle route pour l'API publique collective : annuler une réservation collective.
La fonction chargée de l'annulation est celle qui a été développée pour le backoffice.

### Notes

Je me suis permis de renommer cette fonction puisqu'avec cette PR, celle-ci peut-être appelée par plusieurs types de clients (internes via le backoffice, ou externes via l'api publique).