### PR TITLE
(PC-24666)[PRO] fix: add facetfilters uai for algolia autocomplete cu…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -111,6 +111,12 @@ const AutocompleteComponent = ({
           'venue.publicName',
           'offerer.name',
         ],
+        facetFilters: [
+          [
+            'offer.educationalInstitutionUAICode:all',
+            `offer.educationalInstitutionUAICode:${adageUser.uai}`,
+          ],
+        ],
         distinct: true,
         hitsPerPage: ALGOLIA_NUMBER_VENUES_SUGGESTIONS,
         clickAnalytics: false,


### PR DESCRIPTION
…ltural partner result

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24666

On souhaite voir seulement les partenaires culturels disponibles pour l'UAI de la personne connecté dans les résultats de l'autocomplete