### PR TITLE
(PC-25637)[PRO] feat: add layout offer adage

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
@@ -10,7 +10,7 @@ import styles from './AdageDiscovery.module.scss'
 import CardOfferComponent, { CardOfferModel } from './CardOffer/CardOffer'
 import CardVenue from './CardVenue/CardVenue'
 
-const mockOffer: CardOfferModel = {
+export const mockOffer: CardOfferModel = {
   id: 479,
   name: 'Une chouette à la mer',
   description: 'Une offre vraiment chouette',

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.module.scss
@@ -6,10 +6,11 @@ $offer-image-height: rem.torem(273px);
 $offer-image-width: rem.torem(216px);
 
 .container {
+  position: relative;
   display: flex;
   flex-direction: column;
   width: $offer-image-width;
-  gap: 16px;
+  gap: rem.torem(16px);
 }
 
 .offer-image-container {

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 import {
   CollectiveOfferOfferVenue,
@@ -32,6 +33,9 @@ export interface CardComponentProps {
 }
 
 const CardOfferComponent = ({ offer }: CardComponentProps) => {
+  const [searchParams] = useSearchParams()
+  const adageAuthToken = searchParams.get('token')
+
   const tagInfos = {
     [OfferAddressType.SCHOOL]: [{ logo: logoSchool, text: 'En classe' }],
     [OfferAddressType.OFFERER_VENUE]: [
@@ -45,52 +49,60 @@ const CardOfferComponent = ({ offer }: CardComponentProps) => {
   }
 
   return (
-    <div className={styles.container}>
-      <div className={styles['offer-image-container']}>
-        {offer.imageUrl ? (
-          <img
-            alt=""
-            className={styles['offer-image']}
-            loading="lazy"
-            src={offer.imageUrl}
-          />
-        ) : (
-          <div className={styles['offer-image']}>
-            <SvgIcon src={strokeOfferIcon} alt="" />
-          </div>
-        )}
-        <OfferFavoriteButton
-          offer={offer}
-          className={styles['offer-favorite-button']}
-        />
-      </div>
+    <div className={styles['container']}>
+      <a
+        data-testid="card-offer-link"
+        href={`/adage-iframe/decouverte/offre/${offer.id}?token=${adageAuthToken}`}
+      >
+        <div className={styles['offer-image-container']}>
+          {offer.imageUrl ? (
+            <img
+              alt=""
+              className={styles['offer-image']}
+              loading="lazy"
+              src={offer.imageUrl}
+            />
+          ) : (
+            <div className={styles['offer-image']}>
+              <SvgIcon src={strokeOfferIcon} alt="" />
+            </div>
+          )}
+        </div>
 
-      <div className={styles['offer-tag-container']}>
-        <Tag variant={TagVariant.LIGHT_GREY} className={styles['offer-tag']}>
-          <img
-            alt=""
-            src={tagInfos[offer.offerVenue.addressType][0].logo}
-            className={styles['offer-tag-image']}
-          />
-          <span>{tagInfos[offer.offerVenue.addressType][0].text}</span>
-        </Tag>
-        {tagInfos[offer.offerVenue.addressType].length > 1 && (
+        <div className={styles['offer-tag-container']}>
           <Tag variant={TagVariant.LIGHT_GREY} className={styles['offer-tag']}>
-            <span>{tagInfos[offer.offerVenue.addressType][1].text}</span>
+            <img
+              alt=""
+              src={tagInfos[offer.offerVenue.addressType][0].logo}
+              className={styles['offer-tag-image']}
+            />
+            <span>{tagInfos[offer.offerVenue.addressType][0].text}</span>
           </Tag>
-        )}
-      </div>
+          {tagInfos[offer.offerVenue.addressType].length > 1 && (
+            <Tag
+              variant={TagVariant.LIGHT_GREY}
+              className={styles['offer-tag']}
+            >
+              <span>{tagInfos[offer.offerVenue.addressType][1].text}</span>
+            </Tag>
+          )}
+        </div>
 
-      <div className={styles['offer-name']} title={offer.name}>
-        {offer.name}
-      </div>
+        <div className={styles['offer-name']} title={offer.name}>
+          {offer.name}
+        </div>
 
-      <div className="offer-venue">
-        <div className={styles['offer-venue-name']}>{offer.venue.name}</div>
-        <div
-          className={styles['offer-venue-distance']}
-        >{`à ${offer.venue.distance} km - ${offer.venue.city}`}</div>
-      </div>
+        <div className="offer-venue">
+          <div className={styles['offer-venue-name']}>{offer.venue.name}</div>
+          <div
+            className={styles['offer-venue-distance']}
+          >{`à ${offer.venue.distance} km - ${offer.venue.city}`}</div>
+        </div>
+      </a>
+      <OfferFavoriteButton
+        offer={offer}
+        className={styles['offer-favorite-button']}
+      />
     </div>
   )
 }

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/__specs__/CardOffer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/__specs__/CardOffer.spec.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react'
+import * as router from 'react-router-dom'
 
 import { OfferAddressType } from 'apiClient/adage'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
@@ -71,5 +72,21 @@ describe('CardOffer component', () => {
 
     expect(screen.getByText('Sortie')).toBeInTheDocument()
     expect(screen.getByText('Lieu à définir')).toBeInTheDocument()
+  })
+
+  it('should redirect on click in offer card', async () => {
+    vi.spyOn(router, 'useSearchParams').mockReturnValue([
+      new URLSearchParams({ token: '123' }),
+      vi.fn(),
+    ])
+
+    renderCardOfferComponent({ offer: mockOffer })
+
+    const offerElement = screen.getByTestId('card-offer-link')
+
+    expect(offerElement).toHaveAttribute(
+      'href',
+      '/adage-iframe/decouverte/offre/479?token=123'
+    )
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.module.scss
@@ -1,0 +1,6 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+
+.container {
+    margin-top: rem.torem(32px)
+}

--- a/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+import { mockOffer } from '../AdageDiscovery/AdageDiscovery'
+import Offer from '../OffersInstantSearch/OffersSearch/Offers/Offer'
+
+import styles from './OffersInfos.module.scss'
+
+export const OffersInfos = () => {
+  return (
+    <div className={styles['container']}>
+      <Offer offer={mockOffer} position={0} queryId="" openDetails={true} />
+    </div>
+  )
+}

--- a/pro/src/pages/AdageIframe/app/components/OffersInfos/__specs__/OffersInfos.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInfos/__specs__/OffersInfos.spec.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react'
+
+import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
+import { defaultAdageUser } from 'utils/adageFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { OffersInfos } from '../OffersInfos'
+
+const renderOffersInfos = () => {
+  renderWithProviders(
+    <AdageUserContextProvider adageUser={defaultAdageUser}>
+      <OffersInfos />
+    </AdageUserContextProvider>
+  )
+}
+
+describe('OffersInfos', () => {
+  it('should display offers informations', () => {
+    renderOffersInfos()
+
+    expect(screen.getByText('Une chouette à la mer')).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -38,6 +38,7 @@ export interface OfferProps {
   position: number
   afterFavoriteChange?: (isFavorite: boolean) => void
   isInSuggestions?: boolean
+  openDetails?: boolean
 }
 
 const Offer = ({
@@ -46,8 +47,9 @@ const Offer = ({
   position,
   afterFavoriteChange,
   isInSuggestions,
+  openDetails = false,
 }: OfferProps): JSX.Element => {
-  const [displayDetails, setDisplayDetails] = useState(false)
+  const [displayDetails, setDisplayDetails] = useState(openDetails)
   const isLikeActive = useActiveFeature('WIP_ENABLE_LIKE_IN_ADAGE')
   const isGeolocationActive = useActiveFeature('WIP_ENABLE_ADAGE_GEO_LOCATION')
   const { adageUser } = useAdageUser()

--- a/pro/src/pages/AdageIframe/app/subRoutesAdage.tsx
+++ b/pro/src/pages/AdageIframe/app/subRoutesAdage.tsx
@@ -3,6 +3,7 @@
 import { AdageDiscovery } from './components/AdageDiscovery/AdageDiscovery'
 import { OffersFavorites } from './components/OffersFavorites/OffersFavorites'
 import OffersForMyInstitution from './components/OffersForInstitution/OffersForMyInstitution'
+import { OffersInfos } from './components/OffersInfos/OffersInfos'
 import { OffersInstantSearch } from './components/OffersInstantSearch/OffersInstantSearch'
 
 // TODO: delete when ff WIP_ENABLE_DISCOVERY is deleted
@@ -57,5 +58,11 @@ export const routesAdage = [
     parentPath: '/adage-iframe',
     path: '/mes-favoris',
     title: 'Mes Favoris',
+  },
+  {
+    element: OffersInfos,
+    parentPath: '/adage-iframe',
+    path: '/decouverte/offre/:offerId',
+    title: 'Découvrir une offre',
   },
 ]


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25637

`SOUS FF : WIP_ENABLE_DISCOVERY`

Préparer la page qui permettra d'afficher les détails d'une offre en particulier, lorsqu'on clique sur une offre qui est sur la page découverte, redirection sur une page dédiée à l'offre

<img width="1507" alt="Capture d’écran 2023-11-15 à 13 44 01" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/24752973-76cd-432d-9d90-7506ddafa7ed">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques