### PR TITLE
(PC-25368)[PRO] refactor: spinner wrapper for A11y

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPracticalInformation/CollectiveOfferPracticalInformation.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPracticalInformation/CollectiveOfferPracticalInformation.tsx
@@ -18,27 +18,29 @@ const CollectiveOfferPracticalInformationSection = ({
 }: CollectiveOfferPracticalInformationSectionProps) => {
   const notify = useNotification()
   const { error, isLoading, data: venue } = useGetVenue(offer.venue.id)
-  if (isLoading) {
-    return <Spinner />
-  }
-  if (error) {
+
+  if (error && !isLoading) {
     notify.error(error.message)
-    return null
   }
 
   return (
-    <SummaryLayout.SubSection title="Informations pratiques">
-      <SummaryLayout.Row
-        title="Adresse où se déroulera l’évènement"
-        description={formatOfferEventAddress(offer.offerVenue, venue)}
-      />
-      {offer.isTemplate && (
-        <SummaryLayout.Row
-          title="Informations sur le prix"
-          description={offer.educationalPriceDetail || DEFAULT_RECAP_VALUE}
-        />
+    <>
+      <Spinner isLoading={isLoading} />
+      {!isLoading && !error && (
+        <SummaryLayout.SubSection title="Informations pratiques">
+          <SummaryLayout.Row
+            title="Adresse où se déroulera l’évènement"
+            description={formatOfferEventAddress(offer.offerVenue, venue)}
+          />
+          {offer.isTemplate && (
+            <SummaryLayout.Row
+              title="Informations sur le prix"
+              description={offer.educationalPriceDetail || DEFAULT_RECAP_VALUE}
+            />
+          )}
+        </SummaryLayout.SubSection>
       )}
-    </SummaryLayout.SubSection>
+    </>
   )
 }
 

--- a/pro/src/components/ImageUploader/ButtonImageDelete/__specs__/ButtonImageDelete.spec.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageDelete/__specs__/ButtonImageDelete.spec.tsx
@@ -12,8 +12,8 @@ interface RenderButtonImageDeleteProps {
   props: ButtonImageDeleteProps
 }
 const renderButtonImageDelete = ({ props }: RenderButtonImageDeleteProps) => {
-  return render(
-    <StoreProvider isDev>
+  render(
+    <StoreProvider>
       <ButtonImageDelete {...props} />
     </StoreProvider>
   )
@@ -31,21 +31,23 @@ describe('ButtonImageDelete', () => {
   })
 
   it('should render ButtonImageDelete', async () => {
-    await renderButtonImageDelete({
+    renderButtonImageDelete({
       props,
     })
     expect(
-      screen.getByRole('button', { name: /Supprimer/i })
+      await screen.findByRole('button', { name: /Supprimer/i })
     ).toBeInTheDocument()
 
     expect(screen.queryByText('Supprimer l’image')).not.toBeInTheDocument()
   })
 
   it('should open/close ModalImageDelete on click', async () => {
-    await renderButtonImageDelete({
+    renderButtonImageDelete({
       props,
     })
-    await userEvent.click(screen.getByRole('button', { name: /Supprimer/i }))
+    await userEvent.click(
+      await screen.findByRole('button', { name: /Supprimer/i })
+    )
 
     const modalPreview = await screen.findByText('Supprimer l’image')
     expect(modalPreview).toBeInTheDocument()

--- a/pro/src/components/ImageUploader/ImageUploader.stories.tsx
+++ b/pro/src/components/ImageUploader/ImageUploader.stories.tsx
@@ -14,7 +14,7 @@ export default {
 }
 
 const Template: Story<ImageUploaderProps> = (props) => (
-  <StoreProvider isDev>
+  <StoreProvider>
     <ImageUploader {...props} />
   </StoreProvider>
 )

--- a/pro/src/context/IndividualOfferContext/IndividualOfferContext.tsx
+++ b/pro/src/context/IndividualOfferContext/IndividualOfferContext.tsx
@@ -144,28 +144,29 @@ export function IndividualOfferContextProvider({
     }
   }, [offerId, offerOfferer])
 
-  if (isLoading === true) {
-    return <Spinner />
-  }
-
   return (
-    <IndividualOfferContext.Provider
-      value={{
-        offerId: offer?.id || null,
-        offer,
-        setOffer,
-        categories,
-        subCategories,
-        offererNames,
-        venueList,
-        venueId,
-        offerOfferer,
-        showVenuePopin: showVenuePopin,
-        subcategory,
-        setSubcategory,
-      }}
-    >
-      {children}
-    </IndividualOfferContext.Provider>
+    <>
+      <Spinner isLoading={isLoading} />
+      {!isLoading && (
+        <IndividualOfferContext.Provider
+          value={{
+            offerId: offer?.id || null,
+            offer,
+            setOffer,
+            categories,
+            subCategories,
+            offererNames,
+            venueList,
+            venueId,
+            offerOfferer,
+            showVenuePopin: showVenuePopin,
+            subcategory,
+            setSubcategory,
+          }}
+        >
+          {children}
+        </IndividualOfferContext.Provider>
+      )}
+    </>
   )
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavorites.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavorites.tsx
@@ -43,31 +43,32 @@ export const OffersFavorites = () => {
     }
   }
 
-  if (isLoading) {
-    return <Spinner message="Chargement en cours" />
-  }
-
   return (
     <>
-      <h1>Mes Favoris</h1>
-      {favoriteOffers.length === 0 ? (
-        <OffersFavoritesNoResult />
-      ) : (
-        <ul className={styles['favorite-list']}>
-          {favoriteOffers.map((offer, i) => {
-            return (
-              <Offer
-                offer={offer}
-                queryId=""
-                position={i}
-                key={offer.id}
-                afterFavoriteChange={(isFavorite) => {
-                  favoriteChangeHandler(isFavorite, offer.id)
-                }}
-              ></Offer>
-            )
-          })}
-        </ul>
+      <Spinner isLoading={isLoading} message="Chargement en cours" />
+      {!isLoading && (
+        <>
+          <h1>Mes Favoris</h1>
+          {favoriteOffers.length === 0 ? (
+            <OffersFavoritesNoResult />
+          ) : (
+            <ul className={styles['favorite-list']}>
+              {favoriteOffers.map((offer, i) => {
+                return (
+                  <Offer
+                    offer={offer}
+                    queryId=""
+                    position={i}
+                    key={offer.id}
+                    afterFavoriteChange={(isFavorite) => {
+                      favoriteChangeHandler(isFavorite, offer.id)
+                    }}
+                  ></Offer>
+                )
+              })}
+            </ul>
+          )}
+        </>
       )}
     </>
   )

--- a/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
+++ b/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
@@ -27,30 +27,32 @@ export const CollectiveOfferCreation = ({
     offer
   )
 
-  if (!isReady) {
-    return <Spinner />
-  }
   return (
-    <CollectiveOfferLayout
-      subTitle={offer?.name}
-      isCreation
-      isTemplate={isTemplate}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
-      requestId={requestId}
-    >
-      <OfferEducationalScreen
-        categories={offerEducationalFormData.categories}
-        userOfferers={offerEducationalFormData.offerers}
-        domainsOptions={offerEducationalFormData.domains}
-        nationalPrograms={offerEducationalFormData.nationalPrograms}
-        offer={offer}
-        setOffer={setOffer}
-        getIsOffererEligible={canOffererCreateCollectiveOfferAdapter}
-        mode={Mode.CREATION}
-        isTemplate={isTemplate}
-      />
-      <RouteLeavingGuardCollectiveOfferCreation />
-    </CollectiveOfferLayout>
+    <>
+      <Spinner isLoading={!isReady} />
+      {isReady && (
+        <CollectiveOfferLayout
+          subTitle={offer?.name}
+          isCreation
+          isTemplate={isTemplate}
+          isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+          requestId={requestId}
+        >
+          <OfferEducationalScreen
+            categories={offerEducationalFormData.categories}
+            userOfferers={offerEducationalFormData.offerers}
+            domainsOptions={offerEducationalFormData.domains}
+            nationalPrograms={offerEducationalFormData.nationalPrograms}
+            offer={offer}
+            setOffer={setOffer}
+            getIsOffererEligible={canOffererCreateCollectiveOfferAdapter}
+            mode={Mode.CREATION}
+            isTemplate={isTemplate}
+          />
+          <RouteLeavingGuardCollectiveOfferCreation />
+        </CollectiveOfferLayout>
+      )}
+    </>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferEdition/CollectiveOfferEdition.tsx
+++ b/pro/src/pages/CollectiveOfferEdition/CollectiveOfferEdition.tsx
@@ -21,28 +21,29 @@ const CollectiveOfferEdition = ({
     offer
   )
 
-  if (!isReady || !offer) {
-    return <Spinner />
-  }
-
   return (
-    <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
-      <OfferEducationalScreen
-        categories={offerEducationalFormData.categories}
-        userOfferers={offerEducationalFormData.offerers}
-        domainsOptions={offerEducationalFormData.domains}
-        nationalPrograms={offerEducationalFormData.nationalPrograms}
-        offer={offer}
-        setOffer={setOffer}
-        isOfferActive={offer?.isActive}
-        isOfferBooked={
-          offer?.isTemplate ? false : offer?.collectiveStock?.isBooked
-        }
-        mode={offer?.isEditable ? Mode.EDITION : Mode.READ_ONLY}
-        reloadCollectiveOffer={reloadCollectiveOffer}
-        isTemplate={offer.isTemplate}
-      />
-    </CollectiveOfferLayout>
+    <>
+      <Spinner isLoading={!isReady || !offer} />
+      {isReady && !!offer && (
+        <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+          <OfferEducationalScreen
+            categories={offerEducationalFormData.categories}
+            userOfferers={offerEducationalFormData.offerers}
+            domainsOptions={offerEducationalFormData.domains}
+            nationalPrograms={offerEducationalFormData.nationalPrograms}
+            offer={offer}
+            setOffer={setOffer}
+            isOfferActive={offer?.isActive}
+            isOfferBooked={
+              offer?.isTemplate ? false : offer?.collectiveStock?.isBooked
+            }
+            mode={offer?.isEditable ? Mode.EDITION : Mode.READ_ONLY}
+            reloadCollectiveOffer={reloadCollectiveOffer}
+            isTemplate={offer.isTemplate}
+          />
+        </CollectiveOfferLayout>
+      )}
+    </>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferFromRequest/CollectiveOfferFromRequest.tsx
+++ b/pro/src/pages/CollectiveOfferFromRequest/CollectiveOfferFromRequest.tsx
@@ -79,90 +79,91 @@ const CollectiveOfferFromRequest = (): JSX.Element => {
     fetchData()
   }, [])
 
-  if (isLoading) {
-    return <Spinner />
-  }
-
   return (
     <>
-      <div className={styles['eac-section']}>
-        <Title level={1}>Récapitulatif de la demande</Title>
-      </div>
-      <div className={styles['eac-section']}>
-        Vous avez reçu une demande de création d'offres de la part d'un
-        établissement scolaire. Vous pouvez créer une offre à partir des
-        informations saisies par l'enseignant. Toutes les informations sont
-        modifiables.
-        <br /> L'offre sera visible par l'enseignant sur Adage.
-      </div>
-      <SummaryLayout.Section title="Détails de la demande">
-        <div className={styles['eac-section']}>
-          <SummaryLayout.Row
-            title="Demande reçue le"
-            description={
-              informations?.dateCreated
-                ? getDateToFrenchText(informations?.dateCreated)
-                : '-'
-            }
-          />
-          <SummaryLayout.Row
-            title="Offre concernée"
-            description={offerTemplate?.name}
-          />
-        </div>
-        <div className={styles['eac-section']}>
-          <SummaryLayout.Row
-            title="Etablissement scolaire"
-            description={
-              <div>
-                {`${informations?.institution.institutionType} ${informations?.institution.name}`.trim()}
-                <br />
-                {`${informations?.institution.postalCode} ${informations?.institution.city}`}
-              </div>
-            }
-          />
-          <SummaryLayout.Row
-            title="Prénom et nom de l'enseignant"
-            description={`${informations?.redactor.firstName} ${informations?.redactor.lastName} `}
-          />
-          <SummaryLayout.Row
-            title="Téléphone"
-            description={informations?.phoneNumber ?? '-'}
-          />
-          <SummaryLayout.Row
-            title="Email"
-            description={informations?.redactor.email}
-          />
-        </div>
+      <Spinner isLoading={isLoading} />
+      {!isLoading && (
+        <>
+          <div className={styles['eac-section']}>
+            <Title level={1}>Récapitulatif de la demande</Title>
+          </div>
+          <div className={styles['eac-section']}>
+            Vous avez reçu une demande de création d'offres de la part d'un
+            établissement scolaire. Vous pouvez créer une offre à partir des
+            informations saisies par l'enseignant. Toutes les informations sont
+            modifiables.
+            <br /> L'offre sera visible par l'enseignant sur Adage.
+          </div>
+          <SummaryLayout.Section title="Détails de la demande">
+            <div className={styles['eac-section']}>
+              <SummaryLayout.Row
+                title="Demande reçue le"
+                description={
+                  informations?.dateCreated
+                    ? getDateToFrenchText(informations?.dateCreated)
+                    : '-'
+                }
+              />
+              <SummaryLayout.Row
+                title="Offre concernée"
+                description={offerTemplate?.name}
+              />
+            </div>
+            <div className={styles['eac-section']}>
+              <SummaryLayout.Row
+                title="Etablissement scolaire"
+                description={
+                  <div>
+                    {`${informations?.institution.institutionType} ${informations?.institution.name}`.trim()}
+                    <br />
+                    {`${informations?.institution.postalCode} ${informations?.institution.city}`}
+                  </div>
+                }
+              />
+              <SummaryLayout.Row
+                title="Prénom et nom de l'enseignant"
+                description={`${informations?.redactor.firstName} ${informations?.redactor.lastName} `}
+              />
+              <SummaryLayout.Row
+                title="Téléphone"
+                description={informations?.phoneNumber ?? '-'}
+              />
+              <SummaryLayout.Row
+                title="Email"
+                description={informations?.redactor.email}
+              />
+            </div>
 
-        <SummaryLayout.Row
-          title="Nombre d'élèves"
-          description={informations?.totalStudents ?? '-'}
-        />
-        <SummaryLayout.Row
-          title="Nombre d'accompagnateurs"
-          description={informations?.totalTeachers ?? '-'}
-        />
-        <SummaryLayout.Row
-          title="Date souhaitée"
-          description={
-            informations?.requestedDate
-              ? getDateToFrenchText(informations?.requestedDate)
-              : '-'
-          }
-        />
-        <SummaryLayout.Row
-          title="Descriptif de la demande"
-          description={informations?.comment}
-        />
-      </SummaryLayout.Section>
-      <ActionsBarSticky>
-        <ActionsBarSticky.Right>
-          <Button onClick={handleButtonClick}>
-            Créer l’offre pour l’enseignant
-          </Button>
-        </ActionsBarSticky.Right>
-      </ActionsBarSticky>
+            <SummaryLayout.Row
+              title="Nombre d'élèves"
+              description={informations?.totalStudents ?? '-'}
+            />
+            <SummaryLayout.Row
+              title="Nombre d'accompagnateurs"
+              description={informations?.totalTeachers ?? '-'}
+            />
+            <SummaryLayout.Row
+              title="Date souhaitée"
+              description={
+                informations?.requestedDate
+                  ? getDateToFrenchText(informations?.requestedDate)
+                  : '-'
+              }
+            />
+            <SummaryLayout.Row
+              title="Descriptif de la demande"
+              description={informations?.comment}
+            />
+          </SummaryLayout.Section>
+          <ActionsBarSticky>
+            <ActionsBarSticky.Right>
+              <Button onClick={handleButtonClick}>
+                Créer l’offre pour l’enseignant
+              </Button>
+            </ActionsBarSticky.Right>
+          </ActionsBarSticky>
+        </>
+      )}
     </>
   )
 }

--- a/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -30,25 +30,27 @@ export const CollectiveOfferSummaryCreation = ({
 
   if (error) {
     notify.error(error.message)
-    return <></>
   }
 
-  return isLoading ? (
-    <Spinner />
-  ) : (
-    <CollectiveOfferLayout
-      subTitle={offer?.name}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
-      isTemplate={isTemplate}
-      isCreation={true}
-    >
-      <CollectiveOfferSummaryCreationScreen
-        offer={offer}
-        categories={categories}
-        setOffer={setOffer}
-      />
-      <RouteLeavingGuardCollectiveOfferCreation />
-    </CollectiveOfferLayout>
+  return (
+    <>
+      <Spinner isLoading={isLoading} />
+      {!isLoading && !error && (
+        <CollectiveOfferLayout
+          subTitle={offer?.name}
+          isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+          isTemplate={isTemplate}
+          isCreation={true}
+        >
+          <CollectiveOfferSummaryCreationScreen
+            offer={offer}
+            categories={categories}
+            setOffer={setOffer}
+          />
+          <RouteLeavingGuardCollectiveOfferCreation />
+        </CollectiveOfferLayout>
+      )}
+    </>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -41,17 +41,20 @@ const CollectiveOfferSummaryEdition = ({
 
   const isReady = offer !== null && categories !== null
 
-  return !isReady ? (
-    <Spinner />
-  ) : (
-    <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
-      <CollectiveOfferSummaryEditionScreen
-        offer={offer}
-        categories={categories}
-        reloadCollectiveOffer={reloadCollectiveOffer}
-        mode={Mode.EDITION}
-      />
-    </CollectiveOfferLayout>
+  return (
+    <>
+      <Spinner isLoading={!isReady} />
+      {isReady && (
+        <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+          <CollectiveOfferSummaryEditionScreen
+            offer={offer}
+            categories={categories}
+            reloadCollectiveOffer={reloadCollectiveOffer}
+            mode={Mode.EDITION}
+          />
+        </CollectiveOfferLayout>
+      )}
+    </>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferEditionVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferEditionVisibility.tsx
@@ -60,46 +60,43 @@ const CollectiveOfferVisibility = ({
     notify.success(message)
   }
 
-  if (isLoading) {
-    return <Spinner />
-  }
-
-  if (error) {
-    return null
-  }
-
   return (
-    <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
-      {isOfferInstitutionActive ? (
-        <CollectiveOfferVisibilityScreen
-          mode={offer.isVisibilityEditable ? Mode.EDITION : Mode.READ_ONLY}
-          patchInstitution={patchEducationalInstitutionAdapter}
-          initialValues={extractInitialVisibilityValues(
-            offer.institution,
-            offer.teacher
+    <>
+      <Spinner isLoading={isLoading} />
+      {!isLoading && !error && (
+        <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+          {isOfferInstitutionActive ? (
+            <CollectiveOfferVisibilityScreen
+              mode={offer.isVisibilityEditable ? Mode.EDITION : Mode.READ_ONLY}
+              patchInstitution={patchEducationalInstitutionAdapter}
+              initialValues={extractInitialVisibilityValues(
+                offer.institution,
+                offer.teacher
+              )}
+              onSuccess={onSuccess}
+              institutions={institutionsPayload.institutions}
+              isLoadingInstitutions={isLoading}
+              offer={offer}
+              reloadCollectiveOffer={reloadCollectiveOffer}
+            />
+          ) : (
+            <OldCollectiveOfferVisibility
+              mode={offer.isVisibilityEditable ? Mode.EDITION : Mode.READ_ONLY}
+              patchInstitution={patchEducationalInstitutionAdapter}
+              initialValues={extractInitialVisibilityValues(
+                offer.institution,
+                offer.teacher
+              )}
+              onSuccess={onSuccess}
+              institutions={institutionsPayload.institutions}
+              isLoadingInstitutions={isLoading}
+              offer={offer}
+              reloadCollectiveOffer={reloadCollectiveOffer}
+            />
           )}
-          onSuccess={onSuccess}
-          institutions={institutionsPayload.institutions}
-          isLoadingInstitutions={isLoading}
-          offer={offer}
-          reloadCollectiveOffer={reloadCollectiveOffer}
-        />
-      ) : (
-        <OldCollectiveOfferVisibility
-          mode={offer.isVisibilityEditable ? Mode.EDITION : Mode.READ_ONLY}
-          patchInstitution={patchEducationalInstitutionAdapter}
-          initialValues={extractInitialVisibilityValues(
-            offer.institution,
-            offer.teacher
-          )}
-          onSuccess={onSuccess}
-          institutions={institutionsPayload.institutions}
-          isLoadingInstitutions={isLoading}
-          offer={offer}
-          reloadCollectiveOffer={reloadCollectiveOffer}
-        />
+        </CollectiveOfferLayout>
       )}
-    </CollectiveOfferLayout>
+    </>
   )
 }
 

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -330,7 +330,8 @@ const Venue = ({
           </div>
           {isStatOpen && (
             <>
-              {isStatLoaded ? (
+              <Spinner isLoading={!isStatLoaded} />
+              {isStatLoaded && (
                 <>
                   <VenueOfferSteps
                     venueId={venueId}
@@ -373,8 +374,6 @@ const Venue = ({
                     </div>
                   </div>
                 </>
-              ) : (
-                <Spinner />
               )}
             </>
           )}

--- a/pro/src/pages/IndividualOfferWizard/BookingsSummary/BookingsSummary.tsx
+++ b/pro/src/pages/IndividualOfferWizard/BookingsSummary/BookingsSummary.tsx
@@ -11,18 +11,19 @@ export const BookingsSummary = (): JSX.Element | null => {
   const mode = useOfferWizardMode()
   const { offer, setOffer } = useIndividualOfferContext()
 
-  if (offer === null) {
-    return <Spinner />
-  }
-
   return (
-    <IndivualOfferLayout
-      title="Récapitulatif"
-      offer={offer}
-      setOffer={setOffer}
-      mode={mode}
-    >
-      <BookingsSummaryScreen offer={offer} />
-    </IndivualOfferLayout>
+    <>
+      <Spinner isLoading={offer === null} />
+      {offer !== null && (
+        <IndivualOfferLayout
+          title="Récapitulatif"
+          offer={offer}
+          setOffer={setOffer}
+          mode={mode}
+        >
+          <BookingsSummaryScreen offer={offer} />
+        </IndivualOfferLayout>
+      )}
+    </>
   )
 }

--- a/pro/src/pages/IndividualOfferWizard/Confirmation/Confirmation.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Confirmation/Confirmation.tsx
@@ -11,20 +11,21 @@ const Confirmation = (): JSX.Element => {
   const mode = useOfferWizardMode()
   const { offer, setOffer } = useIndividualOfferContext()
 
-  if (offer === null) {
-    return <Spinner />
-  }
-
   return (
-    <IndivualOfferLayout
-      withStepper={false}
-      offer={offer}
-      setOffer={setOffer}
-      title={getTitle(mode)}
-      mode={mode}
-    >
-      <IndividualOfferConfirmationScreen offer={offer} />
-    </IndivualOfferLayout>
+    <>
+      <Spinner isLoading={offer === null} />
+      {offer !== null && (
+        <IndivualOfferLayout
+          withStepper={false}
+          offer={offer}
+          setOffer={setOffer}
+          title={getTitle(mode)}
+          mode={mode}
+        >
+          <IndividualOfferConfirmationScreen offer={offer} />
+        </IndivualOfferLayout>
+      )}
+    </>
   )
 }
 

--- a/pro/src/pages/IndividualOfferWizard/PriceCategories/PriceCategories.tsx
+++ b/pro/src/pages/IndividualOfferWizard/PriceCategories/PriceCategories.tsx
@@ -15,18 +15,20 @@ export const PriceCategories = (): JSX.Element | null => {
   // submited payload. Due to React 18 render batching behavior and react-router
   // implementation, this component can be rendered before the offer is set in the
   // offer individual context
-  if (offer === null) {
-    return <Spinner />
-  }
 
   return (
-    <IndivualOfferLayout
-      offer={offer}
-      setOffer={setOffer}
-      title={getTitle(mode)}
-      mode={mode}
-    >
-      <PriceCategoriesScreen offer={offer} />
-    </IndivualOfferLayout>
+    <>
+      <Spinner isLoading={offer === null} />
+      {offer !== null && (
+        <IndivualOfferLayout
+          offer={offer}
+          setOffer={setOffer}
+          title={getTitle(mode)}
+          mode={mode}
+        >
+          <PriceCategoriesScreen offer={offer} />
+        </IndivualOfferLayout>
+      )}
+    </>
   )
 }

--- a/pro/src/pages/IndividualOfferWizard/PriceCategoriesSummary/PriceCategoriesSummary.tsx
+++ b/pro/src/pages/IndividualOfferWizard/PriceCategoriesSummary/PriceCategoriesSummary.tsx
@@ -10,22 +10,23 @@ export const PriceCategoriesSummary = (): JSX.Element | null => {
   const mode = useOfferWizardMode()
   const { offer, subCategories, setOffer } = useIndividualOfferContext()
 
-  if (offer === null) {
-    return <Spinner />
-  }
-
   const canBeDuo = subCategories.find(
-    (subCategory) => subCategory.id === offer.subcategoryId
+    (subCategory) => subCategory.id === offer?.subcategoryId
   )?.canBeDuo
 
   return (
-    <IndivualOfferLayout
-      title="Récapitulatif"
-      offer={offer}
-      setOffer={setOffer}
-      mode={mode}
-    >
-      <PriceCategoriesSection offer={offer} canBeDuo={canBeDuo} />
-    </IndivualOfferLayout>
+    <>
+      <Spinner isLoading={offer === null} />
+      {offer !== null && (
+        <IndivualOfferLayout
+          title="Récapitulatif"
+          offer={offer}
+          setOffer={setOffer}
+          mode={mode}
+        >
+          <PriceCategoriesSection offer={offer} canBeDuo={canBeDuo} />
+        </IndivualOfferLayout>
+      )}
+    </>
   )
 }

--- a/pro/src/pages/IndividualOfferWizard/StocksSummary/StocksSummary.tsx
+++ b/pro/src/pages/IndividualOfferWizard/StocksSummary/StocksSummary.tsx
@@ -11,18 +11,19 @@ export const StocksSummary = (): JSX.Element | null => {
   const mode = useOfferWizardMode()
   const { offer, setOffer } = useIndividualOfferContext()
 
-  if (offer === null) {
-    return <Spinner />
-  }
-
   return (
-    <IndivualOfferLayout
-      title="Récapitulatif"
-      offer={offer}
-      setOffer={setOffer}
-      mode={mode}
-    >
-      <StocksSummaryScreen />
-    </IndivualOfferLayout>
+    <>
+      <Spinner isLoading={offer === null} />
+      {offer !== null && (
+        <IndivualOfferLayout
+          title="Récapitulatif"
+          offer={offer}
+          setOffer={setOffer}
+          mode={mode}
+        >
+          <StocksSummaryScreen />
+        </IndivualOfferLayout>
+      )}
+    </>
   )
 }

--- a/pro/src/pages/IndividualOfferWizard/Summary/Summary.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Summary/Summary.tsx
@@ -23,18 +23,20 @@ export const Summary = (): JSX.Element | null => {
   } else {
     title = getTitle(mode)
   }
-  if (offer === null) {
-    return <Spinner />
-  }
 
   return (
-    <IndivualOfferLayout
-      title={title}
-      offer={offer}
-      setOffer={setOffer}
-      mode={mode}
-    >
-      <SummaryScreen />
-    </IndivualOfferLayout>
+    <>
+      <Spinner isLoading={offer === null} />
+      {offer !== null && (
+        <IndivualOfferLayout
+          title={title}
+          offer={offer}
+          setOffer={setOffer}
+          mode={mode}
+        >
+          <SummaryScreen />
+        </IndivualOfferLayout>
+      )}
+    </>
   )
 }

--- a/pro/src/pages/OffererStats/OffererStats.tsx
+++ b/pro/src/pages/OffererStats/OffererStats.tsx
@@ -9,21 +9,26 @@ import { sortByLabel } from 'utils/strings'
 const OffererStats = (): JSX.Element | null => {
   const notify = useNotification()
   const { isLoading, error, data: offererNames } = useGetOffererNames({})
-  if (isLoading) {
-    return <Spinner />
-  }
+
   if (error) {
     notify.error(error.message)
-    return null
   }
 
-  const offererOptions = sortByLabel(
-    offererNames.map((offerer) => ({
-      value: offerer.id.toString(),
-      label: offerer.name,
-    }))
+  return (
+    <>
+      <Spinner isLoading={isLoading} />
+      {!isLoading && !error && (
+        <OffererStatsScreen
+          offererOptions={sortByLabel(
+            offererNames.map((offerer) => ({
+              value: offerer.id.toString(),
+              label: offerer.name,
+            }))
+          )}
+        />
+      )}
+    </>
   )
-  return <OffererStatsScreen offererOptions={offererOptions} />
 }
 
 export default OffererStats

--- a/pro/src/pages/Offers/Offers/Offers.tsx
+++ b/pro/src/pages/Offers/Offers/Offers.tsx
@@ -130,9 +130,8 @@ const Offers = ({
 
   return (
     <div aria-busy={isLoading} aria-live="polite" className="section">
-      {isLoading ? (
-        <Spinner />
-      ) : (
+      <Spinner isLoading={isLoading} />
+      {!isLoading && (
         <>
           {offersCount > MAX_OFFERS_TO_DISPLAY && (
             <Banner type="notification-info">

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -153,26 +153,27 @@ const OffersRoute = (): JSX.Element => {
     loadAllVenuesByProUser()
   }, [offerer?.id])
 
-  if (!initialSearchFilters) {
-    return <Spinner />
-  }
-
   return (
-    <OffersScreen
-      audience={Audience.INDIVIDUAL}
-      categories={categories}
-      currentPageNumber={currentPageNumber}
-      currentUser={currentUser}
-      initialSearchFilters={initialSearchFilters}
-      isLoading={isLoading}
-      loadAndUpdateOffers={loadAndUpdateOffers}
-      offerer={offerer}
-      offers={offers}
-      redirectWithUrlFilters={redirectWithUrlFilters}
-      setOfferer={setOfferer}
-      urlSearchFilters={urlSearchFilters}
-      venues={venues}
-    />
+    <>
+      <Spinner isLoading={!initialSearchFilters} />
+      {initialSearchFilters && (
+        <OffersScreen
+          audience={Audience.INDIVIDUAL}
+          categories={categories}
+          currentPageNumber={currentPageNumber}
+          currentUser={currentUser}
+          initialSearchFilters={initialSearchFilters}
+          isLoading={isLoading}
+          loadAndUpdateOffers={loadAndUpdateOffers}
+          offerer={offerer}
+          offers={offers}
+          redirectWithUrlFilters={redirectWithUrlFilters}
+          setOfferer={setOfferer}
+          urlSearchFilters={urlSearchFilters}
+          venues={venues}
+        />
+      )}
+    </>
   )
 }
 

--- a/pro/src/screens/IndividualOffer/BookingsSummary/BookingsSummary.tsx
+++ b/pro/src/screens/IndividualOffer/BookingsSummary/BookingsSummary.tsx
@@ -85,7 +85,8 @@ export const BookingsSummaryScreen = ({
 
   return (
     <SummaryLayout.Section title="Réservations">
-      {bookings !== null ? (
+      <Spinner isLoading={bookings === null} />
+      {bookings !== null && (
         <>
           <div>{pluralize(filteredBookings.length, 'réservation')}</div>
           <IndividualBookingsTable
@@ -97,8 +98,6 @@ export const BookingsSummaryScreen = ({
             resetFilters={() => setBookingsStatusFilter([])}
           />
         </>
-      ) : (
-        <Spinner />
       )}
     </SummaryLayout.Section>
   )

--- a/pro/src/screens/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
+++ b/pro/src/screens/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
@@ -119,125 +119,126 @@ const CollectiveOfferType = ({
     initializeStates()
   }, [queryOffererId, queryVenueId])
 
-  if (isLoading) {
-    return <Spinner />
-  }
-
   return (
     <>
-      {isValidated && isEligible && (
-        <FormLayout.Section
-          title="Quel est le type de l’offre ?"
-          className={styles['subtype-section']}
-        >
-          <FormLayout.Row inline mdSpaceAfter>
-            <RadioButtonWithImage
-              name="collectiveOfferSubtype"
-              icon={strokeBookedIcon}
-              isChecked={
-                values.collectiveOfferSubtype ===
-                COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE
-              }
-              label="Une offre réservable"
-              description="Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé."
-              onChange={handleChange}
-              value={COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE}
-            />
-          </FormLayout.Row>
+      <Spinner isLoading={isLoading} />
+      {!isLoading && (
+        <>
+          {isValidated && isEligible && (
+            <FormLayout.Section
+              title="Quel est le type de l’offre ?"
+              className={styles['subtype-section']}
+            >
+              <FormLayout.Row inline mdSpaceAfter>
+                <RadioButtonWithImage
+                  name="collectiveOfferSubtype"
+                  icon={strokeBookedIcon}
+                  isChecked={
+                    values.collectiveOfferSubtype ===
+                    COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE
+                  }
+                  label="Une offre réservable"
+                  description="Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé."
+                  onChange={handleChange}
+                  value={COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE}
+                />
+              </FormLayout.Row>
 
-          <FormLayout.Row inline mdSpaceAfter>
-            <RadioButtonWithImage
-              name="collectiveOfferSubtype"
-              icon={strokeTemplateOfferIcon}
-              isChecked={
-                values.collectiveOfferSubtype ===
-                COLLECTIVE_OFFER_SUBTYPE.TEMPLATE
-              }
-              label="Une offre vitrine"
-              description={`Cette offre n’est pas réservable. Elle ${
-                !isDatesForTemplateOffer ? 'n’a ni date, ni prix et' : ''
-              } permet aux enseignants de vous contacter pour co-construire une offre adaptée. Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.`}
-              onChange={handleChange}
-              value={COLLECTIVE_OFFER_SUBTYPE.TEMPLATE}
-            />
-          </FormLayout.Row>
-        </FormLayout.Section>
-      )}
-      {isEligible &&
-        values.collectiveOfferSubtype ===
-          COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE && (
-          <FormLayout.Section
-            title="Créer une nouvelle offre ou dupliquer une offre ?"
-            className={styles['subtype-section']}
-          >
-            <FormLayout.Row inline mdSpaceAfter>
-              <RadioButtonWithImage
-                name="collectiveOfferSubtypeDuplicate"
-                icon={strokeNewOfferIcon}
-                isChecked={
-                  values.collectiveOfferSubtypeDuplicate ===
-                  COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.NEW_OFFER
-                }
-                label="Créer une nouvelle offre"
-                description="Créer une nouvelle offre réservable en partant d’un formulaire vierge."
-                onChange={handleChange}
-                value={COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.NEW_OFFER}
-              />
-            </FormLayout.Row>
-            <FormLayout.Row inline mdSpaceAfter>
-              <RadioButtonWithImage
-                name="collectiveOfferSubtypeDuplicate"
-                icon={duplicateOfferIcon}
-                isChecked={
-                  values.collectiveOfferSubtypeDuplicate ===
-                  COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.DUPLICATE
-                }
-                label="Dupliquer les informations d’une d’offre vitrine"
-                description="Créez une offre réservable en dupliquant les informations d’une offre vitrine existante."
-                onChange={handleChange}
-                value={COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.DUPLICATE}
-              />
-            </FormLayout.Row>
-          </FormLayout.Section>
-        )}
+              <FormLayout.Row inline mdSpaceAfter>
+                <RadioButtonWithImage
+                  name="collectiveOfferSubtype"
+                  icon={strokeTemplateOfferIcon}
+                  isChecked={
+                    values.collectiveOfferSubtype ===
+                    COLLECTIVE_OFFER_SUBTYPE.TEMPLATE
+                  }
+                  label="Une offre vitrine"
+                  description={`Cette offre n’est pas réservable. Elle ${
+                    !isDatesForTemplateOffer ? 'n’a ni date, ni prix et' : ''
+                  } permet aux enseignants de vous contacter pour co-construire une offre adaptée. Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.`}
+                  onChange={handleChange}
+                  value={COLLECTIVE_OFFER_SUBTYPE.TEMPLATE}
+                />
+              </FormLayout.Row>
+            </FormLayout.Section>
+          )}
+          {isEligible &&
+            values.collectiveOfferSubtype ===
+              COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE && (
+              <FormLayout.Section
+                title="Créer une nouvelle offre ou dupliquer une offre ?"
+                className={styles['subtype-section']}
+              >
+                <FormLayout.Row inline mdSpaceAfter>
+                  <RadioButtonWithImage
+                    name="collectiveOfferSubtypeDuplicate"
+                    icon={strokeNewOfferIcon}
+                    isChecked={
+                      values.collectiveOfferSubtypeDuplicate ===
+                      COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.NEW_OFFER
+                    }
+                    label="Créer une nouvelle offre"
+                    description="Créer une nouvelle offre réservable en partant d’un formulaire vierge."
+                    onChange={handleChange}
+                    value={COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.NEW_OFFER}
+                  />
+                </FormLayout.Row>
+                <FormLayout.Row inline mdSpaceAfter>
+                  <RadioButtonWithImage
+                    name="collectiveOfferSubtypeDuplicate"
+                    icon={duplicateOfferIcon}
+                    isChecked={
+                      values.collectiveOfferSubtypeDuplicate ===
+                      COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.DUPLICATE
+                    }
+                    label="Dupliquer les informations d’une d’offre vitrine"
+                    description="Créez une offre réservable en dupliquant les informations d’une offre vitrine existante."
+                    onChange={handleChange}
+                    value={COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.DUPLICATE}
+                  />
+                </FormLayout.Row>
+              </FormLayout.Section>
+            )}
 
-      {values.offerType === OFFER_TYPES.EDUCATIONAL && !isValidated && (
-        <Banner>
-          Votre structure est en cours de validation par les équipes pass
-          Culture.
-        </Banner>
+          {values.offerType === OFFER_TYPES.EDUCATIONAL && !isValidated && (
+            <Banner>
+              Votre structure est en cours de validation par les équipes pass
+              Culture.
+            </Banner>
+          )}
+          {!isEligible &&
+            (lastDmsApplication ? (
+              <Banner
+                links={[
+                  {
+                    href: `/structures/${queryOffererId}/lieux/${lastDmsApplication?.venueId}#venue-collective-data`,
+                    linkTitle: 'Voir ma demande de référencement',
+                  },
+                ]}
+              >
+                Vous avez une demande de référencement en cours de traitement
+              </Banner>
+            ) : (
+              <Banner
+                links={[
+                  {
+                    href: 'https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage',
+                    linkTitle: 'Faire une demande de référencement',
+                  },
+                  {
+                    href: 'https://aide.passculture.app/hc/fr/articles/5700215550364',
+                    linkTitle:
+                      'Ma demande de référencement a été acceptée mais je ne peux toujours pas créer d’offres collectives',
+                  },
+                ]}
+              >
+                Pour proposer des offres à destination d’un groupe scolaire,
+                vous devez être référencé auprès du ministère de l’Éducation
+                Nationale et du ministère de la Culture.
+              </Banner>
+            ))}
+        </>
       )}
-      {!isEligible &&
-        (lastDmsApplication ? (
-          <Banner
-            links={[
-              {
-                href: `/structures/${queryOffererId}/lieux/${lastDmsApplication?.venueId}#venue-collective-data`,
-                linkTitle: 'Voir ma demande de référencement',
-              },
-            ]}
-          >
-            Vous avez une demande de référencement en cours de traitement
-          </Banner>
-        ) : (
-          <Banner
-            links={[
-              {
-                href: 'https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage',
-                linkTitle: 'Faire une demande de référencement',
-              },
-              {
-                href: 'https://aide.passculture.app/hc/fr/articles/5700215550364',
-                linkTitle:
-                  'Ma demande de référencement a été acceptée mais je ne peux toujours pas créer d’offres collectives',
-              },
-            ]}
-          >
-            Pour proposer des offres à destination d’un groupe scolaire, vous
-            devez être référencé auprès du ministère de l’Éducation Nationale et
-            du ministère de la Culture.
-          </Banner>
-        ))}
     </>
   )
 }

--- a/pro/src/screens/OfferType/IndividualOfferType/IndividualOfferType.tsx
+++ b/pro/src/screens/OfferType/IndividualOfferType/IndividualOfferType.tsx
@@ -102,44 +102,43 @@ const IndividualOfferType = (): JSX.Element | null => {
   const venueTypeMostUsedSubcategories =
     venueType && venueTypeSubcategoriesMapping[venueType]
 
-  if (isLoading) {
-    return <Spinner />
-  }
-
   return (
     <>
-      {isCategorySelectionActive && venueTypeMostUsedSubcategories && (
-        <FormLayout.Section
-          title="Quelle est la catégorie de l’offre ?"
-          description="Ces catégories sont suggérées d’après les catégories les plus fréquemment sélectionnées pour votre type de lieu."
-          className={styles['subcategory-section']}
-        >
-          {venueTypeMostUsedSubcategories.map(
-            (subcategory: SubcategoryIdEnum) => (
-              <RadioButton
-                className={styles['individual-radio-button-subcategory']}
-                key={subcategory}
-                withBorder
-                value={subcategory}
-                label={
-                  subcategories.find((s) => s.id === subcategory)?.proLabel ||
-                  ''
-                }
-                name="individualOfferSubcategory"
-                variant={BaseRadioVariant.SECONDARY}
-              />
-            )
-          )}
-          <RadioButton
-            className={styles['individual-radio-button-subcategory']}
-            withBorder
-            value="OTHER"
-            label="Autre"
-            name="individualOfferSubcategory"
-            variant={BaseRadioVariant.SECONDARY}
-          />
-        </FormLayout.Section>
-      )}
+      <Spinner isLoading={isLoading} />
+      {!isLoading &&
+        isCategorySelectionActive &&
+        venueTypeMostUsedSubcategories && (
+          <FormLayout.Section
+            title="Quelle est la catégorie de l’offre ?"
+            description="Ces catégories sont suggérées d’après les catégories les plus fréquemment sélectionnées pour votre type de lieu."
+            className={styles['subcategory-section']}
+          >
+            {venueTypeMostUsedSubcategories.map(
+              (subcategory: SubcategoryIdEnum) => (
+                <RadioButton
+                  className={styles['individual-radio-button-subcategory']}
+                  key={subcategory}
+                  withBorder
+                  value={subcategory}
+                  label={
+                    subcategories.find((s) => s.id === subcategory)?.proLabel ||
+                    ''
+                  }
+                  name="individualOfferSubcategory"
+                  variant={BaseRadioVariant.SECONDARY}
+                />
+              )
+            )}
+            <RadioButton
+              className={styles['individual-radio-button-subcategory']}
+              withBorder
+              value="OTHER"
+              label="Autre"
+              name="individualOfferSubcategory"
+              variant={BaseRadioVariant.SECONDARY}
+            />
+          </FormLayout.Section>
+        )}
 
       {(!venueTypeMostUsedSubcategories ||
         values.individualOfferSubcategory === 'OTHER') && (

--- a/pro/src/screens/SignupJourneyForm/Activity/Activity.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/Activity.tsx
@@ -95,32 +95,32 @@ const Activity = (): JSX.Element => {
     navigate('/parcours-inscription/identification')
   }
 
-  if (isLoadingVenueTypes) {
-    return <Spinner />
-  }
-
-  if (errorVenueTypes) {
-    return <></>
-  }
-
   return (
-    <FormLayout>
-      <FormikProvider value={formik}>
-        <form onSubmit={formik.handleSubmit} data-testid="signup-activity-form">
-          <FormLayout.MandatoryInfo />
-          <ActivityForm venueTypes={venueTypes} />
-          <ActionBar
-            onClickPrevious={handlePreviousStep}
-            onClickNext={handleNextStep}
-            isDisabled={formik.isSubmitting}
-            previousTo={SIGNUP_JOURNEY_STEP_IDS.AUTHENTICATION}
-            nextTo={SIGNUP_JOURNEY_STEP_IDS.VALIDATION}
-            logEvent={logEvent}
-            legalCategoryCode={offerer?.legalCategoryCode}
-          />
-        </form>
-      </FormikProvider>
-    </FormLayout>
+    <>
+      <Spinner isLoading={isLoadingVenueTypes} />
+      {!isLoadingVenueTypes && !errorVenueTypes && (
+        <FormLayout>
+          <FormikProvider value={formik}>
+            <form
+              onSubmit={formik.handleSubmit}
+              data-testid="signup-activity-form"
+            >
+              <FormLayout.MandatoryInfo />
+              <ActivityForm venueTypes={venueTypes} />
+              <ActionBar
+                onClickPrevious={handlePreviousStep}
+                onClickNext={handleNextStep}
+                isDisabled={formik.isSubmitting}
+                previousTo={SIGNUP_JOURNEY_STEP_IDS.AUTHENTICATION}
+                nextTo={SIGNUP_JOURNEY_STEP_IDS.VALIDATION}
+                logEvent={logEvent}
+                legalCategoryCode={offerer?.legalCategoryCode}
+              />
+            </form>
+          </FormikProvider>
+        </FormLayout>
+      )}
+    </>
   )
 }
 

--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
@@ -54,38 +54,26 @@ const Validation = (): JSX.Element => {
     }
   }, [activity, offerer])
 
-  if (isLoadingVenueTypes) {
-    return <Spinner />
-  }
-
-  if (errorVenueTypes) {
-    return <></>
-  }
-
-  if (activity === null || offerer === null) {
-    return <></>
-  }
-
   const onSubmit = async () => {
     /* istanbul ignore next: ENV dependant */
     const token = await getReCaptchaToken('saveNewOnboardingData')
 
     const data: SaveNewOnboardingDataQueryModel = {
-      publicName: offerer.publicName ?? '',
-      siret: offerer.siret.replaceAll(' ', ''),
+      publicName: offerer?.publicName ?? '',
+      siret: offerer?.siret.replaceAll(' ', '') ?? '',
       venueTypeCode:
         /* istanbul ignore next: should not have empty or null venueTypeCode at this step */
-        activity.venueTypeCode,
-      webPresence: activity.socialUrls.join(', '),
+        activity?.venueTypeCode ?? '',
+      webPresence: activity?.socialUrls.join(', ') ?? '',
       target:
         /* istanbul ignore next: the form validation already handles this */
-        activity.targetCustomer ?? Target.EDUCATIONAL,
+        activity?.targetCustomer ?? Target.EDUCATIONAL,
       createVenueWithoutSiret: offerer?.createVenueWithoutSiret ?? false,
-      address: offerer.address,
-      longitude: offerer.longitude ?? 0,
-      latitude: offerer.latitude ?? 0,
-      city: offerer.city,
-      postalCode: offerer.postalCode,
+      address: offerer?.address,
+      longitude: offerer?.longitude ?? 0,
+      latitude: offerer?.latitude ?? 0,
+      city: offerer?.city ?? '',
+      postalCode: offerer?.postalCode ?? '',
       token,
     }
 
@@ -102,105 +90,112 @@ const Validation = (): JSX.Element => {
     navigate('/parcours-inscription/activite')
   }
 
+  const error = errorVenueTypes || activity === null || offerer === null
+
   return (
-    <div className={styles['validation-screen']}>
-      <section>
-        <h1 className={styles['title']}>Validation</h1>
-        <h2 className={styles['subtitle']}>
-          Identification
-          <ButtonLink
-            link={{
-              to: '/parcours-inscription/identification',
-              isExternal: false,
-            }}
-            onClick={() => {
-              logEvent?.(Events.CLICKED_ONBOARDING_FORM_NAVIGATION, {
-                from: location.pathname,
-                to: SIGNUP_JOURNEY_STEP_IDS.AUTHENTICATION,
-                used: OnboardingFormNavigationAction.UpdateFromValidation,
-                categorieJuridiqueUniteLegale: offerer.legalCategoryCode,
-              })
-            }}
-            variant={ButtonVariant.TERNARY}
-            iconPosition={IconPositionEnum.LEFT}
-            icon={fullEditIcon}
-          >
-            Modifier
-          </ButtonLink>
-        </h2>
-        <Banner
-          type={'light'}
-          closable={false}
-          className={styles['data-displaying']}
-        >
-          <div className={styles['data-line']}>
-            {offerer?.publicName || offerer?.name}
-          </div>
-          <div className={styles['data-line']}>{offerer?.siret}</div>
-          <div className={styles['data-line']}>
-            {offerer?.address}, {offerer?.postalCode} {offerer?.city}
-          </div>
-        </Banner>
-      </section>
-      <section className={styles['validation-screen']}>
-        <h2 className={styles['subtitle']}>
-          Activité
-          <ButtonLink
-            link={{
-              to: '/parcours-inscription/activite',
-              isExternal: false,
-            }}
-            onClick={() => {
-              logEvent?.(Events.CLICKED_ONBOARDING_FORM_NAVIGATION, {
-                from: location.pathname,
-                to: SIGNUP_JOURNEY_STEP_IDS.ACTIVITY,
-                used: OnboardingFormNavigationAction.UpdateFromValidation,
-                categorieJuridiqueUniteLegale: offerer.legalCategoryCode,
-              })
-            }}
-            variant={ButtonVariant.TERNARY}
-            iconPosition={IconPositionEnum.LEFT}
-            icon={fullEditIcon}
-          >
-            Modifier
-          </ButtonLink>
-        </h2>
-        <Banner
-          type={'light'}
-          closable={false}
-          className={styles['data-displaying']}
-        >
-          <div className={styles['data-line']}>
-            {
-              venueTypes?.find(
-                (venueType) => venueType.value === activity.venueTypeCode
-              )?.label
-            }
-          </div>
-          {activity.socialUrls.map((url) => (
-            <div className={styles['data-line']} key={url}>
-              {url}
-            </div>
-          ))}
-          <div className={styles['data-line']}>{targetCustomerLabel}</div>
-        </Banner>
-      </section>
-      <Banner type="notification-info">
-        Vous pourrez modifier certaines de ces informations dans la page dédiée
-        de votre espace.
-      </Banner>
-      <ActionBar
-        onClickPrevious={handlePreviousStep}
-        previousTo={SIGNUP_JOURNEY_STEP_IDS.ACTIVITY}
-        nextTo={SIGNUP_JOURNEY_STEP_IDS.COMPLETED}
-        onClickNext={onSubmit}
-        isDisabled={false}
-        withRightIcon={false}
-        nextStepTitle="Valider et créer ma structure"
-        logEvent={logEvent}
-        legalCategoryCode={offerer?.legalCategoryCode}
-      />
-    </div>
+    <>
+      <Spinner isLoading={isLoadingVenueTypes && !error} />
+      {!isLoadingVenueTypes && !error && (
+        <div className={styles['validation-screen']}>
+          <section>
+            <h1 className={styles['title']}>Validation</h1>
+            <h2 className={styles['subtitle']}>
+              Identification
+              <ButtonLink
+                link={{
+                  to: '/parcours-inscription/identification',
+                  isExternal: false,
+                }}
+                onClick={() => {
+                  logEvent?.(Events.CLICKED_ONBOARDING_FORM_NAVIGATION, {
+                    from: location.pathname,
+                    to: SIGNUP_JOURNEY_STEP_IDS.AUTHENTICATION,
+                    used: OnboardingFormNavigationAction.UpdateFromValidation,
+                    categorieJuridiqueUniteLegale: offerer.legalCategoryCode,
+                  })
+                }}
+                variant={ButtonVariant.TERNARY}
+                iconPosition={IconPositionEnum.LEFT}
+                icon={fullEditIcon}
+              >
+                Modifier
+              </ButtonLink>
+            </h2>
+            <Banner
+              type={'light'}
+              closable={false}
+              className={styles['data-displaying']}
+            >
+              <div className={styles['data-line']}>
+                {offerer?.publicName || offerer?.name}
+              </div>
+              <div className={styles['data-line']}>{offerer?.siret}</div>
+              <div className={styles['data-line']}>
+                {offerer?.address}, {offerer?.postalCode} {offerer?.city}
+              </div>
+            </Banner>
+          </section>
+          <section className={styles['validation-screen']}>
+            <h2 className={styles['subtitle']}>
+              Activité
+              <ButtonLink
+                link={{
+                  to: '/parcours-inscription/activite',
+                  isExternal: false,
+                }}
+                onClick={() => {
+                  logEvent?.(Events.CLICKED_ONBOARDING_FORM_NAVIGATION, {
+                    from: location.pathname,
+                    to: SIGNUP_JOURNEY_STEP_IDS.ACTIVITY,
+                    used: OnboardingFormNavigationAction.UpdateFromValidation,
+                    categorieJuridiqueUniteLegale: offerer.legalCategoryCode,
+                  })
+                }}
+                variant={ButtonVariant.TERNARY}
+                iconPosition={IconPositionEnum.LEFT}
+                icon={fullEditIcon}
+              >
+                Modifier
+              </ButtonLink>
+            </h2>
+            <Banner
+              type={'light'}
+              closable={false}
+              className={styles['data-displaying']}
+            >
+              <div className={styles['data-line']}>
+                {
+                  venueTypes?.find(
+                    (venueType) => venueType.value === activity.venueTypeCode
+                  )?.label
+                }
+              </div>
+              {activity.socialUrls.map((url) => (
+                <div className={styles['data-line']} key={url}>
+                  {url}
+                </div>
+              ))}
+              <div className={styles['data-line']}>{targetCustomerLabel}</div>
+            </Banner>
+          </section>
+          <Banner type="notification-info">
+            Vous pourrez modifier certaines de ces informations dans la page
+            dédiée de votre espace.
+          </Banner>
+          <ActionBar
+            onClickPrevious={handlePreviousStep}
+            previousTo={SIGNUP_JOURNEY_STEP_IDS.ACTIVITY}
+            nextTo={SIGNUP_JOURNEY_STEP_IDS.COMPLETED}
+            onClickNext={onSubmit}
+            isDisabled={false}
+            withRightIcon={false}
+            nextStepTitle="Valider et créer ma structure"
+            logEvent={logEvent}
+            legalCategoryCode={offerer?.legalCategoryCode}
+          />
+        </div>
+      )}
+    </>
   )
 }
 

--- a/pro/src/store/StoreProvider/StoreProvider.tsx
+++ b/pro/src/store/StoreProvider/StoreProvider.tsx
@@ -23,16 +23,10 @@ const StoreProvider = ({
 }: StoreProviderProps) => {
   const [currentUser, setCurrentUser] =
     useState<SharedCurrentUserResponseModel | null>()
-  const [features, setFeatures] = useState<FeatureResponseModel[]>()
-  const [initialState, setInitialState] =
-    useState<Partial<RootState | null>>(null)
+  const [features, setFeatures] = useState<FeatureResponseModel[]>([])
+  const [initialState, setInitialState] = useState<Partial<RootState>>()
 
   useEffect(() => {
-    function setEmptyInitialData() {
-      setCurrentUser(null)
-      setFeatures([])
-    }
-
     async function getStoreInitialData() {
       if (isAdageIframe) {
         setCurrentUser(null)
@@ -47,8 +41,11 @@ const StoreProvider = ({
         .then((response) => setFeatures(response))
         .catch(() => setFeatures([]))
     }
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    isDev ? setEmptyInitialData() : getStoreInitialData()
+
+    if (!isDev) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      getStoreInitialData()
+    }
   }, [])
 
   useEffect(() => {
@@ -59,16 +56,14 @@ const StoreProvider = ({
       })
     }
   }, [currentUser, features])
-  if (initialState === null) {
-    return (
-      <main id="content" className="spinner-container">
-        <Spinner />
-      </main>
-    )
-  }
 
   const { store } = createStore(initialState)
-  return <Provider store={store}>{children}</Provider>
+  return (
+    <Provider store={store}>
+      <Spinner isLoading={!initialState} />
+      {initialState && children}
+    </Provider>
+  )
 }
 
 export default StoreProvider

--- a/pro/src/ui-kit/Spinner/Spinner.tsx
+++ b/pro/src/ui-kit/Spinner/Spinner.tsx
@@ -7,35 +7,47 @@ import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 interface SpinnerProps {
   message?: string
   className?: string
+  isLoading?: boolean
 }
 
 const Spinner = ({
   message = 'Chargement en cours',
   className,
+  isLoading = true,
 }: SpinnerProps): JSX.Element => {
   const [nbDots, setNbDots] = useState(3)
-  const [timer, setTimer] = useState<number | null>(null)
+  const [timer, setTimer] = useState<number>()
 
   useEffect(() => {
-    if (timer) {
+    if (isLoading) {
+      if (timer) {
+        window.clearInterval(timer)
+      }
+      const newTimer = window.setInterval(() => {
+        setNbDots((oldVal) => (oldVal % 3) + 1)
+      }, 500)
+      setTimer(newTimer)
+    }
+    return () => {
       window.clearInterval(timer)
     }
-    const newTimer = window.setInterval(() => {
-      setNbDots((oldVal) => (oldVal % 3) + 1)
-    }, 500)
-    setTimer(newTimer)
-    return () => {
-      window.clearInterval(newTimer)
-    }
-  }, [])
+  }, [isLoading])
 
   return (
-    <div className={cn('loading-spinner', className)} data-testid="spinner">
-      <SvgIcon src={strokePass} alt="" className="loading-spinner-icon" />
+    <div className={cn('loading-spinner', className)} role="alert">
+      {isLoading && (
+        <>
+          <SvgIcon src={strokePass} alt="" className="loading-spinner-icon" />
 
-      <div className="content" data-dots={Array(nbDots).fill('.').join('')}>
-        {message}
-      </div>
+          <div
+            data-testid="spinner"
+            className="content"
+            data-dots={Array(nbDots).fill('.').join('')}
+          >
+            {message}
+          </div>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
- (PC-25368)[PRO] refactor: always display spinner wrapper for accessibility
- (PC-25368)[PRO] refactor: always display spinners for accessibility Collective Offers
- (PC-25368)[PRO] refactor: always display spinners for accessibility Individual Offer
- (PC-25368)[PRO] refactor: always display spinners for accessibility various pages

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25368
Toujours afficher le wrapper du Spinner pour que les synthèses vocales puissent interpréter le rôle alert

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques