### PR TITLE
(PC-25906)[API|PRO] fix: homepage views per offer table

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -1100,8 +1100,8 @@ class IndividualOffererSubscription(PcObject, Base, Model):
 
 
 class OffererStatsData(typing.TypedDict, total=False):
-    daily_views: list[OffererViewsModel] | None
-    top_offers: list[TopOffersData] | None
+    daily_views: list[OffererViewsModel]
+    top_offers: list[TopOffersData]
 
 
 class OffererStats(PcObject, Base, Model):

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -282,7 +282,11 @@ def get_offerer_stats(offerer_id: int) -> offerers_serialize.GetOffererStatsResp
     check_user_has_access_to_offerer(current_user, offerer_id)
     stats = api.get_offerer_stats_data(offerer_id)
     if not stats:
-        return offerers_serialize.GetOffererStatsResponseModel(offererId=offerer_id, syncDate=None, jsonData=None)
+        return offerers_serialize.GetOffererStatsResponseModel(
+            offererId=offerer_id,
+            syncDate=None,
+            jsonData=offerers_serialize.OffererStatsDataModel(dailyViews=[], topOffers=[]),
+        )
     top_offers = next(el for el in stats if el.table == TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE)
     daily_offerer_views = next(el for el in stats if el.table == DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE)
     top_offers_data = top_offers.jsonData["top_offers"]

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -309,25 +309,25 @@ class TopOffersResponseData(offerers_models.TopOffersData):
         return cls(offerId=offer_id, offerName=offer.name, image=offer.image, numberOfViews=number_of_views)
 
 
-class OffererStatsData(BaseModel):
-    topOffers: list[TopOffersResponseData] | None
-    dailyViews: list[offerers_models.OffererViewsModel] | None
+class OffererStatsDataModel(BaseModel):
+    topOffers: list[TopOffersResponseData]
+    dailyViews: list[offerers_models.OffererViewsModel]
 
 
 class GetOffererStatsResponseModel(BaseModel):
     offererId: int
     syncDate: datetime | None
-    jsonData: OffererStatsData | None
+    jsonData: OffererStatsDataModel
 
     @classmethod
     def build(
         cls,
         offerer_id: int,
         syncDate: datetime,
-        dailyViews: list[offerers_models.OffererViewsModel] | None,
-        topOffers: list[offerers_models.TopOffersData] | None,
+        dailyViews: list[offerers_models.OffererViewsModel],
+        topOffers: list[offerers_models.TopOffersData],
     ) -> "GetOffererStatsResponseModel":
-        top_offers_response = None
+        top_offers_response = []
         if topOffers:
             top_offers_response = [
                 TopOffersResponseData.build(topOffer["offerId"], topOffer["numberOfViews"]) for topOffer in topOffers  # type: ignore
@@ -336,7 +336,7 @@ class GetOffererStatsResponseModel(BaseModel):
         return cls(
             offererId=offerer_id,
             syncDate=syncDate,
-            jsonData=OffererStatsData(topOffers=top_offers_response, dailyViews=dailyViews),
+            jsonData=OffererStatsDataModel(topOffers=top_offers_response, dailyViews=dailyViews),
         )
 
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerers_stats.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerers_stats.py
@@ -1,7 +1,6 @@
-from datetime import datetime
-from datetime import timedelta
+import datetime
 import logging
-from random import randint
+import random
 
 from pcapi.connectors.big_query.queries.offerer_stats import DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE
 from pcapi.connectors.big_query.queries.offerer_stats import TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE
@@ -12,39 +11,63 @@ import pcapi.core.offers.models as offers_models
 
 logger = logging.getLogger(__name__)
 
+randint_10_000 = random.randint(1, 10_000)
+
+offer_count_cases = [
+    [0, 0, 0, False],
+    [0, 0, 0, True],
+    [0, False],
+    [0, True],
+    [0, 0, True],
+    [randint_10_000, 0, 0, True],
+    [randint_10_000, randint_10_000, 0, True],
+    [randint_10_000, randint_10_000, randint_10_000, True],
+    [randint_10_000, True],
+]
+
+
+def create_top_30_days_offerers_stats(
+    offerer: offerers_models.Offerer, offers: list[offers_models.Offer], count: list[int]
+) -> None:
+    top_3_offers_stats = []
+    for el, numberOfViews in zip(offers, sorted(count, reverse=True)):
+        top_3_offers_stats.append(offerers_models.TopOffersData(offerId=el.id, numberOfViews=numberOfViews))
+
+    offerers_factories.OffererStatsFactory(
+        offerer=offerer,
+        table=TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE,
+        jsonData=offerers_models.OffererStatsData(top_offers=top_3_offers_stats),
+    )
+
+
+def create_180_days_view_stats(offerer: offerers_models.Offerer, has_view: int) -> None:
+    daily_views_stats = []
+    if has_view:
+        views_count = random.randint(0, 1000)
+        for i in range(180):
+            views_count += random.randint(0, 1000) * random.randint(0, 10)
+            daily_views_stats.append(
+                offerers_models.OffererViewsModel(
+                    eventDate=datetime.datetime.utcnow().date() - datetime.timedelta(days=180 - i),
+                    numberOfViews=views_count,
+                )
+            )
+    offerers_factories.OffererStatsFactory(
+        offerer=offerer,
+        table=DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
+        jsonData=offerers_models.OffererStatsData(daily_views=daily_views_stats),
+    )
+
 
 def create_industrial_offerers_stats(
     offerers_by_name: dict[str, offerers_models.Offerer],
     event_offers_by_name: dict[str, offers_models.Offer],
 ) -> None:
-    for _, offerer in offerers_by_name.items():
-        # Create offerer daily views stats
-        daily_views_stats = []
-        views_count = randint(0, 1000)
-        for i in range(180):
-            views_count += randint(0, 1000) * randint(0, 10)
-            daily_views_stats.append(
-                offerers_models.OffererViewsModel(
-                    eventDate=datetime.utcnow().date() - timedelta(days=180 - i),
-                    numberOfViews=views_count,
-                )
-            )
-        offerers_factories.OffererStatsFactory(
-            offerer=offerer,
-            table=DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
-            jsonData=offerers_models.OffererStatsData(daily_views=daily_views_stats),
-        )
-
-        # Create offerer Top 3 offers stats
-        event_offers_generator = list(
-            el for el in event_offers_by_name.values() if el.venue.managingOffererId == offerer.id
-        )
-        top_3_offers_stats = []
-        for el in event_offers_generator[:3]:
-            top_3_offers_stats.append(offerers_models.TopOffersData(offerId=el.id, numberOfViews=el.id * 100))
-
-        offerers_factories.OffererStatsFactory(
-            offerer=offerer,
-            table=TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE,
-            jsonData=offerers_models.OffererStatsData(top_offers=top_3_offers_stats),
-        )
+    offerer_list = list(offerers_by_name.values())
+    # Create different cases for the 9 first offerers
+    # The 10th offerer whill have no data
+    for index, case in enumerate(offer_count_cases):
+        offerer = offerer_list[index]
+        offers = list(el for el in event_offers_by_name.values() if el.venue.managingOffererId == offerer.id)
+        create_top_30_days_offerers_stats(offerer, offers, case[:-1])
+        create_180_days_view_stats(offerer, case[-1])

--- a/api/tests/core/external/offerer_stats_test.py
+++ b/api/tests/core/external/offerer_stats_test.py
@@ -105,7 +105,6 @@ class OffererStatsTest:
             ),
             iter(
                 [
-                    {"offerId": offer1.id, "numberOfViews": 12},
                     {"offerId": offer2.id, "numberOfViews": 10},
                     {"offerId": offer3.id, "numberOfViews": 8},
                 ]
@@ -132,7 +131,42 @@ class OffererStatsTest:
             OffererStats.table == TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE,
         ).one()
         assert offerer_top_offers.jsonData["top_offers"] == [
-            {"offerId": offer1.id, "numberOfViews": 12},
             {"offerId": offer2.id, "numberOfViews": 10},
             {"offerId": offer3.id, "numberOfViews": 8},
+            {"offerId": offer1.id, "numberOfViews": 0},
+        ]
+
+    @patch("pcapi.connectors.big_query.TestingBackend.run_query")
+    def test_get_no_offerer_stats_data(self, mock_run_query_with_params):
+        offerer = OffererFactory()
+        venue = VenueFactory(managingOfferer=offerer)
+        offer1 = OfferFactory(venue=venue)
+        offer2 = OfferFactory(venue=venue)
+        offer3 = OfferFactory(venue=venue)
+
+        mock_run_query_with_params.side_effect = [
+            iter([]),
+            iter([]),
+        ]
+
+        assert OffererStats.query.count() == 0
+
+        api.get_offerer_stats_data(offerer.id)
+
+        # Check that the stats have been created
+
+        offerer_global_stats = OffererStats.query.filter(
+            OffererStats.offererId == offerer.id,
+            OffererStats.table == DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
+        ).one()
+        assert offerer_global_stats.jsonData["daily_views"] == []
+
+        offerer_top_offers = OffererStats.query.filter(
+            OffererStats.offererId == offerer.id,
+            OffererStats.table == TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE,
+        ).one()
+        assert offerer_top_offers.jsonData["top_offers"] == [
+            {"offerId": offer3.id, "numberOfViews": 0},
+            {"offerId": offer2.id, "numberOfViews": 0},
+            {"offerId": offer1.id, "numberOfViews": 0},
         ]

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -153,7 +153,7 @@ export type { OffererApiKey } from './models/OffererApiKey';
 export { OffererMemberStatus } from './models/OffererMemberStatus';
 export type { OffererReimbursementPointListResponseModel } from './models/OffererReimbursementPointListResponseModel';
 export type { OffererReimbursementPointResponseModel } from './models/OffererReimbursementPointResponseModel';
-export type { OffererStatsData } from './models/OffererStatsData';
+export type { OffererStatsDataModel } from './models/OffererStatsDataModel';
 export type { OffererStatsResponseModel } from './models/OffererStatsResponseModel';
 export type { OffererViewsModel } from './models/OffererViewsModel';
 export type { OfferImage } from './models/OfferImage';

--- a/pro/src/apiClient/v1/models/GetOffererStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererStatsResponseModel.ts
@@ -3,10 +3,10 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { OffererStatsData } from './OffererStatsData';
+import type { OffererStatsDataModel } from './OffererStatsDataModel';
 
 export type GetOffererStatsResponseModel = {
-  jsonData?: OffererStatsData | null;
+  jsonData: OffererStatsDataModel;
   offererId: number;
   syncDate?: string | null;
 };

--- a/pro/src/apiClient/v1/models/OffererStatsDataModel.ts
+++ b/pro/src/apiClient/v1/models/OffererStatsDataModel.ts
@@ -6,8 +6,8 @@
 import type { OffererViewsModel } from './OffererViewsModel';
 import type { TopOffersResponseData } from './TopOffersResponseData';
 
-export type OffererStatsData = {
-  dailyViews?: Array<OffererViewsModel> | null;
-  topOffers?: Array<TopOffersResponseData> | null;
+export type OffererStatsDataModel = {
+  dailyViews: Array<OffererViewsModel>;
+  topOffers: Array<TopOffersResponseData>;
 };
 

--- a/pro/src/pages/Home/StatisticsDashboard/MostViewedOffers.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/MostViewedOffers.tsx
@@ -16,7 +16,9 @@ export const MostViewedOffers = ({
   topOffers,
   dailyViews,
 }: MostViewedOffersProps) => {
-  const viewsToday = dailyViews[dailyViews.length - 1].numberOfViews
+  const viewsToday = dailyViews.length
+    ? dailyViews[dailyViews.length - 1].numberOfViews
+    : 0
   const last30daysViews =
     dailyViews.length >= 30
       ? viewsToday - dailyViews[dailyViews.length - 30].numberOfViews

--- a/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
@@ -65,7 +65,8 @@ export const StatisticsDashboard = ({ offerer }: StatisticsDashboardProps) => {
       {!isLoading && (
         <div className="h-card">
           <div className="h-card-inner">
-            {stats?.jsonData?.topOffers && stats.jsonData.dailyViews ? (
+            {stats?.jsonData.topOffers?.length ||
+            stats?.jsonData.dailyViews?.length ? (
               <div className={styles['data-container']}>
                 <MostViewedOffers
                   topOffers={stats.jsonData.topOffers}

--- a/pro/src/pages/Home/StatisticsDashboard/__specs__/StatisticsDashboard.spec.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/__specs__/StatisticsDashboard.spec.tsx
@@ -29,7 +29,7 @@ const renderStatisticsDashboard = (
 describe('StatisticsDashboard', () => {
   it('should render empty state when no statistics', async () => {
     vi.spyOn(api, 'getOffererStats').mockResolvedValueOnce({
-      jsonData: null,
+      jsonData: { dailyViews: [], topOffers: [] },
       syncDate: null,
       offererId: 1,
     })


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25906

Fill missing data for offerer with no views on their offers. This query will be executed at most once a day for an offerer.
For offerer without data in bigquery, it took around 0.3s.

I also changed the serialization to be more clear: 
if lastSync date is None there has never been a sync
if lastSync > 24h a new sync will be done
if lastSync < 24h no sync will be done for now


if dailyViews and topOffers are empty arrays, it means there is nothing to display (only the lastSync param should be used to know the sync state)