### PR TITLE
(PC-24285)[API] feat: limit number of stocks per offer to 2500

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -390,7 +390,7 @@ class WithdrawalTypeEnum(enum.Enum):
 class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, AccessibilityMixin):
     __tablename__ = "offer"
 
-    MAX_STOCKS_PER_OFFER = 10_000
+    MAX_STOCKS_PER_OFFER = 2_500
 
     ageMin = sa.Column(sa.Integer, nullable=True)
     ageMax = sa.Column(sa.Integer, nullable=True)


### PR DESCRIPTION
## But de la pull request
limiter le nombre maximal de stocks à créer à 2500 afin de ne pas surcharger algolia qui n'accepte que 100ko de données

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24285
