### PR TITLE
(BSR)[API] refactor: Store eurocents in `CustomReimbursementRule.amount`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 9470268ecb94 (pre) (head)
-cbd37c328f46 (post) (head)
+6025fbc18ebb (post) (head)

--- a/api/src/pcapi/alembic/versions/20231018T075947_00c2e096a1ac_change_type_of_custom_reimbursement_rule_amount.py
+++ b/api/src/pcapi/alembic/versions/20231018T075947_00c2e096a1ac_change_type_of_custom_reimbursement_rule_amount.py
@@ -1,0 +1,47 @@
+"""Change type of `custom_reimbursement_rule.amount`: numeric -> int
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "00c2e096a1ac"
+down_revision = "cbd37c328f46"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "custom_reimbursement_rule",
+        "amount",
+        existing_type=sa.NUMERIC(precision=10, scale=2),
+        type_=sa.Integer(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "custom_reimbursement_rule",
+        "amount",
+        existing_type=sa.Integer(),
+        type_=sa.NUMERIC(precision=10, scale=2),
+        existing_nullable=True,
+    )
+    # This migration is followed by a second migration that copies the
+    # value from `amountInEuroCents` to `amount`. Whether that second
+    # migration is run or no, if we want to roll back this first
+    # migration, the statement above will restore the type, but we
+    # will already have lost the precision when executing the
+    # `upgrade` path: the numeric value 12.34 will be truncated to the
+    # integer 12. Here is the right place to restore `amount` to its
+    # numeric value.
+    op.execute(
+        """
+        update custom_reimbursement_rule
+        set amount = round("amountInEuroCents"::numeric / 100, 2)
+        where "amountInEuroCents" is not null
+        """
+    )

--- a/api/src/pcapi/alembic/versions/20231018T082411_6025fbc18ebb_copy_custom_reimbursement_rule_amount_in_eurocents_to_amount.py
+++ b/api/src/pcapi/alembic/versions/20231018T082411_6025fbc18ebb_copy_custom_reimbursement_rule_amount_in_eurocents_to_amount.py
@@ -1,0 +1,26 @@
+"""Copy `custom_reimbursement_rule.amountInEurocents` to `amount`
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "6025fbc18ebb"
+down_revision = "00c2e096a1ac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        update custom_reimbursement_rule
+        set amount = "amountInEuroCents"
+        where "amountInEuroCents" is not null
+        """
+    )
+
+
+def downgrade() -> None:
+    # See comment in the `downgrade` path of migration of 00c2e096a1ac.
+    pass

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -2456,7 +2456,7 @@ def _create_reimbursement_rule(
         offerId=offer_id,
         subcategories=subcategories,
         rate=rate,  # only for offerers
-        amount=amount,  # only for offers
+        amount=utils.to_eurocents(amount) if amount is not None else None,  # only for offers
         amountInEuroCents=utils.to_eurocents(amount) if amount is not None else None,
         timespan=(start_date, end_date),
     )

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -191,7 +191,7 @@ class CustomReimbursementRuleFactory(BaseFactory):
             datetime.datetime.utcnow() + datetime.timedelta(days=365),
         ]
     )
-    amount = 5
+    amount = 500
     amountInEuroCents = 500
 
     @classmethod

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -539,10 +539,7 @@ class CustomReimbursementRule(ReimbursementRule, Base, Model):
     # offerer.
     subcategories: list[str] = sqla.Column(sqla_psql.ARRAY(sqla.Text()), server_default="{}")
 
-    # FIXME (dbaty, 2022-09-21): it would be nice to move this to
-    # eurocents like other models do.
-    # Contrary to other models, this amount is in euros, not eurocents.
-    amount: decimal.Decimal = sqla.Column(sqla.Numeric(10, 2), nullable=True)
+    amount: int = sqla.Column(sqla.Integer, nullable=True)
     amountInEuroCents: int = sqla.Column(sqla.Integer, nullable=True)
 
     # rate is between 0 and 1 (included), or NULL if `amount` is set.

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -2758,7 +2758,7 @@ class CreateOfferReimbursementRuleTest:
 
         db.session.refresh(rule)
         assert rule.offer == offer
-        assert rule.amount == Decimal("12.34")
+        assert rule.amount == 1234
         assert rule.amountInEuroCents == 1234
         assert rule.timespan.lower == datetime.datetime(2021, 10, 2, 0, 0)
         assert rule.timespan.upper == datetime.datetime(2021, 10, 3, 0, 0)

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -1,5 +1,3 @@
-import decimal
-
 import pcapi.core.finance.models as finance_models
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
@@ -31,7 +29,7 @@ class AddCustomOfferReimbursementRuleTest:
         assert "Created new rule" in result.output
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offer.id == offer_id
-        assert rule.amount == decimal.Decimal("12.34")
+        assert rule.amount == 1234
         assert rule.amountInEuroCents == 1234
 
     @clean_database
@@ -77,7 +75,7 @@ class AddCustomOfferReimbursementRuleTest:
         assert "Created new rule" in result.output
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offer.id == offer_id
-        assert rule.amount == decimal.Decimal("12.34")
+        assert rule.amount == 1234
         assert rule.amountInEuroCents == 1234
 
 


### PR DESCRIPTION
`CustomReimbursementRule.amount` is one the last model columns (in
`core.finance`) where we store euros and not eurocents. This commit is
the third step in storing eurocents in the `amount` column.

   step 1: add `amountInEurocents` and write in both `amount` and
           `amountInEurocents`. Also, populate `amountInEurocents`
           for existing rows.
   step 2: use `amountInEuroCents` column instead of `amount`.
-> step 3: store eurocents in `amount` column.
   step 4: use `amount` column.
   step 5: drop `amountInEuroCents` column.