### PR TITLE
(BSR)[API] bump: MarkupSafe

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -32,7 +32,6 @@ gql[requests]
 gunicorn==20.0.4
 ipaddress
 isort
-itsdangerous==2.0.1
 Jinja2
 MarkupSafe
 mypy # Not pinned. If a new version introduces new errors we cannot fix in one go, see api/bin/mypy_add_type_ignores.py

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -34,8 +34,8 @@ ipaddress
 isort
 itsdangerous==2.0.1
 Jinja2==3.0.3
-MarkupSafe==2.0.1
-mypy # Not pinned. If a new version introduces new errors we cannot fix in one go, see api/bin/mypy_add_type_ignores.py 
+MarkupSafe
+mypy # Not pinned. If a new version introduces new errors we cannot fix in one go, see api/bin/mypy_add_type_ignores.py
 notion-client==1.0.0
 openpyxl
 pgcli # a tool not used in code. There is no point in pinning its version

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -33,7 +33,7 @@ gunicorn==20.0.4
 ipaddress
 isort
 itsdangerous==2.0.1
-Jinja2==3.0.3
+Jinja2
 MarkupSafe
 mypy # Not pinned. If a new version introduces new errors we cannot fix in one go, see api/bin/mypy_add_type_ignores.py
 notion-client==1.0.0


### PR DESCRIPTION
Bump markupSafe to latest release (2.1.3) https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-3