### PR TITLE
(PC-24258)[BO] feat: display isSynchronisableCompatible

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -863,15 +863,16 @@ def add_criteria_to_offers(
     return True
 
 
-def reject_inappropriate_products(ean: str, send_booking_cancellation_emails: bool = True) -> bool:
-    product_query = models.Product.query.filter(models.Product.extraData["ean"].astext == ean)
-    product_ids = [p.id for p in product_query.with_entities(models.Product.id)]
+def reject_inappropriate_product(ean: str, send_booking_cancellation_emails: bool = True) -> bool:
+    product = models.Product.query.filter(
+        models.Product.extraData["ean"].astext == ean, models.Product.idAtProviders.is_not(None)
+    ).one_or_none()
 
-    if not product_ids:
+    if not product:
         return False
 
     offers_query = models.Offer.query.filter(
-        models.Offer.productId.in_(product_query.with_entities(models.Product.id)),
+        sa.or_(models.Offer.productId == product.id, models.Offer.extraData["ean"].astext == ean),
         models.Offer.validation != models.OfferValidationStatus.REJECTED,
     )
 
@@ -886,17 +887,15 @@ def reject_inappropriate_products(ean: str, send_booking_cancellation_emails: bo
         synchronize_session=False,
     )
 
-    product_query.update(
-        values={"isGcuCompatible": False},
-        synchronize_session=False,
-    )
+    product.isGcuCompatible = False
+    db.session.add(product)
 
     try:
         db.session.commit()
     except Exception as exception:  # pylint: disable=broad-except
         logger.exception(
             "Could not mark product and offers as inappropriate: %s",
-            extra={"ean": ean, "products": product_ids, "exc": str(exception)},
+            extra={"ean": ean, "product": product.id, "exc": str(exception)},
         )
         return False
 
@@ -910,7 +909,7 @@ def reject_inappropriate_products(ean: str, send_booking_cancellation_emails: bo
 
     logger.info(
         "Rejected inappropriate products",
-        extra={"ean": ean, "products": product_ids, "offers": offer_ids, "offer_updated_counts": offer_updated_counts},
+        extra={"ean": ean, "product": product.id, "offers": offer_ids, "offer_updated_counts": offer_updated_counts},
     )
 
     if offer_ids:

--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -263,7 +263,7 @@ class TiteLiveThings(LocalProvider):
                     ineligibility_reason,
                 )
             else:
-                offers_api.reject_inappropriate_products(book_unique_identifier)
+                offers_api.reject_inappropriate_product(book_unique_identifier)
                 logger.info(
                     "Rejecting ineligible ean=%s because reason=%s", book_unique_identifier, ineligibility_reason
                 )

--- a/api/src/pcapi/routes/backoffice/templates/multiple_offers/search_result.html
+++ b/api/src/pcapi/routes/backoffice/templates/multiple_offers/search_result.html
@@ -43,25 +43,33 @@
                 <b>Rejetées :</b> {{ rejected_offers_count }}
               </p>
               <p>
-                <b>compatible avec les CGU :</b>
-                {% if product_compatibility == 'compatible_products' %}
+                <b>Compatible avec les CGU :</b>
+                {% if product_compatibility %}
                   <span class="mx-2 pb-1 badge rounded-pill text-bg-success">
                     <i class="bi bi-check-circle"></i> Oui
                   </span>
-                {% elif product_compatibility == 'incompatible_products' %}
+                {% else %}
                   <span class="mx-2 pb-1 badge rounded-pill text-bg-dark">
                     <i class="bi bi-x-circle"></i> Non
                   </span>
+                {% endif %}
+              </p>
+              <p>
+                <b>Synchronizable :</b>
+                {% if product_synchronisable %}
+                  <span class="mx-2 pb-1 badge rounded-pill text-bg-success">
+                    <i class="bi bi-check-circle"></i> Oui
+                  </span>
                 {% else %}
-                  <span class="mx-2 pb-1 badge rounded-pill text-bg-warning">
-                    <i class="bi bi-radioactive"></i> Partiellement
+                  <span class="mx-2 pb-1 badge rounded-pill text-bg-dark">
+                    <i class="bi bi-x-circle"></i> Non
                   </span>
                 {% endif %}
               </p>
               <p>
                 <b>EAN-13 :</b> {{ ean }}
               </p>
-              {% if has_permission("PRO_FRAUD_ACTIONS") and (product_compatibility != 'incompatible_products' or approved_active_offers_count + approved_inactive_offers_count + pending_offers_count > 0) %}
+              {% if has_permission("PRO_FRAUD_ACTIONS") and (product_compatibility or approved_active_offers_count + approved_inactive_offers_count + pending_offers_count > 0) %}
                 <div>
                   {{ build_modal_form("set-gcu-incompatible", url_for('.set_product_gcu_incompatible'), incompatibility_form,
                   "Rendre le livre et les offres associées incompatibles avec les CGU", "Confirmer",


### PR DESCRIPTION
## But de la pull request

Sur la page Opérations sur plusieurs offres : 
Changement de la manière de calculer isCguCompatible en prenant l'ean d'un seul et unique produit
Affiche la notion isSynchronisableCompatible

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/ec3aca13-aeb9-4765-8797-8e87ed0242d9)

Ticket Jira : https://passculture.atlassian.net/browse/PC-24258

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques