### PR TITLE
 (PC-25909)[API] fix: handle winter & summer time in get_filtered_stocks

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -5,6 +5,7 @@ import operator
 import typing
 
 import flask_sqlalchemy
+import pytz
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 import sqlalchemy.orm as sa_orm
@@ -758,24 +759,46 @@ def _order_stocks_by(
 
 def get_filtered_stocks(
     offer_id: int,
+    venue: offerers_models.Venue,
     date: datetime.date | None = None,
     time: datetime.time | None = None,
     price_category_id: int | None = None,
     order_by: StocksOrderedBy = StocksOrderedBy.BEGINNING_DATETIME,
     order_by_desc: bool = False,
 ) -> flask_sqlalchemy.BaseQuery:
-    query = models.Stock.query.filter(
-        models.Stock.offerId == offer_id,
-        models.Stock.isSoftDeleted == False,
+    query = (
+        models.Stock.query.join(models.Offer)
+        .join(offerers_models.Venue)
+        .filter(
+            models.Stock.offerId == offer_id,
+            models.Stock.isSoftDeleted == False,
+        )
     )
     if price_category_id is not None:
         query = query.filter(models.Stock.priceCategoryId == price_category_id)
     if date is not None:
         query = query.filter(sa.cast(models.Stock.beginningDatetime, sa.Date) == date)
     if time is not None:
+        # Transform user time input into the venue timezone
+        dt = datetime.datetime.combine(datetime.datetime.today(), time)
+        venue_timezone = pytz.timezone(venue.timezone)  # type: ignore [arg-type]
+        venue_time = dt.replace(tzinfo=pytz.utc).astimezone(venue_timezone).time()
+
         query = query.filter(
-            sa.cast(models.Stock.beginningDatetime, sa.Time) >= time.replace(second=0),
-            sa.cast(models.Stock.beginningDatetime, sa.Time) <= time.replace(second=59),
+            sa.cast(
+                sa.func.timezone(
+                    offerers_models.Venue.timezone, sa.func.timezone("UTC", models.Stock.beginningDatetime)
+                ),
+                sa.Time,
+            )
+            >= venue_time.replace(second=0),
+            sa.cast(
+                sa.func.timezone(
+                    offerers_models.Venue.timezone, sa.func.timezone("UTC", models.Stock.beginningDatetime)
+                ),
+                sa.Time,
+            )
+            <= venue_time.replace(second=59),
         )
     return _order_stocks_by(query, order_by, order_by_desc)
 

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -104,6 +104,7 @@ def get_stocks(offer_id: int, query: offers_serialize.StocksQueryModel) -> offer
             price_category_id=query.price_category_id,
             order_by=query.order_by,
             order_by_desc=query.order_by_desc,
+            venue=offer.venue,
         )
         stocks_count = filtered_stocks.count()
         filtered_and_paginated_stocks = offers_repository.get_paginated_stocks(
@@ -162,6 +163,7 @@ def delete_all_filtered_stocks(offer_id: int, body: offers_serialize.DeleteFilte
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
     filters = {
         "offer_id": offer_id,
+        "venue": offer.venue,
         "date": body.date,
         "time": body.time,
         "price_category_id": body.price_category_id,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -43,6 +43,9 @@ from pcapi.sandboxes.scripts.creators.industrial.create_industrial_thing_offers 
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_thing_products import *
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_thing_stocks import *
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_venues import *
+from pcapi.sandboxes.scripts.creators.industrial.create_industrial_venues_with_timezone import (
+    create_industrial_venues_with_timezone,
+)
 from pcapi.sandboxes.scripts.creators.industrial.create_offer_with_thousand_stocks import (
     create_offer_with_thousand_stocks,
 )
@@ -157,3 +160,5 @@ def save_industrial_sandbox() -> None:
     create_industrial_individual_offerers()
 
     create_industrial_bank_accounts()
+
+    create_industrial_venues_with_timezone()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues_with_timezone.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues_with_timezone.py
@@ -1,0 +1,63 @@
+import logging
+
+from pcapi.core.offerers import factories as offerers_factories
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_industrial_venues_with_timezone() -> None:
+    logger.info("create_industrial_venues_with_timezone")
+    offerer = offerers_factories.OffererFactory(name="Structure avec différentes timezones")
+    offerers_factories.UserOffererFactory(offerer=offerer, user__email="offerer_with_timezone@exemple.com")
+
+    # The virtual venue (so it will be on Europe/Paris)
+    offerers_factories.VenueFactory(managingOfferer=offerer, isVirtual=True, siret=None)
+
+    # America/Cayenne
+    offerers_factories.VenueFactory(
+        publicName="America/Cayenne",
+        managingOfferer=offerer,
+        timezone="America/Cayenne",
+        departementCode="973",
+        postalCode="97300",
+    )
+
+    # Indian/Reunion
+    offerers_factories.VenueFactory(
+        publicName="Indian/Reunion",
+        managingOfferer=offerer,
+        timezone="Indian/Reunion",
+        departementCode="974",
+        postalCode="97415",
+    )
+
+    # Pacific/Noumea
+    offerers_factories.VenueFactory(
+        publicName="Pacific/Noumea",
+        managingOfferer=offerer,
+        timezone="Pacific/Noumea",
+        departementCode="988",
+        postalCode="98800",
+    )
+
+    # Timezone with winter & summer time
+    # Europe/Paris
+    offerers_factories.VenueFactory(
+        publicName="Europe/Paris",
+        managingOfferer=offerer,
+        timezone="Europe/Paris",
+        departementCode="78",
+        postalCode="78220",
+    )
+
+    # America/Miquelon
+    offerers_factories.VenueFactory(
+        publicName="America/Miquelon",
+        managingOfferer=offerer,
+        timezone="America/Miquelon",
+        departementCode="975",
+        postalCode="97500",
+    )
+
+    # Pacific/Pitcairn (Clipperton) has no inhabitants, so I don't create venue for it

--- a/api/src/pcapi/workers/update_stocks_job.py
+++ b/api/src/pcapi/workers/update_stocks_job.py
@@ -8,6 +8,7 @@ from pcapi.workers.decorators import job
 def batch_delete_filtered_stocks_job(filters: dict) -> None:
     stocks = offers_repository.get_filtered_stocks(
         offer_id=filters["offer_id"],
+        venue=filters["venue"],
         date=filters["date"],
         time=filters["time"],
         price_category_id=filters["price_category_id"],

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1873,6 +1873,7 @@ class DeleteStocksTest:
         stocks = offers_repository.get_filtered_stocks(
             offer_id=offer.id,
             date=beginning_datetime.date(),
+            venue=offer.venue,
         )
         api.batch_delete_stocks(stocks)
 
@@ -1892,6 +1893,7 @@ class DeleteStocksTest:
         stocks = offers_repository.get_filtered_stocks(
             offer_id=offer.id,
             time=beginning_datetime.time(),
+            venue=offer.venue,
         )
         api.batch_delete_stocks(stocks)
 
@@ -1913,6 +1915,7 @@ class DeleteStocksTest:
         stocks = offers_repository.get_filtered_stocks(
             offer_id=offer.id,
             price_category_id=stock_1.priceCategoryId,
+            venue=offer.venue,
         )
         api.batch_delete_stocks(stocks)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25909

## Objectif du ticket

Des stocks event à la même heure mais à cheval sur l'heure d'été et l'heure d'hiver,  ne sont donc pas stockés à la même heure en UTC dans la bdd, le filtre tel qu'il était implémenté ne renvoyait donc pas tous les résultats (hélas),
 
exemple:  heure d'hiver `2024-03-30T   + 14:54  +  :00Z` heure d'été `2024-03-31T   +  13:54  +   :00Z`

le front envoie  heure + minutes en paramètres, il  l'a préalablement traduit en UTC, 
en recevant le paramètre l'api la serialize en un datetime.time object

on veut faire comprendre à la requête get_filtered_stocks, de bien nous ramener tous les stocks 

## Remarques

Je ne suis absolument pas à l'aise avec les timezone / heure d'été, et pas tellement avec le back :)
J'ai donc beaucoup tatonné jusqu'à avoir une fonction, puis des tests qui fonctionnent
(les tests étaient d'après ce que j'ai compris complètement en UTC)

bref, il est très certainement possible d'améliorer le code ou les tests, 
j'ai ***à peu près*** l'impression de tester ce qu'il faut, ça devrait être possible de refacto sereinement maintenant

et si vous avez connaissance d'une énième subtilité avec les dates/heures (une heure de la lune à Tahiti ou que sais-je), dites le maintenant ou taisez-vous jusqu'au prochain bug :) 

## Contenu du ticket

- Ajout de lieux avec timezone dans la sandbox (pour pouvoir faire des tests manuels)
- modification du filter par heure de get_filtered_stocks
-> ce que j'ai essayer de faire: comparer les dates des stocks et de l'heure reçue dans la même timezone  
- ajout de deux tests pour prouver que ça marche

## Aujourd'hui j'ai appris :

- Sur le territoire Français il ya trois timezones avec une heure d'été et une heure d'hiver : Europe/Paris, America/Miquelon et Pacific/Pitcairn
- Clipperton, sur le fuseau Pacific/Pitcairn est le seul territoire français dans le Pacifique Nord, c'est un atoll sans habitants et son lagon est apparement le seul du monde composé d'eau douce :)  Et surtout, il y aurait le trésor de John Clipperton caché dessus !

![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/ba0d4b7d-b9c0-4ab3-809e-adf7bfd1f428)



## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques