### PR TITLE
(PC-23419)[PRO] fix: display pending section in ReimbursementBankAccount when status is ongoing or on draft

### DIFF
--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 
-import { BankAccountResponseModel } from 'apiClient/v1'
+import {
+  BankAccountApplicationStatus,
+  BankAccountResponseModel,
+} from 'apiClient/v1'
 import fullErrorIcon from 'icons/full-error.svg'
 import fullLinkIcon from 'icons/full-link.svg'
 import fullWaitIcon from 'icons/full-wait.svg'
@@ -34,7 +37,8 @@ const ReimbursementBankAccount = ({
           <div>BIC : {bankAccount.bic}</div>
         </div>
       </div>
-      {!bankAccount.isActive && (
+      {bankAccount.status === BankAccountApplicationStatus.EN_CONSTRUCTION ||
+      bankAccount.status === BankAccountApplicationStatus.EN_INSTRUCTION ? (
         <div className={styles['pending-account']}>
           <SvgIcon
             src={fullWaitIcon}
@@ -54,8 +58,7 @@ const ReimbursementBankAccount = ({
             Suivre le dossier
           </ButtonLink>
         </div>
-      )}
-      {bankAccount.isActive && (
+      ) : (
         <div className={styles['linked-venues-section']}>
           <div className={styles['linked-venues-section-title']}>
             Lieu(x) rattaché(s) à ce compte bancaire

--- a/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
+++ b/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
@@ -196,7 +196,7 @@ describe('ReimbursementBankAccount', () => {
     ).toBeInTheDocument()
   })
 
-  it('should render with all venues linked to the account', () => {
+  it('should not render error and warning messages when all venues are linked', () => {
     render(
       <ReimbursementBankAccount
         bankAccount={bankAccount}

--- a/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
+++ b/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
@@ -26,8 +26,8 @@ describe('ReimbursementBankAccount', () => {
     }
   })
 
-  it('should render with pending bank account', async () => {
-    bankAccount.isActive = false
+  it('should render with pending bank account if status is in draft', () => {
+    bankAccount.status = BankAccountApplicationStatus.EN_CONSTRUCTION
     render(
       <ReimbursementBankAccount
         bankAccount={bankAccount}
@@ -50,138 +50,181 @@ describe('ReimbursementBankAccount', () => {
     ).not.toBeInTheDocument()
   })
 
-  describe('Active bank account', () => {
-    it('should not render venues linked to bank account with only one bank account', async () => {
-      bankAccount.linkedVenues = []
-      render(
-        <ReimbursementBankAccount
-          bankAccount={bankAccount}
-          venuesNotLinkedLength={1}
-          bankAccountsNumber={1}
-        />
+  it('should render with pending bank account if status is on going', () => {
+    bankAccount.status = BankAccountApplicationStatus.EN_INSTRUCTION
+    render(
+      <ReimbursementBankAccount
+        bankAccount={bankAccount}
+        venuesNotLinkedLength={0}
+        bankAccountsNumber={1}
+      />
+    )
+
+    expect(screen.getByText('Bank account label')).toBeInTheDocument()
+    expect(screen.getByText('IBAN : **** 0637')).toBeInTheDocument()
+    expect(screen.getByText('BIC : BDFEFRPP')).toBeInTheDocument()
+
+    expect(
+      screen.getByText(
+        'Compte bancaire en cours de validation par nos services'
       )
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Lieu(x) rattaché(s) à ce compte bancaire')
+    ).not.toBeInTheDocument()
+  })
 
-      expect(
-        screen.getByText('Lieu(x) rattaché(s) à ce compte bancaire')
-      ).toBeInTheDocument()
+  it('should not render venues linked to bank account with only one bank account', () => {
+    bankAccount.linkedVenues = []
+    render(
+      <ReimbursementBankAccount
+        bankAccount={bankAccount}
+        venuesNotLinkedLength={1}
+        bankAccountsNumber={1}
+      />
+    )
 
-      expect(
-        screen.getByText("Aucun lieu n'est rattaché à ce compte bancaire.")
-      ).toBeInTheDocument()
-
-      expect(
-        screen.getByRole('button', { name: 'Rattacher' })
-      ).toBeInTheDocument()
-    })
-
-    it('should render without venues linked to bank account and with all venues linked to another account', async () => {
-      bankAccount.linkedVenues = []
-      render(
-        <ReimbursementBankAccount
-          bankAccount={bankAccount}
-          venuesNotLinkedLength={0}
-          bankAccountsNumber={2}
-        />
+    expect(
+      screen.queryByText(
+        'Compte bancaire en cours de validation par nos services'
       )
+    ).not.toBeInTheDocument()
 
-      expect(
-        screen.getByText(
-          "Aucun lieu n'est rattaché à ce compte bancaire. Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire."
-        )
-      ).toBeInTheDocument()
-    })
+    expect(
+      screen.getByText('Lieu(x) rattaché(s) à ce compte bancaire')
+    ).toBeInTheDocument()
 
-    it('should render with one venue not linked to bank account', async () => {
-      render(
-        <ReimbursementBankAccount
-          bankAccount={bankAccount}
-          venuesNotLinkedLength={1}
-          bankAccountsNumber={2}
-        />
+    expect(
+      screen.getByText("Aucun lieu n'est rattaché à ce compte bancaire.")
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Rattacher' })
+    ).toBeInTheDocument()
+  })
+
+  it('should render without venues linked to bank account and with all venues linked to another account', () => {
+    bankAccount.linkedVenues = []
+    render(
+      <ReimbursementBankAccount
+        bankAccount={bankAccount}
+        venuesNotLinkedLength={0}
+        bankAccountsNumber={2}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        "Aucun lieu n'est rattaché à ce compte bancaire. Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire."
       )
+    ).toBeInTheDocument()
+  })
 
-      expect(
-        screen.queryByText("Aucun lieu n'est rattaché à ce compte bancaire.")
-      ).not.toBeInTheDocument()
-      expect(
-        screen.queryByText(
-          "Aucun lieu n'est rattaché à ce compte bancaire. Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire."
-        )
-      ).not.toBeInTheDocument()
+  it('should render with one venue not linked to bank account', () => {
+    render(
+      <ReimbursementBankAccount
+        bankAccount={bankAccount}
+        venuesNotLinkedLength={1}
+        bankAccountsNumber={2}
+      />
+    )
 
-      expect(
-        screen.getByText("Un de vos lieux n'est pas rattaché.")
-      ).toBeInTheDocument()
+    expect(
+      screen.getByText("Un de vos lieux n'est pas rattaché.")
+    ).toBeInTheDocument()
 
-      expect(
-        screen.getByRole('img', { name: 'Une action est requise' })
-      ).toBeInTheDocument()
-      expect(screen.getByText('Le Petit Rintintin')).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: 'Une action est requise' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Le Petit Rintintin')).toBeInTheDocument()
 
-      expect(
-        screen.getByRole('button', { name: 'Modifier' })
-      ).toBeInTheDocument()
-    })
+    expect(screen.getByRole('button', { name: 'Modifier' })).toBeInTheDocument()
+  })
 
-    it('should render with several venues not linked to bank account', () => {
-      render(
-        <ReimbursementBankAccount
-          bankAccount={bankAccount}
-          venuesNotLinkedLength={2}
-          bankAccountsNumber={1}
-        />
+  it('should render with several venues not linked to bank account', () => {
+    render(
+      <ReimbursementBankAccount
+        bankAccount={bankAccount}
+        venuesNotLinkedLength={2}
+        bankAccountsNumber={1}
+      />
+    )
+
+    expect(
+      screen.queryByText("Aucun lieu n'est rattaché à ce compte bancaire.")
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "Aucun lieu n'est rattaché à ce compte bancaire. Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire."
       )
+    ).not.toBeInTheDocument()
 
-      expect(
-        screen.getByText('Certains de vos lieux ne sont pas rattachés')
-      ).toBeInTheDocument()
-    })
+    expect(
+      screen.getByText('Certains de vos lieux ne sont pas rattachés')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Le Petit Rintintin')).toBeInTheDocument()
 
-    it('should display error icon if no venues are linked to an account', async () => {
-      bankAccount.linkedVenues = []
-      render(
-        <ReimbursementBankAccount
-          bankAccount={bankAccount}
-          venuesNotLinkedLength={2}
-          bankAccountsNumber={1}
-        />
+    expect(screen.getByRole('button', { name: 'Modifier' })).toBeInTheDocument()
+  })
+
+  it('should render with several venues not linked to bank account', () => {
+    render(
+      <ReimbursementBankAccount
+        bankAccount={bankAccount}
+        venuesNotLinkedLength={2}
+        bankAccountsNumber={1}
+      />
+    )
+
+    expect(
+      screen.getByText('Certains de vos lieux ne sont pas rattachés')
+    ).toBeInTheDocument()
+  })
+
+  it('should display error icon if one or more venues are not linked to an account', () => {
+    bankAccount.linkedVenues = []
+    render(
+      <ReimbursementBankAccount
+        bankAccount={bankAccount}
+        venuesNotLinkedLength={2}
+        bankAccountsNumber={1}
+      />
+    )
+
+    expect(
+      screen.getByRole('img', { name: 'Une action est requise' })
+    ).toBeInTheDocument()
+  })
+
+  it('should render with all venues linked to the account', () => {
+    render(
+      <ReimbursementBankAccount
+        bankAccount={bankAccount}
+        venuesNotLinkedLength={0}
+        bankAccountsNumber={1}
+      />
+    )
+
+    expect(
+      screen.queryByRole('img', { name: 'Une action est requise' })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText("Aucun lieu n'est rattaché à ce compte bancaire.")
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText(
+        "Aucun lieu n'est rattaché à ce compte bancaire. Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire."
       )
+    ).not.toBeInTheDocument()
 
-      expect(
-        screen.getByRole('img', { name: 'Une action est requise' })
-      ).toBeInTheDocument()
-    })
+    expect(
+      screen.queryByText("Un de vos lieux n'est pas rattaché.")
+    ).not.toBeInTheDocument()
 
-    it('should render with all venues linked to the account', async () => {
-      render(
-        <ReimbursementBankAccount
-          bankAccount={bankAccount}
-          venuesNotLinkedLength={0}
-          bankAccountsNumber={1}
-        />
-      )
-
-      expect(
-        screen.queryByRole('img', { name: 'Une action est requise' })
-      ).not.toBeInTheDocument()
-
-      expect(
-        screen.queryByText("Aucun lieu n'est rattaché à ce compte bancaire.")
-      ).not.toBeInTheDocument()
-
-      expect(
-        screen.queryByText(
-          "Aucun lieu n'est rattaché à ce compte bancaire. Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire."
-        )
-      ).not.toBeInTheDocument()
-
-      expect(
-        screen.queryByText("Un de vos lieux n'est pas rattaché.")
-      ).not.toBeInTheDocument()
-
-      expect(
-        screen.queryByText('Certains de vos lieux ne sont pas rattachés')
-      ).not.toBeInTheDocument()
-    })
+    expect(
+      screen.queryByText('Certains de vos lieux ne sont pas rattachés')
+    ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -58,7 +58,7 @@ const BankInformations = (): JSX.Element => {
     }
 
     if (offererId) {
-      updateOfferer(offererId)
+      void updateOfferer(offererId)
     }
     if (searchParams.has('structure')) {
       searchParams.delete('structure')
@@ -85,7 +85,7 @@ const BankInformations = (): JSX.Element => {
       }
     }
 
-    selectedOfferer && getSelectedOffererBankAccounts(selectedOfferer.id)
+    selectedOfferer && void getSelectedOffererBankAccounts(selectedOfferer.id)
   }, [selectedOfferer])
 
   if (isOffererBankAccountsLoading || isOffererLoading) {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23419

Avant la condition d'affichage était par rapport à bankAccount.isActive, sauf que dès qu'il est en construction, cette valeur est à True.
Maintenant, la condition se base sur le statut directement.

FF: WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/a3e736de-0f91-40f9-9fec-0f9d21a5ff16)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques