### PR TITLE
(PC-24436)[BO] feat: create individual offer detail page and store validation or rejection author

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-695bc13a7be4 (pre) (head)
+654f1c1c4da3 (pre) (head)
 cd2fcba2f97f (post) (head)

--- a/api/src/pcapi/alembic/versions/20231009T092610_631df26e514b_add_last_author_validation_or_rejection_on_collective_offer_table.py
+++ b/api/src/pcapi/alembic/versions/20231009T092610_631df26e514b_add_last_author_validation_or_rejection_on_collective_offer_table.py
@@ -1,0 +1,30 @@
+"""
+add last author validation or rejection on "collective_offer" table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "631df26e514b"
+down_revision = "695bc13a7be4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("collective_offer", sa.Column("lastValidationAuthorUserId", sa.BigInteger(), nullable=True))
+    op.create_foreign_key(
+        "collective_offer_validation_author_fkey",
+        "collective_offer",
+        "user",
+        ["lastValidationAuthorUserId"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("collective_offer_validation_author_fkey", "collective_offer", type_="foreignkey")
+    op.drop_column("collective_offer", "lastValidationAuthorUserId")

--- a/api/src/pcapi/alembic/versions/20231009T092625_8347a72b24d0_add_last_author_validation_or_rejection_on_collective_template_offer_table.py
+++ b/api/src/pcapi/alembic/versions/20231009T092625_8347a72b24d0_add_last_author_validation_or_rejection_on_collective_template_offer_table.py
@@ -1,0 +1,32 @@
+"""
+add last author validation or rejection on "collective_offer_template" table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "8347a72b24d0"
+down_revision = "631df26e514b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("collective_offer_template", sa.Column("lastValidationAuthorUserId", sa.BigInteger(), nullable=True))
+    op.create_foreign_key(
+        "collective_offer_template_validation_author_fkey",
+        "collective_offer_template",
+        "user",
+        ["lastValidationAuthorUserId"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "collective_offer_template_validation_author_fkey", "collective_offer_template", type_="foreignkey"
+    )
+    op.drop_column("collective_offer_template", "lastValidationAuthorUserId")

--- a/api/src/pcapi/alembic/versions/20231009T092805_654f1c1c4da3_add_last_author_validation_or_rejection_on_offer_table.py
+++ b/api/src/pcapi/alembic/versions/20231009T092805_654f1c1c4da3_add_last_author_validation_or_rejection_on_offer_table.py
@@ -1,0 +1,30 @@
+"""
+add last author validation or rejection on "offer" table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "654f1c1c4da3"
+down_revision = "8347a72b24d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("offer", sa.Column("lastValidationAuthorUserId", sa.BigInteger(), nullable=True))
+    op.create_foreign_key(
+        "offer_validation_author_fkey",
+        "offer",
+        "user",
+        ["lastValidationAuthorUserId"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("offer_validation_author_fkey", "offer", type_="foreignkey")
+    op.drop_column("offer", "lastValidationAuthorUserId")

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -47,6 +47,7 @@ if typing.TYPE_CHECKING:
     from pcapi.core.offerers.models import Venue
     from pcapi.core.offers.models import OfferValidationRule
     from pcapi.core.providers.models import Provider
+    from pcapi.core.users.models import User
 
 
 class StudentLevels(enum.Enum):

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -582,7 +582,7 @@ def list_public_collective_offers(
     ]
 
     if status:
-        filters.append(educational_models.CollectiveOffer.status == status)  # type: ignore [arg-type]
+        filters.append(educational_models.CollectiveOffer.status == status)
     if venue_id:
         filters.append(educational_models.CollectiveOffer.venueId == venue_id)
     if period_beginning_date:

--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -266,7 +266,7 @@ class TiteLiveThings(LocalProvider):
                     ineligibility_reason,
                 )
             else:
-                offers_api.reject_inappropriate_product(book_unique_identifier)
+                offers_api.reject_inappropriate_product(book_unique_identifier, None)
                 logger.info(
                     "Rejecting ineligible ean=%s because reason=%s", book_unique_identifier, ineligibility_reason
                 )

--- a/api/src/pcapi/models/offer_mixin.py
+++ b/api/src/pcapi/models/offer_mixin.py
@@ -1,7 +1,14 @@
 import enum
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import declarative_mixin
+
+
+if TYPE_CHECKING:
+    from pcapi.core.users.models import User
 
 
 class OfferStatus(str, enum.Enum):
@@ -49,3 +56,11 @@ class ValidationMixin:
     @property
     def isApproved(self) -> bool:
         return self.validation == OfferValidationStatus.APPROVED
+
+    @declared_attr
+    def lastValidationAuthorUserId(self) -> Mapped[int | None]:
+        return sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
+
+    @declared_attr
+    def lastValidationAuthor(self) -> Mapped["User | None"]:
+        return sa.orm.relationship("User", foreign_keys=[self.lastValidationAuthorUserId])

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
@@ -5,6 +5,7 @@ from flask import redirect
 from flask import render_template
 from flask import request
 from flask import url_for
+from flask_login import current_user
 import sqlalchemy as sa
 
 from pcapi.core import search
@@ -81,7 +82,7 @@ def _get_collective_offer_templates(
         )
 
     if form.status.data:
-        base_query = base_query.filter(educational_models.CollectiveOfferTemplate.validation.in_(form.status.data))
+        base_query = base_query.filter(educational_models.CollectiveOfferTemplate.validation.in_(form.status.data))  # type: ignore [attr-defined]
 
     if form.only_validated_offerers.data:
         base_query = (
@@ -222,6 +223,7 @@ def _batch_validate_or_reject_collective_offer_templates(
         collective_offer_template.validation = new_validation_status
         collective_offer_template.lastValidationDate = datetime.datetime.utcnow()
         collective_offer_template.lastValidationType = OfferValidationType.MANUAL
+        collective_offer_template.lastValidationAuthorUserId = current_user.id
         if validation is OfferValidationStatus.APPROVED:
             collective_offer_template.isActive = True
 

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -833,6 +833,12 @@ def format_finance_incident_type(incident_kind: finance_models.IncidentType) -> 
             return incident_kind.value
 
 
+def format_stock_quantity(quantity: int | None) -> str:
+    if quantity is None:
+        return "Illimité"
+    return str(quantity)
+
+
 def install_template_filters(app: Flask) -> None:
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
@@ -903,3 +909,4 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_finance_incident_status"] = format_finance_incident_status
     app.jinja_env.filters["format_finance_incident_type"] = format_finance_incident_type
     app.jinja_env.filters["format_finance_incident_type_str"] = format_finance_incident_type_str
+    app.jinja_env.filters["format_stock_quantity"] = format_stock_quantity

--- a/api/src/pcapi/routes/backoffice/multiple_offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/multiple_offers/blueprint.py
@@ -5,6 +5,7 @@ from flask import flash
 from flask import redirect
 from flask import render_template
 from flask import url_for
+from flask_login import current_user
 import sqlalchemy as sa
 
 from pcapi.core.criteria import models as criteria_models
@@ -131,7 +132,7 @@ def set_product_gcu_incompatible() -> utils.BackofficeResponse:
 
     if not form.validate():
         flash(utils.build_form_error_msg(form), "warning")
-    elif offers_api.reject_inappropriate_product(form.ean.data, send_booking_cancellation_emails=False):
+    elif offers_api.reject_inappropriate_product(form.ean.data, current_user, send_booking_cancellation_emails=False):
         flash("Le produit a été rendu incompatible aux CGU et les offres ont été désactivées", "success")
     else:
         flash("Une erreur s'est produite lors de l'opération", "warning")

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -48,6 +48,16 @@
                 <p class="mb-1">
                   <span class="fw-bold">État :</span> {{ collective_offer.validation | format_offer_validation_status }}
                 </p>
+                {% if collective_offer.lastValidationDate %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Date de dernière validation :</span> {{ collective_offer.lastValidationDate | format_date_time }}
+                  </p>
+                {% endif %}
+                {% if collective_offer.lastValidationAuthor %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Utilisateur de la dernière validation :</span> {{ collective_offer.lastValidationAuthor.full_name }}
+                  </p>
+                {% endif %}
                 <p class="mb-1">
                   <span class="fw-bold">Prix :</span>
                   {% if collective_offer.collectiveStock %}{{ collective_offer.collectiveStock.price | format_amount }}{% endif %}

--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -50,6 +50,11 @@
      target="_blank"
      title="{{ hint }} associées au lieu"><i class="bi bi-box-arrow-up-right"></i></a>
 {% endmacro %}
+{% macro build_offer_details_link(offer) %}
+  <a href="{{ url_for('backoffice_web.offer.get_offer_details', offer_id=offer.id) }}"
+     class="link-primary"
+     title="Page de l'offre">{{ offer.id }}</i></a>
+{% endmacro %}
 {% macro build_collective_offer_details_link(offer) %}
   <a href="{{ url_for('backoffice_web.collective_offer.get_collective_offer_details', collective_offer_id=offer.id) }}"
      class="link-primary"

--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -1,0 +1,101 @@
+{% import "components/links.html" as links %}
+{% from "components/presentation/details/tabs.html" import build_details_tab %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_wrapper %}
+{% from "components/presentation/details/tabs.html" import build_details_tab_content %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
+{% from "components/turbo/spinner.html" import build_loading_spinner with context %}
+{% extends "layouts/standard.html" %}
+{% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
+{% block main_content %}
+  <div class="row row-cols-1 g-4 py-3">
+    <div class="col">
+      <div class="card shadow">
+        <div class="card-body">
+          <div class="row justify-content-start align-items-center">
+            <div class="col d-flex align-items-center justify-content-start">
+              <h2 class="card-title mb-3 text-primary">{{ links.build_offer_name_to_pc_pro_link(offer) }}</h2>
+            </div>
+            <div class="col-2"></div>
+          </div>
+          <p class="card-subtitle text-muted mb-3 h5">Offer ID : {{ offer.id }}</p>
+          <div class="row pt-3">
+            <div class="col-4">
+              <div class="fs-6">
+                <p class="mb-1">
+                  <span class="fw-bold">Catégorie :</span> {{ offer.category.pro_label }}
+                </p>
+                <p class="mb-1">
+                  <span class="fw-bold">Sous-catégorie :</span> {{ offer.subcategory.pro_label }}
+                </p>
+                <p class="mb-1">
+                  <span class="fw-bold">Date de création :</span> {{ offer.dateCreated | format_date }}
+                </p>
+              </div>
+            </div>
+            <div class="col-4">
+              <div class="fs-6">
+                <p class="mb-1">
+                  <span class="fw-bold">Statut :</span> {{ offer.status | format_offer_status }}
+                </p>
+                <p class="mb-1">
+                  <span class="fw-bold">État :</span> {{ offer.validation | format_offer_validation_status }}
+                </p>
+                {% if offer.lastValidationDate %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Date de dernière validation :</span> {{ offer.lastValidationDate | format_date_time }}
+                  </p>
+                {% endif %}
+                {% if offer.lastValidationAuthor %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Utilisateur de la dernière validation :</span> {{ offer.lastValidationAuthor.full_name }}
+                  </p>
+                {% endif %}
+              </div>
+            </div>
+            <div class="col-4">
+              <div class="fs-6">
+                <p class="mb-1">
+                  <span class="fw-bold">Structure :</span> {{ links.build_offerer_name_to_details_link(offer.venue.managingOfferer) }}
+                </p>
+              </div>
+              <div class="fs-6">
+                <p class="mb-1">
+                  <span class="fw-bold">Lieu :</span> {{ links.build_venue_name_to_details_link(offer.venue) }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="mt-4">
+        {% call build_details_tabs_wrapper() %}
+          {{ build_details_tab("stock", "Stocks", active_tab == 'stock') }}
+        {% endcall %}
+        {% call build_details_tabs_content_wrapper() %}
+          {% call build_details_tab_content("stock", active_tab == 'stock') %}
+            <table class="table mb-4 my-4">
+              <thead>
+                <tr>
+                  <th scope="col-1">Stock ID</th>
+                  <th scope="col-5" class="col-4">Nombre de stock initial / restant</th>
+                  <th scope="col-3" class="col-2">Prix</th>
+                  <th scope="col-3" class="col-4">Date / Heure</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for stock in offer.stocks | sort(attribute='id') %}
+                  <tr>
+                    <td>{{ stock.id }}</td>
+                    <td>{{ stock.remainingStock | format_stock_quantity }} / {{ stock.initialStock | format_stock_quantity }}</td>
+                    <td>{{ stock.price | format_amount }}</td>
+                    <td>{{ stock.beginningDatetime | format_date_time }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endcall %}
+        {% endcall %}
+      </div>
+    </div>
+  </div>
+{% endblock main_content %}

--- a/api/src/pcapi/routes/backoffice/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/list.html
@@ -136,7 +136,7 @@
                     </ul>
                   </div>
                 </td>
-                <td>{{ offer.id }}</td>
+                <td>{{ links.build_offer_details_link(offer) }}</td>
                 <td>{{ links.build_offer_name_to_pc_pro_link(offer) }}</td>
                 <td>{{ offer.category.pro_label }}</td>
                 <td>{{ offer.subcategory_v2.pro_label }}</td>

--- a/api/src/pcapi/routes/backoffice/titelive/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/titelive/blueprint.py
@@ -135,6 +135,7 @@ def add_product_whitelist(ean: str, title: str) -> utils.BackofficeResponse:
                             "validation": offers_models.OfferValidationStatus.APPROVED,
                             "lastValidationDate": datetime.datetime.utcnow(),
                             "lastValidationType": OfferValidationType.MANUAL,
+                            "lastValidationAuthorUserId": current_user.id,
                         },
                         synchronize_session=False,
                     )

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -385,6 +385,7 @@ def _create_offer_from_product(
     offer.isActive = True
     offer.lastValidationDate = datetime.datetime.utcnow()
     offer.lastValidationType = OfferValidationType.AUTO
+    offer.lastValidationAuthorUserId = None
 
     logger.info(
         "models.Offer has been created",

--- a/api/src/pcapi/scripts/reject_cgu_incompatible_offers.py
+++ b/api/src/pcapi/scripts/reject_cgu_incompatible_offers.py
@@ -39,6 +39,7 @@ def reject_offers(product_id: int, dry_run: bool = True) -> int:
                 "validation": OfferValidationStatus.REJECTED,
                 "lastValidationDate": datetime.utcnow(),
                 "lastValidationType": OfferValidationType.CGU_INCOMPATIBLE_PRODUCT,
+                "lastValidationAuthorUserId": None,
             },
             synchronize_session="fetch",
         )

--- a/api/tests/routes/backoffice/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice/collective_offer_templates_test.py
@@ -442,6 +442,7 @@ class BatchCollectiveOfferTemplatesValidateTest(PostEndpointHelper):
             assert collective_offer_template.isActive is True
             assert collective_offer_template.lastValidationType is OfferValidationType.MANUAL
             assert collective_offer_template.validation is OfferValidationStatus.APPROVED
+            assert collective_offer_template.lastValidationAuthor == legit_user
 
         received_dict = {email.sent_data["To"]: email.sent_data["template"] for email in mails_testing.outbox}
         expected_dict = {

--- a/api/tests/routes/pro/patch_collective_offer_publication_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_publication_test.py
@@ -25,6 +25,9 @@ class Returns204Test:
         assert response.status_code == 200
         assert response.json["status"] == OfferStatus.ACTIVE.value
 
+        offer = educational_models.CollectiveOffer.query.filter_by(id=offer.id).one()
+        assert not offer.lastValidationAuthor
+
     def expect_offer_to_be_pending(self, client):
         stock = educational_factories.CollectiveStockFactory()
         offer = educational_factories.CollectiveOfferFactory(
@@ -49,6 +52,9 @@ class Returns204Test:
         assert response.json["status"] == OfferStatus.PENDING.value
         assert not response.json["isActive"]
 
+        offer = educational_models.CollectiveOffer.query.filter_by(id=offer.id).one()
+        assert not offer.lastValidationAuthor
+
 
 @pytest.mark.usefixtures("db_session")
 class Returns403Test:
@@ -63,6 +69,7 @@ class Returns403Test:
         assert response.status_code == 403
         offer = educational_models.CollectiveOffer.query.filter_by(id=offer.id).one()
         assert offer.validation == OfferValidationStatus.DRAFT
+        assert not offer.lastValidationAuthor
 
 
 @pytest.mark.usefixtures("db_session")
@@ -77,3 +84,4 @@ class Returns401Test:
         assert response.status_code == 401
         offer = educational_models.CollectiveOffer.query.filter_by(id=offer.id).one()
         assert offer.validation == OfferValidationStatus.DRAFT
+        assert not offer.lastValidationAuthor

--- a/api/tests/routes/pro/patch_collective_offer_template_publication_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_publication_test.py
@@ -21,6 +21,7 @@ class Returns204Test:
 
         assert response.status_code == 200
         assert response.json["status"] == OfferStatus.ACTIVE.value
+        assert not offer.lastValidationAuthor
 
     def expect_offer_to_be_pending(self, client):
         offer = educational_factories.CollectiveOfferTemplateFactory(
@@ -44,6 +45,7 @@ class Returns204Test:
         assert response.status_code == 200
         assert response.json["status"] == OfferStatus.PENDING.value
         assert not response.json["isActive"]
+        assert not offer.lastValidationAuthor
 
 
 @pytest.mark.usefixtures("db_session")
@@ -59,6 +61,7 @@ class Returns403Test:
         assert response.status_code == 403
         offer = educational_models.CollectiveOfferTemplate.query.filter_by(id=offer.id).one()
         assert offer.validation == OfferValidationStatus.DRAFT
+        assert not offer.lastValidationAuthor
 
 
 @pytest.mark.usefixtures("db_session")
@@ -73,3 +76,4 @@ class Returns401Test:
         assert response.status_code == 401
         offer = educational_models.CollectiveOfferTemplate.query.filter_by(id=offer.id).one()
         assert offer.validation == OfferValidationStatus.DRAFT
+        assert not offer.lastValidationAuthor


### PR DESCRIPTION
## But de la pull request

Crée une page avec le détail d'une offre individuelle avec un onglet stock et historique.

L'historique reprend l'auteur de la validation ou du rejet de l'offre.

Ticket Jira : https://passculture.atlassian.net/browse/PC-24436

Stocks :
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/cbe1f8aa-040f-445a-8791-caaa6496d83e)


Historique :
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/8436158d-0eff-451c-9897-969b365a57cc)



## Vérifications

- [X] J'ai écrit les tests nécessaires
- [X] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques