### PR TITLE
(PC-25085) should always be able to create offer with widthrawal type

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -172,14 +172,6 @@ class NonLinkedProviderCannotHaveInAppTicket(OfferCreationBaseException):
         )
 
 
-class NonWithdrawableEventOfferCantHaveWithdrawal(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "offer",
-            "La catégorie de l'offre n'accepte pas de modalité de retrait de billet",
-        )
-
-
 class WithdrawableEventOfferMustHaveWithdrawal(OfferCreationBaseException):
     def __init__(self) -> None:
         super().__init__(

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -325,9 +325,6 @@ def check_offer_withdrawal(
     provider: providers_models.Provider | None,
 ) -> None:
     is_offer_withdrawable = subcategory_id in subcategories.WITHDRAWABLE_SUBCATEGORIES
-    if not is_offer_withdrawable and withdrawal_type is not None:
-        raise exceptions.NonWithdrawableEventOfferCantHaveWithdrawal()
-
     if is_offer_withdrawable and withdrawal_type is None:
         raise exceptions.WithdrawableEventOfferMustHaveWithdrawal()
 

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -386,15 +386,17 @@ class CheckOfferWithdrawalTest:
                 provider=None,
             )
 
-    def test_non_withdrawable_event_offer_cant_have_withdrawal(self):
-        with pytest.raises(exceptions.NonWithdrawableEventOfferCantHaveWithdrawal):
-            validation.check_offer_withdrawal(
-                withdrawal_type=WithdrawalTypeEnum.NO_TICKET,
-                withdrawal_delay=None,
-                subcategory_id=subcategories.JEU_EN_LIGNE.id,
-                booking_contact=None,
-                provider=None,
-            )
+    def test_non_withdrawable_event_offer_can_have_withdrawal(self):
+        provider = providers_factories.ProviderFactory(
+            bookingExternalUrl="https://toto.fr/book", cancelExternalUrl="https://toto.fr/cancel"
+        )
+        assert not validation.check_offer_withdrawal(
+            withdrawal_type=WithdrawalTypeEnum.IN_APP,
+            withdrawal_delay=None,
+            subcategory_id=subcategories.FESTIVAL_MUSIQUE.id,
+            booking_contact="toto@mail.fr",
+            provider=provider,
+        )
 
     @pytest.mark.parametrize(
         "withdrawal_type",

--- a/api/tests/routes/pro/patch_offer_test.py
+++ b/api/tests/routes/pro/patch_offer_test.py
@@ -253,18 +253,6 @@ class Returns400Test:
         assert response.status_code == 400
         assert response.json["global"] == ["Les offres refusées ou en attente de validation ne sont pas modifiables"]
 
-    def test_withdrawal_is_checked_when_changed(self, client):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.JEU_EN_LIGNE.id)
-        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
-
-        data = {
-            "withdrawalType": "no_ticket",
-        }
-        response = client.with_session_auth("user@example.com").patch(f"offers/{offer.id}", json=data)
-
-        assert response.status_code == 400
-        assert response.json["offer"] == ["La catégorie de l'offre n'accepte pas de modalité de retrait de billet"]
-
     def test_reuse_unchanged_withdrawal(self, client):
         offer = offers_factories.OfferFactory(
             subcategoryId=subcategories.CONCERT.id,


### PR DESCRIPTION
## But de la pull request
Dans cette PR on veut rendre possible de créer une offre avec un widthrawal type même si la sous catégories ne fait pas partie des WITHDRAWABLE_SUBCATEGORIES.
Ceci est fait parce que depuis l'api publique, un provider peut créer une offre avec un withdrawal type dans tous les cas, mais depuis le front, afin de simplifier le formulaire de création d'offer, on ne permet pas à l'utilisateur de selectionner le withdrawal type si l'offre n'est pas withdrawable.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25085

## Vérifications

- [X] J'ai écrit les tests nécessaires