### PR TITLE
(PC-24373)[BO] feat: show suspension reason on top of user details page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
@@ -12,7 +12,10 @@
             <span class="ms-1">{{ clipboard.copy_to_clipboard(username, "Copier l'état civil") }}</span>
             {% for role in user.roles %}<span class="me-2 badge rounded-pill text-bg-primary align-middle">{{ role | format_role }}</span>{% endfor %}
             {% if not user.isActive %}
-              <span class="badge rounded-pill text-bg-secondary align-middle">{{ user.isActive | format_state }}</span>
+              {% set suspension_reason = user.suspension_reason %}
+              <span class="badge rounded-pill text-bg-secondary align-middle">{{ user.isActive | format_state }}
+                {% if suspension_reason %}: {{ suspension_reason | format_reason_label }}{% endif %}
+              </span>
             {% endif %}
             {% if duplicate_user_id %}
               <small><a href="{{ duplicate_user_id | pc_backoffice_public_account_link }}"
@@ -87,6 +90,12 @@
             <p class="mb-1">
               <span class="fw-bold">Date de dernière connexion :</span> {{ user.lastConnectionDate | format_date_time }}
             </p>
+            {% set suspension_date = user.suspension_date %}
+            {% if suspension_date %}
+              <p class="mb-1">
+                <span class="fw-bold">Date de suspension :</span> {{ user.suspension_date | format_date_time }}
+              </p>
+            {% endif %}
             {% if show_personal_info %}
               <div class="mb-1">
                 <span class="fw-bold">Adresse</span>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24373

![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/3c854b52-d146-4b6c-86e4-705f0fb841ab)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques