### PR TITLE
(PC-25421)[PRO] fix: clear teacher suggestion on institution change

### DIFF
--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -202,6 +202,7 @@ const CollectiveOfferVisibility = ({
       searchTeacherValue.length < 3 ||
       !selectedInstitution
     ) {
+      setTeachersOptions([])
       return
     }
     const { payload } = await getEducationalRedactorsAdapter({
@@ -227,7 +228,6 @@ const CollectiveOfferVisibility = ({
         )
       )
   }
-
   return (
     <>
       <FormLayout.MandatoryInfo />
@@ -267,6 +267,12 @@ const CollectiveOfferVisibility = ({
                         onReset={async () => {
                           setTeachersOptions([])
                           await formik.setFieldValue('search-teacher', '')
+                        }}
+                        onSearch={async () => {
+                          if (formik.dirty) {
+                            await formik.setFieldValue('institution', '')
+                            await formik.setFieldValue('search-teacher', '')
+                          }
                         }}
                         resetOnOpen={false}
                         disabled={mode === Mode.READ_ONLY}

--- a/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -274,6 +274,69 @@ describe('CollectiveOfferVisibility', () => {
     )
   })
 
+  it('should clear teacher suggestion when clearing teacher input', async () => {
+    renderVisibilityStep(props)
+
+    vi.spyOn(
+      api,
+      'getAutocompleteEducationalRedactorsForUai'
+    ).mockResolvedValueOnce([
+      {
+        email: 'compte.test@education.gouv.fr',
+        gender: 'Mr.',
+        name: 'REDA',
+        surname: 'KHTEUR',
+      },
+    ])
+
+    const institutionSelect = screen.getAllByTestId('select')[0]
+    await userEvent.selectOptions(institutionSelect, '12')
+    const teacherInput = screen.getByLabelText(/Prénom et nom de l’enseignant/)
+    await userEvent.type(teacherInput, 'Red')
+
+    expect(
+      screen.getByRole('option', { name: 'KHTEUR REDA' })
+    ).toBeInTheDocument()
+
+    await userEvent.clear(teacherInput)
+
+    expect(
+      screen.queryByRole('option', { name: 'KHTEUR REDA' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should clear teacher suggestion when clearing institution', async () => {
+    renderVisibilityStep(props)
+    vi.spyOn(
+      api,
+      'getAutocompleteEducationalRedactorsForUai'
+    ).mockResolvedValueOnce([
+      {
+        email: 'compte.test@education.gouv.fr',
+        gender: 'Mr.',
+        name: 'REDA',
+        surname: 'KHTEUR',
+      },
+    ])
+    const institutionSelect = screen.getAllByTestId('select')[0]
+    await userEvent.selectOptions(institutionSelect, '12')
+    const teacherInput = screen.getByLabelText(/Prénom et nom de l’enseignant/)
+    await userEvent.type(teacherInput, 'Red')
+
+    expect(
+      screen.getByRole('option', { name: 'KHTEUR REDA' })
+    ).toBeInTheDocument()
+
+    await userEvent.type(
+      screen.getByLabelText(/Nom de l'établissement scolaire ou code UAI/),
+      ' '
+    )
+
+    expect(
+      screen.queryByRole('option', { name: 'KHTEUR REDA' })
+    ).not.toBeInTheDocument()
+  })
+
   describe('edition', () => {
     it('shoud prefill form with initial values', async () => {
       renderVisibilityStep({


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25421

Supprimer les suggestions d'enseignants quand on change d'établissement sur la page visibilité. 

Pour tester le seul établissement avec des enseignants en local est l'établissement avec l'uai 0470009E
[Description du bug avec vidéo ](https://www.notion.so/passcultureapp/New-bug-Staging-R-manence-du-r-sultat-de-recherche-d-un-prof-ff4b0ec2c7554bc2a7fd07eb08360b20)

**Screen de la page associée :** 

![Capture d’écran 2023-10-26 à 16 13 01](https://github.com/pass-culture/pass-culture-main/assets/71768799/60f10e2e-04b4-4661-8fc4-f5699b0ce7f4)

