### PR TITLE
(PC-24149): cancel barcodes with unstored external booking

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -442,7 +442,7 @@ def _cancel_external_booking(booking: Booking, stock: Stock) -> None:
     if offer.lastProvider and offer.lastProvider.hasProviderEnableCharlie:
         barcodes = [external_booking.barcode for external_booking in booking.externalBookings]
         try:
-            external_bookings_api.cancel_event_ticket(offer.lastProvider, stock, barcodes)
+            external_bookings_api.cancel_event_ticket(offer.lastProvider, stock, barcodes, True)
         except external_bookings_exceptions.ExternalBookingException:
             logger.exception("Could not cancel external ticket")
             raise external_bookings_exceptions.ExternalBookingException
@@ -898,7 +898,31 @@ def cancel_unstored_external_bookings() -> None:
 
         external_bookings = ExternalBooking.query.filter_by(barcode=external_booking_info["barcode"]).all()
         if not external_bookings:
-            external_bookings_api.cancel_booking(
-                int(external_booking_info["venue_id"]),
-                [external_booking_info["barcode"]],
-            )
+            if (
+                external_booking_info.get("booking_type")
+                and external_booking_info["booking_type"] == constants.RedisExternalBookingType.EVENT
+            ):
+                provider = providers_repository.get_provider_enabled_for_pro_by_id(
+                    external_booking_info["cancel_event_info"]["provider_id"]
+                )
+                stock = offers_models.Stock.query.filter_by(
+                    id=external_booking_info["cancel_event_info"]["stock_id"]
+                ).one_or_none()
+
+                if not stock or not provider:
+                    logger.error("Couldn't find stock or provider for external booking", extra=external_booking_info)
+                    raise external_bookings_exceptions.ExternalBookingException(
+                        "Error while canceling unstored ticket. Barcode: ",
+                        str(external_booking_info["barcode"]),
+                    )
+                external_bookings_api.cancel_event_ticket(
+                    provider,
+                    stock,
+                    [external_booking_info["barcode"]],
+                    False,
+                )
+            else:
+                external_bookings_api.cancel_booking(
+                    int(external_booking_info["venue_id"]),
+                    [external_booking_info["barcode"]],
+                )

--- a/api/src/pcapi/core/bookings/constants.py
+++ b/api/src/pcapi/core/bookings/constants.py
@@ -1,9 +1,15 @@
 import datetime
+import enum
 import typing
 
 
 if typing.TYPE_CHECKING:
     from pcapi.core.offers.models import Stock
+
+
+class RedisExternalBookingType(str, enum.Enum):
+    CINEMA = "cinema"
+    EVENT = "event"
 
 
 ARCHIVE_DELAY = datetime.timedelta(days=30)

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -6,6 +6,7 @@ import pydantic.v1 as pydantic_v1
 
 from pcapi import settings
 from pcapi.core.bookings.constants import REDIS_EXTERNAL_BOOKINGS_NAME
+from pcapi.core.bookings.constants import RedisExternalBookingType
 import pcapi.core.bookings.models as bookings_models
 from pcapi.core.external_bookings.boost.client import BoostClientAPI
 from pcapi.core.external_bookings.cds.client import CineDigitalServiceAPI
@@ -104,8 +105,12 @@ def book_event_ticket(
             REDIS_EXTERNAL_BOOKINGS_NAME,
             {
                 "barcode": ticket.barcode,
-                "venue_id": booking.venueId,
                 "timestamp": datetime.datetime.utcnow().timestamp(),
+                "booking_type": RedisExternalBookingType.EVENT,
+                "cancel_event_info": {
+                    "provider_id": provider.id,
+                    "stock_id": stock.id,
+                },
             },
         )
     return [
@@ -117,6 +122,7 @@ def cancel_event_ticket(
     provider: providers_models.Provider,
     stock: offers_models.Stock,
     barcodes: list[str],
+    is_booking_saved: bool,
 ) -> None:
     payload = serialize.ExternalEventCancelBookingRequest.build_external_cancel_booking(barcodes)
     headers = {"Content-Type": "application/json"}
@@ -128,7 +134,12 @@ def cancel_event_ticket(
     try:
         parsed_response = pydantic_v1.parse_obj_as(serialize.ExternalEventCancelBookingResponse, response.json())
         if parsed_response.remainingQuantity:
-            stock.quantity = parsed_response.remainingQuantity + stock.dnBookedQuantity - len(barcodes)
+            new_quantity = (
+                parsed_response.remainingQuantity + stock.dnBookedQuantity - len(barcodes)
+                if is_booking_saved
+                else parsed_response.remainingQuantity + stock.dnBookedQuantity
+            )
+            stock.quantity = new_quantity
     except (ValueError, pydantic_v1.ValidationError):
         logger.exception(
             "Could not parse external booking cancel response",

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -104,6 +104,7 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
                 "barcode": sale_confirmation_response.data.code,
                 "venue_id": booking.venueId,
                 "timestamp": datetime.datetime.utcnow().timestamp(),
+                "booking_type": bookings_constants.RedisExternalBookingType.CINEMA,
             },
         )
 

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -12,6 +12,7 @@ from pcapi.connectors.cine_digital_service import post_resource
 from pcapi.connectors.cine_digital_service import put_resource
 import pcapi.connectors.serialization.cine_digital_service_serializers as cds_serializers
 from pcapi.core.bookings.constants import REDIS_EXTERNAL_BOOKINGS_NAME
+from pcapi.core.bookings.constants import RedisExternalBookingType
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.external_bookings.cds.constants as cds_constants
 import pcapi.core.external_bookings.cds.exceptions as cds_exceptions
@@ -248,6 +249,7 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
                     "barcode": ticket.barcode,
                     "venue_id": booking.venueId,
                     "timestamp": datetime.datetime.utcnow().timestamp(),
+                    "booking_type": RedisExternalBookingType.CINEMA,
                 },
             )
 

--- a/api/src/pcapi/core/external_bookings/cgr/client.py
+++ b/api/src/pcapi/core/external_bookings/cgr/client.py
@@ -6,6 +6,7 @@ from pcapi.connectors.cgr.cgr import get_seances_pass_culture
 from pcapi.connectors.cgr.cgr import reservation_pass_culture
 from pcapi.connectors.serialization import cgr_serializers
 from pcapi.core.bookings.constants import REDIS_EXTERNAL_BOOKINGS_NAME
+from pcapi.core.bookings.constants import RedisExternalBookingType
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.external_bookings.models as external_bookings_models
 from pcapi.core.providers.repository import get_cgr_cinema_details
@@ -52,6 +53,7 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
                 "barcode": response.QrCode,
                 "venue_id": booking.venueId,
                 "timestamp": datetime.datetime.utcnow().timestamp(),
+                "booking_type": RedisExternalBookingType.CINEMA,
             },
         )
         if booking.quantity == 2:


### PR DESCRIPTION
## But de la pull request
Appeler l'api de billeterie externe afin d'annuler tout billet non relié à une réservation dans note base de données

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24149

## Vérifications

- [X] J'ai écrit les tests nécessaires