### PR TITLE
(PC-25414)[PRO/API] feat: use new route in event creation summary

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -181,10 +181,10 @@ def get_stocks_stats(offer_id: int) -> offers_serialize.StockStatsResponseModel:
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
     stocks_stats = offers_api.get_stocks_stats(offer_id=offer_id)
     return offers_serialize.StockStatsResponseModel(
-        oldest_stock=stocks_stats.oldest_stock,
-        newest_stock=stocks_stats.newest_stock,
-        stock_count=stocks_stats.stock_count,
-        remaining_quantity=stocks_stats.remaining_quantity,
+        oldestStock=stocks_stats.oldest_stock,
+        newestStock=stocks_stats.newest_stock,
+        stockCount=stocks_stats.stock_count,
+        remainingQuantity=stocks_stats.remaining_quantity,
     )
 
 

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -369,10 +369,13 @@ class GetStocksResponseModel(BaseModel):
 
 
 class StockStatsResponseModel(BaseModel):
-    oldest_stock: datetime.datetime | None
-    newest_stock: datetime.datetime | None
-    stock_count: int | None
-    remaining_quantity: int | None
+    oldestStock: datetime.datetime | None
+    newestStock: datetime.datetime | None
+    stockCount: int | None
+    remainingQuantity: int | None
+
+    class Config:
+        json_encoders = {datetime.datetime: format_into_utc_date}
 
 
 class StocksQueryModel(BaseModel):

--- a/api/tests/routes/pro/get_stocks_stats_test.py
+++ b/api/tests/routes/pro/get_stocks_stats_test.py
@@ -77,8 +77,8 @@ class Returns200Test:
         # Then
         assert response.status_code == 200
         assert response.json == {
-            "stock_count": 2,
-            "oldest_stock": "2020-10-15T01:00:00",
-            "newest_stock": "2020-10-15T02:00:00",
-            "remaining_quantity": 15,
+            "stockCount": 2,
+            "oldestStock": "2020-10-15T01:00:00Z",
+            "newestStock": "2020-10-15T02:00:00Z",
+            "remainingQuantity": 15,
         }

--- a/pro/src/apiClient/v1/models/StockStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/StockStatsResponseModel.ts
@@ -4,9 +4,9 @@
 /* eslint-disable */
 
 export type StockStatsResponseModel = {
-  newest_stock?: string | null;
-  oldest_stock?: string | null;
-  remaining_quantity?: number | null;
-  stock_count?: number | null;
+  newestStock?: string | null;
+  oldestStock?: string | null;
+  remainingQuantity?: number | null;
+  stockCount?: number | null;
 };
 

--- a/pro/src/components/Callout/__specs__/LinkVenueCallout.spec.tsx
+++ b/pro/src/components/Callout/__specs__/LinkVenueCallout.spec.tsx
@@ -52,7 +52,7 @@ describe('LinkVenueCallout', () => {
       },
     ])(
       'should not render the add link venue banner if the offerer  hasValidBankAccount = $hasValidBankAccount and venuesWithNonFreeOffersWithoutBankAccounts = $venuesWithNonFreeOffersWithoutBankAccounts',
-      async ({
+      ({
         hasValidBankAccount,
         venuesWithNonFreeOffersWithoutBankAccounts,
         ...rest

--- a/pro/src/screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen.tsx
@@ -17,7 +17,7 @@ import { RecurrenceSummary } from './RecurrenceSummary'
 import styles from './StocksSummary.module.scss'
 
 export const StocksSummaryScreen = () => {
-  const { offer, subCategories } = useIndividualOfferContext()
+  const { offer } = useIndividualOfferContext()
   const [isLoading, setIsLoading] = useState(false)
   const [stocks, setStocks] = useState<StocksEvent[]>([])
   const notify = useNotification()
@@ -45,9 +45,6 @@ export const StocksSummaryScreen = () => {
   if (offer === null || isLoading) {
     return null
   }
-  const canBeDuo = subCategories.find(
-    (subcategory) => subcategory.id === offer.subcategoryId
-  )?.canBeDuo
 
   const editLink = getIndividualOfferUrl({
     offerId: offer.id,
@@ -73,7 +70,7 @@ export const StocksSummaryScreen = () => {
       {offer.isEvent ? (
         <RecurrenceSummary offer={offer} stocks={stocks} />
       ) : (
-        <StockThingSection offer={offer} canBeDuo={canBeDuo} />
+        <StockThingSection stock={offer.stocks[0]} />
       )}
     </SummaryLayout.Section>
   )

--- a/pro/src/screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen.tsx
@@ -19,7 +19,7 @@ import styles from './StocksSummary.module.scss'
 export const StocksSummaryScreen = () => {
   const { offer } = useIndividualOfferContext()
   const [isLoading, setIsLoading] = useState(false)
-  const [stocks, setStocks] = useState<StocksEvent[]>([])
+  const [stocksEvent, setStocksEvent] = useState<StocksEvent[]>([])
   const notify = useNotification()
 
   useEffect(() => {
@@ -29,7 +29,7 @@ export const StocksSummaryScreen = () => {
         try {
           const response = await api.getStocks(offer.id)
 
-          setStocks(serializeStockEvents(response.stocks))
+          setStocksEvent(serializeStockEvents(response.stocks))
         } catch {
           notify.error(
             'Une erreur est survenue lors du chargement de vos stocks.'
@@ -52,7 +52,10 @@ export const StocksSummaryScreen = () => {
     mode: OFFER_WIZARD_MODE.EDITION,
   })
 
-  const stockWarningText = getStockWarningText(offer)
+  const stockWarningText = getStockWarningText(
+    offer.status,
+    offer.isEvent ? stocksEvent.length : offer.stocks.length
+  )
 
   return (
     <SummaryLayout.Section
@@ -68,7 +71,7 @@ export const StocksSummaryScreen = () => {
       )}
 
       {offer.isEvent ? (
-        <RecurrenceSummary offer={offer} stocks={stocks} />
+        <RecurrenceSummary offer={offer} stocks={stocksEvent} />
       ) : (
         <StockThingSection stock={offer.stocks[0]} />
       )}

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/RecurrenceSection/__specs__/RecurrenceSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/RecurrenceSection/__specs__/RecurrenceSection.spec.tsx
@@ -1,32 +1,64 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 
-import {
-  individualOfferFactory,
-  individualStockFactory,
-} from 'utils/individualApiFactories'
+import { StockStatsResponseModel } from 'apiClient/v1'
 
 import RecurrenceSection from '../RecurrenceSection'
 
 describe('StockEventSection', () => {
-  it('should render all information', () => {
-    const offer = individualOfferFactory({
-      isEvent: true,
-      stocks: [individualStockFactory({ quantity: null })],
-    })
+  it('should render all information when there are several stocks', () => {
+    const stocksStats: StockStatsResponseModel = {
+      stockCount: 2,
+      remainingQuantity: undefined,
+      oldestStock: '2021-01-01T00:00:00+01:00',
+      newestStock: '2021-01-02T00:00:00+01:00',
+    }
 
-    render(<RecurrenceSection offer={offer} />)
+    render(<RecurrenceSection stocksStats={stocksStats} departementCode="" />)
 
     expect(screen.queryByText(/Nombre de dates/)).toBeInTheDocument()
+    expect(screen.queryByText('2')).toBeInTheDocument()
     expect(screen.queryByText(/Période concernée/)).toBeInTheDocument()
+    expect(
+      screen.queryByText('du 01/01/2021 au 02/01/2021')
+    ).toBeInTheDocument()
     expect(screen.queryByText(/Capacité totale/)).toBeInTheDocument()
     expect(screen.queryByText('Illimitée')).toBeInTheDocument()
   })
 
-  it('should not render if there are no stocks', () => {
-    const offer = individualOfferFactory({ stocks: [] })
+  it('should render all information when there are only one stock', () => {
+    const stocksStats: StockStatsResponseModel = {
+      stockCount: 1,
+      remainingQuantity: 637,
+      oldestStock: '2021-01-01T00:00:00+01:00',
+      newestStock: '2021-01-01T00:00:00+01:00',
+    }
 
-    render(<RecurrenceSection offer={offer} />)
+    render(<RecurrenceSection stocksStats={stocksStats} departementCode="" />)
+
+    expect(screen.queryByText(/Nombre de dates/)).toBeInTheDocument()
+    expect(screen.queryByText('1')).toBeInTheDocument()
+    expect(screen.queryByText(/Période concernée/)).toBeInTheDocument()
+    expect(screen.queryByText('le 01/01/2021')).toBeInTheDocument()
+    expect(screen.queryByText(/Capacité totale/)).toBeInTheDocument()
+    expect(screen.queryByText('637 places')).toBeInTheDocument()
+  })
+
+  it('should render 1 place', () => {
+    const stocksStats: StockStatsResponseModel = {
+      stockCount: 27,
+      remainingQuantity: 1,
+      oldestStock: '2021-01-01T00:00:00+01:00',
+      newestStock: '2021-01-01T00:00:00+01:00',
+    }
+
+    render(<RecurrenceSection stocksStats={stocksStats} departementCode="" />)
+
+    expect(screen.queryByText('1 place')).toBeInTheDocument()
+  })
+
+  it('should not render if there are no stocks', () => {
+    render(<RecurrenceSection stocksStats={undefined} departementCode="" />)
 
     expect(screen.queryByText(/Nombre de dates/)).not.toBeInTheDocument()
   })

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockSection.tsx
@@ -30,10 +30,9 @@ export const getStockWarningText = (offer: IndividualOffer) => {
 
 export interface StockSectionProps {
   offer: IndividualOffer
-  canBeDuo?: boolean
 }
 
-const StockSection = ({ offer, canBeDuo }: StockSectionProps): JSX.Element => {
+const StockSection = ({ offer }: StockSectionProps): JSX.Element => {
   const mode = useOfferWizardMode()
 
   const editLink = getIndividualOfferUrl({
@@ -62,7 +61,7 @@ const StockSection = ({ offer, canBeDuo }: StockSectionProps): JSX.Element => {
         {offer.isEvent ? (
           <RecurrenceSection offer={offer} />
         ) : (
-          <StockThingSection offer={offer} canBeDuo={canBeDuo} />
+          <StockThingSection stock={offer.stocks[0]} />
         )}
       </SummaryLayout.Section>
     </>

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/StockThingSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/StockThingSection.tsx
@@ -2,21 +2,18 @@ import { format } from 'date-fns-tz'
 import React from 'react'
 
 import { SummaryLayout } from 'components/SummaryLayout'
-import { IndividualOffer } from 'core/Offers/types'
+import { IndividualOfferStock } from 'core/Offers/types'
 import { FORMAT_DD_MM_YYYY, toDateStrippedOfTimezone } from 'utils/date'
 import { formatPrice } from 'utils/formatPrice'
 
 interface StockThingSectionProps {
-  offer: IndividualOffer
-  canBeDuo?: boolean
+  stock?: IndividualOfferStock
 }
 
-const StockThingSection = ({ offer, canBeDuo }: StockThingSectionProps) => {
-  if (offer.isEvent || offer.stocks.length === 0) {
+const StockThingSection = ({ stock }: StockThingSectionProps) => {
+  if (!stock) {
     return null
   }
-
-  const stock = offer.stocks[0]
 
   return (
     <>
@@ -36,13 +33,6 @@ const StockThingSection = ({ offer, canBeDuo }: StockThingSectionProps) => {
         title="Quantité"
         description={stock.quantity ?? 'Illimité'}
       />
-
-      {canBeDuo && (
-        <SummaryLayout.Row
-          title='Accepter les réservations "Duo"'
-          description={offer.isDuo ? 'Oui' : 'Non'}
-        />
-      )}
     </>
   )
 }

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/__specs__/StockThingSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/__specs__/StockThingSection.spec.tsx
@@ -1,44 +1,25 @@
 import { screen } from '@testing-library/react'
 import React from 'react'
 
-import {
-  individualOfferFactory,
-  individualStockFactory,
-} from 'utils/individualApiFactories'
+import { individualStockFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StockThingSection from '../StockThingSection'
 
 describe('StockThingSection', () => {
   it('should render correctly', () => {
-    const offer = individualOfferFactory({
-      isEvent: false,
-      stocks: [individualStockFactory()],
-    })
+    const stock = individualStockFactory()
 
-    renderWithProviders(<StockThingSection offer={offer} />)
+    renderWithProviders(<StockThingSection stock={stock} />)
 
     expect(screen.queryAllByText(/Prix/)).toHaveLength(1)
   })
 
   it('should not render if there are no stocks', () => {
-    const offer = individualOfferFactory({ stocks: [] })
+    const stock = undefined
 
-    renderWithProviders(<StockThingSection offer={offer} />)
+    renderWithProviders(<StockThingSection stock={stock} />)
 
     expect(screen.queryByText(/Prix/)).not.toBeInTheDocument()
-  })
-
-  it('should render duo informations', () => {
-    const offer = individualOfferFactory({
-      isEvent: false,
-      stocks: [individualStockFactory()],
-    })
-
-    renderWithProviders(<StockThingSection offer={offer} canBeDuo={true} />)
-
-    expect(
-      screen.getByText(/Accepter les réservations "Duo"/)
-    ).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/__specs__/getStockWarningText.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/__specs__/getStockWarningText.spec.tsx
@@ -1,0 +1,46 @@
+import { OfferStatus } from 'apiClient/v1'
+
+import { getStockWarningText } from '../StockSection'
+
+describe('getStockWarningText', () => {
+  const testData = [
+    {
+      offerStatus: OfferStatus.SOLD_OUT,
+      stocksCount: 1,
+      expected: 'Votre stock est épuisé.',
+    },
+    {
+      offerStatus: OfferStatus.EXPIRED,
+      stocksCount: 1,
+      expected: 'Votre stock est expiré.',
+    },
+    {
+      offerStatus: OfferStatus.EXPIRED,
+      stocksCount: 0,
+      expected: 'Vous n’avez aucun stock renseigné.',
+    },
+    {
+      offerStatus: OfferStatus.EXPIRED,
+      stocksCount: null,
+      expected: 'Vous n’avez aucun stock renseigné.',
+    },
+    {
+      offerStatus: OfferStatus.EXPIRED,
+      stocksCount: undefined,
+      expected: 'Vous n’avez aucun stock renseigné.',
+    },
+    {
+      offerStatus: OfferStatus.INACTIVE,
+      stocksCount: 1,
+      expected: false,
+    },
+  ]
+  it.each(testData)(
+    'should render $expected',
+    ({ offerStatus, stocksCount, expected }) => {
+      const result = getStockWarningText(offerStatus, stocksCount)
+
+      expect(result).toStrictEqual(expected)
+    }
+  )
+})

--- a/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -143,7 +143,7 @@ const SummaryScreen = () => {
           )}
 
           {mode === OFFER_WIZARD_MODE.CREATION && (
-            <StockSection offer={offer} canBeDuo={canBeDuo} />
+            <StockSection offer={offer} />
           )}
 
           <ActionBar


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25414

API:
_ réparer serialization (camelCase + UTC)

PRO:
_ refacto summary  stocksThing (enlever des choses inutiles)
_ utilser getStats dans le summary Stock Event (on en a besoin dans le composant au dessus StockSection qui gère les messages d'erreur en cas de pas de stocks par exemple)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques