### PR TITLE
(BSR)[BO] fix: permission to see tech partners items in menu

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
@@ -98,7 +98,7 @@
                 {% endcall %}
               </div>
               <hr />
-              {% if has_permission("MOVE_SIRET") or has_permission("ADVANCED_PRO_SUPPORT") or has_permission("READ_REIMBURSEMENT_RULES") %}
+              {% if has_permission("MOVE_SIRET") or has_permission("MANAGE_TECH_PARTNERS") or has_permission("READ_REIMBURSEMENT_RULES") %}
                 <div class="nav nav-pills flex-column">
                   {% call menu_section("Support Pro") %}
                     {% if has_permission("MOVE_SIRET") %}{{ menu_section_item("Déplacer un SIRET", "backoffice_web.move_siret.move_siret") }}{% endif %}


### PR DESCRIPTION
## But de la pull request

Corriger une permission permettant de voir les liens vers les partenaires techniques dans le menu du backoffice

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques