### PR TITLE
(BSR)[API] refactor: Make `ReimbursementRule.apply()` return eurocents

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -880,9 +880,7 @@ def _price_event(event: models.FinanceEvent) -> models.Pricing:
             for original_line in original_pricing.lines
         ]
     elif is_incident_event:
-        amount = -utils.to_eurocents(
-            rule.apply(booking, event.bookingFinanceIncident.newTotalAmount)
-        )  # outgoing, thus negative
+        amount = -rule.apply(booking, event.bookingFinanceIncident.newTotalAmount)  # outgoing, thus negative
         lines = [
             models.PricingLine(
                 amount=-amount,
@@ -891,7 +889,7 @@ def _price_event(event: models.FinanceEvent) -> models.Pricing:
         ]
     else:
         is_booking_collective = isinstance(booking, educational_models.CollectiveBooking)
-        amount = -utils.to_eurocents(rule.apply(booking))  # outgoing, thus negative
+        amount = -rule.apply(booking)  # outgoing, thus negative
         lines = [
             models.PricingLine(
                 amount=-utils.to_eurocents(
@@ -935,7 +933,7 @@ def _price_booking(
         new_revenue += utils.to_eurocents(booking.total_amount)
     rule_finder = reimbursement.CustomRuleFinder()
     rule = reimbursement.get_reimbursement_rule(booking, rule_finder, new_revenue)
-    amount = -utils.to_eurocents(rule.apply(booking))  # outgoing, thus negative
+    amount = -rule.apply(booking)  # outgoing, thus negative
     # `Pricing.amount` equals the sum of the amount of all lines.
     lines = [
         models.PricingLine(

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -584,11 +584,14 @@ class CustomReimbursementRule(ReimbursementRule, Base, Model):
             return True
         return False
 
-    def apply(self, booking: "bookings_models.Booking", custom_total_amount: int | None = None) -> decimal.Decimal:
+    def apply(
+        self,
+        booking: "bookings_models.Booking",
+        custom_total_amount: int | None = None,
+    ) -> decimal.Decimal:
         if self.amount is not None:
             return booking.quantity * self.amount
-        custom_total_amount_euros = finance_utils.to_euros(custom_total_amount or 0)
-        return (custom_total_amount_euros or booking.total_amount) * self.rate
+        return super().apply(booking, custom_total_amount)
 
     @property
     def description(self) -> str:

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -19,13 +19,13 @@ import sqlalchemy.ext.mutable as sqla_mutable
 import sqlalchemy.orm as sqla_orm
 
 from pcapi import settings
-from pcapi.core.finance import utils as finance_utils
 from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.pc_object import PcObject
 import pcapi.utils.db as db_utils
 
+from . import utils
 from .enum import DepositType
 
 
@@ -499,9 +499,13 @@ class ReimbursementRule:
     def matches(self, booking: "bookings_models.Booking", cumulative_revenue: int) -> bool:
         return self.is_active(booking) and self.is_relevant(booking, cumulative_revenue)
 
-    def apply(self, booking: "bookings_models.Booking", custom_total_amount: int | None = None) -> decimal.Decimal:
-        custom_total_amount_euros = finance_utils.to_euros(custom_total_amount or 0)
-        return decimal.Decimal((custom_total_amount_euros or booking.total_amount) * self.rate)  # type: ignore [attr-defined]
+    def apply(
+        self,
+        booking: "bookings_models.Booking",
+        custom_total_amount: int | None = None,
+    ) -> int:
+        base = custom_total_amount or utils.to_eurocents(booking.total_amount)
+        return utils.round_to_integer(base * self.rate)  # type: ignore [attr-defined]
 
     @property
     def group(self) -> RuleGroup:
@@ -588,9 +592,9 @@ class CustomReimbursementRule(ReimbursementRule, Base, Model):
         self,
         booking: "bookings_models.Booking",
         custom_total_amount: int | None = None,
-    ) -> decimal.Decimal:
+    ) -> int:
         if self.amount is not None:
-            return booking.quantity * self.amount
+            return utils.to_eurocents(booking.quantity * self.amount)
         return super().apply(booking, custom_total_amount)
 
     @property
@@ -923,7 +927,7 @@ class FinanceIncident(Base, Model):
         Returns the amount we want to retrieve from the offerer for this incident.
         """
         return sum(
-            finance_utils.to_eurocents((booking_incident.booking or booking_incident.collectiveBooking).total_amount)
+            utils.to_eurocents((booking_incident.booking or booking_incident.collectiveBooking).total_amount)
             - booking_incident.newTotalAmount
             for booking_incident in self.booking_finance_incidents
         )

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -922,7 +922,7 @@ class FinanceIncident(Base, Model):
         return any(booking_incident.collectiveBooking for booking_incident in self.booking_finance_incidents)
 
     @property
-    def due_amount_by_offerer(self) -> decimal.Decimal:
+    def due_amount_by_offerer(self) -> int:
         """
         Returns the amount we want to retrieve from the offerer for this incident.
         """

--- a/api/src/pcapi/core/finance/utils.py
+++ b/api/src/pcapi/core/finance/utils.py
@@ -7,19 +7,31 @@ import pytz
 
 
 ACCOUNTING_TIMEZONE = pytz.timezone("Europe/Paris")
+ROUNDING = decimal.ROUND_HALF_UP
 
 
 def to_eurocents(amount_in_euros: decimal.Decimal | float) -> int:
     exponent = decimal.Decimal("0.01")
     # 0.010 to 0.014 -> 0.01
     # 0.015 to 0.019 -> 0.02
-    rounding = decimal.ROUND_HALF_UP
-    return int(100 * decimal.Decimal(f"{amount_in_euros}").quantize(exponent, rounding))
+    return int(100 * decimal.Decimal(f"{amount_in_euros}").quantize(exponent, ROUNDING))
 
 
 def to_euros(amount_in_eurocents: int) -> decimal.Decimal:
     exponent = decimal.Decimal("0.01")
     return decimal.Decimal(amount_in_eurocents / 100).quantize(exponent)
+
+
+def round_to_integer(amount: decimal.Decimal) -> int:
+    """Round to the closest integer.
+
+    >>> round(100.4)
+    100
+    >>> round(100.5)
+    101
+    """
+    exponent = decimal.Decimal("1")
+    return int(amount.quantize(exponent, ROUNDING))
 
 
 def fr_percentage_filter(decimal_rate: decimal.Decimal) -> str:

--- a/api/src/pcapi/domain/reimbursement.py
+++ b/api/src/pcapi/domain/reimbursement.py
@@ -35,9 +35,9 @@ class EducationalOffersReimbursement(finance_models.ReimbursementRule):
     def is_relevant(self, booking: Booking | CollectiveBooking, cumulative_revenue: int) -> bool:
         return isinstance(booking, CollectiveBooking)
 
-    def apply(self, booking: CollectiveBooking, custom_total_amount: int | None = None) -> Decimal:
-        custom_total_amount_euros = finance_utils.to_euros(custom_total_amount or 0)
-        return Decimal(custom_total_amount_euros or booking.collectiveStock.price) * self.rate
+    def apply(self, booking: CollectiveBooking, custom_total_amount: int | None = None) -> int:
+        base = custom_total_amount or finance_utils.to_eurocents(booking.collectiveStock.price)
+        return int(base * self.rate)
 
 
 class PhysicalOffersReimbursement(finance_models.ReimbursementRule):

--- a/api/tests/core/finance/test_models.py
+++ b/api/tests/core/finance/test_models.py
@@ -95,8 +95,8 @@ class CustomReimbursementRuleTest:
 
     def test_apply_with_rate(self):
         rule = factories.CustomReimbursementRuleFactory(rate=0.8)
-        single = bookings_factories.BookingFactory(quantity=1)
-        double = bookings_factories.BookingFactory(quantity=2)
+        single = bookings_factories.BookingFactory(quantity=1, amount=10.10)
+        double = bookings_factories.BookingFactory(quantity=2, amount=10.10)
 
         assert rule.apply(single) == Decimal("8.08")
         assert rule.apply(double) == Decimal("16.16")

--- a/api/tests/domain/reimbursement_test.py
+++ b/api/tests/domain/reimbursement_test.py
@@ -78,9 +78,9 @@ class DigitalThingsReimbursementTest:
 @pytest.mark.usefixtures("db_session")
 class EducationalOffersReimbursementTest:
     def test_apply(self):
-        booking = educational_factories.CollectiveBookingFactory(collectiveStock__price=3000)
+        booking = educational_factories.CollectiveBookingFactory(collectiveStock__price=1234)
         rule = reimbursement.EducationalOffersReimbursement()
-        assert rule.apply(booking) == 3000
+        assert rule.apply(booking) == 123400  # eurocents
 
     def test_relevancy(self):
         rule = reimbursement.EducationalOffersReimbursement()
@@ -96,7 +96,7 @@ class PhysicalOffersReimbursementTest:
     def test_apply(self):
         booking = create_non_digital_thing_booking(price=10, quantity=2)
         rule = reimbursement.PhysicalOffersReimbursement()
-        assert rule.apply(booking) == 10 * 2
+        assert rule.apply(booking) == 2000  # eurocents
 
     def test_relevancy(self):
         rule = reimbursement.PhysicalOffersReimbursement()
@@ -116,7 +116,7 @@ class LegacyPreSeptember2021ReimbursementRateByVenueBetween20000And40000Test:
 
     def test_apply(self):
         booking = create_event_booking(price=40, quantity=2)
-        assert self.rule.apply(booking) == Decimal("0.95") * 40 * 2
+        assert self.rule.apply(booking) == 7600  # 0.95 * 40 * 2 * 100 (eurocents)
 
     def test_relevancy_depending_on_revenue(self):
         booking = create_event_booking()
@@ -139,7 +139,7 @@ class LegacyPreSeptember2021ReimbursementRateByVenueBetween40000And150000Test:
 
     def test_apply(self):
         booking = create_event_booking(price=40, quantity=2)
-        assert self.rule.apply(booking) == Decimal("0.85") * 40 * 2
+        assert self.rule.apply(booking) == 6800  # 0.85 * 40 * 2 * 100 (eurocents)
 
     def test_relevancy_depending_on_revenue(self):
         booking = create_event_booking()
@@ -162,7 +162,7 @@ class LegacyPreSeptember2021ReimbursementRateByVenueAbove150000Test:
 
     def test_apply(self):
         booking = create_event_booking(price=40, quantity=2)
-        assert self.rule.apply(booking) == Decimal("0.7") * 40 * 2
+        assert self.rule.apply(booking) == 5600  # 0.7 * 40 * 2 * 100 (eurocents)
 
     def test_relevancy_depending_on_revenue(self):
         booking = create_event_booking()
@@ -183,7 +183,7 @@ class ReimbursementRateByVenueBetween20000And40000Test:
 
     def test_apply(self):
         booking = create_event_booking(price=40, quantity=2)
-        assert self.rule.apply(booking) == Decimal("0.95") * 40 * 2
+        assert self.rule.apply(booking) == 7600  # 0.95 * 40 * 2 * 100 (eurocents)
 
     def test_relevancy_depending_on_revenue(self):
         booking = create_event_booking()
@@ -206,7 +206,7 @@ class ReimbursementRateByVenueBetween40000And150000Test:
 
     def test_apply(self):
         booking = create_event_booking(price=40, quantity=2)
-        assert self.rule.apply(booking) == Decimal("0.92") * 40 * 2
+        assert self.rule.apply(booking) == 7360  # 0.92 * 40 * 2 * 100 (eurocents)
 
     def test_relevancy_depending_on_revenue(self):
         booking = create_event_booking()
@@ -229,7 +229,7 @@ class ReimbursementRateByVenueAbove150000Test:
 
     def test_apply(self):
         booking = create_event_booking(price=40, quantity=2)
-        assert self.rule.apply(booking) == Decimal("0.90") * 40 * 2
+        assert self.rule.apply(booking) == 7200  # 0.90 * 40 * 2 * 100 (eurocents)
 
     def test_relevancy_depending_on_revenue(self):
         booking = create_event_booking()
@@ -255,7 +255,7 @@ class ReimbursementRateForBookBelow20000Test:
         )
 
     def test_apply(self):
-        assert self.rule.apply(self.book_booking) == Decimal(1) * 40 * 2
+        assert self.rule.apply(self.book_booking) == 8000  # 1 * 40 * 2 * 100 (eurocents)
 
     def test_relevancy_depending_on_revenue(self):
         assert self.rule.is_relevant(self.book_booking, 20_000)
@@ -283,7 +283,7 @@ class ReimbursementRateForBookAbove20000Test:
         )
 
     def test_apply(self):
-        assert self.rule.apply(self.book_booking) == Decimal("0.95") * 40 * 2
+        assert self.rule.apply(self.book_booking) == 7600  # 0.95 * 40 * 2 * 100 (eurocents)
 
     def test_relevancy_depending_on_revenue(self):
         assert not self.rule.is_relevant(self.book_booking, 20_000 * 100)


### PR DESCRIPTION
Objectif : faire en sorte de toujours manipuler des centimes avant de
stocker `Pricing.amount`.

Changement précédé de 2 commits de simplification/clarification du
code et des tests.

Prochaine étape (dans une autre pull request, à venir après celle-ci)
: faire en sorte que `CustomReimbursementRuleTest.amount` soit un
montant en centimes et non plus en euros comme actuellement, par souci
d'homogénéité avec tous les autres montants stockés dans les modèles
de `core.finance`.