### PR TITLE
(BSR)[PRO] fix: realign open api client

### DIFF
--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -180,6 +180,7 @@ export type { StockCreationBodyModel } from './models/StockCreationBodyModel';
 export type { StockEditionBodyModel } from './models/StockEditionBodyModel';
 export type { StockIdResponseModel } from './models/StockIdResponseModel';
 export type { StockResponseModel } from './models/StockResponseModel';
+export type { StocksQueryModel } from './models/StocksQueryModel';
 export type { StocksResponseModel } from './models/StocksResponseModel';
 export type { StocksUpsertBodyModel } from './models/StocksUpsertBodyModel';
 export { StudentLevels } from './models/StudentLevels';

--- a/pro/src/apiClient/v1/models/StocksQueryModel.ts
+++ b/pro/src/apiClient/v1/models/StocksQueryModel.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type StocksQueryModel = {
+  date?: string | null;
+  price_category_id?: number | null;
+  time?: string | null;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -87,6 +87,7 @@ import type { SharedLoginUserResponseModel } from '../models/SharedLoginUserResp
 import type { SirenInfo } from '../models/SirenInfo';
 import type { SiretInfo } from '../models/SiretInfo';
 import type { StockIdResponseModel } from '../models/StockIdResponseModel';
+import type { StockResponseModel } from '../models/StockResponseModel';
 import type { StocksResponseModel } from '../models/StocksResponseModel';
 import type { StocksUpsertBodyModel } from '../models/StocksUpsertBodyModel';
 import type { UserEmailValidationResponseModel } from '../models/UserEmailValidationResponseModel';
@@ -1591,6 +1592,39 @@ export class DefaultService {
       url: '/offers/{offer_id}/price_categories/{price_category_id}',
       path: {
         'offer_id': offerId,
+        'price_category_id': priceCategoryId,
+      },
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * get_stocks <GET>
+   * @param offerId
+   * @param date
+   * @param time
+   * @param priceCategoryId
+   * @returns StockResponseModel OK
+   * @throws ApiError
+   */
+  public getStocks(
+    offerId: number,
+    date?: string | null,
+    time?: string | null,
+    priceCategoryId?: number | null,
+  ): CancelablePromise<StockResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/offers/{offer_id}/stocks/',
+      path: {
+        'offer_id': offerId,
+      },
+      query: {
+        'date': date,
+        'time': time,
         'price_category_id': priceCategoryId,
       },
       errors: {


### PR DESCRIPTION
## But de la pull request

BSR

la ci n'a plus l'air d'updaté l'api client automatiquement en attendant j'ai lancé la commande à la main

https://github.com/pass-culture/pass-culture-main/actions/runs/6325619218/job/17178721349

```
 $ ./scripts/generate_api_client_local.sh
{
  stack: 'ResolverError: Error downloading http://localhost/v2/openapi.json \n' +
    'socket hang up\n' +
    '    at /runner/_work/pass-culture-main/pass-culture-main/pro/node_modules/@apidevtools/json-schema-ref-parser/lib/resolvers/http.js:127:16',
  code: 'ERESOLVER',
  message: 'Error downloading http://localhost/v2/openapi.json \nsocket hang up',
  source: 'http://localhost/v2/openapi.json',
  path: null,
  toJSON: [Function: toJSON],
  ioErrorCode: 'ECONNRESET',
  name: 'ResolverError',
  footprint: 'null+http://localhost/v2/openapi.json+ERESOLVER+Error downloading http://localhost/v2/openapi.json \n' +
    'socket hang up',
  toString: [Function: toString]
}
```

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques