### PR TITLE
(PC-24169)[PRO] fix: Wording of the radio button when selecting a boo…

### DIFF
--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -233,7 +233,7 @@ const OfferType = (): JSX.Element => {
                         COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE
                       }
                       label="Une offre réservable"
-                      description="Cette offre a une date et un prix. Vous pouvez choisir de la rendre visible par tous les établissements scolaires ou par un seul."
+                      description="Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé."
                       onChange={handleChange}
                       value={COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE}
                     />

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -137,7 +137,7 @@ describe('screens:OfferIndividual::OfferType', () => {
     )
     await userEvent.click(
       screen.getByRole('radio', {
-        name: 'Une offre réservable Cette offre a une date et un prix. Vous pouvez choisir de la rendre visible par tous les établissements scolaires ou par un seul.',
+        name: 'Une offre réservable Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé.',
       })
     )
     await userEvent.click(
@@ -313,7 +313,7 @@ describe('screens:OfferIndividual::OfferType', () => {
 
     await userEvent.click(
       screen.getByRole('radio', {
-        name: 'Une offre réservable Cette offre a une date et un prix. Vous pouvez choisir de la rendre visible par tous les établissements scolaires ou par un seul.',
+        name: 'Une offre réservable Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé.',
       })
     )
 
@@ -356,7 +356,7 @@ describe('screens:OfferIndividual::OfferType', () => {
 
     await userEvent.click(
       screen.getByRole('radio', {
-        name: 'Une offre réservable Cette offre a une date et un prix. Vous pouvez choisir de la rendre visible par tous les établissements scolaires ou par un seul.',
+        name: 'Une offre réservable Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé.',
       })
     )
 


### PR DESCRIPTION
…kable and collective offer in creation form.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24169

**Raison & objectif :**
Les offres collectives réservables ne peuvent plus être associées à tous les établissements scolaires en meme temps. Par conséquent on doit changer le texte explicatif de ce qu'est une offre réservable.

<img width="616" alt="Capture d’écran 2023-09-01 à 15 32 21" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/94ffd3ee-7260-487e-8f8d-cd60021baed0">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques