### PR TITLE
(PC-24605)[PRO] fix: booking and offer status pending change color

### DIFF
--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/CollectiveOfferStatusCell/CollectiveOfferStatusCell.module.scss
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/CollectiveOfferStatusCell/CollectiveOfferStatusCell.module.scss
@@ -3,7 +3,6 @@
 @use "styles/variables/_colors.scss" as colors;
 
 .status-label-icon {
-  fill: colors.$white; // TODO remove fill once all icons are migrated
   color: colors.$white;
   height: rem.torem(16px);
   margin-right: rem.torem(4px);
@@ -29,8 +28,8 @@
     background-color: colors.$booking-pending-status;
     color: colors.$black;
 
-    &-icon {
-      fill: colors.$black; // TODO remove fill once all icons are migrated
+    .status-label-icon {
+      color: colors.$black;
     }
   }
 

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingStatusCell.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingStatusCell.module.scss
@@ -6,7 +6,6 @@
   @include fonts.caption;
 
   border-radius: rem.torem(5px);
-  color: colors.$white;
   padding: rem.torem(5px) rem.torem(7px);
   white-space: nowrap;
 }

--- a/pro/src/screens/Bookings/BookingsRecapTable/utils/BookingStatus.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/utils/BookingStatus.module.scss
@@ -1,26 +1,35 @@
 @use "styles/variables/_colors.scss" as colors;
 
 .booking-status-booked {
+  color: colors.$white;
   background-color: colors.$secondary;
 }
 
 .booking-status-pending {
   background-color: colors.$booking-pending-status;
   color: colors.$black;
+
+  svg {
+    color: colors.$black;
+  }
 }
 
 .booking-status-validated {
+  color: colors.$white;
   background-color: colors.$accent;
 }
 
 .booking-status-cancelled {
+  color: colors.$white;
   background-color: colors.$grey-dark;
 }
 
 .booking-status-reimbursed {
+  color: colors.$white;
   background-color: colors.$green-valid;
 }
 
 .booking-status-confirmed {
+  color: colors.$white;
   background-color: colors.$black;
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

Changer la couleur pour le status "préréservé" car le contraste jaune/blanc est peu visible dans la page offre collective et réservation collective

Avant : 
<img width="120" alt="Capture d’écran 2023-10-17 à 16 18 00" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/54e1990b-6b84-40cf-87a6-272dfce49b67">

Après:
<img width="120" alt="Capture d’écran 2023-10-17 à 16 18 43" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/d895ed74-78e6-44ff-b250-318c84cd2921">

## Vérifications

- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques