### PR TITLE
(PC-24844)[PRO] feat: Dont display favorite button on bookable offers…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -47,6 +47,11 @@ const Offer = ({
   const isGeolocationActive = useActiveFeature('WIP_ENABLE_ADAGE_GEO_LOCATION')
   const { adageUser } = useAdageUser()
 
+  const canAddOfferToFavorites =
+    isLikeActive &&
+    offer.isTemplate &&
+    adageUser.role !== AdageFrontRoles.READONLY
+
   const openOfferDetails = (
     offer: HydratedCollectiveOffer | HydratedCollectiveOfferTemplate
   ) => {
@@ -161,7 +166,7 @@ const Offer = ({
                 </ul>
               </div>
               <div className={style['offer-details-actions']}>
-                {isLikeActive && (
+                {canAddOfferToFavorites && (
                   <OfferFavoriteButton
                     offer={offer}
                     afterFavoriteChange={afterFavoriteChange}


### PR DESCRIPTION
… and when user is readonly.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24844

**FF à activer**
- WIP_ENABLE_LIKE_IN_ADAGE

**Objectif**
Retirer la possibilité aux admins d'ajouter une offre en favoris (ça ne fonctionne pas pusique les admins ne sont pas identifiables), et retirer la possibilité de mettre en favoris une offre pré-réservable.

<img width="811" alt="Capture d’écran 2023-10-04 à 10 52 07" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/d40ab472-147d-4ef6-88e1-5d9803b8c7a4">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques