### PR TITLE
(BSR)[PRO] ci: Add timeout when waiting for backend migrations in E2E pro tests

### DIFF
--- a/.github/workflows/tests-pro-e2e.yml
+++ b/.github/workflows/tests-pro-e2e.yml
@@ -29,6 +29,7 @@ jobs:
         uses: iFaxity/wait-on-action@v1
         with:
           resource: http://localhost/health/api
+          timeout: 120000
       - name: Load sandbox
         run: ../pc sandbox -n industrial
       # Doc : https://github.com/cypress-io/github-action


### PR DESCRIPTION
I have had a case where the step was still running after more than an
hour. Patience is a virtue... but if the server is not ready within 2
minutes, there is probably something wrong and the server is unlikely
to suddenly become available.

---

L'option `timeout` est en millisecondes, cf. [doc](https://github.com/marketplace/actions/wait-on#timeout).