### PR TITLE
(PC-24576)[PRO] feat: Add offer date range in adage template offers s…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.module.scss
@@ -3,27 +3,24 @@
 
 .offer-summary {
   display: flex;
-  margin-bottom: rem.torem(8px);
+  gap: rem.torem(8px) rem.torem(24px);
   padding: 0;
-
-  &:last-child {
-    margin-bottom: rem.torem(22px);
-  }
+  flex-wrap: wrap;
+  margin: rem.torem(24px) 0;
 
   &-item {
     display: flex;
     align-items: center;
     font-size: rem.torem(12px);
+    gap: 0 rem.torem(4px);
 
-    &:not(:last-of-type) {
-      margin-right: rem.torem(20px);
+    dt {
+      display: flex;
+      align-items: center;
     }
 
     &-icon {
-      margin-right: rem.torem(10px);
       color: colors.$primary;
-      width: rem.torem(24px);
-      height: rem.torem(24px);
     }
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
@@ -1,0 +1,66 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import { HydratedCollectiveOfferTemplate } from 'pages/AdageIframe/app/types/offers'
+import { defaultCollectiveTemplateOffer } from 'utils/adageFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import OfferSummary, { OfferSummaryProps } from '../OfferSummary'
+
+const renderOfferSummary = (props: OfferSummaryProps, storeOverrides?: any) => {
+  renderWithProviders(<OfferSummary {...props} />, { storeOverrides })
+}
+
+describe('offer summary', () => {
+  it('should not show the dates range on template offers if the FF is disabled', () => {
+    const offer: HydratedCollectiveOfferTemplate = {
+      ...defaultCollectiveTemplateOffer,
+      dates: { start: '2023-10-24T00:00:00', end: '2023-10-24T23:59:00' },
+      isTemplate: true,
+    }
+    renderOfferSummary({ offer })
+    expect(
+      screen.queryByText('Le mardi 24 octobre 2023')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should show the dates range on template offers if the FF is enabled', () => {
+    const offer: HydratedCollectiveOfferTemplate = {
+      ...defaultCollectiveTemplateOffer,
+      dates: { start: '2023-10-24T00:00:00', end: '2023-10-24T23:59:00' },
+      isTemplate: true,
+    }
+    renderOfferSummary(
+      { offer },
+      {
+        features: {
+          list: [
+            { isActive: true, nameKey: 'WIP_ENABLE_DATES_OFFER_TEMPLATE' },
+          ],
+        },
+      }
+    )
+    expect(screen.queryByText('Le mardi 24 octobre 2023')).toBeInTheDocument()
+  })
+
+  it('should not show the dates range on template offers if the dates are not defined', () => {
+    const offer: HydratedCollectiveOfferTemplate = {
+      ...defaultCollectiveTemplateOffer,
+      dates: undefined,
+      isTemplate: true,
+    }
+    renderOfferSummary(
+      { offer },
+      {
+        features: {
+          list: [
+            { isActive: true, nameKey: 'WIP_ENABLE_DATES_OFFER_TEMPLATE' },
+          ],
+        },
+      }
+    )
+    expect(
+      screen.queryByText('Le mardi 24 octobre 2023')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -182,7 +182,7 @@ describe('offer', () => {
       const seeMoreButton = await screen.findByRole('button', {
         name: 'en savoir plus',
       })
-      userEvent.click(seeMoreButton)
+      await userEvent.click(seeMoreButton)
 
       await waitFor(() => {
         expect(screen.queryByText('Le détail de mon prix')).toBeInTheDocument()
@@ -259,7 +259,7 @@ describe('offer', () => {
       expect(screen.getByText('Contacter le partenaire culturel'))
     })
 
-    it('should display distance when offer has coordinates and FF is active', async () => {
+    it('should display distance when offer has coordinates and FF is active', () => {
       user.lat = 0
       user.lon = 0
 
@@ -283,7 +283,7 @@ describe('offer', () => {
       ).toBeInTheDocument()
     })
 
-    it('should display can move in your institution is offer intervention area match user one', async () => {
+    it('should display can move in your institution is offer intervention area match user one', () => {
       renderOffers(
         {
           ...offerProps,
@@ -310,7 +310,7 @@ describe('offer', () => {
     })
   })
 
-  it('should not display the distance to venue if the user does not have a valid geoloc', async () => {
+  it('should not display the distance to venue if the user does not have a valid geoloc', () => {
     user.lat = null
     user.lon = null
     renderOffers(
@@ -471,7 +471,7 @@ describe('offer', () => {
     expect(screen.getByText('Supprimer des favoris')).toBeInTheDocument()
   })
 
-  it('should not display favorite button when adage user is admin', async () => {
+  it('should not display favorite button when adage user is admin', () => {
     renderOffers(
       {
         ...offerProps,
@@ -487,7 +487,7 @@ describe('offer', () => {
     expect(screen.queryByText('Enregistrer en favoris')).not.toBeInTheDocument()
   })
 
-  it('should not display favorite button when offer is bookable', async () => {
+  it('should not display favorite button when offer is bookable', () => {
     renderOffers(
       {
         ...offerProps,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24576

**FF à activer**
WIP_ENABLE_DATES_OFFER_TEMPLATE

**Objectif**
Ajouter le champ des dates d'une offre vitrine dans les cartes des offres sur adage. Aussi rework rapide des styles pour correspondre à la maquette.

<img width="995" alt="Capture d’écran 2023-10-27 à 15 57 24" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/70d2b456-9eaf-47fd-933b-88e331144692">



## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques