### PR TITLE
(PC-24138)[BO] fix: incident informations and partial incident pricing

### DIFF
--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -295,7 +295,7 @@ class IndividualBookingFinanceIncidentFactory(BaseFactory):
     booking = factory.SubFactory(bookings_factories.ReimbursedBookingFactory)
     incident = factory.SubFactory(FinanceIncidentFactory)
     beneficiary = factory.SelfAttribute("booking.user")
-    newTotalAmount = 1020
+    newTotalAmount = factory.LazyAttribute(lambda x: x.booking.amount * x.booking.quantity - 100)
 
 
 class CollectiveBookingFinanceIncidentFactory(BaseFactory):
@@ -304,4 +304,4 @@ class CollectiveBookingFinanceIncidentFactory(BaseFactory):
 
     collectiveBooking = factory.SubFactory(educational_factories.ReimbursedCollectiveBookingFactory)
     incident = factory.SubFactory(FinanceIncidentFactory)
-    newTotalAmount = 1020
+    newTotalAmount = factory.LazyAttribute(lambda x: x.collectiveBooking.collectiveStock.price - 100)

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -210,15 +210,17 @@ def format_booking_cancellation_reason(
             return ""
 
 
-def format_booking_status_long(status: bookings_models.BookingStatus) -> str:
+def format_booking_status_long(
+    status: bookings_models.BookingStatus | educational_models.CollectiveBookingStatus,
+) -> str:
     match status:
-        case bookings_models.BookingStatus.CONFIRMED:
+        case bookings_models.BookingStatus.CONFIRMED | educational_models.CollectiveBookingStatus.CONFIRMED:
             return "Réservation confirmée"
-        case bookings_models.BookingStatus.USED:
+        case bookings_models.BookingStatus.USED | educational_models.CollectiveBookingStatus.USED:
             return '<span class="badge text-bg-success">Le jeune a consommé l\'offre</span>'
-        case bookings_models.BookingStatus.CANCELLED:
+        case bookings_models.BookingStatus.CANCELLED | educational_models.CollectiveBookingStatus.CANCELLED:
             return "<span class=\"badge text-bg-danger\">L'offre n'a pas eu lieu</span>"
-        case bookings_models.BookingStatus.REIMBURSED:
+        case bookings_models.BookingStatus.REIMBURSED | educational_models.CollectiveBookingStatus.REIMBURSED:
             return '<span class="badge text-bg-success">AC remboursé</span>'
         case _:
             return status.value

--- a/api/src/pcapi/routes/backoffice/finance/forms.py
+++ b/api/src/pcapi/routes/backoffice/finance/forms.py
@@ -27,7 +27,7 @@ class IncidentCreationForm(FlaskForm):
     origin = fields.PCStringField("Origine de la demande")
 
     total_amount = fields.PCDecimalField(
-        "Montant total de l'incident (à récupérer à la structure)", validators=[Optional()]
+        "Montant de l'incident à récupérer (sans le calcul de barème)", validators=[Optional()]
     )
 
 

--- a/api/src/pcapi/routes/backoffice/finance/validation.py
+++ b/api/src/pcapi/routes/backoffice/finance/validation.py
@@ -63,12 +63,19 @@ def check_incident_collective_booking(collective_booking: educational_models.Col
 
 
 def check_total_amount(
-    input_amount: decimal.Decimal | None, bookings: list[bookings_models.Booking | educational_models.CollectiveBooking]
+    input_amount: decimal.Decimal | None,
+    bookings: list[bookings_models.Booking | educational_models.CollectiveBooking],
+    check_positive_amount: bool = True,
 ) -> bool:
     # Temporary: The total_amount field is optional only for multiple bookings incident (no need for total overpayment)
     if not input_amount:
-        flash("Le montant de l'incident est vide.", "warning")
+        flash("Impossible de créer un incident d'un montant de 0€.", "warning")
         return False
+
+    if check_positive_amount and input_amount < 0:
+        flash("Le montant d'un incident ne peut être négatif.", "warning")
+        return False
+
     max_incident_amount = sum(booking.total_amount for booking in bookings)
     if input_amount > max_incident_amount:
         flash(

--- a/api/src/pcapi/routes/backoffice/templates/finance/incident/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incident/get/details/bookings.html
@@ -73,6 +73,10 @@
                 <span class="fw-bold">Email du pro :</span>
                 {{ booking_finance_incident.booking.venue.bookingEmail | empty_string_if_null }}
               </p>
+              <p class="mb-1">
+                <span class="fw-bold">Montant de la réservation :</span>
+                {{ booking_finance_incident.booking.total_amount | format_amount }}
+              </p>
             </div>
           </td>
         </tr>

--- a/api/src/pcapi/routes/backoffice/templates/finance/incident/get/details/collective_bookings.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incident/get/details/collective_bookings.html
@@ -53,6 +53,10 @@
                 <span class="fw-bold">Catégorie :</span>
                 {{ booking_finance_incident.collectiveBooking.collectiveStock.collectiveOffer.subcategoryId | format_offer_category }}
               </p>
+              <p class="mb-1">
+                <span class="fw-bold">Montant de la réservation :</span>
+                {{ booking_finance_incident.collectiveBooking.total_amount | format_amount }}
+              </p>
             </div>
           </td>
         </tr>

--- a/api/src/pcapi/routes/backoffice/templates/finance/incident/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incident/get/general.html
@@ -41,11 +41,9 @@
             <p class="mb-1">
               <span class="fw-bold">Montant remboursé initialement :</span> {{ total_amount | format_cents }}
             </p>
-            {% if total_amount_of_incident %}
-              <p class="mb-1">
-                <span class="fw-bold">Montant de l'incident :</span> {{ total_amount_of_incident | format_cents }}
-              </p>
-            {% endif %}
+            <p class="mb-1">
+              <span class="fw-bold">Montant de l'incident :</span> {{ incident.due_amount_by_offerer | format_cents }}
+            </p>
             {% if incident.details.author %}
               <p class="mb-1">
                 <span class="fw-bold">Incident créé par :</span> {{ incident.details.author }}

--- a/api/src/pcapi/routes/backoffice/templates/finance/incident/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incident/list.html
@@ -47,7 +47,7 @@
                   <td>{{ incident.kind | format_finance_incident_type | safe }}</td>
                   <td>{{ "Collective" if incident.relates_to_collective_bookings else "Individuelle" }}</td>
                   <td>{{ incident.booking_finance_incidents | length }}</td>
-                  <td>{{ incident.booking_finance_incidents | sum(attribute="newTotalAmount") | format_cents }}</td>
+                  <td>{{ incident.due_amount_by_offerer | format_cents }}</td>
                   <td>{{ links.build_offerer_name_to_details_link(incident.venue.managingOfferer) }}</td>
                   <td>{{ links.build_venue_name_to_details_link(venue) }}</td>
                   <td>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24138

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/d6f3d98d-1d47-44df-9705-5f4c21c952fb)

Correction du wording lors de la création de l'incident : 
- Le montant saisi est le montant à récupérer (vu avec Charline/Solène)

Correction de la valeur de `newTotalAmount` du modèle `BookingFinanceIncident`
Le `newTotalAmount` étant la nouvelle valorisation d'un booking, dans le cas d'un trop percu total sa valeur est de 0.


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques