### PR TITLE
(BSR)[API] ci: Build Docker image from the branch, not from its merged state

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -39,7 +39,8 @@ jobs:
       needs.check-pro-folder-changes.outputs.folder_changed == 'true'
     uses: ./.github/workflows/build-and-push-docker-images.yml
     with:
-      tag: ${{ github.sha }}
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       # Needed to run end-to-end tests, i.e. when either "pro" or
       # "api" source code changes, which is the condition under which
       # this step is run. In other words: always.


### PR DESCRIPTION
Currently (before this commit), when building the Docker image for a
branch (for a pull request), the "checkout" GitHub Action checks out
the latest commit of the branch and merges it to the target branch
(usually master). In other words, the content of the Docker image is
not exactly what is in the branch.

This is the default behaviour of the "checkout" GitHub Action.

This is not what we want. We want the Docker image to contain exactly
what is in the branch. This behaviour is documented here:
https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit

Note that the bug did not affect "version tags" (such as v261). In
that case, the GitHub Action properly checks out a specific commit.