### PR TITLE
(BSR)[API] fix: add user_offerer in sandbox to match reality

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offers_with_activation_codes.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offers_with_activation_codes.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
 
+from pcapi.core.offerers.factories import UserOffererFactory
 from pcapi.core.offerers.factories import VirtualVenueFactory
 from pcapi.core.offers.factories import StockWithActivationCodesFactory
 
@@ -10,8 +11,11 @@ logger = logging.getLogger(__name__)
 
 def create_industrial_offers_with_activation_codes() -> None:
     logger.info("create_industrial_offers_with_activation_codes")
+    user_offerer = UserOffererFactory(offerer__name="Offerer with activation codes")
 
-    venue = VirtualVenueFactory()
+    venue = VirtualVenueFactory(
+        managingOfferer=user_offerer.offerer,
+    )
 
     StockWithActivationCodesFactory.create_batch(
         5, offer__venue=venue, activationCodes__expirationDate=datetime(2030, 2, 5, 0, 0, 0)


### PR DESCRIPTION
## But de la pull request

BSR

il manquait un user_offerer  pour les offres avec codes d'activation, le formaulaire d'offre ne s'affichait donc pas pour ce lieu

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques