### PR TITLE
(PC-24654)[EAC] fix: collectiveOffer.offerVenue->>venueId ne devrait jamais être égal = ""

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -474,7 +474,7 @@ def create_collective_offer_public(
         raise exceptions.EducationalInstitutionIsNotActive()
 
     offer_venue = {
-        "venueId": body.offer_venue.venueId or "",
+        "venueId": body.offer_venue.venueId,
         "addressType": body.offer_venue.addressType,
         "otherAddress": body.offer_venue.otherAddress or "",
     }

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -11,6 +11,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.native.v1.serialization import common_models
 from pcapi.routes.serialization import BaseModel
+from pcapi.routes.serialization.collective_offers_serialize import validate_venue_id
 from pcapi.routes.serialization.national_programs import NationalProgramModel
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
@@ -107,6 +108,8 @@ class CollectiveOfferOfferVenue(BaseModel):
     address: str | None
     postalCode: str | None
     city: str | None
+
+    _validated_venue_id = validator("venueId", pre=True, allow_reuse=True)(validate_venue_id)
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -16,6 +16,7 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import collective_offers_serialize
+from pcapi.routes.serialization.collective_offers_serialize import validate_venue_id
 from pcapi.routes.serialization.national_programs import NationalProgramModel
 from pcapi.serialization.utils import to_camel
 from pcapi.utils import email as email_utils
@@ -48,6 +49,8 @@ class OfferVenueModel(BaseModel):
     venueId: int | None
     otherAddress: str | None
     addressType: collective_offers_serialize.OfferAddressType
+
+    _validated_venue_id = validator("venueId", pre=True, allow_reuse=True)(validate_venue_id)
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -39,6 +39,14 @@ T_GetCollectiveOfferBaseResponseModel = typing.TypeVar(
 )
 
 
+def validate_venue_id(venue_id: int | str | None) -> int | None:
+    # TODO(jeremieb): remove this validator once there is no empty
+    # string stored as a venueId
+    if not venue_id:
+        return None
+    return int(venue_id)  # should not be needed but it makes mypy happy
+
+
 class ListCollectiveOffersQueryModel(BaseModel):
     nameOrIsbn: str | None
     offerer_id: int | None
@@ -358,6 +366,8 @@ class CollectiveOfferVenueBodyModel(BaseModel):
     addressType: OfferAddressType
     otherAddress: str
     venueId: int | None
+
+    _validated_venue_id = validator("venueId", pre=True, allow_reuse=True)(validate_venue_id)
 
     class Config:
         alias_generator = to_camel

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -241,3 +241,17 @@ class CollectiveOfferTest:
 
         # Then
         assert response.status_code == 404
+
+    def test_offer_venue_has_an_empty_string_venue_id(self, client):
+        # TODO(jeremieb): remove this test once there is no empty
+        # string stored as a venueId
+        redactor = educational_factories.EducationalRedactorFactory()
+        stock = educational_factories.CollectiveStockFactory(
+            collectiveOffer__offerVenue={"venueId": "", "addressType": "other", "otherAddress": "REDACTED"}
+        )
+
+        eac_client = client.with_adage_token(email=redactor.email, uai="1234UAI")
+        with assert_no_duplicated_queries():
+            response = eac_client.get(f"/adage-iframe/collective/offers/{stock.collectiveOfferId}")
+
+        assert response.status_code == 200

--- a/pro/src/apiClient/v1/models/GetOffererBankAccountsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererBankAccountsResponseModel.ts
@@ -8,7 +8,10 @@ import type { ManagedVenues } from './ManagedVenues';
 
 export type GetOffererBankAccountsResponseModel = {
   bankAccounts: Array<BankAccountResponseModel>;
+  hasPendingBankAccount: boolean;
+  hasValidBankAccount: boolean;
   id: number;
   managedVenues: Array<ManagedVenues>;
+  venuesWithNonFreeOffersWithoutBankAccounts: Array<number>;
 };
 

--- a/pro/src/apiClient/v1/models/ManagedVenues.ts
+++ b/pro/src/apiClient/v1/models/ManagedVenues.ts
@@ -7,6 +7,6 @@ export type ManagedVenues = {
   bankAccountId?: number | null;
   commonName: string;
   id: number;
-  siret: string;
+  siret?: string | null;
 };
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24654

1. Ne plus permettre d'avoir des venueId égaux à "" pour collective_offer.offerVenue->>venueId lors de la création.
2. Gérer les données existantes en transformant les "" en None lors de la sérialisation.