### PR TITLE
(PC-24244)[PRO] feat: add weight to event address type in algolia search

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -56,6 +56,9 @@ export const OffersInstantSearch = ({
         attributesToRetrieve={attributesToRetrieve}
         clickAnalytics
         facetFilters={facetFilters}
+        filters={
+          'offer.eventAddressType:offererVenue<score=3> OR offer.eventAddressType:school<score=2> OR offer.eventAddressType:other<score=1>'
+        }
         hitsPerPage={8}
         aroundLatLng={geoLocation.latLng}
         aroundRadius={geoLocation.radius}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24244

Ajout d'un critère de tri supplémentaire pour les résultats de recherche Algolia. 

Désormais les offres seront affichées selon les règles d'importance suivantes : 

1. la date de création (paramètre défini dans algolia)
2. le type d’intervention : il faut d’abord afficher les acteurs qui proposent des sorties dans leur lieux. Ce qui correspond au filtre de recherche “sortie chez un partenaire culturel” et à la case “dans votre lieu” ou “autre” dans la création d’offre.
