### PR TITLE
(BSR)[PRO] feat: Moved the orejime block to make it keyboard accessible.

### DIFF
--- a/pro/src/components/SkipLinks/SkipLinks.tsx
+++ b/pro/src/components/SkipLinks/SkipLinks.tsx
@@ -19,6 +19,7 @@ const SkipLinks = ({ displayMenu = false }: SkipLinksProps): JSX.Element => {
     <>
       <a tabIndex={-1} href="#" id="top-page" className="visually-hidden" />
       <nav aria-label="Accès rapide" className={styles['skip-links']}>
+        <div id="orejime"></div>
         {buttons.length > 1 ? (
           <ul className={styles['skip-list']}>
             {buttons.map((button) => {

--- a/pro/src/index.html
+++ b/pro/src/index.html
@@ -72,7 +72,6 @@
 
   <body>
     <div id="root"></div>
-    <div id="orejime"></div>
     <noscript>passCulture Pro a besoin de JavaScript pour fonctionner</noscript>
     <script type="module" src="/index.tsx"></script>
     <script>


### PR DESCRIPTION
## But de la pull request

Faire en sorte que la bannière de cookie soit le premier élément accessible à la navigation clavier.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques