### PR TITLE
(PC-24670)[API] feat: only allow in_app (ie: charlie API) or no_tickets offers for individual offer API

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -166,7 +166,7 @@ class NonLinkedProviderCannotHaveInAppTicket(OfferCreationBaseException):
     def __init__(self) -> None:
         super().__init__(
             "offer",
-            "L'offre ne supporte pas de billet dans l'application mobile",
+            "Vous devez supporter l'interface de billeterie pour créer des offres avec billet",
         )
 
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -10,7 +10,6 @@ import pydantic.v1 as pydantic_v1
 from pydantic.v1.utils import GetterDict
 import typing_extensions
 
-from pcapi import settings
 from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.finance import utils as finance_utils
 from pcapi.core.offers import models as offers_models
@@ -768,82 +767,6 @@ class GetOffersQueryParams(IndexPaginationQueryParams):
 
 class GetDatesQueryParams(IndexPaginationQueryParams):
     pass
-
-
-class PaginationLinks(serialization.ConfiguredBaseModel):
-    current: str = pydantic_v1.Field(
-        ...,
-        description="URL of the current page.",
-        example=f"{settings.API_URL}/public/offers/v1/products?page=1&limit=50",
-    )
-    first: str = pydantic_v1.Field(
-        ...,
-        description="URL of the first page.",
-        example=f"{settings.API_URL}/public/offers/v1/products?page=1&limit=50",
-    )
-    last: str = pydantic_v1.Field(
-        ...,
-        description="URL of the last page.",
-        example=f"{settings.API_URL}/public/offers/v1/products?page=3&limit=50",
-    )
-    next: str | None = pydantic_v1.Field(
-        None,
-        description="URL of the next page.",
-        example=f"{settings.API_URL}/public/offers/v1/products?page=2&limit=50",
-    )
-    previous: str | None = pydantic_v1.Field(None, description="URL of the previous page.", example=None)
-
-    @classmethod
-    def build_pagination_links(
-        cls,
-        base_url: str,
-        current: int,
-        limit: int,
-        items_total: int,
-        venue_id: int | None = None,
-    ) -> "PaginationLinks":
-        url_start = f"{base_url}?venueId={venue_id}&" if venue_id is not None else f"{base_url}?"
-        return cls(
-            first=f"{url_start}page=1&limit={limit}",
-            current=f"{url_start}page={current}&limit={limit}",
-            last=f"{url_start}page={items_total // limit+1}&limit={limit}",
-            next=f"{url_start}page={current + 1}&limit={limit}" if current * limit < items_total else None,
-            previous=f"{url_start}page={current - 1}&limit={limit}" if current > 1 else None,
-        )
-
-
-class Pagination(serialization.ConfiguredBaseModel):
-    current_page: int = pydantic_v1.Field(..., description="Page number of the returned items.", example=1)
-    items_count: int = pydantic_v1.Field(..., description="Number of items returned.", example=50)
-    items_total: int = pydantic_v1.Field(..., description="Total number of items.", example=120)
-    last_page: int = pydantic_v1.Field(..., description="Last page number.", example=3)
-    limit_per_page: int = pydantic_v1.Field(..., description="Maximum number of items per page.", example=50)
-    pages_links: PaginationLinks
-
-    @classmethod
-    def build_pagination(
-        cls,
-        base_url: str,
-        current_page: int,
-        items_count: int,
-        items_total: int,
-        limit: int,
-        venue_id: int | None = None,
-    ) -> "Pagination":
-        return cls(
-            current_page=current_page,
-            items_count=items_count,
-            items_total=items_total,
-            last_page=items_total // limit + 1,
-            limit_per_page=limit,
-            pages_links=PaginationLinks.build_pagination_links(
-                base_url,
-                current_page,
-                limit,
-                items_total,
-                venue_id=venue_id,
-            ),
-        )
 
 
 class ProductOffersResponse(serialization.ConfiguredBaseModel):

--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -123,36 +123,6 @@ class GetEventTest:
             "musicType": None,
         }
 
-    def test_ticket_collection_by_email(self, client):
-        venue, _ = utils.create_offerer_provider_linked_to_venue()
-        event_offer = offers_factories.EventOfferFactory(
-            venue=venue,
-            withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
-            withdrawalDelay=259201,  # 3 days + 1 second
-        )
-
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-            f"/public/offers/v1/events/{event_offer.id}"
-        )
-
-        assert response.status_code == 200
-        assert response.json["ticketCollection"] == {"daysBeforeEvent": 3, "way": "by_email"}
-
-    def test_ticket_collection_on_site(self, client):
-        venue, _ = utils.create_offerer_provider_linked_to_venue()
-        event_offer = offers_factories.EventOfferFactory(
-            venue=venue,
-            withdrawalType=offers_models.WithdrawalTypeEnum.ON_SITE,
-            withdrawalDelay=1801,  # 30 minutes + 1 second
-        )
-
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-            f"/public/offers/v1/events/{event_offer.id}"
-        )
-
-        assert response.status_code == 200
-        assert response.json["ticketCollection"] == {"minutesBeforeEvent": 30, "way": "on_site"}
-
     def test_ticket_collection_in_app(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         event_offer = offers_factories.EventOfferFactory(

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -129,7 +129,7 @@ class PatchEventTest:
 
     @override_features(WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API=True)
     def test_patch_all_fields(self, client):
-        venue, api_key = utils.create_offerer_provider_linked_to_venue()
+        venue, api_key = utils.create_offerer_provider_linked_to_venue(with_charlie=True)
         event_offer = offers_factories.EventOfferFactory(
             venue=venue,
             bookingContact="contact@example.com",
@@ -138,7 +138,7 @@ class PatchEventTest:
             durationMinutes=20,
             isDuo=False,
             lastProvider=api_key.provider,
-            withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
+            withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
             withdrawalDelay=86400,
             withdrawalDetails="Around there",
         )
@@ -146,7 +146,7 @@ class PatchEventTest:
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
             f"/public/offers/v1/events/{event_offer.id}",
             json={
-                "ticketCollection": {"way": "on_site", "minutesBeforeEvent": 60},
+                "ticketCollection": None,  # This should not change
                 "bookingContact": "test@myemail.com",
                 "bookingEmail": "test@myemail.com",
                 "eventDuration": 40,
@@ -154,9 +154,9 @@ class PatchEventTest:
                 "itemCollectionDetails": "Here !",
             },
         )
+
         assert response.status_code == 200
-        assert event_offer.withdrawalType == offers_models.WithdrawalTypeEnum.ON_SITE
-        assert event_offer.withdrawalDelay == 3600
+        assert event_offer.withdrawalType == offers_models.WithdrawalTypeEnum.IN_APP
         assert event_offer.durationMinutes == 40
         assert event_offer.isDuo is True
         assert event_offer.bookingContact == "test@myemail.com"


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24670

We had 4 tickets withdrawal types, we only want API users to create offers without tickets or offers linked to their stocks through charlie api.