### PR TITLE
(BSR)[PRO] fix: improve test flakyness

### DIFF
--- a/pro/src/pages/Desk/__specs__/Desk.spec.tsx
+++ b/pro/src/pages/Desk/__specs__/Desk.spec.tsx
@@ -24,7 +24,7 @@ describe('src | components | Desk', () => {
       expect(contremarque).toHaveValue('ZERRZ')
     })
 
-    it('should display default messages and disable submit button', async () => {
+    it('should display default messages and disable submit button', () => {
       renderDesk()
       expect(screen.getByText('Saisissez une contremarque')).toBeInTheDocument()
       expect(
@@ -158,9 +158,7 @@ describe('src | components | Desk', () => {
       })
       await userEvent.click(confirmModalButton)
 
-      expect(
-        await screen.findByText('Invalidation en cours...')
-      ).toBeInTheDocument()
+      expect(screen.getByText('Invalidation en cours...')).toBeInTheDocument()
 
       await waitFor(() => {
         expect(screen.getByText('Contremarque invalidée !')).toBeInTheDocument()


### PR DESCRIPTION
## But de la pull request

On remplace un `await screen.findByText` qui n'est pas nécessaire par un `screen.getByText` => comme on ne wrap pas le expect dans une promesse celui-ci n'est pas retardé donc moins de risque de race condition