### PR TITLE
(PC-25303)[PRO] style: fix subcategory choice in desk

### DIFF
--- a/pro/src/screens/OfferType/IndividualOfferType/IndividualOfferType.tsx
+++ b/pro/src/screens/OfferType/IndividualOfferType/IndividualOfferType.tsx
@@ -113,36 +113,30 @@ const IndividualOfferType = (): JSX.Element | null => {
           description="Ces catégories sont suggérées d’après les catégories les plus fréquemment sélectionnées pour votre type de lieu."
           className={styles['subcategory-section']}
         >
-          <FormLayout.Row
-            inline
-            mdSpaceAfter
-            className={styles['individual-radio-button-subcategory-group']}
-          >
-            {venueTypeMostUsedSubcategories.map(
-              (subcategory: SubcategoryIdEnum) => (
-                <RadioButton
-                  className={styles['individual-radio-button-subcategory']}
-                  key={subcategory}
-                  withBorder
-                  value={subcategory}
-                  label={
-                    subcategories.find((s) => s.id === subcategory)?.proLabel ||
-                    ''
-                  }
-                  name="individualOfferSubcategory"
-                  variant={BaseRadioVariant.SECONDARY}
-                />
-              )
-            )}
-            <RadioButton
-              className={styles['individual-radio-button-subcategory']}
-              withBorder
-              value="OTHER"
-              label="Autre"
-              name="individualOfferSubcategory"
-              variant={BaseRadioVariant.SECONDARY}
-            />
-          </FormLayout.Row>
+          {venueTypeMostUsedSubcategories.map(
+            (subcategory: SubcategoryIdEnum) => (
+              <RadioButton
+                className={styles['individual-radio-button-subcategory']}
+                key={subcategory}
+                withBorder
+                value={subcategory}
+                label={
+                  subcategories.find((s) => s.id === subcategory)?.proLabel ||
+                  ''
+                }
+                name="individualOfferSubcategory"
+                variant={BaseRadioVariant.SECONDARY}
+              />
+            )
+          )}
+          <RadioButton
+            className={styles['individual-radio-button-subcategory']}
+            withBorder
+            value="OTHER"
+            label="Autre"
+            name="individualOfferSubcategory"
+            variant={BaseRadioVariant.SECONDARY}
+          />
         </FormLayout.Section>
       )}
 

--- a/pro/src/screens/OfferType/OfferType.module.scss
+++ b/pro/src/screens/OfferType/OfferType.module.scss
@@ -30,9 +30,6 @@
 
 .individual-radio-button-subcategory {
   margin-bottom: rem.torem(16px);
+  margin-right: rem.torem(8px);
   width: fit-content;
-}
-
-.individual-radio-button-subcategory-group {
-  flex-flow: wrap;
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25303

cassé à cause de ça
```
@media (min-width: size.$tablet) {
  .form-layout {
    &-row.inline-group {
      flex-wrap: unset;
    }
  }
}
```
le flex-flow: wrap était écrasé
réparé en enlevant FormLayout.Row qui n'avait pas l'ai d'apporter grand chose ici

après :
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/5adcb768-ec3a-4f4c-8676-a569bedb33e1)


avant :
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/87134b5f-5499-49f7-a42d-64fc505cca3b)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques