### PR TITLE
(BSR)[API] ci: fix silent error on db migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,8 +125,10 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           command: |
+            set -e
             POD_NAME=$(kubectl -n ${{ inputs.environment }} get po -l role=api -o jsonpath='{.items[0].metadata.name}')
             kubectl exec -it -n ${{ inputs.environment }} ${POD_NAME} -- bash <<EOF
+            set -e
             flask install_postgres_extensions;
             alembic upgrade pre@head;
             flask install_data
@@ -144,8 +146,10 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           command: |
+            set -e
             POD_NAME=$(kubectl -n ${{ inputs.environment }} get po -l role=api -o json |jq -r '.items[] | select(.spec.containers[0].image | contains("${{ inputs.app_version }}")) | "\(.metadata.name)"'|head -n 1)
             kubectl exec -it -n ${{ inputs.environment }} ${POD_NAME} -- bash <<EOF
+            set -e
             alembic upgrade post@head
             EOF
   deploy-pro-on-testing-on-firebase:


### PR DESCRIPTION
## But de la pull request

Problème remontée dans le canal slack : https://passcultureteam.slack.com/archives/C01CTV65S3A/p1697094435850889

Cela devrait faire en sorte qu'une erreur lors des pre/post migrations plante la CI au lieu d'échouer silencieusement.

Exemple d'une commande qui fail hors du pod : https://github.com/pass-culture/pass-culture-main/actions/runs/6493126545/job/17633457397

Exemple d'une commande qui fail dans le pod : https://github.com/pass-culture/pass-culture-main/actions/runs/6493266593/job/17633881304