### PR TITLE
(BSR)[PRO] fix: ternary button alignement

### DIFF
--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -4,6 +4,10 @@
 @use "styles/mixins/_a11y.scss" as a11y;
 @use "styles/variables/_size.scss" as size;
 
+.content {
+  display: flex;
+}
+
 .button {
   @include fonts.button;
 

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -25,7 +25,6 @@
     height: size.$button-icon-size;
     width: size.$button-icon-size;
     flex-shrink: 0;
-    margin-bottom: auto;
   }
 
   &.button-center {
@@ -137,6 +136,12 @@
       .button-icon {
         margin-right: 0;
       }
+    }
+  }
+
+  &-ternary {
+    .button-icon {
+      margin-bottom: auto;
     }
   }
 

--- a/pro/src/ui-kit/Button/Button.tsx
+++ b/pro/src/ui-kit/Button/Button.tsx
@@ -41,7 +41,7 @@ const Button = ({
     </div>
   )
   const content = (
-    <>
+    <div className={styles['content']}>
       {icon && !isLoading && iconPosition !== IconPositionEnum.RIGHT && (
         <SvgIcon
           src={icon}
@@ -81,7 +81,7 @@ const Button = ({
           width="20"
         />
       )}
-    </>
+    </div>
   )
 
   return (


### PR DESCRIPTION
## But de la pull request

### Bouton ternaire
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/b0bc2ac9-b4c2-4fb4-872c-ed3a50cda328)

### Autres

## Problèmes
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/04dc6eba-022e-45ae-a1b9-5c2d6b5944d8)
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/4ceefdc4-b026-47e7-be2d-e077ba52f83e)

## Résolutions
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/aafc3a8c-68ad-4804-85e4-308ee7206f21)
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/601d4aba-e9c9-4ff9-af63-99c521504bbe)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques