### PR TITLE
(BSR)[API] fix: disable venue provider synchronisation in testing to …

### DIFF
--- a/api/src/pcapi/local_providers/provider_api/synchronize_provider_api.py
+++ b/api/src/pcapi/local_providers/provider_api/synchronize_provider_api.py
@@ -5,6 +5,7 @@ import time
 from typing import Counter
 from typing import Generator
 
+from pcapi import settings
 from pcapi.core.providers.api import synchronize_stocks
 from pcapi.core.providers.models import Provider
 from pcapi.core.providers.models import StockDetail
@@ -24,6 +25,9 @@ def synchronize_venue_provider(venue_provider: VenueProvider) -> None:
 
     start = time.perf_counter()
     logger.info("Starting synchronization of venue=%s provider=%s", venue.id, provider.name)
+    if not settings.IS_TESTING:
+        return
+
     provider_api = provider.getProviderAPI()
 
     stats: Counter = Counter()
@@ -49,6 +53,7 @@ def synchronize_venue_provider(venue_provider: VenueProvider) -> None:
             **stats,
         },
     )
+    return
 
 
 def _get_stocks_by_batch(siret: str, provider_api: ProviderAPI, modified_since: datetime | None) -> Generator:


### PR DESCRIPTION
…avoid error with test data

## But de la pull request
Désactive la synchronisation des stocks pour les lieux en testing qui ne put pas marcher puisque les providers y ont tous des adresses en "example.com"

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques