### PR TITLE
Pc 24862 eac display format for collective offer

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
@@ -1,6 +1,7 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
 
+import { EacFormat } from 'apiClient/v1'
 import {
   categoriesFactory,
   subCategoriesFactory,
@@ -14,6 +15,7 @@ import { renderWithProviders } from 'utils/renderWithProviders'
 import CollectiveOfferSummary, {
   CollectiveOfferSummaryProps,
 } from '../CollectiveOfferSummary'
+import { DEFAULT_RECAP_VALUE } from '../components/constants'
 
 vi.mock('apiClient/api', () => ({
   api: {
@@ -23,11 +25,25 @@ vi.mock('apiClient/api', () => ({
   },
 }))
 
+const isFormatActive = {
+  features: {
+    list: [
+      {
+        nameKey: 'WIP_ENABLE_FORMAT',
+        isActive: true,
+      },
+    ],
+    initialized: true,
+  },
+}
+
 const renderCollectiveOfferSummary = (
   props: CollectiveOfferSummaryProps,
   storeOverrides?: any
 ) => {
-  renderWithProviders(<CollectiveOfferSummary {...props} />, { storeOverrides })
+  renderWithProviders(<CollectiveOfferSummary {...props} />, {
+    storeOverrides: storeOverrides,
+  })
 }
 
 describe('CollectiveOfferSummary', () => {
@@ -75,6 +91,41 @@ describe('CollectiveOfferSummary', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
     expect(screen.getByText('Dispositif national :')).toBeInTheDocument()
     expect(screen.getByText('Collège au cinéma')).toBeInTheDocument()
+  })
+  it('should display format when ff is active', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: {
+          ...props.offer,
+          formats: [EacFormat.PROJECTION_AUDIOVISUELLE, EacFormat.CONCERT],
+        },
+      },
+      isFormatActive
+    )
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getByText('Format :')).toBeInTheDocument()
+    expect(
+      screen.getByText('Projection audiovisuelle, Concert')
+    ).toBeInTheDocument()
+  })
+
+  it('should display defaut format value when null and ff is active', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: {
+          ...props.offer,
+          formats: null,
+        },
+      },
+      isFormatActive
+    )
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getByText('Format :')).toBeInTheDocument()
+    expect(screen.getAllByText(DEFAULT_RECAP_VALUE)[0]).toBeInTheDocument()
   })
 
   it('should display the date and time if the FF is enabled', async () => {

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferTypeSection/CollectiveOfferTypeSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferTypeSection/CollectiveOfferTypeSection.tsx
@@ -6,6 +6,7 @@ import {
   CollectiveOfferTemplate,
   EducationalCategories,
 } from 'core/OfferEducational'
+import useActiveFeature from 'hooks/useActiveFeature'
 
 import { DEFAULT_RECAP_VALUE } from '../constants'
 import { formatDuration } from '../utils/formatDuration'
@@ -36,16 +37,27 @@ const CollectiveOfferTypeSection = ({
 
     return
   }, [offer.subcategoryId])
+  const isFormatActive = useActiveFeature('WIP_ENABLE_FORMAT')
   return (
     <SummaryLayout.SubSection title="Type d’offre">
-      <SummaryLayout.Row
-        title="Catégorie"
-        description={category?.label || DEFAULT_RECAP_VALUE}
-      />
-      <SummaryLayout.Row
-        title="Sous-catégorie"
-        description={subCategory?.label || DEFAULT_RECAP_VALUE}
-      />
+      {isFormatActive ? (
+        <SummaryLayout.Row
+          title="Format"
+          description={offer.formats?.join(', ') || DEFAULT_RECAP_VALUE}
+        />
+      ) : (
+        <>
+          <SummaryLayout.Row
+            title="Catégorie"
+            description={category?.label || DEFAULT_RECAP_VALUE}
+          />
+          <SummaryLayout.Row
+            title="Sous-catégorie"
+            description={subCategory?.label || DEFAULT_RECAP_VALUE}
+          />
+        </>
+      )}
+
       <SummaryLayout.Row
         title="Domaine artistiques et culturels"
         description={offer.domains.map((domain) => domain.name).join(', ')}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
@@ -113,18 +113,35 @@ const OfferSummary = ({ offer }: OfferSummaryProps): JSX.Element => {
 
   const formattedPrice = getFormattedPrice(price)
 
+  const isFormatEnable = useActiveFeature('WIP_ENABLE_FORMAT')
+
   return (
     <dl className={styles['offer-summary']}>
       <div className={styles['offer-summary-item']}>
-        <dt>
-          <SvgIcon
-            alt="Sous-catégorie"
-            src={strokeOfferIcon}
-            className={styles['offer-summary-item-icon']}
-            width="20"
-          />
-        </dt>
-        <dd>{subcategoryLabel}</dd>
+        {isFormatEnable ? (
+          <>
+            <dt>
+              <SvgIcon
+                alt="Format"
+                src={strokeOfferIcon}
+                className={styles['offer-summary-item-icon']}
+              />
+            </dt>
+            <dd>{offer.formats?.join(', ')}</dd>
+          </>
+        ) : (
+          <>
+            <dt>
+              <SvgIcon
+                alt="Sous-catégorie"
+                src={strokeOfferIcon}
+                className={styles['offer-summary-item-icon']}
+                width="20"
+              />
+            </dt>
+            <dd>{subcategoryLabel}</dd>
+          </>
+        )}
       </div>
       <div className={styles['offer-summary-item']}>
         <dt>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import {
   AdageFrontRoles,
   AuthenticatedResponse,
+  EacFormat,
   OfferAddressType,
   StudentLevels,
 } from 'apiClient/adage'
@@ -532,5 +533,21 @@ describe('offer', () => {
       queryId: '1',
       stockId: 825,
     })
+  })
+
+  it('should display format when FF is active', async () => {
+    renderOffers(
+      {
+        ...offerProps,
+        offer: {
+          ...defaultCollectiveTemplateOffer,
+          isTemplate: true,
+          formats: [EacFormat.CONCERT, EacFormat.REPR_SENTATION],
+        },
+      },
+      [{ nameKey: 'WIP_ENABLE_FORMAT', isActive: true }]
+    )
+
+    expect(screen.getByText('Concert, Représentation')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24862

Afficher le format à la place de la sous-catégorie dans le résumé d'une offre collective après création/édition et sur les fiches d'offres sur Adage

FF à activer : WIP_ENABLE_FORMAT