### PR TITLE
(BSR) fix: set preserve-asts to true to fix local mypy bug

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -43,6 +43,10 @@ python_version = "3.10"
 mypy_path = "stubs/"
 disallow_untyped_defs = true
 follow_imports = "silent"
+# The following line solves the internal mypy (v>1.4) error due to
+# the usage of @declared_attr. See github issue here: 
+# https://github.com/sqlalchemy/sqlalchemy/issues/10282
+preserve_asts = true
 ignore_missing_imports = true
 show_column_numbers = true
 warn_unused_ignores = true


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : 

Résoud le bug de l'utilisation de _mypy_ avec version > 1.4 dû à l'utilisation de @declared_attr

La doc [mypy](https://passcultureteam.slack.com/archives/C063RA5LS6A/p1698917043797779) là dessus:
```
# Disable the memory optimization of freeing ASTs when
# possible. This isn't exposed as a command line option
# because it is intended for software integrating with
# mypy. (Like mypyc.)
self.preserve_asts = False
```

On a fait un test sur la taille du cache _mypy_ qui est passé de 60Mo à 69Mo (sans augmenter ensuite lorsqu'on modifie des fichiers dans src/ )


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques