### PR TITLE
(PC-25630)[API] fix: UniqueViolation error on create_offer_from_product

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -320,7 +320,6 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
 
 
 def _get_existing_products(ean_to_create: set[str]) -> list[offers_models.Product]:
-    # FIXME (cepehang, 2023-09-21) remove this condition when the product table is cleaned up
     allowed_product_subcategories = [
         subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
         subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id,
@@ -328,9 +327,12 @@ def _get_existing_products(ean_to_create: set[str]) -> list[offers_models.Produc
     ]
     return offers_models.Product.query.filter(
         offers_models.Product.extraData["ean"].astext.in_(ean_to_create),
-        offers_models.Product.owningOffererId.is_(None),
         offers_models.Product.can_be_synchronized == True,
         offers_models.Product.subcategoryId.in_(allowed_product_subcategories),
+        # FIXME (cepehang, 2023-09-21) remove these condition when the product table is cleaned up
+        offers_models.Product.owningOffererId.is_(None),
+        offers_models.Product.lastProviderId.is_not(None),
+        offers_models.Product.idAtProviders.is_not(None),
     ).all()
 
 


### PR DESCRIPTION
Our product database has flaws. Multiples products exists and we didn't filter them enough. There is a unique constraint on idAtProviders ensuring that we only have one product by ean returned.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25630

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques