### PR TITLE
(PC-25642)[PRO] refactor: add tracker for venue attach button 

### DIFF
--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
+import { useLocation } from 'react-router-dom'
 
 import {
   BankAccountApplicationStatus,
   BankAccountResponseModel,
 } from 'apiClient/v1'
+import { BankAccountEvents } from 'core/FirebaseEvents/constants'
+import useAnalytics from 'hooks/useAnalytics'
 import fullErrorIcon from 'icons/full-error.svg'
 import fullLinkIcon from 'icons/full-link.svg'
 import fullWaitIcon from 'icons/full-wait.svg'
@@ -17,14 +20,18 @@ interface ReimbursementBankAccountProps {
   bankAccount: BankAccountResponseModel
   venuesNotLinkedLength: number
   bankAccountsNumber: number
+  offererId?: number
 }
 
 const ReimbursementBankAccount = ({
   bankAccount,
   venuesNotLinkedLength,
   bankAccountsNumber,
+  offererId,
 }: ReimbursementBankAccountProps): JSX.Element => {
   const hasLinkedVenues = bankAccount.linkedVenues.length > 0
+  const { logEvent } = useAnalytics()
+  const location = useLocation()
 
   return (
     <div className={styles['bank-account']}>
@@ -101,7 +108,19 @@ const ReimbursementBankAccount = ({
               </>
             )}
             {!hasLinkedVenues && venuesNotLinkedLength > 0 && (
-              <Button>Rattacher</Button> // TODO: handle onClick
+              <Button
+                onClick={() => {
+                  logEvent?.(
+                    BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
+                    {
+                      from: location.pathname,
+                      offererId,
+                    }
+                  )
+                }}
+              >
+                Rattacher un lieu
+              </Button>
             )}
           </div>
         </div>

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -158,6 +158,7 @@ const BankInformations = (): JSX.Element => {
                 bankAccountsNumber={
                   selectedOffererBankAccounts?.bankAccounts.length
                 }
+                offererId={selectedOfferer?.id}
                 key={bankAccount.id}
               />
             ))}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25642

FF: WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY
Page remboursements/informations-bancaires, bouton "Rattacher un lieu"

Il faut un lieu avec un compte bancaire, avec aucun lieu de la structure rattaché à un compte bancaire.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques