### PR TITLE
(PC-24140)[API] fix: Return only name and siren when a user asks for attachment using new onboarding

### DIFF
--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -203,10 +203,10 @@ def get_offerer_stats_dashboard_url(
 @private_api.route("/offerers/new", methods=["POST"])
 @login_required
 @spectree_serialize(
-    on_success_status=201, response_model=offerers_serialize.GetOffererResponseModel, api=blueprint.pro_private_schema
+    on_success_status=201, response_model=offerers_serialize.PostOffererResponseModel, api=blueprint.pro_private_schema
 )
 def save_new_onboarding_data(
     body: offerers_serialize.SaveNewOnboardingDataQueryModel,
-) -> offerers_serialize.GetOffererResponseModel:
+) -> offerers_serialize.PostOffererResponseModel:
     user_offerer = api.create_from_onboarding_data(current_user, body)
-    return offerers_serialize.GetOffererResponseModel.from_orm(user_offerer.offerer)
+    return offerers_serialize.PostOffererResponseModel.from_orm(user_offerer.offerer)

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -77,6 +77,8 @@ class PostOffererResponseModel(BaseModel):
         orm_mode = True
 
 
+# GetOffererResponseModel includes sensitive information and can be returned only if authenticated user has a validated
+# access to the offerer. During subscription process, use PostOffererResponseModel
 class GetOffererResponseModel(BaseModel):
     address: str | None
     apiKey: OffererApiKey

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -55,6 +55,19 @@ class Returns200Test:
         assert created_venue.venueTypeCode == offerers_models.VenueTypeCode.MOVIE
         assert created_venue.withdrawalDetails is None
 
+    def test_returns_public_information_only(self, client):
+        user = users_factories.UserFactory(email="pro@example.com")
+
+        client = client.with_session_auth(user.email)
+        response = client.post("/offerers/new", json=REQUEST_BODY)
+
+        created_offerer = offerers_models.Offerer.query.one()
+        assert response.json == {
+            "id": created_offerer.id,
+            "siren": "853318459",
+            "name": "MINISTERE DE LA CULTURE",
+        }
+
 
 class Returns400Test:
     @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.UnknownEntityException())

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1090,12 +1090,12 @@ export class DefaultService {
   /**
    * save_new_onboarding_data <POST>
    * @param requestBody
-   * @returns GetOffererResponseModel Created
+   * @returns PostOffererResponseModel Created
    * @throws ApiError
    */
   public saveNewOnboardingData(
     requestBody?: SaveNewOnboardingDataQueryModel,
-  ): CancelablePromise<GetOffererResponseModel> {
+  ): CancelablePromise<PostOffererResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
       url: '/offerers/new',

--- a/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import { GetOffererResponseModel, Target } from 'apiClient/v1'
+import { PostOffererResponseModel, Target } from 'apiClient/v1'
 import { Address } from 'components/Address'
 import Notification from 'components/Notification/Notification'
 import {
@@ -182,7 +182,7 @@ describe('ValidationScreen', () => {
 
     it('Should send the data on submit and redirect to home', async () => {
       vi.spyOn(api, 'saveNewOnboardingData').mockResolvedValue(
-        {} as GetOffererResponseModel
+        {} as PostOffererResponseModel
       )
       renderValidationScreen(contextValue)
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
@@ -228,7 +228,7 @@ describe('ValidationScreen', () => {
 
     it('Should send data with empty public name', async () => {
       vi.spyOn(api, 'saveNewOnboardingData').mockResolvedValue(
-        {} as GetOffererResponseModel
+        {} as PostOffererResponseModel
       )
       renderValidationScreen(contextValue)
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-24140

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques