### PR TITLE
(PC-24994)[PRO] fix: dont display logo on adage loading page

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/LoaderPage/LoaderPage.tsx
+++ b/pro/src/pages/AdageIframe/app/components/LoaderPage/LoaderPage.tsx
@@ -1,15 +1,10 @@
 import './LoaderPage.scss'
 import * as React from 'react'
 
-import logoPassCultureIcon from 'icons/logo-pass-culture.svg'
 import Spinner from 'ui-kit/Spinner/Spinner'
-import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 export const LoaderPage = (): JSX.Element => (
   <div className="root-adage">
-    <header>
-      <SvgIcon src={logoPassCultureIcon} alt="" viewBox="0 0 71 24" />
-    </header>
     <main className="loader-page" id="content">
       {' '}
       <Spinner />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24994

Ne pas afficher le logo passculture lors du chargement de l'iframe adage 