### PR TITLE
(PC-25048)[PRO] fix: remove useless padding for offer image

### DIFF
--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.module.scss
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.module.scss
@@ -63,6 +63,7 @@
   width: rem.torem(80px);
   height: rem.torem(80px);
   border-radius: rem.torem(4px);
+  padding: 0;
 }
 
 .offer-title {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25048

Fix l'affichage des images par défaut pour les offres vitrines dans l'écran de duplication


![Capture d’écran 2023-10-26 à 09 41 46](https://github.com/pass-culture/pass-culture-main/assets/71768799/0d2d9e66-b9b6-4d76-a908-0a7b9acc61df)
