### PR TITLE
start backend with docker compose

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -86,7 +86,7 @@ jobs:
           resource: http://localhost:5001/health/api
           timeout: 120000
       - name: "Load sandbox"
-        run: ../pc sandbox -n industrial
+        run: ../pc sandbox-ci
       - name: 'Build vite application'
         run: yarn build:development
       - name: 'Serve vite preview'

--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -12,6 +12,10 @@ on:
       GCP_EHP_SERVICE_ACCOUNT:
         required: true
 
+env:
+  region: europe-west1
+  DOCKER_TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
 defaults:
   run:
     working-directory: pro
@@ -52,9 +56,31 @@ jobs:
           restore-keys: |
             v1-yarn-pro-cypress-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --immutable
-      - name: "Run API server"
-        run: docker-compose -f ../docker-compose-backend.yml up flask postgres redis --build -d
-      - name: "Wait for migrations to be run"
+      - name: Get Secret
+        id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v1'
+        with:
+          secrets: |-
+            INFRA_PROD_GCP_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
+            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+
+      - id: openid-auth
+        name: "OpenID Connect Authentication"
+        uses: "google-github-actions/auth@v1"
+        with:
+          create_credentials_file: false
+          token_format: "access_token"
+          workload_identity_provider: ${{ steps.secrets.outputs.INFRA_PROD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      - uses: docker/login-action@v2
+        with:
+          registry: "${{ env.region }}-docker.pkg.dev"
+          username: oauth2accesstoken
+          password: ${{ steps.openid-auth.outputs.access_token }}
+      - name: Run API server
+        run: docker-compose -f ../docker-compose-backend_ci.yml up -d flask
+      - name: Wait for migrations to be run
         uses: iFaxity/wait-on-action@v1
         with:
           resource: http://localhost:5001/health/api

--- a/api/src/pcapi/alembic/versions/sql/schema_init.sql
+++ b/api/src/pcapi/alembic/versions/sql/schema_init.sql
@@ -20,7 +20,7 @@ SET row_security = off;
 -- Name: tiger; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA tiger;
+CREATE SCHEMA IF NOT EXISTS tiger;
 
 
 
@@ -28,7 +28,7 @@ CREATE SCHEMA tiger;
 -- Name: tiger_data; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA tiger_data;
+CREATE SCHEMA IF NOT EXISTS tiger_data;
 
 
 
@@ -36,7 +36,7 @@ CREATE SCHEMA tiger_data;
 -- Name: topology; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA topology;
+CREATE SCHEMA IF NOT EXISTS topology;
 
 
 
@@ -12279,3 +12279,4 @@ ALTER TABLE ONLY public.venue
 -- PostgreSQL database dump complete
 --
 
+RESET search_path;

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -135,3 +135,10 @@ def save_industrial_sandbox() -> None:
     create_industrial_bank_accounts()
 
     create_industrial_venues_with_timezone()
+
+
+def save_industrial_ci_sandbox() -> None:
+    (offerers_by_name, _) = create_industrial_offerers_with_pro_users()
+    create_industrial_pro_users(offerers_by_name)
+    create_industrial_admin_users()
+    create_industrial_venues(offerers_by_name)

--- a/api/src/pcapi/sandboxes/scripts/sandbox_industrial.py
+++ b/api/src/pcapi/sandboxes/scripts/sandbox_industrial.py
@@ -1,4 +1,5 @@
 from pcapi.core.external_bookings.api import disable_external_bookings
+from pcapi.sandboxes.scripts.creators.industrial import save_industrial_ci_sandbox
 from pcapi.sandboxes.scripts.creators.industrial import save_industrial_sandbox
 from pcapi.sandboxes.scripts.creators.test_cases import save_test_cases_sandbox
 
@@ -6,4 +7,9 @@ from pcapi.sandboxes.scripts.creators.test_cases import save_test_cases_sandbox
 def save_sandbox() -> None:
     save_test_cases_sandbox()
     save_industrial_sandbox()
+    disable_external_bookings()
+
+
+def save_ci_sandbox() -> None:
+    save_industrial_ci_sandbox()
     disable_external_bookings()

--- a/api/src/pcapi/sandboxes/scripts/save_sandbox.py
+++ b/api/src/pcapi/sandboxes/scripts/save_sandbox.py
@@ -46,3 +46,11 @@ def _index_all_venues() -> None:
     )
     search.reindex_venue_ids([venue_id for venue_id, in query])
     logger.info("Reindexing done")
+
+
+def save_sandbox_ci() -> None:
+    clean_all_database()
+    script_name = "sandbox_industrial"
+    sandbox_module = getattr(scripts, script_name)
+    sandbox_module.save_ci_sandbox()
+    logger.info("Sandbox ci saved")

--- a/api/src/pcapi/scripts/sandbox.py
+++ b/api/src/pcapi/scripts/sandbox.py
@@ -2,6 +2,7 @@ import click
 
 from pcapi import settings
 from pcapi.sandboxes.scripts.save_sandbox import save_sandbox
+from pcapi.sandboxes.scripts.save_sandbox import save_sandbox_ci
 from pcapi.utils.blueprint import Blueprint
 
 
@@ -17,3 +18,11 @@ def sandbox(name: str, clean: str) -> None:
         save_sandbox(name, with_clean)
     else:
         print("Sandbox is disabled on this environment")
+
+
+@blueprint.cli.command("sandbox-ci")
+def sandbox_ci() -> None:
+    if not settings.IS_E2E_TESTS:
+        print("This sandbox is only for the ci environment")
+        return
+    save_sandbox_ci()

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   postgres:
-    image: cimg/postgres:12.9-postgis
+    image: postgis/postgis:12-3.4-alpine
     container_name: pc-postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -15,7 +15,7 @@ services:
     command: postgres -c logging_collector=on -c log_destination=stderr -c log_min_duration_statement=0 -c log_statement=all -c log_duration=on
 
   postgres-test:
-    image: cimg/postgres:12.9-postgis
+    image: postgis/postgis:12-3.4-alpine
     container_name: pc-postgres-pytest
     volumes:
       - postgres_data_test:/var/lib/postgresql-test/data

--- a/docker-compose-backend_ci.yml
+++ b/docker-compose-backend_ci.yml
@@ -1,0 +1,82 @@
+version: "3.7"
+
+services:
+  postgres:
+    image: cimg/postgres:12.9-postgis
+    container_name: pc-postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - env_file
+    networks:
+      - db_nw
+    ports:
+      - 5434:5432 # This port is used outside docker-compose network (E2E tests and developers launching flask api on their local machines)
+    command: postgres -c logging_collector=on -c log_destination=stderr -c log_min_duration_statement=0 -c log_statement=all -c log_duration=on
+
+  flask:
+    image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi:${DOCKER_TAG}
+    working_dir: /usr/src/app
+    container_name: pc-api
+    command: ["./start-api-when-database-is-ready.sh"]
+    volumes:
+      - ./api:/usr/src/app
+    env_file:
+      - env_file
+    environment:
+      - GUNICORN_PORT=5001
+      - GUNICORN_MAX_REQUESTS=10
+      - GUNICORN_MAX_REQUESTS_JITTER=10
+      - GUNICORN_WORKERS=2
+      - GUNICORN_THREADS=2
+      - GUNICORN_TIMEOUT=10
+      - GUNICORN_LOG_LEVEL=info
+    networks:
+      - db_nw
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - 5001:5001
+    stdin_open: true
+    tty: true
+
+  backoffice:
+    build:
+      context: ./api
+      target: api-flask
+    working_dir: /usr/src/app
+    container_name: pc-backoffice
+    command: ["./start-backoffice-when-api-is-ready.sh"]
+    volumes:
+      - ./api:/usr/src/app
+    env_file:
+      - env_file
+    networks:
+      - db_nw
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - 5002:5001
+    stdin_open: true
+    tty: true
+
+  redis:
+    image: scalingo/redis
+    container_name: pc-redis
+    command: redis-server
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_data:/data
+    networks:
+      - db_nw
+
+networks:
+  db_nw:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker-compose-backend_ci.yml
+++ b/docker-compose-backend_ci.yml
@@ -15,8 +15,7 @@ services:
     command: postgres -c logging_collector=on -c log_destination=stderr -c log_min_duration_statement=0 -c log_statement=all -c log_duration=on
 
   flask:
-    image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi:${DOCKER_TAG}
-    working_dir: /usr/src/app
+    image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi-tests:${DOCKER_TAG}
     container_name: pc-api
     command: ["./start-api-when-database-is-ready.sh"]
     volumes:
@@ -58,7 +57,7 @@ services:
       - postgres
       - redis
     ports:
-      - 5002:5001
+      - 5001:5001
     stdin_open: true
     tty: true
 

--- a/docker-compose-backend_ci.yml
+++ b/docker-compose-backend_ci.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   postgres:
-    image: cimg/postgres:12.9-postgis
+    image: postgis/postgis:12-3.4-alpine
     container_name: pc-postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/docker-compose-backend_ci.yml
+++ b/docker-compose-backend_ci.yml
@@ -30,6 +30,7 @@ services:
       - GUNICORN_THREADS=2
       - GUNICORN_TIMEOUT=10
       - GUNICORN_LOG_LEVEL=info
+      - IS_E2E_TESTS=1
     networks:
       - db_nw
     depends_on:


### PR DESCRIPTION
Dans cette PR on fais 3 changements qui permettent d'améliorer la perf des tests e2e dans la CI:
- On crée un nouveau fichier docker compose qui pull l'image docker buildée depuis le registry au lieu de rebuild
- On crée un nouvelle commande pour lancer une sandbox avec le minimum de données pour les tests e2e au lieu d'utiliser toute la sandbox de testing
- On change l'image postgres utilisée de cimg/postgres qui fait 2.76Go à postgis alpine qui fait 427Mo

Ces changements nous ont permis de descendre le temps que prennent les tests e2e dans la ci de >10min à < 5min