### PR TITLE
Bsr update sqla deprecated fields names (#5429)

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -868,7 +868,7 @@ def archive_old_bookings() -> None:
         .filter(date_condition)
         .filter(
             offers_models.Offer.isDigital.is_(True),  # type: ignore [attr-defined]
-            offers_models.ActivationCode.id.isnot(None),
+            offers_models.ActivationCode.id.is_not(None),
         )
         .with_entities(Booking.id)
         .union(

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -229,7 +229,7 @@ class Booking(PcObject, Base, Model):
 
     @isConfirmed.expression  # type: ignore [no-redef]
     def isConfirmed(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument # type: ignore[no-redef]
-        return and_(cls.cancellationLimitDate.isnot(None), cls.cancellationLimitDate <= datetime.utcnow())
+        return and_(cls.cancellationLimitDate.is_not(None), cls.cancellationLimitDate <= datetime.utcnow())
 
     @hybrid_property
     def is_used_or_reimbursed(self) -> bool:

--- a/api/src/pcapi/core/external/commands/update_sendinblue_pro_attributes.py
+++ b/api/src/pcapi/core/external/commands/update_sendinblue_pro_attributes.py
@@ -15,7 +15,7 @@ def get_all_booking_emails() -> set[str]:
     rows = (
         db.session.query(Venue.bookingEmail)
         .distinct()
-        .filter(Venue.bookingEmail.isnot(None), Venue.bookingEmail != "")
+        .filter(Venue.bookingEmail.is_not(None), Venue.bookingEmail != "")
         .all()
     )
     print(f"{len(rows)} booking emails")

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -522,7 +522,7 @@ def _get_bookings_to_price(
 def _get_events_to_price(window: tuple[datetime.datetime, datetime.datetime]) -> BaseQuery:
     return (
         models.FinanceEvent.query.filter(
-            models.FinanceEvent.pricingPointId.isnot(None),
+            models.FinanceEvent.pricingPointId.is_not(None),
             models.FinanceEvent.status == models.FinanceEventStatus.READY,
             models.FinanceEvent.pricingOrderingDate.between(*window),
         )
@@ -1319,14 +1319,14 @@ def _generate_cashflows(batch: models.CashflowBatch) -> None:
         # wait for the event to happen.
         sqla.or_(
             sqla.and_(
-                models.Pricing.bookingId.isnot(None),
+                models.Pricing.bookingId.is_not(None),
                 sqla.or_(
                     offers_models.Stock.beginningDatetime.is_(None),
                     offers_models.Stock.beginningDatetime < batch.cutoff,
                 ),
             ),
             sqla.and_(
-                models.Pricing.collectiveBookingId.isnot(None),
+                models.Pricing.collectiveBookingId.is_not(None),
                 educational_models.CollectiveStock.beginningDatetime < batch.cutoff,
             ),
         ),
@@ -1403,7 +1403,7 @@ def _generate_cashflows(batch: models.CashflowBatch) -> None:
                         != -100
                         * sqla.case(
                             (
-                                bookings_models.Booking.id.isnot(None),
+                                bookings_models.Booking.id.is_not(None),
                                 bookings_models.Booking.amount * bookings_models.Booking.quantity,
                             ),
                             else_=educational_models.CollectiveStock.price,

--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -215,7 +215,7 @@ def _get_sent_pricings_for_collective_bookings(
             # to the same bookings as the original invoices they
             # complement. We don't want these bookings to be listed
             # twice.
-            models.Invoice.reference.notlike("%.2"),
+            models.Invoice.reference.not_like("%.2"),
         )
         .join(
             educational_models.EducationalRedactor,
@@ -308,7 +308,7 @@ def _get_sent_pricings_for_individual_bookings(
             # to the same bookings as the original invoices they
             # complement. We don't want these bookings to be listed
             # twice.
-            models.Invoice.reference.notlike("%.2"),
+            models.Invoice.reference.not_like("%.2"),
         )
         .join(bookings_models.Booking.offerer)
         .join(bookings_models.Booking.stock)

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -256,7 +256,7 @@ def find_duplicate_id_piece_number_user(id_piece_number: str | None, excluded_us
         return None
     return users_models.User.query.filter(
         users_models.User.id != excluded_user_id,
-        users_models.User.idPieceNumber.isnot(None),
+        users_models.User.idPieceNumber.is_not(None),
         users_models.User.idPieceNumber == format_id_piece_number(id_piece_number),
     ).first()
 

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -50,6 +50,9 @@ class ActionType(enum.Enum):
     FINANCE_INCIDENT_USER_RECREDIT = "Compte re-crédité suite à un incident"
 
 
+ACTION_HISTORY_ORDER_BY = "ActionHistory.actionDate.asc().nullsfirst()"
+
+
 class ActionHistory(PcObject, Base, Model):
     """
     This table aims at logging all actions that should appear in a resource history for support, fraud team, etc.
@@ -93,9 +96,7 @@ class ActionHistory(PcObject, Base, Model):
     user: users_models.User | None = sa.orm.relationship(
         "User",
         foreign_keys=[userId],
-        backref=sa.orm.backref(
-            "action_history", order_by="ActionHistory.actionDate.asc().nullsfirst()", passive_deletes=True
-        ),
+        backref=sa.orm.backref("action_history", order_by=ACTION_HISTORY_ORDER_BY, passive_deletes=True),
     )
 
     offererId: int | None = sa.Column(
@@ -104,9 +105,7 @@ class ActionHistory(PcObject, Base, Model):
     offerer: sa.orm.Mapped["offerers_models.Offerer | None"] = sa.orm.relationship(
         "Offerer",
         foreign_keys=[offererId],
-        backref=sa.orm.backref(
-            "action_history", order_by="ActionHistory.actionDate.asc().nullsfirst()", passive_deletes=True
-        ),
+        backref=sa.orm.backref("action_history", order_by=ACTION_HISTORY_ORDER_BY, passive_deletes=True),
     )
 
     venueId: int | None = sa.Column(
@@ -115,9 +114,7 @@ class ActionHistory(PcObject, Base, Model):
     venue: sa.orm.Mapped["offerers_models.Venue | None"] = sa.orm.relationship(
         "Venue",
         foreign_keys=[venueId],
-        backref=sa.orm.backref(
-            "action_history", order_by="ActionHistory.actionDate.asc().nullsfirst()", passive_deletes=True
-        ),
+        backref=sa.orm.backref("action_history", order_by=ACTION_HISTORY_ORDER_BY, passive_deletes=True),
     )
 
     financeIncidentId: int | None = sa.Column(

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -50,7 +50,7 @@ class ActionType(enum.Enum):
     FINANCE_INCIDENT_USER_RECREDIT = "Compte re-crédité suite à un incident"
 
 
-ACTION_HISTORY_ORDER_BY = "ActionHistory.actionDate.asc().nullsfirst()"
+ACTION_HISTORY_ORDER_BY = "ActionHistory.actionDate.asc().nulls_first()"
 
 
 class ActionHistory(PcObject, Base, Model):

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -359,7 +359,7 @@ def offerer_has_venue_with_adage_id(offerer_id: int) -> bool:
     query = db.session.query(models.Venue.id)
     query = query.join(models.Offerer, models.Venue.managingOfferer)
     query = query.filter(
-        models.Venue.adageId.isnot(None),
+        models.Venue.adageId.is_not(None),
         models.Venue.adageId != "",
         models.Offerer.id == offerer_id,
     )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -217,7 +217,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
 
     @hasBookingLimitDatetimePassed.expression  # type: ignore [no-redef]
     def hasBookingLimitDatetimePassed(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
-        return sa.and_(cls.bookingLimitDatetime.isnot(None), cls.bookingLimitDatetime <= sa.func.now())
+        return sa.and_(cls.bookingLimitDatetime.is_not(None), cls.bookingLimitDatetime <= sa.func.now())
 
     # TODO(fseguin, 2021-03-25): replace unlimited by None (also in the front-end)
     @hybrid_property
@@ -245,7 +245,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
 
     @isEventExpired.expression  # type: ignore [no-redef]
     def isEventExpired(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
-        return sa.and_(cls.beginningDatetime.isnot(None), cls.beginningDatetime <= sa.func.now())
+        return sa.and_(cls.beginningDatetime.is_not(None), cls.beginningDatetime <= sa.func.now())
 
     @hybrid_property
     def isExpired(self) -> bool:
@@ -537,7 +537,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
 
     @isDigital.expression  # type: ignore [no-redef]
     def isDigital(cls) -> bool:  # pylint: disable=no-self-argument
-        return sa.and_(cls.url.isnot(None), cls.url != "")
+        return sa.and_(cls.url.is_not(None), cls.url != "")
 
     @property
     def isEditable(self) -> bool:

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -409,7 +409,7 @@ def _filter_by_creation_mode(query: flask_sqlalchemy.BaseQuery, creation_mode: s
     if creation_mode == MANUAL_CREATION_MODE:
         query = query.filter(models.Offer.lastProviderId.is_(None))
     if creation_mode == IMPORTED_CREATION_MODE:
-        query = query.filter(models.Offer.lastProviderId.isnot(None))
+        query = query.filter(models.Offer.lastProviderId.is_not(None))
 
     return query
 
@@ -588,7 +588,7 @@ def get_expired_offers(interval: typing.List[datetime.datetime]) -> flask_sqlalc
         .filter(
             models.Offer.isActive.is_(True),
             models.Stock.isSoftDeleted.is_(False),
-            models.Stock.bookingLimitDatetime.isnot(None),
+            models.Stock.bookingLimitDatetime.is_not(None),
         )
         .having(sa.func.max(models.Stock.bookingLimitDatetime).between(*interval))  # type: ignore [arg-type]
         .group_by(models.Offer.id)

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -78,7 +78,7 @@ def reset_stock_quantity(venue: offerers_models.Venue) -> None:
     stocks = offers_models.Stock.query.filter(
         offers_models.Stock.offerId == offers_models.Offer.id,
         offers_models.Offer.venue == venue,
-        offers_models.Offer.idAtProvider.isnot(None),
+        offers_models.Offer.idAtProvider.is_not(None),
     )
     stocks.update({"quantity": offers_models.Stock.dnBookedQuantity}, synchronize_session=False)
     db.session.commit()

--- a/api/src/pcapi/core/providers/commands.py
+++ b/api/src/pcapi/core/providers/commands.py
@@ -25,7 +25,7 @@ def _synchronize_venue_providers_apis() -> None:
     # FIXME(viconnex): we should joinedload(Provider.venueProviders) to avoir N+1 queries but sqlalchemy is not able to build the request
     providers_apis = models.Provider.query.filter(
         models.Provider.isActive,
-        models.Provider.apiUrl.isnot(None),
+        models.Provider.apiUrl.is_not(None),
     ).all()
 
     for provider in providers_apis:

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -690,7 +690,7 @@ def reindex_offers_if_ean_booked_since(offer_ids: list, since: datetime.datetime
         .join(bookings_models.Booking.stock)
         .join(offers_models.Stock.offer)
         .join(offers_models.Offer.product)
-        .filter(sa.or_(offers_models.Offer.extraData["ean"].isnot(None)))
+        .filter(sa.or_(offers_models.Offer.extraData["ean"].is_not(None)))
         .with_entities(offers_models.Offer.extraData["ean"].label("ean"))
     )
 

--- a/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
+++ b/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
@@ -83,7 +83,7 @@ def get_fraud_check_to_archive(
             fraud_models.BeneficiaryFraudCheck.dateCreated.between(start_date, end_date),
             fraud_models.BeneficiaryFraudCheck.idPicturesStored.is_(status),
             fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.UBBLE,
-            fraud_models.BeneficiaryFraudCheck.thirdPartyId.notlike(f"{subscription_api.DEPRECATED_UBBLE_PREFIX}%"),
+            fraud_models.BeneficiaryFraudCheck.thirdPartyId.not_like(f"{subscription_api.DEPRECATED_UBBLE_PREFIX}%"),
         )
         .order_by(fraud_models.BeneficiaryFraudCheck.dateCreated.asc())
         .limit(limit)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1172,7 +1172,7 @@ def get_pro_account_base_query(pro_id: int) -> BaseQuery:
 
 def search_backoffice_accounts(search_query: str, order_by: list[str] | None = None) -> BaseQuery:
     bo_accounts = models.User.query.outerjoin(users_models.User.backoffice_profile).filter(
-        perm_models.BackOfficeUserProfile.id.isnot(None),
+        perm_models.BackOfficeUserProfile.id.is_not(None),
     )
 
     if not search_query:

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -427,9 +427,9 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
             sa.func.nullif(
                 sa.func.trim(
                     sa.func.concat(
-                        sa.case([(cls.firstName.isnot(None), cls.firstName)], else_=""),
+                        sa.case([(cls.firstName.is_not(None), cls.firstName)], else_=""),
                         " ",
-                        sa.case([(cls.lastName.isnot(None), cls.lastName)], else_=""),
+                        sa.case([(cls.lastName.is_not(None), cls.lastName)], else_=""),
                     )
                 ),
                 "",

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -294,7 +294,7 @@ def get_pro_users(offerer_id: int) -> utils.BackofficeResponse:
         .filter(offerers_models.UserOfferer.offererId == offerer_id)
         .union(
             db.session.query(history_models.ActionHistory.userId).filter(
-                history_models.ActionHistory.offererId == offerer_id, history_models.ActionHistory.userId.isnot(None)
+                history_models.ActionHistory.offererId == offerer_id, history_models.ActionHistory.userId.is_not(None)
             )
         )
         .distinct()

--- a/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
@@ -174,7 +174,7 @@ def list_offerers_to_be_validated(
         db.session.query(history_models.ActionHistory.comment)
         .filter(
             history_models.ActionHistory.offererId == offerers_models.Offerer.id,
-            history_models.ActionHistory.comment.isnot(None),
+            history_models.ActionHistory.comment.is_not(None),
             history_models.ActionHistory.actionType.in_(
                 [
                     history_models.ActionType.OFFERER_NEW,
@@ -227,7 +227,7 @@ def list_offerers_to_be_validated(
         .select_from(offerers_models.Venue)
         .filter(
             offerers_models.Venue.managingOffererId == offerers_models.Offerer.id,
-            offerers_models.Venue.dms_adage_status.isnot(None),  # type: ignore [attr-defined]
+            offerers_models.Venue.dms_adage_status.is_not(None),  # type: ignore [attr-defined]
         )
         .correlate(offerers_models.Offerer)
         .scalar_subquery()
@@ -278,7 +278,7 @@ def list_users_offerers_to_be_validated(
         .filter(
             history_models.ActionHistory.offererId == offerers_models.Offerer.id,
             history_models.ActionHistory.userId == users_models.User.id,
-            history_models.ActionHistory.comment.isnot(None),
+            history_models.ActionHistory.comment.is_not(None),
             history_models.ActionHistory.actionType.in_(
                 [
                     history_models.ActionType.USER_OFFERER_NEW,

--- a/api/src/pcapi/scripts/subscription/dms/handle_deleted_dms_applications.py
+++ b/api/src/pcapi/scripts/subscription/dms/handle_deleted_dms_applications.py
@@ -23,7 +23,7 @@ def get_latest_deleted_application_datetime(procedure_number: int) -> datetime.d
         fraud_models.BeneficiaryFraudCheck.query.filter(
             fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.DMS,
             fraud_models.BeneficiaryFraudCheck.status == fraud_models.FraudCheckStatus.CANCELED,
-            fraud_models.BeneficiaryFraudCheck.resultContent.isnot(None),
+            fraud_models.BeneficiaryFraudCheck.resultContent.is_not(None),
             fraud_models.BeneficiaryFraudCheck.resultContent["procedure_id"].astext.cast(Integer) == procedure_number,
             fraud_models.BeneficiaryFraudCheck.resultContent.has_key("deletion_datetime"),
         )


### PR DESCRIPTION
## But de la pull request

Depuis Sqlalchemy 1.4, certaines fonctions ont été renomées
cf. https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html#change-8dd50c1cc4d512bf97b23fb0243619af

Petite PR facile pour renomer chez nous

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques