### PR TITLE
(PC-24127) catch error if cancel ticket api returns error for already cancelled ticket

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -437,6 +437,8 @@ def _cancel_external_booking(booking: Booking, stock: Stock) -> None:
         except external_bookings_exceptions.ExternalBookingException:
             logger.exception("Could not cancel external ticket")
             raise external_bookings_exceptions.ExternalBookingException
+        except external_bookings_exceptions.ExternalBookingAlreadyCancelledError as error:
+            logger.info("External ticket already cancelled for booking: %s. Error %s", booking.id, str(error))
         return None
 
     venue_provider_name = external_bookings_api.get_active_cinema_venue_provider(offer.venueId).provider.localClass

--- a/api/src/pcapi/core/external_bookings/exceptions.py
+++ b/api/src/pcapi/core/external_bookings/exceptions.py
@@ -6,6 +6,10 @@ class ExternalBookingSoldOutError(Exception):
     pass
 
 
+class ExternalBookingAlreadyCancelledError(Exception):
+    pass
+
+
 class ExternalBookingNotEnoughSeatsError(Exception):
     def __init__(self, remainingQuantity: int) -> None:
         self.remainingQuantity = remainingQuantity


### PR DESCRIPTION
## But de la pull request
Cette PR a pour but de catcher l'erreur si on essaie d'annuler un billet et que l'api externe renvoie une erreur parceque le billet est déjà annulé.
On log l'erreur pour avoir une trace (ça reste un comportement anormal) et on ne renvoie pas d'erreur afin de bien noter le booking cancelled en bd.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24127

## Vérifications

- [X] J'ai écrit les tests nécessaires
