### PR TITLE
(PC-24579)[ADAGE] ajout de dates de début et de fin pour les offres vitrines

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-385e5ea25130 (pre) (head)
+8425db0af4c1 (pre) (head)
 a09a9a890bcb (post) (head)

--- a/api/src/pcapi/alembic/versions/20231012T160704_8425db0af4c1_add_start_end_interval_to_collective_offer_template.py
+++ b/api/src/pcapi/alembic/versions/20231012T160704_8425db0af4c1_add_start_end_interval_to_collective_offer_template.py
@@ -1,0 +1,37 @@
+"""add start-end daterange to collective offer template"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "8425db0af4c1"
+down_revision = "385e5ea25130"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("collective_offer_template", sa.Column("dateRange", postgresql.TSRANGE(), nullable=True))
+    op.create_unique_constraint(
+        "collective_offer_template_unique_daterange", "collective_offer_template", ["dateRange", "id"]
+    )
+    op.create_check_constraint(
+        constraint_name="template_dates_non_empty_daterange",
+        table_name="collective_offer_template",
+        condition=(
+            '"dateRange" is NULL OR ('
+            'NOT isempty("dateRange") '
+            'AND lower("dateRange") is NOT NULL '
+            'AND upper("dateRange") IS NOT NULL '
+            'AND lower("dateRange") >= "dateCreated")'
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("collective_offer_template_unique_daterange", "collective_offer_template", type_="unique")
+    op.drop_constraint("template_dates_non_empty_daterange", "collective_offer_template", type_="check")
+    op.drop_column("collective_offer_template", "dateRange")

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -3,6 +3,7 @@ import logging
 import typing
 
 from flask_sqlalchemy import BaseQuery
+from psycopg2.extras import DateTimeRange
 
 from pcapi import settings
 from pcapi.core import search
@@ -241,6 +242,9 @@ def create_collective_offer_template(
         interventionArea=offer_data.intervention_area or [],
         priceDetail=offer_data.price_detail,
     )
+
+    if offer_data.dates:
+        collective_offer_template.dateRange = DateTimeRange(offer_data.dates.start, offer_data.dates.end)
 
     collective_offer_template.bookingEmails = offer_data.booking_emails
     db.session.add(collective_offer_template)

--- a/api/src/pcapi/core/educational/exceptions.py
+++ b/api/src/pcapi/core/educational/exceptions.py
@@ -195,3 +195,13 @@ class NoAdageInstitution(Exception):
 
 class MissingAdageInstitution(Exception):
     pass
+
+
+class UpdateCollectiveOfferTemplateError(Exception):
+    field = "global"
+    msg = ""
+
+
+class StartsBeforeOfferCreation(UpdateCollectiveOfferTemplateError):
+    field = "dates.start"
+    msg = "Can't start before template creation date"

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -345,8 +345,11 @@ def edit_collective_offer_template(
         offerers_api.can_offerer_create_educational_offer(offerer.id)
     except educational_exceptions.CulturalPartnerNotFoundException:
         raise ApiErrors({"Partner": "User not in Adage can't edit the offer"}, status_code=403)
+
     try:
         offers_api.update_collective_offer_template(offer_id=offer_id, new_values=new_values)
+    except educational_exceptions.UpdateCollectiveOfferTemplateError as err:
+        raise ApiErrors({err.field: err.msg}, 400)
     except educational_exceptions.VenueIdDontExist:
         raise ApiErrors({"venueId": "The venue does not exist."}, 404)
     except educational_exceptions.OffererOfVenueDontMatchOfferer:

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -4,11 +4,12 @@ import enum
 import typing
 
 import flask
+import pydantic.v1 as pydantic_v1
+from pydantic.v1 import ConstrainedStr
 from pydantic.v1 import EmailStr
 from pydantic.v1 import Field
 from pydantic.v1 import root_validator
 from pydantic.v1 import validator
-from pydantic.v1.types import constr
 
 from pcapi.core.categories.subcategories_v2 import SubcategoryIdEnum
 from pcapi.core.educational.models import CollectiveBooking
@@ -248,6 +249,10 @@ class CollectiveOfferOfferVenueResponseModel(BaseModel):
     _validated_venue_id = validator("venueId", pre=True, allow_reuse=True)(validate_venue_id)
 
 
+class PriceDetail(ConstrainedStr):
+    max_length: int = 1_000
+
+
 class GetCollectiveOfferCollectiveStockResponseModel(BaseModel):
     id: int
     isSoldOut: bool = Field(alias="isBooked")
@@ -256,7 +261,7 @@ class GetCollectiveOfferCollectiveStockResponseModel(BaseModel):
     bookingLimitDatetime: datetime | None
     price: float
     numberOfTickets: int | None
-    priceDetail: str | None = Field(alias="educationalPriceDetail")
+    priceDetail: PriceDetail | None = Field(alias="educationalPriceDetail")
     isEditable: bool = Field(alias="isEducationalStockEditable")
 
     class Config:
@@ -298,7 +303,7 @@ class GetCollectiveOfferBaseResponseModel(BaseModel, AccessibilityComplianceMixi
 
 
 class GetCollectiveOfferTemplateResponseModel(GetCollectiveOfferBaseResponseModel):
-    priceDetail: str | None = Field(alias="educationalPriceDetail")
+    priceDetail: PriceDetail | None = Field(alias="educationalPriceDetail")
 
     class Config:
         orm_mode = True
@@ -451,10 +456,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
 
 
 class PostCollectiveOfferTemplateBodyModel(PostCollectiveOfferBodyModel):
-    if typing.TYPE_CHECKING:
-        price_detail: str | None
-    else:
-        price_detail: constr(max_length=1000) | None
+    price_detail: PriceDetail | None
 
     class Config:
         alias_generator = to_camel
@@ -462,13 +464,7 @@ class PostCollectiveOfferTemplateBodyModel(PostCollectiveOfferBodyModel):
 
 
 class CollectiveOfferTemplateBodyModel(BaseModel):
-    price_detail: str | None = Field(alias="educationalPriceDetail")
-
-    @validator("price_detail")
-    def validate_price_detail(cls, price_detail: str | None) -> str | None:
-        if price_detail and len(price_detail) > 1000:
-            raise ValueError("Le détail du prix ne doit pas excéder 1000 caractères.")
-        return price_detail
+    price_detail: PriceDetail | None = Field(alias="educationalPriceDetail")
 
     class Config:
         alias_generator = to_camel
@@ -550,14 +546,8 @@ class PatchCollectiveOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
 
 
 class PatchCollectiveOfferTemplateBodyModel(PatchCollectiveOfferBodyModel):
-    priceDetail: str | None
+    priceDetail: PriceDetail | None
     domains: list[int] | None
-
-    @validator("priceDetail")
-    def validate_price_detail(cls, price_detail: str | None) -> str | None:
-        if price_detail and len(price_detail) > 1000:
-            raise ValueError("Le détail du prix ne doit pas excéder 1000 caractères.")
-        return price_detail
 
     @validator("domains")
     def validate_domains_collective_offer_template_edition(

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -1,6 +1,8 @@
+from datetime import datetime
+from datetime import timedelta
 from unittest.mock import patch
 
-from freezegun import freeze_time
+from flask import url_for
 import pytest
 
 from pcapi.core.educational.exceptions import CulturalPartnerNotFoundException
@@ -10,49 +12,78 @@ from pcapi.core.educational.factories import EducationalDomainFactory
 from pcapi.core.educational.models import CollectiveOfferTemplate
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers.models import OfferValidationStatus
-import pcapi.core.users.factories as users_factories
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
+PATCH_CAN_CREATE_OFFER_PATH = "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer"
+
+
+@pytest.fixture(name="user_offerer")
+def user_offerer_fixture():
+    return offerers_factories.UserOffererFactory()
+
+
+@pytest.fixture(name="venue")
+def venue_fixture(offerer):
+    return offerers_factories.VenueFactory(managingOfferer=offerer)
+
+
+@pytest.fixture(name="user")
+def user_fixture(user_offerer):
+    return user_offerer.user
+
+
+@pytest.fixture(name="offerer")
+def offerer_fixture(user_offerer):
+    return user_offerer.offerer
+
+
+@pytest.fixture(name="pro_client")
+def pro_client_fixture(client, user):
+    return client.with_session_auth(user.email)
+
+
+@pytest.fixture(name="offer")
+def offer_fixture(venue):
+    return CollectiveOfferTemplateFactory(
+        mentalDisabilityCompliant=False,
+        contactPhone="0600000000",
+        venue=venue,
+        domains=[],
+    )
+
+
+@pytest.fixture(name="template_start")
+def template_start_fixture():
+    return datetime.utcnow() + timedelta(days=1)
+
+
+@pytest.fixture(name="template_end")
+def template_end_fixture(template_start):
+    return template_start + timedelta(days=100)
+
+
 class Returns200Test:
-    @freeze_time("2019-01-01T12:00:00Z")
-    def test_patch_collective_offer_template(self, client):
-        # Given
+    def test_patch_collective_offer_template(self, pro_client, offer, template_start, template_end):
         domain = EducationalDomainFactory(name="Danse")
-        offer = CollectiveOfferTemplateFactory(
-            mentalDisabilityCompliant=False,
-            contactEmail="johndoe@yopmail.com",
-            contactPhone="0600000000",
-            subcategoryId="CINE_PLEIN_AIR",
-            priceDetail="price detail",
-            domains=[],
-        )
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
         national_program = educational_factories.NationalProgramFactory()
 
-        data = {
+        payload = {
             "name": "New name",
             "mentalDisabilityCompliant": True,
             "contactEmail": "toto@example.com",
             "subcategoryId": "CONCERT",
             "priceDetail": "pouet",
-            "domains": [domain.id],
             "nationalProgramId": national_program.id,
+            "dates": {"start": template_start.isoformat(), "end": template_end.isoformat()},
+            "domains": [domain.id],
         }
 
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=payload)
 
-        # Then
         assert response.status_code == 200
         assert response.json["name"] == "New name"
         assert response.json["mentalDisabilityCompliant"]
@@ -70,281 +101,162 @@ class Returns200Test:
         assert updated_offer.subcategoryId == "CONCERT"
         assert updated_offer.priceDetail == "pouet"
         assert updated_offer.domains == [domain]
+        assert updated_offer.dateRange
+        assert updated_offer.start == template_start
+        assert updated_offer.end == template_end
 
 
 class Returns400Test:
-    def test_patch_non_approved_offer_fails(self, app, client):
+    def test_non_approved_offer_fails(self, pro_client, user):
         offer = CollectiveOfferTemplateFactory(validation=OfferValidationStatus.PENDING)
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
+        offerers_factories.UserOffererFactory(user=user, offerer=offer.venue.managingOfferer)
 
-        data = {
-            "visualDisabilityCompliant": True,
-        }
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
+        data = {"visualDisabilityCompliant": True}
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
         assert response.status_code == 400
         assert response.json["global"] == ["Les offres refusées ou en attente de validation ne sont pas modifiables"]
 
-    def test_patch_offer_with_empty_name(self, app, client):
-        # Given
-        offer = CollectiveOfferTemplateFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
+    def test_empty_name(self, pro_client, offer):
         data = {"name": " "}
 
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {"name": [""]}
 
-    def test_patch_offer_with_null_name(self, app, client):
-        # Given
-        offer = CollectiveOfferTemplateFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
+    def test_null_name(self, pro_client, offer):
         data = {"name": None}
 
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {"name": [""]}
 
-    def test_patch_offer_with_non_educational_subcategory(self, app, client):
-        # Given
-        offer = CollectiveOfferTemplateFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
+    def test_non_educational_subcategory(self, pro_client, offer):
         data = {"subcategoryId": "LIVRE_PAPIER"}
 
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {"subcategoryId": "this subcategory is not educational"}
 
-    def test_patch_offer_with_empty_educational_domains(self, client):
-        # Given
-        offer = CollectiveOfferTemplateFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
+    def test_empty_educational_domains(self, pro_client, offer):
         data = {"domains": []}
 
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {"domains": ["domains must have at least one value"]}
 
-    @freeze_time("2019-01-01T12:00:00Z")
-    def test_update_collective_offer_template_with_unknown_national_program(self, client):
-        # Given
-        domain = EducationalDomainFactory(name="Danse")
-        offer = CollectiveOfferTemplateFactory(
-            mentalDisabilityCompliant=False,
-            contactEmail="johndoe@yopmail.com",
-            contactPhone="0600000000",
-            subcategoryId="CINE_PLEIN_AIR",
-            priceDetail="price detail",
-            domains=[],
-        )
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
+    def test_unknown_national_program(self, pro_client, offer):
+        data = {"nationalProgramId": -1}
 
-        data = {
-            "name": "New name",
-            "mentalDisabilityCompliant": True,
-            "contactEmail": "toto@example.com",
-            "subcategoryId": "CONCERT",
-            "priceDetail": "pouet",
-            "domains": [domain.id],
-            "nationalProgramId": -1,
-        }
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
-
-        # Then
         assert response.status_code == 400
         assert response.json == {"global": ["National program not found"]}
 
 
+class InvalidDatesTest:
+    def test_missing_start(self, pro_client, offer, template_end):
+        response = self.send_request(pro_client, offer.id, {"end": template_end.isoformat()})
+        assert response.status_code == 400
+        assert "dates.start" in response.json
+
+    def test_start_is_null(self, pro_client, offer, template_end):
+        response = self.send_request(pro_client, offer.id, {"start": None, "end": template_end.isoformat()})
+        assert response.status_code == 400
+        assert "dates.start" in response.json
+
+    def test_start_is_in_the_past(self, pro_client, offer, template_end):
+        one_week_ago = datetime.utcnow() - timedelta(days=7)
+        dates = {"start": one_week_ago.isoformat(), "end": template_end.isoformat()}
+
+        response = self.send_request(pro_client, offer.id, dates)
+        assert response.status_code == 400
+        assert "dates.start" in response.json
+
+    def test_start_is_after_end(self, pro_client, offer, template_end):
+        dates = {"start": (template_end + timedelta(days=1)).isoformat(), "end": template_end.isoformat()}
+        response = self.send_request(pro_client, offer.id, dates)
+        assert response.status_code == 400
+        assert "dates.__root__" in response.json
+
+    def test_missing_end(self, pro_client, offer, template_start):
+        response = self.send_request(pro_client, offer.id, {"start": template_start.isoformat()})
+        assert response.status_code == 400
+        assert "dates.end" in response.json
+
+    def test_end_is_null(self, pro_client, offer, template_start):
+        response = self.send_request(pro_client, offer.id, {"start": template_start.isoformat(), "end": None})
+        assert response.status_code == 400
+        assert "dates.end" in response.json
+
+    def send_request(self, pro_client, offer_id, dates):
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer_id)
+            return pro_client.patch(endpoint, json={"dates": dates})
+
+
 class Returns403Test:
-    def test_when_user_is_not_attached_to_offerer(self, app, client):
-        # Given
+    def test_user_is_not_attached_to_offerer(self, pro_client):
         offer = CollectiveOfferTemplateFactory(name="Old name")
-        offerers_factories.UserOffererFactory(user__email="user@example.com")
 
-        # When
         data = {"name": "New name"}
-        response = client.with_session_auth("user@example.com").patch(
-            f"/collective/offers-template/{offer.id}", json=data
-        )
+        response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
-        # Then
         assert response.status_code == 403
         assert response.json["global"] == [
             "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
         ]
         assert CollectiveOfferTemplate.query.get(offer.id).name == "Old name"
 
+    def test_replacing_venue_with_different_offerer(self, pro_client, offer):
+        unrelated_venue = offerers_factories.VenueFactory()
+        data = {"venueId": unrelated_venue.id}
 
-class Returns404Test:
-    def test_returns_404_if_offer_does_not_exist(self, app, client):
-        # given
-        users_factories.UserFactory(email="user@example.com")
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
-        # when
-        response = client.with_session_auth("user@example.com").patch("/collective/offers-template/12", json={})
-
-        # then
-        assert response.status_code == 404
-
-    def test_patch_collective_offer_replacing_venue_with_same_offerer(self, client):
-        # Given
-        offer = CollectiveOfferTemplateFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
-        data = {"name": "New name"}
-
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
-
-        # Then
-        assert response.status_code == 200
-        assert response.json["name"] == "New name"
-
-    def test_patch_offer_with_unknown_educational_domain(self, client):
-        # Given
-        offer = CollectiveOfferTemplateFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offer.venue.managingOfferer,
-        )
-        data = {"domains": [0]}
-
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
-
-        # Then
-        assert response.status_code == 404
-        assert response.json["code"] == "EDUCATIONAL_DOMAIN_NOT_FOUND"
-
-    def test_patch_collective_offer_template_replacing_by_unknown_venue(self, client):
-        # Given
-        offerer = offerers_factories.OffererFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offerer,
-        )
-        offer = CollectiveOfferTemplateFactory(venue__managingOfferer=offerer)
-        data = {"venueId": 0}
-
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
-
-        # Then
-        assert response.status_code == 404
-        assert response.json["venueId"] == "The venue does not exist."
-
-    def test_patch_collective_offer_replacing_venue_with_different_offerer(self, client):
-        # Given
-        offerer = offerers_factories.OffererFactory()
-        offerer2 = offerers_factories.OffererFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offerer,
-        )
-        offer = CollectiveOfferTemplateFactory(venue__managingOfferer=offerer)
-        venue2 = offerers_factories.VenueFactory(managingOfferer=offerer2)
-        data = {"venueId": venue2.id}
-
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
-
-        # Then
         assert response.status_code == 403
         assert response.json == {"venueId": "New venue needs to have the same offerer"}
 
-    def test_edit_collective_offer_template_with_offerer_unregister_in_adage(self, client):
-        # GIVEN
+    def test_cultural_partner_not_found(self, pro_client, offer):
+        data = {"name": "Update some random field"}
 
-        offerer = offerers_factories.OffererFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=offerer,
-        )
-        offer = CollectiveOfferTemplateFactory(venue__managingOfferer=offerer)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH, side_effect=CulturalPartnerNotFoundException):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
-        data = {
-            "contactEmail": "toto@example.com",
-        }
-
-        # WHEN
-        client = client.with_session_auth("user@example.com")
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-            side_effect=CulturalPartnerNotFoundException,
-        ):
-            response = client.patch(f"/collective/offers-template/{offer.id}", json=data)
-
-        # THEN
         assert response.status_code == 403
         assert response.json == {"Partner": "User not in Adage can't edit the offer"}
+
+
+class Returns404Test:
+    def test_offer_does_not_exist(self, pro_client):
+        response = pro_client.patch("/collective/offers-template/12", json={})
+        assert response.status_code == 404
+
+    def test_unknown_educational_domain(self, pro_client, offer):
+        data = {"domains": [0]}
+
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
+
+        assert response.status_code == 404
+        assert response.json["code"] == "EDUCATIONAL_DOMAIN_NOT_FOUND"
+
+    def test_replacing_by_unknown_venue(self, pro_client, offer):
+        data = {"venueId": 0}
+
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
+
+        assert response.status_code == 404
+        assert response.json["venueId"] == "The venue does not exist."

--- a/api/tests/routes/pro/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/post_collective_offers_template_test.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -7,59 +9,106 @@ import pcapi.core.educational.exceptions as educational_exceptions
 import pcapi.core.educational.factories as educational_factories
 from pcapi.core.educational.models import CollectiveOfferTemplate
 import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.users.factories as users_factories
 
 
-base_collective_offer_payload = {
-    "description": "Ma super description",
-    "bookingEmails": ["offer1@example.com", "offer2@example.com"],
-    "durationMinutes": 60,
-    "name": "La pièce de théâtre",
-    "contactEmail": "pouet@example.com",
-    "contactPhone": "01 99 00 25 68",
-    "students": ["Lycée - Seconde", "Lycée - Première"],
-    "audioDisabilityCompliant": False,
-    "mentalDisabilityCompliant": True,
-    "motorDisabilityCompliant": False,
-    "visualDisabilityCompliant": False,
-    "interventionArea": ["75", "92", "93"],
-    "templateId": None,
-    "priceDetail": "Le détail ici",
-}
+pytestmark = pytest.mark.usefixtures("db_session")
 
 
-@pytest.mark.usefixtures("db_session")
+PATCH_CAN_CREATE_OFFER_PATH = "pcapi.core.offerers.api.can_offerer_create_educational_offer"
+
+
+@pytest.fixture(name="venue")
+def venue_fixture():
+    return offerers_factories.VenueFactory()
+
+
+@pytest.fixture(name="user_offerer")
+def user_offerer_fixture(venue):
+    return offerers_factories.UserOffererFactory(offerer=venue.managingOfferer)
+
+
+@pytest.fixture(name="user")
+def user_fixture(user_offerer):
+    return user_offerer.user
+
+
+@pytest.fixture(name="offerer")
+def offerer_fixture(user_offerer):
+    return user_offerer.offerer
+
+
+@pytest.fixture(name="pro_client")
+def pro_client_fixture(client, user):
+    return client.with_session_auth(user.email)
+
+
+@pytest.fixture(name="domains")
+def domains_fixture():
+    return [educational_factories.EducationalDomainFactory(), educational_factories.EducationalDomainFactory()]
+
+
+@pytest.fixture(name="offer_venue")
+def offer_venue_fixture(venue):
+    return {
+        "addressType": "school",
+        "venueId": venue.id,
+        "otherAddress": "17 rue aléatoire",
+    }
+
+
+@pytest.fixture(name="template_start", scope="module")
+def template_start_fixture():
+    return datetime.utcnow() + timedelta(days=1)
+
+
+@pytest.fixture(name="template_end", scope="module")
+def template_end_fixture():
+    return datetime.utcnow() + timedelta(days=100)
+
+
+@pytest.fixture(name="payload")
+def payload_fixture(venue, domains, offer_venue, template_start, template_end):
+    return {
+        "description": "Ma super description",
+        "bookingEmails": ["offer1@example.com", "offer2@example.com"],
+        "durationMinutes": 60,
+        "name": "La pièce de théâtre",
+        "contactEmail": "pouet@example.com",
+        "contactPhone": "01 99 00 25 68",
+        "students": ["Lycée - Seconde", "Lycée - Première"],
+        "audioDisabilityCompliant": False,
+        "mentalDisabilityCompliant": True,
+        "motorDisabilityCompliant": False,
+        "visualDisabilityCompliant": False,
+        "interventionArea": ["75", "92", "93"],
+        "templateId": None,
+        "priceDetail": "Le détail ici",
+        "dates": {"start": template_start.isoformat(), "end": template_end.isoformat()},
+        "offerVenue": offer_venue,
+        "domains": [domain.id for domain in domains],
+        "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
+        "venueId": venue.id,
+    }
+
+
 class Returns200Test:
-    def test_create_collective_offer_template(self, client):
-        # Given
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
-        educational_domain1 = educational_factories.EducationalDomainFactory()
-        educational_domain2 = educational_factories.EducationalDomainFactory()
+    def test_create_collective_offer_template(
+        self, pro_client, payload, offerer, venue, offer_venue, domains, template_start, template_end
+    ):
         national_program = educational_factories.NationalProgramFactory()
 
         # When
-        data = {
-            **base_collective_offer_payload,
-            "nationalProgramId": national_program.id,
-            "venueId": venue.id,
-            "domains": [educational_domain1.id, educational_domain1.id, educational_domain2.id],
-            "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": venue.id,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth("user@example.com").post("/collective/offers-template", json=data)
+        data = {**payload, "nationalProgramId": national_program.id}
+
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
 
         # Then
-
         assert response.status_code == 201
+
         offer_id = response.json["id"]
         offer = CollectiveOfferTemplate.query.get(offer_id)
+
         assert offer.bookingEmails == ["offer1@example.com", "offer2@example.com"]
         assert offer.subcategoryId == subcategories.SPECTACLE_REPRESENTATION.id
         assert offer.venue == venue
@@ -72,285 +121,168 @@ class Returns200Test:
         assert offer.mentalDisabilityCompliant is True
         assert offer.contactEmail == "pouet@example.com"
         assert offer.contactPhone == "01 99 00 25 68"
-        assert offer.offerVenue == {
-            "addressType": "school",
-            "venueId": venue.id,
-            "otherAddress": "17 rue aléatoire",
-        }
+        assert offer.offerVenue == offer_venue
         assert offer.interventionArea == ["75", "92", "93"]
         assert len(offer.students) == 2
         assert offer.students[0].value == "Lycée - Seconde"
         assert offer.students[1].value == "Lycée - Première"
         assert len(offer.domains) == 2
-        assert set(offer.domains) == {educational_domain1, educational_domain2}
+        assert set(offer.domains) == set(domains)
         assert offer.description == "Ma super description"
         assert offer.priceDetail == "Le détail ici"
         assert offer.nationalProgramId == national_program.id
+        assert offer.start == template_start
+        assert offer.end == template_end
 
-    def test_create_collective_offer_template_empty_intervention_area(self, client):
-        # Given
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
-        educational_domain = educational_factories.EducationalDomainFactory()
-
-        # When
+    def test_empty_intervention_area(self, pro_client, payload, venue):
         data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "domains": [educational_domain.id],
-            "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "offerVenue": {
-                "addressType": "offererVenue",
-                "otherAddress": "",
-                "venueId": venue.id,
-            },
+            **payload,
+            "offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id},
             "interventionArea": [],
         }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth("user@example.com").post("/collective/offers-template", json=data)
 
-        # Then
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
+
         assert response.status_code == 201
 
 
-@pytest.mark.usefixtures("db_session")
 class Returns403Test:
-    def test_create_collective_offer_template_random_user(self, client):
-        # Given
-        user = users_factories.UserFactory()
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
+    def test_random_user(self, client, payload):
+        user = offerers_factories.UserOffererFactory().user
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "domains": [educational_factories.EducationalDomainFactory().id],
-            "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": venue.id,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth(user.email).post("/collective/offers-template", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = client.with_session_auth(user.email).post("/collective/offers-template", json=payload)
 
-        # Then
         assert response.status_code == 403
         assert CollectiveOfferTemplate.query.count() == 0
 
-    def test_create_collective_offer_template_no_adage_offerer(self, client):
-        # Given
+    def test_no_adage_offerer(self, pro_client, payload):
         def raise_ac(*args, **kwargs):
             raise educational_exceptions.CulturalPartnerNotFoundException("pouet")
 
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
+        with patch(PATCH_CAN_CREATE_OFFER_PATH, side_effect=raise_ac):
+            response = pro_client.post("/collective/offers-template", json=payload)
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "domains": [educational_factories.EducationalDomainFactory().id],
-            "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": venue.id,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer", side_effect=raise_ac):
-            response = client.with_session_auth("user@example.com").post("/collective/offers-template", json=data)
-
-        # Then
         assert response.status_code == 403
         assert CollectiveOfferTemplate.query.count() == 0
 
 
-@pytest.mark.usefixtures("db_session")
 class Returns400Test:
-    def test_create_collective_offer_template_unknown_category(self, client):
-        # Given
-        user = users_factories.UserFactory()
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user=user)
+    def test_missing_category(self, pro_client, payload):
+        del payload["subcategoryId"]
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": 125,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth(user.email).post("/collective/offers-template", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=payload)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {"subcategoryId": ["Ce champ est obligatoire"]}
+
         assert CollectiveOfferTemplate.query.count() == 0
 
-    def test_create_collective_offer_template_unselectable_category(self, client):
-        # Given
-        user = users_factories.UserFactory()
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user=user)
+    def test_unselectable_category(self, pro_client, payload):
+        data = {**payload, "subcategoryId": subcategories.OEUVRE_ART.id}
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "subcategoryId": subcategories.OEUVRE_ART.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": 125,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth(user.email).post("/collective/offers-template", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {
+            "subcategory": ["Une offre ne peut être créée ou éditée en utilisant cette sous-catégorie"]
+        }
+
         assert CollectiveOfferTemplate.query.count() == 0
 
-    def test_create_collective_offer_template_no_collective_category(self, client):
-        # Given
-        user = users_factories.UserFactory()
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user=user)
+    def test_no_collective_category(self, pro_client, payload):
+        data = {**payload, "subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id}
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": 125,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth(user.email).post("/collective/offers-template", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {"offer": ["Cette catégorie d'offre n'est pas éligible aux offres éducationnelles"]}
+
         assert CollectiveOfferTemplate.query.count() == 0
 
-    def test_create_collective_offer_template_empty_domains(self, client):
-        # Given
-        user = users_factories.UserFactory()
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user=user)
+    def test_empty_domains(self, pro_client, payload):
+        data = {**payload, "domains": []}
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": 125,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth(user.email).post("/collective/offers-template", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {"__root__": ["domains must have at least one value"]}
+
         assert CollectiveOfferTemplate.query.count() == 0
 
-    def test_create_collective_offer_template_too_long_price_details(self, client):
-        user = users_factories.UserFactory()
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user=user)
+    def test_too_long_price_details(self, pro_client, payload):
+        data = {**payload, "priceDetail": "a" * 1001}
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": 125,
-                "otherAddress": "17 rue aléatoire",
-            },
-            "priceDetail": "a" * 1001,
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth(user.email).post("/collective/offers-template", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
 
-        # Then
         assert response.status_code == 400
+        assert response.json == {"priceDetail": ["ensure this value has at most 1000 characters"]}
+
         assert CollectiveOfferTemplate.query.count() == 0
 
 
-@pytest.mark.usefixtures("db_session")
+class InvalidDatesTest:
+    def test_missing_start(self, pro_client, payload, template_end):
+        response = self.send_request(pro_client, payload, {"end": template_end.isoformat()})
+        assert response.status_code == 400
+        assert "dates.start" in response.json
+
+    def test_start_is_null(self, pro_client, payload, template_end):
+        response = self.send_request(pro_client, payload, {"start": None, "end": template_end.isoformat()})
+        assert response.status_code == 400
+        assert "dates.start" in response.json
+
+    def test_start_is_in_the_past(self, pro_client, payload, template_end):
+        one_week_ago = datetime.utcnow() - timedelta(days=7)
+        dates_extra = {"start": one_week_ago.isoformat(), "end": template_end.isoformat()}
+
+        response = self.send_request(pro_client, payload, dates_extra)
+        assert response.status_code == 400
+        assert "dates.start" in response.json
+
+    def test_start_is_after_end(self, pro_client, payload, template_end):
+        dates_extra = {"start": (template_end + timedelta(days=1)).isoformat(), "end": template_end.isoformat()}
+        response = self.send_request(pro_client, payload, dates_extra)
+        assert response.status_code == 400
+        assert "dates.__root__" in response.json
+
+    def test_missing_end(self, pro_client, payload, template_start):
+        response = self.send_request(pro_client, payload, {"start": template_start.isoformat()})
+        assert response.status_code == 400
+        assert "dates.end" in response.json
+
+    def test_end_is_null(self, pro_client, payload, template_start):
+        response = self.send_request(pro_client, payload, {"start": template_start.isoformat(), "end": None})
+        assert response.status_code == 400
+        assert "dates.end" in response.json
+
+    def send_request(self, pro_client, payload, dates_extra):
+        data = {**payload, "dates": {**dates_extra}}
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            return pro_client.post("/collective/offers-template", json=data)
+
+
 class Returns404Test:
-    def test_create_collective_offer_template_with_unknown_domain(self, client):
-        # Given
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
-        educational_domain1 = educational_factories.EducationalDomainFactory()
-        educational_domain2 = educational_factories.EducationalDomainFactory()
+    def test_unknown_domain(self, pro_client, payload):
+        data = {**payload, "domains": [0]}
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "venueId": venue.id,
-            "domains": [0, educational_domain1.id, educational_domain2.id],
-            "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": venue.id,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth("user@example.com").post("/collective/offers-template", json=data)
-
-        # Then
         assert response.status_code == 404
         assert response.json == {"code": "EDUCATIONAL_DOMAIN_NOT_FOUND"}
 
-    def test_create_collective_offer_template_with_unknown_national_program(self, client):
-        # Given
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
-        educational_domain1 = educational_factories.EducationalDomainFactory()
-        educational_domain2 = educational_factories.EducationalDomainFactory()
+    def test_unknown_national_program(self, pro_client, payload):
+        data = {**payload, "nationalProgramId": -1}
 
-        # When
-        data = {
-            **base_collective_offer_payload,
-            "nationalProgramId": -1,
-            "venueId": venue.id,
-            "domains": [educational_domain1.id, educational_domain1.id, educational_domain2.id],
-            "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "offerVenue": {
-                "addressType": "school",
-                "venueId": venue.id,
-                "otherAddress": "17 rue aléatoire",
-            },
-        }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_session_auth("user@example.com").post("/collective/offers-template", json=data)
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
         assert response.json == {"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_NOT_FOUND"}

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -61,6 +61,8 @@ export type { CreateThumbnailBodyModel } from './models/CreateThumbnailBodyModel
 export type { CreateThumbnailResponseModel } from './models/CreateThumbnailResponseModel';
 export type { CropParams } from './models/CropParams';
 export type { CulturalPartner } from './models/CulturalPartner';
+export type { DateRangeModel } from './models/DateRangeModel';
+export type { DateRangeOnCreateModel } from './models/DateRangeOnCreateModel';
 export type { DeleteFilteredStockListBody } from './models/DeleteFilteredStockListBody';
 export type { DeleteOfferRequestBody } from './models/DeleteOfferRequestBody';
 export type { DeleteStockListBody } from './models/DeleteStockListBody';

--- a/pro/src/apiClient/v1/models/DateRangeModel.ts
+++ b/pro/src/apiClient/v1/models/DateRangeModel.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type DateRangeModel = {
+  end: string;
+  start: string;
+};
+

--- a/pro/src/apiClient/v1/models/DateRangeOnCreateModel.ts
+++ b/pro/src/apiClient/v1/models/DateRangeOnCreateModel.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type DateRangeOnCreateModel = {
+  end: string;
+  start: string;
+};
+

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
+import type { DateRangeModel } from './DateRangeModel';
 import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 
@@ -12,6 +13,7 @@ export type PatchCollectiveOfferTemplateBodyModel = {
   bookingEmails?: Array<string> | null;
   contactEmail?: string | null;
   contactPhone?: string | null;
+  dates?: DateRangeModel | null;
   description?: string | null;
   domains?: Array<number> | null;
   durationMinutes?: number | null;

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
+import type { DateRangeOnCreateModel } from './DateRangeOnCreateModel';
 import type { StudentLevels } from './StudentLevels';
 
 export type PostCollectiveOfferTemplateBodyModel = {
@@ -11,6 +12,7 @@ export type PostCollectiveOfferTemplateBodyModel = {
   bookingEmails: Array<string>;
   contactEmail: string;
   contactPhone?: string | null;
+  dates?: DateRangeOnCreateModel | null;
   description: string;
   domains?: Array<number> | null;
   durationMinutes?: number | null;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24579

Ajout de dates de début et de fin aux offres vitrines (collectives). Une offre vitrine ne peut pas avoir plus de 10 paires de dates et chacune doit au minimum avoir un début (la fin est optionnelle).

## Au passage

1. Petite refacto pour le champ `price_detail`/`priceDetail` dans les modèles _pydantic_.
2. Refacto des tests: ajout de _fixture_ pour supprimer du code dans les méthodes de tests, simplification de quelques tests, suppression d'un ou deux tests qui ne semblaient pas vitaux et difficiles à comprendre (que teste-t-on ? Quelle est la réelle différence avec le précédent ?), renommage de méthodes pour mieux faire ressortir le cas de test.