### PR TITLE
ci: Lancer seulement les tests nécessaires, selon les fichiers ("pro/" ou "api/") modifiés

### DIFF
--- a/.github/workflows/check-folder-changes.yml
+++ b/.github/workflows/check-folder-changes.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: folder-check-changed-files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v39
         with:
           files: |
             ${{ inputs.folder }}/**

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -10,21 +10,9 @@ defaults:
     working-directory: api
 
 jobs:
-  build-tests-docker-image:
-    name: Build tests docker image
-    uses: ./.github/workflows/build-and-push-docker-images.yml
-    with:
-      tag: ${{ github.sha }}
-      tests: true
-      # Extra builds when tests are run on master before deployment on testing
-      pcapi: ${{ github.ref == 'refs/heads/master' }}
-      console: ${{ github.ref == 'refs/heads/master' }}
-    secrets: inherit
-
   quality-checks:
     name: Quality checks
     runs-on: [self-hosted, linux, x64]
-    needs: build-tests-docker-image
     permissions:
       id-token: write
       contents: read
@@ -93,7 +81,6 @@ jobs:
   pylint-check:
     name: Pylint
     runs-on: [self-hosted, linux, x64]
-    needs: build-tests-docker-image
     permissions:
       id-token: write
       contents: read
@@ -156,7 +143,6 @@ jobs:
       DATABASE_URL_TEST: postgresql://pytest:pytest@postgres:5432/pass_culture
       REDIS_URL: redis://redis:6379
     runs-on: [self-hosted, linux, x64]
-    needs: build-tests-docker-image
     permissions:
       id-token: write
       contents: read
@@ -277,7 +263,6 @@ jobs:
             "tests --ignore=tests/core --ignore=tests/routes",
             "tests/routes/backoffice -m 'backoffice'",
           ]
-    needs: build-tests-docker-image
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -27,30 +27,32 @@ jobs:
     with:
       folder: pro
 
-  test-deploy-variable:
-    name: Check if deployment is required
-    runs-on: [self-hosted, linux, x64]
+  build-api:
+    name: Build API (backend) Docker image
     needs:
       - check-api-folder-changes
       - check-pro-folder-changes
-    outputs:
-      deploy: ${{ steps.check.outputs.deploy }}
-    steps:
-      - name: Check values
-        id: check
-        run: |
-          if \
-          [ "${{ needs.check-api-folder-changes.outputs.folder_changed }}" = "true" ] || \
-          [ "${{ needs.check-pro-folder-changes.outputs.folder_changed }}" = "true" ];
-          then
-            echo "deploy=true" >> $GITHUB_OUTPUT
-          else
-            echo "deploy=false" >> $GITHUB_OUTPUT
-          fi
+    if: |
+      needs.check-api-folder-changes.outputs.folder_changed == 'true' ||
+      needs.check-pro-folder-changes.outputs.folder_changed == 'true'
+    uses: ./.github/workflows/build-and-push-docker-images.yml
+    with:
+      tag: ${{ github.sha }}
+      # Needed to run end-to-end tests, i.e. when either "pro" or
+      # "api" source code changes, which is the condition under which
+      # this step is run. In other words: always.
+      pcapi: true
+      # Extra when tests are run on master before deployment on testing.
+      console: ${{ github.ref == 'refs/heads/master' }}
+      # Needed to run backend tests.
+      tests: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
+    secrets: inherit
 
   test-api:
     name: Test api
-    needs: check-api-folder-changes
+    needs:
+      - check-api-folder-changes
+      - build-api
     if: needs.check-api-folder-changes.outputs.folder_changed == 'true'
     uses: ./.github/workflows/tests-api.yml
     secrets: inherit
@@ -65,8 +67,13 @@ jobs:
       CACHE_BUCKET_NAME: passculture-infra-prod-github-runner-cache
 
   test-pro-e2e:
-    needs: test-deploy-variable
-    if: needs.test-deploy-variable.outputs.deploy == 'true'
+    needs:
+      - check-api-folder-changes
+      - check-pro-folder-changes
+      - build-api
+    if: |
+      needs.check-api-folder-changes.outputs.folder_changed == 'true' ||
+      needs.check-pro-folder-changes.outputs.folder_changed == 'true'
     name: Tests pro E2E
     uses: ./.github/workflows/tests-pro-e2e.yml
     secrets: inherit
@@ -85,7 +92,6 @@ jobs:
   deploy-to-testing:
     name: Deploy to testing
     needs:
-      - test-deploy-variable
       - test-api
       - test-pro
     if: |

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -50,14 +50,14 @@ jobs:
 
   test-api:
     name: Test api
-    needs: test-deploy-variable
-    if: needs.test-deploy-variable.outputs.deploy == 'true'
+    needs: check-api-folder-changes
+    if: needs.check-api-folder-changes.outputs.folder_changed == 'true'
     uses: ./.github/workflows/tests-api.yml
     secrets: inherit
 
   test-pro:
-    needs: test-deploy-variable
-    if: needs.test-deploy-variable.outputs.deploy == 'true'
+    needs: check-pro-folder-changes
+    if: needs.check-pro-folder-changes.outputs.folder_changed == 'true'
     name: Tests pro
     uses: ./.github/workflows/tests-pro.yml
     secrets: inherit


### PR DESCRIPTION
Objectif :

- quand un fichier du dossier `pro/` est modifié, on lance les tests
  pro "classiques" (unit tests, qualité, etc.) et les tests pro
  end-to-end

- quand un fichier du dossier `api/` est modifié, on lance les tests
  backend (unit tests, qualité, etc.) et les tests pro end-to-end

Exemples d'exécutions des tests : 

- modification de "api" et de "pro" : https://github.com/pass-culture/pass-culture-main/actions/runs/6454946983?pr=8426
- modification de "api" seulement : https://github.com/pass-culture/pass-culture-main/actions/runs/6456456320?pr=8426
- modification de "pro" seulement : https://github.com/pass-culture/pass-culture-main/actions/runs/6456713579?pr=8426
- aucune modification (ni "api", ni "pro") : https://github.com/pass-culture/pass-culture-main/actions/runs/6456989756?pr=8426
