### PR TITLE
(PC-23978)[PRO] perf: Optimize performances for the normalization of …

### DIFF
--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -1,5 +1,5 @@
 import { FormikProvider, useFormik } from 'formik'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import {
   EducationalInstitutionResponseModel,
@@ -29,7 +29,11 @@ import { ButtonLink, SubmitButton } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import SelectAutocomplete from 'ui-kit/form/SelectAutoComplete/SelectAutocomplete'
 import Spinner from 'ui-kit/Spinner/Spinner'
-import { searchPatternInOptions } from 'utils/searchPatternInOptions'
+import {
+  normalizeStrForSearch,
+  searchPatternInOptions,
+  SelectOptionNormalized,
+} from 'utils/searchPatternInOptions'
 
 import getEducationalRedactorsAdapter from './adapters/getEducationalRedactorAdapter'
 import styles from './CollectiveOfferVisibility.module.scss'
@@ -54,7 +58,7 @@ export interface CollectiveOfferVisibilityProps {
   reloadCollectiveOffer?: () => void
   requestId?: string | null
 }
-interface InstitutionOption extends SelectOption {
+interface InstitutionOption extends SelectOptionNormalized {
   postalCode?: string
   city?: string
   name: string
@@ -87,22 +91,30 @@ const CollectiveOfferVisibility = ({
   const [requestInformations, setRequestInformations] =
     useState<GetCollectiveOfferRequestResponseModel | null>(null)
 
-  const institutionsOptions: InstitutionOption[] = institutions.map(
-    ({ name, id, city, postalCode, institutionType, institutionId }) => ({
-      label: formatInstitutionDisplayName({
-        name,
-        institutionType: institutionType || '',
-        institutionId,
-        city,
-        postalCode,
-      }),
-      value: String(id),
-      city,
-      postalCode,
-      name,
-      institutionType: institutionType ?? '',
-      institutionId: institutionId,
-    })
+  const institutionsOptions: InstitutionOption[] = useMemo(
+    () =>
+      institutions.map(
+        ({ name, id, city, postalCode, institutionType, institutionId }) => {
+          const label = formatInstitutionDisplayName({
+            name,
+            institutionType: institutionType || '',
+            institutionId,
+            city,
+            postalCode,
+          })
+          return {
+            label: label,
+            normalizedLabel: normalizeStrForSearch(label),
+            value: String(id),
+            city,
+            postalCode,
+            name,
+            institutionType: institutionType ?? '',
+            institutionId: institutionId,
+          }
+        }
+      ),
+    [institutions]
   )
 
   const getOfferRequestInformation = async () => {

--- a/pro/src/screens/OldCollectiveOfferVisibility/OldCollectiveOfferVisibility.tsx
+++ b/pro/src/screens/OldCollectiveOfferVisibility/OldCollectiveOfferVisibility.tsx
@@ -1,5 +1,5 @@
 import { FormikProvider, useFormik } from 'formik'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import {
   EducationalInstitutionResponseModel,
@@ -29,7 +29,11 @@ import RadioGroup from 'ui-kit/form/RadioGroup'
 import SelectAutocomplete from 'ui-kit/form/SelectAutoComplete/SelectAutocomplete'
 import { BaseRadioVariant } from 'ui-kit/form/shared/BaseRadio/types'
 import Spinner from 'ui-kit/Spinner/Spinner'
-import { searchPatternInOptions } from 'utils/searchPatternInOptions'
+import {
+  normalizeStrForSearch,
+  searchPatternInOptions,
+  SelectOptionNormalized,
+} from 'utils/searchPatternInOptions'
 
 import styles from './OldCollectiveOfferVisibility.module.scss'
 import validationSchema from './validationSchema'
@@ -53,7 +57,7 @@ export interface OldCollectiveOfferVisibilityProps {
   reloadCollectiveOffer?: () => void
   requestId?: string | null
 }
-interface InstitutionOption extends SelectOption {
+interface InstitutionOption extends SelectOptionNormalized {
   postalCode?: string
   city?: string
   name: string
@@ -141,18 +145,26 @@ const CollectiveOfferVisibility = ({
         teacher => teacher.value === formik.values.teacher
       ) ?? null
 
-  const institutionsOptions: InstitutionOption[] = institutions.map(
-    ({ name, id, city, postalCode, institutionType, institutionId }) => ({
-      label: `${
-        institutionType ?? ''
-      } ${name} - ${city} - ${institutionId}`.trim(),
-      value: String(id),
-      city,
-      postalCode,
-      name,
-      institutionType: institutionType ?? '',
-      institutionId: institutionId,
-    })
+  const institutionsOptions: InstitutionOption[] = useMemo(
+    () =>
+      institutions.map(
+        ({ name, id, city, postalCode, institutionType, institutionId }) => {
+          const label = `${
+            institutionType ?? ''
+          } ${name} - ${city} - ${institutionId}`
+          return {
+            label: label,
+            normalizedLabel: normalizeStrForSearch(label),
+            value: String(id),
+            city,
+            postalCode,
+            name,
+            institutionType: institutionType ?? '',
+            institutionId: institutionId,
+          }
+        }
+      ),
+    [institutions]
   )
 
   const selectedInstitution: InstitutionOption | null = requestId

--- a/pro/src/utils/searchPatternInOptions.ts
+++ b/pro/src/utils/searchPatternInOptions.ts
@@ -1,6 +1,8 @@
 import { SelectOption } from 'custom_types/form'
 
-const normalizeStr = (str: string): string => {
+export type SelectOptionNormalized = SelectOption & { normalizedLabel?: string }
+
+export const normalizeStrForSearch = (str: string): string => {
   return (
     str
       .trim()
@@ -13,17 +15,30 @@ const normalizeStr = (str: string): string => {
 }
 
 export const searchPatternInOptions = (
-  options: SelectOption[],
+  options: SelectOptionNormalized[],
   pattern: string,
   maxDisplayedCount?: number
-): SelectOption[] => {
-  //  Filter options containing all of the pattern words
-  const matchingOptions = options.filter(option => {
-    const normalizedOptionLabel = normalizeStr(option.label)
-    return normalizeStr(pattern || '')
+): SelectOptionNormalized[] => {
+  const matchingOptions: SelectOptionNormalized[] = []
+
+  for (let i = 0; i < options.length; i++) {
+    //  Only search for matches while there are less matches found than max expected results
+    if (maxDisplayedCount && matchingOptions.length >= maxDisplayedCount) {
+      break
+    }
+
+    const normalizedOptionLabel =
+      options[i].normalizedLabel ?? normalizeStrForSearch(options[i].label)
+
+    //  Look for options containing all of the pattern words
+    const isLabelMatchingPattern = normalizeStrForSearch(pattern || '')
       .split(' ')
       .every(word => normalizedOptionLabel.includes(word))
-  })
 
-  return matchingOptions.slice(0, maxDisplayedCount ?? options.length)
+    if (isLabelMatchingPattern) {
+      matchingOptions.push(options[i])
+    }
+  }
+
+  return matchingOptions
 }


### PR DESCRIPTION
…labels in the search function of SelectAutocomplete, and in the render cycle of CollectiveOfferVisibility.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23978

Optimisation de la recherche :
- Ne rechercher que jusqu'a ce qu'on ait au moins autant de résultats que la limite demandée
- Pré-calculer les labels des options en `normalizedLabel`
- Ne pré-calculer les labels que lorsque c'est nécessaire à l'aide de `useMemo`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques