### PR TITLE
(BSR)[API] docs: Mentionner que la docstring d'une migration doit tenir en une ligne

### DIFF
--- a/api/src/pcapi/alembic/script.py.mako
+++ b/api/src/pcapi/alembic/script.py.mako
@@ -1,8 +1,8 @@
 """FIXME: Cher auteur de cette migration : le message ci-dessous
 apparaît dans la sortie de `alembic history`. Tu dois supprimer ce
 FIXME et faire en sorte que le message ci-dessous soit en anglais,
-clair et lisible (un peu comme un message de commit). Exemple : Add
-"blob" column to "offer" table.
+clair, en une seule ligne et lisible (un peu comme un message de
+commit). Exemple : Add "blob" column to "offer" table.
 
 ${message}
 """

--- a/api/src/pcapi/alembic/versions/20231025T015954_2a720f939c92_add_formats_to_collective_offers_and_templates.py
+++ b/api/src/pcapi/alembic/versions/20231025T015954_2a720f939c92_add_formats_to_collective_offers_and_templates.py
@@ -1,5 +1,4 @@
-"""add formats to collective offers (and templates)
-+ subcategoryId becomes nullable (before being removed)"""
+"""Add "formats" to collective offers (and templates) + make "subcategoryId" nullable"""
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql


### PR DESCRIPTION
... et correction de la docstring d'une migration récente qui a ce problème.