### PR TITLE
(PC-24119)[PRO] review adage filters

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -67,6 +67,18 @@ export const OfferFilters = ({
     }
     return 0
   }
+
+  const resetLocalisationFilterState = () => {
+    if (
+      (localisationFilterState === LocalisationFilterStates.DEPARTMENTS &&
+        formik.values.departments.length === 0) ||
+      (localisationFilterState === LocalisationFilterStates.ACADEMIES &&
+        formik.values.academies.length === 0)
+    ) {
+      setLocalisationFilterState(LocalisationFilterStates.NONE)
+    }
+  }
+
   const activeLocalisationFilterCount = getActiveLocalisationFilterCount()
 
   const [domainsOptions, setDomainsOptions] = useState<Option<number>[]>([])
@@ -93,6 +105,8 @@ export const OfferFilters = ({
   const onSearch = (modalName: string) => {
     formik.handleSubmit()
     setModalOpenStatus(prevState => ({ ...prevState, [modalName]: false }))
+
+    resetLocalisationFilterState()
   }
   useEffect(() => {
     const loadFiltersOptions = async () => {
@@ -192,7 +206,10 @@ export const OfferFilters = ({
                 isOpen={modalOpenStatus['localisation']}
                 setIsOpen={setModalOpenStatus}
                 filterName="localisation"
-                handleSubmit={formik.handleSubmit}
+                handleSubmit={() => {
+                  resetLocalisationFilterState()
+                  formik.handleSubmit()
+                }}
               >
                 {localisationFilterState === LocalisationFilterStates.NONE && (
                   <ModalFilterLayout
@@ -371,15 +388,18 @@ export const OfferFilters = ({
                     label="Niveau scolaire"
                     options={studentsOptions}
                     isOpen={modalOpenStatus['students']}
-                    sortOptions={(options, selectedOptions) =>
+                    sortOptions={(options, selectedOptions) => {
                       //  Implement custom sort to not sort results alphabetically
-                      [...options].sort((option1, option2) => {
-                        return selectedOptions.has(option1.value) &&
-                          !selectedOptions.has(option2.value)
+                      return options.sort((option1, option2) => {
+                        const isSelected1 = selectedOptions.has(option1.value)
+                        const isSelected2 = selectedOptions.has(option2.value)
+                        return isSelected1 === isSelected2
+                          ? 0
+                          : isSelected1 && !isSelected2
                           ? -1
                           : 1
                       })
-                    }
+                    }}
                   />
                 </ModalFilterLayout>
               </AdageButtonFilter>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -78,13 +78,16 @@ export const OfferFilters = ({
   const onReset = (
     modalName: string,
     value: string | string[] | number,
-    fieldName?: string
+    fieldName?: string,
+    closeModal: boolean = true
   ) => {
     clearFormikFieldValue(fieldName || modalName, value)
     if (modalName === 'localisation') {
       setLocalisationFilterState(LocalisationFilterStates.NONE)
     }
-    setModalOpenStatus(prevState => ({ ...prevState, [modalName]: false }))
+    if (closeModal) {
+      setModalOpenStatus(prevState => ({ ...prevState, [modalName]: false }))
+    }
   }
 
   const onSearch = (modalName: string) => {
@@ -247,7 +250,9 @@ export const OfferFilters = ({
                 {localisationFilterState ===
                   LocalisationFilterStates.DEPARTMENTS && (
                   <ModalFilterLayout
-                    onClean={() => onReset('localisation', [], 'departments')}
+                    onClean={() =>
+                      onReset('localisation', [], 'departments', false)
+                    }
                     onSearch={() => onSearch('localisation')}
                     title="Choisir un département"
                   >
@@ -263,7 +268,9 @@ export const OfferFilters = ({
                 {localisationFilterState ===
                   LocalisationFilterStates.ACADEMIES && (
                   <ModalFilterLayout
-                    onClean={() => onReset('localisation', [], 'academies')}
+                    onClean={() =>
+                      onReset('localisation', [], 'academies', false)
+                    }
                     onSearch={() => onSearch('localisation')}
                     title="Choisir une académie"
                   >
@@ -279,7 +286,9 @@ export const OfferFilters = ({
                 {localisationFilterState ===
                   LocalisationFilterStates.GEOLOCATION && (
                   <ModalFilterLayout
-                    onClean={() => onReset('localisation', 50, 'geolocRadius')}
+                    onClean={() =>
+                      onReset('localisation', 50, 'geolocRadius', false)
+                    }
                     onSearch={() => onSearch('localisation')}
                     title="Autour de mon établissement scolaire"
                   >

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -362,6 +362,15 @@ export const OfferFilters = ({
                     label="Niveau scolaire"
                     options={studentsOptions}
                     isOpen={modalOpenStatus['students']}
+                    sortOptions={(options, selectedOptions) =>
+                      //  Implement custom sort to not sort results alphabetically
+                      [...options].sort((option1, option2) => {
+                        return selectedOptions.has(option1.value) &&
+                          !selectedOptions.has(option2.value)
+                          ? -1
+                          : 1
+                      })
+                    }
                   />
                 </ModalFilterLayout>
               </AdageButtonFilter>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -367,4 +367,26 @@ describe('OfferFilters', () => {
 
     expect(screen.getByText('Cinéma')).toBeInTheDocument()
   })
+
+  it('should sort students options with selected first but keep initial order otherwise', async () => {
+    renderOfferFilters({
+      initialValues: {
+        ...initialValues,
+        students: ['Collège - 5e'],
+      },
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Niveau scolaire (1)' })
+    )
+
+    const options = screen.getAllByRole('option')
+
+    //  Verify that the selected option comes first
+    expect(options[0]).toHaveAccessibleName('Collège - 5e')
+
+    //  Verify that non-selected options aren't sorted alphabetically
+    expect(options[1]).toHaveAccessibleName('Collège - 6e')
+    expect(options[options.length - 1]).toHaveAccessibleName('CAP - 2e année')
+  })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/studentsOptions.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/studentsOptions.ts
@@ -3,20 +3,20 @@ export const studentsOptions = [
   { label: 'Collège - 5e', value: 'Collège - 5e' },
   { label: 'Collège - 4e', value: 'Collège - 4e' },
   { label: 'Collège - 3e', value: 'Collège - 3e' },
-  { label: 'CAP - 1re année', value: 'CAP - 1re année' },
-  { label: 'CAP - 2e année', value: 'CAP - 2e année' },
   { label: 'Lycée - Seconde', value: 'Lycée - Seconde' },
   { label: 'Lycée - Première', value: 'Lycée - Première' },
   { label: 'Lycée - Terminale', value: 'Lycée - Terminale' },
+  { label: 'CAP - 1re année', value: 'CAP - 1re année' },
+  { label: 'CAP - 2e année', value: 'CAP - 2e année' },
 ]
 
 // Delete with FF : WIP_ENABLE_NEW_ADAGE_FILTERS
 export const oldStudentsOptions = [
   { label: 'Collège - 4e', value: 'Collège - 4e' },
   { label: 'Collège - 3e', value: 'Collège - 3e' },
-  { label: 'CAP - 1re année', value: 'CAP - 1re année' },
-  { label: 'CAP - 2e année', value: 'CAP - 2e année' },
   { label: 'Lycée - Seconde', value: 'Lycée - Seconde' },
   { label: 'Lycée - Première', value: 'Lycée - Première' },
   { label: 'Lycée - Terminale', value: 'Lycée - Terminale' },
+  { label: 'CAP - 1re année', value: 'CAP - 1re année' },
+  { label: 'CAP - 2e année', value: 'CAP - 2e année' },
 ]

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -326,4 +326,41 @@ describe('offersSearch component', () => {
       screen.getByText('Dans quelle zone géographique')
     ).toBeInTheDocument()
   })
+
+  it('should go back to the localisation main menu when reopening the localisation multiselect after having submitted it with no values selected', async () => {
+    renderOffersSearchComponent(props, user)
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Réinitialiser les filtres' })
+    )
+
+    const localisationFilter = screen.getByRole('button', {
+      name: 'Localisation des partenaires',
+    })
+    await userEvent.click(localisationFilter)
+
+    expect(
+      screen.getByText('Dans quelle zone géographique')
+    ).toBeInTheDocument()
+
+    //  Open the departments submenu, thus set the localisation menu to department
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Choisir un département' })
+    )
+
+    //  Submit without having selected anything
+    await userEvent.click(
+      screen.getAllByRole('button', {
+        name: 'Rechercher',
+      })[1]
+    )
+
+    //  Reopen localisation filter
+    await userEvent.click(localisationFilter)
+
+    //  We see the location menu and not the departments list
+    expect(
+      screen.getByText('Dans quelle zone géographique')
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -310,4 +310,20 @@ describe('offersSearch component', () => {
     expect(screen.getByLabelText('75 - Paris', { exact: false })).toBeChecked()
     expect(screen.getByLabelText('30 - Gard', { exact: false })).toBeChecked()
   })
+
+  it('should go back to localisation main menu when reseting the localisation modal', async () => {
+    renderOffersSearchComponent(props, user)
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /Localisation des partenaires/,
+      })
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Réinitialiser' }))
+
+    expect(
+      screen.getByText('Dans quelle zone géographique')
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.tsx
+++ b/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.tsx
@@ -17,6 +17,10 @@ interface AdageMultiselectProps {
   name: string
   label: string
   isOpen: boolean
+  sortOptions?: (
+    items: ItemProps[],
+    selectedItems: Set<ItemProps['value']>
+  ) => ItemProps[]
 }
 
 const filterItems = (items: ItemProps[], inputValue: string) => {
@@ -24,7 +28,7 @@ const filterItems = (items: ItemProps[], inputValue: string) => {
   return items.filter(item => item.label.match(regExp))
 }
 
-const sortItems = (
+const defaultSortOptions = (
   items: ItemProps[],
   selectedItems: Set<ItemProps['value']>
 ) => {
@@ -62,6 +66,7 @@ const AdageMultiselect = ({
   name,
   label,
   isOpen,
+  sortOptions,
 }: AdageMultiselectProps) => {
   // We need to maintain the input value in state so that we can use it in itemToString
   const [inputValue, setInputValue] = useState('')
@@ -116,7 +121,9 @@ const AdageMultiselect = ({
   useEffect(() => {
     setInputValue('')
     setDownshiftInputValue('')
-    setSortedOptions(sortItems(options, new Set(field.value)))
+    setSortedOptions(
+      (sortOptions ?? defaultSortOptions)(options, new Set(field.value))
+    )
   }, [isOpen])
 
   return (
@@ -142,7 +149,7 @@ const AdageMultiselect = ({
           'aria-activedescendant': getInputProps()['aria-activedescendant'],
         })}
       >
-        {filterItems(options, inputValue).map((item, index) => {
+        {filterItems(sortedOptions, inputValue).map((item, index) => {
           // we cannot pass down the ref to basecheckbox as it is a function component
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { ref, ...itemProps } = getItemProps({ item, index })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24119

**FF à activer :**
- WIP_ENABLE_ADAGE_GEO_LOCATION
- WIP_ENABLE_NEW_ADAGE_HEADER
- WIP_ENABLE_NEW_ADAGE_FILTERS

**Objectif :**
Revue de l'interface et des interactions des filtres adage.

**Réalisation :**
- Réorganisation des options dans le select Niveau Scolaire pour avoir Collège et Lycée avant CAP. Création d'une prop `sortOptions` dans le multiselect donnant une fonction de sort et ainsi éviter le tri par défaut qui impose un ordre alphabétique des options invalide dans le cas du Niveau Scolaire.
- Pour le multiselect de localisation (avec sous menu), ajout d'une condition dans le `onReset` pour ne pas fermer la modal dans ce cas. Ainsi la modal reste ouverte mais son contenu devient le choix des différents types de filtres localisation.
- Pour le multiselect de localisation, appeler `resetLocalisationMenuState` quand on valide une sélection dans un sous-menu localisation pour revenir au menu principal de localisation la prochaine fois qu'on ouvre cette modal dans le cas ou les filtres appliqués sont vides.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques