### PR TITLE
(PC-25524)[PRO] feat: ajout de new test pour réca d'offre

### DIFF
--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/RecurrenceSection/RecurrenceSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/RecurrenceSection/RecurrenceSection.tsx
@@ -14,17 +14,18 @@ const RecurrenceSection = ({
   stocksStats,
   departementCode,
 }: RecurrenceSectionProps) => {
-  if (!stocksStats?.stockCount) {
+  if (!stocksStats?.stockCount && stocksStats?.stockCount !== 0) {
     return null
   }
 
   function formatCapacity(capacity: number): string {
-    return capacity === 1 ? `${capacity} place` : `${capacity} places`
+    return capacity <= 1 ? `${capacity} place` : `${capacity} places`
   }
 
-  const totalCapacity = stocksStats.remainingQuantity
-    ? formatCapacity(stocksStats.remainingQuantity)
-    : 'Illimitée'
+  const totalCapacity =
+    stocksStats.remainingQuantity || stocksStats.remainingQuantity === 0
+      ? formatCapacity(stocksStats.remainingQuantity)
+      : 'Illimitée'
 
   let periodText = ''
   const { oldestStock, newestStock } = stocksStats

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/RecurrenceSection/__specs__/RecurrenceSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/RecurrenceSection/__specs__/RecurrenceSection.spec.tsx
@@ -16,14 +16,12 @@ describe('StockEventSection', () => {
 
     render(<RecurrenceSection stocksStats={stocksStats} departementCode="" />)
 
-    expect(screen.queryByText(/Nombre de dates/)).toBeInTheDocument()
-    expect(screen.queryByText('2')).toBeInTheDocument()
-    expect(screen.queryByText(/Période concernée/)).toBeInTheDocument()
-    expect(
-      screen.queryByText('du 01/01/2021 au 02/01/2021')
-    ).toBeInTheDocument()
-    expect(screen.queryByText(/Capacité totale/)).toBeInTheDocument()
-    expect(screen.queryByText('Illimitée')).toBeInTheDocument()
+    expect(screen.getByText(/Nombre de dates/)).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText(/Période concernée/)).toBeInTheDocument()
+    expect(screen.getByText('du 01/01/2021 au 02/01/2021')).toBeInTheDocument()
+    expect(screen.getByText(/Capacité totale/)).toBeInTheDocument()
+    expect(screen.getByText('Illimitée')).toBeInTheDocument()
   })
 
   it('should render all information when there are only one stock', () => {
@@ -35,13 +33,20 @@ describe('StockEventSection', () => {
     }
 
     render(<RecurrenceSection stocksStats={stocksStats} departementCode="" />)
+  })
 
-    expect(screen.queryByText(/Nombre de dates/)).toBeInTheDocument()
-    expect(screen.queryByText('1')).toBeInTheDocument()
-    expect(screen.queryByText(/Période concernée/)).toBeInTheDocument()
-    expect(screen.queryByText('le 01/01/2021')).toBeInTheDocument()
-    expect(screen.queryByText(/Capacité totale/)).toBeInTheDocument()
-    expect(screen.queryByText('637 places')).toBeInTheDocument()
+  it("displays 0 when remainingQuantity is 0 but not 'Illimitée'", () => {
+    const stocksStats = {
+      stockCount: 1,
+      remainingQuantity: 0,
+      oldestStock: '2021-01-01T00:00:00+01:00',
+      newestStock: '2021-01-03T00:00:00+01:00',
+    }
+
+    render(<RecurrenceSection stocksStats={stocksStats} departementCode="" />)
+
+    expect(screen.queryByText('Illimitée')).not.toBeInTheDocument()
+    expect(screen.getByText('0 place')).toBeInTheDocument()
   })
 
   it('should render 1 place', () => {
@@ -54,7 +59,7 @@ describe('StockEventSection', () => {
 
     render(<RecurrenceSection stocksStats={stocksStats} departementCode="" />)
 
-    expect(screen.queryByText('1 place')).toBeInTheDocument()
+    expect(screen.getByText('1 place')).toBeInTheDocument()
   })
 
   it('should not render if there are no stocks', () => {


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25524

Branche: PC-25524-offres-creation-event

## But de la pull request

Remplacer query by get.

Consulter Récapitulatif  de création des offres-événements. 

Code: RecurrenceSection, Stock Summary Event '0 ' - stocks affiche "Illimitée". 

→ si remainingQuantity = 0 il faut afficher '0' dans ce cas et ajouter le test qui le prouve.

<img width="723" alt="Capture d’écran 2023-11-15 à 14 39 17" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/e1754bd0-2ca7-41b0-ae84-f4f9d259ac66">

Logique:

Pour javascript '0' est considéré comme null ou undefined.

toto = null
toto ? "zero" : "pas zero"
==> pas zero

toto = 0
toto ? "zero" : "pas zero"
==> pas zero

toto = 2
toto ? "zero" : "pas zero"
==> zero


RecurrenceSection.tsx , RecurrenceSection.spec.tsx  

1. Définition de stocksStats avec remainingQuantity et stockCount à zéro pour simuler un cas où la quantité est `nulle`.

2. Rendu du composant <RecurrenceSection> avec les stocksStats définis à 'zéro'.

3. Vérification des éléments rendus pour s'assurer que les valeurs attendues sont présentes dans le rendu.

4. 'Illimitée' ne doit pas être présent dans le rendu et que '**0 place'** doit être présent.


```
 **// Affichage du DOM actuel pour le déboggage
  console.log(prettyDOM())**

```
