### PR TITLE
(PC-24979)[API] fix: clean_all_database needed to delete CollectiveOfferEducationalRedactor and CollectiveOfferTemplateEducationalRedactor

### DIFF
--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -53,6 +53,8 @@ def clean_all_database(*args, **kwargs):  # type: ignore [no-untyped-def]
     educational_models.CollectiveBooking.query.delete()
     educational_models.CollectiveDmsApplication.query.delete()
     educational_models.CollectiveOfferRequest.query.delete()
+    educational_models.CollectiveOfferEducationalRedactor.query.delete()
+    educational_models.CollectiveOfferTemplateEducationalRedactor.query.delete()
     bookings_models.ExternalBooking.query.delete()
     bookings_models.Booking.query.delete()
     educational_models.CollectiveStock.query.delete()


### PR DESCRIPTION


## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24979

## Vérifications

to resolve bug https://sentry.passculture.team/organizations/sentry/issues/429061/?environment=testing&project=5&query=+server_name%3Adeploy-sandbox-%2A&statsPeriod=24h