### PR TITLE
(PC-25542)[PRO] feat: tracking adage discovery tab

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -36,6 +36,7 @@ class AdageHeaderLink(enum.Enum):
     MY_INSITUTION_OFFERS = "my_institution_offers"
     ADAGE_LINK = "adage_link"
     MY_FAVORITES = "my_favorites"
+    DISCOVERY = "discovery"
 
 
 class AdageHeaderLogBody(AdageBaseModel):

--- a/pro/src/apiClient/adage/models/AdageHeaderLink.ts
+++ b/pro/src/apiClient/adage/models/AdageHeaderLink.ts
@@ -11,4 +11,5 @@ export enum AdageHeaderLink {
   MY_INSTITUTION_OFFERS = 'my_institution_offers',
   ADAGE_LINK = 'adage_link',
   MY_FAVORITES = 'my_favorites',
+  DISCOVERY = 'discovery',
 }

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
@@ -56,7 +56,7 @@ export const AdageHeaderMenu = ({ adageUser }: AdageHeaderMenuProps) => {
                     [styles['adage-header-link-active']]: isActive,
                   })
                 }}
-                /*onClick={() => logAdageLinkClick(AdageHeaderLink.DISCOVERY)} */
+                onClick={() => logAdageLinkClick(AdageHeaderLink.DISCOVERY)}
               >
                 <SvgIcon src={strokePassIcon} alt="" width="20" />
                 Découvrir


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25542

SOUS FF : `WIP_ENABLE_DISCOVERY`

Ajout du tracker pour l'onglet "Découvrir" sur adage