### PR TITLE
(BSR)[PRO] ci: e2e are stable enough they can make ci fail

### DIFF
--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -186,9 +186,6 @@ jobs:
       # Doc : https://github.com/cypress-io/github-action
       - name: Cypress run
         uses: cypress-io/github-action@v5
-        # E2E tests are not stable enough for now.
-        # Once they are reliable, we can remove the following line.
-        continue-on-error: true
         with:
           build: yarn build:development
           start: yarn serve


### PR DESCRIPTION
## But de la pull request

BSR

les tests e2e semblent suffisemment stable maintenant, ils peuvent faire échouer la ci, 
motivé par un bug qu'un aurait vu plus tôt si ça avait été le cas : 
https://passculture.atlassian.net/browse/PC-24821

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques