### PR TITLE
(PC-24828)[API] feat: Send correct price error to front

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -599,6 +599,7 @@ def edit_stock(
     if price_category is not UNCHANGED and price_category is not None and price_category is not stock.priceCategory:
         modifications["priceCategory"] = price_category
         modifications["price"] = price_category.price
+        validation.check_stock_price(price_category.price, stock.offer)
 
     if quantity is not UNCHANGED and quantity != stock.quantity:
         modifications["quantity"] = quantity

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -72,6 +72,8 @@ def upsert_stocks(
 
     stocks_to_edit = [stock for stock in body.stocks if isinstance(stock, serialization.StockEditionBodyModel)]
     stocks_to_create = [stock for stock in body.stocks if isinstance(stock, serialization.StockCreationBodyModel)]
+    offers_validation.check_stocks_price(stocks_to_edit, offer)
+    offers_validation.check_stocks_price(stocks_to_create, offer)
     if stocks_to_create:
         number_of_existing_stocks = _get_number_of_existing_stocks(body.offer_id)
         if number_of_existing_stocks + len(stocks_to_create) > offers_models.Offer.MAX_STOCKS_PER_OFFER:


### PR DESCRIPTION
## But de la pull request

On veut renvoyer au front dans le bon champ l'erreur créé lors de la validation du prix (s'il est négatif ou > 300€) lors de l'édition d'un stock.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24828

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques