### PR TITLE
(PC-24294)[API] fix: Yet another logs (again) to catch dnBookedQuantity inconsistencies

### DIFF
--- a/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
@@ -122,6 +122,16 @@ class BoostStocks(LocalProvider):
         self.last_offer = offer
 
     def fill_stock_attributes(self, stock: offers_models.Stock) -> None:
+        self.logger.info(
+            "Starting filling stock attributes in BoostStocks",
+            extra={
+                "stock_id": stock.id,
+                "stock_quantity": stock.quantity,
+                "stock_dnBookedQuantity": stock.dnBookedQuantity,
+                "offer_id": stock.offerId,
+            },
+        )
+
         stock.offer = self.last_offer
         # a pydantic validator has already converted the showDate to a UTC datetime
         stock.beginningDatetime = self.showtime_details.showDate
@@ -162,6 +172,16 @@ class BoostStocks(LocalProvider):
             price_label = self.pcu_pricing.title
             price_category = self.get_or_create_price_category(price, price_label)
             stock.priceCategory = price_category
+
+        self.logger.info(
+            "Ending filling stock attributes in BoostStocks",
+            extra={
+                "stock_id": stock.id,
+                "stock_quantity": stock.quantity,
+                "stock_dnBookedQuantity": stock.dnBookedQuantity,
+                "offer_id": stock.offerId,
+            },
+        )
 
     def get_or_create_price_category(self, price: decimal.Decimal, price_label: str) -> offers_models.PriceCategory:
         if self.last_offer not in self.price_category_lists_by_offer:

--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -136,6 +136,16 @@ class CDSStocks(LocalProvider):
         self.last_offer = cds_offer
 
     def fill_stock_attributes(self, cds_stock: offers_models.Stock):  # type: ignore [no-untyped-def]
+        self.logger.info(
+            "Starting filling stock attributes in CDSStocks",
+            extra={
+                "stock_id": cds_stock.id,
+                "stock_quantity": cds_stock.quantity,
+                "stock_dnBookedQuantity": cds_stock.dnBookedQuantity,
+                "offer_id": cds_stock.offerId,
+            },
+        )
+
         cds_stock.offer = self.last_offer
 
         showtime_uuid = _get_showtimes_uuid_by_idAtProvider(cds_stock.idAtProviders)  # type: ignore [arg-type]
@@ -178,6 +188,16 @@ class CDSStocks(LocalProvider):
             cds_stock.price = show_price
             price_category = self.get_or_create_price_category(show_price, price_label)
             cds_stock.priceCategory = price_category
+
+        self.logger.info(
+            "Ending filling stock attributes in CDSStocks",
+            extra={
+                "stock_id": cds_stock.id,
+                "stock_quantity": cds_stock.quantity,
+                "stock_dnBookedQuantity": cds_stock.dnBookedQuantity,
+                "offer_id": cds_stock.offerId,
+            },
+        )
 
     def get_or_create_price_category(self, price: decimal.Decimal, price_label: str) -> offers_models.PriceCategory:
         if self.last_offer not in self.price_category_lists_by_offer:

--- a/api/src/pcapi/local_providers/cinema_providers/cgr/cgr_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cgr/cgr_stocks.py
@@ -124,6 +124,16 @@ class CGRStocks(LocalProvider):
         self.last_offer = offer
 
     def fill_stock_attributes(self, stock: offers_models.Stock) -> None:
+        self.logger.info(
+            "Starting filling stock attributes in CGRStocks",
+            extra={
+                "stock_id": stock.id,
+                "stock_quantity": stock.quantity,
+                "stock_dnBookedQuantity": stock.dnBookedQuantity,
+                "offer_id": stock.offerId,
+            },
+        )
+
         assert self.last_offer
         stock.offer = self.last_offer
 
@@ -170,6 +180,16 @@ class CGRStocks(LocalProvider):
             price_category = self.get_or_create_price_category(show_price, price_label)
 
             stock.priceCategory = price_category
+
+        self.logger.info(
+            "Ending filling stock attributes in CGRStocks",
+            extra={
+                "stock_id": stock.id,
+                "stock_quantity": stock.quantity,
+                "stock_dnBookedQuantity": stock.dnBookedQuantity,
+                "offer_id": stock.offerId,
+            },
+        )
 
     def get_or_create_price_category(self, price: decimal.Decimal, price_label: str) -> offers_models.PriceCategory:
         assert self.last_offer

--- a/api/src/pcapi/local_providers/local_provider.py
+++ b/api/src/pcapi/local_providers/local_provider.py
@@ -40,6 +40,8 @@ class LocalProvider(Iterator):
         self.erroredThumbs = 0
         self.provider = get_provider_by_local_class(self.__class__.__name__)
 
+        self.logger = logger
+
     @property
     @abstractmethod
     def can_create(self):  # type: ignore [no-untyped-def]


### PR DESCRIPTION
dnBookedQuantity inconsistencies appears during race condition between `synchronize_.*_stocks`
and booking of a user.
Specifically, when a booking on a stock occurs when its synchronization is in progress.
During the booking `dnBookedQuantity` is updated at its right value, and then, at the end of the
synchronization, `dnBookedQuantity` has is old value back (and Stock.quantity correctly updated)

However, concurrent `UPDATE` is precisely why a DBMS is designed for, the first `UPDATE` should
acquire a lock and the second `UPDATE` occurs when the first one is released, hence those logs to
understand what is going on.
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques