### PR TITLE
(PC-25579)[API] chore: create check offer status exception

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -261,3 +261,12 @@ class TiteLiveAPINotExistingEAN(Exception):
 
 class NotUpdateProductOrOffers(Exception):
     pass
+
+
+class OfferEditionBaseException(ClientError):
+    pass
+
+
+class RejectedOrPendingOfferNotEditable(OfferEditionBaseException):
+    def __init__(self) -> None:
+        super().__init__("global", "Les offres refusées ou en attente de validation ne sont pas modifiables")

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -258,9 +258,7 @@ def check_validation_status(
     offer: models.Offer | educational_models.CollectiveOffer | educational_models.CollectiveOfferTemplate,
 ) -> None:
     if offer.validation in (models.OfferValidationStatus.REJECTED, models.OfferValidationStatus.PENDING):
-        error = api_errors.ApiErrors()
-        error.add_error("global", "Les offres refusées ou en attente de validation ne sont pas modifiables")
-        raise error
+        raise exceptions.RejectedOrPendingOfferNotEditable()
 
 
 def check_offer_is_digital(offer: models.Offer) -> None:

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -279,6 +279,8 @@ def edit_collective_offer(
             {"code": "EDUCATIONAL_DOMAIN_NOT_FOUND"},
             status_code=404,
         )
+    except offers_exceptions.OfferEditionBaseException as error:
+        raise ApiErrors(error.errors, status_code=400)
 
     offer = educational_api_offer.get_collective_offer_by_id(offer_id)
     if offer.template and (not offer.template.domains or not offer.template.interventionArea):
@@ -367,6 +369,8 @@ def edit_collective_offer_template(
             {"code": "EDUCATIONAL_DOMAIN_NOT_FOUND"},
             status_code=404,
         )
+    except offers_exceptions.OfferEditionBaseException as error:
+        raise ApiErrors(error.errors, status_code=400)
     offer = educational_api_offer.get_collective_offer_template_by_id(offer_id)
     return collective_offers_serialize.GetCollectiveOfferTemplateResponseModel.from_orm(offer)
 

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -349,7 +349,7 @@ def patch_offer(
                 withdrawalType=update_body.get("withdrawalType", offers_api.UNCHANGED),
                 shouldSendMail=update_body.get("shouldSendMail") or False,
             )
-    except exceptions.OfferCreationBaseException as error:
+    except (exceptions.OfferCreationBaseException, exceptions.OfferEditionBaseException) as error:
         raise api_errors.ApiErrors(error.errors, status_code=400)
 
     return offers_serialize.GetIndividualOfferResponseModel.from_orm(offer)

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -136,6 +136,8 @@ def upsert_stocks(
             {"stocks": ["La date limite de réservation ne peut être postérieure à la date de début de l'évènement"]},
             status_code=400,
         )
+    except offers_exceptions.OfferEditionBaseException as error:
+        raise ApiErrors(error.errors, status_code=400)
 
     offers_api.handle_stocks_edition(edited_stocks_with_update_info)
 
@@ -159,7 +161,8 @@ def delete_stock(stock_id: int) -> serialization.StockIdResponseModel:
 
     offerer_id = stock.offer.venue.managingOffererId
     check_user_has_access_to_offerer(current_user, offerer_id)
-
-    offers_api.delete_stock(stock)
-
+    try:
+        offers_api.delete_stock(stock)
+    except offers_exceptions.OfferEditionBaseException as error:
+        raise ApiErrors(error.errors, status_code=400)
     return serialization.StockIdResponseModel.from_orm(stock)

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -107,7 +107,7 @@ def post_event_offer(body: serialization.EventOfferCreation) -> serialization.Ev
 
             offers_api.publish_offer(created_offer, user=None)
 
-    except offers_exceptions.OfferCreationBaseException as error:
+    except (offers_exceptions.OfferCreationBaseException, offers_exceptions.OfferEditionBaseException) as error:
         raise api_errors.ApiErrors(error.errors, status_code=400)
 
     return serialization.EventOfferResponse.build_event_offer(created_offer)
@@ -241,7 +241,7 @@ def edit_event(event_id: int, body: serialization.EventOfferEdition) -> serializ
                 withdrawalDetails=update_body.get("withdrawal_details", offers_api.UNCHANGED),
                 **utils.compute_accessibility_edition_fields(update_body.get("accessibility")),
             )
-    except offers_exceptions.OfferCreationBaseException as error:
+    except (offers_exceptions.OfferCreationBaseException, offers_exceptions.OfferEditionBaseException) as error:
         raise api_errors.ApiErrors(error.errors, status_code=400)
 
     return serialization.EventOfferResponse.build_event_offer(offer)
@@ -421,7 +421,7 @@ def post_event_dates(event_id: int, body: serialization.DatesCreation) -> serial
                         creating_provider=current_api_key.provider,
                     )
                 )
-    except offers_exceptions.OfferCreationBaseException as error:
+    except (offers_exceptions.OfferCreationBaseException, offers_exceptions.OfferEditionBaseException) as error:
         raise api_errors.ApiErrors(error.errors, status_code=400)
 
     return serialization.PostDatesResponse(
@@ -597,7 +597,7 @@ def patch_event_date(
                 editing_provider=current_api_key.provider,
             )
         offers_api.handle_stocks_edition([(stock_to_edit, is_beginning_updated)])
-    except offers_exceptions.OfferCreationBaseException as error:
+    except (offers_exceptions.OfferCreationBaseException, offers_exceptions.OfferEditionBaseException) as error:
         raise api_errors.ApiErrors(error.errors, status_code=400)
     return serialization.DateResponse.build_date(edited_date)
 

--- a/api/tests/core/educational/api/test_edit_collective_offer_stock.py
+++ b/api/tests/core/educational/api/test_edit_collective_offer_stock.py
@@ -285,7 +285,7 @@ class returnErrorTest:
         )
 
         # When
-        with pytest.raises(offers_exceptions.ApiErrors) as error:
+        with pytest.raises(offers_exceptions.RejectedOrPendingOfferNotEditable) as error:
             educational_api_stock.edit_collective_stock(
                 stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
             )

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -15,10 +15,10 @@ from pcapi.core.educational.api import stock as educational_api_stock
 from pcapi.core.educational.api.offer import unindex_expired_collective_offers
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveStock
+from pcapi.core.offers import exceptions as offers_exceptions
 import pcapi.core.search.testing as search_testing
 from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
-from pcapi.models import api_errors
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.routes.serialization import collective_stock_serialize
 
@@ -83,7 +83,7 @@ class CreateCollectiveOfferStocksTest:
         )
 
         # When
-        with pytest.raises(api_errors.ApiErrors) as error:
+        with pytest.raises(offers_exceptions.RejectedOrPendingOfferNotEditable) as error:
             educational_api_stock.create_collective_stock(stock_data=created_stock_data, user=user)
 
         # Then

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -211,7 +211,7 @@ class CreateStockTest:
     def test_create_stock_for_non_approved_offer_fails(self, mocked_send_first_venue_approved_offer_email_to_pro):
         offer = factories.ThingOfferFactory(validation=models.OfferValidationStatus.PENDING)
 
-        with pytest.raises(api_errors.ApiErrors) as error:
+        with pytest.raises(exceptions.RejectedOrPendingOfferNotEditable) as error:
             api.create_stock(offer=offer, price=10, quantity=7)
 
         assert error.value.errors == {
@@ -506,7 +506,7 @@ class EditStockTest:
         offer = factories.ThingOfferFactory(validation=models.OfferValidationStatus.PENDING)
         existing_stock = factories.StockFactory(offer=offer, price=10)
 
-        with pytest.raises(api_errors.ApiErrors) as error:
+        with pytest.raises(exceptions.RejectedOrPendingOfferNotEditable) as error:
             api.edit_stock(stock=existing_stock, price=5, quantity=7)
 
         assert error.value.errors == {
@@ -965,7 +965,7 @@ class UpdateOfferTest:
     def test_update_non_approved_offer_fails(self):
         pending_offer = factories.OfferFactory(name="Soliloquy", validation=models.OfferValidationStatus.PENDING)
 
-        with pytest.raises(api_errors.ApiErrors) as error:
+        with pytest.raises(exceptions.RejectedOrPendingOfferNotEditable) as error:
             api.update_offer(pending_offer, name="Monologue")
 
         assert error.value.errors == {

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -160,7 +160,7 @@ class CheckStockIsDeletableTest:
         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING)
         stock = offers_factories.StockFactory(offer=offer)
 
-        with pytest.raises(ApiErrors) as error:
+        with pytest.raises(exceptions.RejectedOrPendingOfferNotEditable) as error:
             validation.check_stock_is_deletable(stock)
 
         assert error.value.errors["global"] == [
@@ -233,12 +233,8 @@ class CheckStockIsUpdatableTest:
         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING)
         stock = offers_factories.StockFactory(offer=offer)
 
-        with pytest.raises(ApiErrors) as error:
+        with pytest.raises(exceptions.RejectedOrPendingOfferNotEditable):
             validation.check_stock_is_updatable(stock)
-
-        assert error.value.errors["global"] == [
-            "Les offres refusées ou en attente de validation ne sont pas modifiables"
-        ]
 
     def test_offer_from_non_allocine_provider(self):
         provider = providers_factories.APIProviderFactory()
@@ -342,7 +338,7 @@ class CheckValidationStatusTest:
     def test_pending_offer(self):
         pending_validation_offer = offers_factories.OfferFactory(validation=OfferValidationStatus.PENDING)
 
-        with pytest.raises(ApiErrors) as error:
+        with pytest.raises(exceptions.RejectedOrPendingOfferNotEditable) as error:
             validation.check_validation_status(pending_validation_offer)
 
         assert error.value.errors["global"] == [
@@ -352,7 +348,7 @@ class CheckValidationStatusTest:
     def test_rejected_offer(self):
         rejected_offer = offers_factories.OfferFactory(validation=OfferValidationStatus.REJECTED)
 
-        with pytest.raises(ApiErrors) as error:
+        with pytest.raises(exceptions.RejectedOrPendingOfferNotEditable) as error:
             validation.check_validation_status(rejected_offer)
 
         assert error.value.errors["global"] == [


### PR DESCRIPTION
Rejected or pending offers are not editable, this broke our product ean API.
The idea is to have a non blocking error for this API

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25579