### PR TITLE
(BSR)[API] feat: Add logs in `repository.save` on error

### DIFF
--- a/api/src/pcapi/repository/repository.py
+++ b/api/src/pcapi/repository/repository.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy.exc import DataError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.exc import InternalError
@@ -7,6 +9,9 @@ from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.pc_object import PcObject
 from pcapi.validation.models import entity_validator
+
+
+logger = logging.getLogger(__name__)
 
 
 def delete(*models: Model) -> None:
@@ -44,22 +49,27 @@ def save(*models: Model, commit: bool = True) -> None:
     try:
         db.session.commit()
     except DataError as data_error:
+        logger.exception("Error in repository.save: %s", data_error, extra={"models": models})
         api_errors.add_error(*models[0].restize_data_error(data_error))
         db.session.rollback()
         raise api_errors
     except IntegrityError as integrity_error:
+        logger.exception("Error in repository.save: %s", integrity_error, extra={"models": models})
         api_errors.add_error(*models[0].restize_integrity_error(integrity_error))
         db.session.rollback()
         raise api_errors
     except InternalError as internal_error:
+        logger.exception("Error in repository.save: %s", internal_error, extra={"models": models})
         api_errors.add_error(*models[0].restize_internal_error(internal_error))
         db.session.rollback()
         raise api_errors
     except TypeError as type_error:
+        logger.exception("Error in repository.save: %s", type_error, extra={"models": models})
         api_errors.add_error(*PcObject.restize_type_error(type_error))
         db.session.rollback()
         raise api_errors
     except ValueError as value_error:
+        logger.exception("Error in repository.save: %s", value_error, extra={"models": models})
         api_errors.add_error(*PcObject.restize_value_error(value_error))
         db.session.rollback()
         raise api_errors


### PR DESCRIPTION
These except clauses were useful before Pydantic was used. Now
Pydantic should validate most input and we should very rarely
get an exception when calling `commit()`. If an exception is
raised, it's probably because we forgot to validate input and
we should fix that.

Once errors are logged and then fixed, we'll know if we can remove
this error handling (or maybe move it to route error handlers).