### PR TITLE
(PC-24145)[API] feat: add offerer_venues to collective api

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/venues.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/venues.py
@@ -1,3 +1,4 @@
+from pcapi.core.offerers import api as offerers_api
 from pcapi.core.providers import repository as providers_repository
 from pcapi.routes.public import blueprints
 from pcapi.routes.public.collective.serialization import offers as offers_serialization
@@ -36,3 +37,32 @@ def list_venues() -> serialization.CollectiveOffersListVenuesResponseModel:
     return serialization.CollectiveOffersListVenuesResponseModel(
         __root__=[venues_serialization.VenueResponse.build_model(venue) for venue in venues]
     )
+
+
+@blueprints.v2_prefixed_public_api.route("/collective/offerer_venues", methods=["GET"])
+@spectree_serialize(
+    api=blueprints.v2_prefixed_public_api_schema,
+    tags=["API offres collectives"],
+    resp=SpectreeResponse(
+        HTTP_200=(
+            venues_serialization.GetOfferersVenuesResponse,
+            "La liste des lieux, groupés par structures",
+        ),
+        HTTP_401=(
+            offers_serialization.AuthErrorResponseModel,
+            "Authentification nécessaire",
+        ),
+    ),
+)
+@api_key_required
+def get_offerer_venues(
+    query: venues_serialization.GetOfferersVenuesQuery,
+) -> venues_serialization.GetOfferersVenuesResponse:
+    # in French, to be used by Swagger for the API documentation
+    """Récupération des lieux associés au fournisseur authentifié
+    par le jeton d'API; groupés par structures.
+
+    Tous les lieux enregistrés, sont listés ici avec leurs coordonnées.
+    """
+    rows = offerers_api.get_providers_offerer_and_venues(current_api_key.provider, query.siren)
+    return venues_serialization.GetOfferersVenuesResponse.serialize_offerers_venues(rows)

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -21,7 +21,6 @@ from pcapi.routes import serialization
 from pcapi.routes.public.individual_offers.v1.base_serialization import IndexPaginationQueryParams
 import pcapi.routes.public.serialization.accessibility as accessibility_serialization
 from pcapi.routes.public.serialization.utils import StrEnum
-import pcapi.routes.public.serialization.venues as venues_serialization
 from pcapi.serialization import utils as serialization_utils
 from pcapi.utils import date as date_utils
 
@@ -923,31 +922,6 @@ class GetDatesResponse(serialization.ConfiguredBaseModel):
 
     class Config:
         json_encoders = {datetime.datetime: date_utils.format_into_utc_date}
-
-
-class OffererResponse(serialization.ConfiguredBaseModel):
-    id: int
-    dateCreated: datetime.datetime = pydantic_v1.Field(..., alias="createdDatetime")
-    name: str = pydantic_v1.Field(example="Structure A")
-    siren: str | None = pydantic_v1.Field(example="123456789")
-
-
-class GetOffererVenuesResponse(serialization.ConfiguredBaseModel):
-    offerer: OffererResponse = pydantic_v1.Field(
-        ..., description="Offerer to which the venues belong. Entity linked to the api key used."
-    )
-    venues: typing.List[venues_serialization.VenueResponse]
-
-
-class GetOfferersVenuesResponse(serialization.BaseModel):
-    __root__: typing.List[GetOffererVenuesResponse]
-
-    class Config:
-        json_encoders = {datetime.datetime: date_utils.format_into_utc_date}
-
-
-class GetOfferersVenuesQuery(serialization.ConfiguredBaseModel):
-    siren: str | None = pydantic_v1.Field(example="123456789", regex=r"^\d{9}$")
 
 
 class GetProductsListByEansQuery(serialization.ConfiguredBaseModel):

--- a/api/tests/routes/public/blueprint_v2_openapi_test.py
+++ b/api/tests/routes/public/blueprint_v2_openapi_test.py
@@ -247,6 +247,41 @@ def test_public_api(client, app):
                     "title": "GetListEducationalInstitutionsQueryModel",
                     "type": "object",
                 },
+                "GetOffererVenuesResponse": {
+                    "properties": {
+                        "offerer": {
+                            "allOf": [{"$ref": "#/components/schemas/OffererResponse"}],
+                            "description": "Offerer to which the venues belong. Entity linked to the api key used.",
+                            "title": "Offerer",
+                        },
+                        "venues": {
+                            "items": {"$ref": "#/components/schemas/VenueResponse"},
+                            "title": "Venues",
+                            "type": "array",
+                        },
+                    },
+                    "required": ["offerer", "venues"],
+                    "title": "GetOffererVenuesResponse",
+                    "type": "object",
+                },
+                "GetOfferersVenuesQuery": {
+                    "properties": {
+                        "siren": {
+                            "example": "123456789",
+                            "nullable": True,
+                            "pattern": "^\\d{9}$",
+                            "title": "Siren",
+                            "type": "string",
+                        }
+                    },
+                    "title": "GetOfferersVenuesQuery",
+                    "type": "object",
+                },
+                "GetOfferersVenuesResponse": {
+                    "items": {"$ref": "#/components/schemas/GetOffererVenuesResponse"},
+                    "title": "GetOfferersVenuesResponse",
+                    "type": "array",
+                },
                 "GetPublicCollectiveOfferResponseModel": {
                     "additionalProperties": False,
                     "properties": {
@@ -401,6 +436,17 @@ def test_public_api(client, app):
                     },
                     "required": ["addressType"],
                     "title": "OfferVenueModel",
+                    "type": "object",
+                },
+                "OffererResponse": {
+                    "properties": {
+                        "createdDatetime": {"format": "date-time", "title": "Createddatetime", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "name": {"example": "Structure A", "title": "Name", "type": "string"},
+                        "siren": {"example": "123456789", "nullable": True, "title": "Siren", "type": "string"},
+                    },
+                    "required": ["id", "createdDatetime", "name"],
+                    "title": "OffererResponse",
                     "type": "object",
                 },
                 "PartialAccessibility": {
@@ -1111,6 +1157,52 @@ def test_public_api(client, app):
                     },
                     "security": [{"ApiKeyAuth": []}],
                     "summary": "Liste de tous les dispositifs nationaux connus",
+                    "tags": ["API offres collectives"],
+                }
+            },
+            "/v2/collective/offerer_venues": {
+                "get": {
+                    "description": "Tous les lieux enregistrés, sont listés ici avec leurs coordonnées.",
+                    "operationId": "GetOffererVenues",
+                    "parameters": [
+                        {
+                            "description": "",
+                            "in": "query",
+                            "name": "siren",
+                            "required": False,
+                            "schema": {
+                                "example": "123456789",
+                                "nullable": True,
+                                "pattern": "^\\d{9}$",
+                                "title": "Siren",
+                                "type": "string",
+                            },
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/GetOfferersVenuesResponse"}
+                                }
+                            },
+                            "description": "La liste des lieux, groupés par structures",
+                        },
+                        "401": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
+                            },
+                            "description": "Authentification nécessaire",
+                        },
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable Entity",
+                        },
+                    },
+                    "security": [{"ApiKeyAuth": []}],
+                    "summary": "Récupération des lieux associés au fournisseur authentifié par le jeton d'API; groupés par structures.",
                     "tags": ["API offres collectives"],
                 }
             },

--- a/api/tests/routes/public/collective/endpoints/get_collective_offers_venues_test.py
+++ b/api/tests/routes/public/collective/endpoints/get_collective_offers_venues_test.py
@@ -5,6 +5,7 @@ import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.providers.factories as providers_factories
+from pcapi.utils.date import format_into_utc_date
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -77,4 +78,85 @@ class CollectiveOffersGetVenuesTest:
         response = client.get(url_for("pro_public_api_v2.list_venues"))
 
         # Then
+        assert response.status_code == 401
+
+
+class GetOfferersVenuesTest:
+    def test_get_offerers_venues(self, client):
+        provider = providers_factories.ProviderFactory()
+        venue = providers_factories.VenueProviderFactory(provider=provider).venue
+        offerers_factories.ApiKeyFactory(provider=provider)
+
+        offerers_factories.VenueFactory()  # excluded from results
+
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            url_for("pro_public_api_v2.get_offerer_venues")
+        )
+
+        assert response.status_code == 200
+
+        offerer = venue.managingOfferer
+        assert response.json == [
+            {
+                "offerer": {
+                    "createdDatetime": format_into_utc_date(offerer.dateCreated),
+                    "id": offerer.id,
+                    "name": offerer.name,
+                    "siren": offerer.siren,
+                },
+                "venues": [
+                    {
+                        "id": venue.id,
+                        "legalName": venue.name,
+                        "location": {
+                            "address": venue.address,
+                            "city": venue.city,
+                            "postalCode": venue.postalCode,
+                            "type": "physical" if not venue.isVirtual else "digital",
+                        },
+                        "siretComment": venue.comment,
+                        "createdDatetime": format_into_utc_date(venue.dateCreated),
+                        "publicName": venue.publicName,
+                        "siret": venue.siret,
+                        "activityDomain": venue.venueTypeCode.name,
+                        "accessibility": {
+                            "audioDisabilityCompliant": venue.audioDisabilityCompliant,
+                            "mentalDisabilityCompliant": venue.mentalDisabilityCompliant,
+                            "motorDisabilityCompliant": venue.motorDisabilityCompliant,
+                            "visualDisabilityCompliant": venue.visualDisabilityCompliant,
+                        },
+                    }
+                ],
+            }
+        ]
+
+    def test_filter_offerers_venues_by_siren(self, client):
+        siren = "123456789"
+
+        provider = providers_factories.ProviderFactory()
+        venue = providers_factories.VenueProviderFactory(venue__managingOfferer__siren=siren, provider=provider).venue
+        offerers_factories.ApiKeyFactory(provider=provider)
+
+        providers_factories.VenueProviderFactory(provider=provider)  # excluded
+
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            url_for("pro_public_api_v2.get_offerer_venues", siren=siren)
+        )
+
+        assert response.status_code == 200
+
+        assert len(response.json) == 1
+        assert response.json[0]["offerer"]["siren"] == siren
+
+        assert len(response.json[0]["venues"]) == 1
+        assert response.json[0]["venues"][0]["id"] == venue.id
+
+    def test_filter_offerers_venues_by_siren_error(self, client):
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            url_for("pro_public_api_v2.get_offerer_venues", siren="not a siren")
+        )
+        assert response.status_code == 400
+
+    def test_unauthenticated_client(self, client):
+        response = client.get(url_for("pro_public_api_v2.get_offerer_venues", siren="123456789"))
         assert response.status_code == 401

--- a/pro/src/apiClient/v2/index.ts
+++ b/pro/src/apiClient/v2/index.ts
@@ -31,11 +31,15 @@ export type { CollectiveOffersSubCategoryResponseModel } from './models/Collecti
 export type { ErrorResponseModel } from './models/ErrorResponseModel';
 export type { GetBookingResponse } from './models/GetBookingResponse';
 export type { GetListEducationalInstitutionsQueryModel } from './models/GetListEducationalInstitutionsQueryModel';
+export type { GetOfferersVenuesQuery } from './models/GetOfferersVenuesQuery';
+export type { GetOfferersVenuesResponse } from './models/GetOfferersVenuesResponse';
+export type { GetOffererVenuesResponse } from './models/GetOffererVenuesResponse';
 export type { GetPublicCollectiveOfferResponseModel } from './models/GetPublicCollectiveOfferResponseModel';
 export type { ListCollectiveOffersQueryModel } from './models/ListCollectiveOffersQueryModel';
 export type { ListNationalProgramsResponseModel } from './models/ListNationalProgramsResponseModel';
 export type { NationalProgramModel } from './models/NationalProgramModel';
 export { OfferAddressType } from './models/OfferAddressType';
+export type { OffererResponse } from './models/OffererResponse';
 export { OfferStatus } from './models/OfferStatus';
 export type { OfferVenueModel } from './models/OfferVenueModel';
 export type { PartialAccessibility } from './models/PartialAccessibility';

--- a/pro/src/apiClient/v2/models/GetOffererVenuesResponse.ts
+++ b/pro/src/apiClient/v2/models/GetOffererVenuesResponse.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { OffererResponse } from './OffererResponse';
+import type { VenueResponse } from './VenueResponse';
+
+export type GetOffererVenuesResponse = {
+  /**
+   * Offerer to which the venues belong. Entity linked to the api key used.
+   */
+  offerer: OffererResponse;
+  venues: Array<VenueResponse>;
+};
+

--- a/pro/src/apiClient/v2/models/GetOfferersVenuesQuery.ts
+++ b/pro/src/apiClient/v2/models/GetOfferersVenuesQuery.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type GetOfferersVenuesQuery = {
+  siren?: string | null;
+};
+

--- a/pro/src/apiClient/v2/models/GetOfferersVenuesResponse.ts
+++ b/pro/src/apiClient/v2/models/GetOfferersVenuesResponse.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { GetOffererVenuesResponse } from './GetOffererVenuesResponse';
+
+export type GetOfferersVenuesResponse = Array<GetOffererVenuesResponse>;

--- a/pro/src/apiClient/v2/models/OffererResponse.ts
+++ b/pro/src/apiClient/v2/models/OffererResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type OffererResponse = {
+  createdDatetime: string;
+  id: number;
+  name: string;
+  siren?: string | null;
+};
+

--- a/pro/src/apiClient/v2/services/ApiOffresCollectivesService.ts
+++ b/pro/src/apiClient/v2/services/ApiOffresCollectivesService.ts
@@ -9,6 +9,7 @@ import type { CollectiveOffersListResponseModel } from '../models/CollectiveOffe
 import type { CollectiveOffersListStudentLevelsResponseModel } from '../models/CollectiveOffersListStudentLevelsResponseModel';
 import type { CollectiveOffersListSubCategoriesResponseModel } from '../models/CollectiveOffersListSubCategoriesResponseModel';
 import type { CollectiveOffersListVenuesResponseModel } from '../models/CollectiveOffersListVenuesResponseModel';
+import type { GetOfferersVenuesResponse } from '../models/GetOfferersVenuesResponse';
 import type { GetPublicCollectiveOfferResponseModel } from '../models/GetPublicCollectiveOfferResponseModel';
 import type { ListNationalProgramsResponseModel } from '../models/ListNationalProgramsResponseModel';
 import type { OfferStatus } from '../models/OfferStatus';
@@ -129,6 +130,29 @@ export class ApiOffresCollectivesService {
       errors: {
         401: `Authentification nécessaire`,
         403: `Vous n'avez pas les droits nécessaires pour voir ces informations`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * Récupération des lieux associés au fournisseur authentifié par le jeton d'API; groupés par structures.
+   * Tous les lieux enregistrés, sont listés ici avec leurs coordonnées.
+   * @param siren
+   * @returns GetOfferersVenuesResponse La liste des lieux, groupés par structures
+   * @throws ApiError
+   */
+  public getOffererVenues(
+    siren?: string | null,
+  ): CancelablePromise<GetOfferersVenuesResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v2/collective/offerer_venues',
+      query: {
+        'siren': siren,
+      },
+      errors: {
+        401: `Authentification nécessaire`,
         422: `Unprocessable Entity`,
       },
     });


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24145

Ajouter une route `offerer_venues` à l'api publique collective.
Le but est d'avoir les deux mêmes routes côtés apis individuelle et collective. En attendant de les unifier un jour...