### PR TITLE
(BSR)[API] style: Make Alembic migration 14e9b22809ef comment a one-liner

### DIFF
--- a/api/src/pcapi/alembic/versions/20230928T130528_14e9b22809ef_add_hmac_key_column_to_provider_table.py
+++ b/api/src/pcapi/alembic/versions/20230928T130528_14e9b22809ef_add_hmac_key_column_to_provider_table.py
@@ -1,6 +1,4 @@
-"""
-Add hmac key column to provider table
-This key will be used to sign the payload send to providers in charlie api
+"""Add `provider.hmacKey` column
 """
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
The comment is shown when running `alembic history` (among other
places). Having more than one line makes the output hard to read:

    $ alembic history
    bdb5f7cdd367 -> 14e9b22809ef (pre) (head), Add hmac key column to provider table
    This key will be used to sign the payload send to providers in charlie api
    ef07f9582155 -> bdb5f7cdd367 (pre), Add column `experienceDetails` in individual_offerer_subscription table

Now it's clearer:

    $ alembic history | head -n 2
    bdb5f7cdd367 -> 14e9b22809ef (pre) (head), Add `provider.hmacKey` column
    ef07f9582155 -> bdb5f7cdd367 (pre), Add column `experienceDetails` in individual_offerer_subscription table