### PR TITLE
(PC-24417)[API] feat: add route for stock stats

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -42,6 +42,7 @@ import pcapi.core.users.models as users_models
 from pcapi.domain.pro_offers.offers_recap import OffersRecap
 from pcapi.models import db
 from pcapi.models import feature
+from pcapi.models.api_errors import ApiErrors
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.repository import repository
@@ -54,6 +55,7 @@ from pcapi.workers import push_notification_job
 from . import exceptions
 from . import models
 from . import repository as offers_repository
+from . import serialize as offers_serialize
 from . import validation
 
 
@@ -1338,3 +1340,29 @@ def approves_provider_product_and_rejected_offers(ean: str) -> None:
             extra={"ean": ean, "product": product.id, "offers": offer_ids, "exc": str(exception)},
         )
         raise exceptions.NotUpdateProductOrOffers(exception)
+
+
+def get_stocks_stats(offer_id: int) -> offers_serialize.StocksStats:
+    data = (
+        models.Stock.query.with_entities(
+            sa.func.min(models.Stock.beginningDatetime),
+            sa.func.max(models.Stock.beginningDatetime),
+            sa.func.count(models.Stock.id),
+            sa.case(
+                (models.Stock.query.filter(models.Stock.remainingQuantity == None).exists(), None),
+                else_=sa.cast(sa.func.sum(models.Stock.remainingQuantity), sa.Integer),
+            ),
+        )
+        .filter(models.Stock.offerId == offer_id)
+        .group_by(models.Stock.offerId)
+        .one_or_none()
+    )
+    try:
+        return offers_serialize.StocksStats(*data)
+    except TypeError:
+        raise ApiErrors(
+            errors={
+                "global": ["L'offre en cours de création ne possède aucun Stock"],
+            },
+            status_code=404,
+        )

--- a/api/src/pcapi/core/offers/serialize.py
+++ b/api/src/pcapi/core/offers/serialize.py
@@ -1,3 +1,5 @@
+import dataclasses
+from datetime import datetime
 import enum
 
 
@@ -8,3 +10,11 @@ def serialize_offer_type_educational_or_individual(offer_is_educational: bool) -
 class CollectiveOfferType(enum.Enum):
     offer = "offer"
     template = "template"
+
+
+@dataclasses.dataclass
+class StocksStats:
+    oldest_stock: datetime | None
+    newest_stock: datetime | None
+    stock_count: int | None
+    remaining_quantity: int | None

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -365,6 +365,13 @@ class GetStocksResponseModel(BaseModel):
     stock_count: int
 
 
+class StockStatsResponseModel(BaseModel):
+    oldest_stock: datetime.datetime | None
+    newest_stock: datetime.datetime | None
+    stock_count: int | None
+    remaining_quantity: int | None
+
+
 class StocksQueryModel(BaseModel):
     date: datetime.date | None
     time: datetime.time | None

--- a/api/tests/routes/pro/get_stocks_stats_test.py
+++ b/api/tests/routes/pro/get_stocks_stats_test.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+from datetime import timedelta
+
+from freezegun import freeze_time
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
+import pcapi.core.users.factories as users_factories
+
+from tests.conftest import TestClient
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns403Test:
+    def test_access_by_beneficiary(self, client):
+        # Given
+        beneficiary = users_factories.BeneficiaryGrant18Factory()
+        offer = offers_factories.ThingOfferFactory(venue__latitude=None, venue__longitude=None)
+
+        # When
+        response = client.with_session_auth(email=beneficiary.email).get(f"/offers/{offer.id}/stocks-stats")
+
+        # Then
+        assert response.status_code == 403
+
+    def test_access_by_unauthorized_pro_user(self, app):
+        # Given
+        pro_user = users_factories.ProFactory()
+        offer = offers_factories.ThingOfferFactory(venue__latitude=None, venue__longitude=None)
+
+        # When
+        client = TestClient(app.test_client()).with_session_auth(email=pro_user.email)
+        response = client.get(f"/offers/{offer.id}/stocks-stats")
+
+        # Then
+        assert response.status_code == 403
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns200Test:
+    def test_basic(self, client):
+        # Given
+        user_offerer = offerers_factories.UserOffererFactory()
+        offer = offers_factories.ThingOfferFactory(venue__managingOfferer=user_offerer.offerer)
+        offers_factories.StockFactory(offer=offer)
+
+        # When
+        response = client.with_session_auth(email=user_offerer.user.email).get(f"/offers/{offer.id}/stocks-stats")
+        print(response.json)
+
+        # Then
+        assert response.status_code == 200
+
+    @freeze_time("2020-10-15 00:00:00")
+    def test_returns_stats(self, client):
+        # Given
+        now = datetime.utcnow()
+        user_offerer = offerers_factories.UserOffererFactory()
+        offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
+        offers_factories.StockFactory(
+            beginningDatetime=now + timedelta(hours=1),
+            quantity=20,
+            dnBookedQuantity=10,
+            offer=offer,
+        )
+        offers_factories.StockFactory(
+            beginningDatetime=now + timedelta(hours=2),
+            quantity=30,
+            dnBookedQuantity=25,
+            offer=offer,
+        )
+
+        # When
+        response = client.with_session_auth(email=user_offerer.user.email).get(f"/offers/{offer.id}/stocks-stats")
+
+        # Then
+        assert response.status_code == 200
+        assert response.json == {
+            "stock_count": 2,
+            "oldest_stock": "2020-10-15T01:00:00",
+            "newest_stock": "2020-10-15T02:00:00",
+            "remaining_quantity": 15,
+        }

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -187,6 +187,7 @@ export type { StockResponseModel } from './models/StockResponseModel';
 export { StocksOrderedBy } from './models/StocksOrderedBy';
 export type { StocksQueryModel } from './models/StocksQueryModel';
 export type { StocksResponseModel } from './models/StocksResponseModel';
+export type { StockStatsResponseModel } from './models/StockStatsResponseModel';
 export type { StocksUpsertBodyModel } from './models/StocksUpsertBodyModel';
 export { StudentLevels } from './models/StudentLevels';
 export { SubcategoryIdEnum } from './models/SubcategoryIdEnum';

--- a/pro/src/apiClient/v1/models/StockStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/StockStatsResponseModel.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type StockStatsResponseModel = {
+  newest_stock?: string | null;
+  oldest_stock?: string | null;
+  remaining_quantity?: number | null;
+  stock_count?: number | null;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -93,6 +93,7 @@ import type { SiretInfo } from '../models/SiretInfo';
 import type { StockIdResponseModel } from '../models/StockIdResponseModel';
 import type { StocksOrderedBy } from '../models/StocksOrderedBy';
 import type { StocksResponseModel } from '../models/StocksResponseModel';
+import type { StockStatsResponseModel } from '../models/StockStatsResponseModel';
 import type { StocksUpsertBodyModel } from '../models/StocksUpsertBodyModel';
 import type { UserEmailValidationResponseModel } from '../models/UserEmailValidationResponseModel';
 import type { UserHasBookingResponse } from '../models/UserHasBookingResponse';
@@ -1629,6 +1630,28 @@ export class DefaultService {
       path: {
         'offer_id': offerId,
         'price_category_id': priceCategoryId,
+      },
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * get_stocks_stats <GET>
+   * @param offerId
+   * @returns StockStatsResponseModel OK
+   * @throws ApiError
+   */
+  public getStocksStats(
+    offerId: number,
+  ): CancelablePromise<StockStatsResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/offers/{offer_id}/stocks-stats',
+      path: {
+        'offer_id': offerId,
       },
       errors: {
         403: `Forbidden`,


### PR DESCRIPTION
## But de la pull request

On veut créer une route GET pour stocks/<offer_id>/stocks-stats qui renvoie les données des stocks suivantes pour une offre : 
- beginningDatetime du stock le plus ancien
- beginningDatetime du stock le plus récent
- le nombre total de stock
- la quantité restante

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24417

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques