### PR TITLE
(PC-24224)[PRO] fix: skipLinks should always be left side

### DIFF
--- a/pro/src/components/SkipLinks/SkipLinks.module.scss
+++ b/pro/src/components/SkipLinks/SkipLinks.module.scss
@@ -28,12 +28,13 @@
     gap: rem.torem(16px);
     align-items: center;
     height: rem.torem(32px);
-    justify-content: flex-end;
+
+    @media (min-width: size.$desktop) {
+      justify-content: flex-end;
+    }
 
     // Align skiplink to passculture logo, add logo margin and padding of a nav item creating more space
-    margin-right: calc(
-      size.$nav-brand-margin-right + size.$header-nav-item-padding + rem.torem(4px)
-    );
+    margin-right: calc(size.$nav-brand-margin-right + size.$header-nav-item-padding + rem.torem(4px));
 
     &-button {
       color: colors.$white;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24224

![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/8bebca5c-89fd-4fed-87b7-4032503e0ab2)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques