### PR TITLE
(BSR) fix: do not call Zendesk Sell in integration env

### DIFF
--- a/api/.env.integration
+++ b/api/.env.integration
@@ -71,4 +71,4 @@ SMS_NOTIFICATION_BACKEND=pcapi.notifications.sms.backends.sendinblue.SendinblueB
 WEBAPP_V2_URL=https://integration.passculture.app
 WEBAPP_V2_REDIRECT_URL=https://redirect.integration.passculture.app
 ZENDESK_SELL_API_URL=https://api.getbase.com
-ZENDESK_SELL_BACKEND=pcapi.core.external.backends.zendesk_sell.ZendeskSellReadOnlyBackend
+ZENDESK_SELL_BACKEND=pcapi.core.external.backends.logger.LoggerBackend


### PR DESCRIPTION
## But de la pull request

Ne pas faire d'appels d'API vers Zendesk Sell dans l'environnement integration

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques