### PR TITLE
(PC-25248)[PRO] feat: add venue tag

### DIFF
--- a/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
@@ -145,7 +145,7 @@ describe('app', () => {
       }))
     })
 
-    it('should show search offers input with filter on venue public name when siret is provided and public name exists', async () => {
+    it('should display venue tag when siret is provided and public name exists', async () => {
       const mockLocation = {
         ...window.location,
         search: '?siret=123456789',
@@ -156,12 +156,12 @@ describe('app', () => {
       renderApp(venue)
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
-      const inputElement = screen.getByLabelText('Autocomplete')
-
-      expect(inputElement).toHaveValue("Lib de Par's")
+      expect(
+        screen.getByRole('button', { name: /Lieu : Lib de Par's/ })
+      ).toBeInTheDocument()
     })
 
-    it('should show search offers input with filter on venue public name when venueId is provided and public name exists', async () => {
+    it('should venue tag when venueId is provided and public name exists', async () => {
       // Given
       const mockLocation = {
         ...window.location,
@@ -175,9 +175,9 @@ describe('app', () => {
 
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
-      const inputElement = screen.getByLabelText('Autocomplete')
-
-      expect(inputElement).toHaveValue("Lib de Par's")
+      expect(
+        screen.getByRole('button', { name: /Lieu : Lib de Par's/ })
+      ).toBeInTheDocument()
     })
 
     it('should add geo location filter when user has latitude and longitude', async () => {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -56,8 +56,10 @@ type AutocompleteProps = {
 export type SuggestionItem = AutocompleteQuerySuggestionsHit & {
   label: string
   venue: {
+    id: string
     name: string
     publicName: string
+    departmentCode: string
   }
   offerer: {
     name: string
@@ -199,18 +201,19 @@ export const Autocomplete = ({
       return {
         ...source,
         sourceId: VENUE_SUGGESTIONS_SOURCE_ID,
-        onSelect({ item }) {
+        async onSelect({ item }) {
           const venueDisplayName = item.venue.publicName || item.venue.name
-          autocomplete.setQuery(venueDisplayName)
-          refine(venueDisplayName)
+          autocomplete.setQuery('')
+          await formik.setFieldValue('venue', { ...item.venue, relative: [] })
+          await formik.submitForm()
 
           if (isLocalStorageEnabled) {
             addSuggestionToHistory(venueDisplayName)
           }
 
-          void logAutocompleteSuggestionClick(
+          await logAutocompleteSuggestionClick(
             SuggestionType.VENUE,
-            item.venue.publicName || item.venue.name
+            venueDisplayName
           )
         },
         getItems(params) {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.tsx
@@ -83,8 +83,22 @@ const FiltersTags = ({
     )
   }
 
+  const getVenueTag = () => {
+    if (!values.venue) {
+      return null
+    }
+    const venueDisplayName = `Lieu :  ${
+      values.venue.publicName || values.venue.name
+    }`
+    return createTag(venueDisplayName, async () => {
+      await setFieldValue('venue', null)
+      handleSubmit()
+    })
+  }
+
   return (
     <div className={styles.container}>
+      {getVenueTag()}
       {getOfferAdressTypeTag()}
       {getGeoLocalisationTag()}
       {values.academies.map((academy) =>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/__specs__/FiltersTags.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/__specs__/FiltersTags.spec.tsx
@@ -39,6 +39,35 @@ const renderFiltersTag = (
   )
 }
 describe('FiltersTag', () => {
+  describe('venue filter', () => {
+    const venueFilter = {
+      id: 1,
+      name: 'Mon super lieu',
+      relative: [],
+      departementCode: '75',
+    }
+
+    it('should display venue name in tag', () => {
+      renderFiltersTag({
+        ...ADAGE_FILTERS_DEFAULT_VALUES,
+        venue: venueFilter,
+      })
+
+      expect(screen.getByText(/Lieu : Mon super lieu/)).toBeInTheDocument()
+    })
+    it('should remove venue tag on click', async () => {
+      renderFiltersTag({
+        ...ADAGE_FILTERS_DEFAULT_VALUES,
+        venue: { ...venueFilter, publicName: 'Public name' },
+      })
+      await userEvent.click(
+        screen.getByRole('button', { name: /Lieu : Public name/ })
+      )
+      expect(
+        screen.queryByRole('button', { name: /Lieu : Public name/ })
+      ).not.toBeInTheDocument()
+    })
+  })
   describe('event address type', () => {
     it('should render in my school tag if event adress type school is selected', () => {
       renderFiltersTag({

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -68,6 +68,7 @@ const initialValues = {
   categories: [],
   formats: [],
   geolocRadius: 50,
+  venue: null,
 }
 
 describe('OfferFilters', () => {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -18,7 +18,6 @@ import { DEFAULT_GEO_RADIUS, MAIN_INDEX_ID } from '../OffersInstantSearch'
 import {
   ADAGE_FILTERS_DEFAULT_VALUES,
   adageFiltersToFacetFilters,
-  computeFiltersInitialValues,
   serializeFiltersForData,
 } from '../utils'
 
@@ -50,6 +49,7 @@ export interface SearchFormValues {
   categories: string[][]
   geolocRadius: number
   formats: string[]
+  venue: VenueResponse | null
 }
 
 export const OffersSearch = ({
@@ -150,7 +150,7 @@ export const OffersSearch = ({
   }
 
   const formik = useFormik<SearchFormValues>({
-    initialValues: computeFiltersInitialValues(venueFilter),
+    initialValues: { ...ADAGE_FILTERS_DEFAULT_VALUES, venue: venueFilter },
     enableReinitialize: true,
     onSubmit: handleSubmit,
   })
@@ -172,7 +172,7 @@ export const OffersSearch = ({
     <>
       <FormikContext.Provider value={formik}>
         <Autocomplete
-          initialQuery={venueFilter?.publicName || venueFilter?.name || ''}
+          initialQuery={''}
           placeholder={
             'Rechercher par mot-clé, par partenaire culturel, par nom d’offre...'
           }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -365,7 +365,7 @@ describe('offersSearch component', () => {
     expect(setGeoRadiusMock).not.toHaveBeenCalled()
   })
 
-  it('should filters department on venue filter if provided', async () => {
+  it('should filters venue id on venue filter if provided', async () => {
     renderOffersSearchComponent(
       {
         ...props,
@@ -378,12 +378,11 @@ describe('offersSearch component', () => {
       },
       user
     )
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: /Localisation des partenaires/,
-      })
-    )
-    expect(screen.getByRole('option', { name: '75 - Paris' })).toBeChecked()
+
+    const tagVenue = await screen.findByRole('button', {
+      name: /Lieu : test/,
+    })
+    expect(tagVenue).toBeInTheDocument()
   })
 
   it('should go back to the localisation main menu when reopening the localisation multiselect after having submitted it with no values selected', async () => {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/utils.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/utils.spec.ts
@@ -3,6 +3,13 @@ import { EacFormat } from 'apiClient/adage'
 import { SearchFormValues } from '../OffersSearch/OffersSearch'
 import { adageFiltersToFacetFilters, serializeFiltersForData } from '../utils'
 
+const venueFilter = {
+  id: 123,
+  name: 'test',
+  departementCode: '01',
+  relative: [456],
+}
+
 describe('adageFiltersToFacetFilters', () => {
   const domains: string[] = ['1']
   const students: string[] = ['Collège - 4e']
@@ -23,6 +30,7 @@ describe('adageFiltersToFacetFilters', () => {
         academies,
         categories,
         formats,
+        venue: venueFilter,
       })
     ).toStrictEqual({
       queryFilters: [
@@ -34,6 +42,7 @@ describe('adageFiltersToFacetFilters', () => {
         ['offer.subcategoryId:categorie1', 'offer.subcategoryId:categorie2'],
         ['formats:Concert'],
         ['offer.educationalInstitutionUAICode:all'],
+        ['venue.id:123', 'venue.id:456'],
       ],
       filtersKeys: [
         'eventAddressType',
@@ -43,6 +52,7 @@ describe('adageFiltersToFacetFilters', () => {
         'academies',
         'categories',
         'formats',
+        'venue',
       ],
     })
   })
@@ -61,6 +71,7 @@ describe('adageFiltersToFacetFilters', () => {
         academies,
         categories,
         formats,
+        venue: null,
       })
     ).toStrictEqual({
       queryFilters: [
@@ -96,6 +107,7 @@ describe('adageFiltersToFacetFilters', () => {
         academies,
         categories,
         formats,
+        venue: null,
       })
     ).toStrictEqual({
       queryFilters: [
@@ -129,6 +141,7 @@ describe('adageFiltersToFacetFilters', () => {
         academies,
         categories,
         formats,
+        venue: null,
       })
     ).toStrictEqual({
       queryFilters: [
@@ -169,6 +182,7 @@ describe('serializeFiltersForData', () => {
       categories: [['subcat1', 'subcat3']],
       formats: [EacFormat.CONCERT],
       geolocRadius: 10,
+      venue: null,
     }
     const result = serializeFiltersForData(
       filters,
@@ -188,6 +202,7 @@ describe('serializeFiltersForData', () => {
       categories: ['Category 1', 'Category 2'],
       formats: ['Concert'],
       geolocRadius: 10,
+      venue: undefined,
     })
   })
   it('should not serialize serialise formats if ff is not active', () => {
@@ -200,6 +215,7 @@ describe('serializeFiltersForData', () => {
       categories: [['subcat1', 'subcat3']],
       formats: [EacFormat.CONCERT],
       geolocRadius: 10,
+      venue: venueFilter,
     }
     const result = serializeFiltersForData(
       filters,
@@ -219,6 +235,7 @@ describe('serializeFiltersForData', () => {
       categories: ['Category 1', 'Category 2'],
       formats: undefined,
       geolocRadius: 10,
+      venue: [123, 456],
     })
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
@@ -15,21 +15,7 @@ export const ADAGE_FILTERS_DEFAULT_VALUES: SearchFormValues = {
   eventAddressType: OfferAddressType.OTHER,
   geolocRadius: 50,
   formats: [],
-}
-
-export const computeFiltersInitialValues = (
-  venueFilter?: VenueResponse | null
-) => {
-  const venueDepartementFilter =
-    venueFilter && venueFilter.departementCode
-      ? [venueFilter.departementCode]
-      : []
-  return {
-    ...ADAGE_FILTERS_DEFAULT_VALUES,
-    departments: venueFilter
-      ? venueDepartementFilter
-      : ADAGE_FILTERS_DEFAULT_VALUES.departments,
-  }
+  venue: null,
 }
 
 export const adageFiltersToFacetFilters = ({
@@ -41,6 +27,7 @@ export const adageFiltersToFacetFilters = ({
   academies,
   categories,
   formats,
+  venue,
 }: {
   domains: string[]
   uai?: string[] | null
@@ -50,6 +37,7 @@ export const adageFiltersToFacetFilters = ({
   eventAddressType: string
   categories: string[][]
   formats: string[]
+  venue: VenueResponse | null
 }) => {
   const updatedFilters: Facets = []
   const filtersKeys: string[] = []
@@ -100,6 +88,13 @@ export const adageFiltersToFacetFilters = ({
     categoryValue.map((subcategoryId) => `offer.subcategoryId:${subcategoryId}`)
   )
 
+  const filteredVenues = venue
+    ? [
+        `venue.id:${venue.id}`,
+        ...venue.relative.map((venueId) => `venue.id:${venueId}`),
+      ]
+    : []
+
   if (filteredStudents.length > 0) {
     filtersKeys.push('students')
     updatedFilters.push(filteredStudents)
@@ -139,6 +134,11 @@ export const adageFiltersToFacetFilters = ({
     )
   }
 
+  if (filteredVenues.length > 0) {
+    filtersKeys.push('venue')
+    updatedFilters.push(filteredVenues)
+  }
+
   return {
     queryFilters: updatedFilters,
     filtersKeys: filtersKeys,
@@ -169,5 +169,8 @@ export const serializeFiltersForData = (
         studentsForData.find((s) => s.label === student)?.valueForData
     ),
     formats: isFormatEnable ? filters.formats : undefined,
+    venue: filters.venue
+      ? [filters.venue.id, ...filters.venue.relative.map((venueId) => venueId)]
+      : undefined,
   }
 }

--- a/pro/src/utils/__specs__/facetFilters.spec.ts
+++ b/pro/src/utils/__specs__/facetFilters.spec.ts
@@ -20,11 +20,11 @@ describe('getDefaultFacetFilterUAICodeValue', () => {
     const venueFilter = {
       id: 1,
       name: 'test',
-      relative: [],
+      relative: [2],
       departementCode: '30',
     }
     const expectedFilters = [
-      ['venue.departmentCode:30', 'offer.interventionArea:30'],
+      ['venue.id:1', 'venue.id:2'],
       ['offer.educationalInstitutionUAICode:all'],
     ]
 

--- a/pro/src/utils/facetFilters.ts
+++ b/pro/src/utils/facetFilters.ts
@@ -9,15 +9,14 @@ export const getDefaultFacetFilterUAICodeValue = (
   if (uai) {
     institutionIdFilters.push(`offer.educationalInstitutionUAICode:${uai}`)
   }
-  const venueDepartmentFilter =
-    venueFilter && venueFilter.departementCode
-      ? [
-          `venue.departmentCode:${venueFilter?.departementCode}`,
-          `offer.interventionArea:${venueFilter?.departementCode}`,
-        ]
-      : []
+  const venueIdFilter = venueFilter
+    ? [
+        `venue.id:${venueFilter?.id}`,
+        ...venueFilter.relative.map((venueId) => `venue.id:${venueId}`),
+      ]
+    : []
 
-  return venueDepartmentFilter.length > 0
-    ? [venueDepartmentFilter, institutionIdFilters]
+  return venueIdFilter.length > 0
+    ? [venueIdFilter, institutionIdFilters]
     : [institutionIdFilters]
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25248

Afficher un tag lieu quand on arrive de la cartographie Adage ou qu'on clique sur une suggestion de l'autocomplete

Pour tester l'arrivée depuis la carto, ajouter `&venue=[VENUE_ID]` dans l'url de l'iframe adage 

_Note : Le coverage manquant concerne le code plugin algolia, non testé comme expliqué par le commentaire du istanbul ignore_

**Screen** 

![Capture d’écran 2023-11-02 à 16 04 34](https://github.com/pass-culture/pass-culture-main/assets/71768799/f0a8df96-a6ba-4c74-9187-2de3da77d81d)
