### PR TITLE
(PC-24012)[PRO] fix: stock filtering by date in western timezone

### DIFF
--- a/pro/src/components/StocksEventList/stocksFiltering.ts
+++ b/pro/src/components/StocksEventList/stocksFiltering.ts
@@ -55,8 +55,9 @@ export const filterAndSortStocks = (
   const { dateFilter, hourFilter, priceCategoryFilter } = filters
   const filteredStocks = stocks.filter(stock => {
     const stockDate = new Date(stock.beginningDatetime)
+    const [year, month, day] = dateFilter.split('-')
+    const date = new Date(parseInt(year), parseInt(month) - 1, parseInt(day))
 
-    const date = new Date(dateFilter)
     if (isDateValid(date)) {
       const isSameDay =
         stockDate.getFullYear() === date.getFullYear() &&


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24012

même problème qu'avant, le new Date mettait la date un jour avant
fix en faisant new Date(year, month, day)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques