### PR TITLE
(PC-24342)[PRO] feat: add offerer filter for bank information

### DIFF
--- a/pro/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/pro/src/components/Breadcrumb/Breadcrumb.tsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom'
 
 import Stepper from 'components/Stepper'
 import fullArrowRightIcon from 'icons/full-arrow-right.svg'
-import fullErrorIcon from 'icons/full-error.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './Breadcrumb.module.scss'
@@ -69,14 +68,6 @@ const Breadcrumb = ({
                   to={step.url}
                 >
                   {step.label}
-                  {step.hasWarning && (
-                    <SvgIcon
-                      src={fullErrorIcon}
-                      alt="Une action est requise dans cet onglet"
-                      width="20"
-                      className={styles['error-icon']}
-                    />
-                  )}
                 </Link>
               ) : step.hash ? (
                 <a
@@ -84,27 +75,9 @@ const Breadcrumb = ({
                   onClick={step.onClick ? step.onClick : undefined}
                 >
                   {step.label}
-                  {step.hasWarning && (
-                    <SvgIcon
-                      src={fullErrorIcon}
-                      alt="Une action est requise dans cet onglet"
-                      width="20"
-                      className={styles['error-icon']}
-                    />
-                  )}
                 </a>
               ) : (
-                <span>
-                  {step.label}
-                  {step.hasWarning && (
-                    <SvgIcon
-                      src={fullErrorIcon}
-                      alt="Une action est requise dans cet onglet"
-                      width="20"
-                      className={styles['error-icon']}
-                    />
-                  )}
-                </span>
+                <span>{step.label}</span>
               )}
             </span>
 

--- a/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
+++ b/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import type { Step } from 'components/Breadcrumb'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
-import Breadcrumb, { BreadcrumbStyle, BreadcrumbProps } from '../Breadcrumb'
+import Breadcrumb, { BreadcrumbProps, BreadcrumbStyle } from '../Breadcrumb'
 
 const renderBreadcrumb = (props: BreadcrumbProps) => {
   renderWithProviders(<Breadcrumb {...props} />)
@@ -126,55 +126,6 @@ describe('Breadcrumb', () => {
       informationLink && (await userEvent.click(informationLink))
 
       expect(onClick).toHaveBeenCalledTimes(1)
-    })
-
-    it('should render error icon if step has warning', async () => {
-      props.steps.push({
-        id: '5',
-        label: 'Informations bancaires',
-        hasWarning: true,
-      })
-      renderBreadcrumb(props)
-      expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
-      expect(
-        screen.getByRole('img', {
-          name: 'Une action est requise dans cet onglet',
-        })
-      ).toBeInTheDocument()
-    })
-
-    it('should render error icon if step has url ans has warning', async () => {
-      props.steps.pop()
-      props.steps.push({
-        id: '6',
-        label: 'step with url',
-        url: 'https://example.com',
-        hasWarning: true,
-      })
-      renderBreadcrumb(props)
-      expect(screen.getByText('step with url')).toBeInTheDocument()
-      expect(
-        screen.getByRole('img', {
-          name: 'Une action est requise dans cet onglet',
-        })
-      ).toBeInTheDocument()
-    })
-
-    it('should render error icon if step has hash ans has warning', async () => {
-      props.steps.pop()
-      props.steps.push({
-        id: '7',
-        label: 'step with hash',
-        hash: 'hash',
-        hasWarning: true,
-      })
-      renderBreadcrumb(props)
-      expect(screen.getByText('step with hash')).toBeInTheDocument()
-      expect(
-        screen.getByRole('img', {
-          name: 'Une action est requise dans cet onglet',
-        })
-      ).toBeInTheDocument()
     })
   })
 

--- a/pro/src/components/Breadcrumb/types.ts
+++ b/pro/src/components/Breadcrumb/types.ts
@@ -1,10 +1,9 @@
 export type Step = {
   id: string
-  label: string
+  label: React.ReactNode
   onClick?: (e: React.MouseEvent) => void
   url?: string
   hash?: string
-  hasWarning?: boolean
 }
 
 export interface StepPattern {

--- a/pro/src/components/Callout/AddBankAccountCallout.tsx
+++ b/pro/src/components/Callout/AddBankAccountCallout.tsx
@@ -11,10 +11,10 @@ export interface AddBankAccountCalloutProps {
 const AddBankAccountCallout = ({
   titleOnly = false,
 }: AddBankAccountCalloutProps): JSX.Element | null => {
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
-  if (!isNewBankDetailsJourneyEnable) {
+  if (!isNewBankDetailsJourneyEnabled) {
     return null
   }
 

--- a/pro/src/components/Callout/LinkVenueCallout.tsx
+++ b/pro/src/components/Callout/LinkVenueCallout.tsx
@@ -13,10 +13,10 @@ const LinkVenueCallout = ({
   titleOnly = false,
   hasMultipleVenuesToLink = false,
 }: LinkVenueCalloutProps): JSX.Element | null => {
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
-  if (!isNewBankDetailsJourneyEnable) {
+  if (!isNewBankDetailsJourneyEnabled) {
     return null
   }
 

--- a/pro/src/components/Callout/PendingBankAccountCallout.tsx
+++ b/pro/src/components/Callout/PendingBankAccountCallout.tsx
@@ -11,10 +11,10 @@ export interface PendingBankAccountCalloutProps {
 const PendingBankAccountCallout = ({
   titleOnly = false,
 }: PendingBankAccountCalloutProps): JSX.Element | null => {
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
-  if (!isNewBankDetailsJourneyEnable) {
+  if (!isNewBankDetailsJourneyEnabled) {
     return null
   }
 

--- a/pro/src/components/ReimbursementsBreadcrumb/ReimbursementsBreadcrumb.tsx
+++ b/pro/src/components/ReimbursementsBreadcrumb/ReimbursementsBreadcrumb.tsx
@@ -4,42 +4,69 @@ import Breadcrumb, { BreadcrumbStyle } from 'components/Breadcrumb'
 import { useReimbursementContext } from 'context/ReimbursementContext/ReimbursementContext'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useActiveStep from 'hooks/useActiveStep'
+import fullErrorIcon from 'icons/full-error.svg'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import {
   OLD_STEP_LIST,
   OLD_STEP_NAMES,
   STEP_ID_BANK_INFORMATIONS,
-  STEP_LIST,
+  STEP_ID_DETAILS,
+  STEP_ID_INVOICES,
   STEP_NAMES,
 } from './constants'
+import styles from './ReimbursmentsBreadcrumb.module.scss'
 
 const ReimbursementsBreadcrumb = () => {
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
   const { selectedOfferer } = useReimbursementContext()
 
   const activeStep = useActiveStep(
-    isNewBankDetailsJourneyEnable ? STEP_NAMES : OLD_STEP_NAMES
+    isNewBankDetailsJourneyEnabled ? STEP_NAMES : OLD_STEP_NAMES
   )
+  const hasWarning =
+    (selectedOfferer &&
+      selectedOfferer?.venuesWithNonFreeOffersWithoutBankAccounts.length > 0) ??
+    false
 
   const getSteps = () => {
-    return STEP_LIST.map(step => {
-      if (step.id === STEP_ID_BANK_INFORMATIONS) {
-        step.hasWarning =
-          (selectedOfferer &&
-            selectedOfferer?.venuesWithNonFreeOffersWithoutBankAccounts.length >
-              0) ??
-          false
-      }
-      return step
-    })
+    return [
+      {
+        id: STEP_ID_INVOICES,
+        label: 'Justificatifs',
+        url: '/remboursements/justificatifs',
+      },
+      {
+        id: STEP_ID_DETAILS,
+        label: 'Détails',
+        url: '/remboursements/details',
+      },
+      {
+        id: STEP_ID_BANK_INFORMATIONS,
+        label: (
+          <>
+            Informations bancaires{' '}
+            {hasWarning && (
+              <SvgIcon
+                src={fullErrorIcon}
+                alt="Une action est requise dans cet onglet"
+                width="20"
+                className={styles['error-icon']}
+              />
+            )}
+          </>
+        ),
+        url: '/remboursements/informations-bancaires',
+      },
+    ]
   }
 
   return (
     <Breadcrumb
       activeStep={activeStep}
-      steps={isNewBankDetailsJourneyEnable ? getSteps() : OLD_STEP_LIST}
+      steps={isNewBankDetailsJourneyEnabled ? getSteps() : OLD_STEP_LIST}
       styleType={BreadcrumbStyle.TAB}
     />
   )

--- a/pro/src/components/ReimbursementsBreadcrumb/ReimbursmentsBreadcrumb.module.scss
+++ b/pro/src/components/ReimbursementsBreadcrumb/ReimbursmentsBreadcrumb.module.scss
@@ -1,0 +1,7 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_colors.scss" as colors;
+
+.error-icon {
+  margin-left: rem.torem(8px);
+  color: colors.$primary;
+}

--- a/pro/src/components/ReimbursementsBreadcrumb/constants.ts
+++ b/pro/src/components/ReimbursementsBreadcrumb/constants.ts
@@ -1,7 +1,5 @@
-import { Step } from 'components/Breadcrumb'
-
-const STEP_ID_INVOICES = 'justificatifs'
-const STEP_ID_DETAILS = 'details'
+export const STEP_ID_INVOICES = 'justificatifs'
+export const STEP_ID_DETAILS = 'details'
 export const STEP_ID_BANK_INFORMATIONS = 'informations-bancaires'
 
 // TODO: Remove after WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY deleted
@@ -24,23 +22,5 @@ export const OLD_STEP_LIST = [
     id: STEP_ID_DETAILS,
     label: 'Détails des remboursements',
     url: '/remboursements/details',
-  },
-]
-
-export const STEP_LIST: Step[] = [
-  {
-    id: STEP_ID_INVOICES,
-    label: 'Justificatifs',
-    url: '/remboursements/justificatifs',
-  },
-  {
-    id: STEP_ID_DETAILS,
-    label: 'Détails',
-    url: '/remboursements/details',
-  },
-  {
-    id: STEP_ID_BANK_INFORMATIONS,
-    label: 'Informations bancaires',
-    url: '/remboursements/informations-bancaires',
   },
 ]

--- a/pro/src/components/VenueForm/VenueForm.tsx
+++ b/pro/src/components/VenueForm/VenueForm.tsx
@@ -85,7 +85,7 @@ const VenueForm = ({
   const {
     values: { isPermanent },
   } = useFormikContext<VenueFormValues>()
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
   const shouldDisplayImageVenueUploaderSection = isPermanent
@@ -171,8 +171,8 @@ const VenueForm = ({
               canCreateCollectiveOffer={canOffererCreateCollectiveOffer}
             />
           )}
-        {((!isNewBankDetailsJourneyEnable && !isCreatingVenue) ||
-          (isNewBankDetailsJourneyEnable && !venue?.siret)) &&
+        {((!isNewBankDetailsJourneyEnabled && !isCreatingVenue) ||
+          (isNewBankDetailsJourneyEnabled && !venue?.siret)) &&
           venue && (
             <ReimbursementFields
               offerer={offerer}

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -42,7 +42,7 @@ const VenueOfferSteps = ({
   demarchesSimplifieesApplicationId,
 }: VenueOfferStepsProps) => {
   const isVenueCreationAvailable = useActiveFeature('API_SIRENE_AVAILABLE')
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
   const venueCreationUrl = isVenueCreationAvailable
@@ -166,7 +166,7 @@ const VenueOfferSteps = ({
             </div>
           )}
           {(shouldDisplayEACInformationSection ||
-            (!isNewBankDetailsJourneyEnable &&
+            (!isNewBankDetailsJourneyEnabled &&
               hasPendingBankInformationApplication)) && (
             <div className="h-card-inner">
               <h3 className={styles['card-title']}>Démarche en cours : </h3>
@@ -190,7 +190,7 @@ const VenueOfferSteps = ({
                     Suivre ma demande de référencement ADAGE
                   </ButtonLink>
                 )}
-                {!isNewBankDetailsJourneyEnable &&
+                {!isNewBankDetailsJourneyEnabled &&
                   hasPendingBankInformationApplication && (
                     <ButtonLink
                       className={styles['step-button-width']}

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -200,6 +200,7 @@ const Venue = ({
       })
       setIsStatLoaded(true)
     }
+
     if (isStatOpen && !isStatLoaded) {
       updateStats()
     }

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
@@ -37,7 +37,7 @@ const PricingPoint = ({
   const [isBannerVisible, setIsBannerVisible] = useState(true)
   const [pricingPointSelectField] = useField({ name: 'venueSiret' })
 
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
 
@@ -75,7 +75,7 @@ const PricingPoint = ({
 
   return (
     <>
-      {!isNewBankDetailsJourneyEnable && (
+      {!isNewBankDetailsJourneyEnabled && (
         <div className="main-list-title">
           <Title as="h3" className="sub-title" level={4}>
             Barème de remboursement

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
@@ -22,7 +22,7 @@ const ReimbursementFields = ({
   scrollToSection,
   venue,
 }: ReimbursementFieldsProps) => {
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
   const venueHaveSiret = !!venue.siret
@@ -44,7 +44,7 @@ const ReimbursementFields = ({
       <div ref={scrollToReimbursementSection} id="reimbursement-section">
         <FormLayout.Section
           title={
-            isNewBankDetailsJourneyEnable
+            isNewBankDetailsJourneyEnabled
               ? 'Barème de remboursement'
               : 'Remboursement'
           }
@@ -73,7 +73,7 @@ const ReimbursementFields = ({
                 />
               )}
 
-              {!isNewBankDetailsJourneyEnable && (
+              {!isNewBankDetailsJourneyEnabled && (
                 <ReimbursementPoint
                   offerer={offerer}
                   readOnly={readOnly}

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.module.scss
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.module.scss
@@ -1,5 +1,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/variables/_colors.scss" as colors;
 
 .title {
 	@include fonts.title3;
@@ -16,6 +17,35 @@
 	width: fit-content;
 }
 
-.add-bank-account-button {
+.add-bank-account-button, .spinner, .select-offerer-section {
 	margin-top: rem.torem(32px);
+}
+
+.select-offerer-input {
+	width: rem.torem(433px);
+
+	&-label {
+		margin-bottom: rem.torem(8px);
+		width: rem.torem(433px);
+	}
+}
+
+.no-offerer-selected {
+  @include fonts.title4;
+
+	display: flex;
+	flex-direction: column;
+	text-align: center;
+	justify-content: center;
+	margin: rem.torem(32px) 0;
+	
+	.repayment-icon {
+		color: colors.$grey-medium;
+		margin: 0 auto;
+	}
+
+	&-text {
+		width: rem.torem(600px);
+		margin: 0 auto;
+	}
 }

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -24,7 +24,9 @@ const BankInformations = (): JSX.Element => {
 
   const [isOffererBankAccountsLoading, setIsOffererBankAccountsLoading] =
     useState<boolean>(false)
-  const [, setSelectedOffererBankAccounts] =
+  // TODO: use bank accounts
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [selectedOffererBankAccounts, setSelectedOffererBankAccounts] =
     useState<GetOffererBankAccountsResponseModel | null>(null)
   const [searchParams, setSearchParams] = useSearchParams()
   const [isOffererLoading, setIsOffererLoading] = useState<boolean>(false)
@@ -32,12 +34,9 @@ const BankInformations = (): JSX.Element => {
   const { structure: offererId } = Object.fromEntries(searchParams)
 
   const [offererOptions, setOffererOptions] = useState<SelectOption[]>([])
-  const selectedOffererId = selectedOfferer?.id.toString() ?? ''
 
   const updateOfferer = async (newOffererId: string) => {
-    if (newOffererId === '') {
-      setSelectedOfferer(null)
-    } else {
+    if (newOffererId !== '') {
       setIsOffererLoading(true)
       const offerer = await api.getOfferer(Number(newOffererId))
       setSelectedOfferer(offerer)
@@ -49,11 +48,15 @@ const BankInformations = (): JSX.Element => {
     if (offererId && offerers && offerers?.length > 0) {
       updateOfferer(offererId)
     }
-    if (searchParams.has('structure')) {
-      searchParams.delete('structure')
-      setSearchParams(searchParams)
-    }
   }, [])
+
+  if (
+    searchParams.has('structure') &&
+    Number(offererId) === selectedOfferer?.id
+  ) {
+    searchParams.delete('structure')
+    setSearchParams(searchParams)
+  }
 
   useEffect(() => {
     if (offerers && offerers.length > 1) {
@@ -126,11 +129,10 @@ const BankInformations = (): JSX.Element => {
             </div>
             <SelectInput
               onChange={e => updateOfferer(e.target.value)}
-              id="selected-offerer"
               data-testid="select-input-offerer"
               name="offererId"
               options={offererOptions}
-              value={selectedOffererId}
+              value={selectedOfferer?.id.toString() ?? ''}
             />
           </div>
         </div>
@@ -139,6 +141,7 @@ const BankInformations = (): JSX.Element => {
         icon={fullMoreIcon}
         className={styles['add-bank-account-button']}
         variant={
+          /* istanbul ignore next : graphic changes */
           selectedOfferer &&
           selectedOfferer?.venuesWithNonFreeOffersWithoutBankAccounts.length > 0
             ? ButtonVariant.SECONDARY

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -8,12 +8,10 @@ import { SelectOption } from 'custom_types/form'
 import useNotification from 'hooks/useNotification'
 import fullLinkIcon from 'icons/full-link.svg'
 import fullMoreIcon from 'icons/full-more.svg'
-import strokeMoneyIcon from 'icons/stroke-repayment.svg'
 import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import SelectInput from 'ui-kit/form/Select/SelectInput'
 import Spinner from 'ui-kit/Spinner/Spinner'
-import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { sortByLabel } from 'utils/strings'
 
 import styles from './BankInformations.module.scss'
@@ -65,13 +63,7 @@ const BankInformations = (): JSX.Element => {
           label: item['name'],
         }))
       )
-      setOffererOptions([
-        {
-          label: 'Sélectionnez une structure',
-          value: '',
-        },
-        ...initialOffererOptions,
-      ])
+      setOffererOptions(initialOffererOptions)
     }
   }, [offerers])
 
@@ -141,37 +133,20 @@ const BankInformations = (): JSX.Element => {
               value={selectedOffererId}
             />
           </div>
-          {selectedOffererId === '' && (
-            <div className={styles['no-offerer-selected']}>
-              <SvgIcon
-                src={strokeMoneyIcon}
-                alt={''}
-                width="88"
-                className={styles['repayment-icon']}
-              />
-              <span className={styles['no-offerer-selected-text']}>
-                Sélectionnez une structure pour faire apparaitre tous les
-                comptes bancaires associés
-              </span>
-            </div>
-          )}
         </div>
       )}
-      {!(offerers && offerers?.length > 1 && selectedOffererId === '') && (
-        <Button
-          icon={fullMoreIcon}
-          className={styles['add-bank-account-button']}
-          variant={
-            selectedOfferer &&
-            selectedOfferer?.venuesWithNonFreeOffersWithoutBankAccounts.length >
-              0
-              ? ButtonVariant.SECONDARY
-              : ButtonVariant.PRIMARY
-          }
-        >
-          Ajouter un compte bancaire
-        </Button>
-      )}
+      <Button
+        icon={fullMoreIcon}
+        className={styles['add-bank-account-button']}
+        variant={
+          selectedOfferer &&
+          selectedOfferer?.venuesWithNonFreeOffersWithoutBankAccounts.length > 0
+            ? ButtonVariant.SECONDARY
+            : ButtonVariant.PRIMARY
+        }
+      >
+        Ajouter un compte bancaire
+      </Button>
     </>
   )
 }

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -1,33 +1,31 @@
-import { screen, waitForElementToBeRemoved } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import React from "react";
-import { Routes, Route } from "react-router-dom";
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Route, Routes } from 'react-router-dom'
 
-import { api } from "apiClient/api";
-import Notification from "components/Notification/Notification";
+import { api } from 'apiClient/api'
+import Notification from 'components/Notification/Notification'
 import {
   ReimbursementContext,
-  ReimbursementContextValues
-} from "context/ReimbursementContext/ReimbursementContext";
-import { defautGetOffererResponseModel } from "utils/apiFactories";
-import { renderWithProviders } from "utils/renderWithProviders";
+  ReimbursementContextValues,
+} from 'context/ReimbursementContext/ReimbursementContext'
+import { defautGetOffererResponseModel } from 'utils/apiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
-import BankInformations from "../BankInformations";
+import BankInformations from '../BankInformations'
 
 const renderBankInformations = (
   customContext: Partial<ReimbursementContextValues> = {},
   storeOverrides: any,
-  initialRouterEntriesOverrides = "/remboursements/informations-bancaires"
+  initialRouterEntriesOverrides = '/remboursements/informations-bancaires'
 ) => {
   const contextValues: ReimbursementContextValues = {
     offerers: [],
     selectedOfferer: null,
-    setOfferers: () => {
-    },
-    setSelectedOfferer: () => {
-    },
-    ...customContext
-  };
+    setOfferers: () => {},
+    setSelectedOfferer: () => {},
+    ...customContext,
+  }
   renderWithProviders(
     <>
       <ReimbursementContext.Provider value={contextValues}>
@@ -43,205 +41,194 @@ const renderBankInformations = (
     </>,
     {
       storeOverrides,
-      initialRouterEntries: [initialRouterEntriesOverrides]
+      initialRouterEntries: [initialRouterEntriesOverrides],
     }
-  );
-};
+  )
+}
 
-describe("BankInformations page", () => {
-  let store: any;
-  let customContext: Partial<ReimbursementContextValues>;
+describe('BankInformations page', () => {
+  let store: any
+  let customContext: Partial<ReimbursementContextValues>
 
   beforeEach(() => {
     store = {
       user: {
         currentUser: {
-          isAdmin: false
+          isAdmin: false,
         },
-        initialized: true
-      }
-    };
+        initialized: true,
+      },
+    }
 
     customContext = {
       selectedOfferer: {
         ...defautGetOffererResponseModel,
-        hasValidBankAccount: false
+        hasValidBankAccount: false,
       },
       offerers: [
         {
-          ...defautGetOffererResponseModel
-        }
-      ]
-    };
+          ...defautGetOffererResponseModel,
+        },
+        {
+          ...defautGetOffererResponseModel,
+          id: 2,
+          name: 'second offerer',
+        },
+      ],
+    }
 
-    vi.spyOn(api, "getOffererBankAccountsAndAttachedVenues").mockResolvedValue({
+    vi.spyOn(api, 'getOffererBankAccountsAndAttachedVenues').mockResolvedValue({
       id: 1,
       bankAccounts: [],
-      managedVenues: []
-    });
-  });
+      managedVenues: [],
+    })
+  })
 
-  it("should has not validated bank account message", async () => {
-    renderBankInformations(customContext, store);
+  it('should not display validated bank account message', async () => {
+    renderBankInformations(customContext, store)
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-    expect(screen.getByText("Informations bancaires")).toBeInTheDocument();
+    expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
     expect(
       screen.getByText(
-        "Ajoutez au moins un compte bancaire pour percevoir vos remboursements."
+        'Ajoutez au moins un compte bancaire pour percevoir vos remboursements.'
       )
-    ).toBeInTheDocument();
-    expect(screen.getByText("Ajouter un compte bancaire")).toBeInTheDocument();
-    expect(screen.getByText("En savoir plus")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Structure")).not.toBeInTheDocument();
-  });
+    ).toBeInTheDocument()
+    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
+    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Structure')).not.toBeInTheDocument()
+  })
 
-  it("should render message when the user has a valid bank account and no pending one", async () => {
+  it('should render message when the user has a valid bank account and no pending one', async () => {
     if (customContext.selectedOfferer) {
       customContext.selectedOfferer = {
         ...customContext.selectedOfferer,
-        hasValidBankAccount: true
-      };
+        hasValidBankAccount: true,
+      }
     }
-    renderBankInformations(customContext, store);
+    renderBankInformations(customContext, store)
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-    expect(screen.getByText("Informations bancaires")).toBeInTheDocument();
+    expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
     expect(
       screen.queryByText(
-        "Ajoutez au moins un compte bancaire pour percevoir vos remboursements."
+        'Ajoutez au moins un compte bancaire pour percevoir vos remboursements.'
       )
-    ).not.toBeInTheDocument();
+    ).not.toBeInTheDocument()
     expect(
       screen.getByText(
         "Vous pouvez ajouter plusieurs comptes bancaires afin de percevoir les remboursements de vos offres. Chaque compte bancaire fera l'objet d'un remboursement et d'un justificatif de remboursement distincts."
       )
-    ).toBeInTheDocument();
-    expect(screen.getByText("Ajouter un compte bancaire")).toBeInTheDocument();
-    expect(screen.getByText("En savoir plus")).toBeInTheDocument();
-  });
+    ).toBeInTheDocument()
+    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
+    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
+  })
 
-  it("should render message when has a pending bank account and no valid one", async () => {
+  it('should render message when has a pending bank account and no valid one', async () => {
     if (customContext.selectedOfferer) {
       customContext.selectedOfferer = {
         ...customContext.selectedOfferer,
-        hasPendingBankAccount: true
-      };
+        hasPendingBankAccount: true,
+      }
     }
-    renderBankInformations(customContext, store);
+    renderBankInformations(customContext, store)
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-    expect(screen.getByText("Informations bancaires")).toBeInTheDocument();
+    expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
     expect(
       screen.queryByText(
-        "Ajoutez au moins un compte bancaire pour percevoir vos remboursements."
+        'Ajoutez au moins un compte bancaire pour percevoir vos remboursements.'
       )
-    ).not.toBeInTheDocument();
+    ).not.toBeInTheDocument()
     expect(
       screen.getByText(
         "Vous pouvez ajouter plusieurs comptes bancaires afin de percevoir les remboursements de vos offres. Chaque compte bancaire fera l'objet d'un remboursement et d'un justificatif de remboursement distincts."
       )
-    ).toBeInTheDocument();
-    expect(screen.getByText("Ajouter un compte bancaire")).toBeInTheDocument();
-    expect(screen.getByText("En savoir plus")).toBeInTheDocument();
-  });
+    ).toBeInTheDocument()
+    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
+    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
+  })
 
-  it("should render default page if error on getOffererBankAccountsAndAttachedVenues request", async () => {
+  it('should render default page if error on getOffererBankAccountsAndAttachedVenues request', async () => {
     vi.spyOn(
       api,
-      "getOffererBankAccountsAndAttachedVenues"
-    ).mockRejectedValueOnce({});
+      'getOffererBankAccountsAndAttachedVenues'
+    ).mockRejectedValueOnce({})
 
-    renderBankInformations(customContext, store);
+    renderBankInformations(customContext, store)
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
-
-    expect(api.getOffererBankAccountsAndAttachedVenues).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("Informations bancaires")).toBeInTheDocument()
-    << <
-    <
-    <
-    << HEAD
-      expect(
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+    expect(api.getOffererBankAccountsAndAttachedVenues).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
+    expect(
       screen.getByText(
-        "Impossible de récupérer les informations relatives à vos comptes bancaires."
-      );
-  ).
-    toBeInTheDocument()
-    === === =
-      it(
-        "should render message when hasValidBankAccount and hasPendingBankAccount"
-      );
+        'Impossible de récupérer les informations relatives à vos comptes bancaires.'
+      )
+    ).toBeInTheDocument()
+  })
 
-    it("should render with default offerer select and update render on select element", async () => {
-      vi.spyOn(api, "listOfferersNames").mockResolvedValue({
-        offerersNames: [
-          {
-            id: 1,
-            name: "first offerer"
-          },
-          {
-            id: 2,
-            name: "second offerer"
-          }
-        ]
-      });
-      renderBankInformations(customContext, store);
-      await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
-
-      const selectInput = screen.getByTestId("select-input-offerer");
-      expect(
-        screen.getByDisplayValue("Sélectionnez une structure")
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          "Sélectionnez une structure pour faire apparaitre tous les comptes bancaires associés"
-        )
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByText("Ajouter un compte bancaire")
-      ).not.toBeInTheDocument();
-
-      await userEvent.selectOptions(selectInput, "second offerer");
-
-      expect(screen.getByText("second offerer")).toBeInTheDocument();
-
-      expect(
-        screen.queryByText(
-          "Sélectionnez une structure pour faire apparaitre tous les comptes bancaires associés"
-        )
-      ).not.toBeInTheDocument();
-      expect(screen.getByText("Ajouter un compte bancaire")).toBeInTheDocument();
-    });
-
-    it("should render select input with correct offerer if url has offerer parameter", async () => {
-      vi.spyOn(api, "listOfferersNames").mockResolvedValue({
-        offerersNames: [
-          {
-            id: 1,
-            name: "first offerer"
-          },
-          {
-            id: 2,
-            name: "second offerer"
-          }
-        ]
-      });
-      renderBankInformations(
-        store,
-        "/remboursements/informations-bancaires?struture=2"
-      );
-      await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
-      expect(screen.getByText("second offerer")).toBeInTheDocument();
+  it('should render with default offerer select and update render on select element', async () => {
+    vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
+      offerersNames: [
+        {
+          id: 1,
+          name: 'first offerer',
+        },
+        {
+          id: 2,
+          name: 'second offerer',
+        },
+      ],
     })
-    >>> >>> > b05d35a27f((PC - 24342)[PRO]
-    feat: add;
-    offerer;
-    filter in BankInformations;
-    component;
-  )
-  });
-});
+    renderBankInformations(customContext, store)
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+    const selectInput = screen.getByTestId('select-input-offerer')
+    expect(
+      screen.getByDisplayValue('Sélectionnez une structure')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Sélectionnez une structure pour faire apparaitre tous les comptes bancaires associés'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Ajouter un compte bancaire')
+    ).not.toBeInTheDocument()
+
+    await userEvent.selectOptions(selectInput, 'second offerer')
+
+    expect(screen.getByText('second offerer')).toBeInTheDocument()
+
+    expect(
+      screen.queryByText(
+        'Sélectionnez une structure pour faire apparaitre tous les comptes bancaires associés'
+      )
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
+  })
+
+  it('should render select input with correct offerer if url has offerer parameter', async () => {
+    vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
+      offerersNames: [
+        {
+          id: 1,
+          name: 'first offerer',
+        },
+        {
+          id: 2,
+          name: 'second offerer',
+        },
+      ],
+    })
+    renderBankInformations(
+      store,
+      '/remboursements/informations-bancaires?struture=2'
+    )
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+    expect(screen.getByText('second offerer')).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -1,7 +1,6 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
-import { Route, Routes } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { GetOffererResponseModel } from 'apiClient/v1'
@@ -17,7 +16,6 @@ import BankInformations from '../BankInformations'
 
 const renderBankInformations = (
   customContext: Partial<ReimbursementContextValues> = {},
-  storeOverrides: any,
   initialRouterEntriesOverrides = '/remboursements/informations-bancaires'
 ) => {
   const contextValues: ReimbursementContextValues = {
@@ -30,18 +28,11 @@ const renderBankInformations = (
   renderWithProviders(
     <>
       <ReimbursementContext.Provider value={contextValues}>
-        <Routes>
-          <Route
-            path="/remboursements/informations-bancaires"
-            element={<BankInformations />}
-          />
-          <BankInformations />
-        </Routes>
+        <BankInformations />
       </ReimbursementContext.Provider>
       <Notification />
     </>,
     {
-      storeOverrides,
       initialRouterEntries: [initialRouterEntriesOverrides],
     }
   )
@@ -72,6 +63,7 @@ describe('BankInformations page', () => {
       offerers: [
         {
           ...defautGetOffererResponseModel,
+          name: 'first offerer',
         },
         {
           ...defautGetOffererResponseModel,
@@ -103,7 +95,6 @@ describe('BankInformations page', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
     expect(screen.getByText('En savoir plus')).toBeInTheDocument()
-    expect(screen.queryByLabelText('Structure')).not.toBeInTheDocument()
   })
 
   it('should render message when the user has a valid bank account and no pending one', async () => {
@@ -177,18 +168,6 @@ describe('BankInformations page', () => {
   })
 
   it('should render with default offerer select and update render on select element', async () => {
-    vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
-      offerersNames: [
-        {
-          id: 1,
-          name: 'first offerer',
-        },
-        {
-          id: 2,
-          name: 'second offerer',
-        },
-      ],
-    })
     renderBankInformations(customContext, store)
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
@@ -209,23 +188,13 @@ describe('BankInformations page', () => {
   })
 
   it('should render select input with correct offerer if url has offerer parameter', async () => {
-    vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
-      offerersNames: [
-        {
-          id: 1,
-          name: 'first offerer',
-        },
-        {
-          id: 2,
-          name: 'second offerer',
-        },
-      ],
-    })
     renderBankInformations(
-      store,
+      customContext,
       '/remboursements/informations-bancaires?struture=2'
     )
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+    expect(api.getOffererBankAccountsAndAttachedVenues).toHaveBeenCalledTimes(1)
     expect(screen.getByText('second offerer')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -1,157 +1,247 @@
-import { screen, waitForElementToBeRemoved } from '@testing-library/react'
-import React from 'react'
+import { screen, waitForElementToBeRemoved } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Routes, Route } from "react-router-dom";
 
-import { api } from 'apiClient/api'
-import Notification from 'components/Notification/Notification'
+import { api } from "apiClient/api";
+import Notification from "components/Notification/Notification";
 import {
   ReimbursementContext,
-  ReimbursementContextValues,
-} from 'context/ReimbursementContext/ReimbursementContext'
-import { defautGetOffererResponseModel } from 'utils/apiFactories'
-import { renderWithProviders } from 'utils/renderWithProviders'
+  ReimbursementContextValues
+} from "context/ReimbursementContext/ReimbursementContext";
+import { defautGetOffererResponseModel } from "utils/apiFactories";
+import { renderWithProviders } from "utils/renderWithProviders";
 
-import BankInformations from '../BankInformations'
+import BankInformations from "../BankInformations";
 
 const renderBankInformations = (
   customContext: Partial<ReimbursementContextValues> = {},
-  storeOverrides: any
+  storeOverrides: any,
+  initialRouterEntriesOverrides = "/remboursements/informations-bancaires"
 ) => {
   const contextValues: ReimbursementContextValues = {
     offerers: [],
     selectedOfferer: null,
-    setOfferers: () => {},
-    setSelectedOfferer: () => {},
-    ...customContext,
-  }
+    setOfferers: () => {
+    },
+    setSelectedOfferer: () => {
+    },
+    ...customContext
+  };
   renderWithProviders(
     <>
       <ReimbursementContext.Provider value={contextValues}>
-        <BankInformations />
+        <Routes>
+          <Route
+            path="/remboursements/informations-bancaires"
+            element={<BankInformations />}
+          />
+          <BankInformations />
+        </Routes>
       </ReimbursementContext.Provider>
       <Notification />
     </>,
     {
       storeOverrides,
+      initialRouterEntries: [initialRouterEntriesOverrides]
     }
-  )
-}
+  );
+};
 
-describe('BankInformations page', () => {
-  let store: any
-  let customContext: Partial<ReimbursementContextValues>
+describe("BankInformations page", () => {
+  let store: any;
+  let customContext: Partial<ReimbursementContextValues>;
 
   beforeEach(() => {
     store = {
       user: {
         currentUser: {
-          isAdmin: false,
+          isAdmin: false
         },
-        initialized: true,
-      },
-    }
+        initialized: true
+      }
+    };
 
     customContext = {
       selectedOfferer: {
         ...defautGetOffererResponseModel,
-        hasValidBankAccount: false,
+        hasValidBankAccount: false
       },
       offerers: [
         {
-          ...defautGetOffererResponseModel,
-        },
-      ],
-    }
+          ...defautGetOffererResponseModel
+        }
+      ]
+    };
 
-    vi.spyOn(api, 'getOffererBankAccountsAndAttachedVenues').mockResolvedValue({
+    vi.spyOn(api, "getOffererBankAccountsAndAttachedVenues").mockResolvedValue({
       id: 1,
       bankAccounts: [],
-      managedVenues: [],
-    })
-  })
+      managedVenues: []
+    });
+  });
 
-  it('should has not validated bank account message', async () => {
-    renderBankInformations(customContext, store)
+  it("should has not validated bank account message", async () => {
+    renderBankInformations(customContext, store);
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
 
-    expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
+    expect(screen.getByText("Informations bancaires")).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Ajoutez au moins un compte bancaire pour percevoir vos remboursements.'
+        "Ajoutez au moins un compte bancaire pour percevoir vos remboursements."
       )
-    ).toBeInTheDocument()
-    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
-    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
-  })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ajouter un compte bancaire")).toBeInTheDocument();
+    expect(screen.getByText("En savoir plus")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Structure")).not.toBeInTheDocument();
+  });
 
-  it('should render message when the user has a valid bank account and no pending one', async () => {
+  it("should render message when the user has a valid bank account and no pending one", async () => {
     if (customContext.selectedOfferer) {
       customContext.selectedOfferer = {
         ...customContext.selectedOfferer,
-        hasValidBankAccount: true,
-      }
+        hasValidBankAccount: true
+      };
     }
-    renderBankInformations(customContext, store)
+    renderBankInformations(customContext, store);
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
 
-    expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
+    expect(screen.getByText("Informations bancaires")).toBeInTheDocument();
     expect(
       screen.queryByText(
-        'Ajoutez au moins un compte bancaire pour percevoir vos remboursements.'
+        "Ajoutez au moins un compte bancaire pour percevoir vos remboursements."
       )
-    ).not.toBeInTheDocument()
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText(
         "Vous pouvez ajouter plusieurs comptes bancaires afin de percevoir les remboursements de vos offres. Chaque compte bancaire fera l'objet d'un remboursement et d'un justificatif de remboursement distincts."
       )
-    ).toBeInTheDocument()
-    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
-    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
-  })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ajouter un compte bancaire")).toBeInTheDocument();
+    expect(screen.getByText("En savoir plus")).toBeInTheDocument();
+  });
 
-  it('should render message when has a pending bank account and no valid one', async () => {
+  it("should render message when has a pending bank account and no valid one", async () => {
     if (customContext.selectedOfferer) {
       customContext.selectedOfferer = {
         ...customContext.selectedOfferer,
-        hasPendingBankAccount: true,
-      }
+        hasPendingBankAccount: true
+      };
     }
-    renderBankInformations(customContext, store)
+    renderBankInformations(customContext, store);
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
 
-    expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
+    expect(screen.getByText("Informations bancaires")).toBeInTheDocument();
     expect(
       screen.queryByText(
-        'Ajoutez au moins un compte bancaire pour percevoir vos remboursements.'
+        "Ajoutez au moins un compte bancaire pour percevoir vos remboursements."
       )
-    ).not.toBeInTheDocument()
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText(
         "Vous pouvez ajouter plusieurs comptes bancaires afin de percevoir les remboursements de vos offres. Chaque compte bancaire fera l'objet d'un remboursement et d'un justificatif de remboursement distincts."
       )
-    ).toBeInTheDocument()
-    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
-    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
-  })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ajouter un compte bancaire")).toBeInTheDocument();
+    expect(screen.getByText("En savoir plus")).toBeInTheDocument();
+  });
 
-  it('should render default page if error on getOffererBankAccountsAndAttachedVenues request', async () => {
+  it("should render default page if error on getOffererBankAccountsAndAttachedVenues request", async () => {
     vi.spyOn(
       api,
-      'getOffererBankAccountsAndAttachedVenues'
-    ).mockRejectedValueOnce({})
+      "getOffererBankAccountsAndAttachedVenues"
+    ).mockRejectedValueOnce({});
 
-    renderBankInformations(customContext, store)
+    renderBankInformations(customContext, store);
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
 
-    expect(api.getOffererBankAccountsAndAttachedVenues).toHaveBeenCalledTimes(1)
-    expect(screen.getByText('Informations bancaires')).toBeInTheDocument()
-    expect(
+    expect(api.getOffererBankAccountsAndAttachedVenues).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Informations bancaires")).toBeInTheDocument()
+    << <
+    <
+    <
+    << HEAD
+      expect(
       screen.getByText(
-        'Impossible de récupérer les informations relatives à vos comptes bancaires.'
-      )
-    ).toBeInTheDocument()
-  })
-})
+        "Impossible de récupérer les informations relatives à vos comptes bancaires."
+      );
+  ).
+    toBeInTheDocument()
+    === === =
+      it(
+        "should render message when hasValidBankAccount and hasPendingBankAccount"
+      );
+
+    it("should render with default offerer select and update render on select element", async () => {
+      vi.spyOn(api, "listOfferersNames").mockResolvedValue({
+        offerersNames: [
+          {
+            id: 1,
+            name: "first offerer"
+          },
+          {
+            id: 2,
+            name: "second offerer"
+          }
+        ]
+      });
+      renderBankInformations(customContext, store);
+      await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
+
+      const selectInput = screen.getByTestId("select-input-offerer");
+      expect(
+        screen.getByDisplayValue("Sélectionnez une structure")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Sélectionnez une structure pour faire apparaitre tous les comptes bancaires associés"
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Ajouter un compte bancaire")
+      ).not.toBeInTheDocument();
+
+      await userEvent.selectOptions(selectInput, "second offerer");
+
+      expect(screen.getByText("second offerer")).toBeInTheDocument();
+
+      expect(
+        screen.queryByText(
+          "Sélectionnez une structure pour faire apparaitre tous les comptes bancaires associés"
+        )
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Ajouter un compte bancaire")).toBeInTheDocument();
+    });
+
+    it("should render select input with correct offerer if url has offerer parameter", async () => {
+      vi.spyOn(api, "listOfferersNames").mockResolvedValue({
+        offerersNames: [
+          {
+            id: 1,
+            name: "first offerer"
+          },
+          {
+            id: 2,
+            name: "second offerer"
+          }
+        ]
+      });
+      renderBankInformations(
+        store,
+        "/remboursements/informations-bancaires?struture=2"
+      );
+      await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
+      expect(screen.getByText("second offerer")).toBeInTheDocument();
+    })
+    >>> >>> > b05d35a27f((PC - 24342)[PRO]
+    feat: add;
+    offerer;
+    filter in BankInformations;
+    component;
+  )
+  });
+});

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
+import { GetOffererResponseModel } from 'apiClient/v1'
 import Notification from 'components/Notification/Notification'
 import {
   ReimbursementContext,
@@ -49,6 +50,7 @@ const renderBankInformations = (
 describe('BankInformations page', () => {
   let store: any
   let customContext: Partial<ReimbursementContextValues>
+  let offerer: GetOffererResponseModel
 
   beforeEach(() => {
     store = {
@@ -60,11 +62,13 @@ describe('BankInformations page', () => {
       },
     }
 
+    offerer = {
+      ...defautGetOffererResponseModel,
+      hasValidBankAccount: false,
+    }
+
     customContext = {
-      selectedOfferer: {
-        ...defautGetOffererResponseModel,
-        hasValidBankAccount: false,
-      },
+      selectedOfferer: offerer,
       offerers: [
         {
           ...defautGetOffererResponseModel,
@@ -82,6 +86,8 @@ describe('BankInformations page', () => {
       bankAccounts: [],
       managedVenues: [],
     })
+
+    vi.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
   })
 
   it('should not display validated bank account message', async () => {
@@ -187,17 +193,8 @@ describe('BankInformations page', () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
     const selectInput = screen.getByTestId('select-input-offerer')
-    expect(
-      screen.getByDisplayValue('Sélectionnez une structure')
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'Sélectionnez une structure pour faire apparaitre tous les comptes bancaires associés'
-      )
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText('Ajouter un compte bancaire')
-    ).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('first offerer')).toBeInTheDocument()
+    expect(screen.queryByText('Ajouter un compte bancaire')).toBeInTheDocument()
 
     await userEvent.selectOptions(selectInput, 'second offerer')
 

--- a/pro/src/pages/Reimbursements/Reimbursements.tsx
+++ b/pro/src/pages/Reimbursements/Reimbursements.tsx
@@ -19,7 +19,7 @@ import Spinner from 'ui-kit/Spinner/Spinner'
 import Titles from 'ui-kit/Titles/Titles'
 
 const Reimbursements = (): JSX.Element => {
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
 
@@ -27,7 +27,7 @@ const Reimbursements = (): JSX.Element => {
 
   const { setOfferers, setSelectedOfferer } = useReimbursementContext()
 
-  const routes = isNewBankDetailsJourneyEnable
+  const routes = isNewBankDetailsJourneyEnabled
     ? routesReimbursements
     : oldRoutesReimbursements
 
@@ -37,7 +37,7 @@ const Reimbursements = (): JSX.Element => {
       try {
         const { offerersNames } = await api.listOfferersNames()
         setOfferers(offerersNames)
-        if (offerersNames.length >= 0) {
+        if (offerersNames.length >= 1) {
           const offerer = await api.getOfferer(offerersNames[0].id)
           setSelectedOfferer(offerer)
         }
@@ -46,12 +46,12 @@ const Reimbursements = (): JSX.Element => {
         setIsOfferersLoading(false)
       }
     }
-    if (isNewBankDetailsJourneyEnable) {
+    if (isNewBankDetailsJourneyEnabled) {
       fetchData()
     }
   }, [])
 
-  if (isOfferersLoading && isNewBankDetailsJourneyEnable) {
+  if (isOfferersLoading && isNewBankDetailsJourneyEnabled) {
     return <Spinner />
   }
 
@@ -59,7 +59,7 @@ const Reimbursements = (): JSX.Element => {
     <>
       <Titles title="Remboursements" />
       <>
-        {!isNewBankDetailsJourneyEnable && (
+        {!isNewBankDetailsJourneyEnabled && (
           <>
             {/* TODO: displaying condition when offerer is available here. (Done in another branch)*/}
             <AddBankAccountCallout titleOnly={true} />

--- a/pro/src/pages/Reimbursements/Reimbursements.tsx
+++ b/pro/src/pages/Reimbursements/Reimbursements.tsx
@@ -37,7 +37,7 @@ const Reimbursements = (): JSX.Element => {
       try {
         const { offerersNames } = await api.listOfferersNames()
         setOfferers(offerersNames)
-        if (offerersNames.length > 0) {
+        if (offerersNames.length >= 0) {
           const offerer = await api.getOfferer(offerersNames[0].id)
           setSelectedOfferer(offerer)
         }

--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/ReimbursementsInvoices.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/ReimbursementsInvoices.tsx
@@ -25,7 +25,7 @@ import { InvoiceTable } from './InvoiceTable'
 import NoInvoicesYet from './NoInvoicesYet'
 
 const ReimbursementsInvoices = (): JSX.Element => {
-  const isNewBankDetailsJourneyEnable = useActiveFeature(
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
   const ALL_REIMBURSEMENT_POINT_OPTION_ID = 'all'
@@ -159,7 +159,7 @@ const ReimbursementsInvoices = (): JSX.Element => {
   if (reimbursementPointsOptions.length === 0) {
     return (
       <div className="no-refunds">
-        {isNewBankDetailsJourneyEnable && <BannerReimbursementsInfo />}
+        {isNewBankDetailsJourneyEnabled && <BannerReimbursementsInfo />}
         <SvgIcon
           src={strokeNoBookingIcon}
           alt=""
@@ -173,7 +173,7 @@ const ReimbursementsInvoices = (): JSX.Element => {
   }
   return (
     <>
-      {isNewBankDetailsJourneyEnable && <BannerReimbursementsInfo />}
+      {isNewBankDetailsJourneyEnabled && <BannerReimbursementsInfo />}
       <InvoicesFilters
         areFiltersDefault={areFiltersDefault}
         filters={filters}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24342

Ajouter un filtre sur la page informations-bancaires pour séléctionner une structure et mettre à jour les informations.

Activer le FF: WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY
url: remboursements/informations-bancaires

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/9942c3a9-e299-4809-a9dd-4fe54b2874b0)

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/f003361e-cbb5-4cc4-9841-7563b76cea6e)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques