### PR TITLE
(PC-24357)[API] refactor: delete event qrcode and new venue pages ff

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 ef07f9582155 (pre) (head)
-eade6ec3120d (post) (head)
+2edee580308f (post) (head)

--- a/api/src/pcapi/alembic/versions/20230920T150335_2edee580308f_delete_event_qrcode_and_new_venue_pages_ff.py
+++ b/api/src/pcapi/alembic/versions/20230920T150335_2edee580308f_delete_event_qrcode_and_new_venue_pages_ff.py
@@ -1,0 +1,45 @@
+"""
+Delete Event QR Code & New Venue Pages FF
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "2edee580308f"
+down_revision = "eade6ec3120d"
+branch_labels = None
+depends_on = None
+
+
+def get_flag_venue():  # type: ignore [no-untyped-def]
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="ENABLE_NEW_VENUE_PAGES",
+        isActive=False,
+        description="Utiliser la nouvelle version des pages d'edition et de creation de lieux",
+    )
+
+
+def get_flag_qr():  # type: ignore [no-untyped-def]
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="PRO_DISABLE_EVENTS_QRCODE",
+        isActive=True,
+        description="Active la possibilité de différencier le type d’envoi des billets \
+            sur une offre et le retrait du QR code sur la réservation",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag_qr())
+    feature.remove_feature_from_database(get_flag_venue())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag_qr())
+    feature.add_feature_to_database(get_flag_venue())

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -328,7 +328,7 @@ def check_offer_withdrawal(
     if not is_offer_withdrawable and withdrawal_type is not None:
         raise exceptions.NonWithdrawableEventOfferCantHaveWithdrawal()
 
-    if FeatureToggle.PRO_DISABLE_EVENTS_QRCODE.is_active() and is_offer_withdrawable and withdrawal_type is None:
+    if is_offer_withdrawable and withdrawal_type is None:
         raise exceptions.WithdrawableEventOfferMustHaveWithdrawal()
 
     if FeatureToggle.WIP_MANDATORY_BOOKING_CONTACT.is_active() and is_offer_withdrawable and not booking_contact:

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -65,7 +65,6 @@ class FeatureToggle(enum.Enum):
     ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING = (
         "Active le mode debug Firebase pour l'Id Check intégrée à l'application native"
     )
-    ENABLE_NEW_VENUE_PAGES = "Utiliser la nouvelle version des pages d'edition et de creation de lieux"
     ENABLE_PHONE_VALIDATION = "Active la validation du numéro de téléphone"
     ENABLE_PRO_ACCOUNT_CREATION = "Permettre l'inscription des comptes professionels"
     ENABLE_PRO_BOOKINGS_V2 = "Activer l'affichage de la page booking avec la nouvelle architecture."
@@ -81,7 +80,6 @@ class FeatureToggle(enum.Enum):
     )
     PRICE_BOOKINGS = "Active la valorisation des réservations"
     PRICE_FINANCE_EVENTS = "Active la valorisation des événements de finance"
-    PRO_DISABLE_EVENTS_QRCODE = "Active la possibilité de différencier le type d’envoi des billets sur une offre et le retrait du QR code sur la réservation"
     SYNCHRONIZE_ALLOCINE = "Permettre la synchronisation journalière avec Allociné"
     SYNCHRONIZE_TITELIVE_PRODUCTS = "Permettre limport journalier du référentiel des livres"
     SYNCHRONIZE_TITELIVE_PRODUCTS_DESCRIPTION = "Permettre limport journalier des résumés des livres"
@@ -175,13 +173,13 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.ENABLE_FRONT_IMAGE_RESIZING,
     FeatureToggle.ENABLE_IOS_OFFERS_LINK_WITH_REDIRECTION,
     FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING,
-    FeatureToggle.ENABLE_NEW_VENUE_PAGES,
     FeatureToggle.ENABLE_PRO_BOOKINGS_V2,
     FeatureToggle.ENABLE_UBBLE_SUBSCRIPTION_LIMITATION,
+    FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
+    FeatureToggle.ENABLE_EAC_FINANCIAL_PROTECTION,
     FeatureToggle.ENABLE_ZENDESK_SELL_CREATION,
     FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
     FeatureToggle.PRICE_FINANCE_EVENTS,
-    FeatureToggle.PRO_DISABLE_EVENTS_QRCODE,
     FeatureToggle.SYNCHRONIZE_TITELIVE_API_MUSIC_PRODUCTS,
     FeatureToggle.WIP_ADD_CLG_6_5_COLLECTIVE_OFFER,
     FeatureToggle.WIP_BACKOFFICE_ENABLE_REDIRECT_SINGLE_RESULT,

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -28,7 +28,6 @@ def get_settings() -> serializers.SettingsResponse:
         FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING,
         FeatureToggle.ENABLE_PHONE_VALIDATION,
         FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
-        FeatureToggle.PRO_DISABLE_EVENTS_QRCODE,
         FeatureToggle.APP_ENABLE_AUTOCOMPLETE,
     )
 
@@ -43,6 +42,6 @@ def get_settings() -> serializers.SettingsResponse:
         id_check_address_autocompletion=features[FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION],
         is_recaptcha_enabled=features[FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA],
         object_storage_url=OBJECT_STORAGE_URL,
-        pro_disable_events_qrcode=features[FeatureToggle.PRO_DISABLE_EVENTS_QRCODE],
+        pro_disable_events_qrcode=True,  # FIXME (ogeber, 2023-09-19): We can't remove this one until the mobile app doesn't remove this field
         account_unsuspension_limit=constants.ACCOUNT_UNSUSPENSION_DELAY,
     )

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -760,6 +760,7 @@ class CreateOfferTest:
                 name="A pretty good offer",
                 subcategory_id=subcategories.CONCERT.id,
                 booking_contact="booking@conta.ct",
+                withdrawal_type=models.WithdrawalTypeEnum.NO_TICKET,
                 audio_disability_compliant=True,
                 mental_disability_compliant=True,
                 motor_disability_compliant=True,

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -429,7 +429,6 @@ class CheckOfferWithdrawalTest:
                 provider=None,
             )
 
-    @override_features(PRO_DISABLE_EVENTS_QRCODE=True)
     @pytest.mark.parametrize(
         "subcategory_id",
         subcategories.WITHDRAWABLE_SUBCATEGORIES,
@@ -443,36 +442,20 @@ class CheckOfferWithdrawalTest:
             provider=None,
         )
 
-    # @TODO: bruno: remove this test when removing the feature flag PC-14050
-    @override_features(PRO_DISABLE_EVENTS_QRCODE=False)
-    def test_withdrawable_event_offer_can_have_no_withdrawal_type(self):
-        """
-        Test retrocompatibility when disable events QRCode feature toggle is off
-        withdrawable event offer can have no withdrawal type
-        """
-        assert not validation.check_offer_withdrawal(
-            withdrawal_type=None,
-            withdrawal_delay=None,
-            subcategory_id=subcategories.CONCERT.id,
-            booking_contact="booking@conta.ct",
-            provider=None,
-        )
-
-    @override_features(PRO_DISABLE_EVENTS_QRCODE=True)
     def test_withdrawable_event_offer_must_have_withdrawal(self):
         with pytest.raises(exceptions.WithdrawableEventOfferMustHaveWithdrawal):
             validation.check_offer_withdrawal(
                 withdrawal_type=None,
                 withdrawal_delay=None,
                 subcategory_id=subcategories.FESTIVAL_MUSIQUE.id,
-                booking_contact=None,
+                booking_contact="booking@conta.ct",
                 provider=None,
             )
 
     def test_withdrawable_event_offer_must_have_booking_contact(self):
         with pytest.raises(exceptions.WithdrawableEventOfferMustHaveBookingContact):
             validation.check_offer_withdrawal(
-                withdrawal_type=None,
+                withdrawal_type=WithdrawalTypeEnum.NO_TICKET,
                 withdrawal_delay=None,
                 subcategory_id=subcategories.FESTIVAL_MUSIQUE.id,
                 booking_contact=None,
@@ -482,7 +465,7 @@ class CheckOfferWithdrawalTest:
     @override_features(WIP_MANDATORY_BOOKING_CONTACT=False)
     def test_withdrawable_event_offer_can_have_no_booking_contact(self):
         assert not validation.check_offer_withdrawal(
-            withdrawal_type=None,
+            withdrawal_type=WithdrawalTypeEnum.NO_TICKET,
             withdrawal_delay=None,
             subcategory_id=subcategories.FESTIVAL_MUSIQUE.id,
             booking_contact=None,

--- a/api/tests/routes/native/v1/settings_test.py
+++ b/api/tests/routes/native/v1/settings_test.py
@@ -17,7 +17,6 @@ class SettingsTest:
         ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING=False,
         ENABLE_PHONE_VALIDATION=True,
         ID_CHECK_ADDRESS_AUTOCOMPLETION=True,
-        PRO_DISABLE_EVENTS_QRCODE=False,
         APP_ENABLE_AUTOCOMPLETE=True,
     )
     def test_get_settings_feature_combination_1(self, app):
@@ -35,7 +34,7 @@ class SettingsTest:
             "idCheckAddressAutocompletion": True,
             "isRecaptchaEnabled": True,
             "objectStorageUrl": "http://localhost/storage",
-            "proDisableEventsQrcode": False,
+            "proDisableEventsQrcode": True,
             "accountUnsuspensionLimit": 60,
         }
 
@@ -47,7 +46,6 @@ class SettingsTest:
         ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING=True,
         ENABLE_PHONE_VALIDATION=False,
         ID_CHECK_ADDRESS_AUTOCOMPLETION=False,
-        PRO_DISABLE_EVENTS_QRCODE=True,
         APP_ENABLE_AUTOCOMPLETE=False,
     )
     def test_get_settings_feature_combination_2(self, app):


### PR DESCRIPTION
## But de la pull request

Suppression des FF PRO_DISABLE_EVENTS_QRCODE et ENABLE_NEW_VENUE_PAGES

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24357

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques