### PR TITLE
(BSR) chore: update vscode settings made obsolete by the latest version

### DIFF
--- a/api/.vscode/extensions.json
+++ b/api/.vscode/extensions.json
@@ -1,3 +1,9 @@
 {
-    "recommendations": ["ms-python.vscode-pylance", "ms-python.python", ]
+    "recommendations": [
+        "ms-python.vscode-pylance",
+        "ms-python.python",
+        "ms-python.pylint",
+        "ms-python.mypy-type-checker",
+        "ms-python.black-formatter"
+    ]
 }

--- a/api/.vscode/settings.json
+++ b/api/.vscode/settings.json
@@ -1,16 +1,14 @@
 {
-  "python.linting.pylintEnabled": true,
-  "python.linting.mypyEnabled": true,
-  "python.linting.ignorePatterns": ["**/tests/**"],
+  "pylint.importStrategy": "fromEnvironment",
+  "pylint.ignorePatterns": ["**/tests/**"],
   "editor.codeActionsOnSave": {
     "source.organizeImports": true
   },
   "editor.formatOnSave": true,
   "python.testing.unittestEnabled": false,
-  "python.testing.nosetestsEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.formatting.provider": "black",
+  "black-formatter.importStrategy": "fromEnvironment",
   "liveshare.languages.allowGuestCommandControl": true,
   "liveshare.allowGuestDebugControl": true,
   "liveshare.allowGuestTaskControl": true,


### PR DESCRIPTION
## But de la pull request

Mise à jour des settings vscode dépréciés
Ajout des extensions recommandées qui remplacent ces settings (black, mypy, pylint)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques