### PR TITLE
(PC-25727)[API] feat: Titelive copy product data to offers data

### DIFF
--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2530,3 +2530,203 @@ class GetStocksStatsTest:
         assert error.value.errors == {
             "global": ["L'offre en cours de création ne possède aucun Stock"],
         }
+
+
+@pytest.mark.usefixtures("db_session")
+class FillOffersExtraDataFromProductExtraDataTest:
+    @mock.patch("pcapi.core.search.async_index_offer_ids")
+    def test_should_no_fill_offer_extra_data_from_product_data_with_unknown_product(self, mocked_async_index_offer_ids):
+        # Given
+        product_id = 404
+
+        # When
+        with pytest.raises(ProductNotFound):
+            api.fill_offer_extra_data_from_product_data(product_id)
+
+        # Then
+        mocked_async_index_offer_ids.assert_not_called()
+
+    @mock.patch("pcapi.core.search.async_index_offer_ids")
+    def test_should_fill_offer_extra_data_from_product_data_with_no_offers(self, mocked_async_index_offer_ids):
+        # Given
+        provider = providers_factories.APIProviderFactory()
+        ean = "ean-de-test"
+        product = factories.ThingProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            extraData={"gtl_id": "12345678"},
+            lastProvider=provider,
+            idAtProviders=ean,
+        )
+
+        # When
+        api.fill_offer_extra_data_from_product_data(product.id)
+
+        # Then
+        mocked_async_index_offer_ids.assert_not_called()
+
+    @mock.patch("pcapi.core.search.async_index_offer_ids")
+    def test_should_fill_offer_extra_data_from_product_data_when_offer_not_have_extra_data(
+        self, mocked_async_index_offer_ids
+    ):
+        # Given
+        provider = providers_factories.APIProviderFactory()
+        ean = "ean-de-test"
+        product = factories.ThingProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            extraData={
+                "gtl_id": "12345678",
+                "csr_id": "1901",
+                "code_clil": "4300",
+                "isbn": None,
+                "dewey": None,
+                "rayon": "Bandes dessinées adultes / Comics",
+                "author": "Collectif",
+                "bookFormat": "BEAUX LIVRES",
+                "prix_livre": "4.90",
+                "editeur": "Panini Comics Mag",
+                "comic_series": None,
+                "distributeur": "Makassar",
+                "date_parution": "24/12/2015",
+            },
+            lastProvider=provider,
+            idAtProviders=ean,
+            name="title",
+        )
+        offer = factories.OfferFactory(product=product, extraData={})
+
+        # When
+        api.fill_offer_extra_data_from_product_data(product.id)
+
+        # Then
+        offer = models.Offer.query.filter_by(id=offer.id).one()
+        assert offer.name == "title"
+        assert offer.extraData["gtl_id"] == "12345678"
+        assert offer.extraData["csr_id"] == "1901"
+        assert offer.extraData["code_clil"] == "4300"
+        assert not offer.extraData["isbn"]
+        assert not offer.extraData["dewey"]
+        assert offer.extraData["rayon"] == "Bandes dessinées adultes / Comics"
+        assert offer.extraData["author"] == "Collectif"
+        assert offer.extraData["bookFormat"] == "BEAUX LIVRES"
+        assert offer.extraData["prix_livre"] == "4.90"
+        assert offer.extraData["editeur"] == "Panini Comics Mag"
+        assert not offer.extraData["comic_series"]
+        assert offer.extraData["distributeur"] == "Makassar"
+        assert offer.extraData["date_parution"] == "24/12/2015"
+
+        mocked_async_index_offer_ids.assert_called()
+        assert set(mocked_async_index_offer_ids.call_args[0][0]) == set([offer.id])
+
+    @mock.patch("pcapi.core.search.async_index_offer_ids")
+    def test_should_fill_offer_extra_data_from_product_data_when_offer_have_gtl(self, mocked_async_index_offer_ids):
+        # Given
+        provider = providers_factories.APIProviderFactory()
+        ean = "ean-de-test"
+        product = factories.ThingProductFactory(
+            name="title2",
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            extraData={
+                "gtl_id": "12345678",
+                "csr_id": "1901",
+                "code_clil": "4300",
+                "isbn": None,
+                "dewey": None,
+                "rayon": "Bandes dessinées adultes / Comics",
+                "author": "Collectif",
+                "bookFormat": "BEAUX LIVRES",
+                "prix_livre": "4.90",
+                "editeur": "Panini Comics Mag",
+                "comic_series": None,
+                "distributeur": "Makassar",
+                "date_parution": "24/12/2015",
+            },
+            lastProvider=provider,
+            idAtProviders=ean,
+        )
+
+        offer = factories.OfferFactory(
+            product=product,
+            name="title",
+            extraData={
+                "gtl_id": "10000000",
+                "csr_id": "1661",
+                "code_clil": "5000",
+                "isbn": "dd",
+                "dewey": "1",
+                "rayon": "Adultes / Comics",
+                "author": "Lectif",
+                "bookFormat": "LIVRES",
+                "prix_livre": "66.90",
+                "editeur": "Comics Mag",
+                "comic_series": None,
+                "distributeur": "LaRkassar",
+                "date_parution": "30/12/2010",
+            },
+        )
+
+        # When
+        api.fill_offer_extra_data_from_product_data(product.id)
+
+        # Then
+        offer = models.Offer.query.filter_by(id=offer.id).one()
+        assert offer.extraData["gtl_id"] == "12345678"
+        assert offer.name == "title2"
+        assert offer.extraData["gtl_id"] == "12345678"
+        assert offer.extraData["csr_id"] == "1901"
+        assert offer.extraData["code_clil"] == "4300"
+        assert not offer.extraData["isbn"]
+        assert not offer.extraData["dewey"]
+        assert offer.extraData["rayon"] == "Bandes dessinées adultes / Comics"
+        assert offer.extraData["author"] == "Collectif"
+        assert offer.extraData["bookFormat"] == "BEAUX LIVRES"
+        assert offer.extraData["prix_livre"] == "4.90"
+        assert offer.extraData["editeur"] == "Panini Comics Mag"
+        assert not offer.extraData["comic_series"]
+        assert offer.extraData["distributeur"] == "Makassar"
+        assert offer.extraData["date_parution"] == "24/12/2015"
+
+        mocked_async_index_offer_ids.assert_called()
+        assert set(mocked_async_index_offer_ids.call_args[0][0]) == set([offer.id])
+
+    @mock.patch("pcapi.core.search.async_index_offer_ids")
+    def test_should_fill_offer_extra_data_from_product_data_when_many_offers(self, mocked_async_index_offer_ids):
+        # Given
+        provider = providers_factories.APIProviderFactory()
+        ean = "ean-de-test"
+        product = factories.ThingProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            extraData={"gtl_id": "12345678"},
+            lastProvider=provider,
+            idAtProviders=ean,
+        )
+
+        offer = factories.OfferFactory(product=product, extraData={"gtl_id": "10000000"})
+        offer2 = factories.OfferFactory(product=product, extraData={"gtl_id": "12000000"})
+
+        # When
+        api.fill_offer_extra_data_from_product_data(product.id)
+
+        # Then
+        offers = models.Offer.query.filter_by(productId=product.id).all()
+        assert all(offer.extraData["gtl_id"] == "12345678" for offer in offers)
+
+        mocked_async_index_offer_ids.assert_called()
+        assert set(mocked_async_index_offer_ids.call_args[0][0]) == set([offer.id, offer2.id])
+
+    def test_should_fill_offer_extra_data_from_product_data_with_update_exception(self):
+        # Given
+        provider = providers_factories.APIProviderFactory()
+        ean = "ean-de-test"
+        product = factories.ThingProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            extraData={"gtl_id": "12345678"},
+            lastProvider=provider,
+            idAtProviders=ean,
+        )
+
+        factories.OfferFactory(product=product, extraData={"gtl_id": "10000000"})
+
+        # When
+        with pytest.raises(NotUpdateProductOrOffers):
+            with patch("pcapi.models.db.session.commit", side_effect=Exception):
+                api.fill_offer_extra_data_from_product_data(product.id)

--- a/api/tests/local_providers/titelive_descriptions_test.py
+++ b/api/tests/local_providers/titelive_descriptions_test.py
@@ -1,8 +1,12 @@
+import datetime
+import io
 import re
 from unittest.mock import patch
 
 import pytest
 
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers import models as offers_models
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.local_providers import TiteLiveThingDescriptions
 from pcapi.repository import repository
@@ -30,6 +34,48 @@ class TiteLiveThingDescriptionsTest:
             titelive_description_provider.zips = ["Resume191012.zip", "Resume201012.zip"]
 
     class NextTest:
+        @patch(
+            "pcapi.local_providers.titelive_thing_descriptions.titelive_thing_descriptions.get_files_to_process_from_titelive_ftp"
+        )
+        @patch("pcapi.local_providers.titelive_thing_descriptions.titelive_thing_descriptions.get_zip_file_from_ftp")
+        @patch("pcapi.local_providers.titelive_thing_descriptions.titelive_thing_descriptions.get_date_from_filename")
+        @pytest.mark.usefixtures("db_session")
+        def test_should_update_product_and_offers_description(
+            self, mock_get_date_from_filename, mock_get_zip_file_from_ftp, mock_get_files_to_process_from_titelive
+        ):
+            # Given
+            titelive_description_provider = get_provider_by_local_class("TiteLiveThingDescriptions")
+            product = offers_factories.ProductFactory(
+                description="old description",
+                idAtProviders="9782809455069",
+                lastProviderId=titelive_description_provider.id,
+            )
+            offers_factories.OfferFactory(product=product, description="other description")
+
+            tomorrow = (datetime.datetime.utcnow() + datetime.timedelta(days=1)).strftime("%y%m%d")
+
+            mock_get_files_to_process_from_titelive.return_value = [f"Resume{tomorrow}.zip"]
+            mock_zip_file = MockZipFile(
+                filename=f"Resume{tomorrow}.zip", filelist=[MockFile("9782809455069_p.txt", "A passionate description")]
+            )
+            mock_get_zip_file_from_ftp.side_effect = [
+                mock_zip_file,
+            ]
+            mock_get_date_from_filename.side_effect = {tomorrow}
+            repository.save(titelive_description_provider)
+
+            # When
+            titelive_description_provider = TiteLiveThingDescriptions()
+            titelive_description_provider.updateObjects()
+            titelive_description_provider.postTreatment()
+
+            # Then
+            product = offers_models.Product.query.one()
+            assert product.description == "A passionate description"
+
+            offer = offers_models.Offer.query.one()
+            assert offer.description == "A passionate description"
+
         @patch(
             "pcapi.local_providers.titelive_thing_descriptions.titelive_thing_descriptions.get_files_to_process_from_titelive_ftp"
         )
@@ -64,12 +110,29 @@ class TiteLiveThingDescriptionsTest:
 
 
 class MockZipFile:
-    def __init__(self, filename: str):
+    def __init__(self, filename: str, filelist: list = None):
         self.filename = filename
-        self.filelist = [self]
+        self.filelist = filelist if filelist else [self]
 
     def __next__(self):
         return self.filename
 
     def infolist(self):
         return self.filelist
+
+    def open(self, file):
+        return io.BytesIO(file.description.encode("iso-8859-1"))
+
+
+class MockFile:
+    def __init__(self, filename: str, description: str):
+        self._filename = filename
+        self._description = description
+
+    @property
+    def filename(self):
+        return self._filename
+
+    @property
+    def description(self):
+        return self._description


### PR DESCRIPTION
## But de la pull request
En attendant l'uniformisation des données communes des offres et produits.

Lorsque l'on intégre un produit Titelive, par la suite on créé des offres sur ces produits lors la synchro mise en place par les acteurs culturels.
Quand les infos d'un produit est mis à jour par Titelive, il faut mettre les offres associées.

Ticket Jira : https://passculture.atlassian.net/browse/PC-25727

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques