### PR TITLE
(PC-25076)[BO] fix: incident validation popin and amount field locale

### DIFF
--- a/api/src/pcapi/routes/backoffice/finance/forms.py
+++ b/api/src/pcapi/routes/backoffice/finance/forms.py
@@ -23,6 +23,9 @@ class IncidentCompensationModes(enum.Enum):
 
 
 class IncidentCreationForm(FlaskForm):
+    class Meta:
+        locales = ["fr_FR", "fr"]
+
     kind = fields.PCSelectField(
         "Type d'incident",
         choices=[
@@ -35,7 +38,7 @@ class IncidentCreationForm(FlaskForm):
     origin = fields.PCStringField("Origine de la demande")
 
     total_amount = fields.PCDecimalField(
-        "Montant de l'incident à récupérer (sans le calcul de barème)", validators=[Optional()]
+        "Montant de l'incident à récupérer (sans le calcul de barème)", use_locale=True, validators=[Optional()]
     )
 
 

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -99,6 +99,12 @@ class GetIncidentValidationFormTest(GetEndpointHelper):
 
         assert response.status_code == 200
 
+        text_content = html_parser.content_as_text(response.data)
+        assert (
+            f"Vous allez valider un incident de {filters.format_amount(finance_utils.to_euros(booking_incident.incident.due_amount_by_offerer))}"
+            in text_content
+        )
+
 
 class CancelIncidentTest(PostEndpointHelper):
     endpoint = "backoffice_web.finance_incident.cancel_finance_incident"
@@ -194,8 +200,11 @@ class ValidateIncidentTest(PostEndpointHelper):
 
         assert validation_action
         assert validation_action.actionType == history_models.ActionType.FINANCE_INCIDENT_VALIDATED
-        if force_debit_note:
-            assert validation_action.comment == "Génération d'une note de débit à la prochaine échéance."
+        assert (
+            validation_action.comment == "Génération d'une note de débit à la prochaine échéance."
+            if force_debit_note
+            else "Récupération sur les prochaines réservations."
+        )
 
         assert (
             beneficiary_action


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25076

Quelques petits fix sur les incidents :
- Pouvoir saisir le montant avec une virgule
- Afficher le bon montant dans la popin de validation (et formater le montant)
- Afficher dans l'historique le choix de récupérer le montant sur les prochaines réservations

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/668b8df7-8911-4ce7-9f19-204b9bc90d4a)
![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/60b74221-6bfd-4b16-9dd2-7508608e068a)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques