### PR TITLE
(PC-24816)[PRO] style: Center the input button inside the input.

### DIFF
--- a/pro/src/ui-kit/form/shared/BaseInput/BaseInput.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseInput/BaseInput.module.scss
@@ -66,13 +66,9 @@
       background: none;
       border: none;
       height: 100%;
-      margin: 0 rem.torem(16px);
       padding-left: rem.torem(8px);
-
-      svg {
-        width: rem.torem(32px);
-        height: 100%;
-      }
+      display: flex;
+      align-items: center;
     }
   }
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24816

- Correction du style du bouton pour afficher le mot de passe qui a été cassé au passage du fichier `BaseInput.scss` en module.

### Avant
![image](https://github.com/pass-culture/pass-culture-main/assets/114910244/5642923b-0c8f-4511-b4b0-9f1f9d0ed3b5)

### Après
![image](https://github.com/pass-culture/pass-culture-main/assets/114910244/5ae888ff-c2a4-49bb-8da9-8e3c590c1ecb)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques