### PR TITLE
(BSR) fix: Upgrade flask to support werkzeug 3

### DIFF
--- a/app-engine/image-resizing/requirements.txt
+++ b/app-engine/image-resizing/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.2
+Flask<3
 flask-cors==3.0.10
 appengine-python-standard>=0.2.2
 google-cloud-storage==2.5.0


### PR DESCRIPTION
## But de la pull request

Suite à l'apparition de l'erreur :
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```
sur le service image-resizing, il faut pour l'instant limité la version de werkzeug qui est installée avec Flask.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques