### PR TITLE
(BSR)[API] refactor: Simplify `finance.repository.has_reimbursement()`

### DIFF
--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -371,8 +371,6 @@ def cancel_collective_booking(
     with transaction():
         educational_repository.get_and_lock_collective_stock(stock_id=collective_booking.collectiveStock.id)
         db.session.refresh(collective_booking)
-        if collective_booking.status == educational_models.CollectiveBookingStatus.REIMBURSED:
-            raise exceptions.BookingIsAlreadyRefunded()
         if finance_repository.has_reimbursement(collective_booking):
             raise exceptions.BookingIsAlreadyRefunded()
 

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1299,8 +1299,7 @@ class MarkAsUsedTest:
         assert booking.status is not BookingStatus.USED
 
     def test_raise_if_already_reimbursed(self):
-        booking = bookings_factories.UsedBookingFactory()
-        finance_factories.PaymentFactory(booking=booking)
+        booking = bookings_factories.ReimbursedBookingFactory()
         with pytest.raises(exceptions.BookingIsAlreadyRefunded):
             api.mark_as_used(booking)
 
@@ -1350,13 +1349,6 @@ class MarkAsUnusedTest:
     def test_raise_if_has_reimbursement(self):
         booking = bookings_factories.UsedBookingFactory()
         finance_factories.PricingFactory(booking=booking, status=finance_models.PricingStatus.PROCESSED)
-        with pytest.raises(api_errors.ResourceGoneError):
-            api.mark_as_unused(booking)
-        assert booking.status is BookingStatus.USED
-
-    def test_raise_if_has_reimbursement_legacy_payment(self):
-        booking = bookings_factories.UsedBookingFactory()
-        finance_factories.PaymentFactory(booking=booking)
         with pytest.raises(api_errors.ResourceGoneError):
             api.mark_as_unused(booking)
         assert booking.status is BookingStatus.USED

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -583,20 +583,10 @@ class CancelBookingTest(PostEndpointHelper):
             == "Impossible d'annuler une réservation déjà valorisée ou remboursée"
         )
 
-    @pytest.mark.parametrize(
-        "with_pricing,expected_message",
-        [
-            (False, "Impossible d'annuler une réservation déjà utilisée"),
-            (True, "Impossible d'annuler une réservation déjà valorisée ou remboursée"),
-        ],
-    )
-    def test_cant_cancel_reimbursed_booking(self, authenticated_client, bookings, with_pricing, expected_message):
+    def test_cant_cancel_reimbursed_booking(self, authenticated_client, bookings):
         # give
         reimbursed = bookings[3]
         old_status = reimbursed.status
-        if with_pricing:
-            finance_factories.PricingFactory(booking=reimbursed, status=finance_models.PricingStatus.INVOICED)
-            finance_factories.PaymentFactory(booking=reimbursed)
 
         # when
         response = self.post_to_endpoint(
@@ -612,7 +602,10 @@ class CancelBookingTest(PostEndpointHelper):
         assert reimbursed.status == old_status
 
         redirected_response = authenticated_client.get(response.headers["location"])
-        assert html_parser.extract_alert(redirected_response.data) == expected_message
+        assert (
+            html_parser.extract_alert(redirected_response.data)
+            == "Impossible d'annuler une réservation déjà valorisée ou remboursée"
+        )
 
     def test_cant_cancel_cancelled_booking(self, authenticated_client, bookings):
         # give

--- a/api/tests/routes/public/booking_token/v2/get_booking_by_token_v2_test.py
+++ b/api/tests/routes/public/booking_token/v2/get_booking_by_token_v2_test.py
@@ -6,7 +6,6 @@ import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories_v2 as subcategories
-import pcapi.core.finance.factories as finance_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.utils.date import format_into_utc_date
@@ -171,7 +170,7 @@ class Returns403Test:
 
     def test_when_booking_is_refunded(self, client):
         # Given
-        booking = finance_factories.PaymentFactory().booking
+        booking = bookings_factories.ReimbursedBookingFactory()
         pro_user = offerers_factories.UserOffererFactory(offerer=booking.offerer).user
 
         # When

--- a/api/tests/routes/public/booking_token/v2/patch_booking_keep_by_token_test.py
+++ b/api/tests/routes/public/booking_token/v2/patch_booking_keep_by_token_test.py
@@ -3,7 +3,6 @@ import pytest
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
-import pcapi.core.finance.factories as finance_factories
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.users import factories as users_factories
 
@@ -160,7 +159,7 @@ class Returns410Test:
     @pytest.mark.usefixtures("db_session")
     def test_when_user_is_logged_in_and_booking_payment_exists(self, client):
         # Given
-        booking = finance_factories.PaymentFactory().booking
+        booking = bookings_factories.ReimbursedBookingFactory()
         pro_user = offerers_factories.UserOffererFactory(offerer=booking.offerer).user
 
         # When
@@ -170,7 +169,7 @@ class Returns410Test:
         # Then
         assert response.status_code == 410
         assert response.json["payment"] == ["Le remboursement est en cours de traitement"]
-        assert booking.status is BookingStatus.USED
+        assert booking.status is BookingStatus.REIMBURSED
 
     @pytest.mark.usefixtures("db_session")
     def test_when_user_is_logged_in_and_booking_has_been_cancelled_already(self, client):

--- a/api/tests/routes/public/individual_offers/v1/get_booking_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_booking_test.py
@@ -4,7 +4,6 @@ from dateutil.relativedelta import relativedelta
 import pytest
 
 from pcapi.core.bookings import factories as bookings_factories
-from pcapi.core.finance import factories as finance_factories
 from pcapi.core.finance import utils as finance_utils
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
@@ -157,16 +156,13 @@ class GetBookingByTokenReturns403Test:
         # Given
         venue, _ = utils.create_offerer_provider_linked_to_venue()
 
-        offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.StockFactory(offer=offer)
-        payment = finance_factories.PaymentFactory(booking__stock=stock)
+        booking = bookings_factories.ReimbursedBookingFactory(stock=stock)
 
         # When
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-            f"/public/bookings/v1/token/{payment.booking.token}",
-        )
+        client = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY)
+        response = client.get(f"/public/bookings/v1/token/{booking.token}")
 
         # Then
         assert response.status_code == 403

--- a/api/tests/routes/public/individual_offers/v1/patch_cancel_booking_by_token_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_cancel_booking_by_token_test.py
@@ -5,7 +5,6 @@ import pytest
 
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
-from pcapi.core.finance import factories as finance_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 
@@ -136,17 +135,13 @@ class PatchBookingByTokenReturns403Test:
     def test_when_booking_is_refunded(self, client):
         # Given
         venue, _ = utils.create_offerer_provider_linked_to_venue()
-
-        offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.StockFactory(offer=offer)
-        payment = finance_factories.PaymentFactory(booking__stock=stock)
+        booking = bookings_factories.ReimbursedBookingFactory(stock=stock)
 
         # When
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
-            f"/public/bookings/v1/cancel/token/{payment.booking.token}",
-        )
+        client = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY)
+        response = client.patch(f"/public/bookings/v1/cancel/token/{booking.token}")
 
         # Then
         assert response.status_code == 403

--- a/api/tests/routes/public/individual_offers/v1/patch_validate_booking_by_token_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_validate_booking_by_token_test.py
@@ -4,7 +4,6 @@ from dateutil.relativedelta import relativedelta
 import pytest
 
 from pcapi.core.bookings import factories as bookings_factories
-from pcapi.core.finance import factories as finance_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.utils import date as date_utils
@@ -109,16 +108,13 @@ class PatchBookingByTokenReturns403Test:
         # Given
         venue, _ = utils.create_offerer_provider_linked_to_venue()
 
-        offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.StockFactory(offer=offer)
-        payment = finance_factories.PaymentFactory(booking__stock=stock)
+        booking = bookings_factories.ReimbursedBookingFactory(stock=stock)
 
         # When
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
-            f"/public/bookings/v1/use/token/{payment.booking.token}",
-        )
+        client = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY)
+        response = client.patch(f"/public/bookings/v1/use/token/{booking.token}")
 
         # Then
         assert response.status_code == 403


### PR DESCRIPTION
1. Instances of Pricing have been generated for old-style Payment, we
   don't need to look at Payment anymore.

2. Look at the status of the booking first. If it says "reimbursed",
   no need to waste an SQL query to look at pricings.