### PR TITLE
(PC-24781)[BO] fix: avoid exception log in Sentry when updating a venue with an existing SIRET

### DIFF
--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -1067,10 +1067,7 @@ class UpdateVenueTest(PostEndpointHelper):
         response = self.post_to_endpoint(authenticated_client, venue_id=venue.id, form=data)
 
         assert response.status_code == 400
-        assert (
-            html_parser.extract_alert(response.data)
-            == "[siret] Une entrée avec cet identifiant existe déjà dans notre base de données"
-        )
+        assert html_parser.extract_alert(response.data) == "Un autre lieu existe déjà avec le SIRET 11122233344444"
         db.session.refresh(venue)
         assert venue.siret is None
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24781

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques