### PR TITLE
(BSR)[EAC] fix: start/end dates only if dateRange not null

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -662,11 +662,15 @@ class CollectiveOfferTemplate(
         return tuple(parent_args)
 
     @property
-    def start(self) -> datetime:
+    def start(self) -> datetime | None:
+        if not self.dateRange:
+            return None
         return self.dateRange.lower
 
     @property
-    def end(self) -> datetime:
+    def end(self) -> datetime | None:
+        if not self.dateRange:
+            return None
         return self.dateRange.upper
 
     @property

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -280,6 +280,11 @@ class CollectiveOfferTemplateResponseModel(BaseModel, common_models.Accessibilit
         is_favorite: bool,
         offerVenue: offerers_models.Venue | None = None,
     ) -> "CollectiveOfferTemplateResponseModel":
+        if offer.start and offer.end:
+            dates = TemplateDatesModel(start=offer.start, end=offer.end)
+        else:
+            dates = None
+
         return cls(
             id=offer.id,
             subcategoryLabel=offer.subcategory.app_label,
@@ -312,10 +317,7 @@ class CollectiveOfferTemplateResponseModel(BaseModel, common_models.Accessibilit
             mentalDisabilityCompliant=offer.mentalDisabilityCompliant,
             motorDisabilityCompliant=offer.motorDisabilityCompliant,
             visualDisabilityCompliant=offer.visualDisabilityCompliant,
-            dates=TemplateDatesModel(
-                start=offer.start,
-                end=offer.end,
-            ),
+            dates=dates,
             formats=offer.get_formats(),
         )
 


### PR DESCRIPTION
## But de la pull request

Fix : si `dateRange` est vide, `start` et `end` doivent renvoyer `None`.