### PR TITLE
(BSR)[API] fix: bulk insert stock

### DIFF
--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -270,6 +270,7 @@ class GetOfferStockResponseModel(BaseModel):
         allow_population_by_field_name = True
         orm_mode = True
         json_encoders = {datetime.datetime: format_into_utc_date}
+        arbitrary_types_allowed = True
 
 
 class GetOfferManagingOffererResponseModel(BaseModel):


### PR DESCRIPTION
## But de la pull request
La validation de pydantic prend beaucoup de temps, c'est une des raisons pour lesquels on a une erreur lors de l'insertion de plusieurs stocks. (Et les N+1 probablement)