### PR TITLE
(PC-24473)[PRO] feat: log categorie instead of subcategories in adage…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -11,7 +11,6 @@ import strokeBuildingIcon from 'icons/stroke-building.svg'
 import strokeFranceIcon from 'icons/stroke-france.svg'
 import strokeNearIcon from 'icons/stroke-near.svg'
 import { getAcademiesOptionsAdapter } from 'pages/AdageIframe/app/adapters/getAcademiesOptionsAdapter'
-import { getEducationalCategoriesOptionsAdapter } from 'pages/AdageIframe/app/adapters/getEducationalCategoriesOptionsAdapter'
 import { getEducationalDomainsOptionsAdapter } from 'pages/AdageIframe/app/adapters/getEducationalDomainsOptionsAdapter'
 import { departmentOptions } from 'pages/AdageIframe/app/constants/departmentOptions'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
@@ -33,6 +32,7 @@ interface OfferFiltersProps {
   localisationFilterState: LocalisationFilterStates
   setLocalisationFilterState: (state: LocalisationFilterStates) => void
   resetForm: () => void
+  categoriesOptions: Option<string[]>[]
 }
 
 export const OfferFilters = ({
@@ -40,6 +40,7 @@ export const OfferFilters = ({
   localisationFilterState,
   setLocalisationFilterState,
   resetForm,
+  categoriesOptions,
 }: OfferFiltersProps): JSX.Element => {
   const [modalOpenStatus, setModalOpenStatus] = useState<{
     [key: string]: boolean
@@ -83,9 +84,6 @@ export const OfferFilters = ({
 
   const [domainsOptions, setDomainsOptions] = useState<Option<number>[]>([])
   const [academiesOptions, setAcademieOptions] = useState<Option<string>[]>([])
-  const [categoriesOptions, setCategoriesOptions] = useState<
-    Option<string[]>[]
-  >([])
 
   const onReset = (
     modalName: string,
@@ -112,12 +110,6 @@ export const OfferFilters = ({
     const loadFiltersOptions = async () => {
       const domainsResponse = await getEducationalDomainsOptionsAdapter()
       const academiesResponse = await getAcademiesOptionsAdapter()
-      const categoriesResponse =
-        await getEducationalCategoriesOptionsAdapter(null)
-
-      if (categoriesResponse.isOk) {
-        setCategoriesOptions(categoriesResponse.payload.educationalCategories)
-      }
 
       if (domainsResponse.isOk) {
         setDomainsOptions(domainsResponse.payload)

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -4,7 +4,6 @@ import { Formik } from 'formik'
 import React from 'react'
 
 import { AuthenticatedResponse } from 'apiClient/adage'
-import { apiAdage } from 'apiClient/api'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
 import * as pcapi from 'pages/AdageIframe/repository/pcapi/pcapi'
 import { defaultAdageUser } from 'utils/adageFactories'
@@ -56,6 +55,7 @@ const renderOfferFilters = ({
           localisationFilterState={localisationFilterState}
           setLocalisationFilterState={mockSetLocalisationFilterState}
           resetForm={resetFormMock}
+          categoriesOptions={[{ label: 'Cinéma', value: ['CINE_PLEIN_AIR'] }]}
         />
       </Formik>
     </AdageUserContextProvider>,
@@ -352,11 +352,6 @@ describe('OfferFilters', () => {
   })
 
   it('should return categories options when the api call was successful', async () => {
-    vi.spyOn(apiAdage, 'getEducationalOffersCategories').mockResolvedValueOnce({
-      categories: [{ id: 'CINEMA', proLabel: 'Cinéma' }],
-      subcategories: [{ id: 'CINE_PLEIN_AIR', categoryId: 'CINEMA' }],
-    })
-
     renderOfferFilters({
       initialValues: initialValues,
       storeOverrides: isGeolocationActive,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -3,6 +3,7 @@ import { userEvent } from '@testing-library/user-event'
 import type { SearchBoxProvided } from 'react-instantsearch-core'
 
 import { AdageFrontRoles, AuthenticatedResponse } from 'apiClient/adage'
+import { apiAdage } from 'apiClient/api'
 import {
   AlgoliaQueryContextProvider,
   FiltersContextProvider,
@@ -79,7 +80,10 @@ vi.mock('../Offers/Offers', () => {
 
 vi.mock('apiClient/api', () => ({
   apiAdage: {
-    getEducationalOffersCategories: vi.fn(),
+    getEducationalOffersCategories: vi.fn(() => ({
+      categories: [],
+      subcategories: [],
+    })),
     getAcademies: vi.fn(() => ['Amiens', 'Paris']),
   },
 }))
@@ -144,6 +148,10 @@ describe('offersSearch component', () => {
       setGeoRadius: setGeoRadiusMock,
     }
     vi.spyOn(pcapi, 'getEducationalDomains').mockResolvedValue([])
+    vi.spyOn(apiAdage, 'getEducationalOffersCategories').mockResolvedValue({
+      categories: [],
+      subcategories: [],
+    })
     window.IntersectionObserver = vi.fn().mockImplementation(() => ({
       observe: vi.fn(),
       unobserve: vi.fn(),

--- a/pro/src/utils/__specs__/collectiveCategories.spec.ts
+++ b/pro/src/utils/__specs__/collectiveCategories.spec.ts
@@ -1,0 +1,76 @@
+import {
+  filterEducationalSubCategories,
+  inferCategoryLabelsFromSubcategories,
+} from 'utils/collectiveCategories'
+
+describe('filterEducationalSubCategories', () => {
+  it('should return category labels and subcategories', () => {
+    const categoriesResponse = {
+      categories: [
+        { id: 'cat1', proLabel: 'Category 1' },
+        { id: 'cat2', proLabel: 'Category 2' },
+      ],
+      subcategories: [
+        { id: 'subcat1', categoryId: 'cat1' },
+        { id: 'subcat2', categoryId: 'cat1' },
+        { id: 'subcat3', categoryId: 'cat2' },
+      ],
+    }
+
+    const result = filterEducationalSubCategories(categoriesResponse)
+
+    expect(result).toEqual([
+      { label: 'Category 1', value: ['subcat1', 'subcat2'] },
+      { label: 'Category 2', value: ['subcat3'] },
+    ])
+  })
+
+  it('should return empty array if categories or subcategories are not defined', () => {
+    const categoriesResponse = {
+      categories: [],
+      subcategories: [],
+    }
+
+    const result = filterEducationalSubCategories(categoriesResponse)
+
+    expect(result).toEqual([])
+  })
+})
+
+describe('inferCategoryLabelsFromSubcategories', () => {
+  it('should return category labels given subcategories array', () => {
+    const subCategories = [
+      ['subcat1', 'subcat2'],
+      ['subcat2', 'subcat3'],
+    ]
+
+    const categoriesOptions = [
+      { label: 'Category 1', value: ['subcat1', 'subcat2'] },
+      { label: 'Category 2', value: ['subcat2', 'subcat3'] },
+    ]
+
+    const result = inferCategoryLabelsFromSubcategories(
+      subCategories,
+      categoriesOptions
+    )
+
+    expect(result).toEqual(['Category 1', 'Category 2'])
+  })
+  it('should return empty label if subcatgory does not match any subcategories array', () => {
+    const subCategories = [
+      ['subcat1', 'subcat2'],
+      ['aaa', 'zzz'],
+    ]
+
+    const categoriesOptions = [
+      { label: 'Category 1', value: ['subcat1', 'subcat2'] },
+    ]
+
+    const result = inferCategoryLabelsFromSubcategories(
+      subCategories,
+      categoriesOptions
+    )
+
+    expect(result).toEqual(['Category 1', ''])
+  })
+})

--- a/pro/src/utils/collectiveCategories.ts
+++ b/pro/src/utils/collectiveCategories.ts
@@ -1,0 +1,35 @@
+import { CategoriesResponseModel } from 'apiClient/adage'
+import { Option } from 'pages/AdageIframe/app/types'
+
+export const filterEducationalSubCategories = ({
+  categories,
+  subcategories,
+}: CategoriesResponseModel): Option<string[]>[] => {
+  if (!subcategories || !categories) {
+    return []
+  }
+  return categories.map(category => ({
+    value: subcategories
+      .filter(subcategory => subcategory.categoryId == category.id)
+      .map(subcategory => subcategory.id),
+    label: category.proLabel,
+  }))
+}
+
+export const inferCategoryLabelsFromSubcategories = (
+  subCategories: string[][],
+  categoriesOptions: Option<string[]>[]
+): string[] => {
+  const categoryLabels = subCategories
+    .map(subCategories => {
+      return subCategories.map(subcategory => {
+        const categoryOption = categoriesOptions.find(option =>
+          option.value.includes(subcategory)
+        )
+        return categoryOption ? categoryOption.label : ''
+      })
+    })
+    .flat()
+
+  return [...new Set(categoryLabels)]
+}


### PR DESCRIPTION
… filter tracking

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24473

Logger le nom des catégories plutôt qu'un tableau de sous-catégories dans le tracking des filtres Adage

FF à activer : WIP_ENABLE_NEW_ADAGE_FILTERS
L'évenement se déclenche lorsqu'une nouvelle recherche est déclenché et/ou au changement de filtre 