### PR TITLE
(BSR) fix: internal error on mypy

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -456,11 +456,11 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def isEducational(self) -> bool:
         return False
 
-    @sa.ext.declarative.declared_attr  # type: ignore [misc]
-    def lastProviderId(cls):  # pylint: disable=no-self-argument
+    @sa.ext.declarative.declared_attr  # type: ignore[misc]
+    def lastProviderId(cls) -> sa.Column:  # pylint: disable=no-self-argument
         return sa.Column(sa.BigInteger, sa.ForeignKey("provider.id"), nullable=True)
 
-    @sa.ext.declarative.declared_attr  # type: ignore [misc]
+    @sa.ext.declarative.declared_attr  # type: ignore[misc]
     def lastProvider(cls):  # pylint: disable=no-self-argument
         return sa.orm.relationship("Provider", foreign_keys=[cls.lastProviderId])
 

--- a/api/src/pcapi/models/providable_mixin.py
+++ b/api/src/pcapi/models/providable_mixin.py
@@ -19,7 +19,7 @@ class ProvidableMixin:
     def lastProviderId(cls) -> Mapped[int | None]:  # pylint: disable=no-self-argument
         return Column(BigInteger, ForeignKey("provider.id"), nullable=True)
 
-    @declared_attr  # type: ignore [misc]
+    @declared_attr  # type: ignore[misc]
     def lastProvider(cls):  # pylint: disable=no-self-argument
         return relationship("Provider", foreign_keys=[cls.lastProviderId])
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : BSR

Lorsqu'on lance mypy (v.1.5.1) en local, on a un bug dû à l'utilisation de @declared_attr 

C'est un bug de mypy > 1.4.0 documenté [ici](https://github.com/sqlalchemy/sqlalchemy/issues/10282)

Avec les modifications effectuées dans cette PR, on évite l'erreur lors des hooks de pre-commit 

(mais si on lance `mypy src/pcapi/workers`, ou n'importe quoi d'autre que `workers` qui ne soit pas `core`  le bug est toujours là)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques