### PR TITLE
(PC-24282)[PRO] feat: update reimbursement link display conditions

### DIFF
--- a/pro/src/pages/Home/Homepage.tsx
+++ b/pro/src/pages/Home/Homepage.tsx
@@ -176,6 +176,10 @@ const Homepage = (): JSX.Element => {
             <VenueOfferSteps
               hasVenue={!hasNoVenueVisible}
               offererId={Number(selectedOffererId)}
+              offererHasBankAccount={
+                selectedOfferer?.hasPendingBankAccount === false &&
+                selectedOfferer?.hasValidBankAccount === false
+              }
             />
           </section>
         )}

--- a/pro/src/pages/Home/Homepage.tsx
+++ b/pro/src/pages/Home/Homepage.tsx
@@ -177,8 +177,8 @@ const Homepage = (): JSX.Element => {
               hasVenue={!hasNoVenueVisible}
               offererId={Number(selectedOffererId)}
               offererHasBankAccount={
-                selectedOfferer?.hasPendingBankAccount === false &&
-                selectedOfferer?.hasValidBankAccount === false
+                selectedOfferer?.hasPendingBankAccount === true ||
+                selectedOfferer?.hasValidBankAccount === true
               }
             />
           </section>

--- a/pro/src/pages/Home/Homepage.tsx
+++ b/pro/src/pages/Home/Homepage.tsx
@@ -176,10 +176,10 @@ const Homepage = (): JSX.Element => {
             <VenueOfferSteps
               hasVenue={!hasNoVenueVisible}
               offererId={Number(selectedOffererId)}
-              offererHasBankAccount={
-                selectedOfferer?.hasPendingBankAccount === true ||
-                selectedOfferer?.hasValidBankAccount === true
-              }
+              offererHasBankAccount={Boolean(
+                selectedOfferer?.hasPendingBankAccount ||
+                  selectedOfferer?.hasValidBankAccount
+              )}
             />
           </section>
         )}

--- a/pro/src/pages/Home/Offerers/Offerers.tsx
+++ b/pro/src/pages/Home/Offerers/Offerers.tsx
@@ -177,6 +177,10 @@ const Offerers = ({
                   ? venues.virtualVenue
                   : null
               }
+              offererHasBankAccount={
+                selectedOfferer.hasPendingBankAccount === false &&
+                selectedOfferer.hasValidBankAccount === false
+              }
             />
           )}
         </>

--- a/pro/src/pages/Home/Offerers/Offerers.tsx
+++ b/pro/src/pages/Home/Offerers/Offerers.tsx
@@ -178,8 +178,8 @@ const Offerers = ({
                   : null
               }
               offererHasBankAccount={
-                selectedOfferer.hasPendingBankAccount === false &&
-                selectedOfferer.hasValidBankAccount === false
+                selectedOfferer.hasPendingBankAccount === true ||
+                selectedOfferer.hasValidBankAccount === true
               }
             />
           )}

--- a/pro/src/pages/Home/Offerers/Offerers.tsx
+++ b/pro/src/pages/Home/Offerers/Offerers.tsx
@@ -177,10 +177,10 @@ const Offerers = ({
                   ? venues.virtualVenue
                   : null
               }
-              offererHasBankAccount={
-                selectedOfferer.hasPendingBankAccount === true ||
-                selectedOfferer.hasValidBankAccount === true
-              }
+              offererHasBankAccount={Boolean(
+                selectedOfferer.hasPendingBankAccount ||
+                  selectedOfferer.hasValidBankAccount
+              )}
             />
           )}
         </>

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -165,7 +165,7 @@ const VenueOfferSteps = ({
                       }}
                       onClick={() => {
                         logEvent?.(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
-                          venue_id: venueId || '',
+                          venue_id: venueId ?? '',
                           from: OFFER_FORM_NAVIGATION_IN.HOME,
                         })
                       }}

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -28,6 +28,7 @@ export interface VenueOfferStepsProps {
   shouldDisplayEACInformationSection?: boolean
   hasPendingBankInformationApplication?: boolean | null
   demarchesSimplifieesApplicationId?: number | null
+  offererHasBankAccount: boolean
 }
 
 const VenueOfferSteps = ({
@@ -39,6 +40,7 @@ const VenueOfferSteps = ({
   hasAdageId = false,
   shouldDisplayEACInformationSection = false,
   hasPendingBankInformationApplication = false,
+  offererHasBankAccount,
   demarchesSimplifieesApplicationId,
 }: VenueOfferStepsProps) => {
   const isVenueCreationAvailable = useActiveFeature('API_SIRENE_AVAILABLE')
@@ -128,26 +130,49 @@ const VenueOfferSteps = ({
                     Créer une offre
                   </ButtonLink>
                 )}
-                {hasMissingReimbursementPoint && (
-                  <ButtonLink
-                    className={styles['step-button-width']}
-                    isDisabled={!hasVenue}
-                    variant={ButtonVariant.BOX}
-                    icon={fullNextIcon}
-                    link={{
-                      to: `/structures/${offererId}/lieux/${venueId}#reimbursement`,
-                      isExternal: false,
-                    }}
-                    onClick={() => {
-                      logEvent?.(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
-                        venue_id: venueId || '',
-                        from: OFFER_FORM_NAVIGATION_IN.HOME,
-                      })
-                    }}
-                  >
-                    Renseigner des coordonnées bancaires
-                  </ButtonLink>
-                )}
+                {!isNewBankDetailsJourneyEnabled &&
+                  hasMissingReimbursementPoint && (
+                    <ButtonLink
+                      className={styles['step-button-width']}
+                      isDisabled={!hasVenue}
+                      variant={ButtonVariant.BOX}
+                      icon={fullNextIcon}
+                      link={{
+                        to: `/structures/${offererId}/lieux/${venueId}#reimbursement`,
+                        isExternal: false,
+                      }}
+                      onClick={() => {
+                        logEvent?.(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
+                          venue_id: venueId || '',
+                          from: OFFER_FORM_NAVIGATION_IN.HOME,
+                        })
+                      }}
+                    >
+                      Renseigner des coordonnées bancaires
+                    </ButtonLink>
+                  )}
+                {isNewBankDetailsJourneyEnabled &&
+                  !hasCreatedOffer &&
+                  !offererHasBankAccount && (
+                    <ButtonLink
+                      className={styles['step-button-width']}
+                      isDisabled={!hasVenue}
+                      variant={ButtonVariant.BOX}
+                      icon={fullNextIcon}
+                      link={{
+                        to: `remboursements/informations-bancaires?structure=${offererId}`,
+                        isExternal: false,
+                      }}
+                      onClick={() => {
+                        logEvent?.(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
+                          venue_id: venueId || '',
+                          from: OFFER_FORM_NAVIGATION_IN.HOME,
+                        })
+                      }}
+                    >
+                      Ajouter un compte bancaire
+                    </ButtonLink>
+                  )}
                 {shouldDisplayEACInformationSection && (
                   <ButtonLink
                     className={styles['step-button-width']}

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
@@ -31,6 +31,7 @@ describe('VenueOfferSteps', () => {
   const props: VenueOfferStepsProps = {
     hasVenue: false,
     offererId: 1,
+    offererHasBankAccount: false,
   }
   it('Should display venue creation link if user has no venue', async () => {
     props.hasVenue = false
@@ -59,6 +60,30 @@ describe('VenueOfferSteps', () => {
     renderVenueOfferSteps(props)
     expect(
       screen.queryByText('Renseigner des coordonnées bancaires')
+    ).not.toBeInTheDocument()
+  })
+  it('Should display bank account link if user has no bank account and no offer on offerer', async () => {
+    props.offererHasBankAccount = false
+    props.hasCreatedOffer = false
+    renderVenueOfferSteps(props, {
+      list: [
+        { isActive: true, nameKey: 'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY' },
+      ],
+    })
+    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Renseigner des coordonnées bancaires')
+    ).not.toBeInTheDocument()
+  })
+  it('Should not display account link if user has bank account on offerer', async () => {
+    props.offererHasBankAccount = true
+    renderVenueOfferSteps(props, {
+      list: [
+        { isActive: true, nameKey: 'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY' },
+      ],
+    })
+    expect(
+      screen.queryByText('Ajouter un compte bancaire')
     ).not.toBeInTheDocument()
   })
   it('Should display eac dms link when condition to display it is true', async () => {

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
@@ -33,36 +33,36 @@ describe('VenueOfferSteps', () => {
     offererId: 1,
     offererHasBankAccount: false,
   }
-  it('Should display venue creation link if user has no venue', async () => {
+  it('Should display venue creation link if user has no venue', () => {
     props.hasVenue = false
     renderVenueOfferSteps(props)
     expect(screen.getByText('Créer un lieu')).toBeInTheDocument()
   })
-  it('Should not display venue creation link if user has venues', async () => {
+  it('Should not display venue creation link if user has venues', () => {
     props.hasVenue = true
     renderVenueOfferSteps(props)
     expect(screen.queryByText('Créer un lieu')).not.toBeInTheDocument()
   })
-  it('Should display offer creation link if user has no offer on venue', async () => {
+  it('Should display offer creation link if user has no offer on venue', () => {
     props.hasVenue = false
     renderVenueOfferSteps(props)
     expect(screen.getByText('Créer une offre')).toBeInTheDocument()
   })
-  it('Should display reimbursement link if user has no ReimbursementPoint on venue', async () => {
+  it('Should display reimbursement link if user has no ReimbursementPoint on venue', () => {
     props.hasMissingReimbursementPoint = true
     renderVenueOfferSteps(props)
     expect(
       screen.getByText('Renseigner des coordonnées bancaires')
     ).toBeInTheDocument()
   })
-  it('Should not display reimbursement link if user has ReimbursementPoint on venue', async () => {
+  it('Should not display reimbursement link if user has ReimbursementPoint on venue', () => {
     props.hasMissingReimbursementPoint = false
     renderVenueOfferSteps(props)
     expect(
       screen.queryByText('Renseigner des coordonnées bancaires')
     ).not.toBeInTheDocument()
   })
-  it('Should display bank account link if user has no bank account and no offer on offerer', async () => {
+  it('Should display bank account link if user has no bank account and no offer on offerer', () => {
     props.offererHasBankAccount = false
     props.hasCreatedOffer = false
     renderVenueOfferSteps(props, {
@@ -75,7 +75,7 @@ describe('VenueOfferSteps', () => {
       screen.queryByText('Renseigner des coordonnées bancaires')
     ).not.toBeInTheDocument()
   })
-  it('Should not display account link if user has bank account on offerer', async () => {
+  it('Should not display account link if user has bank account on offerer', () => {
     props.offererHasBankAccount = true
     renderVenueOfferSteps(props, {
       list: [
@@ -86,7 +86,7 @@ describe('VenueOfferSteps', () => {
       screen.queryByText('Ajouter un compte bancaire')
     ).not.toBeInTheDocument()
   })
-  it('Should display eac dms link when condition to display it is true', async () => {
+  it('Should display eac dms link when condition to display it is true', () => {
     props.shouldDisplayEACInformationSection = true
     renderVenueOfferSteps(props)
     expect(screen.getByText('Démarche en cours :')).toBeInTheDocument()
@@ -95,7 +95,7 @@ describe('VenueOfferSteps', () => {
     ).toBeInTheDocument()
   })
 
-  it('Should display bank information status follow link when condition to display it is true', async () => {
+  it('Should display bank information status follow link when condition to display it is true', () => {
     props.shouldDisplayEACInformationSection = false
     props.hasPendingBankInformationApplication = true
     props.demarchesSimplifieesApplicationId = 1232799
@@ -110,7 +110,7 @@ describe('VenueOfferSteps', () => {
       'https://www.demarches-simplifiees.fr/dossiers/1232799/messagerie'
     )
   })
-  it('Should not display ds application link when the FF is enabled', async () => {
+  it('Should not display ds application link when the FF is enabled', () => {
     renderVenueOfferSteps(props, {
       list: [
         { isActive: true, nameKey: 'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY' },
@@ -124,7 +124,7 @@ describe('VenueOfferSteps', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('redirect to dms even if there is no dms application id', async () => {
+  it('redirect to dms even if there is no dms application id', () => {
     props.hasVenue = false
     props.shouldDisplayEACInformationSection = false
     props.hasPendingBankInformationApplication = true
@@ -137,7 +137,7 @@ describe('VenueOfferSteps', () => {
     ).toHaveAttribute('href', 'https://www.demarches-simplifiees.fr/dossiers')
   })
 
-  it('Should display link for eac informations if has adage id and already created offer', async () => {
+  it('Should display link for eac informations if has adage id and already created offer', () => {
     props.hasVenue = false
     props.hasAdageId = true
     props.shouldDisplayEACInformationSection = true
@@ -149,7 +149,7 @@ describe('VenueOfferSteps', () => {
     ).toBeInTheDocument()
   })
 
-  it('Should display disabled link to eac informations if venue doesnt have adage id', async () => {
+  it('Should display disabled link to eac informations if venue doesnt have adage id', () => {
     props.hasVenue = false
     props.hasAdageId = false
     props.shouldDisplayEACInformationSection = true
@@ -161,7 +161,7 @@ describe('VenueOfferSteps', () => {
     expect(eacInformationsLink).toHaveAttribute('aria-disabled')
   })
 
-  it('should not display dms link if condition to display it is false', async () => {
+  it('should not display dms link if condition to display it is false', () => {
     props.hasVenue = false
     props.shouldDisplayEACInformationSection = false
     renderVenueOfferSteps(props)
@@ -170,7 +170,7 @@ describe('VenueOfferSteps', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should not display venueOfferSteps if no condition to display informations', async () => {
+  it('should not display venueOfferSteps if no condition to display informations', () => {
     props.hasCreatedOffer = true
     props.hasPendingBankInformationApplication = false
     props.shouldDisplayEACInformationSection = false
@@ -180,7 +180,7 @@ describe('VenueOfferSteps', () => {
     expect(screen.queryByTestId('home-offer-steps')).not.toBeInTheDocument()
   })
 
-  it('should display venueOfferSteps if condition to display it', async () => {
+  it('should display venueOfferSteps if condition to display it', () => {
     props.hasCreatedOffer = true
     props.shouldDisplayEACInformationSection = true
     renderVenueOfferSteps(props)

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
@@ -15,7 +15,9 @@ const renderVenueOfferSteps = (
   hasMissingReimbursementPoint = true,
   shouldDisplayEacSection = false,
   hasPendingBankInformationApplication = false,
-  demarchesSimplifieesApplicationId?: number
+  demarchesSimplifieesApplicationId?: number,
+  offererHasBankAccount = false,
+  features?: any
 ) => {
   const currentUser = {
     id: 'EY',
@@ -25,6 +27,7 @@ const renderVenueOfferSteps = (
       initialized: true,
       currentUser,
     },
+    features,
   }
 
   return renderWithProviders(
@@ -38,6 +41,7 @@ const renderVenueOfferSteps = (
         hasPendingBankInformationApplication
       }
       demarchesSimplifieesApplicationId={demarchesSimplifieesApplicationId}
+      offererHasBankAccount={offererHasBankAccount}
     />,
     { storeOverrides, initialRouterEntries: ['/accueil'] }
   )
@@ -78,6 +82,25 @@ describe('VenueOfferSteps', () => {
     await userEvent.click(
       screen.getByText(/Renseigner des coordonnées bancaires/)
     )
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON,
+      {
+        venue_id: venueId,
+        from: 'Home',
+      }
+    )
+  })
+
+  it('should track ReimbursementPoint', async () => {
+    renderVenueOfferSteps(venueId, false, false, false, undefined, false, {
+      list: [
+        { isActive: true, nameKey: 'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY' },
+      ],
+    })
+
+    await userEvent.click(screen.getByText(/Ajouter un compte bancaire/))
 
     expect(mockLogEvent).toHaveBeenCalledTimes(1)
     expect(mockLogEvent).toHaveBeenCalledWith(

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -39,6 +39,7 @@ export interface VenueProps {
   adageInscriptionDate?: string | null
   hasPendingBankInformationApplication?: boolean | null
   demarchesSimplifieesApplicationId?: number | null
+  offererHasBankAccount: boolean
 }
 
 const Venue = ({
@@ -55,6 +56,7 @@ const Venue = ({
   adageInscriptionDate,
   demarchesSimplifieesApplicationId,
   hasPendingBankInformationApplication = false,
+  offererHasBankAccount,
 }: VenueProps) => {
   const venueCreateOfferLink = [
     '/offre/creation',
@@ -349,6 +351,7 @@ const Venue = ({
                     demarchesSimplifieesApplicationId={
                       demarchesSimplifieesApplicationId
                     }
+                    offererHasBankAccount={offererHasBankAccount}
                   />
 
                   <div className="venue-stats">

--- a/pro/src/pages/Home/Venues/VenueList.tsx
+++ b/pro/src/pages/Home/Venues/VenueList.tsx
@@ -9,12 +9,14 @@ interface VenueListProps {
   physicalVenues: GetOffererVenueResponseModel[]
   selectedOffererId: number
   virtualVenue: GetOffererVenueResponseModel | null
+  offererHasBankAccount: boolean
 }
 
 const VenueList = ({
   physicalVenues,
   selectedOffererId,
   virtualVenue,
+  offererHasBankAccount,
 }: VenueListProps) => {
   return (
     <div className="h-venue-list">
@@ -40,6 +42,7 @@ const VenueList = ({
           demarchesSimplifieesApplicationId={
             virtualVenue.demarchesSimplifieesApplicationId
           }
+          offererHasBankAccount={offererHasBankAccount}
         />
       )}
 
@@ -64,6 +67,7 @@ const VenueList = ({
           demarchesSimplifieesApplicationId={
             venue.demarchesSimplifieesApplicationId
           }
+          offererHasBankAccount={offererHasBankAccount}
         />
       ))}
     </div>

--- a/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
@@ -43,6 +43,7 @@ describe('venues', () => {
       name: 'My venue',
       offererId: offererId,
       dmsInformations: null,
+      offererHasBankAccount: false,
     }
     vi.spyOn(api, 'getVenueStats').mockResolvedValue({
       activeBookingsQuantity: 0,

--- a/pro/src/pages/Home/Venues/__specs__/Venue.tracker.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.tracker.spec.tsx
@@ -36,6 +36,7 @@ describe('venue create offer link', () => {
       name: 'My venue',
       offererId: offererId,
       dmsInformations: null,
+      offererHasBankAccount: false,
     }
     vi.spyOn(api, 'getVenueStats').mockResolvedValue({
       activeBookingsQuantity: 0,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24282

FF: WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY

Sous FF, remplace le bouton "Renseigner des coordonées bancaires" par "Ajouter un compte bancaire" qui redirige vers `remboursements/informations-bancaires`
Ce bouton s'affiche s'il n'y a pas d'offre créée, et s'il n'y a pas de compte bancaire au sein de la structure

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/759e658b-b6c9-4227-8f97-4b8cabfd1d3c)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques