### PR TITLE
(PC-24257)[API] fix: Set User.validationToken to None when validte email after a password reset

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -531,6 +531,7 @@ def update_password_and_external_user(user: users_models.User, new_password: str
     user.setPassword(new_password)
     if not user.isEmailValidated:
         user.isEmailValidated = True
+        user.validationToken = None
         external_attributes_api.update_external_user(user)
     repository.save(user)
 

--- a/api/tests/routes/shared/post_new_password_test.py
+++ b/api/tests/routes/shared/post_new_password_test.py
@@ -28,7 +28,7 @@ def test_change_password(client):
 
 @pytest.mark.usefixtures("db_session")
 def test_change_password_validates_email(client):
-    user = users_factories.UserFactory(isEmailValidated=False)
+    user = users_factories.UserFactory(isEmailValidated=False, validationToken="AZERTY123456")
     token = users_factories.TokenFactory(user=user, type=TokenType.RESET_PASSWORD)
     data = {"token": token.value, "newPassword": "N3W_p4ssw0rd"}
 
@@ -45,6 +45,7 @@ def test_change_password_validates_email(client):
     assert len(users_testing.sendinblue_requests) == 1
     sendinblue_data = users_testing.sendinblue_requests[0]
     assert sendinblue_data["attributes"]["IS_EMAIL_VALIDATED"]
+    assert not user.validationToken
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24257

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques