### PR TITLE
(PC-24451)[BO] fix: Underage Ubble identification should no longer be valid for Age-18 if not credited

### DIFF
--- a/api/tests/sandboxes/scripts/create_industrial_app_users_test.py
+++ b/api/tests/sandboxes/scripts/create_industrial_app_users_test.py
@@ -10,8 +10,8 @@ from pcapi.sandboxes.scripts.creators.industrial.create_industrial_app_users imp
 class CreateIndustrialWebappUsersTest:
     def test_create_industrial_app_users(self):
         create_industrial_app_users()
-        assert User.query.count() == 5 * 2 * 2 + 3 * 2 + 2 * 2 + 3 + 11
-        assert finance_models.Deposit.query.count() == 5 * 2 * 2 * 2 + 3 * 2 + 8
+        assert User.query.count() == 5 * 2 * 2 + 7 * 2 + 2 * 2 + 3 + 11
+        assert finance_models.Deposit.query.count() == 5 * 2 * 2 * 2 + 7 * 2 + 8
 
         ex_underage = User.query.filter_by(email="exunderage_18@example.com").first()
         ex_beneficiary = User.query.filter_by(email="exbene_20@example.com").first()


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-24451

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques