### PR TITLE
(BSR)[API] fix: Handle bookings recently marked as unused

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -294,6 +294,10 @@ def price_bookings(
             )
         for booking in bookings:
             if isinstance(booking, bookings_models.Booking):
+                # Handle bookings that were used when we fetched them in `_get_bookings_to_price()`
+                # but have been marked as unused since then.
+                if not booking.dateUsed:
+                    continue
                 last_booking = booking
             else:
                 last_collective_booking = booking
@@ -590,10 +594,6 @@ def price_booking(
 ) -> models.Pricing | None:
     _check_price_events_is_disabled()
 
-    # Handle bookings that were used when we fetched them in `price_bookings()`
-    # but have been marked as unused since then.
-    if not booking.dateUsed:
-        return None
     pricing_point_id = _get_pricing_point_link(booking).pricingPointId
 
     is_booking_collective = isinstance(booking, educational_models.CollectiveBooking)

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -232,9 +232,8 @@ class PriceBookingTest:
         assert pricing.status == models.PricingStatus.VALIDATED
 
     def test_price_booking_that_is_not_used(self):
-        booking = bookings_factories.BookingFactory()
-        pricing = api.price_booking(booking)
-        assert pricing is None
+        bookings_factories.BookingFactory()
+        api.price_bookings(datetime.datetime(1970, 1, 1), batch_size=100)
 
     def test_price_booking_checks_pricing_point(self):
         booking = bookings_factories.UsedBookingFactory()


### PR DESCRIPTION
Litterally the same commit that f188be39b8e542537d0335954c3733cb1b26b33b but moving the snippet upper in the execution so that bug won't happen either in `_get_pricing_point_link`

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques