### PR TITLE
(BSR)[API] fix: venueProvider types in sandbox + disable external bookings on testing

### DIFF
--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -62,7 +62,7 @@ def book_cinema_ticket(
 
 
 def disable_external_bookings() -> None:
-    feature.Feature.query.filter(feature.Feature.name.in_(EXTERNAL_BOOKINGS_FF)).update(
+    feature.Feature.query.filter(feature.Feature.name.in_([ff.value for ff in EXTERNAL_BOOKINGS_FF])).update(
         {"isActive": True}, synchronize_session=False
     )
     db.session.commit()

--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -50,6 +50,8 @@ class ProviderFactory(BaseFactory):
 
 
 class APIProviderFactory(BaseFactory):
+    # This factory creates legacy providers.
+    # The API they uses will be dropped, do not use this factory unless you specifically want to.
     class Meta:
         model = models.Provider
 
@@ -57,6 +59,16 @@ class APIProviderFactory(BaseFactory):
     apiUrl = factory.Sequence("https://{}.example.org/stocks".format)
     enabledForPro = True
     isActive = True
+
+
+class PublicApiProviderFactory(BaseFactory):
+    class Meta:
+        model = models.Provider
+
+    name = factory.Sequence("Public API Provider {}".format)
+    enabledForPro = True
+    isActive = True
+    hmacKey = "secret"
 
 
 class VenueProviderFactory(BaseFactory):

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_collective_api_provider.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_collective_api_provider.py
@@ -4,13 +4,13 @@ import factory
 
 from pcapi.core.offerers.factories import ApiKeyFactory
 from pcapi.core.offerers.models import Venue
-from pcapi.core.providers.factories import APIProviderFactory
+from pcapi.core.providers.factories import PublicApiProviderFactory
 from pcapi.core.providers.factories import VenueProviderFactory
 from pcapi.core.providers.models import Provider
 
 
 def create_collective_api_provider(venues: Sequence[Venue]) -> Provider:
-    provider = APIProviderFactory(name=factory.Sequence("Collectie API Provider {}".format))
+    provider = PublicApiProviderFactory(name=factory.Sequence("Collective API Provider {}".format))
 
     for venue in venues:
         VenueProviderFactory(venue=venue, provider=provider)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
@@ -35,9 +35,8 @@ def create_offerer_provider(
     if with_charlie_url:
         booking_url = settings.CHARLIE_BOOKING_URL
         cancel_booking_url = settings.CHARLIE_CANCEL_BOOKING_URL
-    provider = providers_factories.ProviderFactory(
+    provider = providers_factories.PublicApiProviderFactory(
         name=provider_name,
-        localClass=None,
         isActive=isActive,
         enabledForPro=enabledForPro,
         bookingExternalUrl=booking_url,

--- a/api/src/pcapi/sandboxes/scripts/sandbox_industrial.py
+++ b/api/src/pcapi/sandboxes/scripts/sandbox_industrial.py
@@ -1,3 +1,4 @@
+from pcapi.core.external_bookings.api import disable_external_bookings
 from pcapi.sandboxes.scripts.creators.industrial import save_industrial_sandbox
 from pcapi.sandboxes.scripts.creators.test_cases import save_test_cases_sandbox
 
@@ -5,3 +6,4 @@ from pcapi.sandboxes.scripts.creators.test_cases import save_test_cases_sandbox
 def save_sandbox() -> None:
     save_industrial_sandbox()
     save_test_cases_sandbox()
+    disable_external_bookings()


### PR DESCRIPTION
BSR : 
Trying to fix synchronisation errors + always disable external bookings on testing