### PR TITLE
(PC-24002)[BO] feat: incident finance events

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 ef07f9582155 (pre) (head)
-2edee580308f (post) (head)
+aae5aa12b1c1 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230906T130321_aae5aa12b1c1_update_finance_event_constraints.py
+++ b/api/src/pcapi/alembic/versions/20230906T130321_aae5aa12b1c1_update_finance_event_constraints.py
@@ -1,0 +1,47 @@
+"""Update finance event constraints
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "aae5aa12b1c1"
+down_revision = "2edee580308f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("finance_event", sa.Column("bookingFinanceIncidentId", sa.BigInteger(), nullable=True))
+    op.create_index(
+        "idx_uniq_booking_finance_incident_id",
+        "finance_event",
+        ["bookingFinanceIncidentId", "motive"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('pending', 'ready')"),
+    )
+    op.create_index(
+        op.f("ix_finance_event_bookingFinanceIncidentId"), "finance_event", ["bookingFinanceIncidentId"], unique=False
+    )
+    op.create_foreign_key(None, "finance_event", "booking_finance_incident", ["bookingFinanceIncidentId"], ["id"])
+    op.drop_constraint("finance_event_check", "finance_event")
+    op.create_check_constraint(
+        "finance_event_check",
+        "finance_event",
+        'num_nonnulls("bookingId", "collectiveBookingId", "bookingFinanceIncidentId") = 1',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("finance_event_check", "finance_event")
+    op.drop_index(op.f("ix_finance_event_bookingFinanceIncidentId"), table_name="finance_event")
+    op.drop_index(
+        "idx_uniq_booking_finance_incident_id",
+        table_name="finance_event",
+        postgresql_where=sa.text("status IN ('pending', 'ready')"),
+    )
+    op.drop_column("finance_event", "bookingFinanceIncidentId")
+    op.create_check_constraint(
+        "finance_event_check", "finance_event", 'num_nonnulls("bookingId", "collectiveBookingId") = 1'
+    )

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -285,7 +285,7 @@ def book_offer(
         repository.save(booking, stock)
 
         if booking.status == BookingStatus.USED:
-            finance_api.add_event(booking, finance_models.FinanceEventMotive.BOOKING_USED)
+            finance_api.add_event(finance_models.FinanceEventMotive.BOOKING_USED, booking=booking)
 
     logger.info(
         "Beneficiary booked an offer",
@@ -414,8 +414,8 @@ def _cancel_booking(
                 booking.cancel_booking(reason, cancel_even_if_used)
                 if cancelled_event:
                     finance_api.add_event(
-                        booking,
                         finance_models.FinanceEventMotive.BOOKING_CANCELLED_AFTER_USE,
+                        booking=booking,
                         commit=False,
                     )
                 _cancel_external_booking(booking, stock)
@@ -596,7 +596,7 @@ def cancel_booking_on_user_requested_account_suspension(booking: Booking) -> Non
 def mark_as_used(booking: Booking) -> None:
     validation.check_is_usable(booking)
     booking.mark_as_used()
-    finance_api.add_event(booking, finance_models.FinanceEventMotive.BOOKING_USED, commit=False)
+    finance_api.add_event(finance_models.FinanceEventMotive.BOOKING_USED, booking=booking, commit=False)
     repository.save(booking)
 
     logger.info(
@@ -631,8 +631,8 @@ def mark_as_used_with_uncancelling(booking: Booking) -> None:
             db.session.add(stock)
     db.session.add(booking)
     finance_api.add_event(
-        booking,
         finance_models.FinanceEventMotive.BOOKING_USED_AFTER_CANCELLATION,
+        booking=booking,
         commit=False,
     )
     db.session.commit()
@@ -663,7 +663,7 @@ def mark_as_unused(booking: Booking) -> None:
     validation.check_can_be_mark_as_unused(booking)
     finance_api.cancel_latest_event(booking, finance_models.FinanceEventMotive.BOOKING_USED)
     finance_api.cancel_pricing(booking, finance_models.PricingLogReason.MARK_AS_UNUSED)
-    finance_api.add_event(booking, finance_models.FinanceEventMotive.BOOKING_UNUSED, commit=False)
+    finance_api.add_event(finance_models.FinanceEventMotive.BOOKING_UNUSED, booking=booking, commit=False)
     booking.mark_as_unused_set_confirmed()
     repository.save(booking)
 
@@ -818,8 +818,8 @@ def auto_mark_as_used_after_event() -> None:
     n_individual_bookings_updated = 0
     for booking in individual_bookings:
         finance_api.add_event(
-            booking,
             finance_models.FinanceEventMotive.BOOKING_USED,
+            booking=booking,
             commit=False,
         )
         n_individual_bookings_updated += 1
@@ -844,8 +844,8 @@ def auto_mark_as_used_after_event() -> None:
     n_collective_bookings_updated = 0
     for booking in collective_bookings:
         finance_api.add_event(
-            booking,
             finance_models.FinanceEventMotive.BOOKING_USED,
+            booking=booking,
             commit=False,
         )
         n_collective_bookings_updated += 1

--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -382,8 +382,8 @@ def cancel_collective_booking(
         )
         if cancelled_event:
             finance_api.add_event(
-                collective_booking,
                 finance_models.FinanceEventMotive.BOOKING_CANCELLED_AFTER_USE,
+                booking=collective_booking,
                 commit=False,
             )
         finance_api.cancel_pricing(collective_booking, finance_models.PricingLogReason.MARK_AS_UNUSED)
@@ -411,8 +411,7 @@ def uncancel_collective_booking(
         collective_booking.uncancel_booking()
         if collective_booking.status == educational_models.CollectiveBookingStatus.USED:
             finance_api.add_event(
-                collective_booking,
-                finance_models.FinanceEventMotive.BOOKING_USED_AFTER_CANCELLATION,
+                finance_models.FinanceEventMotive.BOOKING_USED_AFTER_CANCELLATION, booking=collective_booking
             )
         db.session.commit()
 

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1031,12 +1031,13 @@ class CollectiveBooking(PcObject, Base, Model):
         self,
         reason: CollectiveBookingCancellationReasons,
         cancel_even_if_used: bool = False,
+        cancel_even_if_reimbursed: bool = False,
     ) -> None:
         from pcapi.core.educational import exceptions
 
         if self.status is CollectiveBookingStatus.CANCELLED:
             raise exceptions.CollectiveBookingAlreadyCancelled()
-        if self.status is CollectiveBookingStatus.REIMBURSED:
+        if self.status is CollectiveBookingStatus.REIMBURSED and not cancel_even_if_reimbursed:
             raise exceptions.CollectiveBookingIsAlreadyUsed
         if self.status is CollectiveBookingStatus.USED and not cancel_even_if_used:
             raise exceptions.CollectiveBookingIsAlreadyUsed

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -132,6 +132,7 @@ def add_event(
     motive: models.FinanceEventMotive,
     booking: bookings_models.Booking | educational_models.CollectiveBooking | None = None,
     booking_incident: models.BookingFinanceIncident | None = None,
+    incident_validation_date: datetime.datetime = None,
     commit: bool = True,
 ) -> models.FinanceEvent:
     if booking_incident:
@@ -139,14 +140,20 @@ def add_event(
 
     assert booking
     if motive in (
-        models.FinanceEventMotive.BOOKING_USED,
-        models.FinanceEventMotive.BOOKING_USED_AFTER_CANCELLATION,
         models.FinanceEventMotive.INCIDENT_REVERSAL_OF_ORIGINAL_EVENT,
         models.FinanceEventMotive.INCIDENT_NEW_PRICE,
         models.FinanceEventMotive.INCIDENT_COMMERCIAL_GESTURE,
     ):
+        assert incident_validation_date
+        value_date = incident_validation_date
+    elif motive in (
+        models.FinanceEventMotive.BOOKING_USED,
+        models.FinanceEventMotive.BOOKING_USED_AFTER_CANCELLATION,
+    ):
+        assert booking.dateUsed
         value_date = booking.dateUsed
     elif motive == models.FinanceEventMotive.BOOKING_CANCELLED_AFTER_USE:
+        assert booking.cancellationDate
         value_date = booking.cancellationDate
     elif motive == models.FinanceEventMotive.BOOKING_UNUSED:
         # The value is irrelevant because the event won't be priced.

--- a/api/src/pcapi/domain/reimbursement.py
+++ b/api/src/pcapi/domain/reimbursement.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from pcapi.core.bookings.models import Booking
 from pcapi.core.categories import subcategories
 from pcapi.core.educational.models import CollectiveBooking
+from pcapi.core.finance import utils as finance_utils
 import pcapi.core.finance.models as finance_models
 from pcapi.core.offers.models import Offer
 
@@ -34,8 +35,9 @@ class EducationalOffersReimbursement(finance_models.ReimbursementRule):
     def is_relevant(self, booking: Booking | CollectiveBooking, cumulative_revenue: int) -> bool:
         return isinstance(booking, CollectiveBooking)
 
-    def apply(self, booking: CollectiveBooking) -> Decimal:
-        return Decimal(booking.collectiveStock.price) * self.rate
+    def apply(self, booking: CollectiveBooking, custom_total_amount: int | None = None) -> Decimal:
+        custom_total_amount_euros = finance_utils.to_euros(custom_total_amount or 0)
+        return Decimal(custom_total_amount_euros or booking.collectiveStock.price) * self.rate
 
 
 class PhysicalOffersReimbursement(finance_models.ReimbursementRule):

--- a/api/src/pcapi/routes/backoffice/finance/validation.py
+++ b/api/src/pcapi/routes/backoffice/finance/validation.py
@@ -63,12 +63,16 @@ def check_incident_collective_booking(collective_booking: educational_models.Col
 
 
 def check_total_amount(
-    input_amount: decimal.Decimal, bookings: list[bookings_models.Booking | educational_models.CollectiveBooking]
+    input_amount: decimal.Decimal | None, bookings: list[bookings_models.Booking | educational_models.CollectiveBooking]
 ) -> bool:
-    max_incident_amount = -sum(booking.pricing.amount if booking.pricing else 0 for booking in bookings)
-    if input_amount * 100 > max_incident_amount:
+    # Temporary: The total_amount field is optional only for multiple bookings incident (no need for total overpayment)
+    if not input_amount:
+        flash("Le montant de l'incident est vide.", "warning")
+        return False
+    max_incident_amount = sum(booking.total_amount for booking in bookings)
+    if input_amount > max_incident_amount:
         flash(
-            "Le montant de l'incident ne peut pas être supérieur au montant remboursé à l'acteur pour cette réservation.",
+            "Le montant de l'incident ne peut pas être supérieur au montant total des réservations sélectionnées.",
             "warning",
         )
         return False

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -227,14 +227,15 @@ class CreateIncidentFinanceEventTest:
             incident__kind=incident_type,
             newTotalAmount=1010,
         )
-
-        finance_events = _create_finance_events_from_incident(total_booking_incident)
+        validation_date = datetime.datetime.utcnow()
+        finance_events = _create_finance_events_from_incident(total_booking_incident, validation_date)
 
         assert len(finance_events) == 1
         assert finance_events[0].bookingFinanceIncidentId == total_booking_incident.id
         assert finance_events[0].status == finance_models.FinanceEventStatus.PENDING
         assert finance_events[0].venue and finance_events[0].venue == total_booking_incident.booking.venue
         assert finance_events[0].motive == finance_models.FinanceEventMotive.INCIDENT_REVERSAL_OF_ORIGINAL_EVENT
+        assert finance_events[0].valueDate == validation_date
 
     @pytest.mark.parametrize(
         "incident_type",
@@ -253,7 +254,8 @@ class CreateIncidentFinanceEventTest:
             newTotalAmount=10000,
         )
 
-        finance_events = _create_finance_events_from_incident(total_booking_incident)
+        validation_date = datetime.datetime.utcnow()
+        finance_events = _create_finance_events_from_incident(total_booking_incident, validation_date)
 
         assert len(finance_events) == 1
 
@@ -261,6 +263,7 @@ class CreateIncidentFinanceEventTest:
         assert finance_events[0].status == finance_models.FinanceEventStatus.PENDING
         assert finance_events[0].venue and finance_events[0].venue == total_booking_incident.collectiveBooking.venue
         assert finance_events[0].motive == finance_models.FinanceEventMotive.INCIDENT_REVERSAL_OF_ORIGINAL_EVENT
+        assert finance_events[0].valueDate == validation_date
 
     @pytest.mark.parametrize(
         "incident_type",
@@ -279,7 +282,8 @@ class CreateIncidentFinanceEventTest:
             newTotalAmount=600,
         )
 
-        finance_events = _create_finance_events_from_incident(partial_booking_incident)
+        validation_date = datetime.datetime.utcnow()
+        finance_events = _create_finance_events_from_incident(partial_booking_incident, validation_date)
 
         assert len(finance_events) == 2
 
@@ -287,11 +291,13 @@ class CreateIncidentFinanceEventTest:
         assert finance_events[0].status == finance_models.FinanceEventStatus.PENDING
         assert finance_events[0].venue and finance_events[0].venue == partial_booking_incident.booking.venue
         assert finance_events[0].motive == finance_models.FinanceEventMotive.INCIDENT_REVERSAL_OF_ORIGINAL_EVENT
+        assert finance_events[0].valueDate == validation_date
 
         assert finance_events[1].bookingFinanceIncidentId == partial_booking_incident.id
         assert finance_events[1].status == finance_models.FinanceEventStatus.PENDING
         assert finance_events[1].venue and finance_events[0].venue == partial_booking_incident.booking.venue
         assert finance_events[1].motive == finance_models.FinanceEventMotive.INCIDENT_NEW_PRICE
+        assert finance_events[1].valueDate == validation_date
 
     @pytest.mark.parametrize(
         "incident_type",
@@ -310,7 +316,8 @@ class CreateIncidentFinanceEventTest:
             newTotalAmount=5500,
         )
 
-        finance_events = _create_finance_events_from_incident(partial_booking_incident)
+        validation_date = datetime.datetime.utcnow()
+        finance_events = _create_finance_events_from_incident(partial_booking_incident, validation_date)
 
         assert len(finance_events) == 2
 
@@ -318,11 +325,13 @@ class CreateIncidentFinanceEventTest:
         assert finance_events[0].status == finance_models.FinanceEventStatus.PENDING
         assert finance_events[0].venue and finance_events[0].venue == partial_booking_incident.collectiveBooking.venue
         assert finance_events[0].motive == finance_models.FinanceEventMotive.INCIDENT_REVERSAL_OF_ORIGINAL_EVENT
+        assert finance_events[0].valueDate == validation_date
 
         assert finance_events[1].bookingFinanceIncidentId == partial_booking_incident.id
         assert finance_events[1].status == finance_models.FinanceEventStatus.PENDING
         assert finance_events[1].venue and finance_events[1].venue == partial_booking_incident.collectiveBooking.venue
         assert finance_events[1].motive == finance_models.FinanceEventMotive.INCIDENT_NEW_PRICE
+        assert finance_events[1].valueDate == validation_date
 
     def test_create_commercial_gesture_event_on_booking(self):
         booking_incident = finance_factories.IndividualBookingFinanceIncidentFactory(
@@ -332,8 +341,9 @@ class CreateIncidentFinanceEventTest:
             incident__kind=finance_models.IncidentType.COMMERCIAL_GESTURE,
             newTotalAmount=800,
         )
+        validation_date = datetime.datetime.utcnow()
 
-        finance_events = _create_finance_events_from_incident(booking_incident)
+        finance_events = _create_finance_events_from_incident(booking_incident, validation_date)
 
         assert len(finance_events) == 1
 
@@ -341,6 +351,7 @@ class CreateIncidentFinanceEventTest:
         assert finance_events[0].status == finance_models.FinanceEventStatus.PENDING
         assert finance_events[0].venue and finance_events[0].venue == booking_incident.booking.venue
         assert finance_events[0].motive == finance_models.FinanceEventMotive.INCIDENT_COMMERCIAL_GESTURE
+        assert finance_events[0].valueDate == validation_date
 
     def test_create_commercial_gesture_event_on_collective_booking(self):
         booking_incident = finance_factories.CollectiveBookingFinanceIncidentFactory(
@@ -351,7 +362,8 @@ class CreateIncidentFinanceEventTest:
             newTotalAmount=800,
         )
 
-        finance_events = _create_finance_events_from_incident(booking_incident)
+        validation_date = datetime.datetime.utcnow()
+        finance_events = _create_finance_events_from_incident(booking_incident, validation_date)
 
         assert len(finance_events) == 1
 
@@ -359,6 +371,7 @@ class CreateIncidentFinanceEventTest:
         assert finance_events[0].status == finance_models.FinanceEventStatus.PENDING
         assert finance_events[0].venue and finance_events[0].venue == booking_incident.collectiveBooking.venue
         assert finance_events[0].motive == finance_models.FinanceEventMotive.INCIDENT_COMMERCIAL_GESTURE
+        assert finance_events[0].valueDate == validation_date
 
 
 class GetIncidentTest(GetEndpointHelper):

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -614,16 +614,17 @@ class CreateIncidentOnCollectiveBookingTest(PostEndpointHelper):
         assert booking_incidents[0].collectiveBookingId == collective_booking.id
         assert booking_incidents[0].newTotalAmount == 4000
 
-    def test_incident_amount_superior_to_pricing_amount(self, authenticated_client):
+    def test_incident_amount_superior_to_booking_amount(self, authenticated_client):
         collective_booking = educational_factories.ReimbursedCollectiveBookingFactory(
             pricings=[
                 finance_factories.CollectivePricingFactory(status=finance_models.PricingStatus.INVOICED, amount=-4500)
-            ]
+            ],
+            collectiveStock__price=50,
         )
 
         response = self.post_to_endpoint(
             authenticated_client,
-            form={"total_amount": 50, "origin": "Demande E-mail", "kind": finance_models.IncidentType.OVERPAYMENT.name},
+            form={"total_amount": 55, "origin": "Demande E-mail", "kind": finance_models.IncidentType.OVERPAYMENT.name},
             collective_booking_id=collective_booking.id,
         )
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24002

- Création d'événements de finance lors de la validation d'un incident.
- Adaptation de `_price_event()` permettant de valoriser un `FinanceEvent`, pour prendre en charge les incidents
- Adaptation du modèle `FinanceEvent` pour pouvoir le lier à un `FinanceIncident`

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques