### PR TITLE
(PC-24342)[PRO] style: remove bank accounts section when no bank account and link position

### DIFF
--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.module.scss
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.module.scss
@@ -8,13 +8,13 @@
 
 .information {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  gap: rem.torem(8px);
   margin-top: rem.torem(16px);
   margin-bottom: rem.torem(24px);
 }
 
 .information-link-button {
-  margin-top: rem.torem(8px);
   width: fit-content;
 }
 

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -101,8 +101,14 @@ const BankInformations = (): JSX.Element => {
           'Ajoutez au moins un compte bancaire pour percevoir vos remboursements.'}
 
         {(selectedOfferer?.hasValidBankAccount ||
-          selectedOfferer?.hasPendingBankAccount) &&
-          "Vous pouvez ajouter plusieurs comptes bancaires afin de percevoir les remboursements de vos offres. Chaque compte bancaire fera l'objet d'un remboursement et d'un justificatif de remboursement distincts."}
+          selectedOfferer?.hasPendingBankAccount) && (
+          <>
+            Vous pouvez ajouter plusieurs comptes bancaires afin de percevoir
+            les remboursements de vos offres. Chaque compte bancaire fera
+            l'objet d'un remboursement et d'un justificatif de remboursement
+            distincts. <br />
+          </>
+        )}
 
         <ButtonLink
           link={{
@@ -132,21 +138,24 @@ const BankInformations = (): JSX.Element => {
           </div>
         </div>
       )}
-      <div className={styles['bank-accounts']}>
-        {selectedOffererBankAccounts?.bankAccounts.map((bankAccount) => (
-          <ReimbursementBankAccount
-            bankAccount={bankAccount}
-            venuesNotLinkedLength={
-              selectedOfferer?.venuesWithNonFreeOffersWithoutBankAccounts
-                .length ?? 0
-            }
-            bankAccountsNumber={
-              selectedOffererBankAccounts?.bankAccounts.length
-            }
-            key={bankAccount.id}
-          />
-        ))}
-      </div>
+      {selectedOffererBankAccounts &&
+        selectedOffererBankAccounts?.bankAccounts.length > 0 && (
+          <div className={styles['bank-accounts']}>
+            {selectedOffererBankAccounts?.bankAccounts.map((bankAccount) => (
+              <ReimbursementBankAccount
+                bankAccount={bankAccount}
+                venuesNotLinkedLength={
+                  selectedOfferer?.venuesWithNonFreeOffersWithoutBankAccounts
+                    .length ?? 0
+                }
+                bankAccountsNumber={
+                  selectedOffererBankAccounts?.bankAccounts.length
+                }
+                key={bankAccount.id}
+              />
+            ))}
+          </div>
+        )}
       <Button
         icon={fullMoreIcon}
         className={styles['add-bank-account-button']}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24342

FF: WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY

### Placement du lien "à savoir"
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/aea9497b-e496-4a10-b955-5dc806f425c5)
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/3fca17fd-07a1-45d6-a530-bb60cd674440)

### Espace entre CTA et le filtre ou la section d'information
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/d341036e-b4bc-4ecc-9d28-86adeabb841e)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques