### PR TITLE
(BSR)[API] fix: Handle SyntaxError thrown by PIL

### DIFF
--- a/api/src/pcapi/utils/image_conversion.py
+++ b/api/src/pcapi/utils/image_conversion.py
@@ -117,7 +117,13 @@ def _pre_process_image(content: bytes) -> PIL.Image:
     raw_image = PIL.Image.open(io.BytesIO(content))
 
     # Remove exif orientation so that it doesnt rotate after upload
-    transposed_image = ImageOps.exif_transpose(raw_image)
+    try:
+        transposed_image = ImageOps.exif_transpose(raw_image)
+    except SyntaxError as exc:
+        # PIL may raise `SyntaxError("not a TIFF file [...]")` or a
+        # similar message, depending on the expected type of file. In
+        # that case, re-reraise as a more specific, PIL-related error.
+        raise PIL.UnidentifiedImageError() from exc
 
     if transposed_image.mode == "RGBA":
         background = PIL.Image.new("RGB", transposed_image.size, (255, 255, 255))

--- a/api/src/pcapi/utils/image_conversion.py
+++ b/api/src/pcapi/utils/image_conversion.py
@@ -117,7 +117,7 @@ def _pre_process_image(content: bytes) -> PIL.Image:
     raw_image = PIL.Image.open(io.BytesIO(content))
 
     # Remove exif orientation so that it doesnt rotate after upload
-    transposed_image = _transpose_image(raw_image)
+    transposed_image = ImageOps.exif_transpose(raw_image)
 
     if transposed_image.mode == "RGBA":
         background = PIL.Image.new("RGB", transposed_image.size, (255, 255, 255))
@@ -129,10 +129,6 @@ def _pre_process_image(content: bytes) -> PIL.Image:
 
 def _post_process_image(image: PIL.Image) -> bytes:
     return _convert_to_jpeg(image)
-
-
-def _transpose_image(raw_image: PIL.Image) -> PIL.Image:
-    return ImageOps.exif_transpose(raw_image)
 
 
 def _check_ratio(image: PIL.Image, ratio: ImageRatio) -> PIL.Image:

--- a/api/tests/utils/image_conversion_test.py
+++ b/api/tests/utils/image_conversion_test.py
@@ -8,8 +8,8 @@ from pcapi.utils.image_conversion import CropParams
 from pcapi.utils.image_conversion import ImageRatio
 from pcapi.utils.image_conversion import ImageRatioError
 from pcapi.utils.image_conversion import _crop_image
+from pcapi.utils.image_conversion import _pre_process_image
 from pcapi.utils.image_conversion import _resize_image
-from pcapi.utils.image_conversion import _transpose_image
 from pcapi.utils.image_conversion import process_original_image
 from pcapi.utils.image_conversion import standardize_image
 
@@ -50,7 +50,7 @@ class ImageConversionTest:
         assert 274 in exif_info
 
         # when
-        transposed_image = _transpose_image(expected_image)
+        transposed_image = _pre_process_image(image_as_bytes)
 
         # then
         exif_info = transposed_image.getexif()


### PR DESCRIPTION
J'en ai profité pour *inline* une fonction qui n'était utilisée qu'à
un seul endroit. **Il y a donc 2 commits, à relire séparément.**

Je n'ai pas ajouté de test pour la correction du bug (la gestion du
SyntaxError) car je n'ai pas réussi à reproduire. Mais c'est un vrai
bug qu'on voit [sur Sentry](https://sentry.passculture.team/organizations/sentry/issues/427666/events/0e2256250f5b4c1796f79dd1a1201014/?project=5).