### PR TITLE
(PC-25414)[PRO] fix: summary stock thing, some subcategories CAN be duo

### DIFF
--- a/pro/src/screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen.tsx
@@ -17,7 +17,7 @@ import { RecurrenceSummary } from './RecurrenceSummary'
 import styles from './StocksSummary.module.scss'
 
 export const StocksSummaryScreen = () => {
-  const { offer } = useIndividualOfferContext()
+  const { offer, subCategories } = useIndividualOfferContext()
   const [isLoading, setIsLoading] = useState(false)
   const [stocksEvent, setStocksEvent] = useState<StocksEvent[]>([])
   const notify = useNotification()
@@ -57,6 +57,10 @@ export const StocksSummaryScreen = () => {
     offer.isEvent ? stocksEvent.length : offer.stocks.length
   )
 
+  const canBeDuo = subCategories.find(
+    (subcategory) => subcategory.id === offer.subcategoryId
+  )?.canBeDuo
+
   return (
     <SummaryLayout.Section
       title={offer.isEvent ? 'Dates et capacité' : 'Stocks et prix'}
@@ -73,7 +77,11 @@ export const StocksSummaryScreen = () => {
       {offer.isEvent ? (
         <RecurrenceSummary offer={offer} stocks={stocksEvent} />
       ) : (
-        <StockThingSection stock={offer.stocks[0]} />
+        <StockThingSection
+          stock={offer.stocks[0]}
+          canBeDuo={canBeDuo}
+          isDuo={offer.isDuo}
+        />
       )}
     </SummaryLayout.Section>
   )

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockSection.tsx
@@ -36,9 +36,10 @@ export const getStockWarningText = (
 
 export interface StockSectionProps {
   offer: IndividualOffer
+  canBeDuo?: boolean
 }
 
-const StockSection = ({ offer }: StockSectionProps): JSX.Element => {
+const StockSection = ({ offer, canBeDuo }: StockSectionProps): JSX.Element => {
   const mode = useOfferWizardMode()
   const [isLoading, setIsLoading] = useState(false)
   const [stocksEventsStats, setStocksEventsStats] = useState<
@@ -101,7 +102,11 @@ const StockSection = ({ offer }: StockSectionProps): JSX.Element => {
             departementCode={offer.venue.departementCode ?? ''}
           />
         ) : (
-          <StockThingSection stock={offer.stocks[0]} />
+          <StockThingSection
+            stock={offer.stocks[0]}
+            canBeDuo={canBeDuo}
+            isDuo={offer.isDuo}
+          />
         )}
       </SummaryLayout.Section>
     </>

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/StockThingSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/StockThingSection.tsx
@@ -8,9 +8,15 @@ import { formatPrice } from 'utils/formatPrice'
 
 interface StockThingSectionProps {
   stock?: IndividualOfferStock
+  canBeDuo?: boolean
+  isDuo: boolean
 }
 
-const StockThingSection = ({ stock }: StockThingSectionProps) => {
+const StockThingSection = ({
+  stock,
+  canBeDuo,
+  isDuo,
+}: StockThingSectionProps) => {
   if (!stock) {
     return null
   }
@@ -33,6 +39,14 @@ const StockThingSection = ({ stock }: StockThingSectionProps) => {
         title="Quantité"
         description={stock.quantity ?? 'Illimité'}
       />
+
+      {/* Some things offer can be duo like ESCAPE_GAME, CARTE_MUSEE or ABO_MUSEE  */}
+      {canBeDuo && (
+        <SummaryLayout.Row
+          title='Accepter les réservations "Duo"'
+          description={isDuo ? 'Oui' : 'Non'}
+        />
+      )}
     </>
   )
 }

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/__specs__/StockThingSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/__specs__/StockThingSection.spec.tsx
@@ -10,16 +10,33 @@ describe('StockThingSection', () => {
   it('should render correctly', () => {
     const stock = individualStockFactory()
 
-    renderWithProviders(<StockThingSection stock={stock} />)
+    renderWithProviders(
+      <StockThingSection stock={stock} canBeDuo={false} isDuo={false} />
+    )
 
-    expect(screen.queryAllByText(/Prix/)).toHaveLength(1)
+    expect(screen.getByText(/Prix/)).toBeInTheDocument()
   })
 
   it('should not render if there are no stocks', () => {
     const stock = undefined
 
-    renderWithProviders(<StockThingSection stock={stock} />)
+    renderWithProviders(
+      <StockThingSection stock={stock} canBeDuo={false} isDuo={false} />
+    )
 
     expect(screen.queryByText(/Prix/)).not.toBeInTheDocument()
+  })
+
+  it('should render duo informations for can be duo things (like ESCAPE_GAME, CARTE_MUSEE or ABO_MUSEE)', () => {
+    const stock = individualStockFactory()
+
+    renderWithProviders(
+      <StockThingSection stock={stock} canBeDuo={true} isDuo={true} />
+    )
+
+    expect(
+      screen.getByText('Accepter les réservations "Duo" :')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Oui')).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -143,7 +143,7 @@ const SummaryScreen = () => {
           )}
 
           {mode === OFFER_WIZARD_MODE.CREATION && (
-            <StockSection offer={offer} />
+            <StockSection offer={offer} canBeDuo={canBeDuo} />
           )}
 
           <ActionBar


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25414

-> réparer mon commit d'hier : certaines sous-catégories things peuvent bien être duo !!
exemple : ESCAPE_GAME, CARTE_MUSEE ou ABO_MUSEE


en création :
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/2ea54408-bffe-4336-89e7-48db4c27ea1f)

en édition :
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/95bd438f-a8fa-4b1a-8080-b4b29e34db6d)



## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques