### PR TITLE
Ghaliela/pc 24398 notify external api for ticket cancel

### DIFF
--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -51,6 +51,7 @@ from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.models import feature
 import pcapi.notifications.push.testing as push_testing
+from pcapi.tasks.serialization.external_api_booking_notification_tasks import BookingAction
 from pcapi.utils import queue
 
 from tests.conftest import clean_database
@@ -736,6 +737,50 @@ class CancelByBeneficiaryTest:
         assert email_data2["template"] == dataclasses.asdict(
             TransactionalEmail.BOOKING_CANCELLATION_BY_BENEFICIARY_TO_PRO.value
         )  # to offerer
+
+    @patch("pcapi.tasks.external_api_booking_notification_tasks.external_api_booking_notification_task.delay")
+    def test_send_notification_to_external_api_when_cancel_booking(self, mocked_task):
+        provider = providers_factories.ProviderFactory(
+            name="Technical provider", localClass=None, notificationExternalUrl="http://external.api.com/notify"
+        )
+        providers_factories.OffererProviderFactory(provider=provider)
+        stock = offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue__address="1 boulevard Poissonniere",
+            offer__extraData={"ean": "1234567890123"},
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.NO_TICKET,
+            dnBookedQuantity=1,
+            idAtProviders="",
+            lastProvider=provider,
+        )
+        booking = bookings_factories.BookingFactory(stock=stock)
+
+        api.cancel_booking_by_beneficiary(booking.user, booking)
+
+        updated_booking = models.Booking.query.filter().one()
+
+        assert models.Booking.query.filter().count() == 1
+        assert updated_booking.status == BookingStatus.CANCELLED
+
+        assert updated_booking.stock.dnBookedQuantity == 1
+
+        assert mocked_task.call_count == 1
+        notification = mocked_task.call_args.args[0].data
+        assert notification.offer_ean == "1234567890123"
+        assert notification.offer_id == stock.offer.id
+        assert notification.offer_name == stock.offer.name
+        assert notification.offer_price == finance_api.utils.to_eurocents(stock.price)
+        assert notification.stock_id == stock.id
+        assert notification.booking_quantity == booking.quantity
+        assert notification.booking_creation_date == booking.dateCreated
+        assert notification.venue_address == "1 boulevard Poissonniere"
+        assert notification.user_email == booking.user.email
+        assert notification.user_first_name == booking.user.firstName
+        assert notification.user_last_name == booking.user.lastName
+        assert notification.user_phone == booking.user.phoneNumber
+        assert notification.action == BookingAction.CANCEL
+
+        assert mocked_task.call_args.args[0].notificationUrl == provider.notificationExternalUrl
 
     def test_cancel_booking_twice(self):
         booking = bookings_factories.BookingFactory()


### PR DESCRIPTION
## But de la pull request
Envoyer une notification à l'api externe à l'annulation d'un ticket
Uniquement si l'offre n'a pas `IN_APP` comme withdarawal type et si le provider a un url de notification

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23398

## Vérifications

- [X] J'ai écrit les tests nécessaires