### PR TITLE
(PC-23045)[BO] fix: validation status Offerer can't be DELETED

### DIFF
--- a/api/src/pcapi/routes/backoffice/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice/forms/utils.py
@@ -18,6 +18,8 @@ class PCForm(FlaskForm):
 
 
 def choices_from_enum(
-    enum_cls: typing.Type[enum.Enum], formatter: typing.Callable[[typing.Any], str] | None = None
+    enum_cls: typing.Type[enum.Enum],
+    formatter: typing.Callable[[typing.Any], str] | None = None,
+    exclude_opts: typing.Iterable[enum.Enum] = (),
 ) -> list[tuple]:
-    return [(opt.name, formatter(opt) if formatter else opt.value) for opt in enum_cls]
+    return [(opt.name, formatter(opt) if formatter else opt.value) for opt in enum_cls if opt not in exclude_opts]

--- a/api/src/pcapi/routes/backoffice/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offerers/forms.py
@@ -89,7 +89,10 @@ class OffererValidationListForm(utils.PCForm):
         get_label=lambda tag: tag.label or tag.name,
     )
     status = fields.PCSelectMultipleField(
-        "États", choices=utils.choices_from_enum(ValidationStatus, filters.format_validation_status)
+        "États",
+        choices=utils.choices_from_enum(
+            ValidationStatus, formatter=filters.format_validation_status, exclude_opts=(ValidationStatus.DELETED,)
+        ),
     )
     dms_adage_status = fields.PCSelectMultipleField(
         "États du dossier DMS Adage",


### PR DESCRIPTION
## But de la pull request

Fix : Quand on a préservé le status supprimé sur le rattachement d'un pro à une structure, on a fait un effet de bord sur les statuts de validation d'une structure sur le BO. 

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/f9f6e8ec-f196-4398-8da3-a7707c366e2f)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques