### PR TITLE
(PC-24624)[API] refactor: remove support for old reset password token

### DIFF
--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -12,7 +12,6 @@ from pcapi.core.users import api as users_api
 from pcapi.core.users import exceptions as users_exceptions
 from pcapi.core.users import models as user_models
 from pcapi.core.users import repository as users_repo
-from pcapi.core.users.models import TokenType
 from pcapi.core.users.models import User
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.domain.password import check_password_strength
@@ -138,10 +137,7 @@ def reset_password(body: ResetPasswordRequest) -> ResetPasswordResponse:
         token = token_utils.Token.load_and_check(body.reset_password_token, token_utils.TokenType.RESET_PASSWORD)
         user = user_models.User.query.get(token.user_id)
     except users_exceptions.InvalidToken:
-        try:  # TODO abdelmoujibmegzari: remove this except 1 sprint after this https://passculture.atlassian.net/browse/PC-24624
-            user = users_repo.get_user_with_valid_token(body.reset_password_token, [TokenType.RESET_PASSWORD])
-        except users_exceptions.InvalidToken:
-            raise ApiErrors({"token": ["Le token de changement de mot de passe est invalide."]})
+        raise ApiErrors({"token": ["Le token de changement de mot de passe est invalide."]})
 
     user.setPassword(body.new_password)
 

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -16,7 +16,6 @@ from pcapi.core.users import exceptions as users_exceptions
 from pcapi.core.users import repository as users_repo
 from pcapi.core.users.api import update_user_password
 from pcapi.core.users.email import repository as email_repository
-from pcapi.core.users.models import TokenType
 from pcapi.domain.password import check_password_validity
 from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.serialization import users as users_serializers
@@ -178,13 +177,8 @@ def check_activation_token_exists(token: str) -> None:
     # TODO (yacine-pc) 04-10-23 check if this route is needed, remove it else
     try:
         token_utils.Token.load_and_check(token, token_utils.TokenType.RESET_PASSWORD)
-    except (
-        users_exceptions.InvalidToken
-    ):  # TODO abdelmoujibmegzari: remove this except 1 sprint after this https://passculture.atlassian.net/browse/PC-24624
-        try:
-            users_repo.get_user_with_valid_token(token, [TokenType.RESET_PASSWORD], use_token=False)
-        except users_exceptions.InvalidToken:
-            flask.abort(404)
+    except users_exceptions.InvalidToken:
+        flask.abort(404)
 
 
 @blueprint.pro_private_api.route("/users/password", methods=["POST"])

--- a/api/src/pcapi/routes/shared/passwords.py
+++ b/api/src/pcapi/routes/shared/passwords.py
@@ -43,7 +43,6 @@ def reset_password(body: ResetPasswordBodyModel) -> None:
     token = users_api.create_reset_password_token(user)
     if user.is_beneficiary:
         send_email = transactional_mails.send_reset_password_email_to_user
-        # TODO: abdelmoujibmegzari remove lambda when reset password token to pro is replaced by new token
     else:
         send_email = transactional_mails.send_reset_password_email_to_pro
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24624

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques