### PR TITLE
(BSR)[API] fix: public API: cancel booking: send emails

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/bookings.py
@@ -44,6 +44,9 @@ def cancel_collective_booking(booking_id: int) -> None:
     except educational_exceptions.BookingIsAlreadyRefunded:
         raise ApiErrors({"booking": "Impossible d'annuler une réservation remboursée"}, status_code=403)
 
+    educational_api_booking.notify_redactor_that_booking_has_been_cancelled(booking)
+    educational_api_booking.notify_pro_that_booking_has_been_cancelled(booking)
+
 
 def _get_booking(booking_id: int) -> models.CollectiveBooking | None:
     return (

--- a/api/tests/routes/public/collective/endpoints/bookings_test.py
+++ b/api/tests/routes/public/collective/endpoints/bookings_test.py
@@ -4,8 +4,10 @@ from flask import url_for
 from freezegun import freeze_time
 import pytest
 
+from pcapi.core.educational import testing as educational_testing
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.educational.models as educational_models
+from pcapi.core.mails import testing as mails_testing
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.providers.factories as providers_factories
 from pcapi.models import db
@@ -34,6 +36,9 @@ class CancelCollectiveBookingTest:
         assert booking.cancellationReason == educational_models.CollectiveBookingCancellationReasons.PUBLIC_API
         assert booking.cancellationDate == datetime(2023, 1, 1, 10)
         assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
+
+        assert len(educational_testing.adage_requests) == 1
+        assert len(mails_testing.outbox) == 1
 
     def test_cannot_cancel_reimbursed_booking(self, client, venue):
         booking = educational_factories.ReimbursedCollectiveBookingFactory(


### PR DESCRIPTION
## But de la pull request

Fix : envoyer deux emails lorsqu'une réservation collective est annulée via l'api collective. L'un à l'enseignant et l'autre à l'acteur culturel.