### PR TITLE
(PC-24719) add hmac key to sandbox and decoding in mock api

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
@@ -43,6 +43,7 @@ def create_offerer_provider(
         bookingExternalUrl=booking_url,
         cancelExternalUrl=cancel_booking_url,
         notificationExternalUrl=settings.CHARLIE_NOTIFICATION_EXTERNAL_URL,
+        hmacKey="S3cr3tK3y",
     )
 
     offerers_factories.ApiKeyFactory(

--- a/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
+++ b/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
@@ -109,6 +109,10 @@ SET
     "notificationExternalUrl" = 'http://mock-api-billeterie.mock-api-billeterie.svc.cluster.local:5003/notify'
 WHERE "notificationExternalUrl" IS NOT NULL;
 
+UPDATE provider
+SET 
+    "hmacKey" = 's3cr3tK3y'
+WHERE "hmacKey" IS NOT NULL;
 
 UPDATE boost_cinema_details
 SET


### PR DESCRIPTION
## But de la pull request
ajout de la clé de chiffrement hmac au script d'anonimisation et aux données de la sandbox 

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24719