### PR TITLE
Pc 23439 calculate last bookings count by ean

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -674,3 +674,41 @@ def unindex_all_venues() -> None:
         if settings.IS_RUNNING_TESTS:
             raise
         logger.exception("Could not unindex all venues")
+
+
+def reindex_offers_if_ean_booked_since(offer_ids: list, since: datetime.datetime) -> None:
+    """
+    This function loads all offers booked the last x hours and
+    if they have an ean, it will reindex all related offers with the same ean
+    """
+
+    last_x_hours_bookings_with_ean = (
+        bookings_models.Booking.query.filter(
+            bookings_models.Booking.dateCreated >= since,
+            bookings_models.Booking.status != bookings_models.BookingStatus.CANCELLED,
+        )
+        .join(bookings_models.Booking.stock)
+        .join(offers_models.Stock.offer)
+        .join(offers_models.Offer.product)
+        .filter(sa.or_(offers_models.Offer.extraData["ean"].isnot(None)))
+        .with_entities(offers_models.Offer.extraData["ean"].label("ean"))
+    )
+
+    eans = {booking.ean for booking in last_x_hours_bookings_with_ean}
+
+    if not eans:
+        return
+
+    # We reindex all offers with the same ean
+    offer_ids_to_reindex_query = (
+        offers_models.Offer.query.join(offers_models.Offer.product)
+        .filter(offers_models.Offer.id.in_(offer_ids))
+        .filter(offers_models.Offer.extraData["ean"].astext.in_(list(eans)))
+        .with_entities(offers_models.Offer.id)
+    )
+    offer_ids_to_reindex = [offer_id for offer_id, in offer_ids_to_reindex_query]
+
+    logger.info(
+        "Starting to reindex offers with ean booked recently", extra={"offers_count": len(offer_ids_to_reindex)}
+    )
+    reindex_offer_ids(offer_ids_to_reindex, use_national_booking_count=True)

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -149,7 +149,7 @@ def test_serialize_offer_extra_data(
 
 @override_settings(ALGOLIA_LAST_30_DAYS_BOOKINGS_RANGE_THRESHOLDS=[1, 2, 3, 4])
 @pytest.mark.parametrize(
-    "bookings_number, expected_range",
+    "bookings_count, expected_range",
     (
         (0, algolia.Last30DaysBookingsRange.VERY_LOW.value),
         (1, algolia.Last30DaysBookingsRange.LOW.value),
@@ -159,15 +159,15 @@ def test_serialize_offer_extra_data(
         (5, algolia.Last30DaysBookingsRange.VERY_HIGH.value),
     ),
 )
-def test_index_last_30_days_bookings(app, bookings_number, expected_range):
+def test_index_last_30_days_bookings(app, bookings_count, expected_range):
     # given
     offer = offers_factories.StockFactory().offer
 
     # when
-    serialized = algolia.AlgoliaBackend().serialize_offer(offer, bookings_number)
+    serialized = algolia.AlgoliaBackend().serialize_offer(offer, bookings_count)
 
     # then
-    assert serialized["offer"]["last30DaysBookings"] == bookings_number
+    assert serialized["offer"]["last30DaysBookings"] == bookings_count
     assert serialized["offer"]["last30DaysBookingsRange"] == expected_range
 
 


### PR DESCRIPTION
## But de la pull request
Changer le calcul des réservations des 30 derniers jours si l'offre a un ean. Dans ce cas on prend en compte les résas nationales.
Exposer une commande flask pour réindexer les offres concernées (chaque jour)

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23439

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques