### PR TITLE
(PC-24590)[PRO] feat: keep venue & offerer params in offer nav

### DIFF
--- a/pro/src/components/IndividualOfferBreadcrumb/IndividualOfferBreadcrumb.tsx
+++ b/pro/src/components/IndividualOfferBreadcrumb/IndividualOfferBreadcrumb.tsx
@@ -16,6 +16,7 @@ import {
   getOfferSubtypeFromParam,
   isOfferSubtypeEvent,
 } from 'screens/IndividualOffer/InformationsScreen/utils/filterCategories/filterCategories'
+import { computeSearchForNavigation } from 'screens/IndividualOffer/utils/computeSearchForNavigation'
 
 import { OFFER_WIZARD_STEP_IDS } from './constants'
 import styles from './IndividualOfferBreadcrumb.module.scss'
@@ -30,6 +31,7 @@ export const IndividualOfferBreadcrumb = () => {
   )
   const hasStock = offer !== null && offer.stocks.length > 0
   const { search } = useLocation()
+  const venueOrOffererParam = computeSearchForNavigation(search)
   const queryParams = new URLSearchParams(search)
   const queryOfferType = queryParams.get('offer-type')
 
@@ -127,16 +129,16 @@ export const IndividualOfferBreadcrumb = () => {
       isActive: true,
     })
   }
-
+  const params = venueOrOffererParam ? `?${venueOrOffererParam}` : ''
   const stepList = steps.map((stepPattern: StepPattern): Step => {
     const step: Step = {
       id: stepPattern.id,
       label: stepPattern.label,
     }
     if (stepPattern.isActive && stepPattern.path && offer) {
-      step.url = generatePath(stepPattern.path, {
+      step.url = `${generatePath(stepPattern.path, {
         offerId: offer.id,
-      })
+      })}${params}`
     }
     return step
   })

--- a/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
@@ -42,6 +42,7 @@ import strokeMailIcon from 'icons/stroke-mail.svg'
 
 import ActionBar from '../ActionBar/ActionBar'
 import { useIndividualOfferImageUpload } from '../hooks/useIndividualOfferImageUpload'
+import { computeSearchForNavigation } from '../utils/computeSearchForNavigation'
 
 import { computeNextStep } from './utils/computeNextStep'
 import {
@@ -76,6 +77,7 @@ const InformationsScreen = ({
   } = useIndividualOfferContext()
   const { imageOffer, onImageDelete, onImageUpload, handleImageOnSubmit } =
     useIndividualOfferImageUpload()
+  const search = computeSearchForNavigation(location.search)
 
   const isBookingContactEnabled = useActiveFeature(
     'WIP_MANDATORY_BOOKING_CONTACT'
@@ -239,24 +241,28 @@ const InformationsScreen = ({
       }
       // replace url to fix back button
       navigate(
-        getIndividualOfferUrl({
-          step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
-          offerId: receivedOfferId,
-          mode,
-        }),
+        {
+          pathname: getIndividualOfferUrl({
+            step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+            offerId: receivedOfferId,
+            mode,
+          }),
+          search,
+        },
         { replace: true }
       )
 
-      navigate(
-        getIndividualOfferUrl({
+      navigate({
+        pathname: getIndividualOfferUrl({
           offerId: receivedOfferId,
           step: nextStep,
           mode:
             mode === OFFER_WIZARD_MODE.EDITION
               ? OFFER_WIZARD_MODE.READ_ONLY
               : mode,
-        })
-      )
+        }),
+        search,
+      })
       // TODO Should create dedicated event for subcategory, this is not a navigation event
       logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
         from: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
@@ -295,18 +301,9 @@ const InformationsScreen = ({
   })
 
   const handlePreviousStep = () => {
-    const queryParams = new URLSearchParams(location.search)
-    const queryOffererId = queryParams.get('structure')
-    const queryVenueId = queryParams.get('lieu')
-    /* istanbul ignore next: DEBT, TO FIX */
     navigate({
       pathname: '/offre/creation',
-      search:
-        queryOffererId && queryVenueId
-          ? `lieu=${queryVenueId}&structure=${queryOffererId}`
-          : queryOffererId && !queryVenueId
-          ? `structure=${queryOffererId}`
-          : '',
+      search,
     })
   }
 

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesScreen.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesScreen.tsx
@@ -1,6 +1,6 @@
 import { FormikProvider, useFormik } from 'formik'
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import ConfirmDialog from 'components/Dialog/ConfirmDialog'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferBreadcrumb/constants'
@@ -14,6 +14,7 @@ import { useOfferWizardMode } from 'hooks'
 import useNotification from 'hooks/useNotification'
 
 import ActionBar from '../ActionBar/ActionBar'
+import { computeSearchForNavigation } from '../utils/computeSearchForNavigation'
 import { getSuccessMessage } from '../utils/getSuccessMessage'
 
 import { computeInitialValues } from './form/computeInitialValues'
@@ -159,6 +160,8 @@ export const PriceCategoriesScreen = ({
   const [isClickingDraft, setIsClickingDraft] = useState<boolean>(false)
   const notify = useNotification()
   const [popinType, setPopinType] = useState<POPIN_TYPE | null>(null)
+  const location = useLocation()
+  const search = computeSearchForNavigation(location.search)
 
   const isDisabledBySynchronization =
     Boolean(offer.lastProvider) && !isOfferAllocineSynchronized(offer)
@@ -203,7 +206,7 @@ export const PriceCategoriesScreen = ({
       mode:
         mode === OFFER_WIZARD_MODE.EDITION ? OFFER_WIZARD_MODE.READ_ONLY : mode,
     })
-    navigate(afterSubmitUrl)
+    navigate({ pathname: afterSubmitUrl, search })
     if (isClickingDraft || mode === OFFER_WIZARD_MODE.EDITION) {
       notify.success(getSuccessMessage(mode))
     }
@@ -219,13 +222,14 @@ export const PriceCategoriesScreen = ({
   })
 
   const handlePreviousStep = () => {
-    navigate(
-      getIndividualOfferUrl({
+    navigate({
+      pathname: getIndividualOfferUrl({
         offerId: offer.id,
         step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
         mode,
-      })
-    )
+      }),
+      search,
+    })
   }
 
   const handleNextStep =
@@ -248,16 +252,17 @@ export const PriceCategoriesScreen = ({
           notify.success(getSuccessMessage(OFFER_WIZARD_MODE.DRAFT))
           return
         } else {
-          navigate(
-            getIndividualOfferUrl({
+          navigate({
+            pathname: getIndividualOfferUrl({
               offerId: offer.id,
               step: OFFER_WIZARD_STEP_IDS.SUMMARY,
               mode:
                 mode === OFFER_WIZARD_MODE.EDITION
                   ? OFFER_WIZARD_MODE.READ_ONLY
                   : mode,
-            })
-          )
+            }),
+            search,
+          })
           notify.success(getSuccessMessage(OFFER_WIZARD_MODE.EDITION))
         }
       }

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 
 import { api } from 'apiClient/api'
@@ -22,6 +22,7 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 import ActionBar from '../ActionBar/ActionBar'
 import { MAX_STOCKS_PER_OFFER } from '../constants'
 import upsertStocksEventAdapter from '../StocksEventEdition/adapters/upsertStocksEventAdapter'
+import { computeSearchForNavigation } from '../utils/computeSearchForNavigation'
 import { getSuccessMessage } from '../utils/getSuccessMessage'
 
 import { HelpSection } from './HelpSection/HelpSection'
@@ -67,6 +68,8 @@ export const StocksEventCreation = ({
   const { setOffer } = useIndividualOfferContext()
   const notify = useNotification()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const location = useLocation()
+  const search = computeSearchForNavigation(location.search)
 
   const [isRecurrenceModalOpen, setIsRecurrenceModalOpen] = useState(false)
   const onCancel = () => setIsRecurrenceModalOpen(false)
@@ -99,13 +102,14 @@ export const StocksEventCreation = ({
 
   const handlePreviousStep = () => {
     /* istanbul ignore next: DEBT, TO FIX */
-    navigate(
-      getIndividualOfferUrl({
+    navigate({
+      pathname: getIndividualOfferUrl({
         offerId: offer.id,
         step: OFFER_WIZARD_STEP_IDS.TARIFS,
         mode,
-      })
-    )
+      }),
+      search,
+    })
   }
   const stocksToCreate = stocks
     .filter(stock => stock.id === undefined)
@@ -165,15 +169,17 @@ export const StocksEventCreation = ({
         }
       }
 
-      navigate(
-        getIndividualOfferUrl({
+      navigate({
+        pathname: getIndividualOfferUrl({
           offerId: offer.id,
           step: saveDraft
             ? OFFER_WIZARD_STEP_IDS.STOCKS
             : OFFER_WIZARD_STEP_IDS.SUMMARY,
           mode,
-        })
-      )
+        }),
+        search,
+      })
+
       setIsClickingFromActionBar(false)
 
       if (saveDraft) {

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -2,7 +2,7 @@ import { format } from 'date-fns'
 import { FormikProvider, useFormik } from 'formik'
 import isEqual from 'lodash/isEqual'
 import React, { useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { PriceCategoryResponseModel } from 'apiClient/v1'
@@ -32,6 +32,7 @@ import { MAX_STOCKS_PER_OFFER } from '../constants'
 import DialogStocksEventEditConfirm from '../DialogStocksEventEditConfirm/DialogStocksEventEditConfirm'
 import useNotifyFormError from '../hooks/useNotifyFormError'
 import { RecurrenceForm } from '../StocksEventCreation/RecurrenceForm'
+import { computeSearchForNavigation } from '../utils/computeSearchForNavigation'
 import { getSuccessMessage } from '../utils/getSuccessMessage'
 
 import { serializeStockEventEdition } from './adapters/serializers'
@@ -151,6 +152,8 @@ const StocksEventEdition = ({
   const [showStocksEventConfirmModal, setShowStocksEventConfirmModal] =
     useState(false)
   const priceCategoriesOptions = getPriceCategoryOptions(offer.priceCategories)
+  const location = useLocation()
+  const search = computeSearchForNavigation(location.search)
 
   const [isRecurrenceModalOpen, setIsRecurrenceModalOpen] = useState(false)
   const onCancel = () => setIsRecurrenceModalOpen(false)
@@ -252,7 +255,7 @@ const StocksEventEdition = ({
           }),
         })
       }
-      navigate(afterSubmitUrl)
+      navigate({ pathname: afterSubmitUrl, search })
       notify.success(getSuccessMessage(mode))
     } else {
       /* istanbul ignore next: DEBT, TO FIX */
@@ -366,7 +369,7 @@ const StocksEventEdition = ({
           notify.success('Brouillon sauvegardé dans la liste des offres')
           return
         } else {
-          navigate(nextStepUrl)
+          navigate({ pathname: nextStepUrl, search })
           notify.success(getSuccessMessage(mode))
         }
       }
@@ -387,7 +390,7 @@ const StocksEventEdition = ({
         setIsClickingFromActionBar(false)
         /* istanbul ignore next: DEBT to fix */
         if (!saveDraft) {
-          navigate(nextStepUrl)
+          navigate({ pathname: nextStepUrl, search })
         }
         /* istanbul ignore next: DEBT to fix */
         notify.success(getSuccessMessage(mode))
@@ -407,13 +410,14 @@ const StocksEventEdition = ({
 
   const handlePreviousStep = () => {
     /* istanbul ignore next: DEBT, TO FIX */
-    navigate(
-      getIndividualOfferUrl({
+    navigate({
+      pathname: getIndividualOfferUrl({
         offerId: offer.id,
         step: OFFER_WIZARD_STEP_IDS.TARIFS,
         mode,
-      })
-    )
+      }),
+      search,
+    })
   }
 
   const isDisabled = offer.status ? isOfferDisabled(offer.status) : false

--- a/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames'
 import { FormikProvider, useFormik } from 'formik'
 import React, { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import FormLayout, { FormLayoutDescription } from 'components/FormLayout'
@@ -34,6 +34,7 @@ import { getLocalDepartementDateTimeFromUtc } from 'utils/timezone'
 import ActionBar from '../ActionBar/ActionBar'
 import DialogStockThingDeleteConfirm from '../DialogStockDeleteConfirm/DialogStockThingDeleteConfirm'
 import useNotifyFormError from '../hooks/useNotifyFormError'
+import { computeSearchForNavigation } from '../utils/computeSearchForNavigation'
 import { getSuccessMessage } from '../utils/getSuccessMessage'
 
 import ActivationCodeFormDialog from './ActivationCodeFormDialog/ActivationCodeFormDialog'
@@ -68,6 +69,8 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
   const navigate = useNavigate()
   const notify = useNotification()
   const { setOffer, subCategories } = useIndividualOfferContext()
+  const location = useLocation()
+  const search = computeSearchForNavigation(location.search)
 
   const canBeDuo = subCategories.find(
     subCategory => subCategory.id === offer.subcategoryId
@@ -108,7 +111,7 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
         setOffer && setOffer(response.payload)
         formik.resetForm({ values: buildInitialValues(response.payload) })
       }
-      navigate(afterSubmitUrl)
+      navigate({ pathname: afterSubmitUrl, search })
       if (isSubmittingDraft || mode === OFFER_WIZARD_MODE.EDITION) {
         notify.success(message)
       }
@@ -175,7 +178,7 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
           notify.success('Brouillon sauvegardé dans la liste des offres')
           return
         } else {
-          navigate(nextStepUrl)
+          navigate({ pathname: nextStepUrl, search })
           if (mode === OFFER_WIZARD_MODE.EDITION) {
             notify.success(getSuccessMessage(mode))
           }
@@ -188,7 +191,7 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
       const hasSavedStock = formik.values.stockId !== undefined
       if (hasSavedStock && !formik.dirty) {
         if (!saveDraft) {
-          navigate(nextStepUrl)
+          navigate({ pathname: nextStepUrl, search })
         } else {
           notify.success(getSuccessMessage(mode))
         }
@@ -208,13 +211,14 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
 
   const handlePreviousStep = () => {
     /* istanbul ignore next: DEBT, TO FIX */
-    navigate(
-      getIndividualOfferUrl({
+    navigate({
+      pathname: getIndividualOfferUrl({
         offerId: offer.id,
         step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
         mode,
-      })
-    )
+      }),
+      search,
+    })
   }
 
   const onConfirmDeleteStock = async () => {

--- a/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { BannerSummary } from 'components/Banner'
 import RedirectDialog from 'components/Dialog/RedirectDialog'
@@ -28,6 +28,7 @@ import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { getOfferConditionalFields } from 'utils/getOfferConditionalFields'
 
 import ActionBar from '../ActionBar/ActionBar'
+import { computeSearchForNavigation } from '../utils/computeSearchForNavigation'
 
 import { DisplayOfferInAppLink } from './DisplayOfferInAppLink/DisplayOfferInAppLink'
 import OfferSection from './OfferSection/OfferSection'
@@ -41,6 +42,9 @@ const SummaryScreen = () => {
   const notification = useNotification()
   const mode = useOfferWizardMode()
   const navigate = useNavigate()
+  const location = useLocation()
+  const search = computeSearchForNavigation(location.search)
+
   const {
     setOffer,
     venueId,
@@ -93,13 +97,14 @@ const SummaryScreen = () => {
 
   /* istanbul ignore next: DEBT, TO FIX */
   const handlePreviousStep = () => {
-    navigate(
-      getIndividualOfferUrl({
+    navigate({
+      pathname: getIndividualOfferUrl({
         offerId: offer.id,
         step: OFFER_WIZARD_STEP_IDS.STOCKS,
         mode,
-      })
-    )
+      }),
+      search,
+    })
   }
   const offerSubCategory = subCategories.find(s => s.id === offer.subcategoryId)
 
@@ -194,7 +199,7 @@ const SummaryScreen = () => {
                 from: OFFER_WIZARD_STEP_IDS.SUMMARY,
               }
             )
-            navigate(offerConfirmationStepUrl)
+            navigate({ pathname: offerConfirmationStepUrl, search })
           }}
           title="Félicitations, vous avez créé votre offre !"
           redirectText="Renseigner des coordonnées bancaires"

--- a/pro/src/screens/IndividualOffer/utils/__specs__/computeSearchForNavigation.spec.ts
+++ b/pro/src/screens/IndividualOffer/utils/__specs__/computeSearchForNavigation.spec.ts
@@ -1,0 +1,13 @@
+import { computeSearchForNavigation } from '../computeSearchForNavigation'
+
+describe('computeSearchForNavigation', () => {
+  const testedElements = [
+    { input: 'structure=123&lieu=456', expected: 'structure=123&lieu=456' },
+    { input: 'structure=123&somethingUseless=456', expected: 'structure=123' },
+    { input: 'somethingUseless=456', expected: '' },
+    { input: '', expected: '' },
+  ]
+  it.each(testedElements)('should compute right search when %s', element => {
+    expect(computeSearchForNavigation(element.input)).toBe(element.expected)
+  })
+})

--- a/pro/src/screens/IndividualOffer/utils/computeSearchForNavigation.ts
+++ b/pro/src/screens/IndividualOffer/utils/computeSearchForNavigation.ts
@@ -1,0 +1,14 @@
+export const computeSearchForNavigation = (locationSearch: string): string => {
+  const queryParams = new URLSearchParams(locationSearch)
+  const queryOffererId = queryParams.get('structure')
+  const queryVenueId = queryParams.get('lieu')
+
+  let search = ''
+
+  if (queryOffererId && queryVenueId) {
+    search = `structure=${queryOffererId}&lieu=${queryVenueId}`
+  } else if (queryOffererId && !queryVenueId) {
+    search = `structure=${queryOffererId}`
+  }
+  return search
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24590

garder les paramètres structure et lieu dans le parcours de création d'offre, pour pouvoir revenir sur la même page du hub en appuyant sur "étape précédente"

-> ANNULE feature non voulue finalement

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques