### PR TITLE
(PC-25737)[PRO] duplicate template offer without dates

### DIFF
--- a/pro/src/core/OfferEducational/utils/__specs__/createOfferPayload.spec.ts
+++ b/pro/src/core/OfferEducational/utils/__specs__/createOfferPayload.spec.ts
@@ -1,0 +1,44 @@
+import { DEFAULT_EAC_FORM_VALUES } from 'core/OfferEducational/constants'
+
+import { createCollectiveOfferPayload } from '../createOfferPayload'
+
+describe('createOfferPayload', () => {
+  it('should remove dates from a template offer to create a non-template offer', () => {
+    expect(
+      createCollectiveOfferPayload(
+        {
+          ...DEFAULT_EAC_FORM_VALUES,
+          beginningDate: '2021-09-01',
+          endingDate: '2021-09-10',
+        },
+        false
+      )
+    ).toEqual(expect.objectContaining({ dates: undefined }))
+  })
+
+  it('should not remove dates from an offer to create a template offer', () => {
+    expect(
+      createCollectiveOfferPayload(
+        {
+          ...DEFAULT_EAC_FORM_VALUES,
+          beginningDate: '2021-09-01',
+          endingDate: '2021-09-10',
+        },
+        true
+      ).dates
+    ).toBeTruthy()
+  })
+
+  it('should remove dates from an offer that has no valid dates to create a template offer', () => {
+    expect(
+      createCollectiveOfferPayload(
+        {
+          ...DEFAULT_EAC_FORM_VALUES,
+          beginningDate: undefined,
+          endingDate: undefined,
+        },
+        true
+      )
+    ).toEqual(expect.objectContaining({ dates: undefined }))
+  })
+})

--- a/pro/src/core/OfferEducational/utils/createOfferPayload.ts
+++ b/pro/src/core/OfferEducational/utils/createOfferPayload.ts
@@ -55,32 +55,34 @@ export const createCollectiveOfferPayload = (
   isTemplate: boolean,
   offerTemplateId?: number,
   isFormatActive?: boolean
-): PostCollectiveOfferTemplateBodyModel => ({
-  venueId: Number(offer.venueId),
-  subcategoryId: isFormatActive ? null : offer.subCategory,
-  name: offer.title,
-  bookingEmails: offer.notificationEmails,
-  description: offer.description,
-  durationMinutes: parseDuration(offer.duration),
-  ...disabilityCompliances(offer.accessibility),
-  students: serializeParticipants(offer.participants),
-  offerVenue: {
-    ...offer.eventAddress,
-    venueId: Number(offer.eventAddress.venueId),
-  },
-  contactEmail: offer.email,
-  contactPhone: offer.phone,
-  domains: offer.domains.map((domainIdString) => Number(domainIdString)),
-  interventionArea:
-    offer.eventAddress.addressType === OfferAddressType.OFFERER_VENUE
-      ? []
-      : offer.interventionArea,
-  templateId: offerTemplateId,
-  priceDetail: isTemplate ? offer.priceDetail : undefined,
-  nationalProgramId: Number(offer.nationalProgramId),
-  dates:
-    offer.beginningDate && offer.endingDate
-      ? serializeDates(offer.beginningDate, offer.endingDate, offer.hour)
-      : undefined,
-  formats: isFormatActive ? offer.formats : null,
-})
+): PostCollectiveOfferTemplateBodyModel => {
+  return {
+    venueId: Number(offer.venueId),
+    subcategoryId: isFormatActive ? null : offer.subCategory,
+    name: offer.title,
+    bookingEmails: offer.notificationEmails,
+    description: offer.description,
+    durationMinutes: parseDuration(offer.duration),
+    ...disabilityCompliances(offer.accessibility),
+    students: serializeParticipants(offer.participants),
+    offerVenue: {
+      ...offer.eventAddress,
+      venueId: Number(offer.eventAddress.venueId),
+    },
+    contactEmail: offer.email,
+    contactPhone: offer.phone,
+    domains: offer.domains.map((domainIdString) => Number(domainIdString)),
+    interventionArea:
+      offer.eventAddress.addressType === OfferAddressType.OFFERER_VENUE
+        ? []
+        : offer.interventionArea,
+    templateId: offerTemplateId,
+    priceDetail: isTemplate ? offer.priceDetail : undefined,
+    nationalProgramId: Number(offer.nationalProgramId),
+    dates:
+      isTemplate && offer.beginningDate && offer.endingDate
+        ? serializeDates(offer.beginningDate, offer.endingDate, offer.hour)
+        : undefined,
+    formats: isFormatActive ? offer.formats : null,
+  }
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25737

**FF à activer**
WIP_ENABLE_DATES_OFFER_TEMPLATE

**Objectif**
Ne pas set les dates d'une offre template quand on la crée depuis une autre offre.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques