### PR TITLE
(PC-25433)[BO] fix: pro search trackers for analytics

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -104,7 +104,12 @@ def search_public_accounts() -> utils.BackofficeResponse:
         paginated_rows = users_query.paginate(page=form.page.data, per_page=form.per_page.data)
 
     if paginated_rows.total == 1 and FeatureToggle.WIP_BACKOFFICE_ENABLE_REDIRECT_SINGLE_RESULT.is_active():
-        return redirect(url_for(".get_public_account", user_id=paginated_rows.items[0].id, q=form.q.data), code=303)
+        return redirect(
+            url_for(
+                ".get_public_account", user_id=paginated_rows.items[0].id, q=form.q.data, search_rank=1, total_items=1
+            ),
+            code=303,
+        )
 
     next_page = partial(url_for, ".search_public_accounts", **form.raw_data)
     next_pages_urls = search_utils.pagination_links(next_page, form.page.data, paginated_rows.pages)
@@ -118,7 +123,6 @@ def search_public_accounts() -> utils.BackofficeResponse:
         next_pages_urls=next_pages_urls,
         get_link_to_detail=get_public_account_link,
         rows=paginated_rows,
-        q=form.q.data,
     )
 
 
@@ -953,7 +957,11 @@ def comment_public_account(user_id: int) -> utils.BackofficeResponse:
     return redirect(get_public_account_link(user_id, active_tab="history"), code=303)
 
 
-def get_public_account_link(user_id: int, **kwargs: typing.Any) -> str:
+def get_public_account_link(
+    user_id: int, form: account_forms.AccountSearchForm | None = None, **kwargs: typing.Any
+) -> str:
+    if form and form.q.data:
+        kwargs["q"] = form.q.data
     return url_for("backoffice_web.public_accounts.get_public_account", user_id=user_id, **kwargs)
 
 

--- a/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
@@ -34,7 +34,9 @@ bo_users_blueprint = utils.child_backoffice_blueprint(
 )
 
 
-def get_admin_account_link(user_id: int, **kwargs: typing.Any) -> str:
+def get_admin_account_link(user_id: int, form: forms.BOUserSearchForm | None, **kwargs: typing.Any) -> str:
+    if form and form.q.data:
+        kwargs["q"] = form.q.data
     return url_for("backoffice_web.bo_users.get_bo_user", user_id=user_id, **kwargs)
 
 
@@ -112,7 +114,7 @@ def render_bo_user_page(user_id: int, edit_form: forms.EditBOUserForm | None = N
     return render_template(
         "accounts/get.html",
         layout="layouts/admin.html",
-        search_form=forms.BOUserSearchForm(),
+        search_form=forms.BOUserSearchForm(q=request.args.get("q")),
         search_dst=url_for(".search_bo_users"),
         user=user,
         edit_account_form=edit_form,

--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
@@ -2,7 +2,7 @@
 {% from "components/generic_modal.html" import build_modal_form with context %}
 {% import "components/clipboard.html" as clipboard %}
 {% set username = user.firstName | empty_string_if_null + ' ' + user.lastName | empty_string_if_null | upper %}
-<div class="row row-cols-1 g-4 py-3">
+<div class="row row-cols-1 g-4 py-3 pc-strip-query-string">
   <div class="col">
     <div class="card">
       <div class="card-body">

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
@@ -9,7 +9,7 @@
 {% import "components/clipboard.html" as clipboard %}
 {% extends "layouts/pro.html" %}
 {% block pro_main_content %}
-  <div class="row row-cols-1 g-4 py-3">
+  <div class="row row-cols-1 g-4 py-3 pc-strip-query-string">
     <div class="col">
       <div class="card shadow">
         <div class="card-body">

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result.html
@@ -1,4 +1,4 @@
-{% macro result_card_switch(row,index, terms, result_type="public_account") %}
+{% macro result_card_switch(row, index, terms, result_type="public_account") %}
   {% if result_type == "offerer" %}
     {% include "components/search/result_card_offerer.html" %}
   {% elif result_type == "venue" %}
@@ -22,7 +22,11 @@
       </p>
       <div>
         <div class="row row-cols-sm-1 row-cols-md-2 row-cols-lg-3 g-4">
-          {% for row in rows.items %}<div class="col">{{ result_card_switch(row,loop.index,terms, result_type) }}</div>{% endfor %}
+          {% set offset = (rows.page - 1) * rows.per_page %}
+          {% for row in rows.items %}
+            {% set index = offset + loop.index if search_form.q.data else none %}
+            <div class="col">{{ result_card_switch(row, index, terms, result_type) }}</div>
+          {% endfor %}
         </div>
       </div>
     </div>

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card.html
@@ -9,8 +9,14 @@
         {{ build_pro_user_status_badge(row) }}
       {% endif %}
     </h5>
+    {% if result_type == "user" %}
+      {# ConsultCard tracker only for pro #}
+      {% set link = get_link_to_detail(row.id, form=search_form, search_rank=index, total_items=rows.total) %}
+    {% else %}
+      {% set link = get_link_to_detail(row.id, form=search_form) %}
+    {% endif %}
     <h5 class="card-title">
-      <a href="{{ get_link_to_detail(row.id, q=q, search_rank=index, total_items=rows.total) }}"
+      <a href="{{ link }}"
          class="link-primary">{{ row.full_name }}</a>
     </h5>
     <h6 class="card-subtitle mb-4 text-muted">User ID : {{ row.id }}</h6>
@@ -41,10 +47,9 @@
       {% endif %}
     </div>
     <div class="d-flex flex-row-reverse">
-      <a href="{{ get_link_to_detail(row.id, q=q, search_rank=index, total_items=rows.total ) }}"
-         class="btn btn-md btn-outline-primary fw-bold">
-        CONSULTER CE PROFIL <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-  </div>
+    <a href="{{ link }}"
+       class="btn btn-md btn-outline-primary fw-bold">CONSULTER CE PROFIL <i class="bi bi-arrow-right"></i>
+  </a>
+</div>
+</div>
 </div>

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_bank_account.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_bank_account.html
@@ -3,8 +3,9 @@
 <div class="card shadow">
   <div class="card-body">
     <h5 class="mb-3"></h5>
+    {% set link = get_link_to_detail(row.id, form=search_form) %}
     <h5 class="card-title">
-      <a href="{{ get_link_to_detail(row.id, q=q, search_rank=index, total_items=rows.total) }}"
+      <a href="{{ link }}"
          class="link-primary">{{ row.label | upper }}</a>
       <span class="fs-5 ps-4">
         <span class="me-1 pb-1 badge rounded-pill text-bg-warning align-middle">Compte bancaire</span>
@@ -12,10 +13,9 @@
     </h5>
     <h6 class="card-subtitle mt-4 mb-3 text-muted">Bank Account ID : {{ row.id }}</h6>
     <div class="d-flex flex-row-reverse">
-      <a href="{{ get_link_to_detail(row.id, q=q, search_rank=index, total_items=rows.total) }}"
-         class="btn btn-md btn-outline-primary fw-bold">
-        CONSULTER CE COMPTE <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-  </div>
+    <a href="{{ link }}"
+       class="btn btn-md btn-outline-primary fw-bold">CONSULTER CE COMPTE <i class="bi bi-arrow-right"></i>
+  </a>
+</div>
+</div>
 </div>

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_offerer.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_offerer.html
@@ -2,8 +2,9 @@
 <div class="card shadow">
   <div class="card-body">
     <h5 class="mb-3">{{ build_offerer_badges(row) }}</h5>
+    {% set link = get_link_to_detail(row.id, form=search_form, search_rank=index, total_items=rows.total) %}
     <h5 class="card-title">
-      <a href="{{ get_link_to_detail(row.id, q=q, departments=departments, search_rank=index, total_items=rows.total) }}"
+      <a href="{{ link }}"
          class="link-primary">{{ row.name | upper }}</a>
     </h5>
     <div class="row">
@@ -29,10 +30,9 @@
       </div>
     </div>
     <div class="d-flex flex-row-reverse">
-      <a href="{{ get_link_to_detail(row.id, q=q, search_rank=index, departments=departments, total_items=rows.total) }}"
-         class="btn btn-md btn-outline-primary fw-bold">
-        CONSULTER CE PROFIL <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-  </div>
+    <a href="{{ link }}"
+       class="btn btn-md btn-outline-primary fw-bold">CONSULTER CE PROFIL <i class="bi bi-arrow-right"></i>
+  </a>
+</div>
+</div>
 </div>

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
@@ -3,8 +3,9 @@
 <div class="card shadow">
   <div class="card-body">
     <h5 class="mb-3">{{ build_venue_badges(row) }}</h5>
+    {% set link = get_link_to_detail(row.id, form=search_form, search_rank=index, total_items=rows.total) %}
     <h5 class="card-title">
-      <a href="{{ get_link_to_detail(row.id, q=q, departments=departments, search_rank=index, total_items=rows.total) }}"
+      <a href="{{ link }}"
          class="link-primary">{{ row.name | upper }}</a>
     </h5>
     {% if row.publicName and row.publicName != row.name %}
@@ -22,10 +23,9 @@
       </p>
     </div>
     <div class="d-flex flex-row-reverse">
-      <a href="{{ get_link_to_detail(row.id, q=q, departments=departments, search_rank=index, total_items=rows.total) }}"
-         class="btn btn-md btn-outline-primary fw-bold">
-        CONSULTER CE PROFIL <i class="bi bi-arrow-right"></i>
-      </a>
-    </div>
-  </div>
+    <a href="{{ link }}"
+       class="btn btn-md btn-outline-primary fw-bold">CONSULTER CE PROFIL <i class="bi bi-arrow-right"></i>
+  </a>
+</div>
+</div>
 </div>

--- a/api/src/pcapi/routes/backoffice/templates/finance/invoices/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/invoices/get.html
@@ -21,7 +21,6 @@
                     <b>Période couverte:</b> {{ second_last_cashflow_batch.cutoff | format_cutoff_date }}
                   </li>
                 </ul>
-
                 <div class="card-body pt-5">
                   <h5 class="card-title">{{ "Justificatifs en cours de génération" if is_task_already_running else "Prochains justificatifs générés" }}</h5>
                 </div>
@@ -49,10 +48,11 @@
                     {% if number_of_invoices_left_to_generate == 0 %}
                       Génération du fichier CSV en cours
                     {% else %}
-                      Il reste {{ number_of_invoices_left_to_generate }} justificatifs sur {{ number_of_invoices_to_generate }} à générer 
+                      Il reste {{ number_of_invoices_left_to_generate }} justificatifs sur {{ number_of_invoices_to_generate }} à générer
                     {% endif %}
                   {% endif %}
-                  <button type="button" disabled
+                  <button type="button"
+                          disabled
                           class="btn btn-outline-primary"
                           data-bs-toggle="modal"
                           data-bs-target="#generate-invoices-modal">Une tâche est déjà en cours pour générer les justificatifs</button>
@@ -68,17 +68,18 @@
                   </div>
                 {% else %}
                   <div class="card-body">
-                    <button type="button" disabled
+                    <button type="button"
+                            disabled
                             class="btn btn-outline-primary"
                             data-bs-toggle="modal"
                             data-bs-target="#generate-invoices-modal">Il n'y a pas de justificatifs à générer pour le moment</button>
                   </div>
                 {% endif %}
               {% endif %}
-              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  {% endblock page %}
+  </div>
+{% endblock page %}

--- a/api/src/pcapi/routes/backoffice/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/base.html
@@ -65,6 +65,7 @@
     <script src="{{ url_for('static', filename='backoffice/js/addons/pc-date-range-field.js') }}"></script>
     <script src="{{ url_for('static', filename='backoffice/js/addons/pc-form.js') }}"></script>
     <script src="{{ url_for('static', filename='backoffice/js/addons/pc-pro-search-form.js') }}"></script>
+    <script src="{{ url_for('static', filename='backoffice/js/addons/pc-strip-query-string.js') }}"></script>
     <script>
       const app = new PcBackofficeApp({
         addOns: [
@@ -86,6 +87,7 @@
           PcClipBoard,
           PcForm,
           PcProSearchForm,
+          PcStripQueryString,
         ]
       })
     </script>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -12,7 +12,7 @@
 {% set edit_offerer_aria_described_by_id = random_hash() %}
 {% set delete_offerer_aria_described_by_id = random_hash() %}
 {% block pro_main_content %}
-  <div class="row row-cols-1 g-4 py-3">
+  <div class="row row-cols-1 g-4 py-3 pc-strip-query-string">
     <div class="col">
       <div class="card shadow">
         <div class="card-body">

--- a/api/src/pcapi/routes/backoffice/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro_user/get.html
@@ -5,7 +5,7 @@
 {% from "components/turbo/spinner.html" import build_loading_spinner with context %}
 {% extends "layouts/pro.html" %}
 {% block pro_main_content %}
-  <div class="row row-cols-1 g-4 py-3">
+  <div class="row row-cols-1 g-4 py-3 pc-strip-query-string">
     <div class="col">
       <div class="card shadow">
         <div class="card-body">

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -10,7 +10,7 @@
 {% import "components/clipboard.html" as clipboard %}
 {% extends "layouts/pro.html" %}
 {% block pro_main_content %}
-  <div class="row row-cols-1 g-4 py-3">
+  <div class="row row-cols-1 g-4 py-3 pc-strip-query-string">
     <div class="col">
       <div class="card shadow">
         <div class="card-body">

--- a/api/src/pcapi/static/backoffice/js/addons/pc-strip-query-string.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-strip-query-string.js
@@ -1,0 +1,16 @@
+/**
+ * Strips query string from the location bar when the page is displayed.
+ * This is useful for the end-user to copy a clean string without form parameter and without data used to log
+ * backoffice analytics about search performance.
+ */
+class PcStripQueryString extends PcAddOn {
+  static SELECTOR = '.pc-strip-query-string'
+
+  initialize = () => {
+    if (document.querySelector(PcStripQueryString.SELECTOR)) {
+      let url = new URL(document.location.href);
+      url.search = '';
+      window.history.pushState({path: url.toString()}, '', url.toString());
+    }
+  }
+}

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -57,6 +57,7 @@ from .helpers import html_parser
 from .helpers import search as search_helpers
 from .helpers.get import GetEndpointHelper
 from .helpers.post import PostEndpointHelper
+from .helpers.url import assert_response_location
 
 
 pytestmark = [
@@ -199,11 +200,13 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
 
         # redirect on single result
         assert response.status_code == 303
-        assert response.location == url_for(
+        assert_response_location(
+            response,
             "backoffice_web.public_accounts.get_public_account",
             user_id=underage.id,
             q=underage.id,
-            _external=True,
+            search_rank=1,
+            total_items=1,
         )
 
     @pytest.mark.parametrize(

--- a/api/tests/routes/backoffice/helpers/url.py
+++ b/api/tests/routes/backoffice/helpers/url.py
@@ -1,0 +1,22 @@
+from urllib.parse import urlparse
+
+from flask import url_for
+
+
+def assert_url_equals(actual: str, expected: str) -> None:
+    """
+    Check that URL are the same, considering that query parameters may be in a different order
+    """
+    parsed_actual = urlparse(actual)
+    parsed_expected = urlparse(expected)
+
+    assert parsed_actual.scheme == parsed_expected.scheme
+    assert parsed_actual.hostname == parsed_expected.hostname
+    assert parsed_actual.port == parsed_expected.port
+    assert parsed_actual.path == parsed_expected.path
+    assert set(parsed_actual.query.split("&")) == set(parsed_expected.query.split("&"))
+
+
+def assert_response_location(response, endpoint: str, **kwargs) -> None:
+    assert response.location
+    assert_url_equals(response.location, url_for(endpoint, _external=True, **kwargs))

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -21,6 +21,7 @@ from pcapi.utils.human_ids import humanize
 from .helpers import html_parser
 from .helpers import search as search_helpers
 from .helpers.get import GetEndpointHelper
+from .helpers.url import assert_response_location
 
 
 pytestmark = [
@@ -162,11 +163,13 @@ class SearchProUserTest:
             response = authenticated_client.get(url_for(self.endpoint, q=search_query, pro_type=TypeOptions.USER.name))
             assert response.status_code == 303
 
-        assert response.location == url_for(
+        assert_response_location(
+            response,
             "backoffice_web.pro_user.get",
             user_id=self.pro_accounts[2].id,
             q=self.pro_accounts[2].email,
-            _external=True,
+            search_rank=1,
+            total_items=1,
         )
 
     def test_can_search_pro_by_last_name(self, authenticated_client):


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-25433

- corrections :
  - suivre dans ces _trackers_ les pages affichées comme unique résultat de recherche
  - envoyer la bonne position lorsqu'on clique sur un résultat au-delà de la page 1 (ça revenait à 0 à chaque page)
- améliorations : 
  - un peu de factorisation dans les liens
  - à l'affichage, retirer les _query params_ de l'URL dans la barre d'adresse pour permettre de copier/coller un lien propre qui ne ré-enverra pas les _trackers_ de recherche

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques