### PR TITLE
(PC-24203) set charlie booking and cancel url for ehp

### DIFF
--- a/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
+++ b/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
@@ -98,6 +98,12 @@ SET "authToken" = 'anonymized, you may have to set it if you want to use this pr
 WHERE "authToken" IS NOT NULL
 ;
 
+UPDATE provider
+SET 
+    "bookingExternalUrl" = 'http://mock-api-billeterie.mock-api-billeterie.svc.cluster.local:5003/tickets/create',
+    "cancelExternalUrl" = 'http://mock-api-billeterie.mock-api-billeterie.svc.cluster.local:5003/tickets/cancel'
+WHERE "bookingExternalUrl" IS NOT NULL and "cancelExternalUrl" IS NOT NULL;
+
 UPDATE boost_cinema_details
 SET
   password = '',

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -210,10 +210,10 @@ TITELIVE_EPAGINE_API_PASSWORD = secrets_utils.get("TITELIVE_EPAGINE_API_PASSWORD
 
 # CHARLIE URLS
 CHARLIE_BOOKING_URL = os.environ.get(
-    "CHARLIE_API_URL", "https://pass-culture-external-api-mpedokshja-od.a.run.app/tickets/create"
+    "CHARLIE_API_URL", "http://mock-api-billeterie.mock-api-billeterie.svc.cluster.local:5003/tickets/create"
 )
 CHARLIE_CANCEL_BOOKING_URL = os.environ.get(
-    "CHARLIE_CANCEL_BOOKING_URL", "https://pass-culture-external-api-mpedokshja-od.a.run.app/tickets/cancel"
+    "CHARLIE_CANCEL_BOOKING_URL", "http://mock-api-billeterie.mock-api-billeterie.svc.cluster.local:5003/tickets/cancel"
 )
 
 # UBBLE


### PR DESCRIPTION
## But de la pull request
Mettre l'url du mock de l'api charlie dans la sandbox testing et dans le script d'anonymization en staging

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24023