### PR TITLE
(PC-24105)[API] fix: handle booking cancelation from BO 

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -483,8 +483,9 @@ def _execute_cancel_booking(
                     },
                 )
                 return False
-
             stock.dnBookedQuantity -= booking.quantity
+            if booking.activationCode and stock.quantity:
+                stock.quantity -= 1
             repository.save(booking, stock)
     return True
 


### PR DESCRIPTION
## But de la pull request

- en cas d’annulation d’une réservation avec code d’activation depuis le BO 
- modifier la liste des codes d’activation pour supprimer ce code d’activation
- modifier le stock de l’offre pour diminuer la quantité de 1 

Il peut donc arriver que le stock initial soit différent du stock final + réservation

-> suite aux discussions, on choisit de ne pas supprimer les codes d'activation afin de pouvoir garder une trace.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24105

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques