### PR TITLE
(BSR)[PRO] fix: increase e2e request timeout

### DIFF
--- a/pro/cypress.config.ts
+++ b/pro/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     openMode: 0,
   },
   defaultCommandTimeout: 30000,
+  requestTimeout: 30000,
   viewportHeight: 1080,
   viewportWidth: 1920,
   video: true,


### PR DESCRIPTION
La plupart des échecs ont l'air d'être dus à un timeout sur la route patchOffer qui prend plus de 5 secondes (le timeout par défaut est de 5s)