### PR TITLE
(PC-24866)[API] feat: add ff for format instead of cat/sub-cat

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -132,6 +132,7 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_BOOST_SHOWTIMES_FILTER = "Activer le filtre pour les requêtes showtimes Boost"
     WIP_ENABLE_DATES_OFFER_TEMPLATE = "Active la possibilité d'ajouter des dates pour les offres vitrines"
     WIP_HOME_STATS = "Active la possibilité de voir les stats de consultation sur la page d'accueil"
+    WIP_ENABLE_FORMAT = "Activer le remplacement des catégories/sous-catégories par les formats"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -210,6 +211,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ENABLE_DATES_OFFER_TEMPLATE,
     FeatureToggle.WIP_HOME_STATS,
     FeatureToggle.WIP_BEHIND_L7_LOAD_BALANCER,
+    FeatureToggle.WIP_ENABLE_FORMAT,
 )
 
 if settings.IS_PROD or settings.IS_STAGING:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24866

FF : `WIP_ENABLE_FORMAT` pour l'ajout de format à la place des catégories / sous-catégorie pour les offres collectifs