### PR TITLE
(PC-23990)[PRO] fix: Boutons - adapter la hauteur quand le texte passe sur 2 lignes

### DIFF
--- a/pro/src/components/MultiDownloadButtonsModal/MultiDownloadButtonsModal.module.scss
+++ b/pro/src/components/MultiDownloadButtonsModal/MultiDownloadButtonsModal.module.scss
@@ -11,7 +11,7 @@
     padding-left: rem.torem(60px);
 
     .drop-icon {
-      margin-left: rem.torem(80px);
+      margin-left: rem.torem(40px);
       width: rem.torem(16px);
       height: rem.torem(16px);
 

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -7,12 +7,10 @@
 .button {
   @include fonts.button;
 
-  align-items: center;
   margin: auto 0;
   border: rem.torem(2px) solid;
   border-radius: rem.torem(24px);
   display: inline-flex;
-  height: rem.torem(40px);
   justify-content: center;
   padding: 0 rem.torem(16px);
 
@@ -50,6 +48,8 @@
   }
 
   &-primary {
+    min-height: rem.torem(40px);
+    align-items: center;
     color: colors.$white;
     background-color: colors.$primary;
     border-color: colors.$primary;
@@ -71,6 +71,8 @@
   }
 
   &-secondary {
+    min-height: rem.torem(40px);
+    align-items: center;
     color: colors.$primary;
     background-color: colors.$white;
     border-color: colors.$primary;
@@ -109,6 +111,7 @@
     @include fonts.button;
 
     color: colors.$black;
+    align-items: flex-start;
 
     &-pink {
       color: colors.$primary;
@@ -147,12 +150,6 @@
       .button-icon {
         margin-right: 0;
       }
-    }
-  }
-
-  &-link.button-ternary {
-    .button-icon {
-      margin-bottom: auto;
     }
   }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23990

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

Avant

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/434f5327-d8f0-4999-8fc6-8c7d3c75ad7f)

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/833cd1db-6973-494e-84f6-7f3ea16f376a)

Après

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/b62a3256-982b-4ff7-9b03-d90b05238f47)

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/9584f426-6744-495b-a17d-f19579414542)
