### PR TITLE
(BSR)[API] style: Restore "no-member" pylint warning

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -194,7 +194,6 @@ disable = [
     "line-too-long",
     "locally-disabled",
     "missing-docstring",
-    "no-member",
     "protected-access",
     "raise-missing-from",
     "singleton-comparison",


### PR DESCRIPTION
This warnings detects access to unknown functions, methods, etc.

---

C'est un essai. À ce jour (20/09/2023), pylint détecte à tort plein de faux négatifs : 
- sur toutes les méthodes de `session` :  `add()`, `commit()`, `rollback()`, etc. Message : `Instance of 'scoped_session' has no 'rollback' member`
- sur toutes les appels à `is_()` et compagnie sur les "hybrid properties". Message :  `Method 'remainingQuantity' has no 'is_' member`
- etc.

Donc on n'est pas encore vraiment prêt pour modification la configuration de pylint...