### PR TITLE
(PC-24662)[PRO] fix: satisfaction banner readonly

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -7,6 +7,7 @@ import type {
 import { connectInfiniteHits, connectStats } from 'react-instantsearch-dom'
 
 import {
+  AdageFrontRoles,
   CollectiveOfferResponseModel,
   CollectiveOfferTemplateResponseModel,
 } from 'apiClient/adage'
@@ -98,7 +99,9 @@ export const OffersComponent = ({
   const { adageUser } = useAdageUser()
 
   const showSurveySatisfaction =
-    isSatisfactionSurveyActive && !adageUser.preferences?.feedback_form_closed
+    isSatisfactionSurveyActive &&
+    !adageUser.preferences?.feedback_form_closed &&
+    adageUser.role !== AdageFrontRoles.READONLY
 
   const { filtersKeys, hasClickedSearch, setHasClickedSearch } =
     useContext(AnalyticsContext)

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
@@ -466,6 +466,31 @@ describe('offers', () => {
     expect(surveySatisfaction).toBeInTheDocument()
   })
 
+  it('should not display survey satisfaction if user role readonly', async () => {
+    // Given
+    vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(offerInParis)
+    vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(
+      offerInCayenne
+    )
+    // When
+    renderOffers(
+      offersProps,
+      { ...adageUser, role: AdageFrontRoles.READONLY },
+      {
+        features: {
+          list: [{ isActive: true, nameKey: 'WIP_ENABLE_SATISFACTION_SURVEY' }],
+        },
+      }
+    )
+
+    const listItemsInOffer = await screen.findAllByTestId('offer-listitem')
+    expect(listItemsInOffer).toHaveLength(2)
+
+    // Then
+    const surveySatisfaction = screen.queryByText('Enquête de satisfaction')
+    expect(surveySatisfaction).not.toBeInTheDocument()
+  })
+
   it('should not display survey satisfaction if only 1 offer', async () => {
     // Given
     vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce({


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24662

On ne souhaite pas afficher la bannière de satisfaction sur adage si l'utilisateur connecté à le rôle READONLY

## Vérifications

- [x] J'ai écrit les tests nécessaires