### PR TITLE
(PC-24964)[PRO] feat: send label instead of value for domains

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -11,7 +11,6 @@ import strokeBuildingIcon from 'icons/stroke-building.svg'
 import strokeFranceIcon from 'icons/stroke-france.svg'
 import strokeNearIcon from 'icons/stroke-near.svg'
 import { getAcademiesOptionsAdapter } from 'pages/AdageIframe/app/adapters/getAcademiesOptionsAdapter'
-import { getEducationalDomainsOptionsAdapter } from 'pages/AdageIframe/app/adapters/getEducationalDomainsOptionsAdapter'
 import { departmentOptions } from 'pages/AdageIframe/app/constants/departmentOptions'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { Option } from 'pages/AdageIframe/app/types'
@@ -33,6 +32,7 @@ interface OfferFiltersProps {
   setLocalisationFilterState: (state: LocalisationFilterStates) => void
   resetForm: () => void
   categoriesOptions: Option<string[]>[]
+  domainsOptions: Option<number>[]
 }
 
 export const OfferFilters = ({
@@ -41,6 +41,7 @@ export const OfferFilters = ({
   setLocalisationFilterState,
   resetForm,
   categoriesOptions,
+  domainsOptions,
 }: OfferFiltersProps): JSX.Element => {
   const [modalOpenStatus, setModalOpenStatus] = useState<{
     [key: string]: boolean
@@ -82,7 +83,6 @@ export const OfferFilters = ({
 
   const activeLocalisationFilterCount = getActiveLocalisationFilterCount()
 
-  const [domainsOptions, setDomainsOptions] = useState<Option<number>[]>([])
   const [academiesOptions, setAcademieOptions] = useState<Option<string>[]>([])
 
   const onReset = (
@@ -108,12 +108,8 @@ export const OfferFilters = ({
   }
   useEffect(() => {
     const loadFiltersOptions = async () => {
-      const domainsResponse = await getEducationalDomainsOptionsAdapter()
       const academiesResponse = await getAcademiesOptionsAdapter()
 
-      if (domainsResponse.isOk) {
-        setDomainsOptions(domainsResponse.payload)
-      }
       if (academiesResponse.isOk) {
         setAcademieOptions(academiesResponse.payload)
       }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 
 import { AuthenticatedResponse } from 'apiClient/adage'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
-import * as pcapi from 'pages/AdageIframe/repository/pcapi/pcapi'
 import { defaultAdageUser } from 'utils/adageFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -47,6 +46,11 @@ const renderOfferFilters = ({
           setLocalisationFilterState={mockSetLocalisationFilterState}
           resetForm={resetFormMock}
           categoriesOptions={[{ label: 'Cinéma', value: ['CINE_PLEIN_AIR'] }]}
+          domainsOptions={[
+            { value: 1, label: 'Danse' },
+            { value: 2, label: 'Architecture' },
+            { value: 3, label: 'Arts' },
+          ]}
         />
       </Formik>
     </AdageUserContextProvider>,
@@ -173,12 +177,6 @@ describe('OfferFilters', () => {
   })
 
   it('should return domains options when the api call was successful', async () => {
-    vi.spyOn(pcapi, 'getEducationalDomains').mockResolvedValueOnce([
-      { id: 1, name: 'Danse' },
-      { id: 2, name: 'Architecture' },
-      { id: 3, name: 'Arts' },
-    ])
-
     renderOfferFilters({
       initialValues: initialValues,
     })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/studentsOptions.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/studentsOptions.ts
@@ -9,3 +9,15 @@ export const studentsOptions = [
   { label: 'CAP - 1re année', value: 'CAP - 1re année' },
   { label: 'CAP - 2e année', value: 'CAP - 2e année' },
 ]
+
+export const studentsForData = [
+  { label: 'Collège - 6e', valueForData: 'Collège sixième' },
+  { label: 'Collège - 5e', valueForData: 'Collège cinquième' },
+  { label: 'Collège - 4e', valueForData: 'Collège quatrième' },
+  { label: 'Collège - 3e', valueForData: 'Collège troisième' },
+  { label: 'Lycée - Seconde', valueForData: 'Lycée seconde' },
+  { label: 'Lycée - Première', valueForData: 'Lycée première' },
+  { label: 'Lycée - Terminale', valueForData: 'Lycée terminale' },
+  { label: 'CAP - 1re année', valueForData: 'CAP première année' },
+  { label: 'CAP - 2e année', valueForData: 'CAP deuxième année' },
+]

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { AdageFrontRoles, AuthenticatedResponse } from 'apiClient/adage'
@@ -144,7 +144,11 @@ describe('offersSearch component', () => {
       venueFilter: null,
       setGeoRadius: setGeoRadiusMock,
     }
-    vi.spyOn(pcapi, 'getEducationalDomains').mockResolvedValue([])
+    vi.spyOn(pcapi, 'getEducationalDomains').mockResolvedValue([
+      { id: 1, name: 'Danse' },
+      { id: 2, name: 'Architecture' },
+      { id: 3, name: 'Arts' },
+    ])
     vi.spyOn(apiAdage, 'getEducationalOffersCategories').mockResolvedValue({
       categories: [],
       subcategories: [],
@@ -198,9 +202,6 @@ describe('offersSearch component', () => {
   it('should display localisation filter with default state by default', async () => {
     // Given
     renderOffersSearchComponent(props, { ...user, departmentCode: null })
-    await waitFor(() => {
-      expect(pcapi.getEducationalDomains).toHaveBeenCalled()
-    })
 
     // When
     const localisationFilter = screen.getByRole('button', {
@@ -216,9 +217,6 @@ describe('offersSearch component', () => {
   it('should display localisation filter with departments options if user has selected departement filter', async () => {
     // Given
     renderOffersSearchComponent(props, { ...user, departmentCode: null })
-    await waitFor(() => {
-      expect(pcapi.getEducationalDomains).toHaveBeenCalled()
-    })
 
     await userEvent.click(
       screen.getByRole('button', {
@@ -251,9 +249,6 @@ describe('offersSearch component', () => {
   it('should display academies filter with departments options if user has selected academy filter', async () => {
     // Given
     renderOffersSearchComponent(props, { ...user, departmentCode: null })
-    await waitFor(() => {
-      expect(pcapi.getEducationalDomains).toHaveBeenCalled()
-    })
 
     await userEvent.click(
       screen.getByRole('button', {
@@ -288,9 +283,6 @@ describe('offersSearch component', () => {
       { ...user, departmentCode: null },
       isGeolocationActive
     )
-    await waitFor(() => {
-      expect(pcapi.getEducationalDomains).toHaveBeenCalled()
-    })
 
     await userEvent.click(
       screen.getByRole('button', {
@@ -316,10 +308,6 @@ describe('offersSearch component', () => {
       { ...user, departmentCode: null, lat: 0, lon: null },
       isGeolocationActive
     )
-    await waitFor(() => {
-      expect(pcapi.getEducationalDomains).toHaveBeenCalled()
-    })
-
     await userEvent.click(
       screen.getByRole('button', {
         name: 'Localisation des partenaires',

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/utils.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/utils.spec.ts
@@ -1,4 +1,5 @@
-import { adageFiltersToFacetFilters } from '../utils'
+import { SearchFormValues } from '../OffersSearch/OffersSearch'
+import { adageFiltersToFacetFilters, serializeFiltersForData } from '../utils'
 
 describe('adageFiltersToFacetFilters', () => {
   const domains: string[] = ['1']
@@ -133,6 +134,42 @@ describe('adageFiltersToFacetFilters', () => {
         'academies',
         'categories',
       ],
+    })
+  })
+})
+
+describe('serializeFiltersForData', () => {
+  const domainsOptions = [{ value: 1, label: 'domaine1' }]
+  const categoriesOptions = [
+    { label: 'Category 1', value: ['subcat1', 'subcat2'] },
+    { label: 'Category 2', value: ['subcat2', 'subcat3'] },
+  ]
+  it('should return serialized filters', () => {
+    const filters: SearchFormValues = {
+      domains: ['1'],
+      students: ['Collège - 4e'],
+      eventAddressType: 'school',
+      departments: ['01'],
+      academies: ['Paris'],
+      categories: [['subcat1', 'subcat3']],
+      geolocRadius: 10,
+    }
+    const result = serializeFiltersForData(
+      filters,
+      'test',
+      categoriesOptions,
+      domainsOptions
+    )
+
+    expect(result).toStrictEqual({
+      domains: ['domaine1'],
+      query: 'test',
+      students: ['Collège - 4e'],
+      eventAddressType: 'school',
+      departments: ['01'],
+      academies: ['Paris'],
+      categories: ['Category 1', 'Category 2'],
+      geolocRadius: 10,
     })
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/utils.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/utils.spec.ts
@@ -164,7 +164,7 @@ describe('serializeFiltersForData', () => {
     expect(result).toStrictEqual({
       domains: ['domaine1'],
       query: 'test',
-      students: ['Collège - 4e'],
+      students: ['Collège quatrième'],
       eventAddressType: 'school',
       departments: ['01'],
       academies: ['Paris'],

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
@@ -3,6 +3,7 @@ import { OfferAddressType } from 'apiClient/v1'
 import { Facets, Option } from 'pages/AdageIframe/app/types'
 import { inferCategoryLabelsFromSubcategories } from 'utils/collectiveCategories'
 
+import { studentsForData } from './OffersSearch/OfferFilters/studentsOptions'
 import { SearchFormValues } from './OffersSearch/OffersSearch'
 
 export const ADAGE_FILTERS_DEFAULT_VALUES: SearchFormValues = {
@@ -151,6 +152,9 @@ export const serializeFiltersForData = (
     domains: filters.domains.map(
       domainId =>
         domainsOptions.find(option => option.value === Number(domainId))?.label
+    ),
+    students: filters.students.map(
+      student => studentsForData.find(s => s.label === student)?.valueForData
     ),
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
@@ -1,6 +1,7 @@
 import { VenueResponse } from 'apiClient/adage'
 import { OfferAddressType } from 'apiClient/v1'
-import { Facets } from 'pages/AdageIframe/app/types'
+import { Facets, Option } from 'pages/AdageIframe/app/types'
+import { inferCategoryLabelsFromSubcategories } from 'utils/collectiveCategories'
 
 import { SearchFormValues } from './OffersSearch/OffersSearch'
 
@@ -131,5 +132,25 @@ export const adageFiltersToFacetFilters = ({
   return {
     queryFilters: updatedFilters,
     filtersKeys: filtersKeys,
+  }
+}
+
+export const serializeFiltersForData = (
+  filters: SearchFormValues,
+  currentSearch: string | null,
+  categoriesOptions: Option<string[]>[],
+  domainsOptions: Option<number>[]
+) => {
+  return {
+    ...filters,
+    query: currentSearch,
+    categories: inferCategoryLabelsFromSubcategories(
+      filters.categories,
+      categoriesOptions
+    ),
+    domains: filters.domains.map(
+      domainId =>
+        domainsOptions.find(option => option.value === Number(domainId))?.label
+    ),
   }
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24964

Envoyer des valeurs compréhensibles par la data lors du tracking des filtres : 

- Pour les domaines : envoyer le label plutôt que l'id
- Pour le niveau scolaire, le parsing côté GCP semble détecter la valeur comme un float. On ajoute donc une table de correspondance pour simplifier la valeur envoyée. 

**Pour tester :** 

Changer le filtre `Domaines artistiques` ou `Niveau scolaire` dans l'iframe Adage, et regarder l'appel réseau `tracking-filter`
