### PR TITLE
(BSR)[API] style: Replace Black by Ruff formatter

### DIFF
--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -42,11 +42,11 @@ jobs:
         with:
           image: ${{ env.tests_docker_image }}
           run: isort . --check-only
-      - name: Check code is well formatted with black
+      - name: Check code is well formatted with ruff
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.tests_docker_image }}
-          run: black . --check
+          run: ruff format --check .
       - name: Run mypy
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -46,7 +46,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.tests_docker_image }}
-          run: ruff format --check .
+          run: ruff format . && ls . && ls ..
       - name: Run mypy
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -15,131 +15,22 @@ concurrency:
   cancel-in-progress: ${{ github.ref == 'refs/heads/master' && false || true }}
 
 jobs:
-  check-api-folder-changes:
-    name: Check api folder changes
-    uses: ./.github/workflows/check-folder-changes.yml
-    with:
-      folder: api
+  run_ruff_and_show_differences:
+    runs-on: linux
 
-  check-pro-folder-changes:
-    name: Check pro folder changes
-    uses: ./.github/workflows/check-folder-changes.yml
-    with:
-      folder: pro
-
-  build-api:
-    name: Build API (backend) Docker image
-    needs:
-      - check-api-folder-changes
-      - check-pro-folder-changes
-    if: |
-      needs.check-api-folder-changes.outputs.folder_changed == 'true' ||
-      needs.check-pro-folder-changes.outputs.folder_changed == 'true'
-    uses: ./.github/workflows/build-and-push-docker-images.yml
-    with:
-      tag: ${{ github.sha }}
-      # Needed to run end-to-end tests, i.e. when either "pro" or
-      # "api" source code changes, which is the condition under which
-      # this step is run. In other words: always.
-      pcapi: true
-      # Extra when tests are run on master before deployment on testing.
-      console: ${{ github.ref == 'refs/heads/master' }}
-      # Needed to run backend tests.
-      tests: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
-    secrets: inherit
-
-  test-api:
-    name: Test api
-    needs:
-      - check-api-folder-changes
-      - build-api
-    if: needs.check-api-folder-changes.outputs.folder_changed == 'true'
-    uses: ./.github/workflows/tests-api.yml
-    secrets: inherit
-
-  test-pro:
-    needs: check-pro-folder-changes
-    if: needs.check-pro-folder-changes.outputs.folder_changed == 'true'
-    name: Tests pro
-    uses: ./.github/workflows/tests-pro.yml
-    secrets: inherit
-    with:
-      CACHE_BUCKET_NAME: passculture-infra-prod-github-runner-cache
-
-  test-pro-e2e:
-    needs:
-      - check-api-folder-changes
-      - check-pro-folder-changes
-      - build-api
-    if: |
-      needs.check-api-folder-changes.outputs.folder_changed == 'true' ||
-      needs.check-pro-folder-changes.outputs.folder_changed == 'true'
-    name: Tests pro E2E
-    uses: ./.github/workflows/tests-pro-e2e.yml
-    secrets: inherit
-    with:
-      CACHE_BUCKET_NAME: passculture-infra-prod-github-runner-cache
-
-  dependabot-auto-merge:
-    needs:
-      - test-pro
-    if: |
-      github.event_name == 'pull_request' &&
-      github.actor == 'dependabot[bot]'
-    uses: ./.github/workflows/dependabot-auto-merge.yml
-    secrets: inherit
-
-  deploy-to-testing:
-    name: Deploy to testing
-    needs:
-      - test-api
-      - test-pro
-    if: |
-      always() &&
-      github.ref == 'refs/heads/master' &&
-      (needs.test-api.result == 'success' || needs.test-api.result == 'skipped') &&
-      (needs.test-pro.result == 'success' || needs.test-pro.result == 'skipped')
-    uses: ./.github/workflows/deploy.yml
-    with:
-      environment: testing
-      app_version: ${{ github.sha }}
-      teleport_version: 11.1.1
-      teleport_proxy: teleport.ehp.passculture.team:443
-      teleport_kubernetes_cluster: passculture-metier-ehp
-      deploy_api: ${{ needs.test-api.result == 'success' }}
-      deploy_pro: ${{ needs.test-pro.result == 'success' }}
-    secrets: inherit
-
-  notification:
-    name: "Notification"
-    runs-on: [self-hosted, linux, x64]
-    if: ${{ failure() && github.ref == 'refs/heads/master' }}
-    needs:
-      - deploy-to-testing
     steps:
-      - uses: technote-space/workflow-conclusion-action@v3
-      - name: Post to a Slack channel
-        id: slack
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          # channel #alertes-deploiement
-          channel-id: "CQAMNFVPS"
-          payload: |
-            {
-            "attachments": [
-              {
-                "mrkdwn_in": ["text"],
-                "color": "#A30002",
-                "author_name": "${{github.actor}}",
-                "author_link": "https://github.com/${{github.actor}}",
-                "author_icon": "https://github.com/${{github.actor}}.png",
-                "title": "PCAPI Deployment",
-                "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Le déploiement de la version `master` a échoué sur `testing` :boom:"
-              }
-            ],
-            "unfurl_links": false,
-            "unfurl_media": false
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        pip install -U pip ruff
+        pip freeze
+    - name: Run ruff
+      run: |
+        ruff format .
+    - name: Show diff
+      run: |
+        git diff

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,18 +1,3 @@
-[tool.black]
-extend-exclude = '''
-(
-  /(
-    | \.mypy_cache
-    | \.pytest_cache
-    | \.venv
-  )/
-)
-'''
-include = '\.pyi?$'
-line-length = 120
-target-version = ['py310']
-
-
 [tool.coverage.report]
 omit = [
     "tests/*",
@@ -174,3 +159,7 @@ junit_family = "xunit1"
 markers = [
     "backoffice"
 ]
+
+
+[tool.ruff]
+line-length = 120

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -64,6 +64,7 @@ pyyaml==6.0
 requests==2.31.0
 requests_mock
 rq==1.12.0
+ruff
 schwifty==2022.9.0
 semver==2.13.0
 sentry-sdk==1.14.0


### PR DESCRIPTION
Ceci est un test pour voir le résultat d'un remplacement de Black par Ruff, qui dispose depuis hier (13/09/2023) d'un formateur de code.

Intérêts :
- Ruff est beaucoup plus rapide que Black. Cet intérêt semble assez faible : quoique plus lent que Ruff, Black reste suffisamment rapide sur un nombre de fichiers limités, qui est le cas d'usage commun.

Inconvénients :
- Ruff est actuellement (au 14/09/2023, version 0.0.289) légèrement  incompatible avec Black (cf. le diff dans la sortie de la CI que j'ai modifié). Il faudrait voir si, dans les prochaines versions, le formatage par Ruff se rapproche de celui de Black, et  aussi voir les réactions de la communauté Python : est-ce que des projets _notables_ basculent de Black à Ruff ?
