### PR TITLE
(PC-24750)[API] feat: reapprove product and offers rejected for bad cgu

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -243,6 +243,10 @@ class OfferNotFound(Exception):
     pass
 
 
+class ProductNotFound(Exception):
+    pass
+
+
 class CollectiveStockNotFound(Exception):
     pass
 
@@ -260,4 +264,8 @@ class UnexpectedCinemaProvider(Exception):
 
 
 class TiteLiveAPINotExistingEAN(Exception):
+    pass
+
+
+class NotUpdateProductOrOffers(Exception):
     pass

--- a/api/src/pcapi/local_providers/local_provider.py
+++ b/api/src/pcapi/local_providers/local_provider.py
@@ -259,6 +259,9 @@ class LocalProvider(Iterator):
             self.venue_provider.lastSyncDate = datetime.utcnow()
             repository.save(self.venue_provider)
 
+    def postTreatment(self) -> None:
+        pass
+
 
 def _upload_thumb(
     pc_object: HasThumbMixin,

--- a/api/src/pcapi/local_providers/provider_manager.py
+++ b/api/src/pcapi/local_providers/provider_manager.py
@@ -27,6 +27,7 @@ def synchronize_data_for_provider(provider_name: str, limit: int | None = None) 
     try:
         provider = provider_class()
         provider.updateObjects(limit)
+        provider.postTreatment()
     except Exception:  # pylint: disable=broad-except
         logger.exception(build_cron_log_message(name=provider_name, status=CronStatus.FAILED))
 


### PR DESCRIPTION
## But de la pull request

Quand un produit Titelive est rejeté pour cause d'incompatibilité avec les CGU, si le lendemain lors de la synchro de nuit (lecture du FTP), le produit est correct vis-à-vis des CGU, il faut le réactiver, les offres associés aussi.

Ticket Jira : https://passculture.atlassian.net/browse/PC-24752

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques