### PR TITLE
(PC-24376)[BO] feat: display only pending offerers conformite

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -30,6 +30,10 @@ class NotValidatedOffererFactory(OffererFactory):
     validationStatus = ValidationStatus.NEW
 
 
+class PendingOffererFactory(OffererFactory):
+    validationStatus = ValidationStatus.PENDING
+
+
 class RejectedOffererFactory(OffererFactory):
     validationStatus = ValidationStatus.REJECTED
     isActive = False

--- a/api/src/pcapi/routes/backoffice/home.py
+++ b/api/src/pcapi/routes/backoffice/home.py
@@ -60,7 +60,7 @@ def _get_fraud_stats() -> dict[str, typing.Any]:
         sa.select(sa.func.count(offerers_models.Offerer.id))
         .select_from(offerers_models.Offerer)
         .join(offerers_models.Offerer.tags)
-        .filter(offerers_models.Offerer.isWaitingForValidation, offerers_models.OffererTag.name == CONFORMITE_TAG_NAME)
+        .filter(offerers_models.Offerer.isPending, offerers_models.OffererTag.name == CONFORMITE_TAG_NAME)
     )
     conformite_tag_id = (
         sa.select(offerers_models.OffererTag.id)

--- a/api/src/pcapi/routes/backoffice/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice/templates/home/home.html
@@ -51,7 +51,7 @@
           pending_conformite_offerers_count,
           "structure en attente de conformité",
           "structures en attente de conformité",
-          url_for("backoffice_web.validation.list_offerers_to_validate", status=["NEW", "PENDING"], tags=conformite_tag_id, sort="dateCreated", order="desc")) }}
+          url_for("backoffice_web.validation.list_offerers_to_validate", status=["PENDING"], tags=conformite_tag_id, sort="dateCreated", order="desc")) }}
         {% endif %}
       </div>
     {% endif %}

--- a/api/tests/routes/backoffice/home_test.py
+++ b/api/tests/routes/backoffice/home_test.py
@@ -76,9 +76,10 @@ class HomePageTest:
         tag = offerers_factories.OffererTagFactory(name="conformité", label="En attente de conformité")
         other_tag = offerers_factories.OffererTagFactory()
 
-        offerers_factories.NotValidatedOffererFactory(tags=[tag, other_tag])
+        offerers_factories.PendingOffererFactory(tags=[tag, other_tag])
 
         # others should not be counted
+        offerers_factories.NotValidatedOffererFactory(tags=[tag])
         offerers_factories.OffererFactory(tags=[tag])
         offerers_factories.NotValidatedOffererFactory(tags=[other_tag])
 


### PR DESCRIPTION
## But de la pull request

Sous le bouton de la page d'accueil "structure en attente de conformité", on ne remonte dorénavant que ceux en attente et pas en plus les nouvelles

Ticket Jira : https://passculture.atlassian.net/browse/PC-24376

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/09e9ffc9-8d08-4242-be4b-7d159f478056)
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/6d3506f1-04b9-4b28-bbab-5418c5d60983)
