### PR TITLE
(BSR)[API] chore: Restore "no-implicit-optional" mypy error

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -56,9 +56,6 @@ exclude = """
     | src/pcapi/alembic/.*
   )
 """
-# FIXME (dbaty, 2022-11-08): this is temporary until we fix typing
-# annotations that break with the new default value (true).
-no_implicit_optional = false
 # FIXME (dbaty, 2022-11-08): this is temporary until we find a
 # solution to type hybrid_property-decorated methods. Otherwise, mypy
 # reports a "truthy-function" error on code that uses these methods.

--- a/api/src/pcapi/analytics/amplitude/events/subscription.py
+++ b/api/src/pcapi/analytics/amplitude/events/subscription.py
@@ -32,7 +32,7 @@ def track_ubble_error_event(user_id: int, error_codes: list[fraud_models.FraudRe
 def track_dms_error_event(
     user_id: int,
     error_codes: list[fraud_models.FraudReasonCode],
-    field_errors: list[fraud_models.DmsFieldErrorDetails] = None,
+    field_errors: list[fraud_models.DmsFieldErrorDetails] | None = None,
 ) -> None:
     event_properties = (
         {"field_errors": [{"key": field_error.key.value, "value": field_error.value} for field_error in field_errors]}

--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -228,7 +228,7 @@ class SeatCDS:
         seat_location_indices: tuple[int, int],
         screen_infos: ScreenCDS,
         seat_map: SeatmapCDS,
-        hardcoded_seatmap: str = None,
+        hardcoded_seatmap: str | None = None,
     ):
         self.seatRow = seat_location_indices[0]
         self.seatCol = seat_location_indices[1]

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -167,7 +167,7 @@ def find_expiring_individual_bookings_query() -> BaseQuery:
     )
 
 
-def find_soon_to_be_expiring_individual_bookings_ordered_by_user(given_date: date = None) -> BaseQuery:
+def find_soon_to_be_expiring_individual_bookings_ordered_by_user(given_date: date | None = None) -> BaseQuery:
     given_date = given_date or date.today()
     books_expiring_date = datetime.combine(given_date, time(0, 0)) + constants.BOOKS_BOOKINGS_EXPIRY_NOTIFICATION_DELAY
     other_expiring_date = datetime.combine(given_date, time(0, 0)) + constants.BOOKINGS_EXPIRY_NOTIFICATION_DELAY
@@ -208,7 +208,7 @@ def generate_booking_token() -> str:
     raise ValueError("Could not generate new booking token")
 
 
-def find_user_ids_with_expired_individual_bookings(expired_on: date = None) -> List[int]:
+def find_user_ids_with_expired_individual_bookings(expired_on: date | None = None) -> List[int]:
     expired_on = expired_on or date.today()
     return [
         user_id
@@ -226,7 +226,7 @@ def find_user_ids_with_expired_individual_bookings(expired_on: date = None) -> L
     ]
 
 
-def get_expired_individual_bookings_for_user(user: User, expired_on: date = None) -> list[Booking]:
+def get_expired_individual_bookings_for_user(user: User, expired_on: date | None = None) -> list[Booking]:
     expired_on = expired_on or date.today()
     return Booking.query.filter(
         Booking.user == user,
@@ -237,7 +237,7 @@ def get_expired_individual_bookings_for_user(user: User, expired_on: date = None
     ).all()
 
 
-def find_expired_individual_bookings_ordered_by_offerer(expired_on: date = None) -> list[Booking]:
+def find_expired_individual_bookings_ordered_by_offerer(expired_on: date | None = None) -> list[Booking]:
     expired_on = expired_on or date.today()
     return (
         Booking.query.filter(Booking.status == BookingStatus.CANCELLED)

--- a/api/src/pcapi/core/external/sendinblue.py
+++ b/api/src/pcapi/core/external/sendinblue.py
@@ -164,7 +164,7 @@ def format_list_or_str(raw_value: str | Iterable[str]) -> str:
 def _get_attr(
     attributes: attributes_models.UserAttributes | attributes_models.ProAttributes,
     name: str,
-    func: Callable[[Any], Any] = None,
+    func: Callable[[Any], Any] | None = None,
 ) -> Any:
     value = getattr(attributes, name, None)
     if value is not None and func is not None:

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -132,7 +132,7 @@ def add_event(
     motive: models.FinanceEventMotive,
     booking: bookings_models.Booking | educational_models.CollectiveBooking | None = None,
     booking_incident: models.BookingFinanceIncident | None = None,
-    incident_validation_date: datetime.datetime = None,
+    incident_validation_date: datetime.datetime | None = None,
     commit: bool = True,
 ) -> models.FinanceEvent:
     if booking_incident:
@@ -2399,7 +2399,7 @@ def create_offerer_reimbursement_rule(
     subcategories: list[int],
     rate: decimal.Decimal,
     start_date: datetime.datetime,
-    end_date: datetime.datetime = None,
+    end_date: datetime.datetime | None = None,
 ) -> models.CustomReimbursementRule:
     return _create_reimbursement_rule(
         offerer_id=offerer_id,
@@ -2414,7 +2414,7 @@ def create_offer_reimbursement_rule(
     offer_id: int,
     amount: decimal.Decimal,
     start_date: datetime.datetime,
-    end_date: datetime.datetime = None,
+    end_date: datetime.datetime | None = None,
 ) -> models.CustomReimbursementRule:
     return _create_reimbursement_rule(
         offer_id=offer_id,
@@ -2430,7 +2430,7 @@ def _create_reimbursement_rule(
     subcategories: list[int] | None = None,
     rate: decimal.Decimal | None = None,
     amount: decimal.Decimal | None = None,
-    start_date: datetime.datetime = None,
+    start_date: datetime.datetime | None = None,
     end_date: datetime.datetime | None = None,
 ) -> models.CustomReimbursementRule:
     subcategories = subcategories or []

--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -80,7 +80,7 @@ def add_custom_offer_reimbursement_rule(
     offerer_id: int,
     reimbursed_amount: str,
     valid_from: str,
-    valid_until: str = None,
+    valid_until: str | None = None,
     force: bool = False,
 ) -> None:
     """Add a custom reimbursement rule that is linked to an offer."""

--- a/api/src/pcapi/core/mails/__init__.py
+++ b/api/src/pcapi/core/mails/__init__.py
@@ -1,4 +1,3 @@
-import typing
 from typing import Iterable
 
 from pcapi import settings

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1979,7 +1979,7 @@ class OffererVenues:
 
 
 def get_providers_offerer_and_venues(
-    provider: providers_models.Provider, siren: str = None
+    provider: providers_models.Provider, siren: str | None = None
 ) -> typing.Generator[OffererVenues, None, None]:
     offerers_query = (
         db.session.query(offerers_models.Offerer, offerers_models.Venue)

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -32,7 +32,7 @@ def get_all_venue_labels() -> list[models.VenueLabel]:
 
 def get_all_offerers_for_user(
     user: users_models.User,
-    validated: bool = None,
+    validated: bool | None = None,
     include_non_validated_user_offerers: bool = False,
 ) -> sqla_orm.Query:
     """Return a query of matching, accessible offerers.

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -158,7 +158,7 @@ def update_allocine_venue_provider(
 
 
 def connect_venue_to_provider(
-    venue: offerers_models.Venue, provider: providers_models.Provider, venueIdAtOfferProvider: str = None
+    venue: offerers_models.Venue, provider: providers_models.Provider, venueIdAtOfferProvider: str | None = None
 ) -> providers_models.VenueProvider:
     if provider.hasOffererProvider:
         id_at_provider = None

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -142,9 +142,9 @@ def create_account(
     is_email_validated: bool = False,
     send_activation_mail: bool = True,
     remote_updates: bool = True,
-    phone_number: str = None,
-    apps_flyer_user_id: str = None,
-    apps_flyer_platform: str = None,
+    phone_number: str | None = None,
+    apps_flyer_user_id: str | None = None,
+    apps_flyer_platform: str | None = None,
 ) -> models.User:
     email = email_utils.sanitize_email(email)
     if users_repository.find_user_by_email(email):
@@ -648,7 +648,7 @@ def add_comment_to_user(user: models.User, author_user: models.User, comment: st
 
 
 def get_domains_credit(
-    user: models.User, user_bookings: list[bookings_models.Booking] = None
+    user: models.User, user_bookings: list[bookings_models.Booking] | None = None
 ) -> models.DomainsCredit | None:
     if not user.deposit:
         return None

--- a/api/src/pcapi/domain/bank_informations/bank_informations.py
+++ b/api/src/pcapi/domain/bank_informations/bank_informations.py
@@ -4,13 +4,13 @@ from datetime import datetime
 class BankInformations:
     def __init__(
         self,
-        application_id: str = None,
-        status: str = None,
-        iban: str = None,
-        bic: str = None,
-        offerer_id: int = None,
-        venue_id: int = None,
-        date_modified: datetime = None,
+        application_id: str | None = None,
+        status: str | None = None,
+        iban: str | None = None,
+        bic: str | None = None,
+        offerer_id: int | None = None,
+        venue_id: int | None = None,
+        date_modified: datetime | None = None,
     ):
         self.id = None
         self.application_id = application_id

--- a/api/src/pcapi/domain/demarches_simplifiees.py
+++ b/api/src/pcapi/domain/demarches_simplifiees.py
@@ -46,7 +46,7 @@ class ApplicationDetail:
         dms_token: str | None = None,
         error_annotation_id: str | None = None,
         venue_url_annotation_id: str | None = None,
-        dossier_id: str = None,
+        dossier_id: str | None = None,
     ):
         self.siren = siren
         self.status = status

--- a/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
+++ b/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
@@ -21,7 +21,7 @@ REQUEST_TIMEOUT_FOR_PROVIDERS_IN_SECOND = 60
 
 
 class ProviderAPI:
-    def __init__(self, api_url: str, name: str, authentication_token: str = None):
+    def __init__(self, api_url: str, name: str, authentication_token: str | None = None):
         self.api_url = api_url
         self.name = name
         self.authentication_token = authentication_token

--- a/api/src/pcapi/models/api_errors.py
+++ b/api/src/pcapi/models/api_errors.py
@@ -7,7 +7,7 @@ from pcapi.domain.client_exceptions import ClientError
 class ApiErrors(Exception):
     status_code: int = 400
 
-    def __init__(self, errors: dict = None, status_code: int | None = None):
+    def __init__(self, errors: dict | None = None, status_code: int | None = None):
         self.errors = errors if errors else {}
         if status_code:
             self.status_code = status_code

--- a/api/src/pcapi/routes/backoffice/finance/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/finance/blueprint.py
@@ -503,7 +503,7 @@ def validate_finance_incident(finance_incident_id: int) -> utils.BackofficeRespo
 
 def _create_finance_events_from_incident(
     booking_finance_incident: finance_models.BookingFinanceIncident,
-    incident_validation_date: datetime = None,
+    incident_validation_date: datetime | None = None,
     save: bool = True,
 ) -> list[finance_models.FinanceEvent]:
     finance_events = []

--- a/api/src/pcapi/routes/backoffice/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice/forms/fields.py
@@ -257,10 +257,10 @@ class PCDateRangeField(wtforms.StringField):
     def __init__(
         self,
         label: str,
-        max_date: datetime.date = None,
+        max_date: datetime.date | None = None,
         reset_to_blank: bool = False,
-        calendar_start_date: datetime.date = None,
-        calendar_end_date: datetime.date = None,
+        calendar_start_date: datetime.date | None = None,
+        calendar_end_date: datetime.date | None = None,
         **kwargs: typing.Any,
     ):
         super().__init__(label, **kwargs)

--- a/api/src/pcapi/routes/backoffice/users/forms.py
+++ b/api/src/pcapi/routes/backoffice/users/forms.py
@@ -46,7 +46,7 @@ class UnsuspendUserForm(FlaskForm):
     comment = fields.PCOptCommentField("Commentaire interne optionnel")
 
 
-def get_toggle_suspension_args(user: users_models.User, suspension_type: SuspensionUserType = None) -> dict:
+def get_toggle_suspension_args(user: users_models.User, suspension_type: SuspensionUserType | None = None) -> dict:
     """
     Additional arguments which must be passed to render_template when the page may show suspend/unsuspend button.
     """

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -477,7 +477,7 @@ class ProductsOfferByEanCreation(serialization.ConfiguredBaseModel):
 
 
 class DecimalPriceGetterDict(GetterDict):
-    def get(self, key: str, default: typing.Any = None) -> typing.Any:
+    def get(self, key: str, default: typing.Any | None = None) -> typing.Any:
         if key == "price" and isinstance(self._obj.price, decimal.Decimal):
             return finance_utils.to_eurocents(self._obj.price)
         return super().get(key, default)

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -26,7 +26,7 @@ from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 
 
 class SubcategoryGetterDict(GetterDict):
-    def get(self, key: str, default: Any = None) -> Any:
+    def get(self, key: str, default: Any | None = None) -> Any:
         if key == "conditional_fields":
             return list(self._obj.conditional_fields.keys())
         return super().get(key, default)

--- a/api/src/pcapi/sandboxes/scripts/creators/data/utils.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/utils.py
@@ -18,7 +18,7 @@ def get_occurrence_short_name(concatened_names_with_a_date: str) -> str:
     return short_name
 
 
-def get_price_by_short_name(occurrence_short_name: str = None) -> Decimal:
+def get_price_by_short_name(occurrence_short_name: str | None = None) -> Decimal:
     if occurrence_short_name is None:
         return Decimal(0)
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
@@ -24,7 +24,7 @@ def create_offerer_provider(
     name: str,
     isActive: bool = True,
     enabledForPro: bool = True,
-    provider_name: str = None,
+    provider_name: str | None = None,
     with_charlie_url: bool = False,
 ) -> typing.Tuple[offerers_models.Offerer, providers_models.Provider]:
     offerer = offerers_factories.OffererFactory(name=name)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/utils.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/utils.py
@@ -18,7 +18,7 @@ def get_occurrence_short_name(concatened_names_with_a_date: str) -> str:
     return short_name
 
 
-def get_price_by_short_name(occurrence_short_name: str = None) -> Decimal:
+def get_price_by_short_name(occurrence_short_name: str | None = None) -> Decimal:
     if occurrence_short_name is None:
         return Decimal(0)
 

--- a/api/src/pcapi/scheduled_tasks/logger.py
+++ b/api/src/pcapi/scheduled_tasks/logger.py
@@ -10,7 +10,7 @@ class CronStatus(Enum):
         return self.value
 
 
-def build_cron_log_message(name: str, status: CronStatus, duration: int = None):  # type: ignore [no-untyped-def]
+def build_cron_log_message(name: str, status: CronStatus, duration: int | None = None):  # type: ignore [no-untyped-def]
     log_message = f"type=cron name={name} status={status}"
 
     if duration:

--- a/api/src/pcapi/scripts/booking/handle_expired_bookings.py
+++ b/api/src/pcapi/scripts/booking/handle_expired_bookings.py
@@ -107,7 +107,7 @@ def cancel_expired_bookings(query: BaseQuery, batch_size: int = 500) -> None:
     logger.info("[cancel_expired_bookings] %d Bookings have been cancelled", updated_total)
 
 
-def notify_users_of_expired_individual_bookings(expired_on: datetime.date = None) -> None:
+def notify_users_of_expired_individual_bookings(expired_on: datetime.date | None = None) -> None:
     expired_on = expired_on or datetime.date.today()
 
     logger.info("[notify_users_of_expired_bookings] Start")
@@ -130,7 +130,7 @@ def notify_users_of_expired_individual_bookings(expired_on: datetime.date = None
     logger.info("[notify_users_of_expired_bookings] End")
 
 
-def notify_offerers_of_expired_individual_bookings(expired_on: datetime.date = None) -> None:
+def notify_offerers_of_expired_individual_bookings(expired_on: datetime.date | None = None) -> None:
     expired_on = expired_on or datetime.date.today()
     logger.info("[notify_offerers_of_expired_bookings] Start")
 

--- a/api/src/pcapi/scripts/booking/notify_soon_to_be_expired_bookings.py
+++ b/api/src/pcapi/scripts/booking/notify_soon_to_be_expired_bookings.py
@@ -20,7 +20,7 @@ def notify_soon_to_be_expired_individual_bookings() -> None:
     logger.info("[notify_soon_to_be_expired_individual_bookings] End")
 
 
-def notify_users_of_soon_to_be_expired_individual_bookings(given_date: datetime.date = None) -> None:
+def notify_users_of_soon_to_be_expired_individual_bookings(given_date: datetime.date | None = None) -> None:
     logger.info("[notify_users_of_soon_to_be_expired_bookings] Start")
 
     expired_individual_bookings_grouped_by_user = {

--- a/api/src/pcapi/serialization/decorator.py
+++ b/api/src/pcapi/serialization/decorator.py
@@ -27,7 +27,7 @@ def _make_json_response(
     status_code: int,
     by_alias: bool,
     exclude_none: bool = False,
-    headers: dict = None,
+    headers: dict | None = None,
 ) -> Response:
     """serializes model, creates JSON response with given status code"""
     if status_code == 204:
@@ -43,7 +43,7 @@ def _make_json_response(
     return response
 
 
-def _make_string_response(content: BaseModel | None, status_code: int, headers: dict = None) -> Response:
+def _make_string_response(content: BaseModel | None, status_code: int, headers: dict | None = None) -> Response:
     """serializes model, creates JSON response with given status code"""
     if status_code == 204:
         return make_response("", 204)
@@ -61,12 +61,12 @@ def _make_string_response(content: BaseModel | None, status_code: int, headers: 
 # - form : the form data
 # You should type these arguments as pydantic models.
 def spectree_serialize(
-    headers: Type[BaseModel] = None,
-    cookies: Type[BaseModel] = None,
-    response_model: Type[BaseModel] = None,
+    headers: Type[BaseModel] | None = None,
+    cookies: Type[BaseModel] | None = None,
+    response_model: Type[BaseModel] | None = None,
     tags: Sequence = (),
-    before: Callable = None,
-    after: Callable = None,
+    before: Callable | None = None,
+    after: Callable | None = None,
     response_by_alias: bool = True,
     exclude_none: bool = False,
     on_success_status: int = 200,

--- a/api/src/pcapi/serialization/spec_tree.py
+++ b/api/src/pcapi/serialization/spec_tree.py
@@ -70,5 +70,5 @@ class ExtendedSpecTree(SpecTree):
 
 
 class ExtendResponse(Response):
-    def generate_spec(self, _naming_strategy: Callable[[Type[BaseModel]], str] = None) -> Dict[str, Any]:
+    def generate_spec(self, _naming_strategy: Callable[[Type[BaseModel]], str] | None = None) -> Dict[str, Any]:
         return super().generate_spec(naming_strategy=get_model_key)

--- a/api/src/pcapi/tasks/cloud_task.py
+++ b/api/src/pcapi/tasks/cloud_task.py
@@ -32,8 +32,8 @@ def get_client():  # type: ignore [no-untyped-def]
 def enqueue_task(
     queue: str,
     http_request: tasks_v2.HttpRequest,
-    task_id: str = None,
-    schedule_time: datetime = None,
+    task_id: str | None = None,
+    schedule_time: datetime | None = None,
     task_request_timeout: int | None = None,
 ) -> str | None:
     client = get_client()

--- a/api/src/pcapi/utils/pdf.py
+++ b/api/src/pcapi/utils/pdf.py
@@ -74,7 +74,7 @@ class CachingUrlFetcher:
 url_cache = CachingUrlFetcher()
 
 
-def generate_pdf_from_html(html_content: str, metadata: PdfMetadata = None) -> bytes:
+def generate_pdf_from_html(html_content: str, metadata: PdfMetadata | None = None) -> bytes:
     document = weasyprint.HTML(string=html_content, url_fetcher=url_cache.fetch_url).render()
     metadata = metadata or PdfMetadata()
     # a W3C date, as expected by Weasyprint

--- a/api/src/pcapi/workers/worker.py
+++ b/api/src/pcapi/workers/worker.py
@@ -28,7 +28,7 @@ low_queue = Queue("low", connection=conn, default_timeout=3600, is_async=(not se
 logger = logging.getLogger(__name__)
 
 
-def log_worker_error(job: Job, exception_type: Type, exception_value: Exception, traceback: Any = None) -> None:
+def log_worker_error(job: Job, exception_type: Type, exception_value: Exception, traceback: Any | None = None) -> None:
     # This handler is called by `rq.Worker.handle_exception()` from an
     # `except` clause, so we can (and should) use `logger.exception`.
     logger.exception(


### PR DESCRIPTION
mypy reports this error when we write this:

    def func(x: int = None):

Instead, we should write this:

    def func(x: int | None = None):