### PR TITLE
(PC-24158)[PRO] fix: Skip tests relative to the 6e/5e modal in coll…

### DIFF
--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -114,7 +114,9 @@ describe('OfferEducationalStock', () => {
     expect(testProps.onSubmit).toHaveBeenCalled()
   })
 
-  describe('wrong students modal', () => {
+  //  FIXME (guillaumeMgz, 2023-08-31)
+  //  Tests disabled until the modal about 6e/5e being disabled until 2023-09-01 is deleted
+  describe.skip('wrong students modal', () => {
     it('should navigate to offer creation if user click modify participants', async () => {
       const offer = collectiveOfferFactory({
         id: 1,
@@ -310,5 +312,29 @@ describe('OfferEducationalStock', () => {
 
       screen.getByText("L'heure doit être postérieure à l'heure actuelle")
     })
+  })
+
+  //  FIXME (guillaumeMgz, 2023-08-31)
+  //  Test to be removed when the modal is deleted
+  it('should submit callback when clicking next step with 6e or 5e', async () => {
+    const offer = collectiveOfferFactory({
+      id: 1,
+      students: [
+        StudentLevels.COLL_GE_6E,
+        StudentLevels.COLL_GE_5E,
+        StudentLevels.COLL_GE_4E,
+      ],
+    })
+    const testProps: OfferEducationalStockProps = {
+      ...defaultProps,
+      offer,
+      initialValues: initialValuesNotEmpty,
+      mode: Mode.CREATION,
+    }
+    renderWithProviders(<OfferEducationalStock {...testProps} />)
+    const submitButton = screen.getByRole('button', { name: 'Étape suivante' })
+    await userEvent.click(submitButton)
+
+    expect(testProps.onSubmit).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
…ective offer form Dates page.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24158

Les 6e et 5e étant ajouté demain au form de création d'une offre collective, la modal qui s'affiche quand on crée une offre et qu'on a choisit 6e ou 5e alors que la date de début de l'offre est avant la date d'activation des 6e 5e (le 1er sept) n'existe plus. Par conséquent on peut retirer les tests liés à cette modal.
- Skip de tous les tests de la modal qui ne peut plus s'ouvrir avant de traiter le ticket de suppression définitive de la modal
- Création d'un test temporaire qui vérifie que le formulaire est validé même si on a 6e et 5e

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques