### PR TITLE
(PC-24562)[PRO] fix: display max between confirmed and cancellation l…

### DIFF
--- a/pro/src/pages/AdageIframe/app/App.tsx
+++ b/pro/src/pages/AdageIframe/app/App.tsx
@@ -36,7 +36,7 @@ export const App = (): JSX.Element => {
     const getRelativeOffers = params.get('all') === 'true'
     apiAdage
       .authenticate()
-      .then(user => setUser(user))
+      .then((user) => setUser(user))
       .then(async () => {
         if (siret) {
           try {

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine/CollectiveTimeLine.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine/CollectiveTimeLine.tsx
@@ -1,4 +1,4 @@
-import { addDays, isBefore } from 'date-fns'
+import { addDays, isBefore, max } from 'date-fns'
 import React from 'react'
 
 import {
@@ -76,6 +76,15 @@ const CollectiveTimeLine = ({
       bookingRecap.bookingStatusHistory.length - 1
     ].date
   )
+  const confirmedDate = getDateToFrenchText(
+    max([
+      new Date(bookingRecap.bookingCancellationLimitDate),
+      bookingRecap.bookingConfirmationDate
+        ? new Date(bookingRecap.bookingConfirmationDate)
+        : new Date(),
+    ]).toString()
+  )
+
   const { logEvent } = useAnalytics()
 
   const logModifyBookingLimitDateClick = () => {
@@ -114,7 +123,7 @@ const CollectiveTimeLine = ({
           Réservation confirmée
         </div>
         <div>
-          {cancellationLimitDate}
+          {confirmedDate}
           <br />
           La réservation n’est plus annulable par l’établissement scolaire
         </div>
@@ -129,7 +138,7 @@ const CollectiveTimeLine = ({
           Réservation confirmée
         </div>
         <div>
-          {cancellationLimitDate}
+          {confirmedDate}
           <br />
           <br />
           {!eventHasPassed ? (


### PR DESCRIPTION
…imit date

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24562

Une réservation collective est considérée comme `Confirmée` quand sa date limite d'annulation est passée. Cependant il peut arriver que cette date soit inférieure à la date de confirmation par l'établissement scolaire. Dans ce cas on veut afficher cette dernière date à l'étape **Réservation Confirmée** pour éviter toute confusion

## Screen 

![Capture d’écran 2023-10-19 à 09 56 47](https://github.com/pass-culture/pass-culture-main/assets/71768799/96a9be1a-2841-48e7-b4dc-638a8d07e923)
