### PR TITLE
(PC-25357)[PRO] fix: display error message on email inscription field

### DIFF
--- a/pro/src/ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput.tsx
+++ b/pro/src/ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput.tsx
@@ -42,8 +42,8 @@ const EmailSpellCheckInput = <FormType,>({
       if (suggestion) {
         setEmailValidationTip(suggestion)
       }
-      setFieldTouched(field.name, true)
     }
+    setFieldTouched(field.name, true)
   }
   const resetEmailValidation = () => {
     setEmailValidationTip(null)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25357

Afficher le message d'erreur sous le champ email quand on quitte le champ en n'ayant encore rien saisi dedans


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques