### PR TITLE
(BSR)[API] feat: Add NOT NULL constraint on `offerer.dsToken`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 9470268ecb94 (pre) (head)
-6025fbc18ebb (post) (head)
+c65dc74438f0 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231025T152847_c65dc74438f0_not_null_on_offerer_ds_token.py
+++ b/api/src/pcapi/alembic/versions/20231025T152847_c65dc74438f0_not_null_on_offerer_ds_token.py
@@ -1,0 +1,20 @@
+"""Add NOT NULL constraint on "offerer.dsToken"
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "c65dc74438f0"
+down_revision = "6025fbc18ebb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("offerer", "dsToken", existing_type=sa.TEXT(), nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("offerer", "dsToken", existing_type=sa.TEXT(), nullable=True)

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -836,7 +836,7 @@ class Offerer(
     offererProviders: list["OffererProvider"] = sa.orm.relationship("OffererProvider", back_populates="offerer")
     thumb_path_component = "offerers"
 
-    dsToken: str = Column(Text, nullable=True, unique=True)
+    dsToken: str = Column(Text, nullable=False, unique=True)
 
     bankAccounts: list[finance_models.BankAccount] = sa.orm.relationship(
         finance_models.BankAccount,


### PR DESCRIPTION
All offerers should now be created with a `dsToken` (and all existing
offerers have one).

---

Cette PR sera mergée lorsque [ce commit](https://github.com/pass-culture/pass-culture-main/commit/87b3cbd4f156c68dd61231a7e0761371e4349d6d) aura été déployé en production (lundi 30/10). Il corrige le dernier endroit où l'on oubliait de remplir la colonne `dsToken`.