### PR TITLE
(PC-24531)[PRO] style: Make checkbox focus outline around input unles…

### DIFF
--- a/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.module.scss
@@ -131,12 +131,12 @@
         border-color: forms.$input-border-color-error;
       }
     }
-  }
 
-  &:focus-within {
-    outline: rem.torem(1px) solid colors.$input-text-color;
-    outline-offset: rem.torem(4px);
-    border-radius: rem.torem(4px);
+    &:focus-visible {
+      outline: rem.torem(1px) solid colors.$input-text-color;
+      outline-offset: rem.torem(4px);
+      border-radius: rem.torem(4px);
+    }
   }
 }
 
@@ -144,8 +144,17 @@
   border: rem.torem(1px) solid colors.$grey-semi-dark;
   border-radius: rem.torem(6px);
   min-width: 100%;
-  display: flex;
   padding-left: rem.torem(16px);
   padding-top: rem.torem(16px);
   padding-bottom: rem.torem(16px);
+
+  .base-checkbox-input:focus-visible {
+    outline: none;
+  }
+
+  &:focus-within {
+    outline: rem.torem(1px) solid colors.$input-text-color;
+    outline-offset: rem.torem(4px);
+    border-radius: rem.torem(4px);
+  }
 }


### PR DESCRIPTION
…s it's a checkbox with borders

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24531

**Objectif**
Eviter que l'outline du focus d'une checkbox prenne toute la largeur disponible même si le label est court.

**Realisation**
Ca m'a semblé mieux de passer le style focus sur l'input directement (validé par Charlotte) sauf quand il s'agit d'un checkbox avec border (voir screens). 
Ainsi on peut tout de même utiliser `focus-visible` (sauf sur les checkbox avec border).

<img width="170" alt="Capture d’écran 2023-09-18 à 18 36 19" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/60be4328-05e7-4eed-bc19-48f1d9b1f75b">
<img width="202" alt="Capture d’écran 2023-09-18 à 18 36 25" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/40a6e098-a4f2-445a-99ba-6edac557657d">
<img width="196" alt="Capture d’écran 2023-09-18 à 18 36 51" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/ead9c7ba-c9cc-41c2-a25d-39a0df60bd5c">
<img width="907" alt="Capture d’écran 2023-09-18 à 18 37 00" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/f8288944-3fbe-4b1e-80e1-464455e341ec">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques