### PR TITLE
(BSR)[API] fix: the data team can't extract data from a list

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -252,7 +252,7 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
         if not_found_eans:
             logger.warning(
                 "Some provided eans were not found",
-                extra={"eans": not_found_eans, "venue": venue_id},
+                extra={"eans": ",".join(not_found_eans), "venue": venue_id},
                 technical_message_id="ean.not_found",
             )
         for product in existing_products:


### PR DESCRIPTION
It seems that bigquery (or the way the data team uses it) cannot extract lists.
We changed that to have a string of eans separated by commas