### PR TITLE
(bsr) eac: fix offer template dates tz

### DIFF
--- a/api/src/pcapi/alembic/versions/20231012T160704_8425db0af4c1_add_start_end_interval_to_collective_offer_template.py
+++ b/api/src/pcapi/alembic/versions/20231012T160704_8425db0af4c1_add_start_end_interval_to_collective_offer_template.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
             'NOT isempty("dateRange") '
             'AND lower("dateRange") is NOT NULL '
             'AND upper("dateRange") IS NOT NULL '
-            'AND lower("dateRange") >= "dateCreated")'
+            'AND lower("dateRange")::date >= "dateCreated"::date)'
         ),
     )
 

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -632,7 +632,7 @@ class CollectiveOfferTemplate(
             'NOT isempty("dateRange") '
             'AND lower("dateRange") is NOT NULL '
             'AND upper("dateRange") IS NOT NULL '
-            'AND lower("dateRange") >= "dateCreated")',
+            'AND lower("dateRange")::date >= "dateCreated"::date)',
             name="template_dates_non_empty_daterange",
         ),
     )

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -373,7 +373,7 @@ def update_collective_offer_template(offer_id: int, new_values: dict) -> None:
         start = new_values["dates"]["start"]
         end = new_values["dates"]["end"]
 
-        if start <= offer_to_update.dateCreated:
+        if start.date() < offer_to_update.dateCreated.date():
             raise educational_exceptions.StartsBeforeOfferCreation()
 
         offer_to_update.dateRange = DateTimeRange(start, end)

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -119,7 +119,19 @@ def as_utc_without_timezone(d: datetime.datetime) -> datetime.datetime:
     # as UTC datetimes *without* any timezone. We need to remove the timezone to prevent from errors like:
     # - wrongly detection of a change for a datetime field
     # - we compare this "timezone aware" datetime with another one that is not
+    #
+    # Warning:
+    # this function might add an offset when converting to UTC.
     return d.astimezone(pytz.utc).replace(tzinfo=None)
+
+
+def without_timezone(d: datetime.datetime) -> datetime.datetime:
+    """Copy input without timezone information
+
+    The day, hour, etc. are copied without any translation regarding
+    the original timezone.
+    """
+    return datetime.datetime(d.year, d.month, d.day, d.hour, d.minute, d.second, d.microsecond)
 
 
 def check_date_in_future_and_remove_timezone(value: datetime.datetime | None) -> datetime.datetime | None:

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -12,6 +12,7 @@ from pcapi.core.educational.factories import EducationalDomainFactory
 from pcapi.core.educational.models import CollectiveOfferTemplate
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers.models import OfferValidationStatus
+from pcapi.utils.date import format_into_utc_date
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -104,6 +105,19 @@ class Returns200Test:
         assert updated_offer.dateRange
         assert updated_offer.start == template_start
         assert updated_offer.end == template_end
+
+    def test_with_tz_aware_dates(self, pro_client, offer, template_start, template_end):
+        payload = {
+            "dates": {
+                "start": format_into_utc_date(template_start),
+                "end": format_into_utc_date(template_end),
+            },
+        }
+
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=payload)
+
+        assert response.status_code == 200
 
 
 class Returns400Test:

--- a/api/tests/routes/pro/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/post_collective_offers_template_test.py
@@ -9,6 +9,7 @@ import pcapi.core.educational.exceptions as educational_exceptions
 import pcapi.core.educational.factories as educational_factories
 from pcapi.core.educational.models import CollectiveOfferTemplate
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.utils.date import format_into_utc_date
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -139,6 +140,20 @@ class Returns200Test:
             **payload,
             "offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id},
             "interventionArea": [],
+        }
+
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
+
+        assert response.status_code == 201
+
+    def test_with_tz_aware_dates(self, pro_client, payload, template_start, template_end):
+        data = {
+            **payload,
+            "dates": {
+                "start": format_into_utc_date(template_start),
+                "end": format_into_utc_date(template_end),
+            },
         }
 
         with patch(PATCH_CAN_CREATE_OFFER_PATH):


### PR DESCRIPTION
## But de la pull request

Ticket Jira d'origine (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24579

Les dates de débuts et de fin des offres vitrines ([ajoutées tout récemment](https://github.com/pass-culture/pass-culture-main/pull/8513)) n'acceptent pas les _datetimes_ sous forme de texte avec un Z à la fin (➡️ UTC).

Le problème est que l'on se retrouvait à comparer des _datetimes_ sans _timezone_ avec d'autres qui en ont, ce qui créé des erreurs. Ces comparaisons se font lors de la validation des dates (par exemple, le début ne doit pas être avant la fin).