### PR TITLE
(BSR)[API] fix: offerer stats top offers order

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
+++ b/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
@@ -58,7 +58,7 @@ class OffersData(BaseQuery):
             `{settings.BIG_QUERY_NOTIFICATIONS_TABLE_BASENAME}.{TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE}`
         WHERE
             offerer_id = @offerer_id
-        ORDER BY consult_rank DESC
+        ORDER BY numberOfViews DESC
         LIMIT 3
         """
 


### PR DESCRIPTION
## But de la pull request
La requête big query pour récupérer les top offres par offerer renvoie des données dans un ordre qui semble aléatoire car elle est trié par consult_rank, que j'avais supposait triait la table par nombre de vues. Sauf que le champs contient des données pas cohérent avec cette hypothèse:
![image](https://github.com/pass-culture/pass-culture-main/assets/56326095/34676981-0462-4900-a724-68fbe19b4431)

On trie alors dans cette par nombre de vues directement