### PR TITLE
(PC-25243)[BO] fix: Display invitation until user has validated account

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -437,7 +437,14 @@ def get_pro_users(offerer_id: int) -> utils.BackofficeResponse:
     users_invited = (
         offerers_models.OffererInvitation.query.options(options)
         .filter(offerers_models.OffererInvitation.offererId == offerer_id)
-        .filter(~sa.exists().where(users_models.User.email == offerers_models.OffererInvitation.email))
+        .filter(
+            ~sa.exists().where(
+                sa.and_(
+                    users_models.User.email == offerers_models.OffererInvitation.email,
+                    users_models.User.id.in_(user_ids_subquery),
+                )
+            )
+        )
         .order_by(offerers_models.OffererInvitation.id)
         .all()
     )


### PR DESCRIPTION
## But de la pull request

Tant qu'un utilisateur invité n'a pas cliqué sur le lien de validation de sa création de compte reçu par mail, il n'est pas rattaché à une structure. (Non présence d'un UserOfferer)

Du coup, quand il créait son compte utilisateur, la ligne d'invitation disparaissait du BO durant ce laps de temps.

Ticket Jira : https://passculture.atlassian.net/browse/PC-25243

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques