### PR TITLE
(PC-25612)[API] bump: MarkupSafe

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -36,8 +36,8 @@ ipaddress
 isort
 itsdangerous==2.0.1
 Jinja2==3.0.3
-MarkupSafe==2.0.1
-mypy # Not pinned. If a new version introduces new errors we cannot fix in one go, see api/bin/mypy_add_type_ignores.py 
+MarkupSafe
+mypy # Not pinned. If a new version introduces new errors we cannot fix in one go, see api/bin/mypy_add_type_ignores.py
 notion-client==1.0.0
 openpyxl
 pgcli # a tool not used in code. There is no point in pinning its version


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25612

Unpin markupSafe current version is [v2.1.3](https://markupsafe.palletsprojects.com/en/2.1.x/changes/)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques