### PR TITLE
(PC-24115)[PRO] feat: add venue suggestions for adage autocomplete

### DIFF
--- a/api/src/pcapi/algolia_settings_collective_offers.json
+++ b/api/src/pcapi/algolia_settings_collective_offers.json
@@ -7,7 +7,7 @@
   "attributesToRetrieve": null,
   "ignorePlurals": ["fr"],
   "removeStopWords": ["fr"],
-  "distinct": true,
+  "distinct": false,
   "unretrievableAttributes": null,
   "optionalWords": null,
   "queryLanguages": ["fr"],
@@ -26,7 +26,7 @@
   "attributesToSnippet": null,
   "attributesToHighlight": null,
   "paginationLimitedTo": 50000,
-  "attributeForDistinct": "distinct",
+  "attributeForDistinct": "venue.name",
   "exactOnSingleWordQuery": "attribute",
   "disableTypoToleranceOnAttributes": ["distinct"],
   "ranking": [

--- a/pro/package.json
+++ b/pro/package.json
@@ -30,6 +30,7 @@
     "build-storybook": "NODE_PATH=src storybook build -o docs-build"
   },
   "dependencies": {
+    "@algolia/autocomplete-plugin-query-suggestions": "^1.11.0",
     "@algolia/autocomplete-plugin-recent-searches": "^1.11.0",
     "@firebase/analytics": "^0.10.0",
     "@firebase/app": "^0.9.18",

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -38,6 +38,7 @@ export const AppLayout = ({
             `offer.educationalInstitutionUAICode:${adageUser.uai}`,
           ]}
           hitsPerPage={8}
+          distinct={false}
         />
         <AdageHeader />
       </InstantSearch>

--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
@@ -46,6 +46,7 @@ const OffersForMyInstitution = ({
         clickAnalytics
         facetFilters={[`offer.educationalInstitutionUAICode:${adageUser.uai}`]}
         hitsPerPage={8}
+        distinct={false}
       />
       <AnalyticsContextProvider>
         <OffersInstitutionList

--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/__specs__/OffersForMyInstitution.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/__specs__/OffersForMyInstitution.spec.tsx
@@ -73,6 +73,7 @@ describe('OffersInstitutionList', () => {
         clickAnalytics: true,
         facetFilters: ['offer.educationalInstitutionUAICode:1234567A'],
         hitsPerPage: 8,
+        distinct: false,
       },
       {}
     )

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -62,6 +62,7 @@ export const OffersInstantSearch = ({
         hitsPerPage={8}
         aroundLatLng={geoLocation.latLng}
         aroundRadius={geoLocation.radius}
+        distinct={false}
       />
       <AnalyticsContextProvider>
         {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
@@ -88,6 +88,7 @@
 
         &-clean {
           @include fonts.caption;
+
           margin-left: rem.torem(8px);
           text-decoration: none;
         }
@@ -100,6 +101,7 @@
 
       &-item {
         @include fonts.body;
+
         display: flex;
         gap: rem.torem(8px);
         align-items: center;
@@ -113,9 +115,11 @@
         &[aria-selected="true"] {
           background-color: colors.$grey-light;
         }
+
         &-icon {
           color: colors.$grey-dark;
         }
+
         svg {
           width: rem.torem(16px) !important;
         }
@@ -149,9 +153,5 @@
   svg {
     max-width: rem.torem(16px);
     margin-right: rem.torem(4px) !important;
-  }
-
-  &-no-result {
-    margin-top: rem.torem(40px);
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
@@ -77,7 +77,7 @@
       display: none;
     }
 
-    &-recent-search {
+    &-autocomplete {
       &-text {
         @include fonts.caption;
 
@@ -85,14 +85,13 @@
         display: flex;
         align-items: center;
         margin-bottom: rem.torem(18px);
-      
+
         &-clean {
           @include fonts.caption;
-      
           margin-left: rem.torem(8px);
           text-decoration: none;
         }
-      
+
         svg {
           width: rem.torem(16px) !important;
           margin-right: rem.torem(4px) !important;
@@ -101,7 +100,6 @@
 
       &-item {
         @include fonts.body;
-  
         display: flex;
         gap: rem.torem(8px);
         align-items: center;
@@ -110,10 +108,14 @@
         width: 100%;
         padding: rem.torem(8px);
 
-        &:hover, &:focus-within, &[aria-selected="true"] {
+        &:hover,
+        &:focus-within,
+        &[aria-selected="true"] {
           background-color: colors.$grey-light;
         }
-      
+        &-icon {
+          color: colors.$grey-dark;
+        }
         svg {
           width: rem.torem(16px) !important;
         }
@@ -146,7 +148,7 @@
 
   svg {
     max-width: rem.torem(16px);
-    margin-right: rem.torem(4px) !important
+    margin-right: rem.torem(4px) !important;
   }
 
   &-no-result {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -42,7 +42,7 @@ type AutocompleteProps = SearchBoxProvided & {
   placeholder: string
 }
 
-type SuggestionItem = AutocompleteQuerySuggestionsHit & {
+export type SuggestionItem = AutocompleteQuerySuggestionsHit & {
   label: string
   venue: {
     name: string
@@ -99,6 +99,7 @@ const AutocompleteComponent = ({
   })
 
   const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
+  /* istanbul ignore next: We dont want to test algolia implementation */
   const venuesSuggestionsPlugin = createQuerySuggestionsPlugin<SuggestionItem>({
     searchClient: searchClient,
     indexName: ALGOLIA_COLLECTIVE_OFFERS_INDEX,
@@ -355,9 +356,9 @@ const AutocompleteComponent = ({
                             b.venue.publicName || b.venue.name
                           )
                         )
-                        .map((item, index) => (
+                        .map(item => (
                           <li
-                            key={`item-${index}`}
+                            key={`item-${item.objectID}`}
                             className={styles['dialog-panel-autocomplete-item']}
                             {...autocomplete.getItemProps({
                               item,

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -38,6 +38,16 @@
   dependencies:
     "@algolia/autocomplete-shared" "1.11.0"
 
+"@algolia/autocomplete-plugin-query-suggestions@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-query-suggestions/-/autocomplete-plugin-query-suggestions-1.11.0.tgz#9881c7c31481a03a6f6e318d6723d494deadd205"
+  integrity sha512-awczuqV8hydlTMeuiDFhHzx+5HLD+pSVxySb4LgT60mUuT8cmivAnxm2NrgEulamDeFj7LKFR9fXHpkIs5LTnA==
+  dependencies:
+    "@algolia/autocomplete-core" "1.11.0"
+    "@algolia/autocomplete-js" "1.11.0"
+    "@algolia/autocomplete-preset-algolia" "1.11.0"
+    "@algolia/autocomplete-shared" "1.11.0"
+
 "@algolia/autocomplete-plugin-recent-searches@^1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-recent-searches/-/autocomplete-plugin-recent-searches-1.11.0.tgz#04797198f37dd322e643a51931103c6300f8a38a"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24115

Afficher des suggestions de lieux dans la barre de recherche Adage. 

**Subtilité tech :** 

On ajoute dans la config algolia un attributeForDistinct pour grouper les offres par lieux lors de la proposition de suggestions. Il faut donc désactiver ce paramètrage pour les autres recherche (`distinct=false`)

![Capture d’écran 2023-09-14 à 14 39 51](https://github.com/pass-culture/pass-culture-main/assets/71768799/b2cd09b8-eeaa-4170-bafd-6dd6ec4007d8)


FF à activer : WIP_ENABLE_SEARCH_HISTORY_ADAGE
