### PR TITLE
(PC-25389)[PRO] feat: eac add artistic domain playlist

### DIFF
--- a/pro/src/pages/AdageIframe/app/App.tsx
+++ b/pro/src/pages/AdageIframe/app/App.tsx
@@ -23,14 +23,15 @@ import {
 import { AdageUserContextProvider } from './providers/AdageUserContext'
 
 export const App = (): JSX.Element => {
+  const params = new URLSearchParams(window.location.search)
   const [user, setUser] = useState<AuthenticatedResponse | null>()
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [venueFilter, setVenueFilter] = useState<VenueResponse | null>(null)
+  const domainId = Number(params.get('domain'))
 
   const notification = useNotification()
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
     const siret = params.get('siret')
     const venueId = Number(params.get('venue'))
     const getRelativeOffers = params.get('all') === 'true'
@@ -98,12 +99,16 @@ export const App = (): JSX.Element => {
   return (
     <AdageUserContextProvider adageUser={user}>
       <FiltersContextProvider venueFilter={venueFilter}>
-        <FacetFiltersContextProvider uai={user?.uai} venueFilter={venueFilter}>
+        <FacetFiltersContextProvider
+          uai={user?.uai}
+          venueFilter={venueFilter}
+          domainFilter={domainId}
+        >
           {user?.role &&
           [AdageFrontRoles.READONLY, AdageFrontRoles.REDACTOR].includes(
             user.role
           ) ? (
-            <AppLayout venueFilter={venueFilter} />
+            <AppLayout venueFilter={venueFilter} domainFilter={domainId} />
           ) : (
             <UnauthenticatedError />
           )}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.module.scss
@@ -50,3 +50,8 @@
     margin-right: rem.torem(4px) !important;
   }
 }
+
+.section-domains-card {
+  display: inline-flex;
+  gap: rem.torem(32px);
+}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
@@ -85,9 +85,11 @@ const mockVenue = {
 }
 
 export const AdageDiscovery = () => {
+  const params = new URLSearchParams(location.search)
   const [domainsOptions, setDomainsOptions] = useState<Option<number>[]>([])
 
   const notification = useNotification()
+  const adageAuthToken = params.get('token')
 
   useEffect(() => {
     const getAllDomains = async () => {
@@ -178,9 +180,11 @@ export const AdageDiscovery = () => {
 
               return (
                 <DomainsCard
+                  key={`domains-${elm.value}`}
                   title={elm.label}
                   color={colorAndMotif.color}
                   src={colorAndMotif.src}
+                  href={`/adage-iframe?token=${adageAuthToken}&domain=${elm.value}`}
                 />
               )
             })}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
@@ -1,14 +1,25 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { OfferAddressType, StudentLevels } from 'apiClient/adage'
+import { api } from 'apiClient/api'
+import { GET_DATA_ERROR_MESSAGE } from 'core/shared/constants'
+import useNotification from 'hooks/useNotification'
 import bannerDiscovery from 'icons/banner-discovery-adage.svg'
 import fullLinkIcon from 'icons/full-link.svg'
+import { Option } from 'pages/AdageIframe/app/types'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
 import styles from './AdageDiscovery.module.scss'
 import CardOfferComponent, { CardOfferModel } from './CardOffer/CardOffer'
 import CardVenue from './CardVenue/CardVenue'
+import circles from './DomainsCard/assets/circles.svg'
+import ellipses from './DomainsCard/assets/ellipses.svg'
+import pills from './DomainsCard/assets/pills.svg'
+import rectangles from './DomainsCard/assets/rectangles.svg'
+import squares from './DomainsCard/assets/squares.svg'
+import triangles from './DomainsCard/assets/triangles.svg'
+import DomainsCard from './DomainsCard/DomainsCard'
 
 const mockOffer: CardOfferModel = {
   id: 479,
@@ -74,6 +85,36 @@ const mockVenue = {
 }
 
 export const AdageDiscovery = () => {
+  const [domainsOptions, setDomainsOptions] = useState<Option<number>[]>([])
+
+  const notification = useNotification()
+
+  useEffect(() => {
+    const getAllDomains = async () => {
+      try {
+        const result = await api.listEducationalDomains()
+
+        return setDomainsOptions(
+          result.map(({ id, name }) => ({ value: id, label: name }))
+        )
+      } catch {
+        notification.error(GET_DATA_ERROR_MESSAGE)
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    getAllDomains()
+  }, [])
+
+  const colorAndMotifOrder = [
+    { color: 'orange', src: squares },
+    { color: 'purple', src: pills },
+    { color: 'pink', src: triangles },
+    { color: 'green', src: rectangles },
+    { color: 'red', src: ellipses },
+    { color: 'blue', src: circles },
+  ]
+
   return (
     <div className={styles['discovery']}>
       <img
@@ -130,7 +171,20 @@ export const AdageDiscovery = () => {
           <h1 className={styles['section-title']}>
             Explorez les domaines artistiques
           </h1>
-          <div> TODO: Playlist domaines artistiques à ajouter</div>
+          <div className={styles['section-domains-card']}>
+            {domainsOptions.map((elm, key) => {
+              const colorAndMotif =
+                colorAndMotifOrder[key % colorAndMotifOrder.length]
+
+              return (
+                <DomainsCard
+                  title={elm.label}
+                  color={colorAndMotif.color}
+                  src={colorAndMotif.src}
+                />
+              )
+            })}
+          </div>
         </div>
         <div>
           <h1 className={styles['section-title']}>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.module.scss
@@ -1,0 +1,50 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/variables/_colors.scss" as colors;
+
+.container {
+    display: flex;
+    align-items: flex-end;
+    position: relative;
+    width: rem.torem(186px);
+    height: rem.torem(96px);
+    border-radius: rem.torem(16px);
+
+    &-img {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+    }
+
+    &-title {
+        @include fonts.button;
+
+        color: colors.$white;
+        padding: 0 rem.torem(12px) rem.torem(12px) rem.torem(12px);
+    }
+
+    &-orange {
+        background: linear-gradient(rgb(250 159 22 / 100%), rgb(184 89 1 / 100%));
+    }
+
+    &-purple {
+        background: linear-gradient(rgb(173 135 255 / 100%), rgb(131 55 233 / 100%))
+    }
+
+    &-pink {
+        background: linear-gradient(rgb(236 52 120 / 100%), rgb(192 19 113 / 100%));
+    }
+
+    &-green {
+        background: linear-gradient(rgb(39 220 168 / 100%), rgb(14 132 116 / 100%));
+    }
+
+    &-red {
+        background: linear-gradient(rgb(248 115 61 / 100%), rgb(202 63 19 / 100%));
+    }
+
+    &-blue {
+        background: linear-gradient(rgb(31 197 233 / 100%), rgb(14 120 183 / 100%));
+    }
+}
+

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.module.scss
@@ -7,8 +7,14 @@
     align-items: flex-end;
     position: relative;
     width: rem.torem(186px);
-    height: rem.torem(96px);
+    min-height: rem.torem(96px);
     border-radius: rem.torem(16px);
+
+    &:focus-visible {
+        outline: rem.torem(2px) solid colors.$input-text-color;
+        outline-offset: rem.torem(2px);
+        border-radius: rem.torem(16px);
+    }
 
     &-img {
         position: absolute;

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.tsx
@@ -1,0 +1,20 @@
+import cn from 'classnames'
+
+import styles from './DomainsCard.module.scss'
+
+interface DomainsCardProps {
+  title: string
+  color: string
+  src: string
+}
+
+const DomainsCard = ({ title, color, src }: DomainsCardProps) => {
+  return (
+    <div className={cn(styles['container'], styles[`container-${color}`])}>
+      <img src={src} alt="" className={styles['container-img']} />
+      <div className={styles['container-title']}>{title}</div>
+    </div>
+  )
+}
+
+export default DomainsCard

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.tsx
@@ -2,18 +2,22 @@ import cn from 'classnames'
 
 import styles from './DomainsCard.module.scss'
 
-interface DomainsCardProps {
+export interface DomainsCardProps {
   title: string
   color: string
   src: string
+  href: string
 }
 
-const DomainsCard = ({ title, color, src }: DomainsCardProps) => {
+const DomainsCard = ({ title, color, src, href }: DomainsCardProps) => {
   return (
-    <div className={cn(styles['container'], styles[`container-${color}`])}>
+    <a
+      className={cn(styles['container'], styles[`container-${color}`])}
+      href={href}
+    >
       <img src={src} alt="" className={styles['container-img']} />
       <div className={styles['container-title']}>{title}</div>
-    </div>
+    </a>
   )
 }
 

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/__specs__/DomainsCard.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/__specs__/DomainsCard.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+
+import DomainsCard, { DomainsCardProps } from '../DomainsCard'
+
+const renderDomainsCardComponent = ({
+  title,
+  color,
+  src,
+  href,
+}: DomainsCardProps) => {
+  render(<DomainsCard title={title} color={color} src={src} href={href} />)
+}
+
+describe('CardOffer component', () => {
+  it('should render domains card', () => {
+    renderDomainsCardComponent({
+      title: 'Test domains card',
+      color: 'green',
+      src: 'src',
+      href: 'href',
+    })
+
+    expect(screen.getByText('Test domains card')).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/circles.svg
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/circles.svg
@@ -1,0 +1,24 @@
+<svg width="186" height="108" viewBox="0 0 186 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="circles" clip-path="url(#clip0_2328_815)">
+<rect id="Rectangle 1166" opacity="0.2" x="166.513" y="38.3853" width="45.1137" height="45.1137" rx="22.5569" transform="rotate(-162.142 166.513 38.3853)" fill="url(#paint0_linear_2328_815)"/>
+<rect id="Rectangle 1167" opacity="0.2" x="181.374" y="56.0105" width="23.0024" height="23.0024" rx="11.5012" transform="rotate(-139.963 181.374 56.0105)" fill="url(#paint1_linear_2328_815)"/>
+<rect id="Rectangle 1168" opacity="0.2" x="148.898" y="73.0261" width="16.7303" height="16.7303" rx="8.36517" transform="rotate(-116.569 148.898 73.0261)" fill="url(#paint2_linear_2328_815)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_2328_815" x1="189.07" y1="38.3853" x2="189.07" y2="83.499" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="0.728846" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2328_815" x1="192.875" y1="56.0105" x2="192.875" y2="79.0129" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_2328_815" x1="157.263" y1="73.0261" x2="157.263" y2="89.7565" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_2328_815">
+<rect width="186" height="108" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/ellipses.svg
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/ellipses.svg
@@ -1,0 +1,24 @@
+<svg width="186" height="108" viewBox="0 0 186 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ellipses" clip-path="url(#clip0_2328_919)">
+<ellipse id="Ellipse 262" opacity="0.2" cx="140.186" cy="39.9968" rx="20.577" ry="10.0104" transform="rotate(-11.7682 140.186 39.9968)" fill="url(#paint0_linear_2328_919)"/>
+<ellipse id="Ellipse 264" opacity="0.2" cx="162.221" cy="9" rx="28.1056" ry="16.3314" transform="rotate(-137.668 162.221 9)" fill="url(#paint1_linear_2328_919)"/>
+<ellipse id="Ellipse 263" opacity="0.2" cx="166.266" cy="53.7995" rx="9.30407" ry="5.49786" transform="rotate(-61.556 166.266 53.7995)" fill="url(#paint2_linear_2328_919)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_2328_919" x1="134.644" y1="46.1446" x2="159.505" y2="24.1634" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2328_919" x1="162.221" y1="-7.3314" x2="162.221" y2="25.3314" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_2328_919" x1="166.266" y1="48.3017" x2="166.266" y2="59.2974" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_2328_919">
+<rect width="186" height="108" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/pills.svg
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/pills.svg
@@ -1,0 +1,24 @@
+<svg width="186" height="88" viewBox="0 0 186 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="pills" clip-path="url(#clip0_2328_1074)">
+<rect id="Rectangle 1169" opacity="0.2" x="133.536" y="33.0979" width="30.7432" height="60.8397" rx="15.3716" transform="rotate(-108.07 133.536 33.0979)" fill="url(#paint0_linear_2328_1074)"/>
+<rect id="Rectangle 1170" opacity="0.2" x="140.494" y="57.1838" width="11.9888" height="28.5183" rx="5.99439" transform="rotate(-128.687 140.494 57.1838)" fill="url(#paint1_linear_2328_1074)"/>
+<rect id="Rectangle 1171" opacity="0.2" x="186.878" y="66.114" width="14.4143" height="41.7734" rx="7.20717" transform="rotate(-164.328 186.878 66.114)" fill="url(#paint2_linear_2328_1074)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_2328_1074" x1="148.908" y1="33.0979" x2="148.908" y2="93.9376" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2328_1074" x1="146.488" y1="57.1838" x2="146.488" y2="85.7021" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_2328_1074" x1="194.086" y1="66.114" x2="194.086" y2="107.887" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_2328_1074">
+<rect width="186" height="88" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/rectangles.svg
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/rectangles.svg
@@ -1,0 +1,24 @@
+<svg width="186" height="68" viewBox="0 0 186 68" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="rectangles" clip-path="url(#clip0_2328_833)">
+<rect id="Rectangle 1165" opacity="0.2" x="148.452" y="23.8752" width="12.8062" height="36.0836" rx="2" transform="rotate(159.851 148.452 23.8752)" fill="url(#paint0_linear_2328_833)"/>
+<rect id="Rectangle 1166" opacity="0.2" x="196.073" y="69.8037" width="53.8518" height="26.3161" rx="2" transform="rotate(-166.47 196.073 69.8037)" fill="url(#paint1_linear_2328_833)"/>
+<rect id="Rectangle 1167" opacity="0.2" x="157" y="14.8708" width="40.6373" height="20.3226" rx="2" transform="rotate(-37.7358 157 14.8708)" fill="url(#paint2_linear_2328_833)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_2328_833" x1="154.855" y1="23.8752" x2="154.855" y2="59.9588" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2328_833" x1="253.039" y1="76.3097" x2="198.266" y2="89.1738" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_2328_833" x1="156.14" y1="24.0575" x2="193.693" y2="37.499" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_2328_833">
+<rect width="186" height="68" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/squares.svg
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/squares.svg
@@ -1,0 +1,27 @@
+<svg width="186" height="108" viewBox="0 0 186 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="squares" clip-path="url(#clip0_2328_953)">
+<rect id="Rectangle 1165" opacity="0.2" x="138.177" y="27.8767" width="24.7319" height="24.7319" rx="2" transform="rotate(-120.596 138.177 27.8767)" fill="url(#paint0_linear_2328_953)"/>
+<rect id="Rectangle 1166" opacity="0.2" x="129.07" y="57.074" width="18.9584" height="18.9584" rx="2" transform="rotate(-137.917 129.07 57.074)" fill="url(#paint1_linear_2328_953)"/>
+<rect id="Rectangle 1167" opacity="0.2" x="154.086" y="65.7393" width="38.7203" height="38.7203" rx="2" transform="rotate(-100.991 154.086 65.7393)" fill="url(#paint2_linear_2328_953)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_2328_953" x1="150.543" y1="27.8767" x2="150.543" y2="52.6086" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="0.0001" stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2328_953" x1="138.55" y1="57.074" x2="138.55" y2="76.0324" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="0.0001" stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_2328_953" x1="173.447" y1="65.7393" x2="173.447" y2="104.46" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="0.0001" stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_2328_953">
+<rect width="186" height="108" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/triangles.svg
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/assets/triangles.svg
@@ -1,0 +1,24 @@
+<svg width="186" height="108" viewBox="0 0 186 108" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="triangles" clip-path="url(#clip0_2328_483)">
+<path id="Polygon 1" opacity="0.2" d="M142.996 -20.73C142.929 -22.2732 144.562 -23.3068 145.928 -22.5856L208.878 10.6549C210.237 11.3726 210.312 13.2915 209.014 14.1134L149.16 51.9929C147.861 52.8149 146.159 51.9255 146.092 50.3899L142.996 -20.73Z" fill="url(#paint0_linear_2328_483)"/>
+<path id="Polygon 2" opacity="0.2" d="M114.465 29.8005C112.941 29.5448 112.27 27.7321 113.26 26.5463L123.518 14.2584C124.503 13.0785 126.396 13.4045 126.929 14.846L132.457 29.7832C132.991 31.2247 131.767 32.7042 130.251 32.4498L114.465 29.8005Z" fill="url(#paint1_linear_2328_483)"/>
+<path id="Polygon 3" opacity="0.2" d="M180.455 37.8616C181.133 36.4737 183.061 36.3459 183.917 37.6321L196.794 56.9932C197.645 58.273 196.794 59.9947 195.261 60.0964L172.175 61.6266C170.641 61.7282 169.571 60.1339 170.246 58.7529L180.455 37.8616Z" fill="url(#paint2_linear_2328_483)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_2328_483" x1="131.438" y1="38.5477" x2="177.566" y2="25.7322" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2328_483" x1="111.025" y1="29.2233" x2="129.693" y2="22.3146" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_2328_483" x1="181.986" y1="34.7285" x2="190.08" y2="71.8598" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_2328_483">
+<rect width="186" height="108" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
@@ -1,12 +1,23 @@
 // @vitest-environment happy-dom
-import { screen } from '@testing-library/react'
-import React from 'react'
+import { screen, waitFor } from '@testing-library/react'
 
 import { AdageFrontRoles, AuthenticatedResponse } from 'apiClient/adage'
+import { api } from 'apiClient/api'
+import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
+import * as useNotification from 'hooks/useNotification'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { AdageDiscovery } from '../AdageDiscovery'
+
+vi.mock('apiClient/api', () => ({
+  api: {
+    listEducationalDomains: vi.fn(() => [
+      { id: 1, name: 'Danse' },
+      { id: 2, name: 'Architecture' },
+    ]),
+  },
+}))
 
 const renderAdageDiscovery = (user: AuthenticatedResponse) => {
   renderWithProviders(
@@ -17,6 +28,7 @@ const renderAdageDiscovery = (user: AuthenticatedResponse) => {
 }
 
 describe('AdageDiscovery', () => {
+  const notifyError = vi.fn()
   const user = {
     role: AdageFrontRoles.REDACTOR,
     uai: 'uai',
@@ -25,11 +37,42 @@ describe('AdageDiscovery', () => {
     institutionCity: 'ALES',
   }
 
+  beforeEach(() => {
+    vi.spyOn(useNotification, 'default').mockImplementation(() => ({
+      ...vi.importActual('hooks/useNotification'),
+      error: notifyError,
+    }))
+  })
+
   it('should render adage discovery', () => {
     renderAdageDiscovery(user)
 
     expect(
       screen.getByText('Les nouvelles offres publiées')
     ).toBeInTheDocument()
+  })
+
+  it('should render artistic domains playlist', async () => {
+    renderAdageDiscovery(user)
+
+    expect(
+      await screen.findByRole('link', {
+        name: 'Danse',
+      })
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByRole('link', {
+        name: 'Architecture',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('should show an error message notification when domains could not be fetched', async () => {
+    vi.spyOn(api, 'listEducationalDomains').mockRejectedValueOnce(null)
+
+    renderAdageDiscovery(user)
+    await waitFor(() => expect(api.listEducationalDomains).toHaveBeenCalled())
+
+    expect(notifyError).toHaveBeenNthCalledWith(1, GET_DATA_ERROR_MESSAGE)
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -19,8 +19,10 @@ import styles from './AppLayout.module.scss'
 
 export const AppLayout = ({
   venueFilter,
+  domainFilter,
 }: {
   venueFilter: VenueResponse | null
+  domainFilter: number | null
 }): JSX.Element => {
   const { adageUser } = useAdageUser()
   const { pathname } = useLocation()
@@ -60,7 +62,12 @@ export const AppLayout = ({
               <Route
                 key={path}
                 path={path}
-                element={<Component venueFilter={venueFilter} />}
+                element={
+                  <Component
+                    venueFilter={venueFilter}
+                    domainFilter={domainFilter}
+                  />
+                }
               />
             )
           })}

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/__specs__/AppLayout.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/__specs__/AppLayout.spec.tsx
@@ -82,7 +82,7 @@ const renderAppLayout = (initialRoute = '/') => {
     <AdageUserContextProvider adageUser={defaultAdageUser}>
       <FiltersContextProvider>
         <AlgoliaQueryContextProvider>
-          <AppLayout venueFilter={null} />
+          <AppLayout venueFilter={null} domainFilter={null} />
         </AlgoliaQueryContextProvider>
       </FiltersContextProvider>
     </AdageUserContextProvider>,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -38,8 +38,10 @@ export const DEFAULT_GEO_RADIUS = 30000000 // 30 000 km ensure we get all result
 
 export const OffersInstantSearch = ({
   venueFilter,
+  domainFilter,
 }: {
   venueFilter: VenueResponse | null
+  domainFilter: number | null
 }): JSX.Element => {
   const { facetFilters, setFacetFilters } = useContext(FacetFiltersContext)
 
@@ -97,6 +99,7 @@ export const OffersInstantSearch = ({
           <OffersSearch
             venueFilter={venueFilter || venueFilterFromParam}
             setGeoRadius={setGeoRadius}
+            domainFilter={domainFilter}
           />
         </AnalyticsContextProvider>
       </Index>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -37,6 +37,7 @@ export enum LocalisationFilterStates {
 
 export interface SearchProps {
   venueFilter: VenueResponse | null
+  domainFilter: number | null
   setGeoRadius: (geoRadius: number) => void
 }
 
@@ -54,6 +55,7 @@ export interface SearchFormValues {
 
 export const OffersSearch = ({
   venueFilter,
+  domainFilter,
   setGeoRadius,
 }: SearchProps): JSX.Element => {
   const { setFacetFilters } = useContext(FacetFiltersContext)
@@ -89,6 +91,12 @@ export const OffersSearch = ({
     const getAllDomains = async () => {
       try {
         const result = await api.listEducationalDomains()
+
+        const domainFromPath =
+          domainFilter && result.find((elm) => elm.id === domainFilter)
+
+        domainFromPath &&
+          (await formik.setFieldValue('domains', [domainFromPath.id]))
 
         return setDomainsOptions(
           result.map(({ id, name }) => ({ value: id, label: name }))
@@ -150,10 +158,14 @@ export const OffersSearch = ({
   }
 
   const formik = useFormik<SearchFormValues>({
-    initialValues: { ...ADAGE_FILTERS_DEFAULT_VALUES, venue: venueFilter },
+    initialValues: {
+      ...ADAGE_FILTERS_DEFAULT_VALUES,
+      venue: venueFilter,
+    },
     enableReinitialize: true,
     onSubmit: handleSubmit,
   })
+
   const getActiveLocalisationFilter = () => {
     if (formik.values.departments.length > 0) {
       return LocalisationFilterStates.DEPARTMENTS
@@ -168,6 +180,7 @@ export const OffersSearch = ({
 
   const offerFilterRef = useRef<HTMLDivElement>(null)
   const isOfferFiltersVisible = useIsElementVisible(offerFilterRef)
+
   return (
     <>
       <FormikContext.Provider value={formik}>

--- a/pro/src/pages/AdageIframe/app/providers/FacetFiltersContextProvider.tsx
+++ b/pro/src/pages/AdageIframe/app/providers/FacetFiltersContextProvider.tsx
@@ -23,13 +23,15 @@ export const FacetFiltersContextProvider = ({
   children,
   uai,
   venueFilter,
+  domainFilter,
 }: {
   children: ReactNode | ReactNode[]
   uai?: string | null
   venueFilter?: VenueResponse | null
+  domainFilter?: number | null
 }): JSX.Element => {
   const [facetFilters, setFacetFilters] = useState<Facets>([
-    ...getDefaultFacetFilterUAICodeValue(uai, venueFilter),
+    ...getDefaultFacetFilterUAICodeValue(uai, venueFilter, domainFilter),
   ])
 
   const value = useMemo(

--- a/pro/src/pages/AdageIframe/app/providers/FiltersContextProvider.tsx
+++ b/pro/src/pages/AdageIframe/app/providers/FiltersContextProvider.tsx
@@ -1,13 +1,13 @@
 import React, { createContext, ReactNode, useMemo, useReducer } from 'react'
 
 import { VenueResponse } from 'apiClient/adage'
+import { Option, Filters } from 'pages/AdageIframe/app/types'
 
 import {
   filtersReducer,
   FiltersReducerAction,
 } from '../components/OffersInstantSearch/OffersSearch/filtersReducer'
 import { INITIAL_FILTERS } from '../constants'
-import { Filters } from '../types'
 
 type FiltersContextType = {
   currentFilters: Filters
@@ -25,14 +25,17 @@ const FiltersContext = createContext<FiltersContextType>(
 
 export const FiltersContextProvider = ({
   venueFilter,
+  domainFilter,
   children,
 }: {
   venueFilter?: VenueResponse | null
+  domainFilter?: Option<number> | null
   children: ReactNode | ReactNode[]
 }): JSX.Element => {
   const [currentFilters, dispatchCurrentFilters] = useReducer(filtersReducer, {
     ...INITIAL_FILTERS,
     onlyInMyDpt: venueFilter ? false : INITIAL_FILTERS.onlyInMyDpt,
+    domains: domainFilter ? [domainFilter] : [],
   })
 
   const value = useMemo(

--- a/pro/src/utils/__specs__/facetFilters.spec.ts
+++ b/pro/src/utils/__specs__/facetFilters.spec.ts
@@ -32,4 +32,15 @@ describe('getDefaultFacetFilterUAICodeValue', () => {
       expectedFilters
     )
   })
+
+  it('should return filters with artistic domain id filter if valued', () => {
+    const expectedFilters = [
+      ['offer.domains:1'],
+      ['offer.educationalInstitutionUAICode:all'],
+    ]
+
+    expect(getDefaultFacetFilterUAICodeValue(null, null, 1)).toEqual(
+      expectedFilters
+    )
+  })
 })

--- a/pro/src/utils/facetFilters.ts
+++ b/pro/src/utils/facetFilters.ts
@@ -2,9 +2,11 @@ import { VenueResponse } from 'apiClient/adage'
 
 export const getDefaultFacetFilterUAICodeValue = (
   uai?: string | null,
-  venueFilter?: VenueResponse | null
+  venueFilter?: VenueResponse | null,
+  domainFilter?: number | null
 ) => {
   const institutionIdFilters = ['offer.educationalInstitutionUAICode:all']
+  const defaultValue = [institutionIdFilters]
 
   if (uai) {
     institutionIdFilters.push(`offer.educationalInstitutionUAICode:${uai}`)
@@ -16,7 +18,10 @@ export const getDefaultFacetFilterUAICodeValue = (
       ]
     : []
 
-  return venueIdFilter.length > 0
-    ? [venueIdFilter, institutionIdFilters]
-    : [institutionIdFilters]
+  const domainIdFilter = domainFilter ? [`offer.domains:${domainFilter}`] : []
+
+  venueIdFilter.length > 0 && defaultValue.unshift(venueIdFilter)
+  domainIdFilter.length > 0 && defaultValue.unshift(domainIdFilter)
+
+  return defaultValue
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25389

Sous FF : `WIP_ENABLE_DISCOVERY`

Création du composant pour les domaines artistiques de la page découverte sur adage

![image](https://github.com/pass-culture/pass-culture-main/assets/119043808/d26dd656-ca06-40a1-bff7-4e4731e32169)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques