### PR TITLE
(BSR)[BO] fix: prevent form submit when required fields

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/components/forms/search_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/search_field.html
@@ -1,6 +1,6 @@
 <span class="input-group-text bg-white"><i class="bi bi-search"></i></span>
 {% set search_field_id = random_hash() %}
-<input {% if field.flags.required %}required{% endif %}
+<input {% if field.flags.required %}required {% endif +%}
        type="text"
        class="form-control col-8 border-start-0 value-element-form"
        id="{{ search_field_id }}"

--- a/api/src/pcapi/routes/backoffice/templates/components/forms/select_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/select_field.html
@@ -5,7 +5,7 @@
           name="{{ field.name }}"
           data-original-name="{{ field.name }}"
           aria-label="{{ field.name }}"
-          {% if field.flags.required %}required{% endif %}
+          {% if field.flags.required %}required {% endif +%}
           data-default-value="{{ field.default }}">
     {% if not field.default %}<option value=""></option>{% endif %}
     {% for choice_value, choice_label in field.choices %}

--- a/api/src/pcapi/routes/backoffice/templates/components/forms/select_with_placeholder_value_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/select_with_placeholder_value_field.html
@@ -5,7 +5,7 @@
           name="{{ field.name }}"
           data-original-name="{{ field.name }}"
           aria-label="{{ field.name }}"
-          {% if field.flags.required %}required{% endif %}>
+          {% if field.flags.required %}required {% endif +%}>
     <option value=""
             {% if not field.data %}selected{% endif %}>---Sélectionnez une valeur---</option>
     {% for choice_value, choice_label in field.choices %}

--- a/api/src/pcapi/routes/backoffice/templates/components/forms/string_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/string_field.html
@@ -8,7 +8,7 @@
            data-original-name="{{ field.name }}"
            class="form-control value-element-form {% if field.flags.required %}pc-required{% endif %}"
            value="{{ field.data | empty_string_if_null }}"
-           {% if field.flags.required %}required{% endif %}
+           {% if field.flags.required %}required {% endif +%}
            {% if field.flags.pattern %}pattern="{{ field.flags.pattern }}"{% endif %}
            {% if field.flags.minlength %}minlength="{{ field.flags.minlength }}"{% endif %}
            {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %}

--- a/api/src/pcapi/routes/backoffice/templates/components/forms/textarea_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/textarea_field.html
@@ -4,7 +4,7 @@
             data-original-name="{{ field.name }}"
             class="form-control pc-override-custom-textarea-enter value-element-form {% if field.flags.required %}pc-required{% endif %}"
             rows="{{ field.rows }}"
-            {% if field.flags.required %}required=""{% endif %}
+            {% if field.flags.required %}required {% endif +%}
             {% if field.flags.minlength %}minlength="{{ field.flags.minlength }}"{% endif %}
             {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %}>{{ field.data | empty_string_if_null }}</textarea>
   <label class="label-element-form"


### PR DESCRIPTION
## But de la pull request

- Les champs "required" définis dans les formulaires Flasks n'empêchaient pas le submit du formulaire.

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/da135e1f-8b4f-4dbf-9ad9-a4d214959a7e)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques