### PR TITLE
(PC-25316)[API] fix: error for truncated image

### DIFF
--- a/api/src/pcapi/utils/image_conversion.py
+++ b/api/src/pcapi/utils/image_conversion.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import PIL
 from PIL import Image
+from PIL import ImageFile
 from PIL import ImageOps
 from pydantic.v1 import confloat
 
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
     CropParam = float
 else:
     CropParam = confloat(ge=0.0, le=1.0)
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
 @dataclass

--- a/api/tests/utils/image_conversion_test.py
+++ b/api/tests/utils/image_conversion_test.py
@@ -104,3 +104,7 @@ class ImageConversionTest:
         assert result_image.width < original_image.width
         assert result_image.height < original_image.height
         assert (result_image.width / result_image.height) == pytest.approx(expected_ratio, 0.01)
+
+    def test_do_not_raise_error_when_image_is_truncated(self):
+        image_as_bytes = (IMAGES_DIR / "mouette_full_size.jpg").read_bytes()
+        assert _pre_process_image(image_as_bytes[:-25]).size == (1786, 1785)


### PR DESCRIPTION
## But de la pull request

Permet de résoudre l'`OSError`  qui est levée dans le cas où on crée une miniature à partir d'une image tronquée. 

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25316

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques