### PR TITLE
(PC-24394)[API] feat: add notification external url column to provider

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-cecf1fb49589 (pre) (head)
+b09c37d295a9 (pre) (head)
 c21c9c622d05 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230912T153108_b09c37d295a9_add_notification_external_url_column_to_provider_table.py
+++ b/api/src/pcapi/alembic/versions/20230912T153108_b09c37d295a9_add_notification_external_url_column_to_provider_table.py
@@ -1,0 +1,21 @@
+"""
+add notification external url column to provider
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "b09c37d295a9"
+down_revision = "cecf1fb49589"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("provider", sa.Column("notificationExternalUrl", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("provider", "notificationExternalUrl")

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -67,6 +67,7 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
     logoUrl: str = Column(Text(), nullable=True)
     bookingExternalUrl: str = Column(Text(), nullable=True)
     cancelExternalUrl: str = Column(Text(), nullable=True)
+    notificationExternalUrl: str = Column(Text(), nullable=True)
     pricesInCents: bool = Column(Boolean, nullable=False, default=False, server_default=expression.false())
 
     collectiveOffers: sa_orm.Mapped["CollectiveOffer"] = relationship("CollectiveOffer", back_populates="provider")

--- a/api/src/pcapi/routes/backoffice/providers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/providers/blueprint.py
@@ -73,6 +73,7 @@ def create_provider() -> utils.BackofficeResponse:
             isActive=form.is_active.data,
             bookingExternalUrl=form.booking_external_url.data,
             cancelExternalUrl=form.cancel_external_url.data,
+            notificationExternalUrl=form.notification_external_url.data,
         )
         offerer, is_offerer_new = _get_or_create_offerer(form)
         offerer_provider = offerers_models.OffererProvider(offerer=offerer, provider=provider)
@@ -125,6 +126,7 @@ def get_update_provider_form(provider_id: int) -> utils.BackofficeResponse:
         is_active=provider.isActive,
         booking_external_url=provider.bookingExternalUrl,
         cancel_external_url=provider.cancelExternalUrl,
+        notification_external_url=provider.notificationExternalUrl,
     )
 
     return render_template(
@@ -153,6 +155,7 @@ def update_provider(provider_id: int) -> utils.BackofficeResponse:
     provider.isActive = form.is_active.data
     provider.bookingExternalUrl = form.booking_external_url.data
     provider.cancelExternalUrl = form.cancel_external_url.data
+    provider.notificationExternalUrl = form.notification_external_url.data
 
     try:
         db.session.add(provider)

--- a/api/src/pcapi/routes/backoffice/providers/forms.py
+++ b/api/src/pcapi/routes/backoffice/providers/forms.py
@@ -48,6 +48,13 @@ class CreateProviderForm(FlaskForm):
             wtforms.validators.Length(max=1024, message="Doit contenir moins de %(max)d caractères"),
         ),
     )
+    notification_external_url = fields.PCOptStringField(
+        "URL de la route de notification de nouvelles réservations ou d'annulation de réservations",
+        validators=(
+            wtforms.validators.URL("Doit être une URL valide"),
+            wtforms.validators.Length(max=1024, message="Doit contenir moins de %(max)d caractères"),
+        ),
+    )
     enabled_for_pro = fields.PCSwitchBooleanField("Actif pour les pros", default="checked")
     is_active = fields.PCSwitchBooleanField("Actif", default="checked")
 

--- a/api/src/pcapi/routes/backoffice/providers/forms.py
+++ b/api/src/pcapi/routes/backoffice/providers/forms.py
@@ -38,6 +38,7 @@ class CreateProviderForm(FlaskForm):
         "URL de la route de validation de reservation",
         validators=(
             wtforms.validators.Optional(""),
+            wtforms.validators.URL("Doit être une URL valide"),
             wtforms.validators.Length(max=1024, message="Doit contenir moins de %(max)d caractères"),
         ),
     )
@@ -45,12 +46,14 @@ class CreateProviderForm(FlaskForm):
         "URL de la route d'annulation de reservation",
         validators=(
             wtforms.validators.Optional(""),
+            wtforms.validators.URL("Doit être une URL valide"),
             wtforms.validators.Length(max=1024, message="Doit contenir moins de %(max)d caractères"),
         ),
     )
     notification_external_url = fields.PCOptStringField(
         "URL de la route de notification de nouvelles réservations ou d'annulation de réservations",
         validators=(
+            wtforms.validators.Optional(""),
             wtforms.validators.URL("Doit être une URL valide"),
             wtforms.validators.Length(max=1024, message="Doit contenir moins de %(max)d caractères"),
         ),

--- a/api/tests/routes/backoffice/providers_test.py
+++ b/api/tests/routes/backoffice/providers_test.py
@@ -68,6 +68,7 @@ class CreateProviderTest(PostEndpointHelper):
             "logo_url": "https://example.org/image.png",
             "booking_external_url": "https://example.org/booking",
             "cancel_external_url": "https://example.org/cancel",
+            "notification_external_url": "https://example.org/notify",
             "enabled_for_pro": False,
             "is_active": True,
         }
@@ -87,6 +88,7 @@ class CreateProviderTest(PostEndpointHelper):
         assert created_provider.isActive == form_data["is_active"]
         assert created_provider.bookingExternalUrl == form_data["booking_external_url"]
         assert created_provider.cancelExternalUrl == form_data["cancel_external_url"]
+        assert created_provider.notificationExternalUrl == form_data["notification_external_url"]
 
         assert created_provider.offererProvider is not None
         created_offerer = created_provider.offererProvider.offerer
@@ -110,6 +112,7 @@ class CreateProviderTest(PostEndpointHelper):
             "logo_url": "https://example.org/image.png",
             "booking_external_url": "https://example.org/booking",
             "cancel_external_url": "https://example.org/cancel",
+            "notification_external_url": "https://example.org/notify",
             "enabled_for_pro": False,
             "is_active": True,
         }
@@ -129,6 +132,7 @@ class CreateProviderTest(PostEndpointHelper):
         assert created_provider.isActive == form_data["is_active"]
         assert created_provider.bookingExternalUrl == form_data["booking_external_url"]
         assert created_provider.cancelExternalUrl == form_data["cancel_external_url"]
+        assert created_provider.notificationExternalUrl == form_data["notification_external_url"]
 
         assert offerers_models.Offerer.query.count() == 1
         assert created_provider.offererProvider.offerer == offerer
@@ -155,6 +159,7 @@ class UpdateProviderTest(PostEndpointHelper):
             "logo_url": "https://example.org/image.png",
             "booking_external_url": "https://example.org/booking",
             "cancel_external_url": "https://example.org/cancel",
+            "notification_external_url": "https://example.org/notify",
             "enabled_for_pro": False,
             "is_active": True,
         }
@@ -172,6 +177,7 @@ class UpdateProviderTest(PostEndpointHelper):
         assert updated_provider.isActive == form_data["is_active"]
         assert updated_provider.bookingExternalUrl == form_data["booking_external_url"]
         assert updated_provider.cancelExternalUrl == form_data["cancel_external_url"]
+        assert updated_provider.notificationExternalUrl == form_data["notification_external_url"]
         assert not updated_provider.apiKeys
 
         assert offerer.name != form_data["name"]


### PR DESCRIPTION
## But de la pull request
Ajouter la colonne notification external url à la table provider:
Cette url va être appelée avec les données de la réservation lorsqu'un jeune effectue une réservation ou à chaque annulation de réservation

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24394

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [X] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data