### PR TITLE
(PC-24928)[PRO] fix: Fix dont display all cached adage offers.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -34,10 +34,9 @@ export interface OffersProps {
   isBackToTopVisibile?: boolean
 }
 
-type OfferMap = Map<
-  string,
-  HydratedCollectiveOffer | HydratedCollectiveOfferTemplate
->
+type HydratedOffer = HydratedCollectiveOffer | HydratedCollectiveOfferTemplate
+
+type OfferMap = Map<string, HydratedOffer>
 
 export const Offers = ({
   handleResetFiltersAndLaunchSearch,
@@ -110,7 +109,9 @@ export const Offers = ({
       })
   }, [results?.queryID])
 
-  const offers = [...fetchedOffers.values()]
+  const offers = hits
+    .map(hit => fetchedOffers.get(hit.objectID))
+    .filter((offer): offer is HydratedOffer => !!offer)
 
   if (queriesAreLoading && offers.length === 0) {
     return (

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
@@ -331,6 +331,11 @@ describe('offers', () => {
       nbHits: 1,
     }))
 
+    vi.spyOn(instantSearch, 'useInfiniteHits').mockImplementationOnce(() => ({
+      ...defaultUseInfiniteHitsReturn,
+      hits: searchFakeResults,
+    }))
+
     vi.spyOn(instantSearch, 'useInfiniteHits').mockImplementation(() => ({
       ...defaultUseInfiniteHitsReturn,
       hits: [otherFakeSearchResult],
@@ -344,17 +349,12 @@ describe('offers', () => {
     )
 
     // Then
-    const otherOfferName = await screen.findByText(otherOffer.name)
-    expect(otherOfferName).toBeInTheDocument()
-    expect(screen.getAllByTestId('offer-listitem')).toHaveLength(1)
+    expect(await screen.findByText(otherOffer.name)).toBeInTheDocument()
+
     expect(screen.queryByText(offerInParis.name)).not.toBeInTheDocument()
     expect(screen.queryByText(offerInCayenne.name)).not.toBeInTheDocument()
+
     expect(screen.getByText('1 résultat')).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'Vous avez vu toutes les offres qui correspondent à votre recherche.'
-      )
-    ).toBeInTheDocument()
   })
 
   it('should show most recent results and cancel previous request', async () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24928

**Objectif**
Correction du bug suivant : quand on recherche par mot clé les offres adage, le cache des offres est affiché à la place d'afficher les offres reçues.

**A noter**
La syntaxe `.filter((offer): offer is HydratedOffer => !!offer)` semble nécessaire pour que typescript comprenne que les offers ne seront pas `undefined` dans le map du JSX. J'ai pas trouvé plus propre mais peut-être bien que c'est possible ?

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques