### PR TITLE
(PC-25129)[API] fix: Fix `cancel_collective_booking()` when booking is used

### DIFF
--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -376,15 +376,19 @@ def cancel_collective_booking(
         if finance_repository.has_reimbursement(collective_booking):
             raise exceptions.BookingIsAlreadyRefunded()
 
+        finance_api.cancel_pricing(
+            collective_booking,
+            finance_models.PricingLogReason.MARK_AS_UNUSED,
+            commit=False,
+        )
         cancelled_event = finance_api.cancel_latest_event(collective_booking)
+        collective_booking.cancel_booking(reason=reason, cancel_even_if_used=True)
         if cancelled_event:
             finance_api.add_event(
                 finance_models.FinanceEventMotive.BOOKING_CANCELLED_AFTER_USE,
                 booking=collective_booking,
                 commit=False,
             )
-        finance_api.cancel_pricing(collective_booking, finance_models.PricingLogReason.MARK_AS_UNUSED)
-        collective_booking.cancel_booking(reason=reason, cancel_even_if_used=True)
 
         db.session.commit()
     search.async_index_collective_offer_ids([collective_booking.collectiveStock.collectiveOfferId])

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -89,8 +89,15 @@ class _BaseFinanceEventFactory(BaseFactory):
 class UsedBookingFinanceEventFactory(_BaseFinanceEventFactory):
     booking = factory.SubFactory(bookings_factories.UsedBookingFactory)
     motive = models.FinanceEventMotive.BOOKING_USED
-    venue = factory.LazyAttribute(lambda event: (event.booking or event.collectiveBooking).venue)
-    valueDate = factory.LazyAttribute(lambda event: (event.booking or event.collectiveBooking).dateUsed)
+    venue = factory.LazyAttribute(lambda event: event.booking.venue)
+    valueDate = factory.LazyAttribute(lambda event: event.booking.dateUsed)
+
+
+class UsedCollectiveBookingFinanceEventFactory(_BaseFinanceEventFactory):
+    collectiveBooking = factory.SubFactory(educational_factories.UsedCollectiveBookingFactory)
+    motive = models.FinanceEventMotive.BOOKING_USED
+    venue = factory.LazyAttribute(lambda event: event.collectiveBooking.venue)
+    valueDate = factory.LazyAttribute(lambda event: event.collectiveBooking.dateUsed)
 
 
 class FinanceEventFactory(BaseFactory):

--- a/api/tests/core/educational/api/test_booking.py
+++ b/api/tests/core/educational/api/test_booking.py
@@ -1,0 +1,49 @@
+import pytest
+
+import pcapi.core.educational.api.booking as educational_booking_api
+import pcapi.core.educational.exceptions as educational_exceptions
+import pcapi.core.educational.factories as educational_factories
+import pcapi.core.educational.models as educational_models
+import pcapi.core.finance.factories as finance_factories
+import pcapi.core.finance.models as finance_models
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class CancelCollectiveBookingTest:
+    def test_can_cancel_before_it_is_used(self):
+        booking = educational_factories.CollectiveBookingFactory()
+
+        educational_booking_api.cancel_collective_booking(
+            booking,
+            educational_models.CollectiveBookingCancellationReasons.OFFERER,
+        )
+        assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
+
+    def test_can_cancel_already_used(self):
+        finance_event = finance_factories.UsedCollectiveBookingFinanceEventFactory()
+        booking = finance_event.collectiveBooking
+
+        educational_booking_api.cancel_collective_booking(
+            booking,
+            educational_models.CollectiveBookingCancellationReasons.OFFERER,
+        )
+        assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
+        assert finance_event.status == finance_models.FinanceEventStatus.CANCELLED
+
+    def test_cannot_cancel_already_reimbursed(self):
+        finance_event = finance_factories.UsedCollectiveBookingFinanceEventFactory(
+            status=finance_models.FinanceEventStatus.PRICED,
+            collectiveBooking__status=educational_models.CollectiveBookingStatus.REIMBURSED,
+            collectiveBooking__collectiveStock__collectiveOffer__venue__pricing_point="self",
+        )
+        booking = finance_event.collectiveBooking
+
+        with pytest.raises(educational_exceptions.BookingIsAlreadyRefunded):
+            educational_booking_api.cancel_collective_booking(
+                booking,
+                educational_models.CollectiveBookingCancellationReasons.OFFERER,
+            )
+        assert booking.status == educational_models.CollectiveBookingStatus.REIMBURSED
+        assert finance_event.status == finance_models.FinanceEventStatus.PRICED


### PR DESCRIPTION
The fix is similar to b91a9b1419feec67d81: the cancellation date of
the booking must have been set for `add_event()` to use it.

---

Ticket : https://passculture.atlassian.net/browse/PC-25129