### PR TITLE
(PC-24770)[ADAGE] fix: permettre aux non-rédacteurs de projets de voir des offres

### DIFF
--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -136,3 +136,17 @@ class CollectiveOfferTemplateTest:
         offer = educational_factories.CollectiveOfferTemplateFactory(validation=validation)
         response = eac_client.get(f"/adage-iframe/collective/offers-template/{offer.id}")
         assert response.status_code == 404
+
+    def test_non_redactor_is_ok(self, eac_client):
+        """Ensure that an authenticated user that is a not an
+        educational redactor can still fetch offers informations.
+        """
+        offer = educational_factories.CollectiveOfferTemplateFactory()
+        dst = url_for("adage_iframe.get_collective_offer_template", offer_id=offer.id)
+
+        # 1. fetch redactor
+        # 2. fetch collective offer and related data
+        with assert_num_queries(2):
+            response = eac_client.get(dst)
+
+        assert response.status_code == 200

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -21,7 +21,7 @@ EMAIL = "toto@mail.com"
 
 
 @pytest.fixture(name="eac_client")
-def eac_token_fixture(client):
+def eac_client_fixture(client):
     return client.with_adage_token(email=EMAIL, uai="1234UAI")
 
 

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -21,7 +21,7 @@ EMAIL = "toto@mail.com"
 
 
 @pytest.fixture(name="eac_client")
-def eac_token_fixture(client):
+def eac_client_fixture(client):
     return client.with_adage_token(email=EMAIL, uai="1234UAI")
 
 

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -178,3 +178,17 @@ class CollectiveOfferTest:
         eac_client = client.with_adage_token(email=redactor.email, uai="1234UAI")
         response = eac_client.get(f"/adage-iframe/collective/offers/{stock.collectiveOfferId}")
         assert response.status_code == 200
+
+    def test_non_redactor_is_ok(self, eac_client):
+        """Ensure that an authenticated user that is a not an
+        educational redactor can still fetch offers informations.
+        """
+        offer = educational_factories.CollectiveStockFactory().collectiveOffer
+        dst = url_for("adage_iframe.get_collective_offer", offer_id=offer.id)
+
+        # 1. fetch redactor
+        # 2. fetch collective offer and related data
+        with assert_num_queries(2):
+            response = eac_client.get(dst)
+
+        assert response.status_code == 200


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24770

Bug: suite à l'ajout du champ isFavorite dans la réponse des offres
collectives et vitrines, seuls les rédacteurs de projet pouvaient accéder à
ces ressources.

Pour savoir si l'offre a été mise en favori par l'utilisateur, on va le
chercher en base données puis on regarde s'il a l'offre en favori ou non.

Le problème est que les utilisateurs (authentifiés) ne sont pas toujours des
rédacteurs de projets et n'ont donc pas toujours un compte en base. Et l'on
répondait, à tort, avec une erreur 403.

### Au passage

J'ai ajouté deux commits : 

le premier pour corriger une faute dans le nom d'une fonction de fixture.
le second pour ajouter une petite _refacto_.