### PR TITLE
PC-24392-fix_status_filter(API) fix: portail pro: réparer le filtre des statuts des offres

### DIFF
--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -44,7 +44,7 @@ def get_collective_offers(
         offerer_id=query.offerer_id,
         venue_id=query.venue_id,
         name_keywords=query.nameOrIsbn,
-        status=query.status,
+        status=query.status.value if query.status else None,
         period_beginning_date=query.period_beginning_date,
         period_ending_date=query.period_ending_date,
         offer_type=query.collective_offer_type,

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -47,7 +47,7 @@ def list_offers(query: offers_serialize.ListOffersQueryModel) -> offers_serializ
         offerer_id=query.offerer_id,
         venue_id=query.venue_id,
         name_keywords_or_ean=query.name_or_ean,
-        status=query.status,
+        status=query.status.value if query.status else None,
         creation_mode=query.creation_mode,
         period_beginning_date=query.period_beginning_date,
         period_ending_date=query.period_ending_date,

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -14,6 +14,7 @@ from pcapi.core.categories.subcategories import SubcategoryIdEnum
 from pcapi.core.educational.models import CollectiveBooking
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveOffer
+from pcapi.core.educational.models import CollectiveOfferDisplayedStatus
 from pcapi.core.educational.models import CollectiveOfferTemplate
 from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import StudentLevels
@@ -41,7 +42,7 @@ T_GetCollectiveOfferBaseResponseModel = typing.TypeVar(
 class ListCollectiveOffersQueryModel(BaseModel):
     nameOrIsbn: str | None
     offerer_id: int | None
-    status: OfferStatus | None
+    status: CollectiveOfferDisplayedStatus | None
     venue_id: int | None
     categoryId: str | None
     creation_mode: str | None

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -12,6 +12,7 @@ from pydantic.v1 import validator
 from pydantic.v1.utils import GetterDict
 
 from pcapi.core.categories.subcategories import SubcategoryIdEnum
+from pcapi.core.educational.models import CollectiveOfferDisplayedStatus
 from pcapi.core.offers import models as offers_models
 from pcapi.core.offers import repository as offers_repository
 from pcapi.core.offers.serialize import CollectiveOfferType
@@ -221,7 +222,7 @@ class ListOffersQueryModel(BaseModel):
     # is shared on the offer search page
     name_or_ean: str | None = Field(alias="nameOrIsbn")
     offerer_id: int | None
-    status: OfferStatus | None
+    status: OfferStatus | CollectiveOfferDisplayedStatus | None
     venue_id: int | None
     categoryId: str | None
     creation_mode: str | None

--- a/api/tests/routes/pro/get_all_collective_offers_test.py
+++ b/api/tests/routes/pro/get_all_collective_offers_test.py
@@ -5,6 +5,7 @@ import pytest
 
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.educational.models as educational_models
+from pcapi.core.educational.models import CollectiveOfferDisplayedStatus
 import pcapi.core.offerers.factories as offerer_factories
 import pcapi.core.providers.factories as providers_factories
 import pcapi.core.users.factories as users_factories
@@ -362,14 +363,13 @@ class Return400Test:
 
         # When
         client = TestClient(app.test_client()).with_session_auth(email=user.email)
-        response = client.get("/collective/offers?status=PUBLISH")
+        response = client.get("/collective/offers?status=NOT_A_VALID_STATUS")
 
         # Then
         assert response.status_code == 400
-        assert response.json == {
-            "status": [
-                "value is not a valid enumeration member; permitted: 'ACTIVE', "
-                "'PENDING', 'EXPIRED', 'REJECTED', 'SOLD_OUT', 'INACTIVE', "
-                "'DRAFT'"
-            ]
-        }
+
+        msg = response.json["status"][0]
+        assert msg.startswith("value is not a valid enumeration member")
+
+        for value in CollectiveOfferDisplayedStatus:
+            assert value.name in msg

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -8,12 +8,27 @@ import pytest
 from pcapi.core import testing
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.educational.models as educational_models
+from pcapi.core.educational.models import CollectiveOfferDisplayedStatus
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.users.factories as users_factories
 
 
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
+    def test_filtering(self, client):
+        offer = educational_factories.PendingCollectiveBookingFactory().collectiveStock.collectiveOffer
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        client = client.with_session_auth(email="user@example.com")
+
+        dst = url_for("Private API.get_collective_offers", status=CollectiveOfferDisplayedStatus.PREBOOKED.value)
+        response = client.get(dst)
+
+        assert response.status_code == 200
+
+        assert len(response.json) == 1
+        assert response.json[0]["id"] == offer.id
+
     def test_basics(self, client):
         # Given
         template = educational_factories.CollectiveOfferTemplateFactory()

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -355,14 +355,11 @@ class Returns400Test:
         pro = users_factories.ProFactory()
 
         # when
-        response = TestClient(app.test_client()).with_session_auth(email=pro.email).get("/offers?status=PUBLISH")
+        response = TestClient(app.test_client()).with_session_auth(email=pro.email).get("/offers?status=NOPENOPENOPE")
 
         # then
-        assert response.status_code == 400
-        assert response.json == {
-            "status": [
-                "value is not a valid enumeration member; permitted: 'ACTIVE', "
-                "'PENDING', 'EXPIRED', 'REJECTED', 'SOLD_OUT', 'INACTIVE', "
-                "'DRAFT'"
-            ]
-        }
+        msg = response.json["status"][0]
+        assert msg.startswith("value is not a valid enumeration member")
+
+        for value in OfferStatus:
+            assert value.name in msg

--- a/pro/src/apiClient/adage/models/AdageHeaderLink.ts
+++ b/pro/src/apiClient/adage/models/AdageHeaderLink.ts
@@ -9,6 +9,5 @@
 export enum AdageHeaderLink {
   SEARCH = 'search',
   MY_INSTITUTION_OFFERS = 'my_institution_offers',
-  MY_FAVORITES = 'my_favorites',
   ADAGE_LINK = 'adage_link',
 }

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -38,6 +38,7 @@ export type { CollectiveBookingEducationalRedactorResponseModel } from './models
 export type { CollectiveBookingResponseModel } from './models/CollectiveBookingResponseModel';
 export { CollectiveBookingStatus } from './models/CollectiveBookingStatus';
 export { CollectiveBookingStatusFilter } from './models/CollectiveBookingStatusFilter';
+export { CollectiveOfferDisplayedStatus } from './models/CollectiveOfferDisplayedStatus';
 export type { CollectiveOfferInstitutionModel } from './models/CollectiveOfferInstitutionModel';
 export type { CollectiveOfferOfferVenueResponseModel } from './models/CollectiveOfferOfferVenueResponseModel';
 export type { CollectiveOfferRedactorModel } from './models/CollectiveOfferRedactorModel';

--- a/pro/src/apiClient/v1/models/CollectiveOfferDisplayedStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferDisplayedStatus.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * An enumeration.
+ */
+export enum CollectiveOfferDisplayedStatus {
+  ACTIVE = 'ACTIVE',
+  PENDING = 'PENDING',
+  REJECTED = 'REJECTED',
+  PREBOOKED = 'PREBOOKED',
+  BOOKED = 'BOOKED',
+  INACTIVE = 'INACTIVE',
+  EXPIRED = 'EXPIRED',
+  ENDED = 'ENDED',
+}

--- a/pro/src/apiClient/v1/models/ListCollectiveOffersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveOffersQueryModel.ts
@@ -3,8 +3,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { CollectiveOfferDisplayedStatus } from './CollectiveOfferDisplayedStatus';
 import type { CollectiveOfferType } from './CollectiveOfferType';
-import type { OfferStatus } from './OfferStatus';
 
 export type ListCollectiveOffersQueryModel = {
   categoryId?: string | null;
@@ -14,7 +14,7 @@ export type ListCollectiveOffersQueryModel = {
   offererId?: number | null;
   periodBeginningDate?: string | null;
   periodEndingDate?: string | null;
-  status?: OfferStatus | null;
+  status?: CollectiveOfferDisplayedStatus | null;
   venueId?: number | null;
 };
 

--- a/pro/src/apiClient/v1/models/ListOffersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersQueryModel.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { CollectiveOfferDisplayedStatus } from './CollectiveOfferDisplayedStatus';
 import type { CollectiveOfferType } from './CollectiveOfferType';
 import type { OfferStatus } from './OfferStatus';
 
@@ -14,7 +15,7 @@ export type ListOffersQueryModel = {
   offererId?: number | null;
   periodBeginningDate?: string | null;
   periodEndingDate?: string | null;
-  status?: OfferStatus | null;
+  status?: (OfferStatus | CollectiveOfferDisplayedStatus) | null;
   venueId?: number | null;
 };
 

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -13,6 +13,7 @@ import type { ChangePasswordBodyModel } from '../models/ChangePasswordBodyModel'
 import type { ChangeProEmailBody } from '../models/ChangeProEmailBody';
 import type { CollectiveBookingByIdResponseModel } from '../models/CollectiveBookingByIdResponseModel';
 import type { CollectiveBookingStatusFilter } from '../models/CollectiveBookingStatusFilter';
+import type { CollectiveOfferDisplayedStatus } from '../models/CollectiveOfferDisplayedStatus';
 import type { CollectiveOfferResponseIdModel } from '../models/CollectiveOfferResponseIdModel';
 import type { CollectiveOfferTemplateBodyModel } from '../models/CollectiveOfferTemplateBodyModel';
 import type { CollectiveOfferTemplateResponseIdModel } from '../models/CollectiveOfferTemplateResponseIdModel';
@@ -282,7 +283,7 @@ export class DefaultService {
   public getCollectiveOffers(
     nameOrIsbn?: string | null,
     offererId?: number | null,
-    status?: OfferStatus | null,
+    status?: CollectiveOfferDisplayedStatus | null,
     venueId?: number | null,
     categoryId?: string | null,
     creationMode?: string | null,
@@ -1306,7 +1307,7 @@ export class DefaultService {
   public listOffers(
     nameOrIsbn?: string | null,
     offererId?: number | null,
-    status?: OfferStatus | null,
+    status?: (OfferStatus | CollectiveOfferDisplayedStatus) | null,
     venueId?: number | null,
     categoryId?: string | null,
     creationMode?: string | null,

--- a/pro/src/pages/CollectiveOffers/adapters/getFilteredCollectiveOffersAdapter.ts
+++ b/pro/src/pages/CollectiveOffers/adapters/getFilteredCollectiveOffersAdapter.ts
@@ -1,4 +1,5 @@
 import { api } from 'apiClient/api'
+import { CollectiveOfferDisplayedStatus } from 'apiClient/v1'
 import { Offer, SearchFiltersParams } from 'core/Offers/types'
 import { serializeApiFilters } from 'core/Offers/utils'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
@@ -41,7 +42,7 @@ const getFilteredCollectiveOffersAdapter: GetFilteredCollectiveOffersAdapter =
       const offers = await api.getCollectiveOffers(
         nameOrIsbn,
         offererId,
-        status,
+        status as CollectiveOfferDisplayedStatus,
         venueId,
         categoryId,
         creationMode,

--- a/pro/src/pages/Offers/adapters/getFilteredOffersAdapter.ts
+++ b/pro/src/pages/Offers/adapters/getFilteredOffersAdapter.ts
@@ -1,4 +1,5 @@
 import { api } from 'apiClient/api'
+import { OfferStatus } from 'apiClient/v1'
 import { Offer, SearchFiltersParams } from 'core/Offers/types'
 import { serializeApiFilters } from 'core/Offers/utils'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
@@ -36,7 +37,7 @@ export const getFilteredOffersAdapter: GetFilteredOffersAdapter =
       const offers = await api.listOffers(
         nameOrIsbn,
         offererId,
-        status,
+        status as OfferStatus,
         venueId,
         categoryId,
         creationMode,

--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -67,9 +67,9 @@ interface InstitutionOption extends SelectOptionNormalized {
 }
 
 interface TeacherOption extends SelectOption {
-  surname: string
+  surname?: string | null
   name: string
-  gender: string
+  gender?: string | null
   email: string
 }
 

--- a/pro/src/screens/OldCollectiveOfferVisibility/OldCollectiveOfferVisibility.tsx
+++ b/pro/src/screens/OldCollectiveOfferVisibility/OldCollectiveOfferVisibility.tsx
@@ -66,9 +66,9 @@ interface InstitutionOption extends SelectOptionNormalized {
 }
 
 interface TeacherOption extends SelectOption {
-  surname: string
+  surname?: string | null
   name: string
-  gender: string
+  gender?: string | null
   email: string
 }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-PC-24392

Les valeurs attendues pour le filtre semblent avoir changé.
Cette PR vient utiliser l'enum qui correspond aux valeurs auxquelles s'attend le portail pro.

### Note

Les fonctions de filtres utilisent un statut de type str au lieu d'un enum, je n'ai pas creusé plus.