### PR TITLE
(PC-24202)[API] feat: Send reset password email when unsuspending user suspended for suspicious login

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -414,6 +414,7 @@ def _cancel_bookings_of_user_on_requested_account_suspension(
 def unsuspend_account(
     user: models.User, actor: models.User, comment: str | None = None, send_email: bool = False
 ) -> None:
+    suspension_reason = user.suspension_reason
     user.isActive = True
     action = history_api.log_action(
         history_models.ActionType.USER_UNSUSPENDED, author=actor, user=user, comment=comment, save=False
@@ -432,6 +433,9 @@ def unsuspend_account(
 
     if send_email:
         transactional_mails.send_unsuspension_email(user)
+
+    if suspension_reason == constants.SuspensionReason.SUSPICIOUS_LOGIN_REPORTED_BY_USER:
+        request_password_reset(user)
 
 
 def change_email(

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -388,6 +388,38 @@ class UnsuspendAccountTest:
             history[0], user, author, history_models.ActionType.USER_UNSUSPENDED, reason=None, comment=comment
         )
 
+    def should_send_reset_password_email_when_user_is_suspended_for_suspicious_login(self):
+        user = users_factories.UserFactory(isActive=False)
+        history_factories.SuspendedUserActionHistoryFactory(
+            user=user, reason=users_constants.SuspensionReason.SUSPICIOUS_LOGIN_REPORTED_BY_USER
+        )
+        author = users_factories.AdminFactory()
+
+        users_api.unsuspend_account(user, author)
+
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0].sent_data["params"]["RESET_PASSWORD_LINK"]
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            users_constants.SuspensionReason.FRAUD_SUSPICION,
+            users_constants.SuspensionReason.UPON_USER_REQUEST,
+            users_constants.SuspensionReason.SUSPENSION_FOR_INVESTIGATION_TEMP,
+            users_constants.SuspensionReason.FRAUD_FAKE_DOCUMENT,
+        ],
+    )
+    def should_not_send_reset_password_email_when_user_is_suspended_for_reason_other_than_suspicious_login(
+        self, reason
+    ):
+        user = users_factories.UserFactory(isActive=False)
+        history_factories.SuspendedUserActionHistoryFactory(user=user, reason=reason)
+        author = users_factories.AdminFactory()
+
+        users_api.unsuspend_account(user, author)
+
+        assert len(mails_testing.outbox) == 0
+
 
 @pytest.mark.usefixtures("db_session")
 class ChangeUserEmailTest:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24202

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques