### PR TITLE
(PC-25306)[PRO] feat: Clear categories before domains in adage zero r…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/OffersSuggestions.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/OffersSuggestions.tsx
@@ -52,16 +52,16 @@ const getPossibleFilterValues = (
   const possibleFacetFilters = []
   //  The returned array should be in the order of preferred suggestion filters
 
-  if (formValues.eventAddressType !== OfferAddressType.OTHER) {
+  if (formValues.categories.length !== 0) {
     possibleFacetFilters.push({
       values: {
         ...formValues,
         eventAddressType: OfferAddressType.OTHER,
+        domains: [],
+        categories: [],
         geolocRadius: DEFAULT_GEO_RADIUS,
       },
-      headerMessage: (
-        <>Découvrez des offres qui relèvent d’autres types d’intervention</>
-      ),
+      headerMessage: 'Découvrez des offres qui relèvent d’autres catégories',
     })
   }
 
@@ -73,22 +73,20 @@ const getPossibleFilterValues = (
         domains: [],
         geolocRadius: DEFAULT_GEO_RADIUS,
       },
-      headerMessage: (
-        <>Découvrez des offres qui relèvent d’autres domaines artistiques</>
-      ),
+      headerMessage:
+        'Découvrez des offres qui relèvent d’autres domaines artistiques',
     })
   }
 
-  if (formValues.categories.length !== 0) {
+  if (formValues.eventAddressType !== OfferAddressType.OTHER) {
     possibleFacetFilters.push({
       values: {
         ...formValues,
         eventAddressType: OfferAddressType.OTHER,
-        domains: [],
-        categories: [],
         geolocRadius: DEFAULT_GEO_RADIUS,
       },
-      headerMessage: <>Découvrez des offres qui relèvent d’autres catégories</>,
+      headerMessage:
+        'Découvrez des offres qui relèvent d’autres types d’intervention',
     })
   }
 
@@ -101,12 +99,8 @@ const getPossibleFilterValues = (
         categories: [],
         eventAddressType: OfferAddressType.OTHER,
       },
-      headerMessage: (
-        <>
-          Découvrez des propositions de sorties scolaires à proximité de votre
-          établissement
-        </>
-      ),
+      headerMessage:
+        ' Découvrez des propositions de sorties scolaires à proximité de votre établissement',
     },
     {
       values: {
@@ -116,12 +110,8 @@ const getPossibleFilterValues = (
         categories: [],
         eventAddressType: OfferAddressType.OFFERER_VENUE,
       },
-      headerMessage: (
-        <>
-          Découvrez les offres de partenaires culturels locaux prêts à
-          intervenir dans votre classe
-        </>
-      ),
+      headerMessage:
+        'Découvrez les offres de partenaires culturels locaux prêts à intervenir dans votre classe',
     }
   )
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/__specs__/OffersSuggestions.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/__specs__/OffersSuggestions.spec.tsx
@@ -259,7 +259,7 @@ describe('OffersSuggestions', () => {
     )
   })
 
-  it("should clear the categories filters but keep the domains filters when clearing domains didn't give any result", () => {
+  it("should clear the domains filters filters but keep the categories when clearing categories didn't give any result", () => {
     vi.spyOn(
       instantSearch as {
         useInstantSearch: () => InstantSearchHookResultMock
@@ -312,7 +312,9 @@ describe('OffersSuggestions', () => {
 
     expect(Configure).toHaveBeenCalledTimes(4)
     expect(
-      screen.getByText('Découvrez des offres qui relèvent d’autres catégories')
+      screen.getByText(
+        'Découvrez des offres qui relèvent d’autres domaines artistiques'
+      )
     )
   })
 


### PR DESCRIPTION
…esult suggestions.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25306

**Objectif**
Réorganiser l'ordre de création des indexes algolia dans les suggestions adage pour que la suppression du filtre catégorie pour obtenir des suggestions soit prioritaire sur la suppression du filtre domaines artistiques. De même la suppression du filtre type d'intervention a été corrigé.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques