### PR TITLE
(BSR)[API] Typage : Passage des arguments de type liste/séquence nullable en liste/séquence normale

### DIFF
--- a/api/src/pcapi/core/mails/__init__.py
+++ b/api/src/pcapi/core/mails/__init__.py
@@ -14,7 +14,7 @@ def send(
     *,
     recipients: Iterable[str],
     data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
-    bcc_recipients: Iterable[str] = None,
+    bcc_recipients: Iterable[str] = (),
 ) -> bool:
     """Try to send an email and return whether it was successful."""
     if isinstance(recipients, str):

--- a/api/src/pcapi/core/mails/backends/base.py
+++ b/api/src/pcapi/core/mails/backends/base.py
@@ -10,7 +10,7 @@ class BaseBackend:
         self,
         recipients: Iterable,
         data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
-        bcc_recipients: Iterable = None,
+        bcc_recipients: Iterable[str] = (),
     ) -> models.MailResult:
         raise NotImplementedError()
 

--- a/api/src/pcapi/core/mails/backends/logger.py
+++ b/api/src/pcapi/core/mails/backends/logger.py
@@ -21,7 +21,7 @@ class LoggerBackend(BaseBackend):
         self,
         recipients: typing.Iterable[str],
         data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
-        bcc_recipients: typing.Iterable[str] = None,
+        bcc_recipients: typing.Iterable[str] = (),
     ) -> models.MailResult:
         recipients = ", ".join(recipients)
         if bcc_recipients:

--- a/api/src/pcapi/core/mails/backends/testing.py
+++ b/api/src/pcapi/core/mails/backends/testing.py
@@ -18,7 +18,7 @@ class TestingBackend(BaseBackend):
         self,
         recipients: Iterable[str],
         data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
-        bcc_recipients: Iterable[str] = None,
+        bcc_recipients: Iterable[str] = (),
     ) -> models.MailResult:
         sent_data = asdict(data)
         sent_data["To"] = ", ".join(recipients)

--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -365,19 +365,15 @@ class RegistrationStep:
         description: str,
         subscription_item_status: str,
         icon: str,
-        fraud_actions_history: list[dict] = None,
+        fraud_actions_history: typing.Iterable[dict] = (),
         is_active: bool = False,
         is_disabled: bool = False,
     ):
-        if fraud_actions_history is not None:
-            self.fraud_actions_history = fraud_actions_history
-        else:
-            self.fraud_actions_history = []
-
         self.step_id = step_id
         self.description = description
         self.subscription_item_status = subscription_item_status
         self.icon = icon
+        self.fraud_actions_history = list(fraud_actions_history)
         self.status = {
             "error": _get_status(subscription_item_status) is RegistrationStepStatus.ERROR,
             "success": _get_status(subscription_item_status) is RegistrationStepStatus.SUCCESS,

--- a/api/src/pcapi/routes/backoffice/templates/components/public_accounts/registration_steps.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/public_accounts/registration_steps.html
@@ -16,7 +16,7 @@
       <tbody>
         {% if fraud_actions|length == 0 %}
           <tr>
-            <td colspan="8">Aucune données</td>
+            <td colspan="8">Aucune donnée</td>
           </tr>
         {% else %}
           {% for fraud_action in fraud_actions %}

--- a/api/src/pcapi/tasks/serialization/sendinblue_tasks.py
+++ b/api/src/pcapi/tasks/serialization/sendinblue_tasks.py
@@ -1,3 +1,5 @@
+import pydantic.v1
+
 from pcapi.routes.serialization import BaseModel
 
 
@@ -10,7 +12,7 @@ class UpdateSendinblueContactRequest(BaseModel):
 
 class SendTransactionalEmailRequest(BaseModel):
     recipients: list[str]
-    bcc_recipients: list[str] | None = None
+    bcc_recipients: list[str] = pydantic.v1.Field(default_factory=list)
     params: dict | None = None
     template_id: int | None = None
     tags: list[str] | None = None

--- a/api/tests/core/mails/tests.py
+++ b/api/tests/core/mails/tests.py
@@ -201,7 +201,7 @@ class SendTest:
         assert mock_send_transactional_email_secondary_task.call_count == 0
         assert caplog.messages == [
             "An email would be sent via Sendinblue to=lucy.ellingson@example.com, avery.kelly@example.com, "
-            "bcc=None: {'template': {'id_prod': 11, 'id_not_prod': 12, 'tags': ['some', 'stuff'], 'use_priority_queue':"
+            "bcc=(): {'template': {'id_prod': 11, 'id_not_prod': 12, 'tags': ['some', 'stuff'], 'use_priority_queue':"
             " False, 'sender': <TransactionalSender.SUPPORT: EmailInfo(email='support@example.com',"
             " name='pass Culture')>, 'send_to_ehp': False}, 'params': {}, 'reply_to': {'email': 'reply_to@example.com',"
             " 'name': 'Tom S.'}}"


### PR DESCRIPTION
2 commits à relire séparément (+ 1 commit de correction de typo),  qui traite de la même chose.

Accepter une liste ou `None` est fastidieux. On doit alors gérer ces 2 types (notamment quand on souhaite itérer, compléter, etc.). N'accepter qu'une liste (et jamais `None`) rend la manipulation plus simple. On pourra toujours envoyer une liste vide si l'on ne veut pas de valeur. (Dans cette PR, il n'y a pas d'intérêt à distinguer `None` d'une liste vide.)