### PR TITLE
(PC-24432)[PRO] feat: add strong balise to word matching with query s…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -39,6 +39,7 @@ import {
 } from 'utils/config'
 
 import styles from './Autocomplete.module.scss'
+import { Highlight } from './Highlight'
 
 type AutocompleteProps = {
   initialQuery: string
@@ -46,7 +47,7 @@ type AutocompleteProps = {
   setCurrentSearch: (search: string) => void
 }
 
-type SuggestionItem = AutocompleteQuerySuggestionsHit & {
+export type SuggestionItem = AutocompleteQuerySuggestionsHit & {
   label: string
   venue: {
     name: string
@@ -513,7 +514,16 @@ export const Autocomplete = ({
                               styles['dialog-panel-autocomplete-item-icon']
                             }
                           />
-                          {item.venue.publicName || item.venue.name}
+                          <div>
+                            <Highlight
+                              hit={item}
+                              attribute={[
+                                'venue',
+                                item.venue.publicName ? 'publicName' : 'name',
+                              ]}
+                              tagName="strong"
+                            />
+                          </div>
                         </li>
                       ))}
                     </ul>
@@ -551,17 +561,24 @@ export const Autocomplete = ({
                                 styles['dialog-panel-autocomplete-item-icon']
                               }
                             />
-                            {item.query} {shouldDisplayCategory && 'dans '}
-                            <span
-                              className={
-                                styles['dialog-panel-autocomplete-category']
-                              }
-                            >
-                              {shouldDisplayCategory &&
-                                getCategoriesFromSubcategory(
-                                  item['offer.subcategoryId'][0]
-                                ).label}
-                            </span>
+                            <div>
+                              <Highlight
+                                hit={item}
+                                attribute={['query']}
+                                tagName="strong"
+                              />
+                              {shouldDisplayCategory && ' dans '}
+                              <span
+                                className={
+                                  styles['dialog-panel-autocomplete-category']
+                                }
+                              >
+                                {shouldDisplayCategory &&
+                                  getCategoriesFromSubcategory(
+                                    item['offer.subcategoryId'][0]
+                                  ).label}
+                              </span>
+                            </div>
                           </li>
                         )
                       })}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Highlight.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Highlight.tsx
@@ -1,0 +1,31 @@
+import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia'
+import { createElement, Fragment } from 'react'
+
+import { SuggestionItem } from './Autocomplete'
+
+type HighlightHitParams = {
+  hit: SuggestionItem
+  attribute: keyof SuggestionItem | string[]
+  tagName?: string
+}
+
+export function Highlight({
+  hit,
+  attribute,
+  tagName = 'mark',
+}: HighlightHitParams): JSX.Element {
+  return createElement(
+    Fragment,
+    {},
+    parseAlgoliaHitHighlight({
+      hit,
+      attribute,
+    }).map(({ value, isHighlighted }, index) => {
+      if (isHighlighted) {
+        return createElement(tagName, { key: index }, value)
+      }
+
+      return value
+    })
+  )
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24432

Lorsque l'on fait une recherche on souhaite mettre en gras la recherche concernée dans la réponse des suggestions

<img width="1512" alt="Capture d’écran 2023-10-03 à 13 43 00" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/ecf87ac4-986d-458a-af5d-031fa4efec03">

## Vérifications

- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai écrit les tests nécessaires
