### PR TITLE
(PC-24808)[BO] feat: add bank account detail page

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1384,6 +1384,25 @@ def get_venue_base_query(venue_id: int) -> BaseQuery:
     return models.Venue.query.outerjoin(offerers_models.VenueContact).filter(models.Venue.id == venue_id)
 
 
+def get_bank_account_base_query(bank_account_id: int) -> BaseQuery:
+    return finance_models.BankAccount.filter(finance_models.BankAccount.id == bank_account_id)
+
+
+def search_bank_account(search_query: str, *_: typing.Any) -> BaseQuery:
+    bank_accounts = finance_models.BankAccount.query.options(sa.orm.joinedload(finance_models.BankAccount.offerer))
+
+    search_query = search_query.strip()
+    if not search_query:
+        return bank_accounts.filter(False)
+
+    if search_query.isnumeric():
+        bank_accounts = bank_accounts.filter(finance_models.BankAccount.id == int(search_query))
+    else:
+        return bank_accounts.filter(False)
+
+    return bank_accounts
+
+
 def get_offerer_basic_info(offerer_id: int) -> sa.engine.Row:
     bank_informations_query = sa.select(sa.func.jsonb_object_agg(sa.text("status"), sa.text("number"))).select_from(
         sa.select(

--- a/api/src/pcapi/routes/backoffice/__init__.py
+++ b/api/src/pcapi/routes/backoffice/__init__.py
@@ -15,6 +15,7 @@ def install_routes(app: Flask) -> None:
     from .accounts import blueprint as accounts_blueprint
     from .admin import blueprint as admin_blueprint
     from .admin import bo_users_blueprint
+    from .bank_account import blueprint as bank_account_blueprint
     from .bookings import collective_bookings_blueprint
     from .bookings import individual_bookings_blueprint
     from .collective_offers import collective_offer_templates_blueprint

--- a/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
@@ -1,0 +1,94 @@
+from datetime import datetime
+
+from flask import render_template
+from flask import request
+from flask import url_for
+import sqlalchemy as sa
+from werkzeug.exceptions import NotFound
+
+from pcapi.connectors.dms import api as dms_api
+from pcapi.core.finance import models as finance_models
+from pcapi.core.history import models as history_models
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.permissions import models as perm_models
+from pcapi.core.users import models as users_models
+from pcapi.routes.backoffice import utils
+from pcapi.routes.backoffice.forms import search as search_forms
+from pcapi.routes.backoffice.forms.search import TypeOptions
+from pcapi.utils.human_ids import humanize
+
+
+bank_blueprint = utils.child_backoffice_blueprint(
+    "bank_account",
+    __name__,
+    url_prefix="/pro/bank-account",
+    permission=perm_models.Permissions.READ_PRO_ENTITY,
+)
+
+
+def render_bank_account_details(bank_account: finance_models.BankAccount) -> str:
+    return render_template(
+        "bank_account/get.html",
+        search_form=search_forms.CompactProSearchForm(q=request.args.get("q"), pro_type=TypeOptions.BANK_ACCOUNT.name),
+        search_dst=url_for("backoffice_web.search_pro"),
+        bank_account=bank_account,
+        humanized_bank_account_id=humanize(bank_account.id),
+        dms_stats=dms_api.get_dms_stats(bank_account.dsApplicationId),
+        active_tab=request.args.get("active_tab", "linked_venues"),
+    )
+
+
+@bank_blueprint.route("/<int:bank_account_id>", methods=["GET"])
+def get(bank_account_id: int) -> utils.BackofficeResponse:
+    bank_account = (
+        finance_models.BankAccount.query.filter(finance_models.BankAccount.id == bank_account_id)
+        .options(
+            sa.orm.joinedload(finance_models.BankAccount.offerer),
+        )
+        .one_or_none()
+    )
+    if not bank_account:
+        raise NotFound()
+
+    return render_bank_account_details(bank_account)
+
+
+@bank_blueprint.route("/<int:bank_account_id>/linked_venues", methods=["GET"])
+def get_linked_venues(bank_account_id: int) -> utils.BackofficeResponse:
+    linked_venues = (
+        offerers_models.VenueBankAccountLink.query.filter(
+            offerers_models.VenueBankAccountLink.bankAccountId == bank_account_id,
+            offerers_models.VenueBankAccountLink.timespan.contains(datetime.utcnow()),
+        ).options(
+            sa.orm.joinedload(offerers_models.VenueBankAccountLink.venue).load_only(
+                offerers_models.Venue.id,
+                offerers_models.Venue.name,
+                offerers_models.Venue.publicName,
+                offerers_models.Venue.isVirtual,
+                offerers_models.Venue.managingOffererId,
+            )
+        )
+    ).all()
+
+    return render_template(
+        "bank_account/get/linked_venues.html", linked_venues=linked_venues, bank_account_id=bank_account_id
+    )
+
+
+@bank_blueprint.route("/<int:bank_account_id>/history", methods=["GET"])
+def get_history(bank_account_id: int) -> utils.BackofficeResponse:
+    actions_history = (
+        history_models.ActionHistory.query.filter_by(bankAccountId=bank_account_id)
+        .order_by(history_models.ActionHistory.actionDate.desc())
+        .options(
+            sa.orm.joinedload(history_models.ActionHistory.authorUser).load_only(
+                users_models.User.id, users_models.User.firstName, users_models.User.lastName
+            ),
+        )
+        .all()
+    )
+
+    return render_template(
+        "bank_account/get/history.html",
+        actions=actions_history,
+    )

--- a/api/src/pcapi/routes/backoffice/forms/search.py
+++ b/api/src/pcapi/routes/backoffice/forms/search.py
@@ -15,6 +15,7 @@ class TypeOptions(enum.Enum):
     OFFERER = "offerer"
     VENUE = "venue"
     USER = "user"
+    BANK_ACCOUNT = "bank-account"
 
 
 def format_search_type_options(type_option: TypeOptions) -> str:
@@ -25,6 +26,8 @@ def format_search_type_options(type_option: TypeOptions) -> str:
             return "Lieu"
         case TypeOptions.USER:
             return "Compte pro"
+        case TypeOptions.BANK_ACCOUNT:
+            return "Compte bancaire"
         case _:
             return type_option.value
 

--- a/api/src/pcapi/routes/backoffice/pro.py
+++ b/api/src/pcapi/routes/backoffice/pro.py
@@ -60,6 +60,15 @@ class VenueContext(Context):
         return url_for(".venue.get", venue_id=row_id, **kwargs)
 
 
+class BankAccountContext(Context):
+    fetch_rows_func = offerers_api.search_bank_account
+    get_item_base_query = offerers_api.get_bank_account_base_query
+
+    @classmethod
+    def get_pro_link(cls, row_id: int, **kwargs: typing.Any) -> str:
+        return url_for(".bank_account.get", bank_account_id=row_id, **kwargs)
+
+
 def render_search_template(form: search_forms.ProSearchForm | None = None) -> str:
     if form is None:
         preferences = current_user.backoffice_profile.preferences
@@ -133,4 +142,5 @@ def get_context(pro_type: search_forms.TypeOptions) -> typing.Type[Context]:
         search_forms.TypeOptions.USER: UserContext,
         search_forms.TypeOptions.OFFERER: OffererContext,
         search_forms.TypeOptions.VENUE: VenueContext,
+        search_forms.TypeOptions.BANK_ACCOUNT: BankAccountContext,
     }[pro_type]

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
@@ -1,0 +1,99 @@
+{% from "components/forms.html" import build_form_fields_group with context %}
+{% import "components/links.html" as links %}
+{% from "components/presentation/details/tabs.html" import build_details_tab %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_wrapper %}
+{% from "components/presentation/details/tabs.html" import build_details_tab_content %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
+{% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
+{% from "components/turbo/spinner.html" import build_loading_spinner with context %}
+{% import "components/clipboard.html" as clipboard %}
+{% extends "layouts/pro.html" %}
+{% block pro_main_content %}
+  <div class="row row-cols-1 g-4 py-3">
+    <div class="col">
+      <div class="card shadow">
+        <div class="card-body">
+          <div class="d-flex flex-fill align-items-center">
+            <h2 class="card-title text-primary">{{ bank_account.label }}</h2>
+            <span class="fs-5 ps-4">
+              <span class="me-1 pb-1 badge rounded-pill text-bg-warning align-middle">Compte bancaire</span>
+            </span>
+            {% if dms_stats %}
+              <div class="d-flex row-reverse justify-content-end flex-grow-1">
+                <a href="{{ dms_stats.url }}"
+                   target="_blank"
+                   class="card-link">
+                  <button class="btn btn-outline-primary lead fw-bold mt-2 mx-3"
+                          type="button">ACCÉDER AU DOSSIER DMS CB</button>
+                </a>
+              </div>
+            {% endif %}
+          </div>
+          <p class="card-subtitle text-muted mb-3 h5">Bank Account ID : {{ bank_account.id }}</p>
+          <p class="card-subtitle text-muted mb-3 h5">Humanized ID : {{ humanized_bank_account_id }}</p>
+          <div class="row pt-3">
+            <div class="col-4">
+              <div class="fs-6">
+                <p class="mb-1">
+                  <span class="fw-bold">IBAN :</span>
+                  {{ bank_account.iban }}
+                </p>
+                <p class="mb-4">
+                  <span class="fw-bold">BIC :</span>
+                  {{ bank_account.bic }}
+                </p>
+                <p class="mb-1">
+                  <span class="fw-bold">Structure :</span>
+                  {{ links.build_offerer_name_to_details_link(bank_account.offerer) }}
+                </p>
+              </div>
+            </div>
+            <div class="col-4">
+              <div class="fs-6">
+                {% if dms_stats %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Statut DMS CB :</span>
+                    {{ dms_stats.status | format_dms_status }}
+                  </p>
+                  {% if dms_stats.status == "accepte" %}
+                    <p class="mb-4">
+                      <span class="fw-bold">Date de validation du dossier DMS CB :</span>
+                      {{ dms_stats.lastChangeDate | format_date }}
+                    </p>
+                  {% else %}
+                    <p class="mb-4">
+                      <span class="fw-bold">Date de dépôt du dossier DMS CB :</span>
+                      {{ dms_stats.subscriptionDate | format_date }}
+                    </p>
+                  {% endif %}
+                {% else %}
+                  <p class="mb-4">
+                    <span class="fw-bold">Pas de dossier DMS CB</span>
+                  </p>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="mt-4">
+        {% call build_details_tabs_wrapper() %}
+          {{ build_details_tab("linked-venues", "Lieux associés", active_tab == 'linked_venues') }}
+          {{ build_details_tab("history", "Historique du compte bancaire", active_tab == 'history') }}
+        {% endcall %}
+        {% call build_details_tabs_content_wrapper() %}
+          {% call build_details_tab_content("linked-venues", active_tab == 'linked_venues') %}
+            <turbo-frame data-turbo="false" id="bank_account_venues_frame" loading="lazy" src="{{ url_for("backoffice_web.bank_account.get_linked_venues", bank_account_id=bank_account.id) }}">
+            {{ build_loading_spinner() }}
+            </turbo-frame>
+          {% endcall %}
+          {% call build_details_tab_content("history", active_tab == 'history') %}
+            <turbo-frame data-turbo="false" id="bank_account_history_frame" loading="lazy" src="{{ url_for("backoffice_web.bank_account.get_history", bank_account_id=bank_account.id) }}">
+            {{ build_loading_spinner() }}
+            </turbo-frame>
+          {% endcall %}
+        {% endcall %}
+      </div>
+    </div>
+  </div>
+{% endblock pro_main_content %}

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get/history.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get/history.html
@@ -1,0 +1,5 @@
+{% from "components/history/view.html" import build_history_view with context %}
+<turbo-frame id="bank_account_history_frame">
+{% call build_history_view(dst, form, actions, true) %}
+{% endcall %}
+</turbo-frame>

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get/linked_venues.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get/linked_venues.html
@@ -1,0 +1,23 @@
+{% import "components/links.html" as links %}
+<turbo-frame id="bank_account_venues_frame">
+<table class="table table-hover my-4">
+  <thead>
+    <tr>
+      <th scope="col"></th>
+      <th scope="col">ID</th>
+      <th scope="col">Nom</th>
+      <th scope="col">Date de rattachement</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for link_venue in linked_venues %}
+      <tr>
+        <th scope="row"></th>
+        <td class="fw-bolder">{{ links.build_venue_name_to_details_link(link_venue.venue, text_attr="id") }}</td>
+        <td class="text-break">{{ links.build_venue_name_to_pc_pro_link(link_venue.venue, public_name=true) }}</td>
+        <td>{{ link_venue.timespan.lower | format_date_time }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</turbo-frame>

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result.html
@@ -3,6 +3,8 @@
     {% include "components/search/result_card_offerer.html" %}
   {% elif result_type == "venue" %}
     {% include "components/search/result_card_venue.html" %}
+  {% elif result_type == "bank-account" %}
+    {% include "components/search/result_card_bank_account.html" %}
   {% else %}
     {% include "components/search/result_card.html" %}
   {% endif %}

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_bank_account.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_bank_account.html
@@ -1,0 +1,21 @@
+{% from "components/badges.html" import build_venue_badges %}
+{% from "components/links.html" import build_offerer_name_to_details_link %}
+<div class="card shadow">
+  <div class="card-body">
+    <h5 class="mb-3"></h5>
+    <h5 class="card-title">
+      <a href="{{ get_link_to_detail(row.id, q=q, search_rank=index, total_items=rows.total) }}"
+         class="link-primary">{{ row.label | upper }}</a>
+      <span class="fs-5 ps-4">
+        <span class="me-1 pb-1 badge rounded-pill text-bg-warning align-middle">Compte bancaire</span>
+      </span>
+    </h5>
+    <h6 class="card-subtitle mt-4 mb-3 text-muted">Bank Account ID : {{ row.id }}</h6>
+    <div class="d-flex flex-row-reverse">
+      <a href="{{ get_link_to_detail(row.id, q=q, search_rank=index, total_items=rows.total) }}"
+         class="btn btn-md btn-outline-primary fw-bold">
+        CONSULTER CE COMPTE <i class="bi bi-arrow-right"></i>
+      </a>
+    </div>
+  </div>
+</div>

--- a/api/src/pcapi/routes/backoffice/venues/serialization.py
+++ b/api/src/pcapi/routes/backoffice/venues/serialization.py
@@ -1,5 +1,3 @@
-import datetime
-
 from pcapi.routes.serialization import BaseModel
 
 
@@ -10,10 +8,3 @@ class VenueBankInformation(BaseModel):
     reimbursement_point_url: str | None
     bic: str | None
     iban: str | None
-
-
-class VenueDmsStats(BaseModel):
-    status: str
-    subscriptionDate: datetime.datetime
-    lastChangeDate: datetime.datetime
-    url: str

--- a/api/tests/routes/backoffice/bank_account_test.py
+++ b/api/tests/routes/backoffice/bank_account_test.py
@@ -1,0 +1,233 @@
+import datetime
+from unittest import mock
+
+from flask import url_for
+import pytest
+
+from pcapi.core.finance import factories as finance_factories
+from pcapi.core.history import factories as history_factories
+from pcapi.core.history import models as history_models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.permissions import models as perm_models
+from pcapi.core.testing import assert_num_queries
+from pcapi.utils.human_ids import humanize
+
+from .helpers import html_parser
+from .helpers.get import GetEndpointHelper
+
+
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice,
+]
+
+
+class GetBankAccountTest(GetEndpointHelper):
+    endpoint = "backoffice_web.bank_account.get"
+    endpoint_kwargs = {"bank_account_id": 1}
+    needed_permission = perm_models.Permissions.READ_PRO_ENTITY
+
+    # get session (1 query)
+    # get user with profile and permissions (1 query)
+    # get bank_account (1 query)
+    expected_num_queries = 3
+
+    def test_get_bank_account(self, authenticated_client):
+        bank_account = finance_factories.BankAccountFactory()
+
+        url = url_for(self.endpoint, bank_account_id=bank_account.id)
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        response_text = html_parser.content_as_text(response.data)
+        assert bank_account.label in response_text
+        assert f"Bank Account ID : {bank_account.id} " in response_text
+        assert f"Humanized ID : {humanize(bank_account.id)} " in response_text
+        assert f"IBAN : {bank_account.iban} " in response_text
+        assert f"BIC : {bank_account.bic} " in response_text
+        assert "Statut dossier DMS Adage :" not in response_text
+        assert "Pas de dossier DMS CB" in response_text
+        assert "ACCÉDER AU DOSSIER DMS CB" not in response_text
+
+    def test_get_venue_dms_stats(self, authenticated_client):
+        with mock.patch("pcapi.connectors.dms.api.DMSGraphQLClient.get_bank_info_status") as bank_info_mock:
+            bank_info_mock.return_value = {
+                "dossier": {
+                    "state": "en_construction",
+                    "dateDepot": "2022-09-21T16:30:22+02:00",
+                    "dateDerniereModification": "2022-09-22T16:30:22+02:00",
+                }
+            }
+            bank_account = finance_factories.BankAccountFactory()
+
+            url = url_for(self.endpoint, bank_account_id=bank_account.id)
+
+            with assert_num_queries(self.expected_num_queries):
+                response = authenticated_client.get(url)
+                assert response.status_code == 200
+
+        # then
+        response_text = html_parser.content_as_text(response.data)
+        assert "Statut DMS CB : En construction" in response_text
+        assert "Date de dépôt du dossier DMS CB : 21/09/2022" in response_text
+        assert "Date de validation du dossier DMS CB" not in response_text
+        assert "ACCÉDER AU DOSSIER DMS CB" in response_text
+
+    def test_get_venue_dms_stats_for_accepted_file(self, authenticated_client, venue_with_draft_bank_info):
+        with mock.patch("pcapi.connectors.dms.api.DMSGraphQLClient.get_bank_info_status") as bank_info_mock:
+            bank_info_mock.return_value = {
+                "dossier": {
+                    "state": "accepte",
+                    "dateDepot": "2022-09-21T16:30:22+02:00",
+                    "dateDerniereModification": "2022-09-23T16:30:22+02:00",
+                }
+            }
+            bank_account = finance_factories.BankAccountFactory()
+
+            url = url_for(self.endpoint, bank_account_id=bank_account.id)
+
+            with assert_num_queries(self.expected_num_queries):
+                response = authenticated_client.get(url)
+                assert response.status_code == 200
+
+        response_text = html_parser.content_as_text(response.data)
+        assert "Statut DMS CB : Accepté" in response_text
+        assert "Date de validation du dossier DMS CB : 23/09/2022" in response_text
+        assert "Date de dépôt du dossier DMS CB" not in response_text
+        assert "ACCÉDER AU DOSSIER DMS CB" in response_text
+
+
+class GetBankAccountVenuesTest(GetEndpointHelper):
+    endpoint = "backoffice_web.bank_account.get_linked_venues"
+    endpoint_kwargs = {"bank_account_id": 1}
+    needed_permission = perm_models.Permissions.READ_PRO_ENTITY
+
+    # - session + authenticated user (2 queries)
+    # - venues with joined data (1 query)
+    expected_num_queries = 3
+
+    def test_get_linked_venues(self, authenticated_client):
+        bank_account = finance_factories.BankAccountFactory()
+        bank_account2 = finance_factories.BankAccountFactory()
+
+        offerer = offerers_factories.OffererFactory()
+        venue_1 = offerers_factories.VenueFactory(managingOfferer=offerer)
+        venue_2 = offerers_factories.VenueFactory(managingOfferer=offerer)
+
+        link_venue1_date = datetime.datetime(2022, 10, 3, 13, 1)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue_1, bankAccount=bank_account, timespan=(link_venue1_date,)
+        )
+        link_venue2_date = datetime.datetime(2023, 8, 4, 14, 2)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue_2, bankAccount=bank_account, timespan=(link_venue2_date,)
+        )
+
+        offerers_factories.VenueBankAccountLinkFactory(venue=venue_1, bankAccount=bank_account2)
+
+        # Don't interfere
+        other_offerer = offerers_factories.OffererFactory()
+        offerers_factories.VenueFactory(managingOfferer=other_offerer)
+
+        url = url_for(self.endpoint, bank_account_id=bank_account.id)
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 2
+
+        # Sort before checking rows data to avoid flaky test
+        rows = sorted(rows, key=lambda row: int(row["ID"]))
+
+        assert rows[0]["ID"] == str(venue_1.id)
+        assert rows[0]["Nom"] == venue_1.name
+        assert rows[0]["Date de rattachement"].startswith(link_venue1_date.strftime("%d/%m/%Y à "))
+
+        assert rows[1]["ID"] == str(venue_2.id)
+        assert rows[1]["Nom"] == venue_2.name
+        assert rows[1]["Date de rattachement"].startswith(link_venue2_date.strftime("%d/%m/%Y à "))
+
+
+class GetOffererHistoryTest(GetEndpointHelper):
+    endpoint = "backoffice_web.bank_account.get_history"
+    endpoint_kwargs = {"bank_account_id": 1}
+    needed_permission = perm_models.Permissions.READ_PRO_ENTITY
+
+    # - session + authenticated user (2 queries)
+    # - full history with joined data (1 query)
+    expected_num_queries = 3
+
+    def test_no_action(self, authenticated_client):
+        bank_account = finance_factories.BankAccountFactory()
+
+        url = url_for(self.endpoint, bank_account_id=bank_account.id)
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        assert html_parser.count_table_rows(response.data) == 0
+
+    def test_get_history(self, authenticated_client, legit_user):
+        bank_account = finance_factories.BankAccountFactory()
+
+        action = history_factories.ActionHistoryFactory(
+            bankAccount=bank_account,
+            actionType=history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED,
+            authorUser=legit_user,
+            user=legit_user,
+        )
+
+        url = url_for(self.endpoint, bank_account_id=bank_account.id)
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 1
+        assert rows[0]["Type"] == history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED.value
+        assert rows[0]["Date/Heure"].startswith(action.actionDate.strftime("Le %d/%m/%Y à "))
+        assert rows[0]["Auteur"] == action.authorUser.full_name
+
+    def test_get_full_sorted_history(self, authenticated_client, legit_user):
+        # given
+        bank_account = finance_factories.BankAccountFactory()
+
+        link_action = history_factories.ActionHistoryFactory(
+            actionDate=datetime.datetime(2022, 10, 3, 13, 1),
+            actionType=history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED,
+            authorUser=legit_user,
+            user=legit_user,
+            bankAccount=bank_account,
+        )
+        unlink_action = history_factories.ActionHistoryFactory(
+            actionDate=datetime.datetime(2022, 10, 4, 14, 2),
+            actionType=history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_DEPRECATED,
+            authorUser=legit_user,
+            user=legit_user,
+            bankAccount=bank_account,
+        )
+
+        url = url_for(self.endpoint, bank_account_id=bank_account.id)
+
+        # when
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        # then
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 2
+
+        assert rows[0]["Type"] == "Lieu dissocié d'un compte bancaire"
+        assert rows[0]["Date/Heure"].startswith(unlink_action.actionDate.strftime("Le %d/%m/%Y à "))
+        assert rows[0]["Auteur"] == legit_user.full_name
+
+        assert rows[1]["Type"] == "Lieu associé à un compte bancaire"
+        assert rows[1]["Date/Heure"].startswith(link_action.actionDate.strftime("Le %d/%m/%Y à "))
+        assert rows[1]["Auteur"] == legit_user.full_name


### PR DESCRIPTION
## But de la pull request

Affiche le detail d'un compte bancaire, retrouvable via la recherche d'un acteur culturel.
L'onglet Remboursements n'a plus à faire, faute de nouveau modèle.

Ticket Jira : https://passculture.atlassian.net/browse/PC-24808

Page sans DMS:
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/f51c5a33-fcea-44fd-8649-7491ad9779ee)


Historique : 
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/7d79e25e-40a5-4551-94b5-e1a8e89de8ec)

Avec DMS :
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/82dcef14-257b-41c9-99a5-261e3a09154a)


## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques