### PR TITLE
(PC-24623)[BO] feat: button index offer in algolia from offer page

### DIFF
--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -661,4 +661,22 @@ def get_offer_details(offer_id: int) -> utils.BackofficeResponse:
     if not offer:
         raise NotFound()
 
-    return render_template("offer/details.html", offer=offer, active_tab=request.args.get("active_tab", "stock"))
+    return render_template(
+        "offer/details.html",
+        offer=offer,
+        active_tab=request.args.get("active_tab", "stock"),
+        reindex_offer_form=empty_forms.EmptyForm(),
+    )
+
+
+@list_offers_blueprint.route("/<int:offer_id>/reindex", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.ADVANCED_PRO_SUPPORT)
+def reindex(offer_id: int) -> utils.BackofficeResponse:
+    search.async_index_offer_ids({offer_id})
+
+    flash("La resynchronisation de l'offre a été demandée.", "success")
+
+    if request.referrer:
+        return redirect(request.referrer)
+
+    return redirect(url_for("backoffice_web.offer.get_offer_details", offer_id=offer_id))

--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -30,6 +30,14 @@
                 <p class="mb-1">
                   <span class="fw-bold">Date de création :</span> {{ offer.dateCreated | format_date }}
                 </p>
+                {% if has_permission("ADVANCED_PRO_SUPPORT") and reindex_offer_form %}
+                  <form action="{{ url_for('.reindex', offer_id=offer.id) }}"
+                        name="{{ url_for('.reindex', offer_id=offer.id) | action_to_name }}"
+                        method="post">
+                    {{ reindex_offer_form.csrf_token }}
+                    <button class="btn btn-outline-primary btn-sm fw-bold mt-1">Resynchroniser l'offre dans Algolia</button>
+                  </form>
+                {% endif %}
               </div>
             </div>
             <div class="col-4">


### PR DESCRIPTION
## But de la pull request

Ajout un bouton sur le détail d'une offre pour resynchroniser l'offre dans algolia

Ticket Jira : https://passculture.atlassian.net/browse/PC-24623

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/9bd6a494-9550-48e5-8d9a-64fc40bca85f)


## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques