### PR TITLE
(PC-24509)[API] feat: allow create in app event with disabled FF

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -36,11 +36,6 @@ def _deserialize_ticket_collection(
             return offers_models.WithdrawalTypeEnum.NO_TICKET, None
         return None, None
 
-    if not feature.FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API.is_active():
-        raise api_errors.ApiErrors(
-            {"global": "During this API Beta, it is only possible to create events without tickets."}, status_code=400
-        )
-
     if isinstance(ticket_collection, serialization.InAppDetails):
         if not (current_api_key.provider.hasProviderEnableCharlie):
             raise api_errors.ApiErrors(
@@ -48,6 +43,11 @@ def _deserialize_ticket_collection(
                 status_code=400,
             )
         return offers_models.WithdrawalTypeEnum.IN_APP, None
+
+    if not feature.FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API.is_active():
+        raise api_errors.ApiErrors(
+            {"global": "During this API Beta, it is only possible to create events without tickets."}, status_code=400
+        )
 
     if isinstance(ticket_collection, serialization.SentByEmailDetails):
         return offers_models.WithdrawalTypeEnum.BY_EMAIL, ticket_collection.daysBeforeEvent * 24 * 3600

--- a/api/tests/routes/public/individual_offers/v1/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_event_test.py
@@ -244,7 +244,6 @@ class PostEventTest:
         assert created_offer.withdrawalType == offers_models.WithdrawalTypeEnum.BY_EMAIL
         assert created_offer.withdrawalDelay == 3 * 24 * 3600
 
-    @override_features(WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API=True)
     def test_event_with_in_app_ticket(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue(with_charlie=True)
 


### PR DESCRIPTION
## But de la pull request
Permettre la création d'evennement in_app indépendamment du FF

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24509

- [X] J'ai écrit les tests nécessaires