### PR TITLE
(BSR)[API] feat: add cache to retrieve feature flags only once by htt…

### DIFF
--- a/api/src/pcapi/core/testing.py
+++ b/api/src/pcapi/core/testing.py
@@ -320,7 +320,7 @@ class override_features(TestContextDecorator):
         # Clear the feature cache on request if any
         if flask.has_request_context():
             if hasattr(flask.request, "_cached_features"):
-                flask.request._cached_features = {}
+                del flask.request._cached_features
 
     def disable(self) -> None:
         for name, status in self.apply_to_revert.items():
@@ -329,7 +329,7 @@ class override_features(TestContextDecorator):
         # Clear the feature cache on request if any
         if flask.has_request_context():
             if hasattr(flask.request, "_cached_features"):
-                flask.request._cached_features = {}
+                del flask.request._cached_features
 
 
 def clean_temporary_files(test_function: typing.Callable) -> typing.Callable:

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -2688,6 +2688,6 @@ class TestQueriesTest:
             .one()
         )
 
-        # 3 features flags checked, no N+1 query when fraud checks and reviews joinedloaded
-        with assert_num_queries(3):
+        # 3 features flags checked in one query, no N+1 query when fraud checks and reviews joinedloaded
+        with assert_num_queries(1):
             subscription_api.get_user_subscription_state(fetched_user)

--- a/api/tests/models/feature_test.py
+++ b/api/tests/models/feature_test.py
@@ -67,6 +67,12 @@ class FeatureToggleTest:
         finally:
             flask._request_ctx_stack.push(context)
 
+    def test_one_request_for_all_flags(self):
+        with assert_num_queries(1):
+            FeatureToggle.SYNCHRONIZE_ALLOCINE.is_active()
+            FeatureToggle.DISABLE_CGR_EXTERNAL_BOOKINGS.is_active()
+            FeatureToggle.ALGOLIA_BOOKINGS_NUMBER_COMPUTATION.is_active()
+
 
 @pytest.mark.usefixtures("db_session")
 class FeatureTest:

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -356,11 +356,8 @@ class SearchVenueTest:
     # - fetch authenticated user
     # - fetch results
     # - fetch count for pagination
-    # - fetch feature flag: WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY (to build form options)
+    # - fetch all feature flags
     expected_num_queries = 5
-
-    # - fetch feature flag: WIP_BACKOFFICE_ENABLE_REDIRECT_SINGLE_RESULT when one single result is returned
-    expected_num_queries_with_ff = expected_num_queries + 1
 
     def _create_venues(
         self,
@@ -398,7 +395,7 @@ class SearchVenueTest:
 
         # when
         venue_id = self.venues[2].id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, q=venue_id, pro_type=TypeOptions.VENUE.name))
 
         # then
@@ -413,7 +410,7 @@ class SearchVenueTest:
         self._create_venues()
 
         # when
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, q=siret, pro_type=TypeOptions.VENUE.name))
 
         # then
@@ -428,7 +425,7 @@ class SearchVenueTest:
 
         # when
         email = self.venues[1].bookingEmail
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, q=email, pro_type=TypeOptions.VENUE.name))
 
         # then
@@ -461,7 +458,7 @@ class SearchVenueTest:
 
         # when
         email = self.venues[1].contact.email
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, q=email, pro_type=TypeOptions.VENUE.name))
 
         # then
@@ -532,7 +529,7 @@ class SearchVenueTest:
         )
 
         # when
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, q=query, pro_type=TypeOptions.VENUE.name))
 
         # then

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -316,9 +316,7 @@ class AccountTest:
         assert response.status_code == 200
         client.with_token(user.email)
         n_queries = 1  # get user
-        n_queries += 1  # get feature allow_id_check_registration
-        n_queries += 1  # get feature enable_ubble
-        n_queries += 1  # get feature enable_subscription_limitation
+        n_queries += 1  # get all feature flages
         n_queries += 1  # get bookings
 
         with testing.assert_num_queries(n_queries):

--- a/api/tests/routes/native/v1/banner_test.py
+++ b/api/tests/routes/native/v1/banner_test.py
@@ -17,8 +17,8 @@ class BannerTest:
     # - authenticated user
     # - user joinloaded with subscription data
     expected_num_queries_without_subscription_check = 2
-    # - 3 feature flags checked
-    expected_num_queries_with_subscription_check = expected_num_queries_without_subscription_check + 3
+    # - all feature flags checked
+    expected_num_queries_with_subscription_check = expected_num_queries_without_subscription_check + 1
 
     def setup_method(self):
         self.geolocation_banner = {


### PR DESCRIPTION
…p request

## But de la pull request

Change la façon dont les FF sont consulté dans la db. Au lieu de les remonter un par un selon les besoins on les remontes tous dés qu'on en a besoin d'un et on les stocke dans le contexte de la requete.

Disclamer perfs: Remonter tout le contenu de la table ne devrait pas être lourd car on remonte moins de 100 lignes composés d'uns string court et d'un boolean.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques