### PR TITLE
(PC-24904)[EAC] API collective: fix: toujours mettre un priceDetail

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -328,8 +328,8 @@ def patch_collective_offer_public(
                 },
                 status_code=400,
             )
-    if new_values.get("educationalPriceDetail", None):
-        new_values["priceDetail"] = new_values.pop("educationalPriceDetail")
+
+    new_values["priceDetail"] = new_values.pop("educationalPriceDetail", None)
 
     # access control
     try:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24904

Bug: lorsqu'un utilisateur essaie de mettre à jour une offre collective via l'API publique, si educationalPriceDetail est renseigné mais nul, tout plante (erreur 500) à cause d'une ValueError non gérée.

Le problème est que le contrôleur ajoute un champ priceDetail dont on sait quoi faire (c'est une colonne du stock collectif) uniquement si educationalPriceDetail n'est pas nul. Dans le cas contraire... la variable new_values dont on se sert pour tout mettre à jour utilise un champ educationalPriceDetail dont personne ne sait quoi faire et qui génère une ValueError.

Fix: toujours générer un priceDetail à partir du educationalPriceDetail.