### PR TITLE
(PC-25010)[API] fix: IntegrityError on remove siret when finance events are priced

### DIFF
--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -93,6 +93,19 @@ class UsedBookingFinanceEventFactory(_BaseFinanceEventFactory):
     valueDate = factory.LazyAttribute(lambda event: (event.booking or event.collectiveBooking).dateUsed)
 
 
+class FinanceEventFactory(BaseFactory):
+    class Meta:
+        model = models.FinanceEvent
+
+    valueDate = factory.LazyAttribute(lambda o: (o.booking or o.collectiveBooking).dateUsed)
+    pricingOrderingDate = factory.LazyFunction(datetime.datetime.utcnow)
+    status = models.FinanceEventStatus.PRICED
+    motive = models.FinanceEventMotive.BOOKING_USED
+    booking = factory.SubFactory(bookings_factories.UsedBookingFactory)
+    venue = factory.LazyAttribute(lambda o: o.venue)
+    pricingPoint = factory.LazyAttribute(lambda o: o.venue.current_pricing_point)
+
+
 class _BasePricingFactory(BaseFactory):
     class Meta:
         model = models.Pricing

--- a/api/src/pcapi/core/finance/siret_api.py
+++ b/api/src/pcapi/core/finance/siret_api.py
@@ -182,6 +182,7 @@ def _delete_ongoing_pricings(venue: offerers_models.Venue) -> None:
         update finance_event
         set
           "pricingPointId" = NULL,
+          "pricingOrderingDate" = NULL,
           status = :pending_finance_event_status
         where
           "pricingPointId" = :venue_id

--- a/api/tests/core/finance/test_siret_api.py
+++ b/api/tests/core/finance/test_siret_api.py
@@ -17,7 +17,10 @@ class DeleteSiretTest:
         dependent_venue = offerers_factories.VenueFactory(pricing_point=venue)
         initial_statuses = set(models.PricingStatus) - {models.PricingStatus.PENDING}
         for status in initial_statuses:
-            factories.PricingFactory(pricingPoint=venue, status=status)
+            finance_event = factories.FinanceEventFactory(venue=venue)
+            factories.PricingFactory(
+                booking=finance_event.booking, pricingPoint=venue, status=status, event=finance_event
+            )
         assert models.Pricing.query.count() == 5
 
         siret_api.remove_siret(venue, comment="no SIRET because reasons", apply_changes=True)


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-25010
https://sentry.passculture.team/organizations/sentry/issues/429085/?project=5

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques