### PR TITLE
(PC-23769)[PRO] feat: disable next in hub when type or subcategory ar…

### DIFF
--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -110,6 +110,20 @@ const OfferType = (): JSX.Element => {
   })
   const { values, handleChange } = formik
 
+  const isDisableForEducationnal =
+    values.offerType === OFFER_TYPES.EDUCATIONAL && !isEligible
+
+  const hasNotChosenSubcategory =
+    values.individualOfferSubcategory === '' ||
+    values.individualOfferSubcategory === 'OTHER'
+
+  const hasNotChosenOfferType = values.individualOfferSubtype === ''
+
+  const isDisableForIndividual =
+    values.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO &&
+    hasNotChosenOfferType &&
+    hasNotChosenSubcategory
+
   return (
     <div className={styles['offer-type-container']}>
       <h1 className={styles['offer-type-title']}>Créer une offre</h1>
@@ -152,7 +166,7 @@ const OfferType = (): JSX.Element => {
             )}
             <ActionsBar
               disableNextButton={
-                values.offerType === OFFER_TYPES.EDUCATIONAL && !isEligible
+                isDisableForEducationnal || isDisableForIndividual
               }
             />
           </FormLayout>

--- a/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
@@ -101,19 +101,23 @@ describe('screens:IndividualOffer::OfferType', () => {
     })
   })
 
-  it('should redirect just with venue when venue and type was not selected', async () => {
+  it('should diable button when type or subcategory was not selected', async () => {
     renderOfferTypes('123')
 
     expect(
       await screen.findByText('Quelle est la catégorie de l’offre ?')
     ).toBeInTheDocument()
-    await userEvent.click(screen.getByText('Autre'))
-    await userEvent.click(screen.getByText('Étape suivante'))
 
-    expect(mockNavigate).toHaveBeenCalledWith({
-      pathname: '/offre/individuelle/creation/informations',
-      search: 'lieu=123',
-    })
+    // subcategory is not selected
+    expect(screen.getByText('Étape suivante')).toBeDisabled()
+
+    await userEvent.click(screen.getByText('Autre'))
+
+    // type is not selected
+    expect(screen.getByText('Étape suivante')).toBeDisabled()
+
+    await userEvent.click(screen.getByText('Un évènement physique daté'))
+    expect(screen.getByText('Étape suivante')).not.toBeDisabled()
   })
 
   it('should redirect with subcategory when venue and subcategory selected', async () => {


### PR DESCRIPTION
…e not selected

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23769

désactiver le bouton quand ni la sous-catégorie, ni le type ne sont sélectionnés

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques