### PR TITLE
PC-24654: EAC: fix: collectiveOffer.offerVenue->>venueId ne devrait jamais être égal = "" (suite)

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -246,6 +246,8 @@ class CollectiveOfferOfferVenueResponseModel(BaseModel):
     otherAddress: str
     venueId: int | None
 
+    _validated_venue_id = validator("venueId", pre=True, allow_reuse=True)(validate_venue_id)
+
 
 class GetCollectiveOfferCollectiveStockResponseModel(BaseModel):
     id: int

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -182,6 +182,25 @@ class Returns200Test:
         assert response.json["status"] == "INACTIVE"
         assert response.json["isActive"] is False
 
+    def test_offer_venue_has_an_empty_string_venue_id(self, client):
+        # TODO(jeremieb): remove this test once there is no empty
+        # string stored as a venueId
+        offer = educational_factories.CollectiveOfferFactory(
+            offerVenue={"venueId": "", "addressType": "offererVenue", "otherAddress": "some address"}
+        )
+
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        client = client.with_session_auth(email="user@example.com")
+        response = client.get(f"/collective/offers/{offer.id}")
+
+        assert response.status_code == 200
+        assert response.json["offerVenue"] == {
+            "venueId": None,
+            "addressType": "offererVenue",
+            "otherAddress": "some address",
+        }
+
 
 @pytest.mark.usefixtures("db_session")
 class Returns403Test:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24885

Ne plus permettre d'avoir des venueId égaux à "" pour collective_offer.offerVenue->>venueId lors de la création.
Gérer les données existantes en transformant les "" en None lors de la sérialisation.

Il manquait le fix pour le portail pro dans la précédente PR : https://github.com/pass-culture/pass-culture-main/pull/8351