### PR TITLE
(PC-24280)[API] fix: Handle dsToken prefix for offerers.

### DIFF
--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -9,6 +9,7 @@ from pcapi import settings
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.offerers.models import Target
 import pcapi.core.offerers.repository as offerers_repository
+from pcapi.domain.demarches_simplifiees import DMS_TOKEN_PRO_PREFIX
 from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceMixin
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization.venues_serialize import DMSApplicationForEAC
@@ -101,6 +102,7 @@ class GetOffererResponseModel(BaseModel):
 
     @classmethod
     def from_orm(cls, offerer: offerers_models.Offerer) -> "GetOffererResponseModel":
+        offerer.dsToken = DMS_TOKEN_PRO_PREFIX + offerer.dsToken
         offerer.apiKey = {
             "maxAllowed": settings.MAX_API_KEY_PER_OFFERER,
             "prefixes": offerers_repository.get_api_key_prefixes(offerer.id),


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24280

- Rajout du prefix "PRO" pour les dsToken pour les offerers aussi.


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques