### PR TITLE
(BSR)[API] feat: Log errors in `archive_past_identification_pictures()`

### DIFF
--- a/api/src/pcapi/core/external/attributes/api.py
+++ b/api/src/pcapi/core/external/attributes/api.py
@@ -478,7 +478,7 @@ def get_user_bookings(user: users_models.User) -> List[bookings_models.Booking]:
             bookings_models.Booking.userId == user.id,
             bookings_models.Booking.status != bookings_models.BookingStatus.CANCELLED,
         )
-        .order_by(db.desc(bookings_models.Booking.dateCreated))
+        .order_by(bookings_models.Booking.dateCreated.desc())
         .all()
     )
 

--- a/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
+++ b/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.subscription import api as subscription_api
@@ -9,6 +10,8 @@ from pcapi.utils.requests import ExternalAPIException
 
 DEFAULT_LIMIT = 1000
 DEFAULT_ID_PICTURE_STORE_STATUS = None
+
+logger = logging.getLogger()
 
 
 class UbbleIdentificationPicturesArchiveResult:
@@ -65,6 +68,7 @@ def archive_past_identification_pictures(
                 result.add_result(False)
             except Exception:  # pylint: disable=broad-except
                 # Catch all exception. Watch logs to find errors during archive
+                logger.exception("Error in archive_past_identification_pictures")
                 result.add_result()
 
         # Offset and limit are used to window query result inside loop.


### PR DESCRIPTION
The comment says: "Watch logs to find errors during archive". Well,
there won't be much to watch if we don't log anything...