### PR TITLE
(PC-24638)[PRO] feat: limit MAX_STOCKS_PER_OFFER to 2500

### DIFF
--- a/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
@@ -154,7 +154,9 @@ export const StocksEventCreation = ({
         return
       }
       if (stocks.length > MAX_STOCKS_PER_OFFER) {
-        notify.error('Veuillez créer moins de 10 000 occurrences par offre.')
+        notify.error(
+          `Veuillez créer moins de ${MAX_STOCKS_PER_OFFER} occurrences par offre.`
+        )
         setIsSubmitting(false)
         return
       }

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
@@ -308,8 +308,9 @@ describe('navigation and submit', () => {
 
     await userEvent.click(screen.getByText('Étape suivante'))
 
+    // when not in test 1 is replaced by MAX_STOCKS_PER_OFFER
     expect(
-      screen.getByText('Veuillez créer moins de 10 000 occurrences par offre.')
+      screen.getByText('Veuillez créer moins de 1 occurrences par offre.')
     ).toBeInTheDocument()
   })
 

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -242,7 +242,9 @@ const StocksEventEdition = ({
     }
 
     if (allStocks.length > MAX_STOCKS_PER_OFFER) {
-      notify.error('Veuillez créer moins de 10 000 occurrences par offre.')
+      notify.error(
+        `Veuillez créer moins de ${MAX_STOCKS_PER_OFFER} occurrences par offre.`
+      )
       return
     }
 

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
@@ -457,9 +457,10 @@ describe('screens:StocksEventEdition', () => {
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
     )
 
+    // when not in test 1 is replaced by MAX_STOCKS_PER_OFFER
     expect(
       await screen.findByText(
-        'Veuillez créer moins de 10 000 occurrences par offre.'
+        'Veuillez créer moins de 1 occurrences par offre.'
       )
     ).toBeInTheDocument()
   })

--- a/pro/src/screens/IndividualOffer/constants.ts
+++ b/pro/src/screens/IndividualOffer/constants.ts
@@ -1,1 +1,1 @@
-export const MAX_STOCKS_PER_OFFER = 10000
+export const MAX_STOCKS_PER_OFFER = 2500


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24638

limiter la création de stocks à 2500

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques