### PR TITLE
(PC-25337)[BO] fix: add index on last validate author fk for delete user

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 45372e34d18c (pre) (head)
-6025fbc18ebb (post) (head)
+80ee25f3632d (post) (head)

--- a/api/src/pcapi/alembic/versions/20231023T155523_a98c6b643561_create_index_on_last_validation_author_fkey_on_offer_table.py
+++ b/api/src/pcapi/alembic/versions/20231023T155523_a98c6b643561_create_index_on_last_validation_author_fkey_on_offer_table.py
@@ -1,0 +1,27 @@
+"""
+create index on last validation author fk on "offer" table
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "a98c6b643561"
+down_revision = "6025fbc18ebb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_offer_lastValidationAuthorUserId"
+        ON offer("lastValidationAuthorUserId")
+        WHERE "lastValidationAuthorUserId" IS NOT NULL;
+    """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_offer_lastValidationAuthorUserId", "offer")

--- a/api/src/pcapi/alembic/versions/20231023T172057_00d812005230_create_index_on_last_validation_author_fk_on_collective_offer_table.py
+++ b/api/src/pcapi/alembic/versions/20231023T172057_00d812005230_create_index_on_last_validation_author_fk_on_collective_offer_table.py
@@ -1,0 +1,27 @@
+"""
+create index on last validation author fk on "collective_offer" table
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "00d812005230"
+down_revision = "a98c6b643561"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_collective_offer_lastValidationAuthorUserId"
+        ON collective_offer("lastValidationAuthorUserId")
+        WHERE "lastValidationAuthorUserId" IS NOT NULL;
+    """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_collective_offer_lastValidationAuthorUserId", "collective_offer")

--- a/api/src/pcapi/alembic/versions/20231023T204024_80ee25f3632d_create_index_on_last_validation_author_fk_on_collective_offer_template_table.py
+++ b/api/src/pcapi/alembic/versions/20231023T204024_80ee25f3632d_create_index_on_last_validation_author_fk_on_collective_offer_template_table.py
@@ -1,0 +1,27 @@
+"""
+create index on last validation author fk on "collective_offer_template" table
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "80ee25f3632d"
+down_revision = "00d812005230"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_collective_offer_template_lastValidationAuthorUserId"
+        ON collective_offer_template("lastValidationAuthorUserId")
+        WHERE "lastValidationAuthorUserId" IS NOT NULL;
+    """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_collective_offer_template_lastValidationAuthorUserId", "collective_offer_template")

--- a/api/src/pcapi/models/offer_mixin.py
+++ b/api/src/pcapi/models/offer_mixin.py
@@ -64,3 +64,13 @@ class ValidationMixin:
     @declared_attr
     def lastValidationAuthor(self) -> Mapped["User | None"]:
         return sa.orm.relationship("User", foreign_keys=[self.lastValidationAuthorUserId])
+
+    @declared_attr
+    def __table_args__(self):
+        return (
+            sa.Index(
+                f"idx_{self.__tablename__}_lastValidationAuthorUserId",
+                self.lastValidationAuthorUserId,
+                postgresql_where=self.lastValidationAuthorUserId.is_not(None),
+            ),
+        )


### PR DESCRIPTION
## But de la pull request

Quand on supprime un utilisateur, l'action de mettre à null la colonne lastValidationAuthor de la table offer nécessite de parcourir toute la table visiblement, c'est très couteux en production.

On a essayé de changer la clé étrangère, mais la solution la plus simple semble être l'index sur la clé étrangère.

L'index sera mis à la main en staging et production, d'où if not exists

Ticket Jira : https://passculture.atlassian.net/browse/PC-25337

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [X] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques