### PR TITLE
(PC-24612)[PRO] feat: ajout label et direction d'affichage ON_SITE

### DIFF
--- a/pro/src/components/IndividualOfferForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
@@ -133,6 +133,8 @@ describe('IndividualOffer section: TicketWithdrawal', () => {
     expect(
       screen.getByLabelText('Retrait sur place (guichet, comptoir...)')
     ).toBeDisabled()
-    expect(screen.getByLabelText('Retrait dans l’app')).toBeDisabled()
+    expect(
+      screen.getByLabelText('Les billets seront affichés dans l’application')
+    ).toBeDisabled()
   })
 })

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/TicketWithdrawal/constants.ts
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/TicketWithdrawal/constants.ts
@@ -25,7 +25,7 @@ export const ticketWithdrawalTypeRadios = [
 export const providedTicketWithdrawalTypeRadios = [
   ...ticketWithdrawalTypeRadios,
   {
-    label: 'Retrait dans l’app',
+    label: 'Les billets seront affichés dans l’application',
     value: WithdrawalTypeEnum.IN_APP,
   },
 ]


### PR DESCRIPTION
 https://passculture.atlassian.net/browse/PC-24612

Modifier l'intitulé de la 4ème option de modalité de retrait:

<img width="801" alt="Capture d’écran 2023-09-28 à 16 48 28" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/0bae9284-e3ac-4a8e-866b-1f50f82e9435">


Branche: PC-24612-style-retrait