### PR TITLE
(PC-24285): forbid stock creation with begining date in more than 360 days in the future

### DIFF
--- a/api/src/pcapi/routes/public/books_stocks/serialization.py
+++ b/api/src/pcapi/routes/public/books_stocks/serialization.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timedelta
 import decimal
 import logging
 import typing
@@ -67,6 +68,12 @@ class StockCreationBodyModel(BaseModel):
     price_category_id: int | None
     quantity: int | None = Field(None, ge=0, le=models.Stock.MAX_STOCK_QUANTITY)
 
+    @pydantic_v1.validator("beginning_datetime")
+    def validate_beginning_datetime(cls, begining_datetime: datetime | None) -> datetime | None:
+        if begining_datetime and begining_datetime.timestamp() > (datetime.utcnow() + timedelta(days=360)).timestamp():
+            raise ValueError("Beginning datetime must be less than 360 days in the future")
+        return begining_datetime
+
     class Config:
         alias_generator = to_camel
         extra = "forbid"
@@ -79,6 +86,12 @@ class StockEditionBodyModel(BaseModel):
     price: decimal.Decimal | None
     price_category_id: int | None
     quantity: int | None = Field(None, ge=0, le=models.Stock.MAX_STOCK_QUANTITY)
+
+    @pydantic_v1.validator("beginning_datetime")
+    def validate_beginning_datetime(cls, begining_datetime: datetime | None) -> datetime | None:
+        if begining_datetime and begining_datetime.timestamp() > (datetime.utcnow() + timedelta(days=360)).timestamp():
+            raise ValueError("Beginning datetime must be less than 360 days in the future")
+        return begining_datetime
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -106,6 +106,8 @@ def check_date_in_future_and_remove_timezone(value: datetime.datetime | None) ->
     no_tz_value = as_utc_without_timezone(value)
     if no_tz_value < datetime.datetime.utcnow():
         raise ValueError("The datetime must be in the future.")
+    if no_tz_value > datetime.datetime.utcnow() + datetime.timedelta(days=360):
+        raise ValueError("The datetime must be less than 360 days in the future.")
     return no_tz_value
 
 


### PR DESCRIPTION
Interdire la création de stock ayant une date de début plus de 360 jours dans le future
Cette PR est du au fait que lors de l'indexation sur algolia on envoie les offres avec toutes les dates, et ce payload peut dépasser les 100ko limité par algolia

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24285

## Vérifications

- [X] J'ai écrit les tests nécessaires