### PR TITLE
(PC-24710)[PRO] fix: Trigger the adage search log event when clearing…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -16,6 +16,8 @@ import React, {
   useEffect,
   useRef,
   useContext,
+  Dispatch,
+  SetStateAction,
 } from 'react'
 import { useSearchBox } from 'react-instantsearch'
 
@@ -43,7 +45,7 @@ import styles from './Autocomplete.module.scss'
 type AutocompleteProps = {
   initialQuery: string
   placeholder: string
-  setCurrentSearch: (search: string) => void
+  setCurrentSearch: Dispatch<SetStateAction<string | null>>
 }
 
 type SuggestionItem = AutocompleteQuerySuggestionsHit & {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -88,10 +88,10 @@ export const OffersSearch = ({
     formik.setValues(ADAGE_FILTERS_DEFAULT_VALUES)
     formik.handleSubmit()
   }
-  const [currentSearch, setCurrentSearch] = useState('')
+  const [currentSearch, setCurrentSearch] = useState<string | null>(null)
   const logFiltersOnSearch = (nbHits: number, queryId?: string) => {
     /* istanbul ignore next: TO FIX the current structure make it hard to test, we probably should not mock Offers in OfferSearch tests */
-    if (formik.submitCount > 0 || currentSearch != '') {
+    if (formik.submitCount > 0 || currentSearch !== null) {
       apiAdage.logTrackingFilter({
         iframeFrom: removeParamsFromUrl(location.pathname),
         resultNumber: nbHits,


### PR DESCRIPTION
… the query search value.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24710

**FF à activer**
- WIP_ENABLE_NEW_ADAGE_FILTERS

**Objectif**
Quand on clear le champ de recherche d'adage sans jamais avoir sélectionné de filtre auparavant, il faut que l'appel à `/adage-iframe/logs/tracking-filter` soit fait.

**Réalisation**
La solution réalisée est différente de la strat tech. Cette PR m'a l'air plus naturelle par rapport à l'état actuel du component!


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques