### PR TITLE
(PC-24617)[PRO] fix: Dont use my_favorite adahe header enum while not…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
@@ -93,7 +93,9 @@ export const AdageHeaderMenu = ({
                     [styles['adage-header-link-active']]: isActive,
                   })
                 }}
-                onClick={() => logAdageLinkClick(AdageHeaderLink.MY_FAVORITES)}
+                //  FIXME (guillaumeMgz, 2023-10-22)
+                //  To be re-activated when AdageHeaderLink.MY_FAVORITES is automatically generated
+                /* onClick={() => logAdageLinkClick(AdageHeaderLink.MY_FAVORITES)} */
               >
                 <SvgIcon
                   src={strokeBookmarkIcon}


### PR DESCRIPTION
… automatically generated

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24617

**Objectif**
Ne pas utiliser l'enum my_favorites tant qu'il n'est pas généré par le back (dans la PR favorite back en cours)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques