### PR TITLE
(PC-24981)[PRO] feat: Add a link to the adage offer venue name that r…

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -62,6 +62,7 @@ class OfferVenueResponse(BaseModel):
     publicName: str | None
     coordinates: common_models.Coordinates
     managingOfferer: OfferManagingOffererResponse
+    adageId: str | None
 
     class Config:
         orm_mode = True

--- a/api/tests/routes/adage_iframe/get_all_offers_linked_to_uai_test.py
+++ b/api/tests/routes/adage_iframe/get_all_offers_linked_to_uai_test.py
@@ -75,6 +75,7 @@ class AllOffersByUaiTest:
                         "publicName": collective_offer.venue.publicName,
                         "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
                         "managingOfferer": {"name": collective_offer.venue.managingOfferer.name},
+                        "adageId": None,
                     },
                     "students": ["Lycée - Seconde"],
                     "offerVenue": {
@@ -183,6 +184,7 @@ class AllOffersByUaiTest:
                         "publicName": collective_offer.venue.publicName,
                         "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
                         "managingOfferer": {"name": collective_offer.venue.managingOfferer.name},
+                        "adageId": None,
                     },
                     "students": ["Lycée - Seconde"],
                     "offerVenue": {

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -68,6 +68,7 @@ class CollectiveOfferTemplateTest:
                 "postalCode": "75000",
                 "publicName": offer.venue.publicName,
                 "managingOfferer": {"name": offer.venue.managingOfferer.name},
+                "adageId": None,
             },
             "interventionArea": offer.interventionArea,
             "audioDisabilityCompliant": False,

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -91,6 +91,7 @@ class CollectiveOfferTest:
                 "postalCode": "75000",
                 "publicName": offer.venue.publicName,
                 "managingOfferer": {"name": offer.venue.managingOfferer.name},
+                "adageId": None,
             },
             "audioDisabilityCompliant": False,
             "mentalDisabilityCompliant": False,

--- a/api/tests/routes/adage_iframe/get_favorites_test.py
+++ b/api/tests/routes/adage_iframe/get_favorites_test.py
@@ -80,6 +80,7 @@ class GetFavoriteOfferTest:
                         "publicName": stock.collectiveOffer.venue.publicName,
                         "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
                         "managingOfferer": {"name": stock.collectiveOffer.venue.managingOfferer.name},
+                        "adageId": None,
                     },
                     "students": ["Lycée - Seconde"],
                     "offerVenue": {
@@ -145,6 +146,7 @@ class GetFavoriteOfferTest:
                         "publicName": collective_offer_template.venue.publicName,
                         "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
                         "managingOfferer": {"name": collective_offer_template.venue.managingOfferer.name},
+                        "adageId": None,
                     },
                     "students": ["Lycée - Seconde"],
                     "offerVenue": {

--- a/pro/src/apiClient/adage/models/OfferVenueResponse.ts
+++ b/pro/src/apiClient/adage/models/OfferVenueResponse.ts
@@ -7,6 +7,7 @@ import type { Coordinates } from './Coordinates';
 import type { OfferManagingOffererResponse } from './OfferManagingOffererResponse';
 
 export type OfferVenueResponse = {
+  adageId?: string | null;
   address?: string | null;
   city?: string | null;
   coordinates: Coordinates;

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.module.scss
@@ -95,27 +95,35 @@ $offer-image-width: rem.torem(176px);
       align-items: flex-start;
     }
 
-    .offer-header-label {
+    &-label {
       color: colors.$grey-dark;
     }
 
-    .offer-header-title {
+    &-venue-link {
+      display: flex;
+      align-items: center;
+    }
+
+    &-title {
       margin-bottom: rem.torem(6px);
 
       @include fonts.title3;
     }
 
-    .offer-header-subtitles,
-    .offer-header-teacher {
+    &-subtitles,
+    &-teacher {
       font-weight: 500;
       font-size: rem.torem(15px);
     }
 
-    .offer-header-subtitles {
+    &-subtitles {
       margin-bottom: rem.torem(24px);
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: rem.torem(8px);
     }
 
-    .offer-header-teacher {
+    &-teacher {
       margin-bottom: rem.torem(8px);
     }
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { AdageFrontRoles, OfferAddressType } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
 import useActiveFeature from 'hooks/useActiveFeature'
+import fullLinkIcon from 'icons/full-link.svg'
 import fullUpIcon from 'icons/full-up.svg'
 import strokeFranceIcon from 'icons/stroke-france.svg'
 import strokeLocalisationIcon from 'icons/stroke-localisation.svg'
@@ -14,6 +15,8 @@ import {
   HydratedCollectiveOfferTemplate,
   isCollectiveOffer,
 } from 'pages/AdageIframe/app/types/offers'
+import { ButtonLink } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { Tag, TagVariant } from 'ui-kit/Tag/Tag'
 import { LOGS_DATA } from 'utils/config'
@@ -54,7 +57,7 @@ const Offer = ({
     offer.isTemplate &&
     adageUser.role !== AdageFrontRoles.READONLY
 
-  const openOfferDetails = async (
+  const openOfferDetails = (
     offer: HydratedCollectiveOffer | HydratedCollectiveOfferTemplate
   ) => {
     setDisplayDetails(!displayDetails)
@@ -63,14 +66,14 @@ const Offer = ({
     }
 
     if (!offer.isTemplate) {
-      await apiAdage.logOfferDetailsButtonClick({
+      void apiAdage.logOfferDetailsButtonClick({
         iframeFrom: removeParamsFromUrl(location.pathname),
         stockId: offer.stock.id,
         queryId: queryId,
         isFromNoResult: isInSuggestions,
       })
     } else {
-      await apiAdage.logOfferTemplateDetailsButtonClick({
+      void apiAdage.logOfferTemplateDetailsButtonClick({
         iframeFrom: removeParamsFromUrl(location.pathname),
         offerId: offer.id,
         queryId: queryId,
@@ -78,6 +81,14 @@ const Offer = ({
       })
     }
   }
+
+  function offerVenueLinkClicked() {
+    void apiAdage.logTrackingMap({
+      iframeFrom: removeParamsFromUrl(location.pathname),
+    })
+  }
+
+  const venueAndOffererName = getOfferVenueAndOffererName(offer.venue)
 
   return (
     <li className={style['offer']} data-testid="offer-listitem">
@@ -145,9 +156,27 @@ const Offer = ({
                 <h2 className={style['offer-header-title']}>{offer.name}</h2>
                 <div className={style['offer-header-subtitles']}>
                   <span className={style['offer-header-label']}>
-                    Proposée par{' '}
+                    Proposée par
                   </span>
-                  <span>{getOfferVenueAndOffererName(offer.venue)}</span>
+
+                  {offer.venue.adageId ? (
+                    <ButtonLink
+                      link={{
+                        isExternal: true,
+                        to: `${document.referrer}adage/ressource/partenaires/id/${offer.venue.adageId}`,
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                      }}
+                      variant={ButtonVariant.TERNARY}
+                      className={style['offer-header-venue-link']}
+                      onClick={offerVenueLinkClicked}
+                      icon={fullLinkIcon}
+                    >
+                      {venueAndOffererName}
+                    </ButtonLink>
+                  ) : (
+                    <span>{venueAndOffererName}</span>
+                  )}
                 </div>
                 {isCollectiveOffer(offer) && offer.teacher && (
                   <div className={style['offer-header-teacher']}>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/__spec__/PrebookingButton.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/__spec__/PrebookingButton.spec.tsx
@@ -43,7 +43,7 @@ describe('offer', () => {
   })
 
   describe('offer item', () => {
-    it('should not display when prebooking is not activated', async () => {
+    it('should not display when prebooking is not activated', () => {
       // Given
       renderWithProviders(
         <PrebookingButton
@@ -57,7 +57,7 @@ describe('offer', () => {
       expect(screen.queryByText('Préréserver')).not.toBeInTheDocument()
     })
 
-    it('should display when prebooking is activated', async () => {
+    it('should display when prebooking is activated', () => {
       // Given
       renderWithProviders(
         <PrebookingButton

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -26,6 +26,7 @@ vi.mock('apiClient/api', () => ({
     logOfferTemplateDetailsButtonClick: vi.fn(),
     logFavOfferButtonClick: vi.fn(),
     logContactModalButtonClick: vi.fn(),
+    logTrackingMap: vi.fn(),
     postCollectiveOfferFavorites: vi.fn().mockImplementation(() => {}),
     postCollectiveTemplateFavorites: vi.fn().mockImplementation(() => {}),
     deleteFavoriteForCollectiveOffer: vi.fn().mockImplementation(() => {}),
@@ -51,7 +52,7 @@ const user: AuthenticatedResponse = {
   lon: null,
 }
 
-const renderOffers = (
+const renderOffer = (
   props: OfferProps,
   featuresOverride?: { nameKey: string; isActive: boolean }[],
   adageUser: AuthenticatedResponse | null = user
@@ -77,7 +78,6 @@ describe('offer', () => {
   let offerProps: OfferProps
   beforeEach(() => {
     offerInParis = { ...defaultCollectiveOffer, isTemplate: false }
-
     offerInCayenne = {
       id: 480,
       description: 'Une offre vraiment chouette',
@@ -121,11 +121,13 @@ describe('offer', () => {
       motorDisabilityCompliant: true,
       contactEmail: '',
       contactPhone: '',
-      domains: [],
+      domains: [{ id: 1, name: 'Super domaine' }],
       interventionArea: ['973'],
       isTemplate: false,
       nationalProgram: { name: 'Program Test', id: 123 },
+      imageUrl: 'url',
     }
+
     offerProps = {
       offer: offerInParis,
       queryId: '1',
@@ -136,7 +138,7 @@ describe('offer', () => {
   describe('offer item', () => {
     it('should not show all information at first', async () => {
       // When
-      renderOffers(offerProps)
+      renderOffer(offerProps)
 
       // Then
       const offerName = await screen.findByText(offerInParis.name)
@@ -162,7 +164,7 @@ describe('offer', () => {
 
     it('should show all offer informations if user click on "en savoir plus"', async () => {
       // When
-      renderOffers({ ...offerProps, offer: offerInCayenne })
+      renderOffer({ ...offerProps, offer: offerInCayenne })
 
       const offerName = await screen.findByText(offerInCayenne.name)
       expect(offerName).toBeInTheDocument()
@@ -209,7 +211,7 @@ describe('offer', () => {
       // Given
 
       // When
-      renderOffers({
+      renderOffer({
         ...offerProps,
         offer: {
           ...offerInParis,
@@ -244,7 +246,7 @@ describe('offer', () => {
     })
 
     it('should display request form modal', async () => {
-      renderOffers(
+      renderOffer(
         {
           ...offerProps,
           offer: { ...defaultCollectiveTemplateOffer, isTemplate: true },
@@ -264,7 +266,7 @@ describe('offer', () => {
       user.lat = 0
       user.lon = 0
 
-      renderOffers(
+      renderOffer(
         {
           ...offerProps,
           offer: {
@@ -285,7 +287,7 @@ describe('offer', () => {
     })
 
     it('should display can move in your institution is offer intervention area match user one', () => {
-      renderOffers(
+      renderOffer(
         {
           ...offerProps,
           offer: {
@@ -314,7 +316,7 @@ describe('offer', () => {
   it('should not display the distance to venue if the user does not have a valid geoloc', () => {
     user.lat = null
     user.lon = null
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
       },
@@ -327,7 +329,7 @@ describe('offer', () => {
   })
 
   it('should display the add to favorite button on offers that are not favorite yet', () => {
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
         offer: { ...defaultCollectiveTemplateOffer, isTemplate: true },
@@ -339,7 +341,7 @@ describe('offer', () => {
   })
 
   it('should display the remove from favorite button on offers that are already favorite', () => {
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
         offer: {
@@ -358,7 +360,7 @@ describe('offer', () => {
     vi.spyOn(apiAdage, 'postCollectiveOfferFavorites').mockResolvedValue()
     vi.spyOn(apiAdage, 'deleteFavoriteForCollectiveOffer').mockResolvedValue()
 
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
         offer: { ...defaultCollectiveTemplateOffer, isTemplate: true },
@@ -390,7 +392,7 @@ describe('offer', () => {
       'deleteFavoriteForCollectiveOfferTemplate'
     ).mockResolvedValue()
 
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
         offer: {
@@ -425,7 +427,7 @@ describe('offer', () => {
       null
     )
 
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
         offer: {
@@ -451,7 +453,7 @@ describe('offer', () => {
       'deleteFavoriteForCollectiveOfferTemplate'
     ).mockRejectedValue(null)
 
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
         offer: {
@@ -473,7 +475,7 @@ describe('offer', () => {
   })
 
   it('should not display favorite button when adage user is admin', () => {
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
         offer: {
@@ -489,7 +491,7 @@ describe('offer', () => {
   })
 
   it('should not display favorite button when offer is bookable', () => {
-    renderOffers(
+    renderOffer(
       {
         ...offerProps,
       },
@@ -500,7 +502,7 @@ describe('offer', () => {
   })
 
   it('should log event when clicking on "en savoir plus" button', async () => {
-    renderOffers({
+    renderOffer({
       ...offerProps,
       isInSuggestions: false,
       offer: { ...defaultCollectiveTemplateOffer, isTemplate: true },
@@ -520,7 +522,7 @@ describe('offer', () => {
   })
 
   it('should mention if the log is from a suggestion offer when clicking on "en savoir plus" button', async () => {
-    renderOffers({ ...offerProps, isInSuggestions: true })
+    renderOffer({ ...offerProps, isInSuggestions: true })
 
     const seeMoreButton = await screen.findByRole('button', {
       name: 'en savoir plus',
@@ -535,8 +537,8 @@ describe('offer', () => {
     })
   })
 
-  it('should display format when FF is active', async () => {
-    renderOffers(
+  it('should display format when FF is active', () => {
+    renderOffer(
       {
         ...offerProps,
         offer: {
@@ -549,5 +551,49 @@ describe('offer', () => {
     )
 
     expect(screen.getByText('Concert, Représentation')).toBeInTheDocument()
+  })
+
+  it('should display a link as the name of the venue when the venue has a valid adageId', () => {
+    renderOffer({
+      ...offerProps,
+      offer: {
+        ...offerProps.offer,
+        venue: { ...offerProps.offer.venue, adageId: '123' },
+      },
+    })
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Le Petit Rintintin 33 - Le Petit Rintintin Management (75000)',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('should not display a link as the name of the venue when the venue has no valid adageId', () => {
+    renderOffer(offerProps)
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'Le Petit Rintintin 33 - Le Petit Rintintin Management (75000)',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should trigger a tracking event when the venue name link is clicked', async () => {
+    renderOffer({
+      ...offerProps,
+      offer: {
+        ...offerProps.offer,
+        venue: { ...offerProps.offer.venue, adageId: '123' },
+      },
+    })
+
+    const link = screen.getByRole('link', {
+      name: 'Le Petit Rintintin 33 - Le Petit Rintintin Management (75000)',
+    })
+
+    await userEvent.click(link)
+
+    expect(apiAdage.logTrackingMap).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
…edirects to the adage map page.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24981

**Objectif**
Ajouter un lien de redirection vers la cateographie adage depuis les noms des lieux dans les offres ADAGE

**Réalisation**
Comme on n'a pas encore l'id côté adage (`adageId`) dans le front, j'ai aussi ajouté la clé côté api

<img width="1140" alt="Capture d’écran 2023-10-20 à 15 14 18" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/855da961-bd53-4f44-b6f1-97b64eea240f">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques