### PR TITLE
(BSR)[API] fix: delete event price retrocompatibility code

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -670,22 +670,11 @@ class BaseStockResponse(serialization.ConfiguredBaseModel):
         )
 
 
-# FIXME (cepehang, 2023-02-02): remove after price category generation script
-class PartialPriceCategoryResponse(serialization.ConfiguredBaseModel):
-    id: None = None
-    label: None = None
-    price: pydantic_v1.StrictInt = PRICE_FIELD
-
-    @classmethod
-    def build_partial_price_category(cls, price: decimal.Decimal) -> "PartialPriceCategoryResponse":
-        return cls(price=finance_utils.to_eurocents(price))
-
-
 class DateResponse(BaseStockResponse):
     id: int
     beginning_datetime: datetime.datetime = BEGINNING_DATETIME_FIELD
     booking_limit_datetime: datetime.datetime = BOOKING_LIMIT_DATETIME_FIELD
-    price_category: PriceCategoryResponse | PartialPriceCategoryResponse
+    price_category: PriceCategoryResponse
 
     @classmethod
     def build_date(cls, stock: offers_models.Stock) -> "DateResponse":
@@ -693,9 +682,7 @@ class DateResponse(BaseStockResponse):
         return cls(
             id=stock.id,
             beginning_datetime=stock.beginningDatetime,  # type: ignore [arg-type]
-            price_category=PriceCategoryResponse.from_orm(stock.priceCategory)
-            if stock.priceCategory
-            else PartialPriceCategoryResponse.build_partial_price_category(stock.price),
+            price_category=PriceCategoryResponse.from_orm(stock.priceCategory),
             **stock_response.dict(),
         )
 

--- a/api/tests/routes/public/individual_offers/v1/get_event_dates_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_dates_test.py
@@ -28,11 +28,12 @@ class GetEventDatesTest:
             bookingLimitDatetime=datetime.datetime(2023, 1, 15, 13, 0, 0),
             beginningDatetime=datetime.datetime(2023, 1, 15, 13, 0, 0),
         )
+        not_booked_price_category = offers_factories.PriceCategoryFactory(
+            offer=event_offer, price=299.99, priceCategoryLabel__label="ultra vip"
+        )
         stock_without_booking = offers_factories.EventStockFactory(
             offer=event_offer,
-            # FIXME (cepehang, 2023-02-02): remove price and None price category after price category generation script
-            price=12.34,
-            priceCategory=None,
+            priceCategory=not_booked_price_category,
             quantity=2,
             bookingLimitDatetime=datetime.datetime(2023, 1, 15, 13, 0, 0),
             beginningDatetime=datetime.datetime(2023, 1, 15, 13, 0, 0),
@@ -60,7 +61,11 @@ class GetEventDatesTest:
                 "bookedQuantity": 0,
                 "bookingLimitDatetime": "2023-01-15T13:00:00Z",
                 "id": stock_without_booking.id,
-                "priceCategory": {"id": None, "label": None, "price": 1234},
+                "priceCategory": {
+                    "id": not_booked_price_category.id,
+                    "label": not_booked_price_category.label,
+                    "price": not_booked_price_category.price * 100,
+                },
                 "quantity": 2,
             },
         ]


### PR DESCRIPTION
Code inutile depuis la migration des tarifs des offres évènements.