### PR TITLE
(PC-23937)[PRO] feat: tracking ab testing individual offer

### DIFF
--- a/pro/src/screens/OfferIndividual/Informations/Informations.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/Informations.tsx
@@ -267,6 +267,7 @@ const Informations = ({
         isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
         isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
         offerId: receivedOfferId,
+        subcategoryId: formik.values.subcategoryId,
       })
 
       if (isSubmittingDraft) {

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
@@ -428,6 +428,7 @@ describe('screens:OfferIndividual::Informations::creation', () => {
         isDraft: true,
         isEdition: false,
         offerId: offerId,
+        subcategoryId: 'physical',
         to: 'informations',
         used: 'DraftButtons',
       }

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
@@ -403,6 +403,7 @@ describe('screens:OfferIndividual::Informations::creation', () => {
         isDraft: true,
         isEdition: false,
         offerId: offerId,
+        subcategoryId: 'physical',
         to: 'stocks',
         used: 'StickyButtons',
       }
@@ -430,6 +431,7 @@ describe('screens:OfferIndividual::Informations::creation', () => {
         isDraft: true,
         isEdition: false,
         offerId: offerId,
+        subcategoryId: 'physical',
         to: 'informations',
         used: 'DraftButtons',
       }

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.draft.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.draft.spec.tsx
@@ -342,6 +342,7 @@ describe('screens:OfferIndividual::Informations:draft', () => {
         isDraft: true,
         isEdition: true,
         offerId: offerId,
+        subcategoryId: 'SCID physical',
         to: 'stocks',
         used: 'StickyButtons',
       }
@@ -361,6 +362,7 @@ describe('screens:OfferIndividual::Informations:draft', () => {
         isDraft: true,
         isEdition: true,
         offerId: offerId,
+        subcategoryId: 'SCID physical',
         to: 'informations',
         used: 'DraftButtons',
       }

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -500,6 +500,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
         isDraft: false,
         isEdition: true,
         offerId: offer.id,
+        subcategoryId: 'SCID physical',
         to: 'recapitulatif',
         used: 'StickyButtons',
       }

--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -10,7 +10,6 @@ import {
   OFFER_FORM_NAVIGATION_MEDIUM,
 } from 'core/FirebaseEvents/constants'
 import {
-  INDIVIDUAL_OFFER_SUBTYPE,
   COLLECTIVE_OFFER_SUBTYPE,
   OFFER_TYPES,
   OFFER_WIZARD_MODE,
@@ -39,7 +38,7 @@ const OfferType = (): JSX.Element => {
     collectiveOfferSubtype: COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE,
     collectiveOfferSubtypeDuplicate:
       COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.NEW_OFFER,
-    individualOfferSubtype: INDIVIDUAL_OFFER_SUBTYPE.PHYSICAL_GOOD,
+    individualOfferSubtype: '',
     individualOfferSubcategory: '',
   }
 

--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -50,6 +50,7 @@ const OfferType = (): JSX.Element => {
     if (values.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO) {
       logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
         offerType: values.individualOfferSubtype,
+        subcategoryId: values.individualOfferSubcategory,
         to: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
         from: OFFER_FORM_HOMEPAGE,
         used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,

--- a/pro/src/screens/OfferType/types.ts
+++ b/pro/src/screens/OfferType/types.ts
@@ -10,6 +10,6 @@ export interface OfferTypeFormValues {
   offerType: OFFER_TYPES
   collectiveOfferSubtype: COLLECTIVE_OFFER_SUBTYPE
   collectiveOfferSubtypeDuplicate: COLLECTIVE_OFFER_SUBTYPE_DUPLICATE
-  individualOfferSubtype: INDIVIDUAL_OFFER_SUBTYPE
+  individualOfferSubtype: INDIVIDUAL_OFFER_SUBTYPE | ''
   individualOfferSubcategory: SubcategoryIdEnum | 'OTHER' | ''
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23937

- ne pas préselectionner de choix de catégorie dans le hub
- ajouter sous-categorie dans tracking du hub
- ajouter sous-categorie dans tracking création offre (page information)
- appeler postProFlags quand on utilise la feature

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques