### PR TITLE
(PC-24850)[EAC] fix: offer.providerId pas offer.provider.id

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -102,13 +102,9 @@ def get_collective_offer_public(
             status_code=404,
         )
 
-    if offer.provider.id != current_api_key.providerId:
-        raise ApiErrors(
-            errors={
-                "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."],
-            },
-            status_code=403,
-        )
+    if offer.providerId != current_api_key.providerId:
+        msg = "Vous n'avez pas le droit d'accéder à une ressource que vous n'avez pas créée via cette API"
+        raise ApiErrors(errors={"global": [msg]}, status_code=403)
 
     return offers_serialization.GetPublicCollectiveOfferResponseModel.from_orm(offer)
 

--- a/api/tests/routes/public/collective/endpoints/get_collective_offers_test.py
+++ b/api/tests/routes/public/collective/endpoints/get_collective_offers_test.py
@@ -215,3 +215,16 @@ class CollectiveOffersPublicGetOfferTest:
 
         # Then
         assert response.status_code == 401
+
+    def test_user_did_not_create_offer_using_the_api(self, client):
+        """Ensure that a user cannot fetch an offer that he did not
+        created with the API"""
+        venue_provider = provider_factories.VenueProviderFactory()
+        offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
+
+        offer = educational_factories.CollectiveStockFactory().collectiveOffer
+
+        api_client = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY)
+        response = api_client.get(f"/v2/collective/offers/{offer.id}")
+
+        assert response.status_code == 403


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24850

Si l'offre collective n'a pas de provider, alors offer.provider.id génère une erreur ('NoneType' object has no attribute 'id').

Fix: accéder directement à l'id du provider.