### PR TITLE
(PC-21354)[API] fix: isActivable must be true when Provider is active

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -719,7 +719,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
 
     @property
     def isActivable(self) -> bool:
-        if self.status == OfferStatus.REJECTED or not self.isBookable:
+        if self.status == OfferStatus.REJECTED:
             return False
         if (
             self.lastProviderId

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -634,11 +634,6 @@ class OfferIsActivableTest:
         rejected_offer = factories.OfferFactory(validation=models.OfferValidationStatus.REJECTED)
         assert not rejected_offer.isActivable
 
-    def test_not_activable_if_not_bookable(self):
-        offer = factories.OfferFactory()
-        factories.StockFactory(offer=offer, quantity=0)
-        assert not offer.isActivable
-
     def test_not_activable_if_no_venue_provider(self):
         inactive_providers = providers_factories.ProviderFactory(isActive=False)
         offer_from_inactive_provider = factories.OfferFactory(
@@ -665,6 +660,20 @@ class OfferIsActivableTest:
         )
         offer_from_active_venue_provider = factories.OfferFactory(
             validation=models.OfferValidationStatus.APPROVED,
+            lastProvider=active_provider,
+            venue=active_venue_provider.venue,
+        )
+        factories.StockFactory(offer=offer_from_active_venue_provider)
+        assert offer_from_active_venue_provider.isActivable
+
+    def test_can_activate_inactive_offer_if_venue_is_active_and_provider_is_not_null(self):
+        active_provider = providers_factories.ProviderFactory()
+        active_venue_provider = providers_factories.VenueProviderFactory(
+            provider=active_provider,
+        )
+        offer_from_active_venue_provider = factories.OfferFactory(
+            validation=models.OfferValidationStatus.APPROVED,
+            isActive=False,
             lastProvider=active_provider,
             venue=active_venue_provider.venue,
         )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-21354

également liée à la [PR 8146](https://github.com/pass-culture/pass-culture-main/pull/8146
) . 

On s'est rendu compte que le test sur isBookable va vérifier si l'offre est active pour voir si elle est *activable* ce qui est à l'origine du bug. On enlève donc cette condition, et si le stock est nul, la personne faisant la réservation en sera de toute façon informée. 

Dans ce fix:
- Suppression du test sur la condition isBookable
- ajout d'un test qui permet de vérifier qu'on peut bien republier une offre si le Provider est actif


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques