### PR TITLE
(BSR)[API] fix: in sandbox data stocks event did not have priceCategory

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_event_stocks.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_event_stocks.py
@@ -38,7 +38,7 @@ def create_data_event_stocks(event_occurrences_by_name: dict[str, EventOccurrenc
 
         name = event_occurrence_with_stocks_name + " / " + str(available) + " / " + str(price) + " / " + "DATA"
 
-        event_stocks_by_name[name] = offers_factories.StockFactory(
+        event_stocks_by_name[name] = offers_factories.EventStockFactory(
             offer=event_occurrence_with_stocks.offer,
             price=price,
             quantity=available,

--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_thing_stocks.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_thing_stocks.py
@@ -23,7 +23,7 @@ def create_data_thing_stocks(thing_offers_by_name: dict[str, Offer]) -> None:
         price = Decimal(1)
 
         name = offer_name + " / " + str(quantity) + " / " + str(price)
-        thing_stocks_by_name[name] = offers_factories.StockFactory(
+        thing_stocks_by_name[name] = offers_factories.ThingStockFactory(
             offer=offer,
             quantity=quantity,
             price=price,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_stocks.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_stocks.py
@@ -29,7 +29,7 @@ def create_industrial_event_stocks(event_occurrences_by_name: dict[str, EventOcc
             event_occurrence_with_stocks_name + " / " + str(available) + " / " + str(event_occurrence_with_stocks.price)
         )
 
-        event_stocks_by_name[name] = offers_factories.StockFactory(
+        event_stocks_by_name[name] = offers_factories.EventStockFactory(
             offer=event_occurrence_with_stocks.offer,
             price=event_occurrence_with_stocks.price,
             quantity=available,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_stocks.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_stocks.py
@@ -36,7 +36,7 @@ def create_industrial_thing_stocks(thing_offers_by_name: dict[str, Offer]) -> No
         short_names_to_increase_price.append(short_name)
 
         name = offer_name + " / " + str(quantity) + " / " + str(price)
-        thing_stocks_by_name[name] = offers_factories.StockFactory(
+        thing_stocks_by_name[name] = offers_factories.ThingStockFactory(
             offer=offer,
             quantity=quantity,
             price=price,


### PR DESCRIPTION
## But de la pull request

BSR

- bien utiliser StockEventFactory pour créer des StocksEvent
- j'en ai profité pour utiliser aussi  StockThingFactory pour les thing (dès fois que ça diverge)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques