### PR TITLE
(PC-24452)[API] feat: Add finance incident in payment file

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -529,7 +529,7 @@ def _price_event(event: models.FinanceEvent) -> models.Pricing:
         amount = -original_pricing.amount  # inverse the original pricing amount (positive)
         lines = [
             models.PricingLine(
-                category=models.PricingLineCategory.OFFERER_RETRIEVAL,
+                category=original_line.category,
                 amount=-original_line.amount,
             )
             for original_line in original_pricing.lines
@@ -538,10 +538,16 @@ def _price_event(event: models.FinanceEvent) -> models.Pricing:
         amount = -rule.apply(booking, event.bookingFinanceIncident.newTotalAmount)  # outgoing, thus negative
         lines = [
             models.PricingLine(
-                amount=-amount,
+                amount=-event.bookingFinanceIncident.newTotalAmount,
                 category=models.PricingLineCategory.OFFERER_REVENUE,
             )
         ]
+        lines.append(
+            models.PricingLine(
+                amount=amount - lines[0].amount,
+                category=models.PricingLineCategory.OFFERER_CONTRIBUTION,
+            )
+        )
     else:
         is_booking_collective = isinstance(booking, educational_models.CollectiveBooking)
         amount = -rule.apply(booking)  # outgoing, thus negative

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -172,7 +172,6 @@ class PricingLineCategory(enum.Enum):
     OFFERER_REVENUE = "offerer revenue"
     OFFERER_CONTRIBUTION = "offerer contribution"
     PASS_CULTURE_COMMISSION = "pass culture commission"
-    OFFERER_RETRIEVAL = "offerer retrieval"
 
 
 class PricingLogReason(enum.Enum):

--- a/api/src/pcapi/core/finance/utils.py
+++ b/api/src/pcapi/core/finance/utils.py
@@ -39,14 +39,20 @@ def fr_percentage_filter(decimal_rate: decimal.Decimal) -> str:
 
 
 def fr_currency_filter(eurocents: int) -> float:
-    """Returns a localized str without signing nor currency symbol"""
-    amount_in_euros = to_euros(abs(eurocents))
+    """Returns a localized str without currency symbol"""
+    amount_in_euros = to_euros(eurocents)
     return numbers.format_decimal(amount_in_euros, format="#,##0.00", locale="fr_FR")
+
+
+def fr_currency_opposite_filter(eurocents: int) -> float:
+    """Returns a localized str without currency symbol"""
+    return fr_currency_filter(-eurocents)
 
 
 def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["fr_percentage"] = fr_percentage_filter
     app.jinja_env.filters["fr_currency"] = fr_currency_filter
+    app.jinja_env.filters["fr_currency_opposite"] = fr_currency_opposite_filter
 
 
 def format_raw_iban_and_bic(raw_data: str | None) -> str | None:

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -121,6 +121,7 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_FORMAT = "Activer le remplacement des catégories/sous-catégories par les formats"
     WIP_ENABLE_DISCOVERY = "Activer la page de découverte dans adage"
     WIP_ENABLE_GOOGLE_SSO = "Activer la connexion SSO pour les jeunes"
+    WIP_ENABLE_FINANCE_INCIDENT = "Active les incidents de finance"
 
     def is_active(self) -> bool:
         if flask.has_request_context():

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -57,7 +57,7 @@
               <th scope="col">ID offre</th>
               <th scope="col">Montant</th>
               <th scope="col">Statut</th>
-              <th scope="col">Évènement comptable</th>
+              {% if is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") %}<th scope="col">Évènement comptable</th>{% endif %}
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
               <th scope="col">Structure</th>
@@ -92,7 +92,7 @@
                                  data-bs-toggle="modal"
                                  data-bs-target=".pc-cancel-booking-modal-{{ collective_booking.id }}">Annuler la réservation</a>
                             </li>
-                          {% elif collective_booking.isReimbursed and has_permission('MANAGE_INCIDENTS') %}
+                          {% elif collective_booking.isReimbursed and has_permission('MANAGE_INCIDENTS') and is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") %}
                             <li class="dropdown-item p-0">
                               <a class="btn btn-sm d-block w-100 text-start px-3"
                                  data-bs-toggle="modal"
@@ -169,8 +169,8 @@
                 <td>{{ collective_offer.id }}</td>
                 <td>{{ collective_booking.total_amount | format_amount }}</td>
                 <td>{{ collective_booking.status | format_booking_status(with_badge=True) | safe }}</td>
-                <td class="text-center">
-                  {% if True %}
+                {% if is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") %}
+                  <td class="text-center">
                     {% for booking_incident in collective_booking.incidents %}
                       {% if booking_incident.incident.status.name == "VALIDATED" %}
                         <a href="{{ url_for('backoffice_web.finance_incidents.get_incident', finance_incident_id=booking_incident.incident.id) }}"
@@ -180,8 +180,8 @@
    data-bs-title="Visualiser l'incident"></i></a>
                       {% endif %}
                     {% endfor %}
-                  {% endif %}
-                </td>
+                  </td>
+                {% endif %}
                 <td>{{ collective_booking.dateCreated | format_date_time }}</td>
                 <td>{{ collective_booking.collectiveStock.beginningDatetime | format_date_time }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(collective_booking.offerer) }}</td>
@@ -191,11 +191,13 @@
             {% endfor %}
           </tbody>
         </table>
-        {% for collective_booking in rows %}
-          {% if collective_booking.isReimbursed and has_permission('MANAGE_INCIDENTS') %}
-            {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_collective_booking_incident_creation_form", collective_booking_id=collective_booking.id), "create-incident-modal-" + collective_booking.id|string) }}
-          {% endif %}
-        {% endfor %}
+        {% if is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") %}
+          {% for collective_booking in rows %}
+            {% if collective_booking.isReimbursed and has_permission('MANAGE_INCIDENTS') %}
+              {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_collective_booking_incident_creation_form", collective_booking_id=collective_booking.id), "create-incident-modal-" + collective_booking.id|string) }}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
@@ -49,7 +49,7 @@
                       data-modal-selector="#batch-cancel-booking-modal">Annuler</button>
             </div>
           {% endif %}
-          {% if has_permission("MANAGE_INCIDENTS") %}
+          {% if has_permission("MANAGE_INCIDENTS") and is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") %}
             <div class="btn-group btn-group-sm"
                  data-toggle="pc-batch-confirm-btn-group"
                  data-toggle-id="table-container-individual-booking-btn-group"
@@ -196,19 +196,21 @@
                 <td>{{ booking.stock.quantity }}</td>
                 <td>{{ booking.total_amount | format_amount }}</td>
                 <td>{{ booking.status | format_booking_status(with_badge=True) | safe }}</td>
-                <td class="text-center">
-                  {% if booking.incidents %}
-                    {% for booking_incident in booking.incidents %}
-                      {% if booking_incident.incident.status.name == "VALIDATED" %}
-                        <a href="{{ url_for('backoffice_web.finance_incidents.get_incident', finance_incident_id=booking_incident.incident.id) }}"
-                           class=""><i class="bi bi-exclamation-triangle-fill text-danger fs-3"
+                {% if is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") %}
+                  <td class="text-center">
+                    {% if booking.incidents %}
+                      {% for booking_incident in booking.incidents %}
+                        {% if booking_incident.incident.status.name == "VALIDATED" %}
+                          <a href="{{ url_for('backoffice_web.finance_incidents.get_incident', finance_incident_id=booking_incident.incident.id) }}"
+                             class=""><i class="bi bi-exclamation-triangle-fill text-danger fs-3"
    data-bs-toggle="tooltip"
    data-bs-placement="top"
    data-bs-title="Visualiser l'incident"></i></a>
-                      {% endif %}
-                    {% endfor %}
-                  {% endif %}
-                </td>
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
+                  </td>
+                {% endif %}
                 <td>{{ booking.dateCreated | format_date_time }}</td>
                 <td>{{ booking.stock.beginningDatetime | format_date_time }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(booking.offerer) }}</td>
@@ -220,7 +222,9 @@
         </table>
         {{ build_lazy_modal(url_for("backoffice_web.individual_bookings.get_batch_validate_individual_bookings_form"), "batch-validate-booking-modal", "true") }}
         {{ build_lazy_modal(url_for("backoffice_web.individual_bookings.get_batch_cancel_individual_bookings_form"), "batch-cancel-booking-modal", "true") }}
-        {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_incident_creation_form"), "incident-creation-modal", "true") }}
+        {% if is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") %}
+          {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_incident_creation_form"), "incident-creation-modal", "true") }}
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -200,7 +200,7 @@
     Remboursement des réservations validées entre le {{ period_start.strftime("%d/%m/%y") }} et le {{ period_end.strftime("%d/%m/%y") }}, sauf cas exceptionnels.
 </h3>
 <h3>
-    Détail des offres remboursées incluant la contribution offreur,
+    Détail des offres remboursées{% if including_finance_incident %} et des incidents de paiement{% endif %} incluant la contribution offreur,
     appliquée selon le barème défini dans nos conditions générales de vente
 </h3>
 <table>
@@ -221,12 +221,12 @@
     </tr>
 {% for line in group.lines %}
     <tr>
-        <td class="headRow">Montant remboursé</td>
+        <td class="headRow">{{ line.label }}</td>
         <td>{{ line.rate|fr_percentage }}</td>
         <td>{{ line.bookings_amount|fr_currency }} €</td>
         <td>{{ line.contribution_rate|fr_percentage }}</td>
         <td>{{ line.contributionAmount|fr_currency }} €</td>
-        <td>{{ line.reimbursedAmount|fr_currency }} €</td>
+        <td>{{ line.reimbursedAmount|fr_currency_opposite }} €</td>
     </tr>
 {% endfor %}
     <tr style="color: dimgrey">
@@ -235,7 +235,7 @@
         <td>{{ group.used_bookings_subtotal|fr_currency }} €</td>
         <td></td>
         <td>{{ group.contribution_subtotal|fr_currency }} €</td>
-        <td>{{ group.reimbursed_amount_subtotal|fr_currency }} €</td>
+        <td>{{ group.reimbursed_amount_subtotal|fr_currency_opposite }} €</td>
     </tr>
 {% endfor %}
     <tr class="bottomTableText">
@@ -244,12 +244,12 @@
         <td>{{ total_used_bookings_amount|fr_currency }} €</td>
         <td></td>
         <td>{{ total_contribution_amount|fr_currency }} €</td>
-        <td>{{ total_reimbursed_amount|fr_currency }} €</td>
+        <td>{{ total_reimbursed_amount|fr_currency_opposite }} €</td>
     </tr>
     </tbody>
 </table>
 <p class="anotations">
-    Au regard de la taxe sur la valeur ajoutée (TVA), les remboursements s’entendent toutes taxes comprises (TTC).
+    Au regard de la taxe sur la valeur ajoutée (TVA), les montants s’entendent toutes taxes comprises (TTC).
     L’Offreur s’engage à s’acquitter de la TVA résultant de
     l’application de son régime fiscal et selon le taux applicable à ses Offres.
     Il est considéré que la contribution offreur relative à l’application du barème constitue une réduction de prix, au
@@ -273,13 +273,13 @@
         <td>Virement {{ cashflow.bankAccount.iban }}</td>
         <td class="cashflow_batch_label">{{ cashflow.batch.label }}</td>
         <td class="cashflow_creation_date">{{ invoice.date.strftime("%d/%m/%Y") }}</td>
-        <td>{{ cashflow.amount|fr_currency }} €</td>
+        <td>{{ cashflow.amount|fr_currency_opposite }} €</td>
         <td>{{ reimbursement_point_name }}</td>
     </tr>
 {% endfor %}
     <tr class="coloredSection bottomTableText">
         <td class="headRow" colspan="3">TOTAL RÈGLEMENT PASS CULTURE</td>
-        <td>{{ invoice.amount|fr_currency }} €</td>
+        <td>{{ invoice.amount|fr_currency_opposite }} €</td>
     </tr>
     </tbody>
 </table>
@@ -299,11 +299,11 @@
 {% for venue in reimbursements_by_venue %}
         <tr>
             <td>{{ venue.venue_name }}</td>
-            <td>{{ venue.validated_booking_amount|fr_currency }} €</td>
-            <td>{{ (venue.validated_booking_amount - venue.reimbursed_amount)|fr_currency }} €</td>
-            <td class="coloredSection">{{ venue.reimbursed_amount|fr_currency }} €</td>
-            <td>{{ venue.individual_amount|fr_currency }} €</td>
-            <td>{{ (venue.reimbursed_amount - venue.individual_amount)|fr_currency }} €</td>
+            <td>{{ venue.validated_booking_amount|fr_currency_opposite }} €</td>
+            <td>{{ (venue.validated_booking_amount - venue.reimbursed_amount)|fr_currency_opposite }} €</td>
+            <td class="coloredSection">{{ venue.reimbursed_amount|fr_currency_opposite }} €</td>
+            <td>{{ venue.individual_amount|fr_currency_opposite }} €</td>
+            <td>{{ (venue.reimbursed_amount - venue.individual_amount)|fr_currency_opposite }} €</td>
         </tr>
 {% endfor %}
     </tbody>

--- a/api/tests/core/finance/test_utils.py
+++ b/api/tests/core/finance/test_utils.py
@@ -49,8 +49,14 @@ def test_fr_percentage_filter():
 
 def test_fr_currency_filter():
     assert utils.fr_currency_filter(0) == "0,00"
-    assert utils.fr_currency_filter(-1234) == "12,34"
+    assert utils.fr_currency_filter(-1234) == "-12,34"
     assert utils.fr_currency_filter(500000) == "5 000,00"
+
+
+def test_fr_currency_opposite_filter():
+    assert utils.fr_currency_opposite_filter(0) == "0,00"
+    assert utils.fr_currency_opposite_filter(-1234) == "12,34"
+    assert utils.fr_currency_opposite_filter(500000) == "-5 000,00"
 
 
 def test_format_raw_iban_and_bic():

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -200,7 +200,7 @@
     Remboursement des réservations validées entre le 01/01/22 et le 14/01/22, sauf cas exceptionnels.
 </h3>
 <h3>
-    Détail des offres remboursées incluant la contribution offreur,
+    Détail des offres remboursées et des incidents de paiement incluant la contribution offreur,
     appliquée selon le barème défini dans nos conditions générales de vente
 </h3>
 <table>
@@ -221,7 +221,7 @@
     </tr>
 
     <tr>
-        <td class="headRow">Montant remboursé</td>
+        <td class="headRow">Réservations</td>
         <td>100 %</td>
         <td>25 896,00 €</td>
         <td>0 %</td>
@@ -230,7 +230,7 @@
     </tr>
 
     <tr>
-        <td class="headRow">Montant remboursé</td>
+        <td class="headRow">Réservations</td>
         <td>95 %</td>
         <td>83,30 €</td>
         <td>5 %</td>
@@ -252,7 +252,7 @@
     </tr>
 
     <tr>
-        <td class="headRow">Montant remboursé</td>
+        <td class="headRow">Réservations</td>
         <td>100 %</td>
         <td>20,00 €</td>
         <td>0 %</td>
@@ -261,7 +261,7 @@
     </tr>
 
     <tr>
-        <td class="headRow">Montant remboursé</td>
+        <td class="headRow">Réservations</td>
         <td>95 %</td>
         <td>40,00 €</td>
         <td>5 %</td>
@@ -283,7 +283,7 @@
     </tr>
 
     <tr>
-        <td class="headRow">Montant remboursé</td>
+        <td class="headRow">Réservations</td>
         <td>0 %</td>
         <td>58,00 €</td>
         <td>100 %</td>
@@ -305,7 +305,7 @@
     </tr>
 
     <tr>
-        <td class="headRow">Montant remboursé</td>
+        <td class="headRow">Réservations</td>
         <td>95,65 %</td>
         <td>23,00 €</td>
         <td>4,35 %</td>
@@ -314,7 +314,16 @@
     </tr>
 
     <tr>
-        <td class="headRow">Montant remboursé</td>
+        <td class="headRow">Incidents</td>
+        <td>95 %</td>
+        <td>-40,00 €</td>
+        <td>5 %</td>
+        <td>-2,00 €</td>
+        <td>-38,00 €</td>
+    </tr>
+
+    <tr>
+        <td class="headRow">Réservations</td>
         <td>94 %</td>
         <td>20,00 €</td>
         <td>6 %</td>
@@ -325,24 +334,24 @@
     <tr style="color: dimgrey">
         <td class="headRow">SOUS-TOTAL</td>
         <td></td>
-        <td>43,00 €</td>
+        <td>3,00 €</td>
         <td></td>
-        <td>2,20 €</td>
-        <td>40,80 €</td>
+        <td>0,20 €</td>
+        <td>2,80 €</td>
     </tr>
 
     <tr class="bottomTableText">
         <td class="headRow">TOTAL</td>
         <td></td>
-        <td>26 140,30 €</td>
+        <td>26 100,30 €</td>
         <td></td>
-        <td>66,36 €</td>
-        <td>26 073,94 €</td>
+        <td>64,36 €</td>
+        <td>26 035,94 €</td>
     </tr>
     </tbody>
 </table>
 <p class="anotations">
-    Au regard de la taxe sur la valeur ajoutée (TVA), les remboursements s’entendent toutes taxes comprises (TTC).
+    Au regard de la taxe sur la valeur ajoutée (TVA), les montants s’entendent toutes taxes comprises (TTC).
     L’Offreur s’engage à s’acquitter de la TVA résultant de
     l’application de son régime fiscal et selon le taux applicable à ses Offres.
     Il est considéré que la contribution offreur relative à l’application du barème constitue une réduction de prix, au
@@ -366,13 +375,13 @@
         <td>Virement FR2710010000000000000000064</td>
         <td class="cashflow_batch_label">1</td>
         <td class="cashflow_creation_date">21/12/2021</td>
-        <td>26 073,94 €</td>
+        <td>26 035,94 €</td>
         <td>Coiffeur justificaTIF</td>
     </tr>
 
     <tr class="coloredSection bottomTableText">
         <td class="headRow" colspan="3">TOTAL RÈGLEMENT PASS CULTURE</td>
-        <td>26 073,94 €</td>
+        <td>26 035,94 €</td>
     </tr>
     </tbody>
 </table>

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -94,10 +94,11 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
     # - fetch session (1 query)
     # - fetch user (1 query)
     # - fetch collective bookings with extra data (1 query)
-    expected_num_queries = 3
+    # - check finance incident feature flag
+    expected_num_queries = 4
 
     def test_list_bookings_without_filter(self, authenticated_client, collective_bookings):
-        with assert_num_queries(self.expected_num_queries - 1):
+        with assert_num_queries(self.expected_num_queries - 2):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -210,7 +211,7 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
 
     def test_list_bookings_by_id_not_found(self, authenticated_client, collective_bookings):
         search_query = str(collective_bookings[-1].id * 1000)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=search_query))
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -87,7 +87,8 @@ class ListIndividualBookingsTest(GetEndpointHelper):
     # - fetch user (1 query)
     expected_num_queries_when_no_query = 2
     # - fetch individual bookings with extra data (1 query)
-    expected_num_queries = expected_num_queries_when_no_query + 1
+    # - check finance incident FF
+    expected_num_queries = expected_num_queries_when_no_query + 2
 
     def test_list_bookings_without_filter(self, authenticated_client, bookings):
         with assert_num_queries(self.expected_num_queries_when_no_query):
@@ -199,7 +200,8 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         assert rows[0]["ID résa"] == str(bookings[0].id)
 
     def test_list_bookings_by_token_not_found(self, authenticated_client, bookings):
-        with assert_num_queries(self.expected_num_queries):
+        # -1 query because no need to check incident ff when no result
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q="IENA06"))
             assert response.status_code == 200
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24452

Ajout de la notion d'incidents dans le justificatif de remboursement. Quelques modifications à noter : 
- Typo "montant remboursé" -> réservations
- Si incident -> "Incidents"
- Si incident, précision que le détail des offres remboursées inclut le montant des incidents
- Le type de PricingLine nouvellement ajouté (`OFFERER_RETRIEVAL`) a été retiré. Dans le cas d'un incident, on souhaite tout de même récupérer le montant de la contribution, on utilisera alors `OFFERER_CONTRIBUTION`, simplement le montant sera négatif

Correctif apporté sur les `PricingLine` générés lors d'un incident de finance partiel (événement de type `new-price`). Création de deux lignes, la première représentant le nouveau montant de la réservation, et une deuxième qui constitue le montant de la contribution.

Ajout d'un flag dédié aux incidents de finance et ajout d'une vérification de ce ff pour la création d'un incident et l'affichage de la page incidents.

Dans l'exemple ci-dessous (dans barème dérogatoire), deux incidents ont été créés sur deux réservations de 30€ déjà remboursées (donc pas celles du document). Parmi ces incidents : 
- Un incident total : -30€
- Un incident partiel de 10€ (nouvelle valorisation de la réservation à 20€) : -10€

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/fd2c9e38-a1c7-46d9-a018-9ca100616b70)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques