### PR TITLE
(PC-23772)[API] feat: add isActivable on Offer

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -24,6 +24,7 @@ import pcapi.core.bookings.constants as bookings_constants
 from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories
 from pcapi.core.categories import subcategories_v2
+from pcapi.core.providers.models import VenueProvider
 from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models import db
@@ -714,6 +715,21 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
             ],
             else_=OfferStatus.ACTIVE.name,
         )
+
+    @property
+    def isActivable(self) -> bool:
+        if self.status == OfferStatus.REJECTED or not self.isBookable:
+            return False
+        if (
+            self.lastProviderId
+            and not VenueProvider.query.filter_by(
+                isActive=True,
+                venueId=self.venueId,
+                providerId=self.lastProviderId,
+            ).one_or_none()
+        ):
+            return False
+        return True
 
 
 class ActivationCode(PcObject, Base, Model):

--- a/api/src/pcapi/domain/pro_offers/offers_recap.py
+++ b/api/src/pcapi/domain/pro_offers/offers_recap.py
@@ -24,7 +24,7 @@ class OfferRecapVenue:
         is_virtual: bool,
         managing_offerer_id: int,
         name: str,
-        public_name: str,
+        public_name: str | None,
         offerer_name: str,
         venue_departement_code: str | None,
     ):
@@ -55,7 +55,7 @@ class OfferRecap:
         venue_managing_offerer_id: int,
         venue_name: str,
         venue_offerer_name: str,
-        venue_public_name: str,
+        venue_public_name: str | None,
         venue_departement_code: str | None,
         stocks: list[dict],
         status: str,

--- a/api/src/pcapi/routes/backoffice/finance/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/finance/blueprint.py
@@ -206,7 +206,7 @@ def get_incident_creation_form() -> utils.BackofficeResponse:
 
         if not bookings or len({booking.venueId for booking in bookings}) > 1:
             return Response(
-                """<div class="alert alert-info m-0">Seules les réservations ayant le statut 'remboursée' et 
+                """<div class="alert alert-info m-0">Seules les réservations ayant le statut 'remboursée' et
                 correspondant au même lieu peuvent faire l'objet d'un incident</div>"""
             )
 
@@ -380,14 +380,14 @@ def _initialize_additional_data(bookings: list[bookings_models.Booking]) -> dict
     if len(bookings) == 1:
         booking = bookings[0]
 
-        additional_data["ID de la réservation"] = booking.id
+        additional_data["ID de la réservation"] = booking.id  # type: ignore [assignment]
         additional_data["Statut de la réservation"] = filters.format_booking_status(booking.status)
         additional_data["Contremarque"] = booking.token
         additional_data["Nom de l'offre"] = booking.stock.offer.name
-        additional_data["Bénéficiaire"] = booking.user.full_name
+        additional_data["Bénéficiaire"] = booking.user.full_name  # type: ignore [assignment]
         additional_data["Montant remboursé à l'acteur"] = f"{-booking.pricing.amount/100 if booking.pricing else 0} €"
     else:
-        additional_data["Nombre de réservations"] = len(bookings)
+        additional_data["Nombre de réservations"] = len(bookings)  # type: ignore [assignment]
         additional_data[
             "Montant remboursé à l'acteur"
         ] = f"{-sum(booking.pricing.amount for booking in bookings if booking.pricing)/100} €"

--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings_serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings_serialization.py
@@ -67,8 +67,8 @@ class GetBookingResponse(serialization.ConfiguredBaseModel):
             offer_ean=extra_data.get("ean"),
             venue_id=booking.venue.id,
             venue_name=booking.venue.name,
-            venue_address=booking.venue.address,
-            venue_departement_code=booking.venue.departementCode,
+            venue_address=booking.venue.address,  # type: ignore [arg-type]
+            venue_departement_code=booking.venue.departementCode,  # type: ignore [arg-type]
             user_email=booking.email,
             user_birth_date=birth_date,
             user_first_name=booking.user.firstName,

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -343,6 +343,7 @@ class GetIndividualOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     extraData: Any
     hasBookingLimitDatetimesPassed: bool
     isActive: bool
+    isActivable: bool
     isDigital: bool
     isDuo: bool
     isEditable: bool

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -627,3 +627,46 @@ class OfferMinPriceTest:
         factories.StockFactory(offer=offer, isSoftDeleted=True, price=10)
 
         assert offer.min_price is None
+
+
+class OfferIsActivableTest:
+    def test_not_activable_if_status_is_rejected(self):
+        rejected_offer = factories.OfferFactory(validation=models.OfferValidationStatus.REJECTED)
+        assert not rejected_offer.isActivable
+
+    def test_not_activable_if_not_bookable(self):
+        offer = factories.OfferFactory()
+        factories.StockFactory(offer=offer, quantity=0)
+        assert not offer.isActivable
+
+    def test_not_activable_if_no_venue_provider(self):
+        inactive_providers = providers_factories.ProviderFactory(isActive=False)
+        offer_from_inactive_provider = factories.OfferFactory(
+            lastProvider=inactive_providers,
+        )
+        assert not offer_from_inactive_provider.isActivable
+
+    def test_not_activable_if_venue_provider_is_inactive(self):
+        inactive_providers = providers_factories.ProviderFactory(isActive=False)
+        inactive_venue_provider = providers_factories.VenueProviderFactory(
+            providerId=inactive_providers.id,
+            isActive=False,
+        )
+        offer_from_inactive_venue_provider = factories.OfferFactory(
+            lastProvider=inactive_providers,
+            venue=inactive_venue_provider.venue,
+        )
+        assert not offer_from_inactive_venue_provider.isActivable
+
+    def test_offer_is_activable(self):
+        active_provider = providers_factories.ProviderFactory()
+        active_venue_provider = providers_factories.VenueProviderFactory(
+            provider=active_provider,
+        )
+        offer_from_active_venue_provider = factories.OfferFactory(
+            validation=models.OfferValidationStatus.APPROVED,
+            lastProvider=active_provider,
+            venue=active_venue_provider.venue,
+        )
+        factories.StockFactory(offer=offer_from_active_venue_provider)
+        assert offer_from_active_venue_provider.isActivable

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -171,6 +171,7 @@ class Returns200Test:
             "externalTicketOfficeUrl": "http://example.net",
             "hasBookingLimitDatetimesPassed": False,
             "isActive": True,
+            "isActivable": True,
             "audioDisabilityCompliant": False,
             "mentalDisabilityCompliant": True,
             "motorDisabilityCompliant": False,

--- a/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
@@ -24,6 +24,7 @@ export type GetIndividualOfferResponseModel = {
   extraData?: any;
   hasBookingLimitDatetimesPassed: boolean;
   id: number;
+  isActivable: boolean;
   isActive: boolean;
   isDigital: boolean;
   isDuo: boolean;

--- a/pro/src/screens/OfferIndividual/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
@@ -167,6 +167,7 @@ describe('screens:StocksEventEdition', () => {
       extraData: null,
       hasBookingLimitDatetimesPassed: true,
       isActive: true,
+      isActivable: true,
       isDigital: false,
       isDuo: false,
       isEditable: true,

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -126,6 +126,7 @@ describe('screens:StocksThing', () => {
       extraData: null,
       hasBookingLimitDatetimesPassed: true,
       isActive: true,
+      isActivable: true,
       isDigital: false,
       isDuo: false,
       isEditable: true,

--- a/pro/src/utils/apiFactories.ts
+++ b/pro/src/utils/apiFactories.ts
@@ -74,6 +74,7 @@ export const GetIndividualOfferFactory = (
   return {
     name: `Le nom de l’offre ${currentOfferId}`,
     isActive: true,
+    isActivable: true,
     isEditable: true,
     isEvent: false,
     isThing: true,


### PR DESCRIPTION
## But de la pull request

Ajout d'une propriété `isActivable` sur les offres pour informer le front qu'une offre n'est plus activable en cas de suppression d’une synchronisation

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23772

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques