### PR TITLE
(BSR)[API] refactor: Add `CustomReimbursementRule.amountInEurocents`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-c5009a056b16 (pre) (head)
-9d9bfc829be5 (post) (head)
+5f59d1bc65a3 (pre) (head)
+f72b113cfe59 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231004T192225_5f59d1bc65a3_add_custom_reimbursement_rule_amount_in_eurocents.py
+++ b/api/src/pcapi/alembic/versions/20231004T192225_5f59d1bc65a3_add_custom_reimbursement_rule_amount_in_eurocents.py
@@ -1,0 +1,19 @@
+"""Add `custom_reimbursement_rule.amountInEuroCents` column"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "5f59d1bc65a3"
+down_revision = "c5009a056b16"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("custom_reimbursement_rule", sa.Column("amountInEuroCents", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("custom_reimbursement_rule", "amountInEuroCents")

--- a/api/src/pcapi/alembic/versions/20231004T193123_f72b113cfe59_populate_custom_reimbursement_rule_amount_in_eurocents.py
+++ b/api/src/pcapi/alembic/versions/20231004T193123_f72b113cfe59_populate_custom_reimbursement_rule_amount_in_eurocents.py
@@ -1,0 +1,25 @@
+"""Populate `custom_reimbursement_rule.amountInEuroCents`"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "f72b113cfe59"
+down_revision = "9d9bfc829be5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+      update custom_reimbursement_rule
+      set "amountInEuroCents" = (100 * amount)::integer
+      where "amountInEuroCents" is null
+    """
+    )
+
+
+def downgrade() -> None:
+    pass  # nothing to do

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -2459,6 +2459,7 @@ def _create_reimbursement_rule(
         subcategories=subcategories,
         rate=rate,  # only for offerers
         amount=amount,  # only for offers
+        amountInEuroCents=utils.to_eurocents(amount) if amount is not None else None,
         timespan=(start_date, end_date),
     )
     validation.validate_reimbursement_rule(rule)

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -539,6 +539,7 @@ class CustomReimbursementRule(ReimbursementRule, Base, Model):
     # eurocents like other models do.
     # Contrary to other models, this amount is in euros, not eurocents.
     amount: decimal.Decimal = sqla.Column(sqla.Numeric(10, 2), nullable=True)
+    amountInEuroCents: int = sqla.Column(sqla.Integer, nullable=True)
 
     # rate is between 0 and 1 (included), or NULL if `amount` is set.
     rate: decimal.Decimal = sqla.Column(sqla.Numeric(5, 4), nullable=True)

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -2759,6 +2759,7 @@ class CreateOfferReimbursementRuleTest:
         db.session.refresh(rule)
         assert rule.offer == offer
         assert rule.amount == Decimal("12.34")
+        assert rule.amountInEuroCents == 1234
         assert rule.timespan.lower == datetime.datetime(2021, 10, 2, 0, 0)
         assert rule.timespan.upper == datetime.datetime(2021, 10, 3, 0, 0)
 

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -32,6 +32,7 @@ class AddCustomOfferReimbursementRuleTest:
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offer.id == offer_id
         assert rule.amount == decimal.Decimal("12.34")
+        assert rule.amountInEuroCents == 1234
 
     @clean_database
     def test_warnings(self, app):
@@ -77,6 +78,7 @@ class AddCustomOfferReimbursementRuleTest:
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offer.id == offer_id
         assert rule.amount == decimal.Decimal("12.34")
+        assert rule.amountInEuroCents == 1234
 
 
 @clean_database


### PR DESCRIPTION
`CustomReimbursementRule.amount` is the last model column where we
store euros and not eurocents. This commit is the first step in
storing eurocents in the `amount` column.

-> step 1: add `amountInEurocents` and write in both `amount` and
           `amountInEurocents`. Also, populate `amountInEurocents`
           for existing rows.
   step 2: use `amountInEuroCents` column instead of `amount`.
   step 3: store eurocents in `amount` column.
   step 4: use `amount` column.
   step 5: drop `amountInEuroCents` column.