### PR TITLE
(PC-25521)[PRO] feat: Format de nombre pluralize

### DIFF
--- a/pro/src/components/StocksEventList/StocksEventList.tsx
+++ b/pro/src/components/StocksEventList/StocksEventList.tsx
@@ -308,9 +308,11 @@ const StocksEventList = ({
       deletionCount: deletionCount,
     })
     notify.success(
-      deletionCount === 1
+      stocksIdToDelete.length === 1
         ? '1 date a été supprimée'
-        : `${deletionCount} dates ont été supprimées`
+        : `${new Intl.NumberFormat('fr-FR').format(
+            stocksIdToDelete.length
+          )} dates ont été supprimées`
     )
   }
 

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/OfferRemainingStockCell/OfferRemainingStockCell.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/OfferRemainingStockCell/OfferRemainingStockCell.tsx
@@ -14,15 +14,12 @@ const OfferRemainingStockCell = ({ stocks }: { stocks: Stock[] }) => {
       }
       totalRemainingStock += Number(stock.remainingQuantity)
     }
-
-    return totalRemainingStock
+    return new Intl.NumberFormat('fr-FR').format(totalRemainingStock)
   }
-
   return (
     <td className={styles['stock-column']}>
       {computeRemainingStockValue(stocks)}
     </td>
   )
 }
-
 export default OfferRemainingStockCell

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/form/onSubmit.ts
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/form/onSubmit.ts
@@ -48,15 +48,17 @@ export const onSubmit = async (
 
   // Upsert stocks if there are stocks to upsert
   if (serializedStocksToAdd.length > 0) {
-    const { isOk, payload } = await upsertStocksEventAdapter({
+    const { isOk } = await upsertStocksEventAdapter({
       offerId: offerId,
       stocks: serializedStocksToAdd,
     })
     if (isOk) {
       notify.success(
-        payload === 1
+        serializedStocksToAdd.length === 1
           ? '1 nouvelle date a été ajoutée'
-          : `${payload} nouvelles dates ont été ajoutées`
+          : `${new Intl.NumberFormat('fr-FR').format(
+              serializedStocksToAdd.length
+            )} nouvelles dates ont été ajoutées`
       )
     } else {
       notify.error(

--- a/pro/src/utils/pluralize.ts
+++ b/pro/src/utils/pluralize.ts
@@ -32,5 +32,9 @@ export const pluralize = (
   string: string,
   pluralizeWith?: string
 ): string => {
-  return `${number} ${pluralizeString(string, number, pluralizeWith)}`
+  return `${new Intl.NumberFormat('fr-FR').format(number)} ${pluralizeString(
+    string,
+    number,
+    pluralizeWith
+  )}`
 }


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25521

## But de la pull request - Ajouter un espace entre les centaines et les milliers pour : 

(https://pro.testing.passculture.team/offres?nom-ou-isbn=1000)

- le chiffre de la colonne stock;

- le nombre de dates sous le titre de l’offre;

- la vue Récap de l’offre;

- le message d’ajout ou de suppression d’occurrences (toaster).

**Mais pluralize est modifiée  pour que ça affecte tous les endroits où elle est utilisée d'un coup (37 endroits dans 13 fichiers).** 

Branche: PC-25521-wording-espace-stock

<img width="847" alt="Capture d’écran 2023-11-20 à 19 38 16" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/4514104b-487b-435f-9ed8-8aa299f8356f">


<img width="535" alt="Capture d’écran 2023-11-20 à 15 26 17" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/28a67eb2-dded-4b5e-b694-aec94ec55cfc">

<img width="1005" alt="Capture d’écran 2023-11-21 à 11 55 10" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/5baaf5cb-923b-47bc-aa6d-f056867839de">

<img width="1260" alt="Capture d’écran 2023-11-21 à 15 23 54" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/879e8f13-d19f-42fd-8e9f-7967e1c2cf75">

