### PR TITLE
(PC-24675)[EAC] feat: subcategories: add format (new field)

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-45372e34d18c (pre) (head)
+2a720f939c92 (pre) (head)
 80ee25f3632d (post) (head)

--- a/api/src/pcapi/alembic/versions/20231025T015954_2a720f939c92_add_formats_to_collective_offers_and_templates.py
+++ b/api/src/pcapi/alembic/versions/20231025T015954_2a720f939c92_add_formats_to_collective_offers_and_templates.py
@@ -1,0 +1,49 @@
+"""add formats to collective offers (and templates)
++ subcategoryId becomes nullable (before being removed)"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "2a720f939c92"
+down_revision = "45372e34d18c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "collective_offer",
+        sa.Column(
+            "formats",
+            postgresql.ARRAY(sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "collective_offer_template",
+        sa.Column(
+            "formats",
+            postgresql.ARRAY(sa.Text()),
+            nullable=True,
+        ),
+    )
+
+    op.alter_column("collective_offer", "subcategoryId", existing_type=sa.TEXT(), nullable=True)
+    op.drop_index("ix_collective_offer_subcategoryId", table_name="collective_offer")
+    op.alter_column("collective_offer_template", "subcategoryId", existing_type=sa.TEXT(), nullable=True)
+    op.drop_index("ix_collective_offer_template_subcategoryId", table_name="collective_offer_template")
+
+
+def downgrade() -> None:
+    op.create_index(
+        "ix_collective_offer_template_subcategoryId", "collective_offer_template", ["subcategoryId"], unique=False
+    )
+    op.alter_column("collective_offer_template", "subcategoryId", existing_type=sa.TEXT(), nullable=False)
+    op.create_index("ix_collective_offer_subcategoryId", "collective_offer", ["subcategoryId"], unique=False)
+    op.alter_column("collective_offer", "subcategoryId", existing_type=sa.TEXT(), nullable=False)
+
+    op.drop_column("collective_offer_template", "formats")
+    op.drop_column("collective_offer", "formats")

--- a/api/src/pcapi/core/categories/subcategories_v2.py
+++ b/api/src/pcapi/core/categories/subcategories_v2.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
+from dataclasses import field
 from enum import Enum
+import typing
 
 from pcapi.core.categories import categories
 from pcapi.domain.book_types import BOOK_MACRO_SECTIONS
@@ -184,6 +186,17 @@ class FieldCondition:
     is_required_in_internal_form: bool = False
 
 
+class EacFormat(Enum):
+    ATELIER_DE_PRATIQUE = "Atelier de pratique"
+    CONCERT = "Concert"
+    CONFERENCE_RENCONTRE = "Conférence, rencontre"
+    FESTIVAL_SALON_CONGRES = "Festival, salon, congrès"
+    PROJECTION_AUDIOVISUELLE = "Projection audiovisuelle"
+    REPRESENTATION = "Représentation"
+    VISITE_GUIDEE = "Visite guidée"
+    VISITE_LIBRE = "Visite libre"
+
+
 @dataclass(frozen=True)
 class Subcategory:
     id: str
@@ -209,6 +222,7 @@ class Subcategory:
     is_bookable_by_underage_when_free: bool = True
     is_bookable_by_underage_when_not_free: bool = True
     can_be_withdrawable: bool = False
+    formats: typing.Sequence[EacFormat] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.search_group_name not in [s.name for s in SearchGroups]:
@@ -391,6 +405,7 @@ SEANCE_CINE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
 )
 EVENEMENT_CINE = Subcategory(
     id="EVENEMENT_CINE",
@@ -413,6 +428,7 @@ EVENEMENT_CINE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
 )
 FESTIVAL_CINE = Subcategory(
     id="FESTIVAL_CINE",
@@ -435,6 +451,7 @@ FESTIVAL_CINE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.FESTIVAL_SALON_CONGRES, EacFormat.PROJECTION_AUDIOVISUELLE],
 )
 CINE_VENTE_DISTANCE = Subcategory(
     id="CINE_VENTE_DISTANCE",
@@ -481,6 +498,7 @@ CINE_PLEIN_AIR = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
 )
 
 # endregion
@@ -503,6 +521,7 @@ CONFERENCE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.CONFERENCE_RENCONTRE],
 )
 RENCONTRE = Subcategory(
     id="RENCONTRE",
@@ -521,6 +540,7 @@ RENCONTRE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.CONFERENCE_RENCONTRE],
 )
 DECOUVERTE_METIERS = Subcategory(
     id="DECOUVERTE_METIERS",
@@ -558,6 +578,7 @@ SALON = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.FESTIVAL_SALON_CONGRES],
 )
 RENCONTRE_EN_LIGNE = Subcategory(
     id="RENCONTRE_EN_LIGNE",
@@ -577,6 +598,7 @@ RENCONTRE_EN_LIGNE = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.NOT_REIMBURSED.value,
     is_bookable_by_underage_when_not_free=False,
+    formats=[EacFormat.CONFERENCE_RENCONTRE],
 )
 # endregion
 # region JEU
@@ -597,6 +619,7 @@ CONCOURS = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.ATELIER_DE_PRATIQUE],
 )
 RENCONTRE_JEU = Subcategory(
     id="RENCONTRE_JEU",
@@ -615,6 +638,7 @@ RENCONTRE_JEU = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.ATELIER_DE_PRATIQUE],
 )
 ESCAPE_GAME = Subcategory(
     id="ESCAPE_GAME",
@@ -651,6 +675,7 @@ EVENEMENT_JEU = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.ATELIER_DE_PRATIQUE],
 )
 JEU_EN_LIGNE = Subcategory(
     id="JEU_EN_LIGNE",
@@ -933,6 +958,7 @@ VISITE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.VISITE_LIBRE],
 )
 VISITE_GUIDEE = Subcategory(
     id="VISITE_GUIDEE",
@@ -951,6 +977,7 @@ VISITE_GUIDEE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.VISITE_GUIDEE],
 )
 EVENEMENT_PATRIMOINE = Subcategory(
     id="EVENEMENT_PATRIMOINE",
@@ -969,6 +996,7 @@ EVENEMENT_PATRIMOINE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.ATELIER_DE_PRATIQUE],
 )
 VISITE_VIRTUELLE = Subcategory(
     id="VISITE_VIRTUELLE",
@@ -1029,6 +1057,7 @@ FESTIVAL_ART_VISUEL = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
     can_be_withdrawable=True,
+    formats=[EacFormat.FESTIVAL_SALON_CONGRES],
 )
 # endregion
 # region MUSIQUE_LIVE
@@ -1060,6 +1089,7 @@ CONCERT = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
     can_be_withdrawable=True,
+    formats=[EacFormat.CONCERT],
 )
 EVENEMENT_MUSIQUE = Subcategory(
     id="EVENEMENT_MUSIQUE",
@@ -1088,6 +1118,7 @@ EVENEMENT_MUSIQUE = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
     can_be_withdrawable=True,
+    formats=[EacFormat.CONCERT],
 )
 LIVESTREAM_MUSIQUE = Subcategory(
     id="LIVESTREAM_MUSIQUE",
@@ -1166,6 +1197,7 @@ FESTIVAL_MUSIQUE = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
     can_be_withdrawable=True,
+    formats=[EacFormat.FESTIVAL_SALON_CONGRES, EacFormat.CONCERT],
 )
 # endregion
 # region MUSIQUE_ENREGISTREE
@@ -1321,6 +1353,7 @@ SEANCE_ESSAI_PRATIQUE_ART = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.ATELIER_DE_PRATIQUE],
 )
 ATELIER_PRATIQUE_ART = Subcategory(
     id="ATELIER_PRATIQUE_ART",
@@ -1339,6 +1372,7 @@ ATELIER_PRATIQUE_ART = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+    formats=[EacFormat.ATELIER_DE_PRATIQUE],
 )
 ABO_PRATIQUE_ART = Subcategory(
     id="ABO_PRATIQUE_ART",
@@ -1503,6 +1537,7 @@ SPECTACLE_REPRESENTATION = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
     can_be_withdrawable=True,
+    formats=[EacFormat.REPRESENTATION],
 )
 SPECTACLE_ENREGISTRE = Subcategory(
     id="SPECTACLE_ENREGISTRE",
@@ -1590,6 +1625,7 @@ FESTIVAL_SPECTACLE = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
     can_be_withdrawable=True,
+    formats=[EacFormat.FESTIVAL_SALON_CONGRES, EacFormat.REPRESENTATION],
 )
 ABO_SPECTACLE = Subcategory(
     id="ABO_SPECTACLE",

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -241,6 +241,7 @@ def create_collective_offer_template(
         visualDisabilityCompliant=offer_data.visual_disability_compliant,
         interventionArea=offer_data.intervention_area or [],
         priceDetail=offer_data.price_detail,
+        formats=offer_data.formats,
     )
 
     if offer_data.dates:
@@ -291,6 +292,7 @@ def create_collective_offer(
         visualDisabilityCompliant=offer_data.visual_disability_compliant,
         interventionArea=offer_data.intervention_area or [],
         templateId=offer_data.template_id,
+        formats=offer_data.formats,
     )
     collective_offer.bookingEmails = offer_data.booking_emails
 
@@ -572,7 +574,7 @@ def edit_collective_offer_public(
         updated_fields.append(key)
 
         if key == "subcategoryId":
-            offer_validation.check_offer_subcategory_is_valid(value)
+            # offer_validation.check_offer_subcategory_is_valid(value)
             offer_validation.check_offer_is_eligible_for_educational(value)
             offer.subcategoryId = value
         elif key == "domains":

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -311,7 +311,10 @@ def check_activation_codes_expiration_datetime_on_stock_edition(
     check_activation_codes_expiration_datetime(activation_codes_expiration_datetime, booking_limit_datetime)
 
 
-def check_offer_is_eligible_for_educational(subcategory_id: str) -> None:
+def check_offer_is_eligible_for_educational(subcategory_id: str | None) -> None:
+    if not subcategory_id:
+        return
+
     subcategory = subcategories.ALL_SUBCATEGORIES_DICT.get(subcategory_id)
     if not subcategory or not subcategory.can_be_educational:
         raise exceptions.SubcategoryNotEligibleForEducationalOffer()
@@ -346,7 +349,9 @@ def check_offer_withdrawal(
             raise exceptions.NonLinkedProviderCannotHaveInAppTicket()
 
 
-def check_offer_subcategory_is_valid(offer_subcategory_id: str) -> None:
+def check_offer_subcategory_is_valid(offer_subcategory_id: str | None) -> None:
+    if not offer_subcategory_id:
+        return
     if offer_subcategory_id not in subcategories.ALL_SUBCATEGORIES_DICT:
         raise exceptions.UnknownOfferSubCategory()
     if not subcategories.ALL_SUBCATEGORIES_DICT[offer_subcategory_id].is_selectable:

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -530,6 +530,9 @@ class AlgoliaBackend(base.SearchBackend):
         department_code = get_department_code_from_postal_code(venue.postalCode)
         latitude, longitude = educational_api_offer.get_offer_coordinates(collective_offer)
 
+        raw_formats = collective_offer.get_formats()
+        formats = [fmt.value for fmt in raw_formats] if raw_formats else None
+
         return {
             "objectID": collective_offer.id,
             "offer": {
@@ -561,6 +564,7 @@ class AlgoliaBackend(base.SearchBackend):
             },
             "_geoloc": format_coordinates(latitude, longitude),
             "isTemplate": False,
+            "formats": formats,
         }
 
     @classmethod
@@ -572,6 +576,9 @@ class AlgoliaBackend(base.SearchBackend):
         date_created = collective_offer_template.dateCreated.timestamp()
         department_code = get_department_code_from_postal_code(venue.postalCode)
         latitude, longitude = educational_api_offer.get_offer_coordinates(collective_offer_template)
+
+        raw_formats = collective_offer_template.get_formats()
+        formats = [fmt.value for fmt in raw_formats] if raw_formats else None
 
         return {
             "objectID": _transform_collective_offer_template_id(collective_offer_template.id),
@@ -602,6 +609,7 @@ class AlgoliaBackend(base.SearchBackend):
             },
             "_geoloc": format_coordinates(latitude, longitude),
             "isTemplate": True,
+            "formats": formats,
         }
 
 

--- a/api/src/pcapi/routes/adage_iframe/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/offers.py
@@ -2,6 +2,7 @@ import logging
 
 from sqlalchemy.orm import exc as orm_exc
 
+import pcapi.core.categories.subcategories_v2 as subcategories
 from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.educational.api import favorite as educational_api_favorite
@@ -74,6 +75,15 @@ def get_educational_eligible_offers_by_uai(
     ]
 
     return serializers.ListCollectiveOffersResponseModel(collectiveOffers=serialized_favorite_offers)
+
+
+@blueprint.adage_iframe.route("/offers/formats", methods=["GET"])
+@spectree_serialize(response_model=serializers.EacFormatsResponseModel, api=blueprint.api)
+@adage_jwt_required
+def get_educational_offers_formats(
+    authenticated_information: AuthenticatedInformation,
+) -> serializers.EacFormatsResponseModel:
+    return serializers.EacFormatsResponseModel(formats=list(subcategories.EacFormat))
 
 
 @blueprint.adage_iframe.route("/collective/offers/<int:offer_id>", methods=["GET"])

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -7,6 +7,8 @@ import typing
 from pydantic.v1 import Field
 from pydantic.v1.class_validators import validator
 
+import pcapi.core.categories.subcategories_v2 as subcategories
+from pcapi.core.categories.subcategories_v2 import EacFormat
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.routes.native.utils import convert_to_cent
@@ -94,6 +96,13 @@ class CategoriesResponseModel(BaseModel):
         orm_mode = True
 
 
+class EacFormatsResponseModel(BaseModel):
+    formats: typing.Sequence[subcategories.EacFormat]
+
+    class Config:
+        use_enum_values = True
+
+
 class OfferAddressType(enum.Enum):
     OFFERER_VENUE = "offererVenue"
     SCHOOL = "school"
@@ -172,6 +181,7 @@ class CollectiveOfferResponseModel(BaseModel, common_models.AccessibilityComplia
     teacher: EducationalRedactorResponseModel | None
     nationalProgram: NationalProgramModel | None
     isFavorite: bool | None
+    formats: typing.Sequence[EacFormat] | None
 
     @classmethod
     def build(
@@ -215,6 +225,7 @@ class CollectiveOfferResponseModel(BaseModel, common_models.AccessibilityComplia
             mentalDisabilityCompliant=offer.mentalDisabilityCompliant,
             motorDisabilityCompliant=offer.motorDisabilityCompliant,
             visualDisabilityCompliant=offer.visualDisabilityCompliant,
+            formats=offer.get_formats(),
         )
 
     class Config:
@@ -260,6 +271,7 @@ class CollectiveOfferTemplateResponseModel(BaseModel, common_models.Accessibilit
     nationalProgram: NationalProgramModel | None
     isFavorite: bool | None
     dates: TemplateDatesModel | None
+    formats: typing.Sequence[EacFormat] | None
 
     @classmethod
     def build(
@@ -304,6 +316,7 @@ class CollectiveOfferTemplateResponseModel(BaseModel, common_models.Accessibilit
                 start=offer.start,
                 end=offer.end,
             ),
+            formats=offer.get_formats(),
         )
 
     class Config:

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -305,7 +305,7 @@ def test_serialize_collective_offer():
         name="Titre formidable",
         description="description formidable",
         students=[StudentLevels.CAP1, StudentLevels.CAP2],
-        subcategoryId=subcategories.LIVRE_PAPIER.id,
+        subcategoryId=subcategories.CONCERT.id,
         venue__postalCode="86140",
         venue__name="La Moyenne Librairie SA",
         venue__publicName="La Moyenne Librairie",
@@ -330,7 +330,7 @@ def test_serialize_collective_offer():
             "dateCreated": 1641031200.0,
             "name": "Titre formidable",
             "students": ["CAP - 1re année", "CAP - 2e année"],
-            "subcategoryId": subcategories.LIVRE_PAPIER.id,
+            "subcategoryId": subcategories.CONCERT.id,
             "domains": [domain1.id, domain2.id],
             "educationalInstitutionUAICode": educational_institution.institutionId,
             "interventionArea": ["1", "90", "94"],
@@ -354,6 +354,7 @@ def test_serialize_collective_offer():
             "lng": float(collective_offer.venue.longitude),
         },
         "isTemplate": False,
+        "formats": [fmt.value for fmt in subcategories.CONCERT.formats],
     }
 
 
@@ -373,7 +374,7 @@ def test_serialize_collective_offer_template():
         name="Titre formidable",
         description="description formidable",
         students=[StudentLevels.CAP1, StudentLevels.CAP2],
-        subcategoryId=subcategories.LIVRE_PAPIER.id,
+        subcategoryId=subcategories.CONCERT.id,
         venue__postalCode="86140",
         venue__name="La Moyenne Librairie SA",
         venue__publicName="La Moyenne Librairie",
@@ -391,7 +392,7 @@ def test_serialize_collective_offer_template():
             "dateCreated": 1641031200.0,
             "name": "Titre formidable",
             "students": ["CAP - 1re année", "CAP - 2e année"],
-            "subcategoryId": subcategories.LIVRE_PAPIER.id,
+            "subcategoryId": subcategories.CONCERT.id,
             "domains": [domain1.id, domain2.id],
             "educationalInstitutionUAICode": "all",
             "interventionArea": [],
@@ -415,4 +416,5 @@ def test_serialize_collective_offer_template():
             "lng": float(venue.longitude),
         },
         "isTemplate": True,
+        "formats": [fmt.value for fmt in subcategories.CONCERT.formats],
     }

--- a/api/tests/routes/adage_iframe/get_all_offers_linked_to_uai_test.py
+++ b/api/tests/routes/adage_iframe/get_all_offers_linked_to_uai_test.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import pytest
 
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.testing import assert_num_queries
 
@@ -18,6 +19,7 @@ class AllOffersByUaiTest:
         educational_institution = educational_factories.EducationalInstitutionFactory()
         national_program = educational_factories.NationalProgramFactory()
         collective_offer = educational_factories.CollectiveOfferFactory(
+            subcategoryId=subcategories.SEANCE_CINE.id,
             domains=[educational_factories.EducationalDomainFactory()],
             institution=educational_institution,
             teacher=educational_factories.EducationalRedactorFactory(),
@@ -112,6 +114,7 @@ class AllOffersByUaiTest:
                         "name": stock.collectiveOffer.nationalProgram.name,
                     },
                     "isFavorite": False,
+                    "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
                 }
             ]
         }
@@ -123,6 +126,7 @@ class AllOffersByUaiTest:
         educational_institution = educational_factories.EducationalInstitutionFactory()
         national_program = educational_factories.NationalProgramFactory()
         collective_offer = educational_factories.CollectiveOfferFactory(
+            subcategoryId=subcategories.SEANCE_CINE.id,
             domains=[educational_factories.EducationalDomainFactory()],
             institution=educational_institution,
             teacher=educational_factories.EducationalRedactorFactory(),
@@ -218,6 +222,7 @@ class AllOffersByUaiTest:
                         "name": stock.collectiveOffer.nationalProgram.name,
                     },
                     "isFavorite": True,
+                    "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
                 }
             ]
         }

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -1,6 +1,7 @@
 from flask import url_for
 import pytest
 
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offerers import factories as offerers_factories
@@ -28,6 +29,7 @@ class CollectiveOfferTemplateTest:
     def test_get_collective_offer_template(self, eac_client, redactor):
         venue = offerers_factories.VenueFactory()
         offer = educational_factories.CollectiveOfferTemplateFactory(
+            subcategoryId=subcategories.SEANCE_CINE.id,
             name="offer name",
             description="offer description",
             priceDetail="détail du prix",
@@ -97,6 +99,7 @@ class CollectiveOfferTemplateTest:
                 "start": format_into_utc_date(offer.start),
                 "end": format_into_utc_date(offer.end),
             },
+            "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
         }
 
     def test_is_a_redactors_favorite(self, eac_client):

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -4,6 +4,7 @@ from flask import url_for
 from freezegun.api import freeze_time
 import pytest
 
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offerers import factories as offerers_factories
@@ -37,6 +38,7 @@ class CollectiveOfferTest:
         institution = educational_factories.EducationalInstitutionFactory(institutionId="12890AI")
         stock = educational_factories.CollectiveStockFactory(
             beginningDatetime=datetime(2021, 5, 15),
+            collectiveOffer__subcategoryId=subcategories.SEANCE_CINE.id,
             collectiveOffer__name="offer name",
             collectiveOffer__description="offer description",
             price=10,
@@ -129,6 +131,7 @@ class CollectiveOfferTest:
             },
             "nationalProgram": {"id": offer.nationalProgramId, "name": offer.nationalProgram.name},
             "isFavorite": False,
+            "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
         }
 
     def test_is_a_redactors_favorite(self, eac_client):

--- a/api/tests/routes/adage_iframe/get_favorites_test.py
+++ b/api/tests/routes/adage_iframe/get_favorites_test.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from freezegun.api import freeze_time
 import pytest
 
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.testing import assert_num_queries
@@ -18,6 +19,7 @@ class GetFavoriteOfferTest:
         national_program = educational_factories.NationalProgramFactory()
         stock = educational_factories.CollectiveStockFactory(
             beginningDatetime=datetime(2021, 5, 15),
+            collectiveOffer__subcategoryId=subcategories.SEANCE_CINE.id,
             collectiveOffer__name="offer name",
             collectiveOffer__description="offer description",
             price=10,
@@ -28,7 +30,9 @@ class GetFavoriteOfferTest:
             collectiveOffer__nationalProgramId=national_program.id,
         )
 
-        collective_offer_template = educational_factories.CollectiveOfferTemplateFactory()
+        collective_offer_template = educational_factories.CollectiveOfferTemplateFactory(
+            subcategoryId=subcategories.EVENEMENT_CINE.id,
+        )
         educational_redactor = educational_factories.EducationalRedactorFactory(
             favoriteCollectiveOffers=[stock.collectiveOffer],
             favoriteCollectiveOfferTemplates=[collective_offer_template],
@@ -116,6 +120,7 @@ class GetFavoriteOfferTest:
                         "id": stock.collectiveOffer.nationalProgram.id,
                         "name": stock.collectiveOffer.nationalProgram.name,
                     },
+                    "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
                 }
             ],
             "favoritesTemplate": [
@@ -171,6 +176,7 @@ class GetFavoriteOfferTest:
                         "start": collective_offer_template.start.isoformat(),
                         "end": collective_offer_template.end.isoformat(),
                     },
+                    "formats": [fmt.value for fmt in subcategories.EVENEMENT_CINE.formats],
                 }
             ],
         }

--- a/api/tests/routes/adage_iframe/get_formats_test.py
+++ b/api/tests/routes/adage_iframe/get_formats_test.py
@@ -1,0 +1,16 @@
+from flask import url_for
+import pytest
+
+from pcapi.core.categories.subcategories_v2 import EacFormat
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class FormatsTest:
+    def test_get_formats(self, client):
+        test_client = client.with_adage_token(email="test@mail.com", uai="12890AI")
+        response = test_client.get(url_for("adage_iframe.get_educational_offers_formats"))
+
+        assert response.status_code == 200
+        assert set(response.json["formats"]) == set(fmt.value for fmt in EacFormat)

--- a/api/tests/routes/pro/get_collective_offer_template_test.py
+++ b/api/tests/routes/pro/get_collective_offer_template_test.py
@@ -39,6 +39,7 @@ class Returns200Test:
             "start": format_into_utc_date(offer.start),
             "end": format_into_utc_date(offer.end),
         }
+        assert response.json["formats"] == offer.formats
 
     def test_performance(self, client):
         # Given

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -6,6 +6,7 @@ from flask import url_for
 import pytest
 
 from pcapi.core import testing
+from pcapi.core.categories import subcategories_v2 as subcategories
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.educational.models as educational_models
 from pcapi.core.educational.models import CollectiveOfferDisplayedStatus
@@ -35,6 +36,7 @@ class Returns200Test:
         stock = educational_factories.CollectiveStockFactory()
         national_program = educational_factories.NationalProgramFactory()
         offer = educational_factories.CollectiveOfferFactory(
+            subcategoryId=subcategories.SEANCE_CINE.id,
             collectiveStock=stock,
             teacher=educational_factories.EducationalRedactorFactory(),
             templateId=template.id,
@@ -70,6 +72,7 @@ class Returns200Test:
         }
         assert response_json["templateId"] == template.id
         assert response_json["nationalProgram"] == {"id": national_program.id, "name": national_program.name}
+        assert response_json["formats"] == [fmt.value for fmt in subcategories.SEANCE_CINE.formats]
 
     def test_sold_out(self, client):
         # Given

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from flask import url_for
 import pytest
 
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational.exceptions import CulturalPartnerNotFoundException
 import pcapi.core.educational.factories as educational_factories
 from pcapi.core.educational.factories import CollectiveOfferTemplateFactory
@@ -80,6 +81,7 @@ class Returns200Test:
             "nationalProgramId": national_program.id,
             "dates": {"start": template_start.isoformat(), "end": template_end.isoformat()},
             "domains": [domain.id],
+            "formats": [subcategories.EacFormat.CONCERT.value],
         }
 
         with patch(PATCH_CAN_CREATE_OFFER_PATH):
@@ -105,6 +107,7 @@ class Returns200Test:
         assert updated_offer.dateRange
         assert updated_offer.start == template_start
         assert updated_offer.end == template_end
+        assert updated_offer.formats == [subcategories.EacFormat.CONCERT]
 
     def test_with_tz_aware_dates(self, pro_client, offer, template_start, template_end):
         payload = {

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 import pytest
 
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational.exceptions import CulturalPartnerNotFoundException
 import pcapi.core.educational.factories as educational_factories
 from pcapi.core.educational.factories import CollectiveBookingFactory
@@ -65,6 +66,7 @@ class Returns200Test:
             "students": ["Collège - 4e"],
             "interventionArea": ["01", "2A"],
             "nationalProgramId": national_program.id,
+            "formats": [subcategories.EacFormat.CONCERT.value],
         }
 
         # WHEN
@@ -98,6 +100,7 @@ class Returns200Test:
         assert updated_offer.domains == [domain]
         assert updated_offer.interventionArea == ["01", "2A"]
         assert updated_offer.description == "Ma super description"
+        assert updated_offer.formats == [subcategories.EacFormat.CONCERT]
 
         expected_payload = EducationalBookingEdition(
             **serialize_collective_booking(booking).dict(),
@@ -112,6 +115,7 @@ class Returns200Test:
                     "subcategoryId",
                     "domains",
                     "description",
+                    "formats",
                 ]
             ),
         )

--- a/api/tests/routes/pro/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/post_collective_offers_template_test.py
@@ -89,6 +89,7 @@ def payload_fixture(venue, domains, offer_venue, template_start, template_end):
         "domains": [domain.id for domain in domains],
         "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
         "venueId": venue.id,
+        "formats": [subcategories.EacFormat.CONCERT.value],
     }
 
 
@@ -184,17 +185,6 @@ class Returns403Test:
 
 
 class Returns400Test:
-    def test_missing_category(self, pro_client, payload):
-        del payload["subcategoryId"]
-
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
-            response = pro_client.post("/collective/offers-template", json=payload)
-
-        assert response.status_code == 400
-        assert response.json == {"subcategoryId": ["Ce champ est obligatoire"]}
-
-        assert CollectiveOfferTemplate.query.count() == 0
-
     def test_unselectable_category(self, pro_client, payload):
         data = {**payload, "subcategoryId": subcategories.OEUVRE_ART.id}
 

--- a/api/tests/routes/pro/post_collective_offers_test.py
+++ b/api/tests/routes/pro/post_collective_offers_test.py
@@ -46,6 +46,7 @@ class Returns200Test:
             "interventionArea": ["75", "92", "93"],
             "templateId": template.id,
             "nationalProgramId": national_program.id,
+            "formats": [subcategories.EacFormat.CONCERT.value],
         }
         with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
@@ -80,6 +81,7 @@ class Returns200Test:
         assert offer.description == "Ma super description"
         assert offer.templateId == template.id
         assert offer.nationalProgramId == national_program.id
+        assert offer.formats == [subcategories.EacFormat.CONCERT]
 
     def test_create_collective_offer_college_6(self, client):
         # Given

--- a/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
+++ b/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from pcapi import settings
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.exceptions import CantGetImageFromUrl
 import pcapi.core.educational.factories as educational_factories
@@ -68,6 +69,7 @@ class Returns200Test:
         institution = educational_factories.EducationalInstitutionFactory()
         national_program = educational_factories.NationalProgramFactory()
         offer = educational_factories.CollectiveOfferFactory(
+            subcategoryId=subcategories.SEANCE_CINE.id,
             venue=venue,
             institution=institution,
             nationalProgram=national_program,
@@ -149,6 +151,7 @@ class Returns200Test:
             "lastBookingId": None,
             "teacher": None,
             "nationalProgram": {"id": national_program.id, "name": national_program.name},
+            "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
         }
 
     def test_duplicate_collective_offer_draft_offer(self, client):

--- a/pro/src/apiClient/adage/index.ts
+++ b/pro/src/apiClient/adage/index.ts
@@ -27,6 +27,8 @@ export type { CollectiveOfferTemplateResponseModel } from './models/CollectiveOf
 export type { CollectiveRequestBody } from './models/CollectiveRequestBody';
 export type { CollectiveRequestResponseModel } from './models/CollectiveRequestResponseModel';
 export type { Coordinates } from './models/Coordinates';
+export { EacFormat } from './models/EacFormat';
+export type { EacFormatsResponseModel } from './models/EacFormatsResponseModel';
 export type { EducationalInstitutionResponseModel } from './models/EducationalInstitutionResponseModel';
 export type { EducationalInstitutionWithBudgetResponseModel } from './models/EducationalInstitutionWithBudgetResponseModel';
 export type { EducationalRedactorResponseModel } from './models/EducationalRedactorResponseModel';

--- a/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 
 import type { CollectiveOfferOfferVenue } from './CollectiveOfferOfferVenue';
+import type { EacFormat } from './EacFormat';
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
 import type { EducationalRedactorResponseModel } from './EducationalRedactorResponseModel';
 import type { NationalProgramModel } from './NationalProgramModel';
@@ -21,6 +22,7 @@ export type CollectiveOfferResponseModel = {
   durationMinutes?: number | null;
   educationalInstitution?: EducationalInstitutionResponseModel | null;
   educationalPriceDetail?: string | null;
+  formats?: Array<EacFormat> | null;
   id: number;
   imageCredit?: string | null;
   imageUrl?: string | null;

--- a/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 
 import type { CollectiveOfferOfferVenue } from './CollectiveOfferOfferVenue';
+import type { EacFormat } from './EacFormat';
 import type { NationalProgramModel } from './NationalProgramModel';
 import type { OfferDomain } from './OfferDomain';
 import type { OfferVenueResponse } from './OfferVenueResponse';
@@ -19,6 +20,7 @@ export type CollectiveOfferTemplateResponseModel = {
   domains: Array<OfferDomain>;
   durationMinutes?: number | null;
   educationalPriceDetail?: string | null;
+  formats?: Array<EacFormat> | null;
   id: number;
   imageCredit?: string | null;
   imageUrl?: string | null;

--- a/pro/src/apiClient/adage/models/EacFormat.ts
+++ b/pro/src/apiClient/adage/models/EacFormat.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * An enumeration.
+ */
+export enum EacFormat {
+  ATELIER_DE_PRATIQUE = 'Atelier de pratique',
+  CONCERT = 'Concert',
+  CONF_RENCE_RENCONTRE = 'Conférence, rencontre',
+  FESTIVAL_SALON_CONGR_S = 'Festival, salon, congrès',
+  PROJECTION_AUDIOVISUELLE = 'Projection audiovisuelle',
+  REPR_SENTATION = 'Représentation',
+  VISITE_GUID_E = 'Visite guidée',
+  VISITE_LIBRE = 'Visite libre',
+}

--- a/pro/src/apiClient/adage/models/EacFormatsResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EacFormatsResponseModel.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { EacFormat } from './EacFormat';
+
+export type EacFormatsResponseModel = {
+  formats: Array<EacFormat>;
+};
+

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -14,6 +14,7 @@ import type { CollectiveOfferResponseModel } from '../models/CollectiveOfferResp
 import type { CollectiveOfferTemplateResponseModel } from '../models/CollectiveOfferTemplateResponseModel';
 import type { CollectiveRequestBody } from '../models/CollectiveRequestBody';
 import type { CollectiveRequestResponseModel } from '../models/CollectiveRequestResponseModel';
+import type { EacFormatsResponseModel } from '../models/EacFormatsResponseModel';
 import type { EducationalInstitutionWithBudgetResponseModel } from '../models/EducationalInstitutionWithBudgetResponseModel';
 import type { FavoritesResponseModel } from '../models/FavoritesResponseModel';
 import type { ListCollectiveOffersResponseModel } from '../models/ListCollectiveOffersResponseModel';
@@ -610,6 +611,22 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'GET',
       url: '/adage-iframe/offers/categories',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * get_educational_offers_formats <GET>
+   * @returns EacFormatsResponseModel OK
+   * @throws ApiError
+   */
+  public getEducationalOffersFormats(): CancelablePromise<EacFormatsResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/adage-iframe/offers/formats',
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Entity`,

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -68,6 +68,7 @@ export type { DeleteOfferRequestBody } from './models/DeleteOfferRequestBody';
 export type { DeleteStockListBody } from './models/DeleteStockListBody';
 export type { DMSApplicationForEAC } from './models/DMSApplicationForEAC';
 export { DMSApplicationstatus } from './models/DMSApplicationstatus';
+export { EacFormat } from './models/EacFormat';
 export type { EditPriceCategoryModel } from './models/EditPriceCategoryModel';
 export type { EditVenueBodyModel } from './models/EditVenueBodyModel';
 export type { EditVenueCollectiveDataBodyModel } from './models/EditVenueCollectiveDataBodyModel';

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
@@ -5,6 +5,7 @@
 
 import type { CollectiveOffersBookingResponseModel } from './CollectiveOffersBookingResponseModel';
 import type { CollectiveOffersStockResponseModel } from './CollectiveOffersStockResponseModel';
+import type { EacFormat } from './EacFormat';
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
 import type { ListOffersVenueResponseModel } from './ListOffersVenueResponseModel';
 import type { NationalProgramModel } from './NationalProgramModel';
@@ -13,6 +14,7 @@ import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 export type CollectiveOfferResponseModel = {
   booking?: CollectiveOffersBookingResponseModel | null;
   educationalInstitution?: EducationalInstitutionResponseModel | null;
+  formats?: Array<EacFormat> | null;
   hasBookingLimitDatetimesPassed: boolean;
   id: number;
   imageCredit?: string | null;

--- a/pro/src/apiClient/v1/models/EacFormat.ts
+++ b/pro/src/apiClient/v1/models/EacFormat.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * An enumeration.
+ */
+export enum EacFormat {
+  ATELIER_DE_PRATIQUE = 'Atelier de pratique',
+  CONCERT = 'Concert',
+  CONF_RENCE_RENCONTRE = 'Conférence, rencontre',
+  FESTIVAL_SALON_CONGR_S = 'Festival, salon, congrès',
+  PROJECTION_AUDIOVISUELLE = 'Projection audiovisuelle',
+  REPR_SENTATION = 'Représentation',
+  VISITE_GUID_E = 'Visite guidée',
+  VISITE_LIBRE = 'Visite libre',
+}

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -5,6 +5,7 @@
 
 import type { CollectiveBookingStatus } from './CollectiveBookingStatus';
 import type { CollectiveOfferOfferVenueResponseModel } from './CollectiveOfferOfferVenueResponseModel';
+import type { EacFormat } from './EacFormat';
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
 import type { EducationalRedactorResponseModel } from './EducationalRedactorResponseModel';
 import type { GetCollectiveOfferCollectiveStockResponseModel } from './GetCollectiveOfferCollectiveStockResponseModel';
@@ -25,6 +26,7 @@ export type GetCollectiveOfferResponseModel = {
   description: string;
   domains: Array<OfferDomain>;
   durationMinutes?: number | null;
+  formats?: Array<EacFormat> | null;
   hasBookingLimitDatetimesPassed: boolean;
   id: number;
   imageCredit?: string | null;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 
 import type { CollectiveOfferOfferVenueResponseModel } from './CollectiveOfferOfferVenueResponseModel';
+import type { EacFormat } from './EacFormat';
 import type { GetCollectiveOfferVenueResponseModel } from './GetCollectiveOfferVenueResponseModel';
 import type { NationalProgramModel } from './NationalProgramModel';
 import type { OfferDomain } from './OfferDomain';
@@ -23,6 +24,7 @@ export type GetCollectiveOfferTemplateResponseModel = {
   domains: Array<OfferDomain>;
   durationMinutes?: number | null;
   educationalPriceDetail?: string | null;
+  formats?: Array<EacFormat> | null;
   hasBookingLimitDatetimesPassed: boolean;
   id: number;
   imageCredit?: string | null;

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferBodyModel.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
+import type { EacFormat } from './EacFormat';
 import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 
@@ -15,6 +16,7 @@ export type PatchCollectiveOfferBodyModel = {
   description?: string | null;
   domains?: Array<number> | null;
   durationMinutes?: number | null;
+  formats?: Array<EacFormat> | null;
   interventionArea?: Array<string> | null;
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
@@ -5,6 +5,7 @@
 
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
 import type { DateRangeModel } from './DateRangeModel';
+import type { EacFormat } from './EacFormat';
 import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 
@@ -17,6 +18,7 @@ export type PatchCollectiveOfferTemplateBodyModel = {
   description?: string | null;
   domains?: Array<number> | null;
   durationMinutes?: number | null;
+  formats?: Array<EacFormat> | null;
   interventionArea?: Array<string> | null;
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
+import type { EacFormat } from './EacFormat';
 import type { StudentLevels } from './StudentLevels';
 
 export type PostCollectiveOfferBodyModel = {
@@ -14,6 +15,7 @@ export type PostCollectiveOfferBodyModel = {
   description: string;
   domains?: Array<number> | null;
   durationMinutes?: number | null;
+  formats?: Array<EacFormat> | null;
   interventionArea?: Array<string> | null;
   mentalDisabilityCompliant?: boolean;
   motorDisabilityCompliant?: boolean;
@@ -22,7 +24,7 @@ export type PostCollectiveOfferBodyModel = {
   offerVenue: CollectiveOfferVenueBodyModel;
   offererId?: string | null;
   students: Array<StudentLevels>;
-  subcategoryId: string;
+  subcategoryId?: string | null;
   templateId?: number | null;
   venueId: number;
   visualDisabilityCompliant?: boolean;

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
@@ -5,6 +5,7 @@
 
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
 import type { DateRangeOnCreateModel } from './DateRangeOnCreateModel';
+import type { EacFormat } from './EacFormat';
 import type { StudentLevels } from './StudentLevels';
 
 export type PostCollectiveOfferTemplateBodyModel = {
@@ -16,6 +17,7 @@ export type PostCollectiveOfferTemplateBodyModel = {
   description: string;
   domains?: Array<number> | null;
   durationMinutes?: number | null;
+  formats?: Array<EacFormat> | null;
   interventionArea?: Array<string> | null;
   mentalDisabilityCompliant?: boolean;
   motorDisabilityCompliant?: boolean;
@@ -25,7 +27,7 @@ export type PostCollectiveOfferTemplateBodyModel = {
   offererId?: string | null;
   priceDetail?: string | null;
   students: Array<StudentLevels>;
-  subcategoryId: string;
+  subcategoryId?: string | null;
   templateId?: number | null;
   venueId: number;
   visualDisabilityCompliant?: boolean;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24675

### Objectif 
Remplacer les sous-catégorie par des formats, pour les offres collectives (et vitrines).

### Implémentation 

1) ajout d'une colonne formats (liste de formats) et
2) ajout d'un champs formats aux sous-catégories utilisées par les offres collectives.

L'ajout au niveau des sous-catégories permet à toutes les offres collectives existantes d'avoir une liste de formats (l'association sous-catégorie -> format est renseignée dans le ticket JIRA). Dans un premier temps, il faudra donc aller chercher les formats dans la colonnes formats et s'il n'y a rien, se baser sur la sous-catégorie.

Cette PR ajoute donc : 

1. une nouvelle colonne formats aux offres collectives (et vitrines) ;
2. la possibilité de renseigner les formats à la création et à l'édition ;
3. une route qui renvoie tous les formats connus ;
4. le champs formats lors de la sérialisation Algolia.

Et la colonne `subcategoryId` devient optionnelle pour les offres collectives et vitrines, elle sera bientôt supprimée (car remplacée par formats).