### PR TITLE
(BSR)[API] refactor: Use `CustomReimbursementRule.amountInEurocents`

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -437,7 +437,7 @@ def price_events(
         loops -= 1
         # Keep last event in the session, we'll need it when calling
         # `_get_loop_query()` for the next loop.
-        with log_elapsed(logger, "Expunged priced bookings from session"):
+        with log_elapsed(logger, "Expunged priced events from session"):
             for event in events:
                 if event != last_event:
                     db.session.expunge(event)

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -185,6 +185,7 @@ class CustomReimbursementRuleFactory(BaseFactory):
         ]
     )
     amount = 5
+    amountInEuroCents = 500
 
     @classmethod
     def _create(
@@ -195,6 +196,7 @@ class CustomReimbursementRuleFactory(BaseFactory):
     ) -> models.CustomReimbursementRule:
         if "rate" in kwargs:
             kwargs["amount"] = None
+            kwargs["amountInEuroCents"] = None
         if "offerer" in kwargs:
             kwargs["offer"] = None
         return super()._create(model_class, *args, **kwargs)

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -593,8 +593,8 @@ class CustomReimbursementRule(ReimbursementRule, Base, Model):
         booking: "bookings_models.Booking",
         custom_total_amount: int | None = None,
     ) -> int:
-        if self.amount is not None:
-            return utils.to_eurocents(booking.quantity * self.amount)
+        if self.amountInEuroCents is not None:
+            return booking.quantity * self.amountInEuroCents
         return super().apply(booking, custom_total_amount)
 
     @property

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
@@ -82,7 +82,7 @@
                   <td>{{ links.build_offer_name_to_pc_pro_link(reimbursement_rule.offer) }}</td>
                 {% endif %}
                 <td>{{ reimbursement_rule.rate | format_rate_multiply_by_100 }}</td>
-                <td>{{ reimbursement_rule.amount | format_amount if reimbursement_rule.amount else "" }}</td>
+                <td>{{ reimbursement_rule.amountInEuroCents | format_cents if reimbursement_rule.amountInEuroCents else "" }}</td>
                 <td>{{ reimbursement_rule.subcategories | format_subcategories }}</td>
                 <td>{{ reimbursement_rule.timespan | format_timespan }}</td>
               </tr>

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -58,7 +58,7 @@ def create_specific_invoice() -> None:
     custom_rule_offer1 = offers_factories.ThingOfferFactory(venue=venue)
     finance_factories.CustomReimbursementRuleFactory(rate=0.94, offer=custom_rule_offer1)
     custom_rule_offer2 = offers_factories.ThingOfferFactory(venue=venue)
-    finance_factories.CustomReimbursementRuleFactory(amount=22, offer=custom_rule_offer2)
+    finance_factories.CustomReimbursementRuleFactory(amountInEuroCents=2200, offer=custom_rule_offer2)
 
     stocks = [
         offers_factories.StockFactory(offer=thing_offer1, price=30),

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1791,7 +1791,7 @@ def test_generate_payments_file():
         booking__stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         booking__stock__offer__venue=offer_venue2,
         standardRule="",
-        customRule=factories.CustomReimbursementRuleFactory(amount=6),
+        customRule=factories.CustomReimbursementRuleFactory(amountInEuroCents=600),
     )
     # pricing for an underage individual booking
     underage_user = users_factories.UnderageBeneficiaryFactory()
@@ -1804,7 +1804,7 @@ def test_generate_payments_file():
         booking__stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         booking__stock__offer__venue=offer_venue2,
         standardRule="",
-        customRule=factories.CustomReimbursementRuleFactory(amount=6),
+        customRule=factories.CustomReimbursementRuleFactory(amountInEuroCents=600),
     )
     # pricing for educational booking
     # check that the right deposit is used for csv
@@ -2014,7 +2014,7 @@ def invoice_test_data():
     custom_rule_offer1 = offers_factories.ThingOfferFactory(venue=venue)
     factories.CustomReimbursementRuleFactory(rate=0.94, offer=custom_rule_offer1)
     custom_rule_offer2 = offers_factories.ThingOfferFactory(venue=venue)
-    factories.CustomReimbursementRuleFactory(amount=22, offer=custom_rule_offer2)
+    factories.CustomReimbursementRuleFactory(amountInEuroCents=2200, offer=custom_rule_offer2)
 
     stocks = [
         offers_factories.StockFactory(offer=thing_offer1, price=30),
@@ -2194,7 +2194,7 @@ class GenerateInvoiceTest:
 
         offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=23)
-        factories.CustomReimbursementRuleFactory(amount=22, offer=offer)
+        factories.CustomReimbursementRuleFactory(amountInEuroCents=2200, offer=offer)
         booking1 = bookings_factories.UsedBookingFactory(stock=stock)
         booking2 = bookings_factories.UsedBookingFactory(stock=stock)
         api.price_booking(booking1)

--- a/api/tests/core/finance/test_models.py
+++ b/api/tests/core/finance/test_models.py
@@ -86,7 +86,7 @@ class CustomReimbursementRuleTest:
         assert not rule.is_relevant(booking2)
 
     def test_apply_with_amount(self):
-        rule = factories.CustomReimbursementRuleFactory(amount=10)
+        rule = factories.CustomReimbursementRuleFactory(amountInEuroCents=1000)
         single = bookings_factories.BookingFactory(quantity=1, amount=12)
         double = bookings_factories.BookingFactory(quantity=2, amount=12)
 

--- a/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
@@ -40,7 +40,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
     def test_list_custom_reimbursement_rules(self, authenticated_client):
         start = datetime.datetime.utcnow() - datetime.timedelta(days=365)
         end = datetime.datetime.utcnow() + datetime.timedelta(days=365)
-        offer_rule = finance_factories.CustomReimbursementRuleFactory(amount=27, timespan=(start, None))
+        offer_rule = finance_factories.CustomReimbursementRuleFactory(amountInEuroCents=2700, timespan=(start, None))
         offerer = offerers_factories.OffererFactory()
         offerer_rule = finance_factories.CustomReimbursementRuleFactory(
             offerer=offerer, rate=0.5, subcategories=["FESTIVAL_LIVRE"]


### PR DESCRIPTION
`CustomReimbursementRule.amount` is one the last model columns (in
`core.finance`) where we store euros and not eurocents. This commit is
the second step in storing eurocents in the `amount` column.

```
   step 1: add `amountInEurocents` and write in both `amount` and
           `amountInEurocents`. Also, populate `amountInEurocents`
           for existing rows.
-> step 2: use `amountInEuroCents` column instead of `amount`.
   step 3: store eurocents in `amount` column.
   step 4: use `amount` column.
   step 5: drop `amountInEuroCents` column.
```