### PR TITLE
(BSR)[PRO] fix: remove double label from icon

### DIFF
--- a/pro/src/components/LegalInfos/LegalInfos.tsx
+++ b/pro/src/components/LegalInfos/LegalInfos.tsx
@@ -87,7 +87,7 @@ const LegalInfos = ({ title, className }: LegalInfoProps): JSX.Element => {
       >
         <SvgIcon
           src={fullMailIcon}
-          alt="Mail à support-pro@passculture.app"
+          alt=""
           className={styles['icon-legal-infos']}
           width="22"
         />


### PR DESCRIPTION
## But de la pull request

Enlever une info en double, comme on a indiqué dans l'intitulé du lien que le contact se fait par mail il n'est pas nécessaire d'avoir le alt sur le picto