### PR TITLE
(BSR)[API] fix: missing: nullable subcategory

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -102,7 +102,7 @@ class CollectiveOfferResponseModel(BaseModel):
     name: str
     stocks: list[CollectiveOffersStockResponseModel]
     booking: CollectiveOffersBookingResponseModel | None
-    subcategoryId: SubcategoryIdEnum
+    subcategoryId: SubcategoryIdEnum | None
     isShowcase: bool
     venue: base_serializers.ListOffersVenueResponseModel
     status: str
@@ -288,7 +288,7 @@ class GetCollectiveOfferBaseResponseModel(BaseModel, AccessibilityComplianceMixi
     isEditable: bool
     id: int
     name: str
-    subcategoryId: SubcategoryIdEnum
+    subcategoryId: SubcategoryIdEnum | None
     venue: GetCollectiveOfferVenueResponseModel
     status: OfferStatus
     domains: list[OfferDomain]

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
@@ -29,7 +29,7 @@ export type CollectiveOfferResponseModel = {
   nationalProgram?: NationalProgramModel | null;
   status: string;
   stocks: Array<CollectiveOffersStockResponseModel>;
-  subcategoryId: SubcategoryIdEnum;
+  subcategoryId?: SubcategoryIdEnum | null;
   templateId?: string | null;
   venue: ListOffersVenueResponseModel;
 };

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -49,7 +49,7 @@ export type GetCollectiveOfferResponseModel = {
   offerVenue: CollectiveOfferOfferVenueResponseModel;
   status: OfferStatus;
   students: Array<StudentLevels>;
-  subcategoryId: SubcategoryIdEnum;
+  subcategoryId?: SubcategoryIdEnum | null;
   teacher?: EducationalRedactorResponseModel | null;
   templateId?: number | null;
   venue: GetCollectiveOfferVenueResponseModel;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
@@ -41,7 +41,7 @@ export type GetCollectiveOfferTemplateResponseModel = {
   offerVenue: CollectiveOfferOfferVenueResponseModel;
   status: OfferStatus;
   students: Array<StudentLevels>;
-  subcategoryId: SubcategoryIdEnum;
+  subcategoryId?: SubcategoryIdEnum | null;
   venue: GetCollectiveOfferVenueResponseModel;
   visualDisabilityCompliant?: boolean | null;
 };


### PR DESCRIPTION
## But de la pull request

**Contexte**
Les offres collectives et vitrines ne sont plus obligées d'avoir des sous-catégories depuis https://github.com/pass-culture/pass-culture-main/pull/8641. Elles seront progressivement remplacées par des _formats_.

**Bug**
Certains modèles de réponse exigeaient encore une sous-catégorie (obligatoire) ce qui pose des soucis puisque la prochaine version du portail pro ne va plus renseigner de sous-catégorie mais directement des formats.