### PR TITLE
(PC-25636)[PRO] breadcrumb component adage

### DIFF
--- a/pro/src/components/Breadcrumb/Breadcrumb.module.scss
+++ b/pro/src/components/Breadcrumb/Breadcrumb.module.scss
@@ -1,0 +1,41 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.breadcrumb {
+  &-list {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: rem.torem(8px);
+    flex-wrap: wrap;
+
+    &-item {
+      display: flex;
+      align-items: center;
+      gap: rem.torem(8px);
+
+      &-arrow {
+        stroke: currentcolor;
+        stroke-width: 3px;
+      }
+
+      &-link {
+        @include fonts.caption;
+
+        display: inline-flex;
+        align-items: center;
+        white-space: nowrap;
+        text-decoration: underline;
+
+        &[aria-current="page"] {
+          color: inherit;
+          text-decoration: unset;
+        }
+
+        &-icon {
+          margin-right: rem.torem(4px);
+        }
+      }
+    }
+  }
+}

--- a/pro/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/pro/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,61 @@
+import rightIcon from 'icons/stroke-right.svg'
+import { ButtonLink } from 'ui-kit'
+import { ButtonLinkProps } from 'ui-kit/Button/ButtonLink'
+import { ButtonVariant } from 'ui-kit/Button/types'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+
+import styles from './Breadcrumb.module.scss'
+
+export type Crumb = {
+  title: string
+  link: ButtonLinkProps['link']
+  icon?: string
+}
+
+type BreadcrumbProps = {
+  crumbs: Crumb[]
+}
+
+export default function Breadcrumb({ crumbs }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Fil d'ariane" className={styles['breadcrumb']}>
+      <ol className={styles['breadcrumb-list']}>
+        {crumbs.map((crumb, i) => {
+          const isLast = i === crumbs.length - 1
+          return (
+            <li className={styles['breadcrumb-list-item']} key={crumb.link.to}>
+              <ButtonLink
+                link={{
+                  ...crumb.link,
+                  'aria-current': isLast ? 'page' : undefined,
+                }}
+                className={styles['breadcrumb-list-item-link']}
+                variant={ButtonVariant.QUATERNARYPINK}
+              >
+                <>
+                  {crumb.icon && (
+                    <SvgIcon
+                      src={crumb.icon}
+                      alt=""
+                      width="16"
+                      className={styles['breadcrumb-list-item-link-icon']}
+                    />
+                  )}
+                  {crumb.title}
+                </>
+              </ButtonLink>
+              {!isLast && (
+                <SvgIcon
+                  alt=""
+                  width="12"
+                  src={rightIcon}
+                  className={styles['breadcrumb-list-item-arrow']}
+                />
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
+++ b/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import Breadcrumb, { Crumb } from '../Breadcrumb'
+
+const crumbs: Crumb[] = [
+  { title: 'Link 1', link: { to: './link1', isExternal: false } },
+  {
+    title: 'Link 2',
+    link: { to: './link2', isExternal: false },
+    icon: 'icon_url',
+  },
+  { title: 'Link 3', link: { to: './link3', isExternal: false } },
+]
+
+describe('Breadcrumb', () => {
+  it('should display a navigation with a list of links', () => {
+    renderWithProviders(<Breadcrumb crumbs={crumbs} />)
+
+    expect(
+      screen.getByRole('navigation', { name: "Fil d'ariane" })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Link 1' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Link 3' })).toBeInTheDocument()
+  })
+
+  it('should announce the last link as the current page for assistive technologies', () => {
+    renderWithProviders(<Breadcrumb crumbs={crumbs} />)
+
+    expect(screen.getByRole('link', { name: 'Link 2' })).not.toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+    expect(screen.getByRole('link', { name: 'Link 3' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavorites.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavorites.tsx
@@ -31,7 +31,6 @@ export const OffersFavorites = () => {
         setFavoriteOffers(response.payload)
       })
     }
-
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchFavorites()
   }, [])
@@ -58,15 +57,16 @@ export const OffersFavorites = () => {
         <ul className={styles['favorite-list']}>
           {favoriteOffers.map((offer, i) => {
             return (
-              <Offer
-                offer={offer}
-                queryId=""
-                position={i}
-                key={offer.id}
-                afterFavoriteChange={(isFavorite) => {
-                  favoriteChangeHandler(isFavorite, offer.id)
-                }}
-              ></Offer>
+              <li key={offer.id} data-testid="offer-listitem">
+                <Offer
+                  offer={offer}
+                  queryId=""
+                  position={i}
+                  afterFavoriteChange={(isFavorite) => {
+                    favoriteChangeHandler(isFavorite, offer.id)
+                  }}
+                ></Offer>
+              </li>
             )
           })}
         </ul>

--- a/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.module.scss
@@ -1,6 +1,9 @@
 @use "styles/mixins/_rem.scss" as rem;
 
+.offers-info {
+  padding: rem.torem(32px) rem.torem(24px);
 
-.container {
-    margin-top: rem.torem(32px)
+  &-breadcrumb {
+    margin-bottom: rem.torem(32px);
+  }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.tsx
@@ -1,4 +1,8 @@
 import React from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+import Breadcrumb from 'components/Breadcrumb/Breadcrumb'
+import strokePassIcon from 'icons/stroke-pass.svg'
 
 import { mockOffer } from '../AdageDiscovery/AdageDiscovery'
 import Offer from '../OffersInstantSearch/OffersSearch/Offers/Offer'
@@ -6,8 +10,32 @@ import Offer from '../OffersInstantSearch/OffersSearch/Offers/Offer'
 import styles from './OffersInfos.module.scss'
 
 export const OffersInfos = () => {
+  const [searchParams] = useSearchParams()
+  const adageAuthToken = searchParams.get('token')
+
   return (
-    <div className={styles['container']}>
+    <div className={styles['offers-info']}>
+      <div className={styles['offers-info-breadcrumb']}>
+        <Breadcrumb
+          crumbs={[
+            {
+              title: 'Découvrir',
+              link: {
+                isExternal: false,
+                to: `/adage-iframe/decouverte?token=${adageAuthToken}`,
+              },
+              icon: strokePassIcon,
+            },
+            {
+              title: mockOffer.name,
+              link: {
+                isExternal: true,
+                to: '#',
+              },
+            },
+          ]}
+        />
+      </div>
       <Offer offer={mockOffer} position={0} queryId="" openDetails={true} />
     </div>
   )

--- a/pro/src/pages/AdageIframe/app/components/OffersInfos/__specs__/OffersInfos.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInfos/__specs__/OffersInfos.spec.tsx
@@ -18,6 +18,14 @@ describe('OffersInfos', () => {
   it('should display offers informations', () => {
     renderOffersInfos()
 
-    expect(screen.getByText('Une chouette à la mer')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Une chouette à la mer' })
+    ).toBeInTheDocument()
+  })
+
+  it('should display the breadcrumb with a link back to the discovery home', () => {
+    renderOffersInfos()
+
+    expect(screen.getByRole('link', { name: 'Découvrir' })).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -93,7 +93,7 @@ const Offer = ({
   const venueAndOffererName = getOfferVenueAndOffererName(offer.venue)
 
   return (
-    <li className={style['offer']} data-testid="offer-listitem">
+    <div className={style['offer']}>
       {offer.venue.coordinates.latitude &&
         offer.venue.coordinates.longitude &&
         (adageUser.lat || adageUser.lat === 0) &&
@@ -260,7 +260,7 @@ const Offer = ({
           {displayDetails && <OfferDetails offer={offer} />}
         </div>
       </div>
-    </li>
+    </div>
   )
 }
 export default Offer

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -142,7 +142,10 @@ export const Offers = ({
       )}
       <ul className={styles['offers-list']}>
         {offers.map((offer, index) => (
-          <div key={`${offer.isTemplate ? 'T' : ''}${offer.id}`}>
+          <li
+            key={`${offer.isTemplate ? 'T' : ''}${offer.id}`}
+            data-testid="offer-listitem"
+          >
             <Offer
               offer={offer}
               position={index}
@@ -159,7 +162,7 @@ export const Offers = ({
             {index === 1 && showSurveySatisfaction && (
               <SurveySatisfaction queryId={results?.queryID} />
             )}
-          </div>
+          </li>
         ))}
         {displayShowMore && (
           <div className={styles['offers-load-more']}>

--- a/pro/src/ui-kit/Button/ButtonLink.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.tsx
@@ -14,6 +14,7 @@ export type LinkProps = {
   rel?: string
   target?: string
   'aria-label'?: string
+  'aria-current'?: 'page'
   type?: string
   download?: boolean
 }
@@ -127,6 +128,7 @@ const ButtonLink = ({
       to={absoluteUrl}
       {...disabled}
       aria-label={linkProps['aria-label']}
+      aria-current={linkProps['aria-current']}
     >
       {body}
     </Link>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25636

**FF à activer**
- WIP_ENABLE_DISCOVERY
- Aller sur adage et entrer dans l'url: `.../adage-iframe/decouverte/offre/1?token=...` pour afficher une offre qui implémente le fil d'Ariane

**Objectif**
Créer un nouveau component `Breadcrumb.tsx` qui affiche un fil d'Ariane, et l'implémenter dans les pages info des offres Adage. Le 2ème commit corrige la structure de les la liste des offres adage pour que on ait ul > li (et pas de li quand on n'a pas de liste).

<img width="751" alt="Capture d’écran 2023-11-21 à 16 39 33" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/0ef253b9-adb6-44c1-a498-f3585c5809e4">
<img width="686" alt="Capture d’écran 2023-11-21 à 16 39 52" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/566726a5-6840-4b78-b777-9b374076e852">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques