### PR TITLE
(PC-24847)[EAC] fix: ne pas générer un mélange d'ApiError et de ValueError

### DIFF
--- a/api/src/pcapi/core/educational/validation.py
+++ b/api/src/pcapi/core/educational/validation.py
@@ -27,7 +27,7 @@ def validate_offer_venue(offer_venue: "OfferVenueModel | None") -> None:
                 f"'{collective_offers_serialize.OfferAddressType.OFFERER_VENUE.value}'"
             )
     elif offer_venue.venueId is not None:
-        raise ValueError(
+        errors["offerVenue.venueId"] = (
             "Ce champ est interdit si 'addressType' ne vaut pas "
             f"'{collective_offers_serialize.OfferAddressType.OFFERER_VENUE.value}'"
         )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24847

La fonction de validation génère des ApiError en cas d'erreur... sauf dans un cas où une ValueError est générée. Cette dernière n'est pas gérée et cela se termine en erreur 500.

Ceci est un fix rapide, on pourrait (devrait ?) déplacer toute cette validation au niveau d'un modèle pydantic afin de se simplifier la vie et de laisser spectree/pydantic/flask gérer tous seuls les erreurs 400.