### PR TITLE
(PC-24280)[PRO] feat: Hide venues dmsToken from venue page with FF enabled.

### DIFF
--- a/pro/src/pages/Offerers/Offerer/OffererDetails/OffererDetails.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/OffererDetails.tsx
@@ -37,6 +37,9 @@ const OffererDetails = () => {
   const isNewOffererLinkEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_USER_OFFERER_LINK'
   )
+  const isNewBankDetailsEnabled = useActiveFeature(
+    'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
+  )
 
   const loadOfferer = useCallback(
     async (id: number) => {
@@ -105,7 +108,7 @@ const OffererDetails = () => {
           /* For the screen reader to spell-out the id, we add a
                 visually hidden span with a space between each character.
                 The other span will be hidden from the screen reader. */
-          offerer.dsToken && (
+          isNewBankDetailsEnabled && offerer.dsToken && (
             <>
               <span className={styles['identifier-hidden']}>
                 Identifiant de structure :{' '}

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetails.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetails.spec.tsx
@@ -61,6 +61,19 @@ describe('src | components | pages | Offerer | OffererDetails', () => {
 
       expect(screen.getByText('Lieux')).toBeInTheDocument()
       expect(screen.getByText('fake venue')).toBeInTheDocument()
+    })
+
+    it('should render identifier', async () => {
+      const storeOverrides = {
+        features: {
+          list: [
+            { isActive: true, nameKey: 'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY' },
+          ],
+        },
+      }
+      renderWithProviders(<OffererDetails />, { storeOverrides })
+      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
       expect(
         screen.getByText('Identifiant de structure : 0123456789abcdef')
       ).toBeInTheDocument()

--- a/pro/src/screens/VenueForm/VenueFormScreen.tsx
+++ b/pro/src/screens/VenueForm/VenueFormScreen.tsx
@@ -21,6 +21,7 @@ import {
 import { Offerer } from 'core/Offerers/types'
 import { Providers, Venue } from 'core/Venue/types'
 import { SelectOption } from 'custom_types/form'
+import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
 import useCurrentUser from 'hooks/useCurrentUser'
 import useNotification from 'hooks/useNotification'
@@ -74,6 +75,10 @@ const VenueFormScreen = ({
 
   const [isWithdrawalDialogOpen, setIsWithdrawalDialogOpen] =
     useState<boolean>(false)
+
+  const isNewBankDetailsEnabled = useActiveFeature(
+    'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
+  )
 
   const handleCancelWithdrawalDialog = async () => {
     setShouldSendMail(false)
@@ -242,7 +247,8 @@ const VenueFormScreen = ({
         </Title>
         {
           /* istanbul ignore next: DEBT, TO FIX */ !isCreatingVenue &&
-            venue && (
+            venue &&
+            !isNewBankDetailsEnabled && (
               <>
                 {/* For the screen reader to spell-out the id, we add a
                 visually hidden span with a space between each character.


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24280

- Cacher le dmsToken sur la page des lieux avec le FF `WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY` activé

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques