### PR TITLE
(BSR)[API] feat: allow job.delay() calls in local environment

### DIFF
--- a/api/src/pcapi/workers/decorators.py
+++ b/api/src/pcapi/workers/decorators.py
@@ -8,6 +8,7 @@ from flask import current_app
 from rq.job import get_current_job
 from rq.queue import Queue
 
+from pcapi.settings import IS_DEV
 from pcapi.settings import IS_RUNNING_TESTS
 from pcapi.workers.logger import job_extra_description
 
@@ -20,7 +21,7 @@ def job(queue: Queue) -> typing.Callable:
         @wraps(func)
         def job_func(*args: typing.Any, **kwargs: typing.Any) -> None:
             current_job = get_current_job()
-            if not current_job or IS_RUNNING_TESTS:
+            if not current_job or IS_RUNNING_TESTS or IS_DEV:
                 # in synchronous calls (as wall in TESTS because queued jobs are executed synchronously)
                 # we don't won't to create another session
                 func(*args, **kwargs)

--- a/api/src/pcapi/workers/worker.py
+++ b/api/src/pcapi/workers/worker.py
@@ -22,8 +22,10 @@ from pcapi.workers.logger import job_extra_description
 blueprint = Blueprint(__name__, __name__)
 conn = redis.from_url(settings.REDIS_URL)
 
-default_queue = Queue("default", connection=conn, is_async=(not settings.IS_RUNNING_TESTS))
-low_queue = Queue("low", connection=conn, default_timeout=3600, is_async=(not settings.IS_RUNNING_TESTS))
+default_queue = Queue("default", connection=conn, is_async=(not (settings.IS_RUNNING_TESTS or settings.IS_DEV)))
+low_queue = Queue(
+    "low", connection=conn, default_timeout=3600, is_async=(not (settings.IS_RUNNING_TESTS or settings.IS_DEV))
+)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
En désactivant toutes les offres d'un lieu on a ces logs :

```
INFO:pcapi.flask_app:HTTP request at /offers/all-active-status
INFO:pcapi.core.offers.api:Batch update of offers
INFO:pcapi.core.offers.api:Offers has been deactivated
INFO:pcapi.workers.decorators:Enqueue job update_all_offers_active_status_job
```