### PR TITLE
(BSR)[API] perf: Do not reindex offers when venue criteria or contact data change

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -64,7 +64,9 @@ class T_UNCHANGED(enum.Enum):
 
 
 UNCHANGED = T_UNCHANGED.TOKEN
-VENUE_ALGOLIA_INDEXED_FIELDS = ["name", "publicName", "postalCode", "city", "latitude", "longitude", "criteria"]
+# List of fields of `Venue` which, when changed, must trigger a
+# reindexation of offers.
+VENUE_ALGOLIA_INDEXED_FIELDS = ["name", "publicName", "postalCode", "city", "latitude", "longitude"]
 API_KEY_SEPARATOR = "_"
 APE_TAG_MAPPING = {"84.11Z": "Collectivité"}
 DMS_TOKEN_REGEX = r"^(?:PRO-)?([a-fA-F0-9]{12})$"
@@ -135,7 +137,7 @@ def update_venue(
     search.async_index_venue_ids([venue.id])
 
     indexing_modifications_fields = set(modifications.keys()) & set(VENUE_ALGOLIA_INDEXED_FIELDS)
-    if indexing_modifications_fields or contact_data:
+    if indexing_modifications_fields:
         search.async_index_offers_of_venue_ids([venue.id])
 
     # Former booking email address shall no longer receive emails about data related to this venue.

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -429,6 +429,8 @@ class AlgoliaBackend(base.SearchBackend):
         gtl_id = product_extra_data.get("gtl_id")
         gtl = titelive_gtl.get_gtl(gtl_id) if gtl_id else None
 
+        # If you update this dictionary, please check whether you need to
+        # also update `core.offerers.api.VENUE_ALGOLIA_INDEXED_FIELDS`.
         object_to_index = {
             "distinct": distinct,
             "objectID": offer.id,


### PR DESCRIPTION
What we send to Algolia when reindexing an offer does not depend on
`Venue.criteria` or contact data (e-mail, website, etc.). Thus,
changing these characteristics of a venue should not trigger a
re-indexation of the offers of this venue.