### PR TITLE
(PC-24193)[API] fix: Change condition for birth date update

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -733,12 +733,9 @@ def update_user_birth_date_if_not_beneficiary(user: users_models.User, birth_dat
     so that the user is correctly redirected for the rest of the process.
     """
     if (
-        (
-            users_api.is_eligible_for_beneficiary_upgrade(user, fraud_api.decide_eligibility(user, birth_date, None))
-            or not user.validatedBirthDate
-        )
-        and birth_date
+        birth_date
         and user.validatedBirthDate != birth_date
+        and (users_api.is_eligible_for_beneficiary_upgrade(user, user.eligibility) or not user.validatedBirthDate)
     ):
         user.validatedBirthDate = birth_date
         pcapi_repository.repository.save(user)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24193

L'update de la date de naissance lors d'une vérification d'identité se base toujours sur l'éligibilité de l'utilisateur à un upgrade.
Seulement maintenant, on se base sur la date actuelle de l'utilisateur et non plus sur celle reçue par le fournisseur d'identité.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques