### PR TITLE
(PC-23864)[API] fix: search: collective offers _geoloc

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -264,6 +264,8 @@ class CollectiveOffer(
 
     isActive: bool = sa.Column(sa.Boolean, nullable=False, server_default=sa.sql.expression.true(), default=True)
 
+    # the venueId is the billing address.
+    # To find where the offer takes place, check offerVenue.
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), nullable=False, index=True)
 
     venue: sa_orm.Mapped["Venue"] = sa.orm.relationship(
@@ -302,6 +304,14 @@ class CollectiveOffer(
 
     contactPhone: str | None = sa.Column(sa.Text, nullable=True)
 
+    # Where the offer takes place
+    # There are three types:
+    #   1. within an educational institution;
+    #   2. within the offerer's place;
+    #   3. in some random place.
+    # Each object should have the same three keys: one for the venue
+    # type, one for the venueId (filled when 1.) and one for the random
+    # place (filled when 3.)
     offerVenue: dict = sa.Column(MutableDict.as_mutable(postgresql.json.JSONB), nullable=False)
 
     interventionArea: list[str] = sa.Column(

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -311,6 +311,8 @@ def test_serialize_collective_offer():
         venue__publicName="La Moyenne Librairie",
         venue__managingOfferer__name="Les Librairies Associées",
         venue__departementCode="86",
+        venue__latitude=algolia.DEFAULT_LATITUDE,
+        venue__longitude=algolia.DEFAULT_LONGITUDE,
         educational_domains=[domain1, domain2],
         institution=educational_institution,
         interventionArea=["1", "90", "94"],
@@ -348,8 +350,8 @@ def test_serialize_collective_offer():
             "publicName": "La Moyenne Librairie",
         },
         "_geoloc": {
-            "lat": collective_offer.venue.latitude,
-            "lng": collective_offer.venue.longitude,
+            "lat": float(collective_offer.venue.latitude),
+            "lng": float(collective_offer.venue.longitude),
         },
         "isTemplate": False,
     }
@@ -364,6 +366,8 @@ def test_serialize_collective_offer_without_institution():
 def test_serialize_collective_offer_template():
     domain1 = educational_factories.EducationalDomainFactory(name="Danse")
     domain2 = educational_factories.EducationalDomainFactory(name="Architecture")
+    venue = offerers_factories.VenueFactory(latitude=algolia.DEFAULT_LATITUDE, longitude=algolia.DEFAULT_LONGITUDE)
+
     collective_offer_template = educational_factories.CollectiveOfferTemplateFactory(
         dateCreated=datetime.datetime(2022, 1, 1, 10, 0, 0),
         name="Titre formidable",
@@ -376,8 +380,8 @@ def test_serialize_collective_offer_template():
         venue__managingOfferer__name="Les Librairies Associées",
         venue__departementCode="86",
         educational_domains=[domain1, domain2],
-        interventionArea=["1", "90", "94"],
-        offerVenue={"addressType": OfferAddressType.SCHOOL, "venueId": None, "otherAddress": "Quelque part"},
+        interventionArea=None,
+        offerVenue={"addressType": OfferAddressType.OFFERER_VENUE, "venueId": venue.id, "otherAddress": ""},
     )
 
     serialized = algolia.AlgoliaBackend().serialize_collective_offer_template(collective_offer_template)
@@ -390,9 +394,9 @@ def test_serialize_collective_offer_template():
             "subcategoryId": subcategories.LIVRE_PAPIER.id,
             "domains": [domain1.id, domain2.id],
             "educationalInstitutionUAICode": "all",
-            "interventionArea": ["1", "90", "94"],
-            "schoolInterventionArea": ["1", "90", "94"],
-            "eventAddressType": OfferAddressType.SCHOOL.value,
+            "interventionArea": [],
+            "schoolInterventionArea": None,
+            "eventAddressType": OfferAddressType.OFFERER_VENUE.value,
             "beginningDatetime": 1641031200.0,
             "description": collective_offer_template.description,
         },
@@ -407,8 +411,8 @@ def test_serialize_collective_offer_template():
             "publicName": "La Moyenne Librairie",
         },
         "_geoloc": {
-            "lat": collective_offer_template.venue.latitude,
-            "lng": collective_offer_template.venue.longitude,
+            "lat": float(venue.latitude),
+            "lng": float(venue.longitude),
         },
         "isTemplate": True,
     }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23864

Fix : les coordonnées utilisées lors de l'indexation des offres collectives (et offres vitrines) étaient celles de l'adresse de facturation. Or, à la création de l'offre, un acteur culturel peut spécifier un lieu dans lequel aura lieu celle-ci : les informations sont dans la colonne `offerVenue` et sous la clé `venueId` (qui sera nulle si l'information n'a pas été fournie à la création).

Cette PR vise à donc à aller chercher ce lieu si l'information existe et utiliser le lieu qui sert pour la facturation dans le cas contraire.