### PR TITLE
jeremieb/fix_spectree_version

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -64,7 +64,7 @@ schwifty==2022.9.0
 semver==2.13.0
 sentry-sdk==1.14.0
 sib-api-v3-sdk
-spectree==1.2.*
+spectree==1.2.1
 # FIXME (dbaty, 2023-01-04): do not use 1.4.46 that has a new
 # deprecation warning for which we're not ready
 # (https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-e67bfa1efbe52ae40aa842124bc40c51).


### PR DESCRIPTION
The 1.2.2 spectree version adds two main changes:

* feat: Support Pydantic root model responses
* feat: Unify response validation

The first seems to cause some problems: pydantic models with a __root__
defined as a list of something returns... a list of something instead of
the expected pydantic model with a list of something.

This leeds to some unexpected behaviour and 500 errors.