### PR TITLE
(PC-24580)[PRO] feat: Display the formatted dates on the summary of t…

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
+++ b/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
@@ -13,6 +13,7 @@ import useActiveFeature from 'hooks/useActiveFeature'
 import styles from './CollectiveOfferSummary.module.scss'
 import CollectiveOfferAccessibilitySection from './components/CollectiveOfferAccessibilitySection'
 import CollectiveOfferContactSection from './components/CollectiveOfferContactSection'
+import CollectiveOfferDateSection from './components/CollectiveOfferDateSection/CollectiveOfferDateSection'
 import CollectiveOfferImagePreview from './components/CollectiveOfferImagePreview'
 import CollectiveOfferNotificationSection from './components/CollectiveOfferNotificationSection'
 import CollectiveOfferParticipantSection from './components/CollectiveOfferParticipantSection'
@@ -41,6 +42,11 @@ const CollectiveOfferSummary = ({
   const isOfferToInstitutionActive = useActiveFeature(
     'WIP_OFFER_TO_INSTITUTION'
   )
+
+  const isTemplateOfferDatesActive = useActiveFeature(
+    'WIP_ENABLE_DATES_OFFER_TEMPLATE'
+  )
+
   return (
     <>
       <SummaryLayout>
@@ -60,6 +66,9 @@ const CollectiveOfferSummary = ({
             <CollectiveOfferVenueSection venue={offer.venue} />
             <CollectiveOfferTypeSection offer={offer} categories={categories} />
             <CollectiveOfferImagePreview offer={offer} />
+            {offer.isTemplate && isTemplateOfferDatesActive && (
+              <CollectiveOfferDateSection offer={offer} />
+            )}
             <CollectiveOfferPracticalInformation offer={offer} />
             <CollectiveOfferParticipantSection students={offer.students} />
             <CollectiveOfferAccessibilitySection offer={offer} />

--- a/pro/src/components/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
@@ -5,7 +5,10 @@ import {
   categoriesFactory,
   subCategoriesFactory,
 } from 'screens/OfferEducational/__tests-utils__'
-import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import {
+  collectiveOfferFactory,
+  collectiveOfferTemplateFactory,
+} from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferSummary, {
@@ -20,8 +23,11 @@ vi.mock('apiClient/api', () => ({
   },
 }))
 
-const renderCollectiveOfferSummary = (props: CollectiveOfferSummaryProps) => {
-  renderWithProviders(<CollectiveOfferSummary {...props} />)
+const renderCollectiveOfferSummary = (
+  props: CollectiveOfferSummaryProps,
+  storeOverrides?: any
+) => {
+  renderWithProviders(<CollectiveOfferSummary {...props} />, { storeOverrides })
 }
 
 describe('CollectiveOfferSummary', () => {
@@ -69,5 +75,29 @@ describe('CollectiveOfferSummary', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
     expect(screen.getByText('Dispositif national :')).toBeInTheDocument()
     expect(screen.getByText('Collège au cinéma')).toBeInTheDocument()
+  })
+
+  it('should display the date and time if the FF is enabled', async () => {
+    const offer = collectiveOfferTemplateFactory({
+      dates: { start: '2023-10-24T09:14:00', end: '2023-10-24T09:16:00' },
+    })
+    renderCollectiveOfferSummary(
+      { ...props, offer },
+      {
+        features: {
+          list: [
+            { isActive: true, nameKey: 'WIP_ENABLE_DATES_OFFER_TEMPLATE' },
+          ],
+        },
+      }
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    const title = screen.getByRole('heading', {
+      name: 'Date et heure',
+    })
+
+    expect(title).toBeInTheDocument()
   })
 })

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/CollectiveOfferDateSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/CollectiveOfferDateSection.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { SummaryLayout } from 'components/SummaryLayout'
+import { CollectiveOfferTemplate } from 'core/OfferEducational'
+import { getRangeToFrenchText, toDateStrippedOfTimezone } from 'utils/date'
+
+export type CollectiveOfferDateSectionProps = {
+  offer: CollectiveOfferTemplate
+}
+
+export default function CollectiveOfferDateSection({
+  offer,
+}: CollectiveOfferDateSectionProps) {
+  if (!offer.dates?.start || !offer.dates?.end) {
+    return null
+  }
+
+  const startDateWithoutTz = toDateStrippedOfTimezone(offer.dates.start)
+  const endDateWithoutTz = toDateStrippedOfTimezone(offer.dates.end)
+
+  const datesFormatted = getRangeToFrenchText(
+    startDateWithoutTz,
+    endDateWithoutTz
+  )
+
+  return (
+    <SummaryLayout.SubSection title="Date et heure">
+      <SummaryLayout.Row description={datesFormatted} />
+    </SummaryLayout.SubSection>
+  )
+}

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/__specs__/CollectiveOfferDateSection.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/__specs__/CollectiveOfferDateSection.spec.tsx
@@ -1,0 +1,42 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import { collectiveOfferTemplateFactory } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import CollectiveOfferDateSection, {
+  CollectiveOfferDateSectionProps,
+} from '../CollectiveOfferDateSection'
+
+const renderCollectiveOfferDateSection = (
+  props: CollectiveOfferDateSectionProps
+) => {
+  renderWithProviders(<CollectiveOfferDateSection {...props} />)
+}
+
+describe('CollectiveOfferDateSection', () => {
+  let props: CollectiveOfferDateSectionProps
+  it('should show the dates section if there are dates in the offer', () => {
+    const offer = collectiveOfferTemplateFactory({
+      dates: { start: '2023-10-24T09:14:00', end: '2023-10-24T09:16:00' },
+    })
+
+    renderCollectiveOfferDateSection({
+      ...props,
+      offer,
+    })
+    expect(screen.getByText('Date et heure')).toBeInTheDocument()
+  })
+
+  it('should not show the dates section if there are no dates in the offer', () => {
+    const offer = collectiveOfferTemplateFactory({
+      dates: undefined,
+    })
+
+    renderCollectiveOfferDateSection({
+      ...props,
+      offer,
+    })
+    expect(screen.queryByText('Date et heure')).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/utils/__specs__/date.spec.ts
+++ b/pro/src/utils/__specs__/date.spec.ts
@@ -1,6 +1,7 @@
 import {
   FORMAT_DD_MM_YYYY_HH_mm,
   formatBrowserTimezonedDateAsUTC,
+  getRangeToFrenchText,
   toDateStrippedOfTimezone,
   toISOStringWithoutMilliseconds,
 } from '../date'
@@ -53,5 +54,54 @@ describe('toISOStringWithoutMilliseconds', () => {
     const dateISOString = toISOStringWithoutMilliseconds(date)
 
     expect(dateISOString).toBe('2020-11-17T08:15:00Z')
+  })
+})
+
+describe('getRangeToFrenchText', () => {
+  it('should display only one day when the starting date and ending date are the same day', () => {
+    const from = new Date('2020-11-17T08:15:00Z')
+    const to = new Date('2020-11-17T23:59:00Z')
+
+    const formattedRange = getRangeToFrenchText(from, to)
+
+    expect(formattedRange).toBe('Le mardi 17 novembre 2020 à 08h15')
+  })
+
+  it('should format the months for both dates when the starting date and ending date are the same year', () => {
+    const from = new Date('2020-11-17T08:15:00Z')
+    const to = new Date('2020-12-10T23:59:00Z')
+
+    const formattedRange = getRangeToFrenchText(from, to)
+
+    expect(formattedRange).toBe('Du 17 novembre au 10 décembre 2020 à 08h15')
+  })
+
+  it('should format the months and years for both dates when the starting date and ending date are on different years', () => {
+    const from = new Date('2020-11-17T08:15:00Z')
+    const to = new Date('2021-01-10T23:59:00Z')
+
+    const formattedRange = getRangeToFrenchText(from, to)
+
+    expect(formattedRange).toBe(
+      'Du 17 novembre 2020 au 10 janvier 2021 à 08h15'
+    )
+  })
+
+  it('should not display the time when the starting date is at midnight', () => {
+    const from = new Date('2020-11-17T00:00:00Z')
+    const to = new Date('2021-01-10T23:59:00Z')
+
+    const formattedRange = getRangeToFrenchText(from, to)
+
+    expect(formattedRange).toBe('Du 17 novembre 2020 au 10 janvier 2021')
+  })
+
+  it('should not display the time minutes when the starting date minutes are 00', () => {
+    const from = new Date('2020-11-17T08:00:00Z')
+    const to = new Date('2021-01-10T23:59:00Z')
+
+    const formattedRange = getRangeToFrenchText(from, to)
+
+    expect(formattedRange).toBe('Du 17 novembre 2020 au 10 janvier 2021 à 08h')
   })
 })

--- a/pro/src/utils/date.ts
+++ b/pro/src/utils/date.ts
@@ -48,6 +48,53 @@ export const getDateToFrenchText = (dateIsoString: string) => {
   return format(noTimeZoneDate, FORMAT_DD_MMMM_YYYY, { locale: fr })
 }
 
+function getDateTimeToFrenchText(
+  date: Date,
+  options: Intl.DateTimeFormatOptions = {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }
+): string {
+  return Intl.DateTimeFormat('fr-FR', options).format(date)
+}
+
+export function getRangeToFrenchText(from: Date, to: Date): string {
+  //  The time displayed will be the one taken from the first date
+
+  const isSameYear = from.getFullYear() === to.getFullYear()
+  const isSameMonth = isSameYear && from.getMonth() === to.getMonth()
+  const isSameDay = isSameYear && isSameMonth && from.getDate() === to.getDate()
+
+  const shouldDisplayTime = from.getHours() !== 0 || from.getMinutes() !== 0
+
+  const timeToFrenchText = getDateTimeToFrenchText(from, {
+    hour: '2-digit',
+    minute: from.getMinutes() === 0 ? undefined : '2-digit',
+  })
+    .replace(':', 'h')
+    .replace(' ', '')
+
+  const formattedTime = shouldDisplayTime ? ` à ${timeToFrenchText}` : ''
+
+  if (isSameDay) {
+    return `Le ${getDateTimeToFrenchText(from, {
+      dateStyle: 'full',
+    })}${formattedTime}`
+  }
+
+  if (isSameYear) {
+    return `Du ${getDateTimeToFrenchText(from, {
+      day: '2-digit',
+      month: 'long',
+    })} au ${getDateTimeToFrenchText(to)}${formattedTime}`
+  }
+
+  return `Du ${getDateTimeToFrenchText(from)} au ${getDateTimeToFrenchText(
+    to
+  )}${formattedTime}`
+}
+
 export const toISOStringWithoutMilliseconds = (date: Date) => {
   return date.toISOString().replace(/\.\d{3}/, '')
 }


### PR DESCRIPTION
…emplate collective offers.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24580

**FF à activer**
- WIP_ENABLE_DATES_OFFER_TEMPLATE

**Objectif**
Ajouter les dates des offres collectives vitrines dans le résumé de l'offre après la création/edition

**A noter**
J'ai créé une fonction à part entière pour le formattage de la range en utilisant au maximum l'api Intl. Il y a une fonction formatRange sur Intl mais il m'a semblé impossible de formatter la structure du string créé (le seule séparateur possible est "-" apparemment)

<img width="876" alt="Capture d’écran 2023-10-27 à 10 13 32" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/047ceeee-4412-47f0-848f-2a71e9328e4a">
<img width="516" alt="Capture d’écran 2023-10-27 à 10 26 15" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/3cae2625-33d8-4e77-8669-2a904fdf1175">
<img width="450" alt="Capture d’écran 2023-10-27 à 10 27 56" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/30db9bc6-124f-456d-86f7-846fc0b8cf55">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques