### PR TITLE
(BSR)[API] Correction de la vérification de l'IP source sur les webhooks Brevo (ex-SendinBlue)

### DIFF
--- a/api/src/pcapi/routes/external/sendinblue.py
+++ b/api/src/pcapi/routes/external/sendinblue.py
@@ -52,7 +52,8 @@ logger = logging.getLogger(__name__)
 
 
 def _check_sendinblue_source_ip() -> None:
-    if request.remote_addr not in SENDINBLUE_IP_RANGE and not settings.IS_DEV:
+    source_ip = ipaddress.IPv4Address(request.remote_addr)
+    if source_ip not in SENDINBLUE_IP_RANGE and not settings.IS_DEV:
         raise ApiErrors(
             {"IP": "Source IP address is not whitelisted"},
             status_code=401,

--- a/api/tests/routes/external/sendinblue_test.py
+++ b/api/tests/routes/external/sendinblue_test.py
@@ -84,24 +84,6 @@ class SubscribeOrUnsubscribeUserTestHelper:
         # Then
         assert response.status_code == 400
 
-    def test_webhook_multiple_ips(self, app):
-        # Given
-        existing_user = UserFactory(
-            email="lucy.ellingson@kennet.ca",
-            notificationSubscriptions={"marketing_push": True, "marketing_email": self.initial_marketing_email},
-        )
-        headers = {"X-Forwarded-For": "185.107.232.1, 1.2.3.4, 4.3.2.1"}
-        data = {"email": "lucy.ellingson@kennet.ca"}
-        assert existing_user.notificationSubscriptions["marketing_email"] is self.initial_marketing_email
-
-        # When
-        response = TestClient(app.test_client()).post(self.endpoint, json=data, headers=headers)
-
-        # Then
-        assert response.status_code == 204
-        db.session.refresh(existing_user)
-        assert existing_user.notificationSubscriptions["marketing_email"] is self.expected_marketing_email
-
 
 @pytest.mark.usefixtures("db_session")
 class UnsubscribeUserTest(SubscribeOrUnsubscribeUserTestHelper):

--- a/api/tests/routes/external/sendinblue_test.py
+++ b/api/tests/routes/external/sendinblue_test.py
@@ -26,7 +26,8 @@ class SubscribeOrUnsubscribeUserTestHelper:
         assert existing_user.notificationSubscriptions["marketing_email"] is self.initial_marketing_email
 
         # When
-        response = TestClient(app.test_client()).post(self.endpoint, json=data, headers=headers)
+        with override_settings(IS_DEV=False):  # enforce source IP check
+            response = TestClient(app.test_client()).post(self.endpoint, json=data, headers=headers)
 
         # Then
         assert response.status_code == 204
@@ -45,7 +46,7 @@ class SubscribeOrUnsubscribeUserTestHelper:
         data = {"email": "lucy.ellingson@kennet.ca"}
 
         # When
-        with override_settings(IS_DEV=False):
+        with override_settings(IS_DEV=False):  # enforce source IP check
             response = TestClient(app.test_client()).post(self.endpoint, json=data, headers=headers)
 
         # Then


### PR DESCRIPTION
Commits à relire séparément. Il y avait _aussi_ un bug dans les tests
(ce qui a fait qu'on n'a pas vu le bug dans l'implémentation).