### PR TITLE
(BSR)[PRO] fix: remove errors in url

### DIFF
--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -62,7 +62,6 @@ const Venue = ({
     new URLSearchParams({
       structure: offererId.toString(),
       lieu: venueId.toString(),
-      numerique: isVirtual ? 'null' : 'undefined',
     }),
   ].join('?')
 

--- a/pro/src/pages/Offers/utils/queryParamsFromOfferer.ts
+++ b/pro/src/pages/Offers/utils/queryParamsFromOfferer.ts
@@ -4,13 +4,11 @@ export const queryParamsFromOfferer = (location: Location) => {
   const queryParams = new URLSearchParams(location.search)
   const hasOfferer = queryParams.has('structure')
   const hasVenue = queryParams.has('lieu')
-  const hasNumerique = queryParams.has('numerique')
   const hasRequest = queryParams.has('requete')
 
   return {
     structure: hasOfferer ? queryParams.get('structure') : '',
     lieu: hasVenue ? queryParams.get('lieu') : '',
-    numerique: hasNumerique,
     requete: hasRequest ? queryParams.get('requete') : '',
   }
 }

--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -56,20 +56,25 @@ const OfferType = (): JSX.Element => {
         used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
       })
 
-      /* istanbul ignore next: condition will be removed when FF active in prod */
+      const params = new URLSearchParams(location.search)
+      if (values.individualOfferSubtype) {
+        params.append('offer-type', values.individualOfferSubtype)
+      } else if (
+        values.individualOfferSubcategory &&
+        values.individualOfferSubcategory !== 'OTHER'
+      ) {
+        params.append('sous-categorie', values.individualOfferSubcategory)
+      }
+
       return navigate({
         pathname: getIndividualOfferUrl({
           step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
           mode: OFFER_WIZARD_MODE.CREATION,
         }),
-        search: `${location.search}${location.search ? '&' : '?'}${
-          values.individualOfferSubcategory &&
-          values.individualOfferSubcategory !== 'OTHER'
-            ? `sous-categorie=${values.individualOfferSubcategory}`
-            : `offer-type=${values.individualOfferSubtype}`
-        }`,
+        search: params.toString(),
       })
     }
+
     // Offer type is EDUCATIONAL
     if (values.collectiveOfferSubtype === COLLECTIVE_OFFER_SUBTYPE.TEMPLATE) {
       return navigate({

--- a/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
@@ -81,7 +81,7 @@ describe('screens:IndividualOffer::OfferType', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       pathname: '/offre/individuelle/creation/informations',
-      search: '?offer-type=PHYSICAL_GOOD',
+      search: 'offer-type=PHYSICAL_GOOD',
     })
   })
 
@@ -97,7 +97,22 @@ describe('screens:IndividualOffer::OfferType', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       pathname: '/offre/individuelle/creation/informations',
-      search: '?lieu=123&offer-type=PHYSICAL_EVENT',
+      search: 'lieu=123&offer-type=PHYSICAL_EVENT',
+    })
+  })
+
+  it('should redirect just with venue when venue and type was not selected', async () => {
+    renderOfferTypes('123')
+
+    expect(
+      await screen.findByText('Quelle est la catégorie de l’offre ?')
+    ).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Autre'))
+    await userEvent.click(screen.getByText('Étape suivante'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/offre/individuelle/creation/informations',
+      search: 'lieu=123',
     })
   })
 
@@ -112,7 +127,7 @@ describe('screens:IndividualOffer::OfferType', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       pathname: '/offre/individuelle/creation/informations',
-      search: '?lieu=123&sous-categorie=SPECTACLE_REPRESENTATION',
+      search: 'lieu=123&sous-categorie=SPECTACLE_REPRESENTATION',
     })
   })
 })


### PR DESCRIPTION
## But de la pull request

BSR

réparer erreur sur les urls : 
- `&numerique=undefined` ou `&numerique=null` pas très beau et inutilisé
- `&offer-type=` quand il n"y en a pas besoin

+ petite refacto de l'url de création d'offre indiv

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques