### PR TITLE
(PC-25257)[PRO] fix: fix collective offer link in bookings

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingOfferCell.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingOfferCell.tsx
@@ -33,7 +33,7 @@ export const BookingOfferCell = ({ booking }: BookingOfferCellProps) => {
   const editionUrl = useOfferEditionURL(
     booking.stock.offerIsEducational,
     booking.stock.offerId,
-    true
+    false
   )
   const eventBeginningDatetime = booking.stock.eventBeginningDatetime
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25257

Le lien vers le détail d'une offre collective depuis la liste des réservations ne fonctionnait pas. On ajoutait un T- devant l'id alors que toutes réservations collectives ne peut être lié qu'à une offre réservable et non vitrine (template)

## Screen 

![Capture d’écran 2023-10-18 à 17 00 27](https://github.com/pass-culture/pass-culture-main/assets/71768799/cb224311-d893-47af-9845-9bb4b140ac6c)
