### PR TITLE
(PC-25428)[PRO] refactor: only put only edited stocks event in payload

### DIFF
--- a/pro/src/screens/IndividualOffer/StocksEventEdition/hasChangesOnStockWithBookings.ts
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/hasChangesOnStockWithBookings.ts
@@ -9,7 +9,7 @@ export const hasChangesOnStockWithBookings = (
     Partial<StockEventFormValues>
   > = initialStocks.reduce(
     (dict: Record<string, Partial<StockEventFormValues>>, stock) => {
-      dict[stock.stockId ?? 'StockEventFormValuesnewStock'] = {
+      dict[stock.stockId] = {
         priceCategoryId: stock.priceCategoryId,
         beginningDate: stock.beginningDate,
         beginningTime: stock.beginningTime,
@@ -20,11 +20,7 @@ export const hasChangesOnStockWithBookings = (
   )
 
   return submittedStocks.some((stock) => {
-    if (
-      !stock.bookingsQuantity ||
-      stock.bookingsQuantity === 0 ||
-      !stock.stockId
-    ) {
+    if (!stock.bookingsQuantity || stock.bookingsQuantity === 0) {
       return false
     }
     const initialStock = initialStocksById[stock.stockId]

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/submitToApi.ts
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/submitToApi.ts
@@ -1,6 +1,3 @@
-import { StocksEvent } from 'components/StocksEventList/StocksEventList'
-import { serializeStockEvents } from 'pages/IndividualOfferWizard/Stocks/serializeStockEvents'
-
 import { serializeStockEventEdition } from './adapters/serializers'
 import upsertStocksEventAdapter from './adapters/upsertStocksEventAdapter'
 import { StockEventFormValues, StocksEventFormik } from './StockFormList/types'
@@ -9,8 +6,7 @@ export const submitToApi = async (
   allStockValues: StockEventFormValues[],
   offerId: number,
   departmentCode: string,
-  setErrors: StocksEventFormik['setErrors'],
-  setStocks: (stocks: StocksEvent[]) => void
+  setErrors: StocksEventFormik['setErrors']
 ) => {
   const {
     isOk,
@@ -24,6 +20,4 @@ export const submitToApi = async (
     setErrors({ stocks: payload.errors })
     throw new Error(upsertStocksMessage)
   }
-
-  setStocks(serializeStockEvents(payload.stocks))
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25428

quand on modifiait les stocks event on envoyait tous les stocks dans le payload,
on n'envoit plus que les stocks modifiés


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques