### PR TITLE
(BSR)[API] test: Fix some e-email addresses in data sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_offerers_with_pro_users.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_offerers_with_pro_users.py
@@ -131,7 +131,7 @@ def create_data_offerers_with_pro_users() -> tuple[dict[str, Offerer], dict[str,
             domain = MOCK_DOMAINS[user_index % len(MOCK_DOMAINS)]
             first_name = MOCK_FIRST_NAMES[user_index % len(MOCK_FIRST_NAMES)]
             last_name = MOCK_LAST_NAMES[user_index % len(MOCK_LAST_NAMES)]
-            email = get_email("{first_name}_Data", last_name, domain)
+            email = get_email(f"{first_name}_data", last_name, domain)
             user_name = f"{first_name} {last_name} DATA"
             user_validation_token = None
             pro = users_factories.ProFactory(


### PR DESCRIPTION
Some users literally had "{first_name}_data.xxx@xxx.xxx", where
`{first_name}` was not interpolated.