### PR TITLE
(PC-24641)[pcapi]: Bump chart version for cloud armor migration on staging, perf, ops

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -21,7 +21,7 @@ environments:
       - chartVersion: 0.21.11
   staging:
     values:
-      - chartVersion: 0.21.9
+      - chartVersion: 0.21.11
   integration:
     values:
       - chartVersion: 0.21.9
@@ -30,7 +30,7 @@ environments:
       - chartVersion: 0.21.9
   ops:
     values:
-      - chartVersion: 0.21.9
+      - chartVersion: 0.21.11
   perf:
     values:
-      - chartVersion: 0.21.9
+      - chartVersion: 0.21.11


### PR DESCRIPTION
## But de la pull request

Ticket Jira: https://passculture.atlassian.net/browse/PC-24641

Afin de pouvoir migrer vers le nouveau load balancer avec cloud armor, nous devons déployer des nouveaux ingress qui utilisent la nouvelle ingress class qui est exposé par le load-balancer global.

