### PR TITLE
(PC-25617)[API] feat: get stocks sends 400 when page is <1

### DIFF
--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -379,7 +379,7 @@ class StocksQueryModel(BaseModel):
     price_category_id: int | None
     order_by: offers_repository.StocksOrderedBy = offers_repository.StocksOrderedBy.BEGINNING_DATETIME
     order_by_desc: bool = False
-    page: int = 1
+    page: int = Field(1, ge=1)
     stocks_limit_per_page: int = offers_repository.LIMIT_STOCKS_PER_PAGE
 
 


### PR DESCRIPTION
## But de la pull request

On veut renvoyer une 400 si la page dans la requête GET stocks est <1

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25617

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques