### PR TITLE
(PC25879)[BO] fix: beneficiary or pro user could be modified from BO users management

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1143,9 +1143,7 @@ def get_pro_account_base_query(pro_id: int) -> BaseQuery:
 
 
 def search_backoffice_accounts(search_query: str) -> BaseQuery:
-    bo_accounts = models.User.query.outerjoin(users_models.User.backoffice_profile).filter(
-        perm_models.BackOfficeUserProfile.id.is_not(None),
-    )
+    bo_accounts = models.User.query.join(users_models.User.backoffice_profile)
 
     if not search_query:
         return bo_accounts

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1138,7 +1138,11 @@ def search_pro_account(search_query: str, *_: typing.Any) -> BaseQuery:
 
 def get_pro_account_base_query(pro_id: int) -> BaseQuery:
     return models.User.query.filter(
-        models.User.id == pro_id and (models.User.has_non_attached_pro_role.is_(True) | models.User.has_pro_role.is_(True))  # type: ignore [attr-defined]
+        models.User.id == pro_id,
+        sa.or_(
+            models.User.has_non_attached_pro_role.is_(True),  # type: ignore [attr-defined]
+            models.User.has_pro_role.is_(True),  # type: ignore [attr-defined]
+        ),
     )
 
 


### PR DESCRIPTION
We have several permissions: manage admin users, manage pro users, manage young users; admin should not be able to update any user without the appropriate permission.

Issue was reported by hunter thibaut670 using pass Culture Bug Bounty

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-25879

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques