### PR TITLE
(BSR)[PRO] fix: beamer config is undefined

### DIFF
--- a/pro/src/beamer.ts
+++ b/pro/src/beamer.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+window.beamer_config = { product_id: 'vjbiYuMS52566', lazy: true }

--- a/pro/src/custom_types/window.d.ts
+++ b/pro/src/custom_types/window.d.ts
@@ -8,6 +8,7 @@ declare global {
       options?: ImageBitmapOptions
     ) => Promise<ImageBitmap>
 
+    beamer_config: Record<string, unknown>
     Beamer: {
       init: () => void
       update: (config: any) => void

--- a/pro/src/index.html
+++ b/pro/src/index.html
@@ -74,9 +74,7 @@
     <div id="root"></div>
     <noscript>passCulture Pro a besoin de JavaScript pour fonctionner</noscript>
     <script type="module" src="/index.tsx"></script>
-    <script>
-      var beamer_config = { product_id: 'vjbiYuMS52566', lazy: true }
-    </script>
+    <script type="module" src="/beamer.ts"></script>
     <script
       data-type="text/javascript"
       type="opt-in"


### PR DESCRIPTION
## But de la pull request

Hypothèse de cause (qui sera vérifiée très vite quand ce sera en prod vu qu'il y a 1000 occurrences de l'erreur par jour) : le check de CSP via hash ne marche pas dans certains cas sur Firefox (probablement un bug navigateur).

En passant par un fichier chargé via url, on évite de passer par le hash potentiellement problématique. Je compte envoyer ça en prod et si effectivement l'erreur ne se produit plus je retirerai le hash manuel dans la déclaration des CSP