### PR TITLE
(PC-24132)[API] feat: adage iframe: return lat&lon from JWT auth token

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/authentication.py
+++ b/api/src/pcapi/routes/adage_iframe/authentication.py
@@ -39,5 +39,7 @@ def authenticate(authenticated_information: AuthenticatedInformation) -> Authent
             institutionCity=institution.city if institution else None,
             email=authenticated_information.email,
             preferences=preferences,
+            lat=authenticated_information.lat,
+            lon=authenticated_information.lon,
         )
     return AuthenticatedResponse(role=AdageFrontRoles.READONLY)

--- a/api/src/pcapi/routes/adage_iframe/security.py
+++ b/api/src/pcapi/routes/adage_iframe/security.py
@@ -45,6 +45,8 @@ def adage_jwt_required(route_function):  # type: ignore [no-untyped-def]
                 firstname=adage_jwt_decoded.get("prenom"),
                 email=adage_jwt_decoded.get("mail"),
                 uai=adage_jwt_decoded.get("uai"),
+                lat=adage_jwt_decoded.get("lat"),
+                lon=adage_jwt_decoded.get("lon"),
             )
             kwargs["authenticated_information"] = authenticated_information
             return route_function(*args, **kwargs)

--- a/api/src/pcapi/routes/adage_iframe/serialization/adage_authentication.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/adage_authentication.py
@@ -23,6 +23,8 @@ class AuthenticatedInformation(BaseModel):
     firstname: str | None
     email: str | None
     uai: str | None
+    lat: float | None
+    lon: float | None
 
 
 class AuthenticatedResponse(BaseModel):
@@ -33,6 +35,8 @@ class AuthenticatedResponse(BaseModel):
     institutionCity: str | None
     email: str | None
     preferences: RedactorPreferences | None
+    lat: float | None
+    lon: float | None
 
     class Config:
         use_enum_values = True

--- a/api/tests/routes/adage_iframe/get_authenticate_test.py
+++ b/api/tests/routes/adage_iframe/get_authenticate_test.py
@@ -8,6 +8,8 @@ from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 
 from tests.conftest import TestClient
+from tests.routes.adage_iframe.utils_create_test_token import DEFAULT_LAT
+from tests.routes.adage_iframe.utils_create_test_token import DEFAULT_LON
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_jwt_default_fake_valid_token
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_jwt_fake_invalid_token
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_jwt_fake_valid_token
@@ -27,6 +29,8 @@ class AuthenticateTest:
             firstname=self.valid_user.get("prenom"),
             email=self.valid_user.get("mail"),
             uai=uai_code,
+            lat=DEFAULT_LAT,
+            lon=DEFAULT_LON,
         )
 
     def test_should_return_redactor_role_when_token_has_an_uai_code(self, app) -> None:
@@ -60,6 +64,8 @@ class AuthenticateTest:
                 "feedback_form_closed": None,
                 "broadcast_help_closed": None,
             },
+            "lat": DEFAULT_LAT,
+            "lon": DEFAULT_LON,
         }
 
     def test_preferences_are_correctly_serialized(self, client) -> None:
@@ -95,6 +101,8 @@ class AuthenticateTest:
             "institutionCity": None,
             "email": None,
             "preferences": None,
+            "lat": None,
+            "lon": None,
         }
 
     valid_user = {
@@ -115,6 +123,8 @@ class AuthenticateTest:
             email=self.valid_user.get("mail"),
             uai=self.valid_user.get("uai"),
             expiration_date=expiration_date,
+            lat=DEFAULT_LAT,
+            lon=DEFAULT_LON,
         )
 
     @staticmethod

--- a/api/tests/routes/adage_iframe/utils_create_test_token.py
+++ b/api/tests/routes/adage_iframe/utils_create_test_token.py
@@ -11,8 +11,18 @@ from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
 from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
 
 
+DEFAULT_LAT = 67.91865044229313
+DEFAULT_LON = 18.572766390584306
+
+
 def create_adage_jwt_default_fake_valid_token(
-    civility: str, lastname: str, firstname: str, email: str, uai: Optional[str]
+    civility: str,
+    lastname: str,
+    firstname: str,
+    email: str,
+    uai: Optional[str],
+    lat: float | None = None,
+    lon: float | None = None,
 ) -> ByteString:
     return create_adage_jwt_fake_valid_token(
         civility=civility,
@@ -21,6 +31,8 @@ def create_adage_jwt_default_fake_valid_token(
         email=email,
         uai=uai,
         expiration_date=datetime.utcnow() + timedelta(days=1),
+        lat=lat,
+        lon=lon,
     )
 
 
@@ -31,6 +43,8 @@ def create_adage_jwt_fake_valid_token(
     email: str,
     uai: Optional[str],
     expiration_date: datetime,
+    lat: float | None = None,
+    lon: float | None = None,
 ) -> ByteString:
     with open(VALID_RSA_PRIVATE_KEY_PATH, "rb") as reader:
         authenticated_informations = {
@@ -39,6 +53,8 @@ def create_adage_jwt_fake_valid_token(
             "prenom": firstname,
             "mail": email,
             "uai": uai,
+            "lat": lat,
+            "lon": lon,
         }
         if expiration_date:
             authenticated_informations["exp"] = expiration_date
@@ -56,6 +72,8 @@ def create_adage_valid_token_with_email(
     lastname: str = "LAPROF",
     firstname: str = "Jeanne",
     uai: str = "EAU123",
+    lat: float | None = None,
+    lon: float | None = None,
 ) -> ByteString:
     return create_adage_jwt_fake_valid_token(
         civility=civility,
@@ -64,11 +82,19 @@ def create_adage_valid_token_with_email(
         email=email,
         uai=uai,
         expiration_date=datetime.utcnow() + timedelta(days=1),
+        lat=lat,
+        lon=lon,
     )
 
 
 def create_adage_jwt_fake_invalid_token(
-    civility: str, lastname: str, firstname: str, email: str, uai: str
+    civility: str,
+    lastname: str,
+    firstname: str,
+    email: str,
+    uai: str,
+    lat: float | None = None,
+    lon: float | None = None,
 ) -> ByteString:
     now = datetime.utcnow()
     with open(INVALID_RSA_PRIVATE_KEY_PATH, "rb") as reader:
@@ -80,6 +106,8 @@ def create_adage_jwt_fake_invalid_token(
                 "mail": email,
                 "uai": uai,
                 "exp": now + timedelta(days=1),
+                "lat": lat,
+                "lon": lon,
             },
             key=reader.read(),
             algorithm=ALGORITHM_RS_256,

--- a/pro/src/apiClient/adage/models/AuthenticatedResponse.ts
+++ b/pro/src/apiClient/adage/models/AuthenticatedResponse.ts
@@ -11,6 +11,8 @@ export type AuthenticatedResponse = {
   email?: string | null;
   institutionCity?: string | null;
   institutionName?: string | null;
+  lat?: number | null;
+  lon?: number | null;
   preferences?: RedactorPreferences | null;
   role: AdageFrontRoles;
   uai?: string | null;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24132

Renvoyer les coordonnées de l'établissement du rédacteur de projet ou du chef d'établissement lors de l'authentification. Ces informations sont contenues dans le JWT généré par Adage.