### PR TITLE
(PC-25009)[API] fix: Handle reCAPTCHA network errors

### DIFF
--- a/api/src/pcapi/connectors/api_recaptcha.py
+++ b/api/src/pcapi/connectors/api_recaptcha.py
@@ -22,8 +22,12 @@ class InvalidRecaptchaTokenException(ApiErrors):
 
 def get_token_validation_and_score(token: str, secret: str) -> dict:
     params = {"secret": secret, "response": token}
-    api_response = requests.post(settings.RECAPTCHA_API_URL, data=params)
-    json_response = api_response.json()
+    try:
+        api_response = requests.post(settings.RECAPTCHA_API_URL, data=params)
+        api_response.raise_for_status()
+        json_response = api_response.json()
+    except requests.exceptions.RequestException as exc:
+        raise ReCaptchaException() from exc
 
     return {
         "success": json_response.get("success"),

--- a/api/tests/connectors/api_recaptcha_test.py
+++ b/api/tests/connectors/api_recaptcha_test.py
@@ -213,3 +213,11 @@ class CheckRecaptchaTokenIsValidTest:
             check_recaptcha_token_is_valid(token, secret=settings.RECAPTCHA_SECRET, version=ReCaptchaVersion.V2)
 
         assert str(exception.value) == "Encountered the following error(s): ['first-error', 'second-error']"
+
+    def test_should_raise_upon_recaptcha_api_error(self, requests_mock):
+        requests_mock.post(
+            settings.RECAPTCHA_API_URL,
+            status_code=502,
+        )
+        with pytest.raises(ReCaptchaException):
+            check_recaptcha_token_is_valid("token", "secret", ReCaptchaVersion.V2)

--- a/api/tests/connectors/api_recaptcha_test.py
+++ b/api/tests/connectors/api_recaptcha_test.py
@@ -73,8 +73,8 @@ class GetTokenValidationAndScoreTest:
         assert result == {"score": None, "success": True, "action": None, "error-codes": []}
 
 
+@override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
 class CheckRecaptchaTokenIsValidTest:
-    @override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
     @patch("pcapi.connectors.api_recaptcha.get_token_validation_and_score")
     def test_v2_should_be_ok(self, recaptcha_response):
         token = generate_fake_token()
@@ -82,7 +82,6 @@ class CheckRecaptchaTokenIsValidTest:
         # No exception means it worked
         check_recaptcha_token_is_valid(token, secret=settings.RECAPTCHA_SECRET, version=ReCaptchaVersion.V2)
 
-    @override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
     @patch("pcapi.connectors.api_recaptcha.get_token_validation_and_score")
     def test_v3_should_be_ok(self, recaptcha_response):
         token = generate_fake_token()
@@ -96,7 +95,6 @@ class CheckRecaptchaTokenIsValidTest:
             minimal_score=0.5,
         )
 
-    @override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
     @patch("pcapi.connectors.api_recaptcha.get_token_validation_and_score")
     def test_should_raise_when_score_is_too_low(self, recaptcha_response):
         # Given
@@ -113,7 +111,6 @@ class CheckRecaptchaTokenIsValidTest:
                 minimal_score=0.5,
             )
 
-    @override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
     @patch("pcapi.connectors.api_recaptcha.get_token_validation_and_score")
     def test_should_raise_when_action_is_not_matching_the_original_action(self, recaptcha_response):
         # Given
@@ -133,7 +130,6 @@ class CheckRecaptchaTokenIsValidTest:
         # Then
         assert str(exception.value) == "The action 'fake-action' does not match 'submit' from the form"
 
-    @override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
     @patch("pcapi.connectors.api_recaptcha.get_token_validation_and_score")
     def test_should_raise_when_token_is_too_old_or_already_used(self, recaptcha_response):
         # Given
@@ -163,7 +159,6 @@ class CheckRecaptchaTokenIsValidTest:
             "bad-request",
         ],
     )
-    @override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
     @patch("pcapi.connectors.api_recaptcha.get_token_validation_and_score")
     def test_should_raise_exception_for_any_other_error_code(self, recaptcha_response, error_code):
         # Given
@@ -183,7 +178,6 @@ class CheckRecaptchaTokenIsValidTest:
                 minimal_score=0.5,
             )
 
-    @override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
     @patch("pcapi.connectors.api_recaptcha.get_token_validation_and_score")
     def test_v3_should_raise_exception_with_details(self, recaptcha_response):
         # Given
@@ -205,7 +199,6 @@ class CheckRecaptchaTokenIsValidTest:
 
         assert str(exception.value) == "Encountered the following error(s): ['first-error', 'second-error']"
 
-    @override_settings(RECAPTCHA_IGNORE_VALIDATION=0)
     @patch("pcapi.connectors.api_recaptcha.get_token_validation_and_score")
     def test_v2_should_raise_exception_with_details(self, recaptcha_response):
         # Given


### PR DESCRIPTION
The reCAPTCHA API sometimes returns a 50x response (or it may
timeout). These errors were not caught and we ended up serving a 500
error response.

Now we re-raise these errors as exceptions that are caught by the
caller and properly turned into a user-facing message that more or
less says: "try again".

---

Plus un commit de simplification de l'usage de `override_settings`, au
passage.