### PR TITLE
(BSR)[API] refactor: Make `CineDigitalServiceAPI.get_hardcoded_setmap()` return a list, not JSON

### DIFF
--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 from typing import Dict
 
 from pydantic.v1 import Field
@@ -228,13 +227,11 @@ class SeatCDS:
         seat_location_indices: tuple[int, int],
         screen_infos: ScreenCDS,
         seat_map: SeatmapCDS,
-        hardcoded_seatmap: str | None = None,
+        hardcoded_seatmap: list,
     ):
         self.seatRow = seat_location_indices[0]
         self.seatCol = seat_location_indices[1]
         if hardcoded_seatmap:
-            hardcoded_seatmap = json.loads(hardcoded_seatmap)
-            assert isinstance(hardcoded_seatmap, list)
             self.seatNumber: str = hardcoded_seatmap[self.seatRow][self.seatCol]
         else:
             seat_number_row = self.seatRow

--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict
+import typing
 
 from pydantic.v1 import Field
 from pydantic.v1 import validator
@@ -163,7 +163,7 @@ class CancelBookingCDS(BaseModel):
 
 
 class CancelBookingsErrorsCDS(BaseModel):
-    __root__: Dict[str, str]
+    __root__: typing.Dict[str, str]
 
 
 class TicketSaleCDS(BaseModel):
@@ -227,12 +227,13 @@ class SeatCDS:
         seat_location_indices: tuple[int, int],
         screen_infos: ScreenCDS,
         seat_map: SeatmapCDS,
-        hardcoded_seatmap: list,
+        hardcoded_seatmap: list[list[str | typing.Literal[0]]],
     ):
         self.seatRow = seat_location_indices[0]
         self.seatCol = seat_location_indices[1]
         if hardcoded_seatmap:
-            self.seatNumber: str = hardcoded_seatmap[self.seatRow][self.seatCol]
+            self.seatNumber = hardcoded_seatmap[self.seatRow][self.seatCol]
+            assert isinstance(self.seatNumber, str)  # cannot be zero (int)
         else:
             seat_number_row = self.seatRow
             seat_number_col = self.seatCol

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 import json
 import math
 from operator import attrgetter
+import typing
 
 from pydantic.v1.tools import parse_obj_as
 
@@ -124,7 +125,14 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
             f"Screen #{screen_id} not found in Cine Digital Service API for cinemaId={self.cinema_id} & url={self.api_url}"
         )
 
-    def get_hardcoded_seatmap(self, show: cds_serializers.ShowCDS) -> list:
+    def get_hardcoded_seatmap(
+        self,
+        show: cds_serializers.ShowCDS,
+    ) -> list[list[str | typing.Literal[0]]]:
+        """Return a matrix (a list of lists) of values, where each
+        value is a seat number as a string (e.g. "A7" or "123"), or
+        zero as an integer when there is no seat.
+        """
         cinema = self.get_cinema_infos()
         encoded_seatmap = None
         for parameter in cinema.cinema_parameters:

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -1,5 +1,6 @@
 import datetime
 from functools import lru_cache
+import json
 import math
 from operator import attrgetter
 
@@ -123,12 +124,17 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
             f"Screen #{screen_id} not found in Cine Digital Service API for cinemaId={self.cinema_id} & url={self.api_url}"
         )
 
-    def get_hardcoded_setmap(self, show: cds_serializers.ShowCDS) -> str | None:
+    def get_hardcoded_setmap(self, show: cds_serializers.ShowCDS) -> list:
         cinema = self.get_cinema_infos()
+        encoded_seatmap = None
         for parameter in cinema.cinema_parameters:
             if parameter.key == cds_constants.SEATMAP_HARDCODED_LABELS_SCREENID + str(show.screen.id):
-                return parameter.value
-        return None
+                encoded_seatmap = parameter.value
+        if not encoded_seatmap:
+            return []
+        seatmap = json.loads(encoded_seatmap)
+        assert isinstance(seatmap, list)
+        return seatmap
 
     def get_available_seat(
         self, show: cds_serializers.ShowCDS, screen: cds_serializers.ScreenCDS

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -124,7 +124,7 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
             f"Screen #{screen_id} not found in Cine Digital Service API for cinemaId={self.cinema_id} & url={self.api_url}"
         )
 
-    def get_hardcoded_setmap(self, show: cds_serializers.ShowCDS) -> list:
+    def get_hardcoded_seatmap(self, show: cds_serializers.ShowCDS) -> list:
         cinema = self.get_cinema_infos()
         encoded_seatmap = None
         for parameter in cinema.cinema_parameters:
@@ -147,7 +147,7 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
             return []
         best_seat = self._get_closest_seat_to_center((seatmap.nb_row // 2, seatmap.nb_col // 2), available_seats_index)
 
-        hardcoded_seatmap = self.get_hardcoded_setmap(show)
+        hardcoded_seatmap = self.get_hardcoded_seatmap(show)
         return [cds_serializers.SeatCDS(best_seat, screen, seatmap, hardcoded_seatmap)]
 
     def get_available_duo_seat(
@@ -174,7 +174,7 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
             available_seats_index.remove(first_seat)
             second_seat = self._get_closest_seat_to_center(seatmap_center, available_seats_index)
 
-        hardcoded_seatmap = self.get_hardcoded_setmap(show)
+        hardcoded_seatmap = self.get_hardcoded_seatmap(show)
 
         return [
             cds_serializers.SeatCDS(first_seat, screen, seatmap, hardcoded_seatmap),

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -551,7 +551,7 @@ class CineDigitalServiceGetScreenTest:
 
 class CineDigitalServiceGetAvailableSingleSeatTest:
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=None)
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=[])
     def test_should_return_seat_available(self, mocked_get_hardcoded_seatmap, mocked_get_resource):
         seatmap_json = [
             [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1],
@@ -595,7 +595,11 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
             [1, 1, 1, 1, 1, 1, 0, 1, 1],
             [1, 1, 1, 1, 1, 1, 0, 1, 1],
         ]
-        mocked_hardcoded_seatmap = '[["P_17","P_15","P_13","P_11","P_9","P_7","P_5","P_3","P_1"], ["M_17","M_15","M_13","M_11","M_9","M_7","M_5","M_3","M_1"], ["O_17","O_15","O_13","O_11","O_9","O_7","O_5","O_3","O_1"]]'
+        mocked_hardcoded_seatmap = [
+            ["P_17", "P_15", "P_13", "P_11", "P_9", "P_7", "P_5", "P_3", "P_1"],
+            ["M_17", "M_15", "M_13", "M_11", "M_9", "M_7", "M_5", "M_3", "M_1"],
+            ["O_17", "O_15", "O_13", "O_11", "O_9", "O_7", "O_5", "O_3", "O_1"],
+        ]
 
         mocked_get_hardcoded_seatmap.return_value = mocked_hardcoded_seatmap
 
@@ -620,8 +624,8 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert best_seat[0].seatNumber == "M_9"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=None)
-    def test_should_not_return_prm_seat(self, mocked_gat_hardcoded_seatmap, mocked_get_resource):
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=[])
+    def test_should_not_return_prm_seat(self, mocked_get_hardcoded_seatmap, mocked_get_resource):
         seatmap_json = [
             [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1],
             [1, 3, 1, 1, 1, 1, 1, 1, 0, 1, 1],
@@ -652,8 +656,8 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert best_seat[0].seatNumber == "D_6"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=None)
-    def test_should_return_seat_infos_according_to_screen(self, mocked_gat_hardcoded_seatmap, mocked_get_resource):
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=[])
+    def test_should_return_seat_infos_according_to_screen(self, mocked_get_hardcoded_seatmap, mocked_get_resource):
         seatmap_json = [
             [3, 3, 3, 3, 0, 0, 3, 3],
             [3, 3, 3, 3, 0, 0, 3, 3],
@@ -708,8 +712,8 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert not best_seat
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=None)
-    def test_should_return_correct_seat_number(self, mocked_gat_hardcoded_seatmap, mocked_get_resource):
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=[])
+    def test_should_return_correct_seat_number(self, mocked_get_hardcoded_seatmap, mocked_get_resource):
         # fmt: off
         seatmap_json = [
             [0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1],  # A
@@ -791,9 +795,10 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
                 [1, 1, 1, 3, 0, 1],
             ]
         )
-        mocked_hardcoded_seatmap = (
-            '[["P_17","P_15","P_13","P_11","P_9","P_7"], ["M_17","M_15","M_13","M_11","M_9","M_7"]]'
-        )
+        mocked_hardcoded_seatmap = [
+            ["P_17", "P_15", "P_13", "P_11", "P_9", "P_7"],
+            ["M_17", "M_15", "M_13", "M_11", "M_9", "M_7"],
+        ]
         screen = cds_serializers.ScreenCDS(
             id=1,
             seatmapfronttoback=True,
@@ -1052,7 +1057,10 @@ class CineDigitalServiceBookTicketTest:
 
         mocked_get_available_seat.return_value = [
             cds_serializers.SeatCDS(
-                (0, 0), create_screen_cds(), cds_serializers.SeatmapCDS(__root__=[[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+                (0, 0),
+                create_screen_cds(),
+                seat_map=cds_serializers.SeatmapCDS(__root__=[[1, 1, 1], [1, 1, 1], [1, 1, 1]]),
+                hardcoded_seatmap=[],
             ),
         ]
 
@@ -1131,8 +1139,8 @@ class CineDigitalServiceBookTicketTest:
         ]
         mocked_seatmap = cds_serializers.SeatmapCDS(__root__=[[1, 1, 1], [1, 1, 1], [1, 1, 1]])
         mocked_get_available_duo_seat.return_value = [
-            cds_serializers.SeatCDS((0, 0), create_screen_cds(), mocked_seatmap),
-            cds_serializers.SeatCDS((0, 1), create_screen_cds(), mocked_seatmap),
+            cds_serializers.SeatCDS((0, 0), create_screen_cds(), mocked_seatmap, hardcoded_seatmap=[]),
+            cds_serializers.SeatCDS((0, 1), create_screen_cds(), mocked_seatmap, hardcoded_seatmap=[]),
         ]
 
         mocked_get_show.return_value = create_show_cds(
@@ -1334,7 +1342,11 @@ class CineDigitalServiceGetHardcodedSeatmapTest:
         cinema_id = "cinemaid_test"
         show = create_show_cds(screen_id=30)
 
-        mocked_hardcoded_seatmap = '["C_17","C_15",0,"C_13","C_11","C_9"], ["B_17","B_15",0,"B_13","B_11","B_9"], ["A_19","A_17","A_15","A_13","A_11"]]'
+        expected_hardcoded_seatmap = [
+            ["C_17", "C_15", 0, "C_13", "C_11", "C_9"],
+            ["B_17", "B_15", 0, "B_13", "B_11", "B_9"],
+            ["A_19", "A_17", "A_15", "A_13", "A_11"],
+        ]
         json_cinema_parameters = [
             {
                 "internetsalegaugeactive": True,
@@ -1342,9 +1354,9 @@ class CineDigitalServiceGetHardcodedSeatmapTest:
                 "cinemaParameters": [
                     {
                         "cinemaid": cinema_id,
-                        "id": 1,
                         "key": "SEATMAP_HARDCODED_LABELS_SCREENID_30",
-                        "value": mocked_hardcoded_seatmap,
+                        "id": 1,
+                        "value": json.dumps(expected_hardcoded_seatmap),
                     }
                 ],
             }
@@ -1360,10 +1372,10 @@ class CineDigitalServiceGetHardcodedSeatmapTest:
 
         hardcoded_seatmap = cine_digital_service.get_hardcoded_setmap(show=show)
 
-        assert hardcoded_seatmap == mocked_hardcoded_seatmap
+        assert hardcoded_seatmap == expected_hardcoded_seatmap
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    def test_should_return_none_when_hardcoded_seatmap_does_not_exists(self, mocked_get_resource):
+    def test_should_return_none_when_hardcoded_seatmap_does_not_exist(self, mocked_get_resource):
         token = "token_test"
         api_url = "apiUrl_test/"
         account_id = "accountid_test"

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -551,7 +551,7 @@ class CineDigitalServiceGetScreenTest:
 
 class CineDigitalServiceGetAvailableSingleSeatTest:
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=[])
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_seatmap", return_value=[])
     def test_should_return_seat_available(self, mocked_get_hardcoded_seatmap, mocked_get_resource):
         seatmap_json = [
             [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1],
@@ -586,7 +586,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert best_seat[0].seatNumber == "E_6"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap")
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_seatmap")
     def test_should_return_seat_available_when_seatmap_is_hardcoded(
         self, mocked_get_hardcoded_seatmap, mocked_get_resource
     ):
@@ -624,7 +624,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert best_seat[0].seatNumber == "M_9"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=[])
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_seatmap", return_value=[])
     def test_should_not_return_prm_seat(self, mocked_get_hardcoded_seatmap, mocked_get_resource):
         seatmap_json = [
             [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1],
@@ -656,7 +656,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert best_seat[0].seatNumber == "D_6"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=[])
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_seatmap", return_value=[])
     def test_should_return_seat_infos_according_to_screen(self, mocked_get_hardcoded_seatmap, mocked_get_resource):
         seatmap_json = [
             [3, 3, 3, 3, 0, 0, 3, 3],
@@ -712,7 +712,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert not best_seat
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=[])
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_seatmap", return_value=[])
     def test_should_return_correct_seat_number(self, mocked_get_hardcoded_seatmap, mocked_get_resource):
         # fmt: off
         seatmap_json = [
@@ -784,10 +784,10 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
         assert duo_seats[0].seatNumber == "B_2"
         assert duo_seats[1].seatNumber == "B_3"
 
-    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap")
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_seatmap")
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_seatmap")
     def test_should_return_duo_seat_if_available_when_seatmap_is_hardcoded(
-        self, mocked_get_seatmap, mocked_get_hardcoded_setmap
+        self, mocked_get_seatmap, mocked_get_hardcoded_seatmap
     ):
         seatmap = cds_serializers.SeatmapCDS(
             __root__=[
@@ -808,7 +808,7 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
         show = create_show_cds(id_=1, screen_id=1)
 
         mocked_get_seatmap.return_value = seatmap
-        mocked_get_hardcoded_setmap.return_value = mocked_hardcoded_seatmap
+        mocked_get_hardcoded_seatmap.return_value = mocked_hardcoded_seatmap
         cine_digital_service = CineDigitalServiceAPI(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
@@ -1370,7 +1370,7 @@ class CineDigitalServiceGetHardcodedSeatmapTest:
             cinema_api_token=token,
         )
 
-        hardcoded_seatmap = cine_digital_service.get_hardcoded_setmap(show=show)
+        hardcoded_seatmap = cine_digital_service.get_hardcoded_seatmap(show=show)
 
         assert hardcoded_seatmap == expected_hardcoded_seatmap
 
@@ -1392,6 +1392,6 @@ class CineDigitalServiceGetHardcodedSeatmapTest:
             cinema_api_token=token,
         )
 
-        hardcoded_seatmap = cine_digital_service.get_hardcoded_setmap(show=show)
+        hardcoded_seatmap = cine_digital_service.get_hardcoded_seatmap(show=show)
 
         assert not hardcoded_seatmap


### PR DESCRIPTION
Code (including typing annotations) is clearer that way.