### PR TITLE
(PC-24988)[API] feat: update offer stocks route to show total stocks

### DIFF
--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -381,6 +381,8 @@ class StocksQueryModel(BaseModel):
     price_category_id: int | None
     order_by: offers_repository.StocksOrderedBy = offers_repository.StocksOrderedBy.BEGINNING_DATETIME
     order_by_desc: bool = False
+    page: int = 1
+    stocks_limit_per_page: int = offers_repository.LIMIT_STOCKS_PER_PAGE
 
 
 class DeleteStockListBody(BaseModel):
@@ -391,7 +393,6 @@ class DeleteStockListBody(BaseModel):
 
 
 class DeleteFilteredStockListBody(BaseModel):
-    offer_id: int
     date: datetime.date | None
     time: datetime.time | None
     price_category_id: int | None

--- a/api/src/pcapi/workers/update_stocks_job.py
+++ b/api/src/pcapi/workers/update_stocks_job.py
@@ -12,5 +12,4 @@ def batch_delete_filtered_stocks_job(filters: dict) -> None:
         time=filters["time"],
         price_category_id=filters["price_category_id"],
     )
-
-    offers_api.batch_delete_stocks(stocks)
+    offers_api.batch_delete_stocks(stocks.all())

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1451,7 +1451,7 @@ class GetStocksListFiltersTest:
         )
 
         # Then
-        assert len(stocks) == 1
+        assert stocks.count() == 1
 
     def test_filtered_stock_by_price_category(self):
         # Given
@@ -1465,7 +1465,7 @@ class GetStocksListFiltersTest:
         )
 
         # Then
-        assert len(stocks) == 1
+        assert stocks.count() == 1
 
     def test_filtered_stock_by_date(self):
         # Given
@@ -1480,7 +1480,7 @@ class GetStocksListFiltersTest:
         )
 
         # Then
-        assert len(stocks) == 1
+        assert stocks.count() == 1
 
     def test_filtered_stocks_by_hour(self):
         # Given
@@ -1501,7 +1501,7 @@ class GetStocksListFiltersTest:
         stocks = repository.get_filtered_stocks(offer_id=offer.id, time=beginning_datetime.time())
 
         # Then
-        assert len(stocks) == 2
+        assert stocks.count() == 2
 
     def test_filtered_stock_by_minutes(self):
         # Given
@@ -1518,7 +1518,7 @@ class GetStocksListFiltersTest:
         )
 
         # Then
-        assert len(stocks) == 1
+        assert stocks.count() == 1
 
     def test_filtered_stock_by_seconds(self):
         # Given
@@ -1535,7 +1535,7 @@ class GetStocksListFiltersTest:
         )
 
         # Then
-        assert len(stocks) == 2
+        assert stocks.count() == 2
 
     @override_features(WIP_PRO_STOCK_PAGINATION=False)
     def test_filtered_stocks_query_by_default(self):
@@ -1551,14 +1551,10 @@ class GetStocksListFiltersTest:
         )
 
         # When
-        stocks = repository.get_filtered_stocks(
-            offer_id=offer.id,
-            stocks_limit_per_page=1,  # Only works because FF is set to False
-            page=1,  # Same as above
-        )
+        stocks = repository.get_filtered_stocks(offer_id=offer.id)
 
         # Then
-        assert len(stocks) == 3
+        assert stocks.count() == 3
         assert stocks[0] == first_stock
         assert stocks[1] == second_stock
         assert stocks[2] == third_stock
@@ -1575,17 +1571,17 @@ class GetStocksListFiltersTest:
         factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime + datetime.timedelta(seconds=30))
 
         # When
-        stocks = repository.get_filtered_stocks(
+        filtered_stocks = repository.get_filtered_stocks(
             offer_id=offer.id,
-            stocks_limit_per_page=stocks_limit_per_page,
-            page=current_page,
             order_by="BEGINNING_DATETIME",
+        )
+        stocks = repository.get_paginated_stocks(
+            stocks_query=filtered_stocks, stocks_limit_per_page=stocks_limit_per_page, page=current_page
         )
 
         # Then
-        assert len(stocks) == 1
+        assert stocks.count() == 1
 
-    @override_features(WIP_PRO_STOCK_PAGINATION=True)
     def test_order_stocks_by_beginning_datetime_desc(self):
         # Given
         beginning_datetime = datetime.datetime(2020, 10, 15, 12, 0, 0)
@@ -1615,7 +1611,6 @@ class GetStocksListFiltersTest:
         assert stocks[3] == stock1
         assert stocks[4] == stock4
 
-    @override_features(WIP_PRO_STOCK_PAGINATION=True)
     def test_order_stocks_by_date(self):
         beginning_datetime = datetime.datetime(2020, 10, 15, 12, 0, 0)
         same_hour_other_day = datetime.datetime(2020, 10, 16, 12, 0, 0)
@@ -1637,14 +1632,13 @@ class GetStocksListFiltersTest:
         )
 
         # Then
-        assert len(stocks) == 5
+        assert stocks.count() == 5
         assert stocks[0] == stock1
         assert stocks[1] == stock4
         assert stocks[2] == stock5
         assert stocks[3] == stock2
         assert stocks[4] == stock3
 
-    @override_features(WIP_PRO_STOCK_PAGINATION=True)
     def test_order_stocks_by_time_desc(self):
         # Given
         beginning_datetime = datetime.datetime(2020, 10, 15, 12, 0, 0)
@@ -1668,14 +1662,13 @@ class GetStocksListFiltersTest:
         )
 
         # Then
-        assert len(stocks) == 5
+        assert stocks.count() == 5
         assert stocks[0] == stock5
         assert stocks[1] == stock3
         assert stocks[2] == stock2
         assert stocks[3] == stock1
         assert stocks[4] == stock4
 
-    @override_features(WIP_PRO_STOCK_PAGINATION=True)
     def test_order_stocks_by_price_category_id(self):
         # Given
         offer = factories.OfferFactory()
@@ -1697,7 +1690,6 @@ class GetStocksListFiltersTest:
         assert stocks[1] == stock3
         assert stocks[2] == stock2
 
-    @override_features(WIP_PRO_STOCK_PAGINATION=True)
     def test_order_stocks_by_booking_limit(self):
         # Given
         booking_limit_datetime = datetime.datetime(2020, 10, 15, 12, 0, 0)
@@ -1726,7 +1718,6 @@ class GetStocksListFiltersTest:
         assert stocks[3] == stock2
         assert stocks[4] == stock3
 
-    @override_features(WIP_PRO_STOCK_PAGINATION=True)
     def test_order_stocks_by_remaining_quantity_desc(self):
         # Given
         offer = factories.OfferFactory()
@@ -1746,7 +1737,6 @@ class GetStocksListFiltersTest:
         assert stocks[1] == stock1
         assert stocks[2] == stock2
 
-    @override_features(WIP_PRO_STOCK_PAGINATION=True)
     def test_order_stocks_by_dn_booked_quantity(self):
         offer = factories.OfferFactory()
         stock1 = factories.EventStockFactory(offer=offer, quantity=5, dnBookedQuantity=20)

--- a/api/tests/routes/pro/delete_filtered_stocks_test.py
+++ b/api/tests/routes/pro/delete_filtered_stocks_test.py
@@ -15,7 +15,7 @@ class Returns204Test:
     def test_delete_filtered_stocks(self, client):
         # Given
         offer = offers_factories.OfferFactory()
-        offers_factories.EventStockFactory(offer=offer, beginningDatetime=datetime.utcnow())
+        offers_factories.EventStockFactory.create_batch(3, offer=offer, beginningDatetime=datetime.utcnow())
         user = users_factories.UserFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offer.venue.managingOfferer)
 

--- a/api/tests/routes/pro/get_stocks_test.py
+++ b/api/tests/routes/pro/get_stocks_test.py
@@ -6,33 +6,30 @@ import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
+from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
-
-from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
 class Returns403Test:
-    def test_access_by_beneficiary(self, app):
+    def test_access_by_beneficiary(self, client):
         # Given
         beneficiary = users_factories.BeneficiaryGrant18Factory()
-        offer = offers_factories.ThingOfferFactory(venue__latitude=None, venue__longitude=None)
+        offer = offers_factories.OfferFactory()
 
         # When
-        client = TestClient(app.test_client()).with_session_auth(email=beneficiary.email)
-        response = client.get(f"/offers/{offer.id}/stocks")
+        response = client.with_session_auth(beneficiary.email).get(f"/offers/{offer.id}/stocks")
 
         # Then
         assert response.status_code == 403
 
-    def test_access_by_unauthorized_pro_user(self, app):
+    def test_access_by_unauthorized_pro_user(self, client):
         # Given
         pro_user = users_factories.ProFactory()
         offer = offers_factories.ThingOfferFactory(venue__latitude=None, venue__longitude=None)
 
         # When
-        client = TestClient(app.test_client()).with_session_auth(email=pro_user.email)
-        response = client.get(f"/offers/{offer.id}/stocks")
+        response = client.with_session_auth(pro_user.email).get(f"/offers/{offer.id}/stocks")
 
         # Then
         assert response.status_code == 403
@@ -40,20 +37,19 @@ class Returns403Test:
 
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
-    def test_basic(self, app):
+    def test_basic(self, client):
         # Given
         user_offerer = offerers_factories.UserOffererFactory()
         offer = offers_factories.ThingOfferFactory(venue__managingOfferer=user_offerer.offerer)
 
         # When
-        client = TestClient(app.test_client()).with_session_auth(email=user_offerer.user.email)
-        response = client.get(f"/offers/{offer.id}/stocks/")
+        response = client.with_session_auth(email=user_offerer.user.email).get(f"/offers/{offer.id}/stocks/")
 
         # Then
         assert response.status_code == 200
 
     @freeze_time("2020-10-15 00:00:00")
-    def test_returns_an_event_stock(self, app):
+    def test_returns_an_event_stock(self, client):
         # Given
         now = datetime.utcnow()
         user_offerer = offerers_factories.UserOffererFactory()
@@ -68,8 +64,7 @@ class Returns200Test:
         )
 
         # When
-        client = TestClient(app.test_client()).with_session_auth(email=user_offerer.user.email)
-        response = client.get(f"/offers/{event_offer.id}/stocks")
+        response = client.with_session_auth(email=user_offerer.user.email).get(f"/offers/{event_offer.id}/stocks")
 
         # Then
         assert response.status_code == 200
@@ -98,7 +93,7 @@ class Returns200Test:
         }
 
     @freeze_time("2020-10-15 00:00:00")
-    def test_returns_a_thing_stock(self, app):
+    def test_returns_a_thing_stock(self, client):
         # Given
         now = datetime.utcnow()
         user_offerer = offerers_factories.UserOffererFactory()
@@ -110,8 +105,7 @@ class Returns200Test:
         )
 
         # When
-        client = TestClient(app.test_client()).with_session_auth(email=user_offerer.user.email)
-        response = client.get(f"/offers/{thing_offer.id}/stocks")
+        response = client.with_session_auth(email=user_offerer.user.email).get(f"/offers/{thing_offer.id}/stocks")
 
         # Then
         assert response.status_code == 200
@@ -139,16 +133,131 @@ class Returns200Test:
             ],
         }
 
-    def test_should_not_return_soft_deleted_stock(self, app):
+    def test_should_not_return_soft_deleted_stock(self, client):
         # Given
         user_offerer = offerers_factories.UserOffererFactory()
         offer = offers_factories.EventOfferFactory(venue__managingOfferer=user_offerer.offerer)
         deleted_stock = offers_factories.EventStockFactory(offer=offer, isSoftDeleted=True)
 
         # When
-        client = TestClient(app.test_client()).with_session_auth(email=user_offerer.user.email)
-        response = client.get(f"/offers/{deleted_stock.offer.id}/stocks")
+        response = client.with_session_auth(email=user_offerer.user.email).get(
+            f"/offers/{deleted_stock.offer.id}/stocks"
+        )
 
         # Then
         assert response.status_code == 200
         assert len(response.json["stocks"]) == 0
+
+    @freeze_time("2020-10-15 00:00:00")
+    @override_features(WIP_PRO_STOCK_PAGINATION=True)
+    def test_should_return_total_stock_count_when_unfiltered(self, client):
+        # Given
+        date_1 = datetime.utcnow()
+        date_2 = datetime.utcnow() + timedelta(days=1)
+        user_offerer = offerers_factories.UserOffererFactory()
+        offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
+        offers_factories.StockFactory.create_batch(3, beginningDatetime=date_1, offer=offer)
+        offers_factories.StockFactory.create_batch(2, beginningDatetime=date_2, offer=offer)
+
+        # When
+        response = client.with_session_auth(email=user_offerer.user.email).get(f"/offers/{offer.id}/stocks")
+        print(response.json)
+
+        assert response.status_code == 200
+        assert response.json["stock_count"] == 5
+        assert len(response.json["stocks"]) == 5
+
+    @override_features(WIP_PRO_STOCK_PAGINATION=True)
+    @freeze_time("2020-10-15 00:00:00")
+    def test_should_return_filtered_stock_count(self, client):
+        # Given
+        now = datetime.utcnow()
+        user_offerer = offerers_factories.UserOffererFactory()
+        offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
+        offers_factories.ThingStockFactory.create_batch(
+            4, dateCreated=now, dateModified=now, beginningDatetime=now, offer=offer
+        )
+        last_stock = offers_factories.ThingStockFactory(
+            dateCreated=now, dateModified=now, beginningDatetime=now + timedelta(seconds=1), offer=offer
+        )
+
+        # When
+        response = client.with_session_auth(email=user_offerer.user.email).get(
+            f"/offers/{offer.id}/stocks?page=3&stocks_limit_per_page=2"
+        )
+
+        # Then
+        assert response.status_code == 200
+        assert response.json == {
+            "stock_count": 5,
+            "stocks": [
+                {
+                    "activationCodesExpirationDatetime": None,
+                    "beginningDatetime": "2020-10-15T00:00:01Z",
+                    "bookingLimitDatetime": "2020-10-12T23:59:01Z",
+                    "bookingsQuantity": 0,
+                    "dateCreated": "2020-10-15T00:00:00Z",
+                    "dateModified": "2020-10-15T00:00:00Z",
+                    "hasActivationCode": False,
+                    "id": last_stock.id,
+                    "isBookable": False,
+                    "isEventDeletable": True,
+                    "isEventExpired": False,
+                    "isSoftDeleted": False,
+                    "price": 10.1,
+                    "priceCategoryId": None,
+                    "quantity": 1000,
+                    "remainingQuantity": 1000,
+                },
+            ],
+        }
+
+    @freeze_time("2020-10-15 00:00:00")
+    @override_features(WIP_PRO_STOCK_PAGINATION=True)
+    def test_should_return_filtered_stock_count_and_filtered_stock_list(self, client):
+        # Given
+        date_1 = datetime.utcnow()
+        date_2 = datetime.utcnow() + timedelta(days=1)
+        user_offerer = offerers_factories.UserOffererFactory()
+        offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
+        offers_factories.StockFactory.create_batch(
+            3, beginningDatetime=date_1, dateCreated=date_1, dateModified=date_1, offer=offer
+        )
+        offers_factories.StockFactory.create_batch(
+            2, beginningDatetime=date_2, dateCreated=date_2, dateModified=date_2, offer=offer
+        )
+        # stock_list = [stock for stock in offer.stocks]
+        stock_limit_per_page = 2
+        # When
+        response = client.with_session_auth(email=user_offerer.user.email).get(
+            f"/offers/{offer.id}/stocks?date={date_1.date()}&stocks_limit_per_page={stock_limit_per_page}"
+        )
+        assert response.status_code == 200
+        assert response.json["stock_count"] == 3
+        assert len(response.json["stocks"]) == 2
+
+    @freeze_time("2020-10-15 00:00:00")
+    @override_features(WIP_PRO_STOCK_PAGINATION=True)
+    def test_should_return_filtered_stock_count_and_filtered_stock_list_with_stocks_inferior_to_limit_per_page(
+        self, client
+    ):
+        # Given
+        date_1 = datetime.utcnow()
+        date_2 = datetime.utcnow() + timedelta(days=1)
+        user_offerer = offerers_factories.UserOffererFactory()
+        offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
+        offers_factories.StockFactory.create_batch(
+            3, beginningDatetime=date_1, dateCreated=date_1, dateModified=date_1, offer=offer
+        )
+        offers_factories.StockFactory.create_batch(
+            2, beginningDatetime=date_2, dateCreated=date_2, dateModified=date_2, offer=offer
+        )
+        # stock_list = [stock for stock in offer.stocks]
+        stock_limit_per_page = 4
+        # When
+        response = client.with_session_auth(email=user_offerer.user.email).get(
+            f"/offers/{offer.id}/stocks?date={date_1.date()}&stocks_limit_per_page={stock_limit_per_page}"
+        )
+        assert response.status_code == 200
+        assert response.json["stock_count"] == 3
+        assert len(response.json["stocks"]) == 3

--- a/pro/src/apiClient/v1/models/DeleteFilteredStockListBody.ts
+++ b/pro/src/apiClient/v1/models/DeleteFilteredStockListBody.ts
@@ -5,7 +5,6 @@
 
 export type DeleteFilteredStockListBody = {
   date?: string | null;
-  offer_id: number;
   price_category_id?: number | null;
   time?: string | null;
 };

--- a/pro/src/apiClient/v1/models/StocksQueryModel.ts
+++ b/pro/src/apiClient/v1/models/StocksQueryModel.ts
@@ -9,7 +9,9 @@ export type StocksQueryModel = {
   date?: string | null;
   order_by?: StocksOrderedBy;
   order_by_desc?: boolean;
+  page?: number;
   price_category_id?: number | null;
+  stocks_limit_per_page?: number;
   time?: string | null;
 };
 

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1668,6 +1668,8 @@ export class DefaultService {
    * @param priceCategoryId
    * @param orderBy
    * @param orderByDesc
+   * @param page
+   * @param stocksLimitPerPage
    * @returns GetStocksResponseModel OK
    * @throws ApiError
    */
@@ -1678,6 +1680,8 @@ export class DefaultService {
     priceCategoryId?: number | null,
     orderBy?: StocksOrderedBy,
     orderByDesc: boolean = false,
+    page: number = 1,
+    stocksLimitPerPage: number = 20,
   ): CancelablePromise<GetStocksResponseModel> {
     return this.httpRequest.request({
       method: 'GET',
@@ -1691,6 +1695,8 @@ export class DefaultService {
         'price_category_id': priceCategoryId,
         'order_by': orderBy,
         'order_by_desc': orderByDesc,
+        'page': page,
+        'stocks_limit_per_page': stocksLimitPerPage,
       },
       errors: {
         403: `Forbidden`,


### PR DESCRIPTION
## But de la pull request

On veut que la route GET pour offer/<offer_id>/stocks nous renvoie 
- le nombre de stocks filtrés (ou le total des stocks dispo pour l'offre en question si on ne filtre pas les stocks)
- la liste des stocks paginés (+ filtrés le cas échéant)

Et dans la query GET, on rajoute le numéro de page & la limite par page

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24988

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques