### PR TITLE
(PC-25116)[API] feat: add google sso for jeune app

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-40dcae913a06 (pre) (head)
+c56e5591f7b5 (pre) (head)
 c3eff57a0838 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231113T164908_c56e5591f7b5_add_sso.py
+++ b/api/src/pcapi/alembic/versions/20231113T164908_c56e5591f7b5_add_sso.py
@@ -1,0 +1,32 @@
+"""
+Add single_sign_on table.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "c56e5591f7b5"
+down_revision = "40dcae913a06"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "single_sign_on",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("userId", sa.BigInteger(), nullable=False),
+        sa.Column("ssoProvider", sa.Text(), nullable=False),
+        sa.Column("ssoUserId", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["userId"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("ssoProvider", "ssoUserId", name="unique_sso_user_per_sso_provider"),
+        sa.UniqueConstraint("ssoProvider", "userId", name="unique_user_per_sso_provider"),
+    )
+    op.create_index(op.f("ix_single_sign_on_userId"), "single_sign_on", ["userId"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_table("single_sign_on")

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -989,6 +989,15 @@ class LoginDeviceHistoryFactory(BaseFactory):
     location = "Paris"
 
 
+class SingleSignOnFactory(BaseFactory):
+    class Meta:
+        model = models.SingleSignOn
+
+    user = factory.SubFactory(UserFactory)
+    ssoProvider = "google"
+    ssoUserId = factory.Sequence("{}".format)
+
+
 class EmailUpdateEntryFactory(UserEmailHistoryFactory):
     eventType = models.EmailHistoryEventTypeEnum.UPDATE_REQUEST.value
 

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -145,3 +145,18 @@ def get_users_with_validated_attachment(offerer: offerers_models.Offerer) -> lis
 def get_and_lock_user(userId: int) -> models.User:
     user = models.User.query.filter(models.User.id == userId).populate_existing().with_for_update().one_or_none()
     return user
+
+
+def get_single_sign_on(sso_provider: str, sso_user_id: str) -> models.SingleSignOn | None:
+    return (
+        models.SingleSignOn.query.filter(
+            models.SingleSignOn.ssoProvider == sso_provider,
+            models.SingleSignOn.ssoUserId == sso_user_id,
+        )
+        .options(sa.orm.joinedload(models.SingleSignOn.user))
+        .one_or_none()
+    )
+
+
+def create_single_sign_on(user: models.User, sso_provider: str, sso_user_id: str) -> models.SingleSignOn:
+    return models.SingleSignOn(user=user, ssoProvider=sso_provider, ssoUserId=sso_user_id)

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -130,6 +130,7 @@ class FeatureToggle(enum.Enum):
     WIP_HOME_STATS = "Active la possibilité de voir les stats de consultation sur la page d'accueil"
     WIP_ENABLE_FORMAT = "Activer le remplacement des catégories/sous-catégories par les formats"
     WIP_ENABLE_DISCOVERY = "Activer la page de découverte dans adage"
+    WIP_ENABLE_GOOGLE_SSO = "Activer la connexion SSO pour les jeunes"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -203,6 +204,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_BEHIND_L7_LOAD_BALANCER,
     FeatureToggle.WIP_ENABLE_FORMAT,
     FeatureToggle.WIP_ENABLE_DISCOVERY,
+    FeatureToggle.WIP_ENABLE_GOOGLE_SSO,
 )
 
 if settings.IS_PROD or settings.IS_STAGING:

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -1,5 +1,3 @@
-from pcapi.utils import requests
-from pcapi import settings
 import logging
 
 from flask_jwt_extended import get_jwt_identity
@@ -34,6 +32,7 @@ from pcapi.routes.native.v1.serialization.authentication import ResetPasswordRes
 from pcapi.routes.native.v1.serialization.authentication import ValidateEmailRequest
 from pcapi.routes.native.v1.serialization.authentication import ValidateEmailResponse
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils.feature import feature_required
 from pcapi.utils.rate_limiting import email_rate_limiter
 from pcapi.utils.rate_limiting import ip_rate_limiter
 
@@ -222,6 +221,7 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
     api=blueprint.api,
 )
 @ip_rate_limiter()
+@feature_required(FeatureToggle.WIP_ENABLE_GOOGLE_SSO)
 def google_auth(body: authentication.GoogleSigninRequest) -> authentication.SigninResponse:
     # postmessage is needed when the app uses a popup to fetch the authorization code
     # see https://stackoverflow.com/questions/71968377

--- a/api/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/api/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -1,96 +1,61 @@
 from pcapi.core.users.models import AccountState
 from pcapi.routes.native.v1.serialization.account import TrustedDevice
-from pcapi.routes.serialization import BaseModel
-from pcapi.serialization.utils import to_camel
+from pcapi.routes.serialization import ConfiguredBaseModel
 
 
-class SigninRequest(BaseModel):
+class SigninRequest(ConfiguredBaseModel):
     identifier: str
     password: str
     device_info: TrustedDevice | None = None
     token: str | None = None
 
-    class Config:
-        alias_generator = to_camel
 
-
-class SigninResponse(BaseModel):
+class SigninResponse(ConfiguredBaseModel):
     refresh_token: str
     access_token: str
     account_state: AccountState
 
-    class Config:
-        alias_generator = to_camel
-        allow_population_by_field_name = True
 
-
-class RefreshResponse(BaseModel):
+class RefreshResponse(ConfiguredBaseModel):
     access_token: str
 
-    class Config:
-        alias_generator = to_camel
-        allow_population_by_field_name = True
 
-
-class RequestPasswordResetRequest(BaseModel):
+class RequestPasswordResetRequest(ConfiguredBaseModel):
     email: str
     token: str | None = None
 
 
-class ResetPasswordRequest(BaseModel):
+class ResetPasswordRequest(ConfiguredBaseModel):
     reset_password_token: str
     new_password: str
     device_info: TrustedDevice | None = None
 
-    class Config:
-        alias_generator = to_camel
-        allow_population_by_field_name = True
 
-
-class ResetPasswordResponse(BaseModel):
+class ResetPasswordResponse(ConfiguredBaseModel):
     access_token: str
     refresh_token: str
 
-    class Config:
-        alias_generator = to_camel
-        allow_population_by_field_name = True
 
-
-class ChangePasswordRequest(BaseModel):
+class ChangePasswordRequest(ConfiguredBaseModel):
     current_password: str
     new_password: str
 
-    class Config:
-        alias_generator = to_camel
 
-
-class ValidateEmailRequest(BaseModel):
+class ValidateEmailRequest(ConfiguredBaseModel):
     email_validation_token: str
     device_info: TrustedDevice | None = None
 
-    class Config:
-        alias_generator = to_camel
-        allow_population_by_field_name = True
 
-
-class ValidateEmailResponse(BaseModel):
+class ValidateEmailResponse(ConfiguredBaseModel):
     access_token: str
     refresh_token: str
 
-    class Config:
-        alias_generator = to_camel
-        allow_population_by_field_name = True
 
-
-class GoogleSigninRequest(BaseModel):
+class GoogleSigninRequest(ConfiguredBaseModel):
     authorization_code: str
 
-    class Config:
-        alias_generator = to_camel
-        allow_population_by_field_name = True
 
-
-class GoogleUser(BaseModel):
+class GoogleUser(ConfiguredBaseModel):
     sub: str
     email: str
     email_verified: bool

--- a/api/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/api/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -80,3 +80,17 @@ class ValidateEmailResponse(BaseModel):
     class Config:
         alias_generator = to_camel
         allow_population_by_field_name = True
+
+
+class GoogleSigninRequest(BaseModel):
+    authorization_code: str
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+
+
+class GoogleUser(BaseModel):
+    sub: str
+    email: str
+    email_verified: bool

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -241,6 +241,7 @@ class SSOSigninTest:
 
     @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
     @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_account_is_active(self, _mock_fetch_access_token, mock_parse_id_token, client, caplog):
         users_factories.SingleSignOnFactory(
             ssoUserId=self.valid_user["sub"], user__email=self.valid_user["email"], user__isActive=True
@@ -256,6 +257,7 @@ class SSOSigninTest:
 
     @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
     @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_account_is_deleted(self, _mock_fetch_access_token, mock_parse_id_token, client):
         user = users_factories.UserFactory(email=self.valid_user["email"], isActive=False)
         users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_user["sub"])
@@ -269,6 +271,7 @@ class SSOSigninTest:
 
     @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
     @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_account_does_not_exist(self, _mock_fetch_access_token, mock_parse_id_token, client, caplog):
         mock_parse_id_token.return_value = self.valid_user
 
@@ -281,6 +284,7 @@ class SSOSigninTest:
 
     @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
     @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_ignores_email_if_found(self, _mock_fetch_access_token, mock_parse_id_token, client):
         user = users_factories.UserFactory(email="another@email.com", isActive=True)
         users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_user["sub"])
@@ -292,6 +296,7 @@ class SSOSigninTest:
 
     @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
     @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_inserts_sso_method_if_email_found(
         self, _mock_fetch_access_token, mock_parse_id_token, client
     ):
@@ -307,6 +312,7 @@ class SSOSigninTest:
 
     @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
     @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_raises_if_email_not_validated(self, _mock_fetch_access_token, mock_parse_id_token, client):
         users_factories.UserFactory(email=self.valid_user["email"], isActive=True)
         unvalidated_email_google_user = copy.deepcopy(self.valid_user)
@@ -319,6 +325,7 @@ class SSOSigninTest:
 
     @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
     @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_does_not_duplicate_ssos(self, _mock_fetch_access_token, mock_parse_id_token, client):
         single_sign_on = users_factories.SingleSignOnFactory(ssoUserId=self.valid_user["sub"])
         mock_parse_id_token.return_value = self.valid_user
@@ -330,6 +337,7 @@ class SSOSigninTest:
 
     @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
     @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_raises_if_another_sso_is_already_configured(
         self, _mock_fetch_access_token, mock_parse_id_token, client
     ):
@@ -340,6 +348,11 @@ class SSOSigninTest:
 
         assert response.status_code == 400
         assert SingleSignOn.query.filter(SingleSignOn.ssoUserId == self.valid_user["sub"]).count() == 0
+
+    def test_sso_is_feature_flagged(self, client):
+        response = client.post("/native/v1/oauth/google/authorize", json={"code": "4/google_code"})
+
+        assert response.status_code == 400
 
 
 class TrustedDeviceFeatureTest:

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -735,6 +735,12 @@ def test_public_api(client):
                     "title": "GenreTypeModel",
                     "type": "object",
                 },
+                "GoogleSigninRequest": {
+                    "properties": {"authorizationCode": {"title": "Authorizationcode", "type": "string"}},
+                    "required": ["authorizationCode"],
+                    "title": "GoogleSigninRequest",
+                    "type": "object",
+                },
                 "HomepageLabelResponseModelv2": {
                     "properties": {
                         "name": {"$ref": "#/components/schemas/_HomepageLabelNameEnumv2"},
@@ -2537,6 +2543,37 @@ def test_public_api(client):
                     },
                     "security": [{"JWTAuth": []}],
                     "summary": "delete_favorite <DELETE>",
+                    "tags": [],
+                }
+            },
+            "/native/v1/oauth/google/authorize": {
+                "post": {
+                    "description": "",
+                    "operationId": "post__native_v1_oauth_google_authorize",
+                    "parameters": [],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/components/schemas/GoogleSigninRequest"}}
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/SigninResponse"}}
+                            },
+                            "description": "OK",
+                        },
+                        "400": {"description": "Bad Request"},
+                        "401": {"description": "Unauthorized"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable Entity",
+                        },
+                    },
+                    "summary": "google_auth <POST>",
                     "tags": [],
                 }
             },


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25116
Page Notion : https://www.notion.so/passcultureapp/Spike-Implications-Backend-946b686524e7444b944add8c506ac3fe

## Etat initial

Le SSO Google a déjà en partie été implémenté par le backoffice. La librairie utilisée est [Flask OAuth Client - Authlib 1.2.1 documentation](https://docs.authlib.org/en/latest/client/flask.html#routes-for-authorization).

Authlib valide pour nous le token Google et nous retrouvons l'utilisateur à travers son email dans notre base de donnée `User`.

## Modèle

Une simple table `single_sign_on` qui pointe vers `user` :

![image](https://github.com/pass-culture/pass-culture-main/assets/26348504/e800a043-45e0-4cf5-98d4-2da05a4ad5c4)

Cette implémentation permet :

- d’éviter d’ajouter une colonne dans la table `user` qui est déjà très chargée et qui risque de devoir être fait manuellement au vu de la taille de la table
- d’ajouter facilement un autre SSO que celui Google, comme educonnect, pour chaque compte
- de retirer facilement la liaison d’un compte au SSO Google.

L’adresse email du côté SSO n’est pas conservé pour permettre à un jeune de changer l’adresse mail associée à son compte Google après la liaison de ses comptes Google et pass Culture.

## Logique d'autorisation

![image](https://github.com/pass-culture/pass-culture-main/assets/26348504/48b0b71a-ccc0-4033-82dd-5d3f562b2675)