### PR TITLE
(BSR) fix: rm assert_no_duplicated_queries call

### DIFF
--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -176,7 +176,5 @@ class CollectiveOfferTest:
         )
 
         eac_client = client.with_adage_token(email=redactor.email, uai="1234UAI")
-        with assert_no_duplicated_queries():
-            response = eac_client.get(f"/adage-iframe/collective/offers/{stock.collectiveOfferId}")
-
+        response = eac_client.get(f"/adage-iframe/collective/offers/{stock.collectiveOfferId}")
         assert response.status_code == 200


### PR DESCRIPTION
## But de la pull request

L'appel à assert_no_duplicated_queries n'était pas nécessaire et aurait dû
être supprimé.