### PR TITLE
(PC-24032)[PRO] feat: Dont clear collective offer visibility SelectAu…

### DIFF
--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -265,6 +265,7 @@ const CollectiveOfferVisibility = ({
                           setTeachersOptions([])
                           formik.setFieldValue('search-teacher', '')
                         }}
+                        resetOnOpen={false}
                         disabled={mode === Mode.READ_ONLY}
                         searchInOptions={(options, pattern) =>
                           searchPatternInOptions(options, pattern, 300)
@@ -288,6 +289,7 @@ const CollectiveOfferVisibility = ({
                   onSearch={() => {
                     onChangeTeacher()
                   }}
+                  resetOnOpen={false}
                   leftIcon={strokeSearch}
                 />
               </FormLayout.Row>

--- a/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -193,7 +193,7 @@ describe('CollectiveOfferVisibility', () => {
     })
   })
 
-  it('should clear search input field when clicking on the input again', async () => {
+  it('should not clear search input field when clicking on the input again', async () => {
     renderVisibilityStep(props)
 
     const institutionInput = await screen.findByLabelText(
@@ -209,7 +209,7 @@ describe('CollectiveOfferVisibility', () => {
 
     await userEvent.click(institutionInput)
 
-    expect(institutionInput).toHaveDisplayValue('')
+    expect(institutionInput).toHaveDisplayValue('Test input')
   })
 
   it('should display an error when the institution could not be saved', async () => {

--- a/pro/src/ui-kit/form/SelectAutoComplete/__specs__/SelectAutocomplete.spec.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/__specs__/SelectAutocomplete.spec.tsx
@@ -336,4 +336,40 @@ describe('SelectAutocomplete', () => {
       ).toBeInTheDocument()
     })
   })
+
+  it('should clear the input on focus', async () => {
+    render(
+      <Formik
+        initialValues={{
+          departement: ['01', '02'],
+          'search-departement': 'Test search',
+        }}
+        onSubmit={vi.fn()}
+      >
+        <SelectAutocomplete {...{ ...props, multi: true }} />
+      </Formik>
+    )
+    await userEvent.click(screen.getByLabelText('Département'))
+
+    expect(screen.getByLabelText('Département')).toHaveValue('')
+  })
+
+  it('should not clear the input on focus', async () => {
+    render(
+      <Formik
+        initialValues={{
+          departement: ['01', '02'],
+          'search-departement': 'Test search',
+        }}
+        onSubmit={vi.fn()}
+      >
+        <SelectAutocomplete
+          {...{ ...props, multi: true, resetOnOpen: false }}
+        />
+      </Formik>
+    )
+    await userEvent.click(screen.getByLabelText('Département'))
+
+    expect(screen.getByLabelText('Département')).toHaveValue('Test search')
+  })
 })


### PR DESCRIPTION
…tocomplete inputs when they're clicked.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24032

Pour reproduire :
- Aller sur l'onglet visibilité de l'édition d'une offre collective
- Avoir activé le FF `WIP_OFFER_TO_INSTITUTION`
- Choisir un établissement dans le select, clicker en dehors du champ puis re-clicker dans le champ sélectionné
- L'input du select ne devrait pas s'être clear

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques