### PR TITLE
jeremieb/fix-use_adageId

### DIFF
--- a/api/src/pcapi/core/educational/api/institution.py
+++ b/api/src/pcapi/core/educational/api/institution.py
@@ -148,7 +148,10 @@ def create_missing_educational_institution_from_adage(destination_uai: str) -> E
     missing institution inside or database if the target uai exists.
     """
     year = find_educational_year_by_date(datetime.utcnow())
-    adage_institutions = get_adage_educational_institutions(year)  # type: ignore [arg-type]
+    if year is None:
+        raise educational_exceptions.EducationalYearNotFound()
+
+    adage_institutions = get_adage_educational_institutions(year.adageId)
     if not adage_institutions:
         raise educational_exceptions.NoAdageInstitution()
 

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -196,6 +196,11 @@ def _get_current_educational_year() -> int:
     return current_educational_year
 
 
+class EducationalCurrentYearFactory(EducationalYearFactory):
+    beginningDate = datetime.datetime(_get_current_educational_year(), 9, 1)
+    expirationDate = datetime.datetime(_get_current_educational_year() + 1, 8, 31, 23, 59, 59)
+
+
 def _get_current_educational_year_adage_id() -> int:
     return _get_current_educational_year() - ADAGE_STARTING_EDUCATIONAL_YEAR
 


### PR DESCRIPTION
## But de la pull request

La fonction devrait être appelée avec un adageId de l'année. Pas tout le modèle EducationalYear.

## Au passage

Le fix faisait planter des tests que j'ai simplifié (à mon sens) au passage pour comprendre ce qui se passait et ce qui devait être testé.