### PR TITLE
(PC-25823)[PRO] fix: search by partner in adage with autocomplete

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -206,6 +206,8 @@ export const Autocomplete = ({
         async onSelect({ item }) {
           const venueDisplayName = item.venue.publicName || item.venue.name
           autocomplete.setQuery('')
+          refine('')
+          setCurrentSearch('')
           await formik.setFieldValue('venue', { ...item.venue, relative: [] })
           await formik.submitForm()
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25823

Lorsqu'on faisait une recherche textuelle sans utiliser l'autocomplete, le texte de recherche ne se supprimait pas pour la nouvelle recherche lorsqu'on sélectionnait un partenaire culturel depuis l'autocomplete ni dans le tracker de recherche