### PR TITLE
(PC-24040)[PRO] fix: set icon size in color for added in adage step

### DIFF
--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
@@ -47,6 +47,11 @@
     align-items: center;
     margin-bottom: rem.torem(32px);
     gap: rem.torem(10px);
+
+    &-icon {
+      color: colors.$green-valid;
+      width: rem.torem(20px);
+    }
   }
 
   &-step-description {

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -358,7 +358,12 @@ const CollectiveDmsTimeline = ({
   ) {
     return (
       <div className={styles['timeline-added-in-adage']}>
-        <SvgIcon src={strokeValidIcon} alt="" />
+        <SvgIcon
+          className={styles['timeline-added-in-adage-icon']}
+          src={strokeValidIcon}
+          alt=""
+          width="20"
+        />
         <span>Ce lieu est référencé sur ADAGE</span>
       </div>
     )
@@ -416,7 +421,12 @@ const CollectiveDmsTimeline = ({
 
       return (
         <div className={styles['timeline-added-in-adage']}>
-          <SvgIcon src={strokeValidIcon} alt="" />
+          <SvgIcon
+            className={styles['timeline-added-in-adage-icon']}
+            src={strokeValidIcon}
+            alt=""
+            width="20"
+          />
           <span>Ce lieu est référencé sur ADAGE</span>
         </div>
       )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24040

Fix la taille et la couleur de l'icone dans le suivi dms d'un lieu. 
Pour voir cette étape : 

- Edition d'un lieu avec adageId et date d'ajout dans adage depuis plus de 30 jours
- Lieu correspondant dans la sandbox accepted_dms eac_complete_30+d

## Screenshot 


| Avant  | Après |
| ------ | ------ |
| ![image](https://github.com/pass-culture/pass-culture-main/assets/71768799/2c9b0902-086a-43f5-bc05-a0c5a95d9612) | ![Capture d’écran 2023-09-07 à 08 49 18](https://github.com/pass-culture/pass-culture-main/assets/71768799/584deafa-c337-46a6-ac35-ab18a6c74e77) |

