### PR TITLE
(PC-24013)[PRO] refactor: Move searchbox to autocomplete & fix tests …

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -5,7 +5,10 @@ import React, {
   BaseSyntheticEvent,
   MouseEvent,
   KeyboardEvent,
+  useEffect,
 } from 'react'
+import type { SearchBoxProvided } from 'react-instantsearch-core'
+import { connectSearchBox } from 'react-instantsearch-dom'
 
 import strokeSearchIcon from 'icons/stroke-search.svg'
 import { Button } from 'ui-kit'
@@ -17,13 +20,16 @@ type SetInstantSearchUiStateOptions = {
   query: string
 }
 
-export function Autocomplete({
-  placeholder,
-  refine,
-}: {
+type AutocompleteProps = SearchBoxProvided & {
+  initialQuery: string
   placeholder: string
-  refine: (...args: any[]) => any
-}) {
+}
+
+const AutocompleteComponent = ({
+  refine,
+  initialQuery,
+  placeholder,
+}: AutocompleteProps) => {
   const [, setInstantSearchUiState] = useState({
     query: '',
   })
@@ -43,10 +49,15 @@ export function Autocomplete({
         onSubmit: ({ state }) => {
           refine(state.query)
         },
-        placeholder,
+        placeholder: placeholder,
       }),
     [placeholder, refine]
   )
+
+  useEffect(() => {
+    autocomplete.setQuery(initialQuery)
+    refine(initialQuery)
+  }, [initialQuery])
 
   const inputRef = React.useRef<HTMLInputElement>(null)
   const formRef = React.useRef<HTMLFormElement>(null)
@@ -83,3 +94,7 @@ export function Autocomplete({
     </div>
   )
 }
+
+export const Autocomplete = connectSearchBox<AutocompleteProps>(
+  AutocompleteComponent
+)

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
@@ -9,23 +9,34 @@ import { Autocomplete } from '../Autocomplete'
 
 const refineMock = vi.fn()
 
-const renderAutocomplete = ({
-  placeholder,
-  refine,
-}: {
-  placeholder: string
-  refine: SearchBoxProvided['refine']
-}) => {
+vi.mock('react-instantsearch-dom', async () => {
+  return {
+    ...((await vi.importActual('react-instantsearch-dom')) ?? {}),
+    Configure: vi.fn(() => <div />),
+    connectSearchBox: vi
+      .fn()
+      .mockImplementation(Component => (props: SearchBoxProvided) => (
+        <Component {...props} refine={refineMock} />
+      )),
+  }
+})
+
+const renderAutocomplete = ({ initialQuery }: { initialQuery: string }) => {
   return renderWithProviders(
-    <Autocomplete placeholder={placeholder} refine={refine} />
+    <Autocomplete
+      initialQuery={initialQuery}
+      placeholder={'Rechercher : nom de l’offre, partenaire culturel'}
+    />
   )
 }
 
 describe('Autocomplete', () => {
   it('should renders the Autocomplete component with placeholder and search button', () => {
-    renderAutocomplete({ placeholder: 'Search', refine: refineMock })
+    renderAutocomplete({ initialQuery: '' })
 
-    const inputElement = screen.getByPlaceholderText('Search')
+    const inputElement = screen.getByPlaceholderText(
+      'Rechercher : nom de l’offre, partenaire culturel'
+    )
     const searchButton = screen.getByText('Rechercher')
 
     expect(inputElement).toBeInTheDocument()
@@ -33,9 +44,11 @@ describe('Autocomplete', () => {
   })
 
   it('should call refine function when the form is submitted', async () => {
-    renderAutocomplete({ placeholder: 'Search', refine: refineMock })
+    renderAutocomplete({ initialQuery: '' })
 
-    const inputElement = screen.getByPlaceholderText('Search')
+    const inputElement = screen.getByPlaceholderText(
+      'Rechercher : nom de l’offre, partenaire culturel'
+    )
     const searchButton = screen.getByText('Rechercher')
 
     await userEvent.type(inputElement, 'test query')
@@ -43,5 +56,20 @@ describe('Autocomplete', () => {
     userEvent.click(searchButton)
 
     await waitFor(() => expect(refineMock).toHaveBeenCalledWith('test query'))
+  })
+
+  it('should set an initial search value on init', async () => {
+    renderAutocomplete({ initialQuery: 'test query 2' })
+
+    const searchButton = screen.getByText('Rechercher')
+
+    await userEvent.click(searchButton)
+
+    const inputElement = screen.getByPlaceholderText(
+      'Rechercher : nom de l’offre, partenaire culturel'
+    )
+
+    expect(inputElement).toHaveValue('test query 2')
+    expect(refineMock).toHaveBeenCalledWith('test query 2')
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -267,6 +267,7 @@ export const Offers = connectInfiniteHits<
 
       const areEqualHasMore = prevHasMore === nextHasMore
       const areEqualDisplayStats = prevDisplayStats === nextDisplayStats
+
       const arePropsEqual =
         areEqualHits && areEqualHasMore && areEqualDisplayStats
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -249,14 +249,18 @@ export const Offers = connectInfiniteHits<
       // If they are not equal, the offers details will be fetched again
       const {
         hits: prevHits,
+        nbHits: prevNbHits,
         hasMore: prevHasMore,
         displayStats: prevDisplayStats,
+        isBackToTopVisibile: prevIsBackToTopVisibile,
       } = prevProps
       const {
         hits: nextHits,
         hasMore: nextHasMore,
+        nbHits: nextNbHits,
         displayStats: nextDisplayStats,
         setIsLoading: nextSetIsLoading,
+        isBackToTopVisibile: nextIsBackToTopVisibile,
       } = nextProps
 
       const prevHitsIds = new Set(prevHits.map(hit => hit.objectID))
@@ -267,9 +271,16 @@ export const Offers = connectInfiniteHits<
 
       const areEqualHasMore = prevHasMore === nextHasMore
       const areEqualDisplayStats = prevDisplayStats === nextDisplayStats
+      const areEqualBackToTopVisible =
+        prevIsBackToTopVisibile === nextIsBackToTopVisibile
+      const areEquelNbHits = prevNbHits === nextNbHits
 
       const arePropsEqual =
-        areEqualHits && areEqualHasMore && areEqualDisplayStats
+        areEqualHits &&
+        areEqualHasMore &&
+        areEqualDisplayStats &&
+        areEqualBackToTopVisible &&
+        areEquelNbHits
 
       if (arePropsEqual) {
         nextSetIsLoading(false)

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -1,10 +1,7 @@
 import './OldOffersSearch.scss'
 
 import { FormikContext, useFormik } from 'formik'
-import { useContext, useEffect, useRef, useState } from 'react'
-import * as React from 'react'
-import type { SearchBoxProvided } from 'react-instantsearch-core'
-import { connectSearchBox } from 'react-instantsearch-dom'
+import { useContext, useRef, useState } from 'react'
 
 import { VenueResponse } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
@@ -39,7 +36,7 @@ export enum LocalisationFilterStates {
   NONE = 'none',
 }
 
-export interface SearchProps extends SearchBoxProvided {
+export interface SearchProps {
   venueFilter: VenueResponse | null
   setGeoLocation: (geoloc: GeoLocation) => void
 }
@@ -59,10 +56,9 @@ enum OfferTab {
   ASSOCIATED_TO_INSTITUTION = 'associatedToInstitution',
 }
 
-export const OffersSearchComponent = ({
+export const OffersSearch = ({
   venueFilter,
   setGeoLocation,
-  refine,
 }: SearchProps): JSX.Element => {
   const [, setIsLoading] = useState<boolean>(false)
   const [activeTab, setActiveTab] = useState(OfferTab.ALL)
@@ -145,9 +141,6 @@ export const OffersSearchComponent = ({
       filterValues: formik ? formik.values : {},
     })
   }
-  useEffect(() => {
-    refine(venueFilter?.publicName || venueFilter?.name || '')
-  }, [venueFilter])
 
   const formik = useFormik<SearchFormValues>({
     initialValues: computeFiltersInitialValues(
@@ -171,18 +164,17 @@ export const OffersSearchComponent = ({
 
   const offerFilterRef = useRef<HTMLDivElement>(null)
   const isOfferFiltersVisible = useIsElementVisible(offerFilterRef)
-
   return (
     <>
       <FormikContext.Provider value={formik}>
         {!!adageUser.uai && !isNewHeaderActive && (
           <Tabs selectedKey={activeTab} tabs={tabs} />
         )}
+        <Autocomplete
+          initialQuery={venueFilter?.publicName || venueFilter?.name || ''}
+          placeholder={'Rechercher : nom de l’offre, partenaire culturel'}
+        />
         <div ref={offerFilterRef}>
-          <Autocomplete
-            placeholder="Rechercher : nom de l’offre, partenaire culturel"
-            refine={refine}
-          />
           <OfferFilters
             className="search-filters"
             localisationFilterState={localisationFilterState}
@@ -203,5 +195,3 @@ export const OffersSearchComponent = ({
     </>
   )
 }
-
-export const OffersSearch = connectSearchBox<SearchProps>(OffersSearchComponent)


### PR DESCRIPTION
…in OfferSearch.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24013

- Refacto du code OffersSearch pour mettre le `connectSearchBox` direct dans l'Autocomplete. 
L'objectif étant de rendre le code de OffersFilters plus concis. Et puisque l'Autocomplete sera le seul component à utiliser la fonction `refine` qui vient de `connectSearchBox` pour la recherche, on a trouvé ça plus logique de mettre cette abstraction directement dans l'Autocomplete.

- La fonction `refine` n'étant plus dispo dans OffersFilters, on a déplacé l'initialisation de la valeur de recherche (fixée au nom de la venue dans le cas ou on ouvre la page des offres Adage depuis  une offre de l'onglet `/adage/ressource/partenaires` d'Adage). 
**A tester : Ouvrir la page des offres avec à la fin de l'url "&venue=[id d'une venue dispo dans les offres]" et vérifier que le nom de la venue se retrouve dans la barre de recherche.**

- Modification des tests OffersSearch et ajout de tests l'Autocomplete sur l'initialisation de la recherche

- Second commit pour corriger les conditions de render du component des Offers (via la fonction `memo`). Sans ça, le bouton "Retour en haut" dans la liste des offres n'est pas re-render et donc n'apparait pas quand on commence à scroll. 
**A tester : Le bouton "Retour en haut" devrait apparaitre quand on scroll et que les filtres ne sont plus visibles. Il doit re-disparaitre quand on scroll en haut de la page ou qu'on click sur le bouton. (voir l'aspect du bouton dans le screen)**

<img width="1225" alt="Capture d’écran 2023-08-30 à 17 30 07" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/28323918-60b7-47bd-8e21-7c67f561b5db">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques