### PR TITLE
(PC-24503)[BO] fix: AttributeError after an admin user is supended 

### DIFF
--- a/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
@@ -118,7 +118,7 @@ def render_bo_user_page(user_id: int, edit_form: forms.EditBOUserForm | None = N
         edit_account_form=edit_form,
         edit_account_dst=url_for(".update_bo_user", user_id=user.id) if edit_form else None,
         history=get_bo_user_history(user),
-        roles=user.backoffice_profile.roles,
+        roles=user.backoffice_profile.roles if user.backoffice_profile else [],
         active_tab=request.args.get("active_tab", "history"),
         **user_forms.get_toggle_suspension_args(user),
     )

--- a/api/tests/routes/backoffice/helpers/post.py
+++ b/api/tests/routes/backoffice/helpers/post.py
@@ -28,7 +28,7 @@ class PostEndpointWithoutPermissionHelper(base.BaseHelper):
         # will generate a csrf token (for the logout button)
         client.get(url_for("backoffice_web.home"))
 
-    def post_to_endpoint(self, client, form=None, **url_kwargs):
+    def post_to_endpoint(self, client, form=None, headers=None, **url_kwargs):
         self.fetch_csrf_token(client)
 
         url = url_for(self.endpoint, **url_kwargs)
@@ -37,7 +37,7 @@ class PostEndpointWithoutPermissionHelper(base.BaseHelper):
             form = {}
 
         form.update(self.form)
-        return client.post(url, form=form)
+        return client.post(url, form=form, headers=headers)
 
     def test_not_logged_in(self, client):
         self.fetch_csrf_token(client)


### PR DESCRIPTION
## But de la pull request

Petite correction suite à une erreur Sentry rencontrée sur testing, liée à https://passculture.atlassian.net/browse/PC-24503

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques