### PR TITLE
(PC-24524)[PRO] bump: userEvent to 14.5.1

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -82,7 +82,7 @@
     "@storybook/react-vite": "^7.4.5",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/user-event": "^14.5.1",
     "@types/lodash.isequal": "^4.5.5",
     "@types/node": "^20.6.5",
     "@types/papaparse": "^5.3.9",

--- a/pro/src/app/__specs__/AppRouter.spec.tsx
+++ b/pro/src/app/__specs__/AppRouter.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { Link } from 'react-router-dom'

--- a/pro/src/components/AdageButtonFilter/__specs__/AdageButtonFilter.spec.tsx
+++ b/pro/src/components/AdageButtonFilter/__specs__/AdageButtonFilter.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/components/Address/__specs__/Address.spec.tsx
+++ b/pro/src/components/Address/__specs__/Address.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/Banner/__specs__/BannerRGS.spec.tsx
+++ b/pro/src/components/Banner/__specs__/BannerRGS.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import BannerRGS from '../BannerRGS'

--- a/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
+++ b/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import type { Step } from 'components/Breadcrumb'

--- a/pro/src/components/ButtonDownloadCSV/__specs__/ButtonDownloadCSV.spec.tsx
+++ b/pro/src/components/ButtonDownloadCSV/__specs__/ButtonDownloadCSV.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { vi } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'

--- a/pro/src/components/ButtonLinkNewWindow/__specs__/ButtonLinkNewWindow.tracker.spec.tsx
+++ b/pro/src/components/ButtonLinkNewWindow/__specs__/ButtonLinkNewWindow.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/components/Dialog/ConfirmDialog/__specs__/ConfirmDialog.spec.tsx
+++ b/pro/src/components/Dialog/ConfirmDialog/__specs__/ConfirmDialog.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import ConfirmDialog from '..'
 

--- a/pro/src/components/Header/__specs__/Header.spec.tsx
+++ b/pro/src/components/Header/__specs__/Header.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/components/ImageUploadBrowserForm/__spec__/ImageUploadForm.spec.tsx
+++ b/pro/src/components/ImageUploadBrowserForm/__spec__/ImageUploadForm.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { UploaderModeEnum } from 'components/ImageUploader/types'

--- a/pro/src/components/ImageUploader/ButtonAppPreview/__specs__/ButtonAppPreview.spec.tsx
+++ b/pro/src/components/ImageUploader/ButtonAppPreview/__specs__/ButtonAppPreview.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { UploaderModeEnum } from 'components/ImageUploader/types'

--- a/pro/src/components/ImageUploader/ButtonImageDelete/__specs__/ButtonImageDelete.spec.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageDelete/__specs__/ButtonImageDelete.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { RootState } from 'store/reducers'

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/__specs__/ModalImageCrop.spec.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/__specs__/ModalImageCrop.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { UploaderModeEnum } from 'components/ImageUploader/types'

--- a/pro/src/components/ImageUploader/ButtonImageEdit/__specs__/ButtonImageEdit.spec.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/__specs__/ButtonImageEdit.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import * as apiHelpers from 'apiClient/helpers'

--- a/pro/src/components/IndividualOfferBreadcrumb/__specs__/IndividualOfferBreadcrumb.spec.tsx
+++ b/pro/src/components/IndividualOfferBreadcrumb/__specs__/IndividualOfferBreadcrumb.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/components/IndividualOfferBreadcrumb/__specs__/IndividualOfferBreadcrumb.tracker.spec.tsx
+++ b/pro/src/components/IndividualOfferBreadcrumb/__specs__/IndividualOfferBreadcrumb.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/components/IndividualOfferForm/Accessibility/__specs__/Accessibility.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/Accessibility/__specs__/Accessibility.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/Categories/__specs__/Categories.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/Categories/__specs__/Categories.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/ExternalLink/__specs__/ExternalLink.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/ExternalLink/__specs__/ExternalLink.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.tracker.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/components/IndividualOfferForm/Informations/__specs__/validationSchema.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/Informations/__specs__/validationSchema.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/Notifications/__specs__/Notifications.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/Notifications/__specs__/Notifications.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/Venue/__specs__/Venue.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/Venue/__specs__/Venue.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/Venue/__specs__/VenueAccessibilityUpdates.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/Venue/__specs__/VenueAccessibilityUpdates.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.BannerAddVenue.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.BannerAddVenue.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
+++ b/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/components/RouteLeavingGuard/__specs__/RouteLeavingGuard.spec.tsx
+++ b/pro/src/components/RouteLeavingGuard/__specs__/RouteLeavingGuard.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Link, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/components/SignupJourneyBreadcrumb/__specs__/SignupJourneyBreadcrumb.spec.tsx
+++ b/pro/src/components/SignupJourneyBreadcrumb/__specs__/SignupJourneyBreadcrumb.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/components/SignupJourneyBreadcrumb/__specs__/SignupJourneyBreadcrumb.trackers.spec.tsx
+++ b/pro/src/components/SignupJourneyBreadcrumb/__specs__/SignupJourneyBreadcrumb.trackers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/components/Stepper/__specs__/Stepper.spec.tsx
+++ b/pro/src/components/Stepper/__specs__/Stepper.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import type { Step } from 'components/Breadcrumb'

--- a/pro/src/components/StockFormActions/__specs__/StockFormActions.spec.tsx
+++ b/pro/src/components/StockFormActions/__specs__/StockFormActions.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import FullTrashIcon from 'icons/full-trash.svg'

--- a/pro/src/components/StocksEventList/__specs__/StocksEventList.spec.tsx
+++ b/pro/src/components/StocksEventList/__specs__/StocksEventList.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { Events } from 'core/FirebaseEvents/constants'

--- a/pro/src/components/TutorialDialog/__specs__/TutorialDialog.spec.tsx
+++ b/pro/src/components/TutorialDialog/__specs__/TutorialDialog.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/components/UserEmailForm/__specs__/UserEmail.spec.tsx
+++ b/pro/src/components/UserEmailForm/__specs__/UserEmail.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/components/UserIdentityForm/__specs__/UserIdentity.spec.tsx
+++ b/pro/src/components/UserIdentityForm/__specs__/UserIdentity.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/components/UserPasswordForm/__specs__/UserPassword.spec.tsx
+++ b/pro/src/components/UserPasswordForm/__specs__/UserPassword.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/components/UserPhoneForm/__specs__/UserPhoneForm.spec.tsx
+++ b/pro/src/components/UserPhoneForm/__specs__/UserPhoneForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/components/VenueForm/Accessibility/__specs__/Accessibility.spec.tsx
+++ b/pro/src/components/VenueForm/Accessibility/__specs__/Accessibility.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/VenueForm/Activity/__specs__/Activity.spec.tsx
+++ b/pro/src/components/VenueForm/Activity/__specs__/Activity.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { DMSApplicationForEAC, DMSApplicationstatus } from 'apiClient/v1'

--- a/pro/src/components/VenueForm/ImageUploaderVenue/__specs__/ImageUploaderVenue.tracker.spec.tsx
+++ b/pro/src/components/VenueForm/ImageUploaderVenue/__specs__/ImageUploaderVenue.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/components/VenueForm/Informations/SiretOrCommentFields/__specs__/SiretOrCommentFields.spec.tsx
+++ b/pro/src/components/VenueForm/Informations/SiretOrCommentFields/__specs__/SiretOrCommentFields.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/components/VenueForm/Informations/__specs__/Informations.spec.tsx
+++ b/pro/src/components/VenueForm/Informations/__specs__/Informations.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/hooks/__specs__/useAccessibilityOptions.spec.tsx
+++ b/pro/src/hooks/__specs__/useAccessibilityOptions.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/hooks/__specs__/useFocus.spec.tsx
+++ b/pro/src/hooks/__specs__/useFocus.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router'
 import { Link } from 'react-router-dom'

--- a/pro/src/hooks/__specs__/useLogNavigation.spec.tsx
+++ b/pro/src/hooks/__specs__/useLogNavigation.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Routes, Route, Link } from 'react-router-dom'
 

--- a/pro/src/hooks/__specs__/usePageTitle.spec.tsx
+++ b/pro/src/hooks/__specs__/usePageTitle.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router'
 import { Link } from 'react-router-dom'

--- a/pro/src/hooks/__specs__/useScrollToFirstErrorAfterSubmit.spec.tsx
+++ b/pro/src/hooks/__specs__/useScrollToFirstErrorAfterSubmit.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik, Form } from 'formik'
 import * as yup from 'yup'
 

--- a/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Configure } from 'react-instantsearch-dom'
 

--- a/pro/src/pages/AdageIframe/app/__spec__/AppFilterTags.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/AppFilterTags.spec.tsx
@@ -3,7 +3,7 @@ import {
   waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Configure } from 'react-instantsearch-dom'
 import type { Mock } from 'vitest'

--- a/pro/src/pages/AdageIframe/app/__spec__/AppResetFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/AppResetFilters.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Configure } from 'react-instantsearch-dom'
 import type { Mock } from 'vitest'

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import type { Hit } from 'react-instantsearch-core'
 

--- a/pro/src/pages/AdageIframe/app/components/DiffuseHelp/__specs__/DiffuseHelp.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/DiffuseHelp/__specs__/DiffuseHelp.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import type { SearchBoxProvided } from 'react-instantsearch-core'
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/RequestFormDialog.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/RequestFormDialog.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { format } from 'date-fns'
 import React from 'react'
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/__specs__/ContactButton.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/__specs__/ContactButton.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { AdageFrontRoles } from 'apiClient/adage'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/__specs__/NoResultsPage.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/__specs__/NoResultsPage.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/__spec__/PrebookingButton.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/__spec__/PrebookingButton.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { OfferStockResponse } from 'apiClient/adage'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
@@ -3,7 +3,7 @@ import {
   waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 import type { Hit } from 'react-instantsearch-core'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import type { SearchBoxProvided } from 'react-instantsearch-core'
 
 import { AdageFrontRoles, AuthenticatedResponse } from 'apiClient/adage'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OldOffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OldOffersSearch.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { AdageFrontRoles, AuthenticatedResponse } from 'apiClient/adage'

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { apiAdage } from 'apiClient/api'

--- a/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/CollectiveOfferFromRequest/__specs__/CollectiveOfferFromRequest.spec.tsx
+++ b/pro/src/pages/CollectiveOfferFromRequest/__specs__/CollectiveOfferFromRequest.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import type { Store } from 'redux'
 

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import * as router from 'react-router-dom'
 import type { Store } from 'redux'

--- a/pro/src/pages/Desk/ButtonInvalidateToken/__specs__/ButtonInvalidateToken.spec.tsx
+++ b/pro/src/pages/Desk/ButtonInvalidateToken/__specs__/ButtonInvalidateToken.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { ButtonInvalidateToken } from '..'
 

--- a/pro/src/pages/Desk/__specs__/Desk.spec.tsx
+++ b/pro/src/pages/Desk/__specs__/Desk.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { CancelablePromise } from 'apiClient/v1'

--- a/pro/src/pages/Home/OffererStats/__specs__/OffererStats.spec.tsx
+++ b/pro/src/pages/Home/OffererStats/__specs__/OffererStats.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { Events } from 'core/FirebaseEvents/constants'

--- a/pro/src/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.tsx
@@ -3,7 +3,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Home/ProfileAndSupport/__specs__/ProfileAndSupport.spec.tsx
+++ b/pro/src/pages/Home/ProfileAndSupport/__specs__/ProfileAndSupport.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Routes, Route } from 'react-router-dom'
 

--- a/pro/src/pages/Home/ProfileAndSupport/__specs__/Support.spec.tsx
+++ b/pro/src/pages/Home/ProfileAndSupport/__specs__/Support.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { Events } from 'core/FirebaseEvents/constants'

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/pages/Home/Venues/__specs__/Venue.tracker.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.tracker.spec.tsx
@@ -3,7 +3,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Home/__specs__/Homepage.spec.tsx
+++ b/pro/src/pages/Home/__specs__/Homepage.spec.tsx
@@ -3,7 +3,7 @@ import {
   waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/IndividualOfferWizard/Confirmation/__specs__/Confirmation.spec.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Confirmation/__specs__/Confirmation.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/pages/LostPassword/__specs__/LostPassword.spec.tsx
+++ b/pro/src/pages/LostPassword/__specs__/LostPassword.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import * as utils from 'utils/recaptcha'

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/ApiKey/__specs__/ApiKey.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/ApiKey/__specs__/ApiKey.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/AttachmentInvitations/__specs__/AttachmentInvitations.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/AttachmentInvitations/__specs__/AttachmentInvitations.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/Venues/VenueItem/__specs__/VenueItem.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/Venues/VenueItem/__specs__/VenueItem.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { VenueTypeCode } from 'apiClient/v1'

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataEdition.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataEdition.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/CinemaProviderForm/__specs__/CinemaProviderForm.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/CinemaProviderForm/__specs__/CinemaProviderForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { SynchronizationEvents } from 'core/FirebaseEvents/constants'

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { SynchronizationEvents } from 'core/FirebaseEvents/constants'

--- a/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.tsx
+++ b/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/pages/Offers/Offers/ActionsBar/ConfirmDialog/DeactivationConfirmDialog/__specs__/DeactivationConfirmDialog.spec.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/ConfirmDialog/DeactivationConfirmDialog/__specs__/DeactivationConfirmDialog.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { Audience } from 'core/shared'

--- a/pro/src/pages/Offers/Offers/ActionsBar/__specs__/ActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/__specs__/ActionsBar.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 import * as router from 'react-router-dom'

--- a/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.tracker.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { OfferStatus } from 'apiClient/v1'

--- a/pro/src/pages/Offers/Offers/OffersTableHead/__specs__/StatusFiltersButton.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OffersTableHead/__specs__/StatusFiltersButton.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 
 import { CollectiveOfferStatus } from 'core/OfferEducational'
 import { ADMINS_DISABLED_FILTERS_MESSAGE } from 'core/Offers/constants'

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Routes, Route } from 'react-router-dom'
 

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementDetails.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementDetails.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
@@ -3,7 +3,7 @@ import {
   waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/ResetPassword/__specs__/ResetPassword.spec.tsx
+++ b/pro/src/pages/ResetPassword/__specs__/ResetPassword.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/pages/SignIn/__specs__/SignIn.spec.tsx
+++ b/pro/src/pages/SignIn/__specs__/SignIn.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import * as router from 'react-router-dom'
 import { Route, Routes } from 'react-router-dom'

--- a/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.tsx
+++ b/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/pages/SignupJourneyRoutes/__specs__/SignupJourneyRoutes.trackers.spec.tsx
+++ b/pro/src/pages/SignupJourneyRoutes/__specs__/SignupJourneyRoutes.trackers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/pages/VenueCreation/__specs__/VenueCreation.spec.tsx
+++ b/pro/src/pages/VenueCreation/__specs__/VenueCreation.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/__specs__/BookingOfferCell.tracking.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/__specs__/BookingOfferCell.tracking.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { Events } from 'core/FirebaseEvents/constants'

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/__specs__/DetailsButtonCell.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/__specs__/DetailsButtonCell.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { CollectiveBookingsEvents } from 'core/FirebaseEvents/constants'

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { addDays } from 'date-fns'
 import React from 'react'
 

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/__specs__/CollectiveTableRow.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/__specs__/CollectiveTableRow.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/Bookings/BookingsRecapTable/Filters/__specs__/FilterByBookingStatus.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/Filters/__specs__/FilterByBookingStatus.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import {

--- a/pro/src/screens/Bookings/BookingsRecapTable/Filters/__specs__/FilterByOmniSearch.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/Filters/__specs__/FilterByOmniSearch.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { Audience } from 'core/shared'

--- a/pro/src/screens/Bookings/BookingsRecapTable/NoFilteredBookings/__specs__/NoFilteredBookings.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/NoFilteredBookings/__specs__/NoFilteredBookings.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import NoFilteredBookings from '../NoFilteredBookings'

--- a/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React, { ComponentProps } from 'react'
 
 import { CollectiveBookingsEvents } from 'core/FirebaseEvents/constants'

--- a/pro/src/screens/Bookings/PreFilters/FilterByBookingStatusPeriod/__specs__/FilterByBookingStatusPeriod.spec.tsx
+++ b/pro/src/screens/Bookings/PreFilters/FilterByBookingStatusPeriod/__specs__/FilterByBookingStatusPeriod.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { DEFAULT_PRE_FILTERS } from 'core/Bookings/constants'

--- a/pro/src/screens/Bookings/PreFilters/__specs__/FilterByEventDate.spec.tsx
+++ b/pro/src/screens/Bookings/PreFilters/__specs__/FilterByEventDate.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { EMPTY_FILTER_VALUE } from 'core/Bookings/constants'

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/__specs__/CollectiveOfferSelectionDuplicationScreen.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/__specs__/CollectiveOfferSelectionDuplicationScreen.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import createFetchMock from 'vitest-fetch-mock'
 

--- a/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/IndividualOffer/ActionBar/__specs__/ActionBar.spec.tsx
+++ b/pro/src/screens/IndividualOffer/ActionBar/__specs__/ActionBar.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferBreadcrumb'

--- a/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.creation.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.creation.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.draft.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.draft.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Informations/__specs__/InformationsScreen.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import {

--- a/pro/src/screens/IndividualOffer/PriceCategories/__specs__/PriceCategories.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategories/__specs__/PriceCategories.RouteLeavingGuard.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/PriceCategories/__specs__/PriceCategories.submit.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategories/__specs__/PriceCategories.submit.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/PriceCategories/__specs__/PriceCategories.trackers.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategories/__specs__/PriceCategories.trackers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/PriceCategories/__specs__/PriceCategoriesForm.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategories/__specs__/PriceCategoriesForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/screens/IndividualOffer/Status/__specs__/StatusToggleButton.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Status/__specs__/StatusToggleButton.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/RecurrenceForm.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/RecurrenceForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { addDays, format } from 'date-fns'
 import React from 'react'
 import { axe } from 'vitest-axe'

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { addDays } from 'date-fns'
 import format from 'date-fns/format'
 import React from 'react'

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import format from 'date-fns/format'
 import React from 'react'
 import { Routes, Route } from 'react-router-dom'

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StocksEventEdition.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StocksEventEdition.RouteLeavingGuard.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import format from 'date-fns/format'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StocksEventEdition.tracker.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StocksEventEdition.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import format from 'date-fns/format'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.RouteLeavingGuard.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.draft.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.draft.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import format from 'date-fns/format'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.tracker.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/Summary/PriceCategoriesSection/__specs__/PriceCategoriesSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Summary/PriceCategoriesSection/__specs__/PriceCategoriesSection.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { Events } from 'core/FirebaseEvents/constants'

--- a/pro/src/screens/IndividualOffer/Summary/StockSection/__specs__/StockSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Summary/StockSection/__specs__/StockSection.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/Summary/StockSection/__specs__/StockSection.tracker.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Summary/StockSection/__specs__/StockSection.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/Summary/__specs__/Summary.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Summary/__specs__/Summary.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { generatePath, Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/IndividualOffer/Summary/__specs__/Summary.tracker.spec.tsx
+++ b/pro/src/screens/IndividualOffer/Summary/__specs__/Summary.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { OfferStatus } from 'apiClient/v1'

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/__specs__/FormNotifications.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/__specs__/FormNotifications.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreation.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreation.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import * as router from 'react-router-dom'
 

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationAccessibilityStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationAccessibilityStep.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { RootState } from 'store/reducers'

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOfferTypeStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOfferTypeStep.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalEventAddressStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalEventAddressStep.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'

--- a/pro/src/screens/OfferEducationalStock/FormStock/__specs__/FormStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/__specs__/FormStock.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { addDays } from 'date-fns'
 import format from 'date-fns/format'
 import { Form, Formik } from 'formik'

--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { addDays, addMinutes, format, subDays } from 'date-fns'
 import React from 'react'
 import * as router from 'react-router-dom'

--- a/pro/src/screens/OfferType/IndividualOfferType/__specs__/IndividualOfferType.spec.tsx
+++ b/pro/src/screens/OfferType/IndividualOfferType/__specs__/IndividualOfferType.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { FormikProvider, useFormik } from 'formik'
 import React from 'react'
 

--- a/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import * as router from 'react-router-dom'
 

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/OffererStats/__specs__/OffererStatsScreen.spec.tsx
+++ b/pro/src/screens/OffererStats/__specs__/OffererStatsScreen.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/OldCollectiveOfferVisibility/__specs__/OldCollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/OldCollectiveOfferVisibility/__specs__/OldCollectiveOfferVisibility.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/SignupJourneyForm/ActionBar/__specs__/ActionBar.trackers.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/ActionBar/__specs__/ActionBar.trackers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityScreen.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import createFetchMock from 'vitest-fetch-mock'

--- a/pro/src/screens/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 import createFetchMock from 'vitest-fetch-mock'

--- a/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/__specs__/ConfirmedAttachment.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/__specs__/ConfirmedAttachment.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/__specs__/ConfirmedAttachment.trackers..spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/__specs__/ConfirmedAttachment.trackers..spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { SIGNUP_JOURNEY_STEP_IDS } from 'components/SignupJourneyBreadcrumb/constants'

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 import createFetchMock from 'vitest-fetch-mock'

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 import createFetchMock from 'vitest-fetch-mock'

--- a/pro/src/screens/SignupJourneyForm/Offerers/__specs__/Offerers.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/__specs__/Offerers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/SignupJourneyForm/Offerers/__specs__/Offerers.trackers.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/__specs__/Offerers.trackers.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'

--- a/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -3,7 +3,7 @@ import {
   waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/SignupJourneyForm/Welcome/__specs__/Welcome.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Welcome/__specs__/Welcome.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 import createFetchMock from 'vitest-fetch-mock'

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.tracker.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.tracker.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 import createFetchMock from 'vitest-fetch-mock'

--- a/pro/src/ui-kit/Button/__specs__/ButtonLink.spec.tsx
+++ b/pro/src/ui-kit/Button/__specs__/ButtonLink.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 

--- a/pro/src/ui-kit/CopyLink/__spec__/CopyLink.spec.tsx
+++ b/pro/src/ui-kit/CopyLink/__spec__/CopyLink.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import CopyLink from 'ui-kit/CopyLink'

--- a/pro/src/ui-kit/Pagination/__specs__/Pagination.spec.tsx
+++ b/pro/src/ui-kit/Pagination/__specs__/Pagination.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { Pagination, PaginationProps } from '../Pagination'

--- a/pro/src/ui-kit/Tag/__specs__/Tag.spec.tsx
+++ b/pro/src/ui-kit/Tag/__specs__/Tag.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import Tag from '../Tag'

--- a/pro/src/ui-kit/Toggle/__specs__/Toggle.spec.tsx
+++ b/pro/src/ui-kit/Toggle/__specs__/Toggle.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import Toggle, { ToggleProps } from '../Toggle'

--- a/pro/src/ui-kit/form/AdageMultiselect/__specs__/AdageMultiselect.spec.tsx
+++ b/pro/src/ui-kit/form/AdageMultiselect/__specs__/AdageMultiselect.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/ui-kit/form/DurationInput/__specs__/DurationInput.spec.tsx
+++ b/pro/src/ui-kit/form/DurationInput/__specs__/DurationInput.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/src/ui-kit/form/EmailSpellCheckInput/__specs__/EmailSpellCheckInput.spec.tsx
+++ b/pro/src/ui-kit/form/EmailSpellCheckInput/__specs__/EmailSpellCheckInput.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/ui-kit/form/MultiSelectAutoComplete/__specs__/MultiSelectAutocomplete.spec.tsx
+++ b/pro/src/ui-kit/form/MultiSelectAutoComplete/__specs__/MultiSelectAutocomplete.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/ui-kit/form/PeriodSelector/__specs__/PeriodSelector.spec.tsx
+++ b/pro/src/ui-kit/form/PeriodSelector/__specs__/PeriodSelector.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import PeriodSelector from '../PeriodSelector'

--- a/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import { parsePhoneNumberFromString } from 'libphonenumber-js'
 import React from 'react'

--- a/pro/src/ui-kit/form/SelectAutoComplete/__specs__/SelectAutocomplete.spec.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/__specs__/SelectAutocomplete.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'

--- a/pro/src/ui-kit/form/TextInputAutocomplete/__specs__/TextInputAutocomplete.spec.tsx
+++ b/pro/src/ui-kit/form/TextInputAutocomplete/__specs__/TextInputAutocomplete.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -2992,10 +2992,10 @@
     "@testing-library/dom" "^9.0.0"
     "@types/react-dom" "^18.0.0"
 
-"@testing-library/user-event@^14.4.3":
-  version "14.4.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
-  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+"@testing-library/user-event@^14.5.1":
+  version "14.5.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.1.tgz#27337d72046d5236b32fd977edee3f74c71d332f"
+  integrity sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24524

-> pas de soucis en local

une erreur eslint est apparue :

> Using exported name 'userEvent' as identifier for default export.eslint[import/no-named-as-default](https://github.com/import-js/eslint-plugin-import/blob/v2.28.1/docs/rules/no-named-as-default.md)

`import userEvent` devient `import { userEvent }`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques