### PR TITLE
(PC-24758)[BO] feat: Add debit note choice to incident validation

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-654f1c1c4da3 (pre) (head)
+385e5ea25130 (pre) (head)
 cd2fcba2f97f (post) (head)

--- a/api/src/pcapi/alembic/versions/20231005T141351_385e5ea25130_add_debit_note_forcing_to_finance_incident.py
+++ b/api/src/pcapi/alembic/versions/20231005T141351_385e5ea25130_add_debit_note_forcing_to_finance_incident.py
@@ -1,0 +1,20 @@
+"""Save debit note forcing choice as a boolean in FinanceIncident model
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "385e5ea25130"
+down_revision = "654f1c1c4da3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("finance_incident", sa.Column("forceDebitNote", sa.Boolean(), server_default="false", nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column("finance_incident", "forceDebitNote")

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -908,6 +908,8 @@ class FinanceIncident(Base, Model):
         sqla_mutable.MutableDict.as_mutable(sqla_psql.JSONB), nullable=False, default={}, server_default="{}"
     )
 
+    forceDebitNote: bool = sqla.Column(sqla.Boolean, nullable=False, server_default="false", default=False)
+
     @property
     def relates_to_collective_bookings(self) -> bool:
         return any(booking_incident.collectiveBooking for booking_incident in self.booking_finance_incidents)

--- a/api/src/pcapi/routes/backoffice/finance/forms.py
+++ b/api/src/pcapi/routes/backoffice/finance/forms.py
@@ -1,3 +1,5 @@
+import enum
+
 from flask_wtf import FlaskForm
 from wtforms.validators import Optional
 
@@ -5,6 +7,7 @@ from pcapi.core.finance import models as finance_models
 from pcapi.routes.backoffice import filters
 from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.routes.backoffice.forms import fields
+from pcapi.routes.backoffice.forms import utils as forms_utils
 
 
 not_implemented_incident_types = [
@@ -12,6 +15,11 @@ not_implemented_incident_types = [
     finance_models.IncidentType.FRAUD,
     finance_models.IncidentType.OFFER_PRICE_REGULATION,
 ]
+
+
+class IncidentCompensationModes(enum.Enum):
+    FORCE_DEBIT_NOTE = "Générer une note de débit à la prochaine échéance"
+    COMPENSATE_ON_BOOKINGS = "Récupérer l'argent sur les prochaines réservations"
 
 
 class IncidentCreationForm(FlaskForm):
@@ -33,3 +41,9 @@ class IncidentCreationForm(FlaskForm):
 
 class BookingIncidentForm(empty_forms.BatchForm, IncidentCreationForm):
     pass
+
+
+class IncidentValidationForm(FlaskForm):
+    compensation_mode = fields.PCSelectField(
+        "Mode de compensation", choices=forms_utils.choices_from_enum(IncidentCompensationModes)
+    )

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -18,6 +18,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.routes.backoffice import filters
 from pcapi.routes.backoffice.filters import format_booking_status
 from pcapi.routes.backoffice.filters import format_date_time
+from pcapi.routes.backoffice.finance import forms as finance_forms
 from pcapi.routes.backoffice.finance.blueprint import _cancel_finance_incident
 from pcapi.routes.backoffice.finance.blueprint import _create_finance_events_from_incident
 
@@ -155,7 +156,8 @@ class ValidateIncidentTest(PostEndpointHelper):
     endpoint_kwargs = {"finance_incident_id": 1}
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
-    def test_validate_incident(self, authenticated_client):
+    @pytest.mark.parametrize("force_debit_note", [True, False])
+    def test_validate_incident(self, authenticated_client, force_debit_note):
         booking_incident = finance_factories.IndividualBookingFinanceIncidentFactory(
             booking__pricings=[
                 finance_factories.PricingFactory(status=finance_models.PricingStatus.INVOICED, amount=-1000)
@@ -164,7 +166,15 @@ class ValidateIncidentTest(PostEndpointHelper):
             newTotalAmount=0,
         )
 
-        response = self.post_to_endpoint(authenticated_client, finance_incident_id=booking_incident.incident.id)
+        response = self.post_to_endpoint(
+            authenticated_client,
+            finance_incident_id=booking_incident.incident.id,
+            form={
+                "compensation_mode": finance_forms.IncidentCompensationModes.FORCE_DEBIT_NOTE.name
+                if force_debit_note
+                else finance_forms.IncidentCompensationModes.COMPENSATE_ON_BOOKINGS.name
+            },
+        )
 
         assert response.status_code == 200
 
@@ -173,6 +183,7 @@ class ValidateIncidentTest(PostEndpointHelper):
 
         updated_incident = finance_models.FinanceIncident.query.get(booking_incident.incidentId)
         assert updated_incident.status == finance_models.IncidentStatus.VALIDATED
+        assert updated_incident.forceDebitNote == force_debit_note
 
         beneficiary_action = history_models.ActionHistory.query.filter(
             history_models.ActionHistory.user == booking_incident.beneficiary
@@ -181,9 +192,11 @@ class ValidateIncidentTest(PostEndpointHelper):
             history_models.ActionHistory.financeIncident == updated_incident
         ).first()
 
-        assert (
-            validation_action and validation_action.actionType == history_models.ActionType.FINANCE_INCIDENT_VALIDATED
-        )
+        assert validation_action
+        assert validation_action.actionType == history_models.ActionType.FINANCE_INCIDENT_VALIDATED
+        if force_debit_note:
+            assert validation_action.comment == "Génération d'une note de débit à la prochaine échéance."
+
         assert (
             beneficiary_action
             and beneficiary_action.actionType == history_models.ActionType.FINANCE_INCIDENT_USER_RECREDIT
@@ -199,7 +212,11 @@ class ValidateIncidentTest(PostEndpointHelper):
     def test_not_validate_incident(self, authenticated_client, initial_status):
         finance_incident = finance_factories.FinanceIncidentFactory(status=initial_status)
 
-        response = self.post_to_endpoint(authenticated_client, finance_incident_id=finance_incident.id)
+        response = self.post_to_endpoint(
+            authenticated_client,
+            finance_incident_id=finance_incident.id,
+            form={"compensation_mode": finance_forms.IncidentCompensationModes.COMPENSATE_ON_BOOKINGS.name},
+        )
 
         assert response.status_code == 303
         assert (


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24758

Ajout du choix sur la stratégie de compensation (récupération sur les prochains justificatifs OU génération d'une note de débit à la validation) dans la modale de validation d'un incident.

Enregistrement de ce choix dans un nouveau champ du modèle `FinanceIncident` nommé `forceDebitNote`. 

Cette donnée sera lu lors de la génération des documents de paiement, et donnera suite à la génération ou non d'une note de débit.

On peut également envisager un bouton annulant ce choix de génération d'une note de débit (en cas d'erreur utilisateur par exemple) passant ce champ à `False`.

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/01d6ed2d-e024-4b06-98db-6c037bf30261)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques