### PR TITLE
(PC-24954)[EAC] fix: pg error: handle foreign key error

### DIFF
--- a/api/src/pcapi/core/educational/api/national_program.py
+++ b/api/src/pcapi/core/educational/api/national_program.py
@@ -43,8 +43,15 @@ def link_or_unlink_offer_to_program(program_id: int | None, offer: AnyCollective
         _unlink_offer(offer, commit)
         return
 
-    program = models.NationalProgram.query.get(program_id)
+    program = get_national_program(program_id)
     if not program:
         raise exceptions.NationalProgramNotFound()
 
     _link_offer(program, offer, commit)
+
+
+def get_national_program(program_id: int | None) -> models.NationalProgram | None:
+    if not program_id:
+        return None
+
+    return models.NationalProgram.query.get(program_id)

--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -1,6 +1,7 @@
 from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.educational import validation as educational_validation
+from pcapi.core.educational.api import national_program as np_api
 from pcapi.core.educational.api import offer as educational_api_offer
 from pcapi.core.offerers import exceptions as offerers_exceptions
 from pcapi.core.offerers import repository as offerers_repository
@@ -466,6 +467,9 @@ def patch_collective_offer_public(
                     status_code=400,
                 )
         image_file = new_values.pop("imageFile")
+
+    if "nationalProgramId" in new_values and not np_api.get_national_program(new_values["nationalProgramId"]):
+        raise ApiErrors(errors={"nationalProgramId": ["Dispositif inconnu"]}, status_code=400)
 
     # real edition
     try:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24954

Lors de la mise à jour d'une offre collective, si l'identifiant du dispositif national est inconnu, une erreur survient et n'est pas gérée.
Cette PR propose un fix rapide mais il serait pas mal de remettre à plat ces différentes routes et trouver un moyen de mieux gérer ces différents types d'erreurs.