### PR TITLE
(BSR)[API] fix: Fix `FinanceEvent.pricingOrderingDate` for finance incidents

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -176,7 +176,14 @@ def add_event(
         pricing_point_id = booking.venue.current_pricing_point_id
         if pricing_point_id:
             status = models.FinanceEventStatus.READY
-            pricing_ordering_date = _get_pricing_ordering_date(booking)
+            if motive in (
+                models.FinanceEventMotive.INCIDENT_REVERSAL_OF_ORIGINAL_EVENT,
+                models.FinanceEventMotive.INCIDENT_NEW_PRICE,
+                models.FinanceEventMotive.INCIDENT_COMMERCIAL_GESTURE,
+            ):
+                pricing_ordering_date = incident_validation_date
+            else:
+                pricing_ordering_date = _get_pricing_ordering_date(booking)
         else:
             status = models.FinanceEventStatus.PENDING
             pricing_ordering_date = None

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -667,16 +667,20 @@ class AddEventTest:
     def test_create_incident_event(self, incident_motive):
         pricing_point = offerers_factories.VenueFactory()
         booking_incident = factories.IndividualBookingFinanceIncidentFactory(
-            booking__stock__offer__venue__pricing_point=pricing_point, incident__venue__pricing_point=pricing_point
+            booking__stock__offer__venue__pricing_point=pricing_point,
+            incident__venue__pricing_point=pricing_point,
         )
         validation_date = datetime.datetime.utcnow()
         event = api.add_event(
-            incident_motive, booking_incident=booking_incident, incident_validation_date=validation_date
+            incident_motive,
+            booking_incident=booking_incident,
+            incident_validation_date=validation_date,
         )
 
         assert event.bookingFinanceIncident == booking_incident
         assert event.status == models.FinanceEventStatus.READY
         assert event.motive == incident_motive
+        assert event.pricingOrderingDate == validation_date
 
 
 class CancelLatestEventTest:


### PR DESCRIPTION
The pricing ordering date cannot be based on the booking validation
date. That date is likely to be earlier than other bookings that
already have been reimbursed. The `price-financee-events` cron would
then fail because it would try to re-price later bookings and would
not be able to delete their pricings.

Instead, we should use the date of the validation of the incident
(which is the date of the creation of the event, and is thus safe to
use).

---

Le bug est visible dans ces 2 entrées Sentry sur staging : [ici](https://sentry.passculture.team/organizations/sentry/issues/428277/events/7408e19631d44abf88dadd3ff4aa9cc6/) et [là](https://sentry.passculture.team/organizations/sentry/issues/428277/events/db8cd621c6db43c48caca283085cdbef/).