### PR TITLE
(PC-25553)[PRO] refactor: turn stats into a list

### DIFF
--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames'
 import { addDays, isBefore } from 'date-fns'
-import React, { Fragment, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { api } from 'apiClient/api'
 import { DMSApplicationForEAC, DMSApplicationstatus } from 'apiClient/v1'
@@ -355,12 +355,12 @@ const Venue = ({
                   />
 
                   <div className="venue-stats">
-                    {venueStatData.map((stat) => (
-                      <Fragment key={stat.label}>
-                        <VenueStat {...stat} />
-                      </Fragment>
-                    ))}
-                    <div className="h-card-col v-add-offer-link">
+                    <ul className="venue-stats-list">
+                      {venueStatData.map((stat) => (
+                        <VenueStat {...stat} key={stat.label} />
+                      ))}
+                    </ul>
+                    <div className="v-add-offer-link">
                       <ButtonLink
                         variant={ButtonVariant.TERNARY}
                         iconPosition={IconPositionEnum.CENTER}

--- a/pro/src/pages/Home/Venues/VenueStat.scss
+++ b/pro/src/pages/Home/Venues/VenueStat.scss
@@ -4,88 +4,83 @@
 @use "styles/variables/_size.scss" as size;
 
 .venue-stats {
-  display: grid;
-  padding-top: rem.torem(24px);
-  grid-template-columns: repeat(1, 1fr);
-  grid-template-rows: repeat(5, 1fr);
+  display: flex;
+  flex-flow: column wrap;
 
-  .separator {
-    background-color: colors.$grey-medium;
-  }
-
-  .h-card-col {
-    padding: rem.torem(12px);
-    flex: 0 0 20%;
+  .venue-stats-list {
     display: flex;
-    align-items: center;
     flex-direction: column;
-    justify-content: space-between;
-    text-align: center;
-    width: 100%;
-
-    &.v-add-offer-link {
-      justify-content: center;
-
-      a {
-        display: flex;
-        align-items: center;
-        flex-direction: column;
-        gap: rem.torem(8px);
-
-        svg {
-          margin-right: 0;
-        }
+ 
+    .h-card-col {
+      padding: rem.torem(12px);
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      justify-content: space-between;
+      border-bottom: solid rem.torem(1px) colors.$grey-medium;
+      text-align: center;
+      
+      .venue-stat-count {
+        @include fonts.title3;
       }
     }
+  }
 
-    &:not(:last-child) {
-      border-bottom: solid rem.torem(1px) colors.$grey-medium;
-    }
+  .v-add-offer-link {
+    justify-content: center;
+    padding: rem.torem(12px);
 
-    .venue-stat-count {
-      @include fonts.title3;
+    a {
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      gap: rem.torem(8px);
+      text-align: center;
+
+      svg {
+        margin-right: 0;
+      }
     }
   }
 }
 
 @media (min-width: size.$mobile) {
   .venue-stats {
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(2, 1fr);
+    .venue-stats-list {
+      flex-flow: row wrap;
 
-    .h-card-col:nth-child(odd):not(:last-child) {
-      border-right: solid rem.torem(1px) colors.$grey-medium;
-    }
+      .h-card-col {
+        flex-basis: 50%;
+      }
 
-    .h-card-col:not(:last-child) {
-      border-bottom: none;
-    }
+      .h-card-col:nth-child(3), .h-card-col:nth-child(4) {
+        border-bottom: none;
+      }
 
-    .h-card-col:nth-child(1),
-    .h-card-col:nth-child(2) {
-      border-bottom: solid rem.torem(1px) colors.$grey-medium;
-    }
-
-    .v-add-offer-link {
-      grid-column: 1 / 3;
+      .h-card-col:nth-child(odd) {
+        border-right: solid rem.torem(1px) colors.$grey-medium;
+      }
     }
   }
 }
 
 @media (min-width: size.$tablet) {
   .venue-stats {
-    grid-template-columns: repeat(5, 1fr);
-    grid-template-rows: repeat(1, 1fr);
+    flex-direction: row;
     margin-bottom: rem.torem(35px);
 
-    .v-add-offer-link {
-      grid-column-start: unset;
-      grid-column-end: unset;
-    }
+    .venue-stats-list {
+      flex-basis: 80%;
 
-    .h-card-col:not(:last-child) {
-      border-bottom: none;
-      border-right: solid rem.torem(1px) colors.$grey-medium;
+      .h-card-col {
+        border-bottom: none;
+        flex-basis: 25%;
+        border-right: solid rem.torem(1px) colors.$grey-medium;
+      }
     }
+  }
+
+  .v-add-offer-link {
+    flex-basis: 20%;
   }
 }

--- a/pro/src/pages/Home/Venues/VenueStat.tsx
+++ b/pro/src/pages/Home/Venues/VenueStat.tsx
@@ -18,7 +18,7 @@ interface VenueStatProps {
 }
 
 const VenueStat = ({ count, label, link, onClick }: VenueStatProps) => (
-  <div className="h-card-col" data-testid="venue-stat">
+  <li className="h-card-col" data-testid="venue-stat">
     {
       /* istanbul ignore next: DEBT, TO FIX */ count ? (
         <div className="venue-stat-count">{count}</div>
@@ -38,7 +38,7 @@ const VenueStat = ({ count, label, link, onClick }: VenueStatProps) => (
     >
       Voir
     </ButtonLink>
-  </div>
+  </li>
 )
 
 export default VenueStat


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25553

Suite à l'audit RGAA - page d'accueil, critère 9.3  Dans chaque page web, chaque [liste](https://ara.numerique.gouv.fr/ressources/glossaire#listes) est-elle correctement structurée ?
la recommandation est de mettre les stats dans une liste

## Revue
Au niveau graphique et fonctionnel, rien ne devrait changer


<img width="887" alt="Capture d’écran 2023-11-20 à 14 30 29 (2)" src="https://github.com/pass-culture/pass-culture-main/assets/101103940/11463924-20fe-4ce1-a97a-f896075c0f3f">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques


