### PR TITLE
(BSR)[CI]: Limit build-on-tags to tag only

### DIFF
--- a/.github/workflows/build-on-tags.yaml
+++ b/.github/workflows/build-on-tags.yaml
@@ -2,6 +2,8 @@ name: Build release
 
 on:
   push:
+    tags:
+      - v*
 
 env:
   PROJECT_ID: passculture-infra-prod


### PR DESCRIPTION
## But de la pull request

Actuellement le job build-on-tags.yaml s'exécutent à chaque push alors qu'il ne doit être joué que sur les tags de release.
