### PR TITLE
(PC-24210)[PRO] feat: improve distance display in adage

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -17,7 +17,7 @@ import {
 import { Tag } from 'ui-kit'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { LOGS_DATA } from 'utils/config'
-import { getDistance } from 'utils/getDistance'
+import { getHumanizeRelativeDistance } from 'utils/getDistance'
 import { removeParamsFromUrl } from 'utils/removeParamsFromUrl'
 
 import ContactButton from './ContactButton'
@@ -82,7 +82,7 @@ const Offer = ({
             />
             <div>
               basé à{' '}
-              {getDistance(
+              {getHumanizeRelativeDistance(
                 {
                   latitude: offer.venue.coordinates.latitude,
                   longitude: offer.venue.coordinates.longitude,
@@ -92,7 +92,7 @@ const Offer = ({
                   longitude: adageUser.lon,
                 }
               )}{' '}
-              km de votre établissement
+              de votre établissement
             </div>
             {offer.offerVenue.addressType !== OfferAddressType.OFFERER_VENUE &&
               adageUser.departmentCode &&

--- a/pro/src/utils/__specs__/getDistance.spec.tsx
+++ b/pro/src/utils/__specs__/getDistance.spec.tsx
@@ -1,19 +1,30 @@
-import { getDistance } from 'utils/getDistance'
+// Distance using https://www.sunearthtools.com/fr/tools/distance.php
+// Center (EiffelTourCoordinates): {latitude: 48.85, longitude: 2.29 }
+
+import { getHumanizeRelativeDistance } from 'utils/getDistance'
 
 describe('getDistance', () => {
-  it('should return the distance between two points', () => {
-    const ParisCoordinates = {
-      latitude: 48.85661,
-      longitude: 2.351499,
+  it.each`
+    lat      | lng       | actualDistance (m) | expected
+    ${48.85} | ${2.2901} | ${7.3}             | ${'7 m'}
+    ${48.85} | ${2.2902} | ${14.6}            | ${'15 m'}
+    ${48.85} | ${2.291}  | ${73.2}            | ${'75 m'}
+    ${48.85} | ${2.292}  | ${146.4}           | ${'150 m'}
+    ${48.85} | ${2.33}   | ${2927.6}          | ${'2,9 km'}
+    ${48.85} | ${2.39}   | ${7319.1}          | ${'7 km'}
+    ${48.85} | ${102.39} | ${6739182.6}       | ${'900+ km'}
+  `(
+    'getHumanizeRelativeDistance($actualDistance) \t= $expected',
+    ({ lat, lng, expected }) => {
+      expect(
+        getHumanizeRelativeDistance(
+          {
+            latitude: lat,
+            longitude: lng,
+          },
+          { latitude: 48.85, longitude: 2.29 }
+        )
+      ).toBe(expected)
     }
-    const LyonCoordinates = {
-      latitude: 45.757814,
-      longitude: 4.832011,
-    }
-
-    const distance = getDistance(ParisCoordinates, LyonCoordinates)
-    // The distance between Paris and Lyon is 392km using this website:
-    // https://www.distance.to/Paris,%C3%8Ele-de-France,FRA/Lyon,Rh%C3%B4ne,Auvergne-Rh%C3%B4ne-Alpes,FRA
-    expect(distance).toBe(392)
-  })
+  )
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24210

Améliorer l'affichage des distances dans les offres Adage. On reprend le code utilisé côté jeune qui permet d'affiner l'affichage en fonction de la distance. 
[Lien du code côté jeune](https://github.com/pass-culture/pass-culture-app-native/blob/cb1f285d24cba635ca45be3bdf560a9d2bc5469f/src/libs/parsers/formatDistance.ts)

## Pour tester 

- Créer une offre réservable sur un lieu éligible adage (par ex `accepted_dms eac_complete_30+d`)
- Changer l'adresse de ce lieu pour ajuster la distance des différentes offres créées
- La localisation de l'utilisateur du collège robert doisneau est la suivante : (48.8566, 2.3522) Hotel de ville de Paris 

## Screens 

![Capture d’écran 2023-10-03 à 08 46 46](https://github.com/pass-culture/pass-culture-main/assets/71768799/4b3721c0-85e8-4b4d-9277-37c3ee6564e1)
![Capture d’écran 2023-10-03 à 08 52 50](https://github.com/pass-culture/pass-culture-main/assets/71768799/527951e6-7920-4cbb-9340-562efc8c6376)
