### PR TITLE
(BSR)[API] fix: fix error on full_index_offers. Use same logis as reindex_offer_ids

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -470,7 +470,7 @@ def get_last_x_days_bookings_count(
     )
 
 
-def _get_offer_bookings_count(offer: offers_models.Offer, last_x_days_bookings_count: BookingsCount) -> int:
+def get_offer_bookings_count(offer: offers_models.Offer, last_x_days_bookings_count: BookingsCount) -> int:
     booking_count_by_offer_id = last_x_days_bookings_count.booking_count_by_offer_id
     booking_count_by_ean = last_x_days_bookings_count.booking_count_by_ean
 
@@ -504,7 +504,7 @@ def reindex_offer_ids(offer_ids: Iterable[int], use_national_booking_count: bool
 
     for offer in offers:
         if offer and offer.is_eligible_for_search:
-            last_x_days_bookings_count_by_offer[offer.id] = _get_offer_bookings_count(offer, last_x_days_bookings_count)
+            last_x_days_bookings_count_by_offer[offer.id] = get_offer_bookings_count(offer, last_x_days_bookings_count)
             to_add.append(offer)
         elif backend.check_offer_is_indexed(offer):
             to_delete_ids.append(offer.id)

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -335,8 +335,8 @@ class GetLastXDaysBookingsTest:
         )
 
         # when
-        result_1 = search._get_offer_bookings_count(offer_with_ean, bookings_count)
-        result_2 = search._get_offer_bookings_count(other_offer_with_ean, bookings_count)
+        result_1 = search.get_offer_bookings_count(offer_with_ean, bookings_count)
+        result_2 = search.get_offer_bookings_count(other_offer_with_ean, bookings_count)
 
         # then
         assert result_1 == 2
@@ -352,7 +352,7 @@ class GetLastXDaysBookingsTest:
 
         bookings_count = search.get_last_x_days_bookings_count(offers=[offer_with_ean], days=30, get_related_eans=True)
 
-        assert search._get_offer_bookings_count(offer_with_ean, bookings_count) == 2
+        assert search.get_offer_bookings_count(offer_with_ean, bookings_count) == 2
 
     def test_get_offer_last_x_days_bookings_ignores_bookings_too_old(self):
         ean_1 = "1234567890123"
@@ -366,4 +366,4 @@ class GetLastXDaysBookingsTest:
         bookings_factories.BookingFactory(stock=offers_factories.StockFactory(offer=other_offer_with_ean))
         bookings_count = search.get_last_x_days_bookings_count(offers=[offer_with_ean], days=30, get_related_eans=True)
 
-        assert search._get_offer_bookings_count(offer_with_ean, bookings_count) == 1
+        assert search.get_offer_bookings_count(offer_with_ean, bookings_count) == 1


### PR DESCRIPTION
## But de la pull request
Corriger une erreur sur master: une fonction non existante est appelée dans full_reindex_offers

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques