### PR TITLE
(PC-24572)[PRO] fix: display venue name if venue has no public name

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferVenueSection/CollectiveOfferVenueSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferVenueSection/CollectiveOfferVenueSection.tsx
@@ -18,7 +18,7 @@ const CollectiveOfferVenueSection = ({
       />
       <SummaryLayout.Row
         title="Lieu"
-        description={venue.publicName ?? venue.name}
+        description={venue.publicName || venue.name}
       />
     </SummaryLayout.SubSection>
   )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24572

Dans la page récap d'une offre le nom du lieu n'est pas affiché si le nom publique est vide alors que dans ce cas on devrait affiché la raison sociale. 

![Capture d’écran 2023-09-25 à 11 53 26](https://github.com/pass-culture/pass-culture-main/assets/71768799/7727aa00-9e5d-4b2d-a4f2-45e6a8a7b2a2)


