### PR TITLE
(BSR)[PRO] fix: Sentry sourcemaps release for hotfixes

### DIFF
--- a/.github/workflows/release--build-hotfix.yml
+++ b/.github/workflows/release--build-hotfix.yml
@@ -84,4 +84,5 @@ jobs:
       ENV: production
       CHANNEL: "${{ needs.find-hotfix-tag-number.outputs.hotfixTagNumber }}"
       EXPIRES: "30d"
+      PUSH_RELEASE_TO_SENTRY: true
       REF: v${{ needs.find-hotfix-tag-number.outputs.hotfixTagNumber }}


### PR DESCRIPTION
## But de la pull request

Les sourcemaps n'étaient pas uploadés sur Sentry lorsque la release est un hotfix et que c'est l'env de production... un oubli dans la config.