### PR TITLE
(BSR)[API] refactor: Use `CustomReimbursementRule.amount` instead of `amountInEuroCents"

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 389e0a92925f (pre) (head)
-80ee25f3632d (post) (head)
+55e87bc5d320 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231106T142559_55e87bc5d320_remove_custom_reimbursement_rule_amount_in_eurocents.py
+++ b/api/src/pcapi/alembic/versions/20231106T142559_55e87bc5d320_remove_custom_reimbursement_rule_amount_in_eurocents.py
@@ -1,0 +1,22 @@
+"""Remove `custom_reimbursement_rule.amountInEurocents` column
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "55e87bc5d320"
+down_revision = "80ee25f3632d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("custom_reimbursement_rule", "amountInEuroCents")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "custom_reimbursement_rule", sa.Column("amountInEuroCents", sa.INTEGER(), autoincrement=False, nullable=True)
+    )

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -2476,7 +2476,6 @@ def _create_reimbursement_rule(
         subcategories=subcategories,
         rate=rate,  # only for offerers
         amount=utils.to_eurocents(amount) if amount is not None else None,  # only for offers
-        amountInEuroCents=utils.to_eurocents(amount) if amount is not None else None,
         timespan=(start_date, end_date),
     )
     validation.validate_reimbursement_rule(rule)

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -192,7 +192,6 @@ class CustomReimbursementRuleFactory(BaseFactory):
         ]
     )
     amount = 500
-    amountInEuroCents = 500
 
     @classmethod
     def _create(
@@ -203,7 +202,6 @@ class CustomReimbursementRuleFactory(BaseFactory):
     ) -> models.CustomReimbursementRule:
         if "rate" in kwargs:
             kwargs["amount"] = None
-            kwargs["amountInEuroCents"] = None
         if "offerer" in kwargs:
             kwargs["offer"] = None
         return super()._create(model_class, *args, **kwargs)

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -539,9 +539,8 @@ class CustomReimbursementRule(ReimbursementRule, Base, Model):
     # offerer.
     subcategories: list[str] = sqla.Column(sqla_psql.ARRAY(sqla.Text()), server_default="{}")
 
+    # The amount of the reimbursement, or NULL if `rate` is set.
     amount: int = sqla.Column(sqla.Integer, nullable=True)
-    amountInEuroCents: int = sqla.Column(sqla.Integer, nullable=True)
-
     # rate is between 0 and 1 (included), or NULL if `amount` is set.
     rate: decimal.Decimal = sqla.Column(sqla.Numeric(5, 4), nullable=True)
 
@@ -590,8 +589,8 @@ class CustomReimbursementRule(ReimbursementRule, Base, Model):
         booking: "bookings_models.Booking",
         custom_total_amount: int | None = None,
     ) -> int:
-        if self.amountInEuroCents is not None:
-            return booking.quantity * self.amountInEuroCents
+        if self.amount is not None:
+            return booking.quantity * self.amount
         return super().apply(booking, custom_total_amount)
 
     @property

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
@@ -82,7 +82,7 @@
                   <td>{{ links.build_offer_name_to_pc_pro_link(reimbursement_rule.offer) }}</td>
                 {% endif %}
                 <td>{{ reimbursement_rule.rate | format_rate_multiply_by_100 }}</td>
-                <td>{{ reimbursement_rule.amountInEuroCents | format_cents if reimbursement_rule.amountInEuroCents else "" }}</td>
+                <td>{{ reimbursement_rule.amount | format_cents if reimbursement_rule.amount else "" }}</td>
                 <td>{{ reimbursement_rule.subcategories | format_subcategories }}</td>
                 <td>{{ reimbursement_rule.timespan | format_timespan }}</td>
               </tr>

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -58,7 +58,7 @@ def create_specific_invoice() -> None:
     custom_rule_offer1 = offers_factories.ThingOfferFactory(venue=venue)
     finance_factories.CustomReimbursementRuleFactory(rate=0.94, offer=custom_rule_offer1)
     custom_rule_offer2 = offers_factories.ThingOfferFactory(venue=venue)
-    finance_factories.CustomReimbursementRuleFactory(amountInEuroCents=2200, offer=custom_rule_offer2)
+    finance_factories.CustomReimbursementRuleFactory(amount=2200, offer=custom_rule_offer2)
 
     stocks = [
         offers_factories.StockFactory(offer=thing_offer1, price=30),

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1791,7 +1791,7 @@ def test_generate_payments_file():
         booking__stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         booking__stock__offer__venue=offer_venue2,
         standardRule="",
-        customRule=factories.CustomReimbursementRuleFactory(amountInEuroCents=600),
+        customRule=factories.CustomReimbursementRuleFactory(amount=600),
     )
     # pricing for an underage individual booking
     underage_user = users_factories.UnderageBeneficiaryFactory()
@@ -1804,7 +1804,7 @@ def test_generate_payments_file():
         booking__stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         booking__stock__offer__venue=offer_venue2,
         standardRule="",
-        customRule=factories.CustomReimbursementRuleFactory(amountInEuroCents=600),
+        customRule=factories.CustomReimbursementRuleFactory(amount=600),
     )
     # pricing for educational booking
     # check that the right deposit is used for csv
@@ -2014,7 +2014,7 @@ def invoice_test_data():
     custom_rule_offer1 = offers_factories.ThingOfferFactory(venue=venue)
     factories.CustomReimbursementRuleFactory(rate=0.94, offer=custom_rule_offer1)
     custom_rule_offer2 = offers_factories.ThingOfferFactory(venue=venue)
-    factories.CustomReimbursementRuleFactory(amountInEuroCents=2200, offer=custom_rule_offer2)
+    factories.CustomReimbursementRuleFactory(amount=2200, offer=custom_rule_offer2)
 
     stocks = [
         offers_factories.StockFactory(offer=thing_offer1, price=30),
@@ -2194,7 +2194,7 @@ class GenerateInvoiceTest:
 
         offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=23)
-        factories.CustomReimbursementRuleFactory(amountInEuroCents=2200, offer=offer)
+        factories.CustomReimbursementRuleFactory(amount=2200, offer=offer)
         booking1 = bookings_factories.UsedBookingFactory(stock=stock)
         booking2 = bookings_factories.UsedBookingFactory(stock=stock)
         api.price_booking(booking1)
@@ -2759,7 +2759,6 @@ class CreateOfferReimbursementRuleTest:
         db.session.refresh(rule)
         assert rule.offer == offer
         assert rule.amount == 1234
-        assert rule.amountInEuroCents == 1234
         assert rule.timespan.lower == datetime.datetime(2021, 10, 2, 0, 0)
         assert rule.timespan.upper == datetime.datetime(2021, 10, 3, 0, 0)
 

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -30,7 +30,6 @@ class AddCustomOfferReimbursementRuleTest:
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offer.id == offer_id
         assert rule.amount == 1234
-        assert rule.amountInEuroCents == 1234
 
     @clean_database
     def test_warnings(self, app):
@@ -76,7 +75,6 @@ class AddCustomOfferReimbursementRuleTest:
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offer.id == offer_id
         assert rule.amount == 1234
-        assert rule.amountInEuroCents == 1234
 
 
 @clean_database

--- a/api/tests/core/finance/test_models.py
+++ b/api/tests/core/finance/test_models.py
@@ -86,7 +86,7 @@ class CustomReimbursementRuleTest:
         assert not rule.is_relevant(booking2)
 
     def test_apply_with_amount(self):
-        rule = factories.CustomReimbursementRuleFactory(amountInEuroCents=1000)
+        rule = factories.CustomReimbursementRuleFactory(amount=1000)
         single = bookings_factories.BookingFactory(quantity=1, amount=12)
         double = bookings_factories.BookingFactory(quantity=2, amount=12)
 

--- a/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
@@ -40,7 +40,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
     def test_list_custom_reimbursement_rules(self, authenticated_client):
         start = datetime.datetime.utcnow() - datetime.timedelta(days=365)
         end = datetime.datetime.utcnow() + datetime.timedelta(days=365)
-        offer_rule = finance_factories.CustomReimbursementRuleFactory(amountInEuroCents=2700, timespan=(start, None))
+        offer_rule = finance_factories.CustomReimbursementRuleFactory(amount=2700, timespan=(start, None))
         offerer = offerers_factories.OffererFactory()
         offerer_rule = finance_factories.CustomReimbursementRuleFactory(
             offerer=offerer, rate=0.5, subcategories=["FESTIVAL_LIVRE"]


### PR DESCRIPTION
`CustomReimbursementRule.amount` is one the last model columns (in
`core.finance`) where we store euros and not eurocents. This commit is
the third step in storing eurocents in the `amount` column.

   step 1: add `amountInEurocents` and write in both `amount` and
           `amountInEurocents`. Also, populate `amountInEurocents`
           for existing rows.
   step 2: use `amountInEuroCents` column instead of `amount`.
   step 3: store eurocents in `amount` column.
-> step 4: use `amount` column.
   step 5: drop `amountInEuroCents` column.

---

Cette PR sera mergée après la MEP de l'étape 3 (lundi 30).