### PR TITLE
(BSR)[BO] fix: avoid displaying "Address: None"

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
@@ -90,7 +90,7 @@
             {% if show_personal_info %}
               <div class="mb-1">
                 <span class="fw-bold">Adresse</span>
-                <p class="mb-0">{{ user.address }}</p>
+                <p class="mb-0">{{ user.address | empty_string_if_null }}</p>
                 <p>{{ user.postalCode | empty_string_if_null }}&nbsp;{{ user.city | empty_string_if_null }}</p>
               </div>
             {% endif %}

--- a/api/src/pcapi/routes/backoffice/templates/admin/users_generator.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/users_generator.html
@@ -75,7 +75,7 @@
                 </p>
                 <div class="mb-1">
                   <span class="fw-bold">Adresse</span>
-                  <p class="mb-0">{{ user.address }}</p>
+                  <p class="mb-0">{{ user.address | empty_string_if_null }}</p>
                   <p>
                     {{ user.postalCode | empty_string_if_null }}&nbsp;{{ user.city |
                     empty_string_if_null }}


### PR DESCRIPTION
## But de la pull request

Éviter l'affichage "Addresse None" comme sur cette capture d'écran : 
![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/bbac4fa0-0c37-41b8-afa0-12a68d288564)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques