### PR TITLE
(PC-24788)[BO] feat: In AE tab, use Adage tag instead of individual/collective switches

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 14e9b22809ef (pre) (head)
-12e531343466 (post) (head)
+ba42ea4318a0 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230929T140843_ba42ea4318a0_patch_individual_offerer_subscription.py
+++ b/api/src/pcapi/alembic/versions/20230929T140843_ba42ea4318a0_patch_individual_offerer_subscription.py
@@ -1,0 +1,40 @@
+"""Finally remove targetsCollectiveOffers and targetsIndividualOffers from individual_offerer_subscription table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "ba42ea4318a0"
+down_revision = "12e531343466"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("individual_offerer_subscription", "targetsCollectiveOffers")
+    op.drop_column("individual_offerer_subscription", "targetsIndividualOffers")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "individual_offerer_subscription",
+        sa.Column(
+            "targetsIndividualOffers",
+            sa.BOOLEAN(),
+            server_default=sa.text("false"),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "individual_offerer_subscription",
+        sa.Column(
+            "targetsCollectiveOffers",
+            sa.BOOLEAN(),
+            server_default=sa.text("false"),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -1060,13 +1060,6 @@ class IndividualOffererSubscription(PcObject, Base, Model):
     isEmailSent: bool = sa.Column(sa.Boolean, nullable=False, server_default=sa.sql.expression.false(), default=False)
     dateEmailSent: date | None = sa.Column(sa.Date, nullable=True)
 
-    targetsCollectiveOffers: bool = sa.Column(
-        sa.Boolean, nullable=False, server_default=sa.sql.expression.false(), default=False
-    )
-    targetsIndividualOffers: bool = sa.Column(
-        sa.Boolean, nullable=False, server_default=sa.sql.expression.false(), default=False
-    )
-
     isCriminalRecordReceived: bool = sa.Column(
         sa.Boolean, nullable=False, server_default=sa.sql.expression.false(), default=False
     )

--- a/api/src/pcapi/routes/backoffice/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offerers/forms.py
@@ -248,8 +248,6 @@ class CreateOffererTagCategoryForm(OffererTagBaseForm):
 class IndividualOffererSubscriptionForm(FlaskForm):
     is_email_sent = fields.PCSwitchBooleanField("Mail envoyé à l'acteur", full_width=True)
     date_email_sent = fields.PCOptDateField("Date d'envoi")
-    collective_offers = fields.PCSwitchBooleanField("Collectif", full_width=True)
-    individual_offers = fields.PCSwitchBooleanField("Individuel", full_width=True)
     is_criminal_record_received = fields.PCSwitchBooleanField("Casier judiciaire reçu", full_width=True)
     date_criminal_record_received = fields.PCOptDateField("Date de réception")
     is_certificate_received = fields.PCSwitchBooleanField("Diplôme reçu", full_width=True)

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -530,6 +530,7 @@ def get_individual_subscription(offerer_id: int) -> utils.BackofficeResponse:
                 educational_models.CollectiveDmsApplication.state,
                 educational_models.CollectiveDmsApplication.lastChangeDate,
             ),
+            sa.orm.joinedload(offerers_models.Offerer.tags),
         )
         .one_or_none()
     )
@@ -542,8 +543,6 @@ def get_individual_subscription(offerer_id: int) -> utils.BackofficeResponse:
         form = offerer_forms.IndividualOffererSubscriptionForm(
             is_email_sent=individual_subscription.isEmailSent,
             date_email_sent=individual_subscription.dateEmailSent,
-            collective_offers=individual_subscription.targetsCollectiveOffers,
-            individual_offers=individual_subscription.targetsIndividualOffers,
             is_criminal_record_received=individual_subscription.isCriminalRecordReceived,
             date_criminal_record_received=individual_subscription.dateCriminalRecordReceived,
             is_certificate_received=individual_subscription.isCertificateReceived,
@@ -574,6 +573,7 @@ def get_individual_subscription(offerer_id: int) -> utils.BackofficeResponse:
         "offerer/get/details/individual_subscription.html",
         individual_subscription=individual_subscription,
         adage_decision=adage_decision,
+        has_adage_tag=any(tag.name == "adage" for tag in offerer.tags),
         form=form,
         dst=url_for("backoffice_web.offerer.update_individual_subscription", offerer_id=offerer_id),
     )
@@ -603,8 +603,6 @@ def update_individual_subscription(offerer_id: int) -> utils.BackofficeResponse:
     data = {
         "isEmailSent": form.is_email_sent.data,
         "dateEmailSent": form.date_email_sent.data,
-        "targetsCollectiveOffers": form.collective_offers.data,
-        "targetsIndividualOffers": form.individual_offers.data,
         "isCriminalRecordReceived": form.is_criminal_record_received.data,
         "dateCriminalRecordReceived": form.date_criminal_record_received.data,
         "isCertificateReceived": form.is_certificate_received.data,

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/individual_subscription.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/individual_subscription.html
@@ -43,7 +43,7 @@
             {{ build_step("Casier judiciaire", "bi-person-vcard", "bi-check-circle-fill text-success" if individual_subscription.isCriminalRecordReceived else ("bi-exclamation-circle-fill text-warning" if individual_subscription), "step-success" if individual_subscription.isCriminalRecordReceived) }}
             {{ build_step("Diplômes", "bi-mortarboard-fill", "bi-check-circle-fill text-success" if individual_subscription.isCertificateReceived else ("bi-exclamation-circle-fill text-warning" if individual_subscription), "step-success" if individual_subscription.isCertificateReceived) }}
             {{ build_step("Certifications professionnelles", "bi-box-fill", "bi-check-circle-fill text-success" if individual_subscription.isExperienceReceived else ("bi-exclamation-circle-fill text-warning" if individual_subscription), "step-success" if individual_subscription.isExperienceReceived) }}
-            {% if individual_subscription.targetsCollectiveOffers %}
+            {% if has_adage_tag or adage_decision %}
               {% if adage_decision == "accepte" %}
                 {{ build_step("Référencement Adage", "bi-briefcase-fill", "bi-check-circle-fill text-success", "step-success") }}
               {% elif adage_decision == "refuse" %}
@@ -71,19 +71,19 @@
         {{ form.is_email_sent }}
         {{ form.date_email_sent }}
       </div>
-      <p class="fw-bold pt-4">Activités</p>
-      <div class="px-3">
-        {{ form.collective_offers }}
-        {{ form.individual_offers }}
-      </div>
-    </div>
-    <div class="col-4">
-      <p class="fw-bold pt-2">Réception du casier judiciaire</p>
+      <p class="fw-bold pt-4">Réception du casier judiciaire</p>
       <div class="px-3">
         {{ form.is_criminal_record_received }}
         {{ form.date_criminal_record_received }}
       </div>
-      <p class="fw-bold pt-4">Diplômes</p>
+      <div class="pt-5 pb-3 px-3">
+        {{ form.csrf_token }}
+        <button type="submit"
+                class="btn btn-primary">Enregistrer</button>
+      </div>
+    </div>
+    <div class="col-4">
+      <p class="fw-bold pt-2">Diplômes</p>
       <div class="px-3">
         {{ form.is_certificate_received }}
         {% set documents_link = get_setting("BACKOFFICE_OFFERERS_DOCUMENTS_LINK") %}
@@ -107,11 +107,6 @@
         </div>
         {{ form.experience_details }}
         {{ form.is_certificate_valid }}
-      </div>
-      <div class="pt-5 pb-3 px-3">
-        {{ form.csrf_token }}
-        <button type="submit"
-                class="btn btn-primary">Enregistrer</button>
       </div>
     </div>
   </form>

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_individual_offerers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_individual_offerers.py
@@ -14,6 +14,7 @@ def create_industrial_individual_offerers() -> None:
     logger.info("create_industrial_individual_offerers")
 
     ae_tag = offerers_models.OffererTag.query.filter_by(name="auto-entrepreneur").one()
+    adage_tag = offerers_models.OffererTag.query.filter_by(name="adage").one()
 
     # offerer with tag but subscription row not yet created
     offerer = offerers_factories.NotValidatedOffererFactory(name="JOE DALTON", tags=[ae_tag])
@@ -37,22 +38,20 @@ def create_industrial_individual_offerers() -> None:
     # individual offerer with Adage application submitted
     offerer = offerers_factories.NotValidatedOffererFactory(
         name="WILLIAM DALTON",
-        tags=[ae_tag],
+        tags=[ae_tag, adage_tag],
         validationStatus=ValidationStatus.PENDING,
     )
     venue = offerers_factories.VenueFactory(name="WILLIAM DALTON", managingOfferer=offerer)
     offerers_factories.UserOffererFactory(
         offerer=offerer, user__firstName="William", user__lastName="Dalton", user__email="william.dalton@example.com"
     )
-    offerers_factories.IndividualOffererSubscription(
-        offerer=offerer, targetsCollectiveOffers=True, targetsIndividualOffers=True
-    )
+    offerers_factories.IndividualOffererSubscription(offerer=offerer)
     educational_factories.CollectiveDmsApplicationFactory(venue=venue, state="en_instruction")
 
     # individual offerer with Adage application accepted and everything received
     offerer = offerers_factories.NotValidatedOffererFactory(
         name="AVERELL DALTON",
-        tags=[ae_tag],
+        tags=[ae_tag, adage_tag],
         validationStatus=ValidationStatus.PENDING,
     )
     venue = offerers_factories.VenueFactory(name="AVERELL DALTON", managingOfferer=offerer)
@@ -61,8 +60,6 @@ def create_industrial_individual_offerers() -> None:
     )
     offerers_factories.IndividualOffererSubscription(
         offerer=offerer,
-        targetsCollectiveOffers=True,
-        targetsIndividualOffers=False,
         isCriminalRecordReceived=True,
         dateCriminalRecordReceived=datetime.date.today() - datetime.timedelta(days=1),
         isCertificateReceived=True,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerer_tags.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerer_tags.py
@@ -27,3 +27,4 @@ def create_industrial_offerer_tags() -> None:
     )
     offerers_factories.OffererTagFactory(name="partenaire-national", label="Partenaire national", categories=[comptage])
     offerers_factories.OffererTagFactory(name=CONFORMITE_TAG_NAME, label="Conformité", categories=[homologation])
+    offerers_factories.OffererTagFactory(name="adage", label="Adage", categories=[homologation])

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -536,6 +536,12 @@ def top_acteur_tag_fixture():
     return offerers_factories.OffererTagFactory(name="top-acteur", label="Top Acteur", categories=[category])
 
 
+@pytest.fixture(name="adage_tag")
+def adage_tag_fixture():
+    category = offerers_factories.OffererTagCategoryFactory(name="homologation", label="Homologation")
+    return offerers_factories.OffererTagFactory(name="adage", label="Adage", categories=[category])
+
+
 @pytest.fixture(name="offerer_tags")
 def offerer_tags_fixture():
     category = offerers_factories.OffererTagCategoryFactory(name="homologation", label="Homologation")

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -3182,9 +3182,9 @@ class GetIndividualOffererSubscriptionTest(GetEndpointHelper):
             },
         )
 
-    def test_with_adage_expected(self, authenticated_client):
+    def test_with_adage_expected(self, authenticated_client, adage_tag):
         individual_subscription = offerers_factories.IndividualOffererSubscription(
-            targetsCollectiveOffers=True, isCertificateReceived=True
+            offerer__tags=[adage_tag], isCertificateReceived=True
         )
         offerer = individual_subscription.offerer
         url = url_for(self.endpoint, offerer_id=offerer.id)
@@ -3213,9 +3213,9 @@ class GetIndividualOffererSubscriptionTest(GetEndpointHelper):
             ("refuse", ["bi-x-circle-fill", "text-danger"]),
         ],
     )
-    def test_with_adage_application(self, authenticated_client, state, expected_adage_classes):
+    def test_with_adage_application(self, authenticated_client, adage_tag, state, expected_adage_classes):
         individual_subscription = offerers_factories.IndividualOffererSubscription(
-            targetsCollectiveOffers=True,
+            offerer__tags=[adage_tag],
             isCriminalRecordReceived=True,
             isCertificateReceived=True,
             isExperienceReceived=True,
@@ -3248,8 +3248,6 @@ class UpdateIndividualOffererSubscriptionTest(PostEndpointHelper):
     def _assert_data(self, individual_subscription: offerers_models.IndividualOffererSubscription, form_data: dict):
         assert individual_subscription.isEmailSent is form_data["is_email_sent"]
         assert individual_subscription.dateEmailSent == datetime.date.fromisoformat(form_data["date_email_sent"])
-        assert individual_subscription.targetsCollectiveOffers is form_data["collective_offers"]
-        assert individual_subscription.targetsIndividualOffers is form_data["individual_offers"]
         assert individual_subscription.isCriminalRecordReceived is form_data["is_criminal_record_received"]
         assert individual_subscription.dateCriminalRecordReceived == (
             datetime.date.fromisoformat(form_data["date_criminal_record_received"])


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-24788

En supprimant les champs demandés dans le ticket, petit rééquilibrage des colonnes : 
![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/8b6b29ea-8441-4ad3-bbdc-d00969002a11)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques