### PR TITLE
(PC-24381)[PRO] feat: implement AB testing for new individual hub

### DIFF
--- a/pro/src/hooks/useNewIndividualOfferType.ts
+++ b/pro/src/hooks/useNewIndividualOfferType.ts
@@ -1,0 +1,17 @@
+import { getValue } from '@firebase/remote-config'
+
+import useActiveFeature from './useActiveFeature'
+import useRemoteConfig from './useRemoteConfig'
+
+function useNewIndividualOfferType() {
+  const isNewOfferCreationJourneyActive = useActiveFeature(
+    'WIP_CATEGORY_SELECTION'
+  )
+  const { remoteConfig } = useRemoteConfig()
+
+  return isNewOfferCreationJourneyActive && remoteConfig
+    ? getValue(remoteConfig, 'PRE_SELECTED_CATEGORIES').asBoolean()
+    : false
+}
+
+export default useNewIndividualOfferType

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -666,7 +666,7 @@ describe('route CollectiveOffers', () => {
 
       screen.getByText('Aucune offre trouvée pour votre recherche')
 
-      await userEvent.click(screen.getByText('afficher toutes les offres'))
+      await userEvent.click(screen.getByText('Afficher toutes les offres'))
 
       expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -933,7 +933,7 @@ describe('route Offers', () => {
 
       screen.getByText('Aucune offre trouvée pour votre recherche')
 
-      await userEvent.click(screen.getByText('afficher toutes les offres'))
+      await userEvent.click(screen.getByText('Afficher toutes les offres'))
 
       expect(api.listOffers).toHaveBeenCalledTimes(2)
       expect(api.listOffers).toHaveBeenNthCalledWith(

--- a/pro/src/screens/OfferType/OfferTypeIndividual/OfferTypeIndividual.tsx
+++ b/pro/src/screens/OfferType/OfferTypeIndividual/OfferTypeIndividual.tsx
@@ -9,7 +9,7 @@ import { INDIVIDUAL_OFFER_SUBTYPE } from 'core/Offers/constants'
 import { OfferSubCategory } from 'core/Offers/types'
 import { getVenueAdapter } from 'core/Venue/adapters/getVenueAdapter'
 import { Venue } from 'core/Venue/types'
-import useActiveFeature from 'hooks/useActiveFeature'
+import useNewIndividualOfferType from 'hooks/useNewIndividualOfferType'
 import strokeDateIcon from 'icons/stroke-date.svg'
 import thingStrokeIcon from 'icons/stroke-thing.svg'
 import strokeVirtualEventIcon from 'icons/stroke-virtual-event.svg'
@@ -30,7 +30,7 @@ const OfferTypeIndividual = (): JSX.Element | null => {
   const [venue, setVenue] = useState<Venue | null>(null)
   const queryParams = new URLSearchParams(location.search)
   const queryVenueId = queryParams.get('lieu')
-  const isCategorySelectionActive = useActiveFeature('WIP_CATEGORY_SELECTION')
+  const isCategorySelectionActive = useNewIndividualOfferType()
 
   useEffect(() => {
     async function loadData() {

--- a/pro/src/screens/OfferType/OfferTypeIndividual/__specs__/OfferTypeIndividual.spec.tsx
+++ b/pro/src/screens/OfferType/OfferTypeIndividual/__specs__/OfferTypeIndividual.spec.tsx
@@ -22,6 +22,17 @@ import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OfferTypeIndiviual from '../OfferTypeIndividual'
 
+vi.mock('hooks/useRemoteConfig', () => ({
+  __esModule: true,
+  default: () => ({
+    remoteConfig: {},
+  }),
+}))
+
+vi.mock('@firebase/remote-config', () => ({
+  getValue: () => ({ asBoolean: () => true }),
+}))
+
 const TestForm = (): JSX.Element => {
   const initialValues: OfferTypeFormValues = {
     offerType: OFFER_TYPES.INDIVIDUAL_OR_DUO,
@@ -95,7 +106,7 @@ describe('OfferTypeIndividual', () => {
     expect(screen.queryByText('Votre offre est :')).not.toBeInTheDocument()
   })
 
-  it('should also display macro choices when clicking on "Autre"', async () => {
+  it('should display macro choices when clicking on "Autre"', async () => {
     renderOfferTypeIndividual(true, '123')
 
     expect(

--- a/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
@@ -14,6 +14,17 @@ import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OfferType from '../OfferType'
 
+vi.mock('hooks/useRemoteConfig', () => ({
+  __esModule: true,
+  default: () => ({
+    remoteConfig: {},
+  }),
+}))
+
+vi.mock('@firebase/remote-config', () => ({
+  getValue: () => ({ asBoolean: () => true }),
+}))
+
 vi.mock('react-router-dom', async () => ({
   ...((await vi.importActual('react-router-dom')) ?? {}),
   useNavigate: vi.fn(),
@@ -74,13 +85,13 @@ describe('screens:OfferIndividual::OfferType', () => {
     })
   })
 
-  it('should redirect with offer type when venue and type selected', async () => {
+  it('should redirect with the offer type when venue and type selected', async () => {
     renderOfferTypes('123')
 
     expect(
       await screen.findByText('Quelle est la catégorie de l’offre ?')
     ).toBeInTheDocument()
-    await userEvent.click(screen.getByText('autre'))
+    await userEvent.click(screen.getByText('Autre'))
     await userEvent.click(screen.getByText('Un évènement physique daté'))
     await userEvent.click(screen.getByText('Étape suivante'))
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24381

- implem de l'AB testing pour le hub individual offer
-> le paramètre PRE_SELECTED_CATEGORIES est récupéré de firebase remoteConfig

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques