### PR TITLE
(PC-24137)[API] fix: keep bookings ongoing when stock is no longer free 

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -74,7 +74,7 @@ def _is_ended_booking(booking: Booking) -> bool:
         # consider future events as "ongoing" even if they are used
         return False
 
-    if (booking.stock.canHaveActivationCodes and booking.activationCode) or booking.stock.is_automatically_used:
+    if (booking.stock.canHaveActivationCodes and booking.activationCode) or booking.display_even_if_used:
         # consider digital bookings and free offer from defined subcategories as special: is_used should be true anyway so
         # let's use displayAsEnded
         return booking.displayAsEnded  # type: ignore [return-value]

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -33,6 +33,7 @@ from pcapi.core.bookings.constants import BOOKINGS_AUTO_EXPIRY_DELAY
 from pcapi.core.bookings.constants import BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY
 from pcapi.core.categories import subcategories
 import pcapi.core.finance.models as finance_models
+from pcapi.core.offers import models as offers_models
 from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
@@ -41,7 +42,6 @@ from pcapi.utils.human_ids import humanize
 
 if TYPE_CHECKING:
     from pcapi.core.offerers import models as offerers_models
-    from pcapi.core.offers import models as offers_models
     from pcapi.core.users import models as users_models
 
 
@@ -315,6 +315,12 @@ class Booking(PcObject, Base, Model):
             return float("{:.2f}".format((-self.pricing.amount / self.amount)))
         except (decimal.DivisionByZero, decimal.InvalidOperation):  # raised when both values are 0
             return None
+
+    @property
+    def display_even_if_used(self) -> bool:
+        return (
+            self.stock.offer.subcategoryId in offers_models.Stock.AUTOMATICALLY_USED_SUBCATEGORIES and self.amount == 0
+        )
 
 
 Booking.trig_ddl = f"""


### PR DESCRIPTION

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24137

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques