### PR TITLE
(BSR)[PRO] fix: remove async assert in notification test

### DIFF
--- a/pro/src/components/Notification/__specs__/Notification.spec.tsx
+++ b/pro/src/components/Notification/__specs__/Notification.spec.tsx
@@ -22,7 +22,7 @@ describe('Notification', () => {
   ]
   it.each(notificationTypes)(
     'should display given %s text with icon',
-    async (notificationType) => {
+    (notificationType) => {
       const notification = {
         text: 'Mon petit succès',
         type: notificationType.type,
@@ -31,7 +31,7 @@ describe('Notification', () => {
 
       renderNotification(notification)
 
-      const notificationElement = await screen.findByText(notification.text)
+      const notificationElement = screen.getByText(notification.text)
       expect(notificationElement).toBeInTheDocument()
       expect(notificationElement).toHaveClass('show')
       expect(notificationElement).toHaveClass(


### PR DESCRIPTION
## But de la pull request

L'assert sur le get du texte de la notif n'a pas besoin d'être async, ce qui retarde l'assert et risque de le faire fail car la notif peut disparaitre