### PR TITLE
(PC-24503)[BO] fix: remove backoffice profile and roles when a PC user is suspended

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -395,6 +395,9 @@ def suspend_account(
     sessions = models.UserSession.query.filter_by(userId=user.id)
     repository.delete(*sessions)
 
+    bo_profile = perm_models.BackOfficeUserProfile.query.filter_by(userId=user.id)
+    repository.delete(*bo_profile)
+
     n_bookings = 0
 
     # Cancel all bookings of the related offerer if the suspended


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24503

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques