### PR TITLE
(FIX) fix build-on-tags ci

### DIFF
--- a/.github/workflows/build-on-tags.yaml
+++ b/.github/workflows/build-on-tags.yaml
@@ -11,6 +11,8 @@ env:
 jobs:
   find-hotfix-tag-number:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    outputs:
+      version: ${{ steps.find-hotfix-tag-number.outputs.version }}
     name: Find hotfix tag number
     runs-on: [self-hosted, linux, x64]
     steps:


### PR DESCRIPTION
Il semble qu'enlever la section output face planter le job : https://github.com/pass-culture/pass-culture-main/actions/runs/6036129729