### PR TITLE
Ghaliela/pc 24902 save data for offerer stats data

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-d12371e730c9 (pre) (head)
+9470268ecb94 (pre) (head)
 cbd37c328f46 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231018T134412_9470268ecb94_add_offerer_stats_table.py
+++ b/api/src/pcapi/alembic/versions/20231018T134412_9470268ecb94_add_offerer_stats_table.py
@@ -1,0 +1,34 @@
+"""
+add offerer_stats table
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "9470268ecb94"
+down_revision = "d12371e730c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "offerer_stats",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("offererId", sa.BigInteger(), nullable=False),
+        sa.Column("syncDate", sa.DateTime(), nullable=False),
+        sa.Column("table", sa.String(length=120), nullable=False),
+        sa.Column("jsonData", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        sa.ForeignKeyConstraint(["offererId"], ["offerer.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("offererId", "table", name="offerer_stats_unique"),
+    )
+    op.create_index("ix_offerer_stats_offererId", "offerer_stats", ["offererId"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_offerer_stats_offererId", table_name="offerer_stats")
+    op.drop_table("offerer_stats")

--- a/api/src/pcapi/connectors/big_query/queries/__init__.py
+++ b/api/src/pcapi/connectors/big_query/queries/__init__.py
@@ -1,4 +1,6 @@
 from .favorites_not_booked import FavoritesNotBooked  # noqa: F401
 from .favorites_not_booked import FavoritesNotBookedModel  # noqa: F401
+from .offerer_stats import OffererViewsPerDay  # noqa: F401
+from .offerer_stats import OffersData
 from .pro_email_churned_40_days_ago import ChurnedProEmail  # noqa: F401
 from .pro_no_bookings_since_40_days_ago import NoBookingsProEmail  # noqa: F401

--- a/api/src/pcapi/connectors/big_query/queries/base.py
+++ b/api/src/pcapi/connectors/big_query/queries/base.py
@@ -22,11 +22,11 @@ class BaseQuery:
     def __init__(self) -> None:
         self.backend = big_query_connector.get_backend()
 
-    def _get_rows(self, page_size: int) -> big_query_connector.BigQueryRowIterator:
-        return self.backend.run_query(self.raw_query, page_size=page_size)
+    def _get_rows(self, page_size: int, **parameters: typing.Any) -> big_query_connector.BigQueryRowIterator:
+        return self.backend.run_query(self.raw_query, page_size=page_size, **parameters)
 
-    def execute(self, page_size: int = 1_000) -> RowIterator:
-        rows = self._get_rows(page_size)
+    def execute(self, page_size: int = 1_000, **parameters: typing.Any) -> RowIterator:
+        rows = self._get_rows(page_size, **parameters)
         for index, row in enumerate(rows):
             try:
                 yield self.model(**typing.cast(Mapping, row))

--- a/api/src/pcapi/connectors/big_query/queries/favorites_not_booked.py
+++ b/api/src/pcapi/connectors/big_query/queries/favorites_not_booked.py
@@ -1,3 +1,5 @@
+import typing
+
 import pydantic.v1 as pydantic_v1
 
 from pcapi import settings
@@ -29,7 +31,7 @@ class FavoritesNotBooked(BaseQuery):
 
     model = FavoritesNotBookedModel
 
-    def execute(self, page_size: int = 1_000) -> RowIterator:
+    def execute(self, page_size: int = 1_000, **parameters: typing.Any) -> RowIterator:
         for row in super().execute(page_size):
             for chunk in chunks.get_chunks(row.user_ids, page_size):
                 yield FavoritesNotBookedModel(offer_id=row.offer_id, offer_name=row.offer_name, user_ids=chunk)

--- a/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
+++ b/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
@@ -1,0 +1,58 @@
+import datetime
+import typing
+
+import pydantic.v1 as pydantic_v1
+
+from pcapi import settings
+
+from .base import BaseQuery
+from .base import RowIterator
+
+
+class OffererViewsModel(pydantic_v1.BaseModel):
+    eventDate: datetime.date
+    numberOfViews: int
+
+
+class OffererViewsPerDay(BaseQuery):
+    @property
+    def raw_query(self) -> str:
+        return f"""
+        SELECT
+            event_date as eventDate,
+            cum_consult as numberOfViews
+        FROM
+            `{settings.BIG_QUERY_NOTIFICATIONS_TABLE_BASENAME}.stats_display_cum_daily_consult_per_offerer_last_180_days`
+        WHERE
+            offerer_id = @offerer_id
+            """
+
+    model = OffererViewsModel
+
+    def execute(self, page_size: int = 180, **parameters: typing.Any) -> RowIterator:
+        for row in super().execute(page_size, **parameters):
+            yield OffererViewsModel(
+                eventDate=datetime.date.fromisoformat(str(row.eventDate)), numberOfViews=row.numberOfViews
+            )
+
+
+class TopOffersData(pydantic_v1.BaseModel):
+    offerId: int
+    numberOfViews: int
+
+
+class OffersData(BaseQuery):
+    @property
+    def raw_query(self) -> str:
+        return f"""
+        SELECT
+            offer_id as offerId,
+            nb_consult_last_30_days as numberOfViews
+        FROM
+            `{settings.BIG_QUERY_NOTIFICATIONS_TABLE_BASENAME}.stats_display_top_3_most_consulted_offers_last_30_days`
+        WHERE
+            offerer_id = @offerer_id
+        order by consult_rank
+        """
+
+    model = TopOffersData

--- a/api/src/pcapi/connectors/big_query/testing_backend.py
+++ b/api/src/pcapi/connectors/big_query/testing_backend.py
@@ -8,5 +8,5 @@ TestingRowIterator = typing.Generator[TestingRow, None, None]
 
 
 class TestingBackend(BaseBackend):
-    def run_query(self, query: str, page_size: int, **parameters: dict[str, str | int]) -> TestingRowIterator:
+    def run_query(self, query: str, page_size: int, **parameters: typing.Any) -> TestingRowIterator:
         yield

--- a/api/src/pcapi/connectors/big_query/testing_backend.py
+++ b/api/src/pcapi/connectors/big_query/testing_backend.py
@@ -8,5 +8,5 @@ TestingRowIterator = typing.Generator[TestingRow, None, None]
 
 
 class TestingBackend(BaseBackend):
-    def run_query(self, query: str, page_size: int) -> TestingRowIterator:
+    def run_query(self, query: str, page_size: int, **parameters: dict[str, str | int]) -> TestingRowIterator:
         yield

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -318,3 +318,11 @@ class IndividualOffererSubscription(BaseFactory):
     offerer = factory.SubFactory(NotValidatedOffererFactory)
     isEmailSent = True
     dateEmailSent = factory.LazyFunction(lambda: datetime.date.today() - datetime.timedelta(days=3))
+
+
+class OffererStatsFactory(BaseFactory):
+    class Meta:
+        model = models.OffererStats
+
+    id = factory.Sequence(int)
+    syncDate = factory.LazyFunction(lambda: datetime.date.today() - datetime.timedelta(hours=3))

--- a/api/tests/core/external/offerer_stats_test.py
+++ b/api/tests/core/external/offerer_stats_test.py
@@ -1,0 +1,136 @@
+from unittest.mock import patch
+
+import pytest
+
+from pcapi.core.offerers import api
+from pcapi.core.offerers.factories import OffererFactory
+from pcapi.core.offerers.factories import OffererStatsFactory
+from pcapi.core.offerers.factories import VenueFactory
+from pcapi.core.offerers.models import OffererStats
+from pcapi.core.offers.factories import OfferFactory
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class OffererStatsTest:
+    @patch("pcapi.connectors.big_query.TestingBackend.run_query")
+    def test_update_offerer_stats_data(self, mock_run_query_with_params):
+        offerer = OffererFactory()
+        venue = VenueFactory(managingOfferer=offerer)
+        offer1 = OfferFactory(venue=venue)
+        offer2 = OfferFactory(venue=venue)
+        offer3 = OfferFactory(venue=venue)
+
+        OffererStatsFactory(
+            offererId=offerer.id,
+            syncDate="2023-10-14",
+            table="stats_display_cum_daily_consult_per_offerer_last_180_days",
+            jsonData={
+                "daily_views": [
+                    {"numberOfViews": 10, "eventDate": "2023-10-14"},
+                    {"numberOfViews": 7, "eventDate": "2023-10-13"},
+                ]
+            },
+        )
+
+        OffererStatsFactory(
+            offererId=offerer.id,
+            syncDate="2023-10-14",
+            table="stats_display_top_3_most_consulted_offers_last_30_days",
+            jsonData={
+                "top_offers": [
+                    {"numberOfViews": 7, "offerId": offer1.id},
+                    {"numberOfViews": 6, "offerId": offer2.id},
+                    {"numberOfViews": 4, "offerId": offer3.id},
+                ]
+            },
+        )
+
+        mock_run_query_with_params.side_effect = [
+            iter(
+                [
+                    {"eventDate": "2023-10-16", "numberOfViews": 15},
+                    {"eventDate": "2023-10-15", "numberOfViews": 10},
+                ]
+            ),
+            iter(
+                [
+                    {"offerId": offer1.id, "numberOfViews": 12},
+                    {"offerId": offer2.id, "numberOfViews": 10},
+                    {"offerId": offer3.id, "numberOfViews": 8},
+                ]
+            ),
+        ]
+
+        api.get_offerer_stats_data(offerer.id)
+
+        # Check that the stats have been updated
+
+        offerer_global_stats = OffererStats.query.filter(
+            OffererStats.offererId == offerer.id,
+            OffererStats.table == "stats_display_cum_daily_consult_per_offerer_last_180_days",
+        ).one()
+        assert offerer_global_stats.jsonData["daily_views"] == [
+            {"eventDate": "2023-10-16", "numberOfViews": 15},
+            {"eventDate": "2023-10-15", "numberOfViews": 10},
+        ]
+
+        offerer_top_offers = OffererStats.query.filter(
+            OffererStats.offererId == offerer.id,
+            OffererStats.table == "stats_display_top_3_most_consulted_offers_last_30_days",
+        ).one()
+        assert offerer_top_offers.jsonData["top_offers"] == [
+            {"offerId": offer1.id, "numberOfViews": 12},
+            {"offerId": offer2.id, "numberOfViews": 10},
+            {"offerId": offer3.id, "numberOfViews": 8},
+        ]
+
+    @patch("pcapi.connectors.big_query.TestingBackend.run_query")
+    def test_create_offerer_stats_data(self, mock_run_query_with_params):
+        offerer = OffererFactory()
+        venue = VenueFactory(managingOfferer=offerer)
+        offer1 = OfferFactory(venue=venue)
+        offer2 = OfferFactory(venue=venue)
+        offer3 = OfferFactory(venue=venue)
+
+        mock_run_query_with_params.side_effect = [
+            iter(
+                [
+                    {"eventDate": "2023-10-16", "numberOfViews": 15},
+                    {"eventDate": "2023-10-15", "numberOfViews": 10},
+                ]
+            ),
+            iter(
+                [
+                    {"offerId": offer1.id, "numberOfViews": 12},
+                    {"offerId": offer2.id, "numberOfViews": 10},
+                    {"offerId": offer3.id, "numberOfViews": 8},
+                ]
+            ),
+        ]
+
+        assert OffererStats.query.count() == 0
+
+        api.get_offerer_stats_data(offerer.id)
+
+        # Check that the stats have been created
+
+        offerer_global_stats = OffererStats.query.filter(
+            OffererStats.offererId == offerer.id,
+            OffererStats.table == "stats_display_cum_daily_consult_per_offerer_last_180_days",
+        ).one()
+        assert offerer_global_stats.jsonData["daily_views"] == [
+            {"eventDate": "2023-10-16", "numberOfViews": 15},
+            {"eventDate": "2023-10-15", "numberOfViews": 10},
+        ]
+
+        offerer_top_offers = OffererStats.query.filter(
+            OffererStats.offererId == offerer.id,
+            OffererStats.table == "stats_display_top_3_most_consulted_offers_last_30_days",
+        ).one()
+        assert offerer_top_offers.jsonData["top_offers"] == [
+            {"offerId": offer1.id, "numberOfViews": 12},
+            {"offerId": offer2.id, "numberOfViews": 10},
+            {"offerId": offer3.id, "numberOfViews": 8},
+        ]


### PR DESCRIPTION
## But de la pull request
Cette PR est pour créer et mettre à jour les tables créées par les équipes data dans notre base de données afin de permettre l'affichages des stats des offerers sur le dashboard du front pro
https://www.notion.so/passcultureapp/POC-affichage-de-statistiques-cot-pro-16132b93a9834d8aa4a935017820382c

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24902

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [X] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
