### PR TITLE
(PC-25351)[API] feat: add bookings count to get offer route

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -575,6 +575,14 @@ def check_stock_consistency() -> list[int]:
     ]
 
 
+def get_bookings_count_by_offer(offer_id: int) -> int:
+    return (
+        models.Stock.query.filter(models.Stock.offerId == offer_id)
+        .with_entities(sa.func.coalesce(sa.func.sum(models.Stock.dnBookedQuantity), 0))
+        .scalar()
+    )
+
+
 def find_event_stocks_happening_in_x_days(number_of_days: int) -> flask_sqlalchemy.BaseQuery:
     target_day = datetime.datetime.utcnow() + datetime.timedelta(days=number_of_days)
     start = datetime.datetime.combine(target_day, datetime.time.min)

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -320,6 +320,7 @@ class PriceCategoryResponseModel(BaseModel):
 class GetIndividualOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     activeMediation: GetOfferMediationResponseModel | None
     bookingContact: str | None
+    bookingsCount: int = 0
     bookingEmail: str | None
     dateCreated: datetime.datetime
     description: str | None
@@ -348,6 +349,11 @@ class GetIndividualOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     withdrawalDetails: str | None
     withdrawalType: offers_models.WithdrawalTypeEnum | None
     status: OfferStatus
+
+    @classmethod
+    def from_orm(cls, offer: offers_models.Offer) -> "GetIndividualOfferResponseModel":
+        offer.bookingsCount = offers_repository.get_bookings_count_by_offer(offer.id)
+        return super().from_orm(offer)
 
     class Config:
         orm_mode = True

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -9,6 +9,7 @@ from pcapi.core.categories import subcategories_v2 as subcategories
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.educational.models as educational_models
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.offers import api
 from pcapi.core.offers import factories
 from pcapi.core.offers import models
 from pcapi.core.offers import repository
@@ -1106,6 +1107,49 @@ class CheckStockConsistenceTest:
 
         stock_ids = set(repository.check_stock_consistency())
         assert stock_ids == {stock2.id, stock4.id, stock6.id}
+
+
+@pytest.mark.usefixtures("db_session")
+class GetBookingCountByOfferTest:
+    def test_get_booking_count(self):
+        # Given
+        offer = factories.OfferFactory()
+        stock = factories.StockFactory(offer=offer, quantity=5)
+        stock_from_another_offer = factories.StockFactory()
+        bookings_factories.BookingFactory.create_batch(2, stock=stock)
+        bookings_factories.UsedBookingFactory.create_batch(1, stock=stock)
+        bookings_factories.CancelledBookingFactory.create_batch(1, stock=stock)
+        bookings_factories.BookingFactory.create_batch(3, stock=stock_from_another_offer)
+
+        # When
+        booking_count = repository.get_bookings_count_by_offer(offer_id=offer.id)
+
+        # Then
+        assert booking_count == 3
+
+    def test_get_booking_count_with_no_bookings(self):
+        # Given
+        offer = factories.OfferFactory()
+        factories.StockFactory(offer=offer, quantity=2)
+
+        # When
+        booking_count = repository.get_bookings_count_by_offer(offer_id=offer.id)
+
+        # Then
+        assert booking_count == 0
+
+    def test_get_booking_count_on_soft_deleted_stock(self):
+        # Given
+        offer = factories.OfferFactory()
+        stock = factories.StockFactory(offer=offer, quantity=5)
+        bookings_factories.BookingFactory.create_batch(2, stock=stock)
+        api.delete_stock(stock)
+
+        # When
+        booking_count = repository.get_bookings_count_by_offer(offer_id=offer.id)
+
+        # Then
+        assert booking_count == 0
 
 
 @pytest.mark.usefixtures("db_session")

--- a/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
@@ -17,6 +17,7 @@ export type GetIndividualOfferResponseModel = {
   audioDisabilityCompliant?: boolean | null;
   bookingContact?: string | null;
   bookingEmail?: string | null;
+  bookingsCount?: number;
   dateCreated: string;
   description?: string | null;
   durationMinutes?: number | null;


### PR DESCRIPTION
## But de la pull request

On rajoute un champ "bookingCount" dans la route get offer afin de renvoyer le nombre de réservations pour une offre

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25351

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques