### PR TITLE
(PC-25297)[BO] feat: Add status structure on pro user details

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/pro_user/get/details/user_offerer.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro_user/get/details/user_offerer.html
@@ -1,4 +1,4 @@
-{% from "components/badges.html" import build_user_offerer_status_badge %}
+{% from "components/badges.html" import build_user_offerer_status_badge, build_offerer_status_badge %}
 {% import "components/links.html" as links %}
 <table class="table table-hover my-4">
   <thead>
@@ -6,6 +6,7 @@
       <th scope="col"></th>
       <th scope="col">ID de la structure</th>
       <th scope="col">Statut du rattachement</th>
+      <th scope="col">Statut structure</th>
       <th scope="col">Nom</th>
       <th scope="col">SIREN</th>
     </tr>
@@ -16,6 +17,7 @@
         <th scope="row"></th>
         <td>{{ user_offerer.offererId }}</td>
         <td>{{ build_user_offerer_status_badge(user_offerer) }}</td>
+        <td>{{ build_offerer_status_badge(user_offerer.offerer) }}</td>
         <td class="text-break">{{ links.build_offerer_name_to_details_link(user_offerer.offerer) }}</td>
         <td>{{ links.build_siren_to_external_link(user_offerer.offerer) }}</td>
       </tr>

--- a/api/tests/routes/backoffice/pro_users_test.py
+++ b/api/tests/routes/backoffice/pro_users_test.py
@@ -330,6 +330,20 @@ class GetProUserOfferersTest(GetEndpointHelper):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
+    def test_get_user_offerers_in_different_offerer_status(self, authenticated_client, pro_user):
+        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerers_factories.PendingOffererFactory())
+        url = url_for(self.endpoint, user_id=pro_user.id)
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        rows = html_parser.extract_table_rows(response.data, parent_class="user_offerers-tab-pane")
+        assert len(rows) == 2
+
+        assert rows[0]["Statut structure"] == "Validée"
+        assert rows[1]["Statut structure"] == "En attente"
+
 
 class ValidateProEmailTest(PostEndpointHelper):
     endpoint = "backoffice_web.pro_user.validate_pro_user_email"


### PR DESCRIPTION
## But de la pull request
Ajout le statut de la structure dans l'onglet rattachement aux structures d'un compte pro

Ticket Jira : https://passculture.atlassian.net/browse/PC-25297

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/ddad62a0-b1b3-40d7-81ce-3a1d5dcb194a)


## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques