### PR TITLE
(BSR)[BO] fix: default pro search type in backoffice pro details pages

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
@@ -78,7 +78,7 @@ def render_offerer_details(
 
     return render_template(
         "offerer/get.html",
-        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.OFFERER),
+        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.OFFERER.name),
         search_dst=url_for("backoffice_v3_web.search_pro"),
         offerer=offerer,
         region=regions_utils.get_region_name_from_postal_code(offerer.postalCode),

--- a/api/src/pcapi/routes/backoffice_v3/pro_users/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro_users/blueprint.py
@@ -56,7 +56,7 @@ def get(user_id: int) -> utils.BackofficeResponse:
 
     return render_template(
         "pro_user/get.html",
-        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.USER),
+        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.USER.name),
         search_dst=url_for("backoffice_v3_web.search_pro"),
         user=user,
         form=form,

--- a/api/src/pcapi/routes/backoffice_v3/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues/blueprint.py
@@ -200,7 +200,7 @@ def render_venue_details(
 
     return render_template(
         "venue/get.html",
-        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.VENUE),
+        search_form=search_forms.ProSearchForm(terms=request.args.get("terms"), pro_type=TypeOptions.VENUE.name),
         search_dst=url_for("backoffice_v3_web.search_pro"),
         venue=venue,
         edit_venue_form=edit_venue_form,


### PR DESCRIPTION
## But de la pull request

En haut des pages de détails pro dans le backoffice, la barre de recherche revient sur « Structure » par défaut au lieu de garder le type de l'objet affiché.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques