### PR TITLE
(PC-25622)[PRO] replace cat filter with format

### DIFF
--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -48,7 +48,8 @@ def get_collective_offers(
         period_beginning_date=query.period_beginning_date,
         period_ending_date=query.period_ending_date,
         offer_type=query.collective_offer_type,
-        formats=query.formats,
+        #   The format should be a list but for now we cannot send a list in the get_collective_offers query params
+        formats=[query.format] if query.format else None,
     )
 
     return collective_offers_serialize.ListCollectiveOffersResponseModel(

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -58,7 +58,7 @@ class ListCollectiveOffersQueryModel(BaseModel):
     period_beginning_date: date | None
     period_ending_date: date | None
     collective_offer_type: CollectiveOfferType | None
-    formats: list[subcategories.EacFormat] | None
+    format: subcategories.EacFormat | None
 
     class Config:
         alias_generator = to_camel

--- a/pro/src/apiClient/v1/models/ListCollectiveOffersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveOffersQueryModel.ts
@@ -11,7 +11,7 @@ export type ListCollectiveOffersQueryModel = {
   categoryId?: string | null;
   collectiveOfferType?: CollectiveOfferType | null;
   creationMode?: string | null;
-  formats?: Array<EacFormat> | null;
+  format?: EacFormat | null;
   nameOrIsbn?: string | null;
   offererId?: number | null;
   periodBeginningDate?: string | null;

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -288,7 +288,7 @@ export class DefaultService {
    * @param periodBeginningDate
    * @param periodEndingDate
    * @param collectiveOfferType
-   * @param formats
+   * @param format
    * @returns ListCollectiveOffersResponseModel OK
    * @throws ApiError
    */
@@ -302,7 +302,7 @@ export class DefaultService {
     periodBeginningDate?: string | null,
     periodEndingDate?: string | null,
     collectiveOfferType?: CollectiveOfferType | null,
-    formats?: Array<EacFormat> | null,
+    format?: EacFormat | null,
   ): CancelablePromise<ListCollectiveOffersResponseModel> {
     return this.httpRequest.request({
       method: 'GET',
@@ -317,7 +317,7 @@ export class DefaultService {
         'periodBeginningDate': periodBeginningDate,
         'periodEndingDate': periodEndingDate,
         'collectiveOfferType': collectiveOfferType,
-        'formats': formats,
+        'format': format,
       },
       errors: {
         403: `Forbidden`,

--- a/pro/src/core/Offers/constants.ts
+++ b/pro/src/core/Offers/constants.ts
@@ -56,6 +56,7 @@ export const ALL_OFFERS = ''
 export const ALL_VENUES = 'all'
 export const ALL_OFFERERS = 'all'
 export const ALL_CATEGORIES = 'all'
+export const ALL_FORMATS = 'all'
 export const ALL_STATUS = 'all'
 export const ALL_CREATION_MODES = 'all'
 export const ALL_COLLECTIVE_OFFER_TYPE = 'all'
@@ -69,6 +70,7 @@ export const DEFAULT_SEARCH_FILTERS: SearchFiltersParams = {
   offererId: 'all',
   venueId: ALL_VENUES,
   categoryId: ALL_CATEGORIES,
+  format: ALL_FORMATS,
   status: ALL_STATUS,
   creationMode: ALL_CREATION_MODES,
   collectiveOfferType: ALL_COLLECTIVE_OFFER_TYPE,
@@ -85,6 +87,11 @@ export const ALL_VENUES_OPTION: SelectOption = {
 export const ALL_CATEGORIES_OPTION: SelectOption = {
   label: 'Toutes',
   value: ALL_CATEGORIES,
+}
+
+export const ALL_FORMATS_OPTION: SelectOption = {
+  label: 'Tous',
+  value: ALL_FORMATS,
 }
 
 export const CREATION_MODES_OPTIONS: SelectOption[] = [

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -6,18 +6,20 @@ import {
   PriceCategoryResponseModel,
   GetOfferVenueResponseModel,
   GetOfferLastProviderResponseModel,
+  EacFormat,
 } from 'apiClient/v1'
 import { CropParams } from 'components/ImageUploader'
 import { CollectiveOfferStatus } from 'core/OfferEducational'
 import { AccessibiltyFormValues } from 'core/shared'
 
-import { ALL_STATUS } from './constants'
+import { ALL_FORMATS, ALL_STATUS } from './constants'
 
 export type SearchFiltersParams = {
   nameOrIsbn: string
   offererId: string
   venueId: string
   categoryId: string
+  format: EacFormat | typeof ALL_FORMATS
   status: OfferStatus | CollectiveOfferStatus | typeof ALL_STATUS
   creationMode: string
   collectiveOfferType: string

--- a/pro/src/core/Offers/utils/serializer.ts
+++ b/pro/src/core/Offers/utils/serializer.ts
@@ -1,12 +1,18 @@
-import { ListOffersQueryModel } from 'apiClient/v1'
+import {
+  ListCollectiveOffersQueryModel,
+  ListOffersQueryModel,
+} from 'apiClient/v1'
 
 import { DEFAULT_SEARCH_FILTERS } from '../constants'
 import { SearchFiltersParams } from '../types'
 
 export const serializeApiFilters = (
   searchFilters: Partial<SearchFiltersParams>
-): ListOffersQueryModel => {
-  const listOffersQueryKeys: (keyof ListOffersQueryModel)[] = [
+): ListOffersQueryModel & ListCollectiveOffersQueryModel => {
+  const listOffersQueryKeys: (
+    | keyof ListOffersQueryModel
+    | keyof ListCollectiveOffersQueryModel
+  )[] = [
     'nameOrIsbn',
     'offererId',
     'status',
@@ -16,9 +22,10 @@ export const serializeApiFilters = (
     'periodBeginningDate',
     'periodEndingDate',
     'collectiveOfferType',
+    'format',
   ]
 
-  const body: ListOffersQueryModel = {}
+  const body: ListOffersQueryModel & ListCollectiveOffersQueryModel = {}
   return listOffersQueryKeys.reduce((accumulator, field) => {
     const filterValue = searchFilters[field]
     if (filterValue && filterValue !== DEFAULT_SEARCH_FILTERS[field]) {

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -56,34 +56,36 @@ const CollectiveOffers = (): JSX.Element => {
       }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     loadOfferer()
   }, [urlSearchFilters.offererId, notify])
 
   useEffect(() => {
-    const loadCategories = () => {
-      api.getCategories().then((categoriesAndSubcategories) => {
-        const categoriesOptions = filterEducationalCategories(
-          categoriesAndSubcategories
-        ).educationalCategories.map((category) => ({
-          value: category.id,
-          label: category.label,
-        }))
+    const loadCategories = async () => {
+      const categoriesAndSubcategories = await api.getCategories()
+      const categoriesOptions = filterEducationalCategories(
+        categoriesAndSubcategories
+      ).educationalCategories.map((category) => ({
+        value: category.id,
+        label: category.label,
+      }))
 
-        setCategories(sortByLabel(categoriesOptions))
-      })
+      setCategories(sortByLabel(categoriesOptions))
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     loadCategories()
   }, [])
 
   useEffect(() => {
-    const loadAllVenuesByProUser = () =>
-      getVenuesForOffererAdapter({
+    const loadAllVenuesByProUser = async () => {
+      const venuesResponse = await getVenuesForOffererAdapter({
         offererId: offerer?.id.toString(),
-      }).then((venuesResponse) =>
-        setVenues(formatAndOrderVenues(venuesResponse.payload))
-      )
+      })
+      setVenues(formatAndOrderVenues(venuesResponse.payload))
+    }
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     loadAllVenuesByProUser()
   }, [offerer?.id])
 
@@ -139,6 +141,7 @@ const CollectiveOffers = (): JSX.Element => {
         venueId: urlSearchFilters.venueId || DEFAULT_SEARCH_FILTERS.venueId,
         categoryId:
           urlSearchFilters.categoryId || DEFAULT_SEARCH_FILTERS.categoryId,
+        format: urlSearchFilters.format || DEFAULT_SEARCH_FILTERS.format,
         status: urlSearchFilters.status
           ? urlSearchFilters.status
           : DEFAULT_SEARCH_FILTERS.status,

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -167,6 +167,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             undefined,
+            undefined,
             undefined
           )
         })
@@ -247,6 +248,7 @@ describe('route CollectiveOffers', () => {
               undefined,
               undefined,
               undefined,
+              undefined,
               undefined
             )
           })
@@ -281,6 +283,7 @@ describe('route CollectiveOffers', () => {
               undefined,
               undefined,
               undefined,
+              undefined,
               undefined
             )
           })
@@ -304,6 +307,7 @@ describe('route CollectiveOffers', () => {
               })
             ).toBeDisabled()
             expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+              undefined,
               undefined,
               undefined,
               undefined,
@@ -341,6 +345,7 @@ describe('route CollectiveOffers', () => {
               undefined,
               'INACTIVE',
               venueId.toString(),
+              undefined,
               undefined,
               undefined,
               undefined,
@@ -397,6 +402,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             undefined,
+            undefined,
             undefined
           )
         })
@@ -413,6 +419,7 @@ describe('route CollectiveOffers', () => {
           // Then
           expect(api.getCollectiveOffers).toHaveBeenCalledWith(
             'search string',
+            undefined,
             undefined,
             undefined,
             undefined,
@@ -444,6 +451,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             undefined,
+            undefined,
             undefined
           )
         })
@@ -470,6 +478,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             undefined,
+            undefined,
             undefined
           )
         })
@@ -493,6 +502,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             '2020-12-25',
             undefined,
+            undefined,
             undefined
           )
         })
@@ -515,6 +525,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             '2020-12-27',
+            undefined,
             undefined
           )
         })
@@ -536,7 +547,8 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             undefined,
-            'template'
+            'template',
+            undefined
           )
         })
       })
@@ -645,6 +657,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
 
@@ -661,6 +674,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
 
@@ -671,6 +685,7 @@ describe('route CollectiveOffers', () => {
       expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(
         3,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -710,6 +725,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
 
@@ -725,6 +741,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
 
@@ -732,6 +749,7 @@ describe('route CollectiveOffers', () => {
       expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(
         3,
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/pro/src/pages/CollectiveOffers/adapters/getFilteredCollectiveOffersAdapter.ts
+++ b/pro/src/pages/CollectiveOffers/adapters/getFilteredCollectiveOffersAdapter.ts
@@ -37,6 +37,7 @@ const getFilteredCollectiveOffersAdapter: GetFilteredCollectiveOffersAdapter =
         periodBeginningDate,
         periodEndingDate,
         collectiveOfferType,
+        format,
       } = serializeApiFilters(apiFilters)
 
       const offers = await api.getCollectiveOffers(
@@ -48,7 +49,8 @@ const getFilteredCollectiveOffersAdapter: GetFilteredCollectiveOffersAdapter =
         creationMode,
         periodBeginningDate,
         periodEndingDate,
-        collectiveOfferType
+        collectiveOfferType,
+        format
       )
 
       return {

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/__specs__/CollectiveOfferSelectionDuplicationScreen.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/__specs__/CollectiveOfferSelectionDuplicationScreen.spec.tsx
@@ -109,7 +109,8 @@ describe('CollectiveOfferConfirmation', () => {
       undefined,
       undefined,
       undefined,
-      'template'
+      'template',
+      undefined
     )
   })
 

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -112,6 +112,17 @@ const FormOfferType = ({
       description="Le type de l’offre permet de la caractériser et de la valoriser au mieux pour les enseignants et chefs d’établissement."
       title="Type d’offre"
     >
+      {domainsOptions.length > 0 && (
+        <FormLayout.Row>
+          <MultiSelectAutocomplete
+            options={domainsOptions}
+            pluralLabel="Domaines artistiques et culturels"
+            label="Domaine artistique et culturel"
+            name="domains"
+            disabled={disableForm}
+          />
+        </FormLayout.Row>
+      )}
       {isFormatActive ? (
         <FormLayout.Row>
           <SelectAutocomplete
@@ -144,17 +155,6 @@ const FormOfferType = ({
             </FormLayout.Row>
           )}
         </>
-      )}
-      {domainsOptions.length > 0 && (
-        <FormLayout.Row>
-          <MultiSelectAutocomplete
-            options={domainsOptions}
-            pluralLabel="Domaines artistiques et culturels"
-            label="Domaine artistique et culturel"
-            name="domains"
-            disabled={disableForm}
-          />
-        </FormLayout.Row>
       )}
       {nationalPrograms.length > 0 && (
         <FormLayout.Row

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -338,7 +338,8 @@ describe('OfferType', () => {
         undefined,
         undefined,
         undefined,
-        'template'
+        'template',
+        undefined
       )
     })
 

--- a/pro/src/screens/Offers/SearchFilters/SearchFilters.tsx
+++ b/pro/src/screens/Offers/SearchFilters/SearchFilters.tsx
@@ -1,8 +1,10 @@
 import React, { FormEvent } from 'react'
 
+import { EacFormat } from 'apiClient/v1'
 import FormLayout from 'components/FormLayout/FormLayout'
 import {
   ALL_CATEGORIES_OPTION,
+  ALL_FORMATS_OPTION,
   ALL_VENUES_OPTION,
   COLLECTIVE_OFFER_TYPES_OPTIONS,
   CREATION_MODES_OPTIONS,
@@ -12,6 +14,7 @@ import { Offerer, SearchFiltersParams } from 'core/Offers/types'
 import { hasSearchFilters } from 'core/Offers/utils'
 import { Audience } from 'core/shared'
 import { SelectOption } from 'custom_types/form'
+import useActiveFeature from 'hooks/useActiveFeature'
 import fullRefreshIcon from 'icons/full-refresh.svg'
 import strokeCloseIcon from 'icons/stroke-close.svg'
 import { Button, SubmitButton } from 'ui-kit'
@@ -52,6 +55,13 @@ const SearchFilters = ({
   categories,
   audience,
 }: SearchFiltersProps): JSX.Element => {
+  const isFormatActive = useActiveFeature('WIP_ENABLE_FORMAT')
+
+  const formats: SelectOption[] = Object.values(EacFormat).map((format) => ({
+    value: format,
+    label: format,
+  }))
+
   const updateSearchFilters = (
     newSearchFilters: Partial<SearchFiltersParams>
   ) => {
@@ -71,6 +81,12 @@ const SearchFilters = ({
 
   const storeSelectedCategory = (event: FormEvent<HTMLSelectElement>) => {
     updateSearchFilters({ categoryId: event.currentTarget.value })
+  }
+
+  const storeSelectedFormat = (event: FormEvent<HTMLSelectElement>) => {
+    updateSearchFilters({
+      format: event.currentTarget.value as EacFormat | 'all',
+    })
   }
 
   const storeCreationMode = (event: FormEvent<HTMLSelectElement>) => {
@@ -158,16 +174,29 @@ const SearchFilters = ({
             />
           </FieldLayout>
 
-          <FieldLayout label="Catégories" name="categorie">
-            <SelectInput
-              defaultOption={ALL_CATEGORIES_OPTION}
-              onChange={storeSelectedCategory}
-              disabled={disableAllFilters}
-              name="categorie"
-              options={categories}
-              value={selectedFilters.categoryId}
-            />
-          </FieldLayout>
+          {isFormatActive && audience === Audience.COLLECTIVE ? (
+            <FieldLayout label="Format" name="format">
+              <SelectInput
+                defaultOption={ALL_FORMATS_OPTION}
+                onChange={storeSelectedFormat}
+                disabled={disableAllFilters}
+                name="format"
+                options={formats}
+                value={selectedFilters.format}
+              />
+            </FieldLayout>
+          ) : (
+            <FieldLayout label="Catégories" name="categorie">
+              <SelectInput
+                defaultOption={ALL_CATEGORIES_OPTION}
+                onChange={storeSelectedCategory}
+                disabled={disableAllFilters}
+                name="categorie"
+                options={categories}
+                value={selectedFilters.categoryId}
+              />
+            </FieldLayout>
+          )}
 
           {audience === Audience.INDIVIDUAL && (
             <FieldLayout label="Mode de création" name="creationMode">

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -9,6 +9,7 @@ import {
   ALL_COLLECTIVE_OFFER_TYPE,
   ALL_CREATION_MODES,
   ALL_EVENT_PERIODS,
+  ALL_FORMATS,
   ALL_OFFERERS,
   ALL_OFFERS,
   ALL_STATUS,
@@ -145,6 +146,7 @@ describe('screen Offers', () => {
       periodBeginningDate: ALL_EVENT_PERIODS,
       periodEndingDate: ALL_EVENT_PERIODS,
       collectiveOfferType: ALL_COLLECTIVE_OFFER_TYPE,
+      format: ALL_FORMATS,
     })
   })
 
@@ -573,6 +575,7 @@ describe('screen Offers', () => {
       periodBeginningDate: DEFAULT_SEARCH_FILTERS.periodBeginningDate,
       periodEndingDate: DEFAULT_SEARCH_FILTERS.periodEndingDate,
       collectiveOfferType: ALL_COLLECTIVE_OFFER_TYPE,
+      format: ALL_FORMATS,
     })
   })
 
@@ -718,5 +721,46 @@ describe('screen Offers', () => {
       expect(thirdOfferCheckbox).not.toBeChecked()
       expect(fourthOfferCheckbox).not.toBeChecked()
     })
+  })
+
+  it('should display the collective offers format when the ff is enabled', () => {
+    renderOffers(
+      { ...props, audience: Audience.COLLECTIVE },
+      {
+        features: {
+          list: [{ isActive: true, nameKey: 'WIP_ENABLE_FORMAT' }],
+        },
+      }
+    )
+
+    expect(screen.getByRole('combobox', { name: 'Format' }))
+  })
+
+  it('should filter on the format when the ff is enabled', async () => {
+    renderOffers(
+      { ...props, audience: Audience.COLLECTIVE },
+      {
+        features: {
+          list: [{ isActive: true, nameKey: 'WIP_ENABLE_FORMAT' }],
+        },
+      }
+    )
+
+    const formatSelect = screen.getByRole('combobox', { name: 'Format' })
+
+    await userEvent.selectOptions(
+      formatSelect,
+      screen.getByRole('option', { name: 'Concert' })
+    )
+
+    const searchButton = screen.getByText('Lancer la recherche')
+
+    await userEvent.click(searchButton)
+
+    expect(props.redirectWithUrlFilters).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'Concert',
+      })
+    )
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25622

**FF à activer**
WIP_ENABLE_FORMAT

**Objectif**
Remplacer le filtre des catégories par le filtre des formats dans la page de la liste des offres collectives sur pro.

**A noter**
L'api a été initialement prévue pour recevoir une liste de filtres format dans l'appel au GET des offres collectives, mais on l'utilise avec un string en attendant d'avoir trouvé une solution à la sérialization d'une liste dans les query params d'une requete GET.

<img width="646" alt="Capture d’écran 2023-11-08 à 16 43 15" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/5f991494-aad7-4599-b7d6-b516156257ea">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques