### PR TITLE
(BSR)[API] fix: Return HTTP 400, not 500, when content-type is not JSON

### DIFF
--- a/api/src/pcapi/routes/native/v1/api_errors/account.py
+++ b/api/src/pcapi/routes/native/v1/api_errors/account.py
@@ -11,9 +11,6 @@ class AccountApiError:
     message: str
 
 
-EMAIL_ALREADY_EXISTS = AccountApiError(
-    code="EMAIL_ALREADY_EXISTS", message="Cet email est déjà utilisé par un autre compte."
-)
 EMAIL_UPDATE_LIMIT = AccountApiError(
     code="EMAIL_UPDATE_LIMIT",
     message=f"Tu ne peux pas modifier ton email plus de {settings.MAX_EMAIL_UPDATE_ATTEMPTS} fois en {date_utils.format_time_in_second_to_human_readable(settings.EMAIL_UPDATE_ATTEMPTS_TTL)}.",
@@ -22,16 +19,6 @@ EMAIL_UPDATE_PENDING = AccountApiError(
     code="EMAIL_UPDATE_PENDING", message="Tu as déjà une demande de modification d'email en cours."
 )
 WRONG_PASSWORD = AccountApiError(code="WRONG_PASSWORD", message="Le mot de passe est incorrect.")
-
-
-class EmailAlreadyExistsError(ApiErrors):
-    def __init__(self, errors: dict = None, status_code: int | None = None):
-        super().__init__(
-            errors={
-                "message": EMAIL_ALREADY_EXISTS.message,
-                "error_code": EMAIL_ALREADY_EXISTS.code,
-            }
-        )
 
 
 class EmailUpdateLimitError(ApiErrors):

--- a/api/tests/serialization/serialization_decorator_test.py
+++ b/api/tests/serialization/serialization_decorator_test.py
@@ -40,9 +40,15 @@ def spectree_post_test_endpoint():
     endpoint_method()
 
 
-@test_blueprint.route("/validation", methods=["POST"])
+@test_blueprint.route("/body-validation", methods=["POST"])
 @spectree_serialize(on_success_status=206)
-def spectree_empty_form_validation(form: TestQueryModel):
+def spectree_body_validation(body: TestQueryModel):
+    return
+
+
+@test_blueprint.route("/form-validation", methods=["POST"])
+@spectree_serialize(on_success_status=206)
+def spectree_form_validation(form: TestQueryModel):
     return
 
 
@@ -149,10 +155,14 @@ class SerializationDecoratorTest:
 
     def test_http_form_validation(self, client):
         response = client.post(
-            "/test-blueprint/validation", form=None, headers={"Content-Type": "application/x-www-form-urlencoded"}
+            "/test-blueprint/form-validation", form=None, headers={"Content-Type": "application/x-www-form-urlencoded"}
         )
 
         assert response.status_code == 400
         assert response.json == {
             "compulsory_int_query": ["Ce champ est obligatoire"],
         }
+
+    def test_post_without_content_type_throws_400(self, client):
+        response = client.post("/test-blueprint/body-validation", headers={})
+        assert response.status_code == 400


### PR DESCRIPTION
Routes that expected a non-empty body raised an HTTP 500 error when
the client did not send the proper "Content-Type: application/json"
HTTP header. Now these routes return a 400.

---

Exemples d'erreur, actuellement : 
- https://sentry.passculture.team/organizations/sentry/issues/425963
- https://sentry.passculture.team/organizations/sentry/issues/426748

---

... et 1 commit supplémentaire de nettoyage au passage.