### PR TITLE
(PC-25025)[API] chore: public offer api - allow to return offer without accessibility

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -57,6 +57,15 @@ class Accessibility(serialization.ConfiguredBaseModel):
     visual_disability_compliant: bool
 
 
+class AccessibilityResponse(serialization.ConfiguredBaseModel):
+    """Accessibility for people with disabilities."""
+
+    audio_disability_compliant: bool | None
+    mental_disability_compliant: bool | None
+    motor_disability_compliant: bool | None
+    visual_disability_compliant: bool | None
+
+
 class PhysicalLocation(serialization.ConfiguredBaseModel):
     type: typing.Literal["physical"] = "physical"
     venue_id: int = pydantic_v1.Field(..., example=1, description="List of venues is available at GET /offerer_venues")
@@ -644,7 +653,7 @@ class PostDatesResponse(serialization.ConfiguredBaseModel):
 
 class OfferResponse(serialization.ConfiguredBaseModel):
     id: int
-    accessibility: Accessibility
+    accessibility: AccessibilityResponse
     booking_contact: pydantic_v1.EmailStr | None = BOOKING_CONTACT_FIELD
     booking_email: pydantic_v1.EmailStr | None = BOOKING_EMAIL_FIELD
     description: str | None = DESCRIPTION_FIELD
@@ -676,7 +685,7 @@ class OfferResponse(serialization.ConfiguredBaseModel):
             booking_contact=offer.bookingContact,  # type: ignore [arg-type]
             booking_email=offer.bookingEmail,  # type: ignore [arg-type]
             description=offer.description,
-            accessibility=Accessibility.from_orm(offer),
+            accessibility=AccessibilityResponse.from_orm(offer),
             external_ticket_office_url=offer.externalTicketOfficeUrl,  # type: ignore [arg-type]
             image=offer.image,  # type: ignore [arg-type]
             is_duo=offer.isDuo,

--- a/api/tests/routes/public/individual_offers/v1/get_product_by_ean_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_by_ean_test.py
@@ -280,3 +280,27 @@ class GetProductByEanTest:
                 }
             ]
         }
+
+    def test_200_when_none_disabilities(self, client):
+        venue, _ = utils.create_offerer_provider_linked_to_venue()
+
+        product_offer = offers_factories.ThingOfferFactory(
+            venue=venue,
+            audioDisabilityCompliant=None,
+            mentalDisabilityCompliant=None,
+            motorDisabilityCompliant=None,
+            visualDisabilityCompliant=None,
+            extraData={"ean": "1234567890123"},
+        )
+
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            f"/public/offers/v1/products/ean?eans={product_offer.extraData['ean']}&venueId={venue.id}"
+        )
+
+        assert response.status_code == 200
+        assert response.json["products"][0]["accessibility"] == {
+            "audioDisabilityCompliant": None,
+            "mentalDisabilityCompliant": None,
+            "motorDisabilityCompliant": None,
+            "visualDisabilityCompliant": None,
+        }


### PR DESCRIPTION
No offer can be created without accessiblity with this API but a case can happen if a provider tries to get an old offer (from another provider and api) by ean.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25025
