### PR TITLE
(PC-24474)[PRO] fix: only call tracking filters when user trigger new…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -40,6 +40,7 @@ import styles from './Autocomplete.module.scss'
 type AutocompleteProps = SearchBoxProvided & {
   initialQuery: string
   placeholder: string
+  setCurrentSearch: (search: string) => void
 }
 
 export type SuggestionItem = AutocompleteQuerySuggestionsHit & {
@@ -61,6 +62,7 @@ const AutocompleteComponent = ({
   refine,
   initialQuery,
   placeholder,
+  setCurrentSearch,
 }: AutocompleteProps) => {
   const [instantSearchUiState, setInstantSearchUiState] = useState<
     AutocompleteState<SuggestionItem>
@@ -161,6 +163,7 @@ const AutocompleteComponent = ({
         },
         onSubmit: ({ state }) => {
           refine(state.query)
+          setCurrentSearch(state.query)
         },
         placeholder,
         plugins: isRecentSearchEnabled

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
@@ -99,6 +99,7 @@ const renderAutocomplete = ({
           placeholder={
             'Rechercher par mot-clé, par partenaire culturel, par nom d’offre...'
           }
+          setCurrentSearch={vi.fn()}
         />
         <a href="#">Second element</a>
       </div>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -117,11 +117,10 @@ export const OffersComponent = ({
 
   useEffect(() => {
     setQueriesAreLoading(true)
-    if (hits.length != 0 && queryId != hits[0].__queryID) {
-      setQueryId(hits[0].__queryID)
-      if (newAdageFilters && logFiltersOnSearch) {
-        logFiltersOnSearch(nbHits, hits[0].__queryID)
-      }
+    const newQueryId = (hits || [])[0]?.__queryID
+    setQueryId(newQueryId)
+    if (newAdageFilters && logFiltersOnSearch && queryId !== newQueryId) {
+      logFiltersOnSearch(nbHits, newQueryId)
     }
     Promise.all(
       hits.map(async hit => {
@@ -274,13 +273,18 @@ export const Offers = connectInfiniteHits<
       const areEqualBackToTopVisible =
         prevIsBackToTopVisibile === nextIsBackToTopVisibile
       const areEquelNbHits = prevNbHits === nextNbHits
+      const areQueryIdEqual =
+        prevNbHits > 0 &&
+        nextNbHits > 0 &&
+        prevHits[0].__queryID === nextHits[0].__queryID
 
       const arePropsEqual =
         areEqualHits &&
         areEqualHasMore &&
         areEqualDisplayStats &&
         areEqualBackToTopVisible &&
-        areEquelNbHits
+        areEquelNbHits &&
+        areQueryIdEqual
 
       if (arePropsEqual) {
         nextSetIsLoading(false)

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -131,15 +131,17 @@ export const OffersSearch = ({
     formik.setValues(ADAGE_FILTERS_DEFAULT_VALUES)
     formik.handleSubmit()
   }
-
-  const logFiltersOnSearch = (nbHits: number, queryId: string) => {
+  const [currentSearch, setCurrentSearch] = useState('')
+  const logFiltersOnSearch = (nbHits: number, queryId?: string) => {
     /* istanbul ignore next: TO FIX the current structure make it hard to test, we probably should not mock Offers in OfferSearch tests */
-    apiAdage.logTrackingFilter({
-      iframeFrom: removeParamsFromUrl(location.pathname),
-      resultNumber: nbHits,
-      queryId: queryId,
-      filterValues: formik ? formik.values : {},
-    })
+    if (formik.submitCount > 0 || currentSearch != '') {
+      apiAdage.logTrackingFilter({
+        iframeFrom: removeParamsFromUrl(location.pathname),
+        resultNumber: nbHits,
+        queryId: queryId ?? null,
+        filterValues: formik ? { ...formik.values, query: currentSearch } : {},
+      })
+    }
   }
 
   const formik = useFormik<SearchFormValues>({
@@ -175,6 +177,7 @@ export const OffersSearch = ({
           placeholder={
             'Rechercher par mot-clé, par partenaire culturel, par nom d’offre...'
           }
+          setCurrentSearch={setCurrentSearch}
         />
         <div ref={offerFilterRef}>
           <OfferFilters


### PR DESCRIPTION
… searc

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24474

**FF à activer**
- WIP_ENABLE_NEW_ADAGE_FILTERS

**Objectif**
Faire en sorte que le tracker des événements adage ne se déclenche pas à l'ouverture de la page. On veut tracker uniquement quand un utilisateur change les filtres de manière volontaire.

**Réalisation**
- Ajout d'une condition au moment du déclenchement pour vérifier que le formulaire formik a été validé au moins une fois avant, ou que le search input a changé (indépendant du formulaire).
- Ajout d'un fix pour que le tracking se déclenche même quand algolia renvoit 0 résultats
