### PR TITLE
(PC-23403)[PRO] fix: statement displaying error icon in Reimbursement…

### DIFF
--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -59,7 +59,8 @@ const ReimbursementBankAccount = ({
         <div className={styles['linked-venues-section']}>
           <div className={styles['linked-venues-section-title']}>
             Lieu(x) rattaché(s) à ce compte bancaire
-            {!hasLinkedVenues && venuesNotLinkedLength > 0 && (
+            {(!hasLinkedVenues ||
+              (hasLinkedVenues && venuesNotLinkedLength > 0)) && (
               <SvgIcon
                 src={fullErrorIcon}
                 alt="Une action est requise"

--- a/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
+++ b/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
@@ -112,6 +112,10 @@ describe('ReimbursementBankAccount', () => {
       expect(
         screen.getByText("Un de vos lieux n'est pas rattaché.")
       ).toBeInTheDocument()
+
+      expect(
+        screen.getByRole('img', { name: 'Une action est requise' })
+      ).toBeInTheDocument()
       expect(screen.getByText('Le Petit Rintintin')).toBeInTheDocument()
 
       expect(
@@ -133,7 +137,7 @@ describe('ReimbursementBankAccount', () => {
       ).toBeInTheDocument()
     })
 
-    it('should display error icon if one or more venues are not linked to an account', async () => {
+    it('should display error icon if no venues are linked to an account', async () => {
       bankAccount.linkedVenues = []
       render(
         <ReimbursementBankAccount


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23403

FF: WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY

![Capture d’écran du 2023-10-20 11-25-35](https://github.com/pass-culture/pass-culture-main/assets/106379750/30ea2d26-6857-45c3-ada5-fb58826d92c5)
![Capture d’écran du 2023-10-20 11-25-24](https://github.com/pass-culture/pass-culture-main/assets/106379750/882e31e4-a416-474b-8e22-fbb579d580c5)
![Capture d’écran du 2023-10-20 11-25-06](https://github.com/pass-culture/pass-culture-main/assets/106379750/f935c05f-6e15-45d0-8582-7052552b3e18)
![Capture d’écran du 2023-10-20 11-24-52](https://github.com/pass-culture/pass-culture-main/assets/106379750/cf697a5e-9534-4974-91df-a4982723fdc5)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques