### PR TITLE
(PC-25836)[API] fix: fraud: add [not] one of rule

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-705d56381bae (pre) (head)
+f81aecdc3793 (pre) (head)
 c2b7386d4962 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231116T114911_f81aecdc3793_add_formats_to_validation_attributes.py
+++ b/api/src/pcapi/alembic/versions/20231116T114911_f81aecdc3793_add_formats_to_validation_attributes.py
@@ -1,0 +1,20 @@
+"""add formats to validation attributes"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "f81aecdc3793"
+down_revision = "705d56381bae"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE offer_validation_attribute ADD VALUE IF NOT EXISTS 'FORMATS'")
+    op.execute("ALTER TYPE offer_validation_rule_operator ADD VALUE IF NOT EXISTS 'INTERSECTS'")
+    op.execute("ALTER TYPE offer_validation_rule_operator ADD VALUE IF NOT EXISTS 'NOT_INTERSECTS'")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -772,6 +772,8 @@ class OfferValidationRuleOperator(enum.Enum):
     NOT_IN = "not in"
     CONTAINS = "contains"
     CONTAINS_EXACTLY = "contains-exact"
+    INTERSECTS = "intersects"
+    NOT_INTERSECTS = "not intersects"
 
 
 class OfferValidationModel(enum.Enum):
@@ -797,6 +799,7 @@ class OfferValidationAttribute(enum.Enum):
     PRICE_DETAIL = "priceDetail"
     SHOW_SUB_TYPE = "showSubType"
     TEXT = "visibleText"
+    FORMATS = "formats"
 
 
 class OfferValidationSubRuleField(enum.Enum):
@@ -883,6 +886,14 @@ class OfferValidationSubRuleField(enum.Enum):
     CATEGORY_COLLECTIVE_OFFER_TEMPLATE = {
         "model": OfferValidationModel.COLLECTIVE_OFFER_TEMPLATE,
         "attribute": OfferValidationAttribute.CATEGORY_ID,
+    }
+    FORMATS_COLLECTIVE_OFFER = {
+        "model": OfferValidationModel.COLLECTIVE_OFFER,
+        "attribute": OfferValidationAttribute.FORMATS,
+    }
+    FORMATS_COLLECTIVE_OFFER_TEMPLATE = {
+        "model": OfferValidationModel.COLLECTIVE_OFFER_TEMPLATE,
+        "attribute": OfferValidationAttribute.FORMATS,
     }
     SHOW_SUB_TYPE_OFFER = {
         "model": OfferValidationModel.OFFER,

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -598,6 +598,10 @@ def format_offer_validation_sub_rule_field(sub_rule_field: offers_models.OfferVa
             return "Le sous-type de spectacle de l'offre individuelle"
         case offers_models.OfferValidationSubRuleField.ID_OFFERER:
             return "La structure proposant l'offre"
+        case offers_models.OfferValidationSubRuleField.FORMATS_COLLECTIVE_OFFER:
+            return "Les formats de l'offre collective"
+        case offers_models.OfferValidationSubRuleField.FORMATS_COLLECTIVE_OFFER_TEMPLATE:
+            return "Les formats de l'offre vitrine"
         case _:
             return sub_rule_field.value
 
@@ -624,6 +628,10 @@ def format_offer_validation_operator(operator: offers_models.OfferValidationRule
             return "contient"
         case offers_models.OfferValidationRuleOperator.CONTAINS_EXACTLY:
             return "contient exactement"
+        case offers_models.OfferValidationRuleOperator.INTERSECTS:
+            return "contiennent"
+        case offers_models.OfferValidationRuleOperator.NOT_INTERSECTS:
+            return "ne contiennent pas"
         case _:
             return operator.value
 

--- a/api/src/pcapi/routes/backoffice/offer_validation_rules/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offer_validation_rules/blueprint.py
@@ -184,6 +184,7 @@ def create_rule() -> utils.BackofficeResponse:
                 or sub_rule_data["subcategories"]
                 or sub_rule_data["categories"]
                 or sub_rule_data["show_sub_type"]
+                or sub_rule_data["formats"]
             )
             sub_rule = offers_models.OfferValidationSubRule(
                 validationRule=new_rule,
@@ -306,6 +307,7 @@ def edit_rule(rule_id: int) -> utils.BackofficeResponse:
                 or sub_rule_data["subcategories"]
                 or sub_rule_data["categories"]
                 or sub_rule_data["show_sub_type"]
+                or sub_rule_data["formats"]
             )
 
             # edit existing subrule

--- a/api/src/pcapi/routes/backoffice/offer_validation_rules/forms.py
+++ b/api/src/pcapi/routes/backoffice/offer_validation_rules/forms.py
@@ -65,6 +65,8 @@ OFFER_VALIDATION_SUB_RULE_FORM_FIELD_CONFIGURATION = {
     "CATEGORY_OFFER": {"field": "categories", "operator": ["IN", "NOT_IN"]},
     "CATEGORY_COLLECTIVE_OFFER": {"field": "categories", "operator": ["IN", "NOT_IN"]},
     "CATEGORY_COLLECTIVE_OFFER_TEMPLATE": {"field": "categories", "operator": ["IN", "NOT_IN"]},
+    "FORMATS_COLLECTIVE_OFFER": {"field": "formats", "operator": ["INTERSECTS", "NOT_INTERSECTS"]},
+    "FORMATS_COLLECTIVE_OFFER_TEMPLATE": {"field": "formats", "operator": ["INTERSECTS", "NOT_INTERSECTS"]},
     "SHOW_SUB_TYPE_OFFER": {"field": "show_sub_type", "operator": ["IN", "NOT_IN"]},
     "ID_OFFERER": {"field": "offerer", "operator": ["IN", "NOT_IN"]},
 }
@@ -152,6 +154,9 @@ class OfferValidationSubRuleForm(FlaskForm):
         "Sous-type de spectacle",
         choices=[(str(s), SHOW_SUB_TYPES_LABEL_BY_CODE[s]) for s in SHOW_SUB_TYPES_LABEL_BY_CODE],
         field_list_compatibility=True,
+    )
+    formats = fields.PCSelectMultipleField(
+        "Formats", choices=utils.choices_from_enum(subcategories_v2.EacFormat), field_list_compatibility=True
     )
 
     form_field_configuration = OFFER_VALIDATION_SUB_RULE_FORM_FIELD_CONFIGURATION
@@ -245,6 +250,14 @@ class OfferValidationSubRuleForm(FlaskForm):
         if operator.data not in self.form_field_configuration.get(self.sub_rule_type.data, {}).get("operator", []):
             raise wtforms.validators.ValidationError("L'opérateur doit être conforme au type de sous-règle choisi")
         return operator
+
+    def validate_formats(self, formats_field: fields.PCSelectMultipleField) -> fields.PCSelectMultipleField:
+        formats_field.data = (
+            formats_field.data
+            if self.form_field_configuration.get(self.sub_rule_type.data, {}).get("field") == "formats"
+            else []
+        )
+        return formats_field
 
 
 class CreateOfferValidationRuleForm(FlaskForm):

--- a/api/src/pcapi/utils/custom_logic.py
+++ b/api/src/pcapi/utils/custom_logic.py
@@ -1,3 +1,4 @@
+import enum
 import typing
 
 from pcapi.utils.clean_accents import clean_accents
@@ -6,6 +7,8 @@ from pcapi.utils.clean_accents import clean_accents
 def sanitize_str(a: typing.Any) -> typing.Any:
     if isinstance(a, str):
         return clean_accents(a.lower())
+    if isinstance(a, enum.Enum):
+        return clean_accents(a.name.lower())
     return a
 
 
@@ -64,6 +67,17 @@ def contains_exact(a: str, b: list[str]) -> bool:
     return any(element in split_a for element in b)
 
 
+def intersects(a: list, b: list) -> bool:
+    """Check if any item from b can be found inside a"""
+    if not a or not b:
+        return False
+
+    sanitized_a = set(sanitize_list(a))
+    sanitized_b = set(sanitize_list(b))
+
+    return bool(sanitized_a.intersection(sanitized_b))
+
+
 OPERATIONS = {
     "==": soft_equals,
     "!=": lambda a, b: not soft_equals(a, b),
@@ -75,4 +89,6 @@ OPERATIONS = {
     "not in": lambda a, b: (sanitize_str(a) not in sanitize_list(b)) if "__contains__" in dir(b) else True,
     "contains": contains,
     "contains-exact": contains_exact,
+    "intersects": intersects,
+    "not intersects": lambda a, b: not intersects(a, b),
 }

--- a/api/tests/routes/backoffice/offer_validation_rules_test.py
+++ b/api/tests/routes/backoffice/offer_validation_rules_test.py
@@ -407,6 +407,32 @@ class CreateOfferValidationRuleTest(PostEndpointHelper):
                     "comparated": {"comparated": ["1101"]},
                 },
             ),
+            (
+                {
+                    "sub_rules-0-sub_rule_type": "FORMATS_COLLECTIVE_OFFER",
+                    "sub_rules-0-operator": "INTERSECTS",
+                    "sub_rules-0-formats": ["CONCERT", "VISITE_LIBRE"],
+                },
+                {
+                    "model": offers_models.OfferValidationModel.COLLECTIVE_OFFER,
+                    "attribute": offers_models.OfferValidationAttribute.FORMATS,
+                    "operator": offers_models.OfferValidationRuleOperator.INTERSECTS,
+                    "comparated": {"comparated": ["CONCERT", "VISITE_LIBRE"]},
+                },
+            ),
+            (
+                {
+                    "sub_rules-0-sub_rule_type": "FORMATS_COLLECTIVE_OFFER_TEMPLATE",
+                    "sub_rules-0-operator": "NOT_INTERSECTS",
+                    "sub_rules-0-formats": ["CONCERT", "VISITE_LIBRE"],
+                },
+                {
+                    "model": offers_models.OfferValidationModel.COLLECTIVE_OFFER_TEMPLATE,
+                    "attribute": offers_models.OfferValidationAttribute.FORMATS,
+                    "operator": offers_models.OfferValidationRuleOperator.NOT_INTERSECTS,
+                    "comparated": {"comparated": ["CONCERT", "VISITE_LIBRE"]},
+                },
+            ),
         ],
     )
     def test_create_offer_validation_rule_with_one_rule(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25836

Fix : permettre de mettre à jour les règles de fraude concernant les offres collectives.
Problème : les formats sont des listes et en l'état les règles disponibles ne permettent pas de manipuler des ensembles.

Les deux nouvelles règles ajoutées (`one of` et `not one of`) permettent de vérifier qu'aucune des valeur indiquée n'est présente parmi les formats (par exemple) de l'offre.