### PR TITLE
(PC-24015)[PRO] feat: add tracker in offerer for invite member button

### DIFF
--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -136,3 +136,7 @@ export enum SynchronizationEvents {
   CLICKED_IMPORT = 'hasClickedImport',
   CLICKED_VALIDATE_IMPORT = 'hasClickedValidateImport',
 }
+
+export enum OffererLinkEvents {
+  CLICKED_INVITE_COLLABORATOR = 'hasClickedInviteCollaborator',
+}

--- a/pro/src/pages/Home/Offerers/OffererDetails.tsx
+++ b/pro/src/pages/Home/Offerers/OffererDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { GetOffererResponseModel } from 'apiClient/v1'
-import { Events } from 'core/FirebaseEvents/constants'
+import { Events, OffererLinkEvents } from 'core/FirebaseEvents/constants'
 import { SelectOption } from 'custom_types/form'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
@@ -98,6 +98,11 @@ const OffererDetails = ({
                 }}
                 icon={fullMoreIcon}
                 isDisabled={!isUserOffererValidated}
+                onClick={() => {
+                  logEvent?.(OffererLinkEvents.CLICKED_INVITE_COLLABORATOR, {
+                    offererId: selectedOfferer.id,
+                  })
+                }}
               >
                 Inviter
               </ButtonLink>

--- a/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.tsx
@@ -220,7 +220,7 @@ describe('offererDetailsLegacy', () => {
     expect(secondOfflineVenueTitle).toBeInTheDocument()
   })
 
-  it('should display invite member button if FF is enable', async () => {
+  it('should display invite member button if FF is enable and track', async () => {
     const storeOverrides = {
       ...store,
       features: {
@@ -230,6 +230,23 @@ describe('offererDetailsLegacy', () => {
     await renderHomePage(storeOverrides)
 
     expect(screen.getByText('Inviter')).toBeInTheDocument()
+  })
+
+  it('should trigger an event when clicking on "Inviter" for offerers', async () => {
+    const storeOverrides = {
+      ...store,
+      features: {
+        list: [{ isActive: true, nameKey: 'WIP_ENABLE_NEW_USER_OFFERER_LINK' }],
+      },
+    }
+    await renderHomePage(storeOverrides)
+
+    await userEvent.click(screen.getByText('Inviter'))
+
+    expect(mockLogEvent).toHaveBeenCalledWith('hasClickedInviteCollaborator', {
+      offererId: 12,
+    })
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
   })
 
   it('should not display virtual venue informations when no virtual offers', async () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24015

- Ajout d'un tracker au clic sur le bouton "Inviter" de la page d'accueil.
- FF à activer: WIP_ENABLE_NEW_USER_OFFERER_LINK

## Vérifications

- [X] J'ai écrit les tests nécessaires