### PR TITLE
(PC-23762)[API] fix: Titelive does not add zeros to the left on GTL id

### DIFF
--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -517,7 +517,7 @@ def get_extra_data_from_infos(infos: dict) -> offers_models.OfferExtraData:
     extra_data["ean"] = infos[INFO_KEYS["EAN13"]]
     if infos[INFO_KEYS["GTL_ID"]]:
         csr_label = get_closest_csr(infos[INFO_KEYS["GTL_ID"]])
-        extra_data["gtl_id"] = infos[INFO_KEYS["GTL_ID"]]
+        extra_data["gtl_id"] = infos[INFO_KEYS["GTL_ID"]].zfill(8)
         if csr_label is not None:
             extra_data["rayon"] = csr_label.get("label")
             extra_data["csr_id"] = csr_label.get("csr_id")


### PR DESCRIPTION
## But de la pull request

Titelive envoie des produits avec gtl_id < 8 caractères, or, nous avons besoin de nous baser sur les 2 premiers caractères pour connaitre la catégorie.

Ticket Jira : https://passculture.atlassian.net/browse/PC-23762

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques