### PR TITLE
(PC-24056)[PRO] fix: timezone resrvations & Stocks limit date

### DIFF
--- a/pro/src/core/Bookings/utils.ts
+++ b/pro/src/core/Bookings/utils.ts
@@ -1,9 +1,5 @@
 import { DEFAULT_PRE_FILTERS } from 'core/Bookings/constants'
 import { APIFilters, PreFiltersParams } from 'core/Bookings/types'
-import {
-  FORMAT_ISO_DATE_ONLY,
-  formatBrowserTimezonedDateAsUTC,
-} from 'utils/date'
 
 export const buildBookingsRecapQuery = ({
   offerVenueId = DEFAULT_PRE_FILTERS.offerVenueId,
@@ -23,10 +19,7 @@ export const buildBookingsRecapQuery = ({
     params.offerType = offerType
   }
   if (offerEventDate !== DEFAULT_PRE_FILTERS.offerEventDate) {
-    params.eventDate = formatBrowserTimezonedDateAsUTC(
-      new Date(offerEventDate),
-      FORMAT_ISO_DATE_ONLY
-    )
+    params.eventDate = offerEventDate
   }
   if (bookingBeginningDate) {
     params.bookingPeriodBeginningDate = bookingBeginningDate

--- a/pro/src/screens/Bookings/Bookings.tsx
+++ b/pro/src/screens/Bookings/Bookings.tsx
@@ -31,10 +31,6 @@ import Spinner from 'ui-kit/Spinner/Spinner'
 import Tabs from 'ui-kit/Tabs'
 import Titles from 'ui-kit/Titles/Titles'
 
-import {
-  FORMAT_ISO_DATE_ONLY,
-  formatBrowserTimezonedDateAsUTC,
-} from '../../utils/date'
 import { stringify } from '../../utils/query-string'
 
 import BookingsRecapTable from './BookingsRecapTable'
@@ -139,9 +135,6 @@ const Bookings = <
     checkUserHasBookings()
   }, [checkUserHasBookings])
 
-  const dateFilterFormat = (date: Date | number) =>
-    formatBrowserTimezonedDateAsUTC(date, FORMAT_ISO_DATE_ONLY)
-
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -186,7 +179,7 @@ const Bookings = <
   const updateUrl = (filter: PreFiltersParams) => {
     const partialUrlInfo = {
       ...(filter.offerEventDate && filter.offerEventDate !== 'all'
-        ? { offerEventDate: dateFilterFormat(new Date(filter.offerEventDate)) }
+        ? { offerEventDate: filter.offerEventDate }
         : {}),
       ...(filter.bookingBeginningDate
         ? {
@@ -202,6 +195,7 @@ const Bookings = <
       ...(filter.offerType ? { offerType: filter.offerType } : {}),
       ...(filter.offerVenueId ? { offerVenueId: filter.offerVenueId } : {}),
     } as Partial<PreFiltersParams>
+
     setUrlParams({
       ...urlParams,
       ...partialUrlInfo,

--- a/pro/src/screens/OfferIndividual/StocksEventEdition/StockFormList/StockFormList.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/StockFormList/StockFormList.tsx
@@ -103,6 +103,14 @@ const StockFormList = ({
   const { page, setPage, previousPage, nextPage, currentPageItems, pageCount } =
     usePagination(values.stocks, STOCKS_PER_PAGE)
 
+  const computeMaxBookingLimitDatetime = (beginningDate: string) => {
+    const [year, month, day] = beginningDate.split('-')
+
+    return beginningDate !== ''
+      ? new Date(parseInt(year), parseInt(month) - 1, parseInt(day))
+      : undefined
+  }
+
   return (
     <FieldArray
       name="stocks"
@@ -406,11 +414,9 @@ const StockFormList = ({
                           label="Date limite de réservation"
                           isLabelHidden
                           minDate={today}
-                          maxDate={
-                            beginningDate !== ''
-                              ? new Date(beginningDate)
-                              : undefined
-                          }
+                          maxDate={computeMaxBookingLimitDatetime(
+                            beginningDate
+                          )}
                           disabled={readOnlyFields.includes(
                             'bookingLimitDatetime'
                           )}

--- a/pro/src/screens/OfferIndividual/StocksEventEdition/adapters/serializers.ts
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/adapters/serializers.ts
@@ -28,8 +28,9 @@ const serializeBookingLimitDatetime = (
       departementCode
     )
   }
+  const [year, month, day] = bookingLimitDatetime.split('-')
   const endOfBookingLimitDayUtcDatetime = getUtcDateTimeFromLocalDepartement(
-    endOfDay(new Date(bookingLimitDatetime)),
+    endOfDay(new Date(parseInt(year), parseInt(month) - 1, parseInt(day))),
     departementCode
   )
   return toISOStringWithoutMilliseconds(endOfBookingLimitDayUtcDatetime)

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -34,7 +34,7 @@ import fullCodeIcon from 'icons/full-code.svg'
 import fullTrashIcon from 'icons/full-trash.svg'
 import strokeEuroIcon from 'icons/stroke-euro.svg'
 import { Checkbox, DatePicker, InfoBox, TextInput } from 'ui-kit'
-import { getToday, isDateValid } from 'utils/date'
+import { getToday, getYearMonthDay, isDateValid } from 'utils/date'
 import { getLocalDepartementDateTimeFromUtc } from 'utils/timezone'
 
 import { ActionBar } from '../ActionBar'
@@ -361,13 +361,19 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
   const readOnlyFields = setFormReadOnlyFields(offer, formik.values)
   const showExpirationDate =
     formik.values.activationCodesExpirationDatetime !== ''
+
+  const [minExpirationYear, minExpirationMonth, minExpirationDay] =
+    getYearMonthDay(formik.values.bookingLimitDatetime)
+  const [maxDateTimeYear, maxDateTimeMonth, maxDateTimeDay] = getYearMonthDay(
+    formik.values.activationCodesExpirationDatetime
+  )
   const minExpirationDate = isDateValid(formik.values.bookingLimitDatetime)
-    ? new Date(formik.values.bookingLimitDatetime)
+    ? new Date(minExpirationYear, minExpirationMonth, minExpirationDay)
     : null
   const maxDateTime = isDateValid(
     formik.values.activationCodesExpirationDatetime
   )
-    ? new Date(formik.values.activationCodesExpirationDatetime)
+    ? new Date(maxDateTimeYear, maxDateTimeMonth, maxDateTimeDay)
     : undefined
 
   return (

--- a/pro/src/screens/OfferIndividual/StocksThing/adapters/serializers.ts
+++ b/pro/src/screens/OfferIndividual/StocksThing/adapters/serializers.ts
@@ -1,7 +1,11 @@
 import endOfDay from 'date-fns/endOfDay'
 
 import { StockCreationBodyModel, StockEditionBodyModel } from 'apiClient/v1'
-import { isDateValid, toISOStringWithoutMilliseconds } from 'utils/date'
+import {
+  getYearMonthDay,
+  isDateValid,
+  toISOStringWithoutMilliseconds,
+} from 'utils/date'
 import { getUtcDateTimeFromLocalDepartement } from 'utils/timezone'
 
 import { StockThingFormValues } from '../'
@@ -21,10 +25,20 @@ export const serializeStockThingList = (
   formValues: StockThingFormValues,
   departementCode: string
 ): StockCreationBodyModel[] | StockEditionBodyModel[] => {
+  const [
+    yearBookingLimitDatetime,
+    monthBookingLimitDatetime,
+    dayBookingLimitDatetime,
+  ] = getYearMonthDay(formValues.bookingLimitDatetime)
+
   const apiStock: StockCreationBodyModel = {
     bookingLimitDatetime: isDateValid(formValues.bookingLimitDatetime)
       ? serializeThingBookingLimitDatetime(
-          new Date(formValues.bookingLimitDatetime),
+          new Date(
+            yearBookingLimitDatetime,
+            monthBookingLimitDatetime,
+            dayBookingLimitDatetime
+          ),
           departementCode
         )
       : null,
@@ -38,9 +52,19 @@ export const serializeStockThingList = (
     apiStock.activationCodes = formValues.activationCodes
     /* istanbul ignore next */
     if (isDateValid(formValues.activationCodesExpirationDatetime)) {
+      const [
+        yearActivationCodesExpirationDatetime,
+        monthActivationCodesExpirationDatetime,
+        dayActivationCodesExpirationDatetime,
+      ] = getYearMonthDay(formValues.activationCodesExpirationDatetime)
+
       apiStock.activationCodesExpirationDatetime =
         serializeThingBookingLimitDatetime(
-          new Date(formValues.activationCodesExpirationDatetime),
+          new Date(
+            yearActivationCodesExpirationDatetime,
+            monthActivationCodesExpirationDatetime,
+            dayActivationCodesExpirationDatetime
+          ),
           departementCode
         )
     }

--- a/pro/src/utils/date.ts
+++ b/pro/src/utils/date.ts
@@ -51,3 +51,8 @@ export const getDateToFrenchText = (dateIsoString: string) => {
 export const toISOStringWithoutMilliseconds = (date: Date) => {
   return date.toISOString().replace(/\.\d{3}/, '')
 }
+
+export const getYearMonthDay = (date: string) => {
+  const [year, month, day] = date.split('-')
+  return [parseInt(year), parseInt(month) - 1, parseInt(day)]
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24056

5 bugs:
- serialization de la recherche des reservations -> inutile de passer en UTC maintenant (on envoit la bonne date au back)
- StockEventEdition : serialization de bookingLimitDatetime (même problème qu'avant pour les UTC - qqch on enregistré un jour avant)
- StockEventEdition :  calcul de la maxDate possible de bookingLimitDate -> on indiquait un jour trop tôt
- StockThing, bookingLimitDate, serialization (enregistrmeent un jour avant)
- StockThing, bookingLimitDate, calcul de maxDate

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques