### PR TITLE
(BSR)[API] test: Remove unnecessary `freeze_time()`

### DIFF
--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -26,7 +26,7 @@ from pcapi.utils.human_ids import humanize
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 def test_sendinblue_send_email():
     booking = BookingFactory(stock=offers_factories.EventStockFactory(price=1.99), dateCreated=datetime.utcnow())
     send_individual_booking_confirmation_email_to_beneficiary(booking)
@@ -43,11 +43,11 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
         template=TransactionalEmail.BOOKING_CONFIRMATION_BY_BENEFICIARY.value,
         params={
             "USER_FIRST_NAME": booking.firstName,
-            "BOOKING_DATE": "15 octobre 2021",
+            "BOOKING_DATE": "15 octobre 2032",
             "BOOKING_HOUR": "14h48",
             "OFFER_NAME": booking.stock.offer.name,
             "OFFERER_NAME": booking.offerer.name,
-            "EVENT_DATE": "14 novembre 2021",
+            "EVENT_DATE": "14 novembre 2032",
             "EVENT_HOUR": "13h48",
             "OFFER_PRICE_CATEGORY": booking.priceCategoryLabel,
             "OFFER_PRICE": f"{booking.total_amount} €" if booking.stock.price > 0 else "Gratuit",
@@ -82,7 +82,7 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
     return email_data
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 def test_should_return_event_specific_data_for_email_when_offer_is_an_event_sendinblue():
     booking = BookingFactory(stock=offers_factories.EventStockFactory(price=23.99), dateCreated=datetime.utcnow())
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
@@ -92,7 +92,7 @@ def test_should_return_event_specific_data_for_email_when_offer_is_an_event_send
     assert email_data == expected
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 def test_should_return_event_specific_data_for_email_when_offer_is_a_duo_event_sendinblue():
     booking = BookingFactory(
         stock=offers_factories.EventStockFactory(price=23.99), dateCreated=datetime.utcnow(), quantity=2
@@ -111,7 +111,7 @@ def test_should_return_event_specific_data_for_email_when_offer_is_a_duo_event_s
     assert email_data == expected
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 def test_should_return_thing_specific_data_for_email_when_offer_is_a_thing_sendinblue():
     stock = offers_factories.ThingStockFactory(
         price=23.99,
@@ -139,7 +139,7 @@ def test_should_return_thing_specific_data_for_email_when_offer_is_a_thing_sendi
     assert email_data == expected
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 def test_should_use_public_name_when_available_sendinblue():
     booking = BookingFactory(
         stock__offer__venue__name="LIBRAIRIE GENERALE UNIVERSITAIRE COLBERT",
@@ -159,7 +159,7 @@ def test_should_use_public_name_when_available_sendinblue():
     assert email_data == expected
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 def test_should_return_withdrawal_details_when_available_sendinblue():
     withdrawal_details = "Conditions de retrait spécifiques."
     booking = BookingFactory(
@@ -179,7 +179,7 @@ def test_should_return_withdrawal_details_when_available_sendinblue():
     assert email_data == expected
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 def test_should_return_offer_tags():
     booking = BookingFactory(
         dateCreated=datetime.utcnow(),
@@ -200,7 +200,7 @@ def test_should_return_offer_tags():
     assert email_data == expected
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 def test_should_return_offer_features():
     stock = offers_factories.ThingStockFactory(
         features=["VO", "IMAX"],
@@ -230,7 +230,7 @@ def test_should_return_offer_features():
     assert email_data == expected
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 class DigitalOffersTestSendinblue:
     def test_should_return_digital_thing_specific_data_for_email_when_offer_is_a_digital_thing_sendinblue(self):
         booking = BookingFactory(
@@ -397,15 +397,15 @@ def test_digital_offer_without_departement_code_information_sendinblue():
     """
     offer = offers_factories.DigitalOfferFactory()
     stock = offers_factories.StockFactory(offer=offer)
-    date_created = datetime(2021, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
+    date_created = datetime(2032, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
     booking = BookingFactory(stock=stock, dateCreated=date_created)
 
     email_data = get_booking_confirmation_to_beneficiary_email_data(booking)
-    assert email_data.params["BOOKING_DATE"] == "1 juillet 2021"
+    assert email_data.params["BOOKING_DATE"] == "1 juillet 2032"
     assert email_data.params["BOOKING_HOUR"] == "12h00"
 
 
-@freeze_time("2021-10-15 12:48:00")
+@freeze_time("2032-10-15 12:48:00")
 class BooksBookingExpirationDateTestSendinblue:
     def test_should_return_new_expiration_delay_data_for_email_when_offer_is_a_book_sendinblue(self):
         booking = BookingFactory(

--- a/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
@@ -1,6 +1,6 @@
 import dataclasses
+import datetime
 
-from freezegun import freeze_time
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
@@ -20,7 +20,6 @@ from pcapi.core.testing import override_features
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-@freeze_time("2021-10-15 12:48:00")
 class SendEventReminderEmailToBeneficiaryTest:
     def test_sendinblue_send_email(self):
         booking = BookingFactory(stock=offers_factories.EventStockFactory())
@@ -56,13 +55,13 @@ class SendEventReminderEmailToBeneficiaryTest:
         assert len(mails_testing.outbox) == 0
 
 
-@freeze_time("2021-10-15 12:48:00")
 class GetBookingEventReminderToBeneficiaryEmailDataTest:
     def test_given_nominal_booking_event(self):
         booking = BookingFactory(
             stock=offers_factories.EventStockFactory(
                 offer__venue__name="Le Petit Rintintin",
                 offer__name="Product",
+                beginningDatetime=datetime.datetime(2032, 1, 1, 10, 30),
             ),
             token="N2XPV5",
         )
@@ -71,9 +70,9 @@ class GetBookingEventReminderToBeneficiaryEmailDataTest:
 
         assert email_data.params == {
             "BOOKING_LINK": f"https://webapp-v2.example.com/reservation/{booking.id}/details",
-            "EVENT_DATETIME_ISO": "2021-11-14T13:48:00+01:00",
-            "EVENT_DATE": "14 novembre 2021",
-            "EVENT_HOUR": "13h48",
+            "EVENT_DATETIME_ISO": "2032-01-01T11:30:00+01:00",
+            "EVENT_DATE": "1 janvier 2032",
+            "EVENT_HOUR": "11h30",
             "IS_DUO_EVENT": False,
             "OFFER_NAME": "Product",
             "OFFER_TAGS": "",


### PR DESCRIPTION
Tests were failing because the user's deposit expired yesterday,
forbidding the user to book. But in fact we don't really need
to use `freeze_time()` here.

If you're reading this in 2032 and the test fails because the event is
in the past: I'm sorry. Contact me and I'll apologize with a drink. :)