### PR TITLE
(PC-25690)[BO] feat: add filter only validated offerer on list venues

### DIFF
--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -97,6 +97,9 @@ def _get_venues(form: forms.GetVenuesListForm) -> list[offerers_models.Venue]:
     if form.offerer.data:
         base_query = base_query.filter(offerers_models.Venue.managingOffererId.in_(form.offerer.data))
 
+    if form.only_validated_offerers.data:
+        base_query = base_query.join(offerers_models.Venue.managingOfferer).filter(offerers_models.Offerer.isValidated)
+
     if form.order.data:
         base_query = base_query.order_by(getattr(getattr(offerers_models.Venue, "id"), form.order.data)())
     # +1 to check if there are more results than requested
@@ -205,6 +208,7 @@ def render_venue_details(
 @utils.permission_required(perm_models.Permissions.MANAGE_PRO_ENTITY)
 def list_venues() -> utils.BackofficeResponse:
     form = forms.GetVenuesListForm(formdata=utils.get_query_params())
+
     if not form.validate():
         return render_template("venue/list.html", rows=[], form=form), 400
 

--- a/api/src/pcapi/routes/backoffice/venues/forms.py
+++ b/api/src/pcapi/routes/backoffice/venues/forms.py
@@ -135,6 +135,7 @@ class GetVenuesListForm(utils.PCForm):
     )
     regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     department = fields.PCSelectMultipleField("Départements", choices=area_choices)
+    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les structures validées")
     limit = fields.PCSelectField(
         "Nombre maximum",
         choices=((100, "100"), (500, "500"), (1000, "1000"), (3000, "3000")),
@@ -145,6 +146,12 @@ class GetVenuesListForm(utils.PCForm):
     order = wtforms.HiddenField(
         "order", default="desc", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("asc", "desc")))
     )
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        super().__init__(*args, **kwargs)
+        if self.is_empty():
+            # default value checked does not work in wtforms.BooleanField
+            self.only_validated_offerers.data = True
 
     def is_empty(self) -> bool:
         return not any(


### PR DESCRIPTION
## But de la pull request

Bouton : Afficher uniquement les structures validées sur la page Actions sur les lieux

Ticket Jira : 

Par défaut:
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/541c975f-0efc-41ea-a262-379ed95eabae)

Avec une recherche
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/8b989ff6-8211-4ec2-8278-f27901e03ecf)

Pas uniquement les structures validées :
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/4ba507bf-a0be-4d57-a195-fa52853638b8)


## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques