### PR TITLE
Script to fix 8-digits on the gtl_id of products

### DIFF
--- a/api/fix_product_gtl_id_minus_8_chars.sh
+++ b/api/fix_product_gtl_id_minus_8_chars.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+BATCH_SIZE=500000
+PRODUCT_ID_MIN=1  # actuall: 10048
+PRODUCT_ID_MAX=5100000  # actually: 5089733
+
+while [[ $PRODUCT_ID_MIN < $PRODUCT_ID_MAX ]]
+do
+    echo "Processing batch starting from $PRODUCT_ID_MIN"
+    # 1. Replace `:PRODUCT_ID_MIN` and `:BATCH_SIZE`.
+    # 2. Remove comments (otherwise, when the next step is applied,
+    #     the first comment will comment out the rest of the whole
+    #     (single) line.
+    # 3. Replace "\n" chars by spaces because "\copy" commands must
+    #    appear on a single line (and our template uses multiple lines
+    #    for clarity)
+    cat product_gtl_id_fixer_template.sql | sed -E "s#:BATCH_SIZE#${BATCH_SIZE}#" | sed -E "s#:PRODUCT_ID_MIN#${PRODUCT_ID_MIN}#g" | sed -E "s#--.*##" | tr "\n" " " | psql ${DATABASE_URL}
+    PRODUCT_ID_MIN=$((PRODUCT_ID_MIN+BATCH_SIZE))
+done

--- a/api/product_gtl_id_fixer_template.sql
+++ b/api/product_gtl_id_fixer_template.sql
@@ -1,0 +1,12 @@
+\copy (
+    UPDATE product
+    SET "jsonData" = jsonb_set(
+        product."jsonData",
+        '{gtl_id}',
+        to_jsonb(lpad(product."jsonData"->>'gtl_id', 8, '0')),
+        true
+    ) WHERE product.id between :PRODUCT_ID_MIN and (:PRODUCT_ID_MIN + :BATCH_SIZE)
+      AND length(product."jsonData"->>'gtl_id') is not null
+      AND length(product."jsonData"->>'gtl_id') < 8
+  returning product.id
+) to 'fixed_gtl_id_of_product_ids_:PRODUCT_ID_MIN.csv'


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-23762

## Vérifications

Le script met à jour uniquement les gtl_id < 8 caractères et loggue dans des fichiers les product_id concernées

Script shell inspiré de : https://github.com/pass-culture/pass-culture-main/pull/7489/files
