### PR TITLE
(PC-24690)[PRO] fix: auto-validate offerer in integration environment

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -606,7 +606,10 @@ def _fill_in_offerer(
     offerer.name = offerer_informations.name
     offerer.postalCode = offerer_informations.postalCode
     offerer.siren = offerer_informations.siren
-    offerer.validationStatus = ValidationStatus.NEW
+    if settings.IS_INTEGRATION:
+        offerer.validationStatus = ValidationStatus.VALIDATED
+    else:
+        offerer.validationStatus = ValidationStatus.NEW
     offerer.isActive = True
     offerer.dateCreated = datetime.utcnow()
 

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from pcapi.connectors import sirene
 import pcapi.core.offerers.models as offerers_models
+from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
 
 
@@ -68,6 +69,17 @@ class Returns200Test:
             "siren": "853318459",
             "name": "MINISTERE DE LA CULTURE",
         }
+
+    @override_settings(IS_INTEGRATION=True)
+    def test_validated_in_integration(self, client):
+        user = users_factories.UserFactory(email="pro@example.com")
+
+        client = client.with_session_auth(user.email)
+        response = client.post("/offerers/new", json=REQUEST_BODY)
+
+        assert response.status_code == 201
+        created_offerer = offerers_models.Offerer.query.one()
+        assert created_offerer.isValidated
 
 
 class Returns400Test:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24690

La validation automatique des structures en integration ne fonctionnait plus, semble-t-il, depuis le passage au nouveau parcours d'inscription.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques