### PR TITLE
(BSR)[PRO] chore: Spell it "évènement", not "événement"

### DIFF
--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -25,8 +25,8 @@ class BaseBookingListForm(FlaskForm):
         max_date=datetime.date.today(),
         reset_to_blank=True,
     )
-    event_from_date = fields.PCDateField("Événement du", validators=(wtforms.validators.Optional(),))
-    event_to_date = fields.PCDateField("Événement jusqu'au", validators=(wtforms.validators.Optional(),))
+    event_from_date = fields.PCDateField("Évènement du", validators=(wtforms.validators.Optional(),))
+    event_to_date = fields.PCDateField("Évènement jusqu'au", validators=(wtforms.validators.Optional(),))
     limit = fields.PCSelectField(
         "Nombre maximum",
         choices=((20, "20"), (100, "100"), (500, "500"), (1000, "1000")),

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -57,7 +57,7 @@
               <th scope="col">ID offre</th>
               <th scope="col">Montant</th>
               <th scope="col">Statut</th>
-              <th scope="col">Événement comptable</th>
+              <th scope="col">Évènement comptable</th>
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
               <th scope="col">Structure</th>

--- a/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
@@ -84,7 +84,7 @@
               <th scope="col">Stock</th>
               <th scope="col">Montant</th>
               <th scope="col">Statut</th>
-              <th scope="col">Événement comptable</th>
+              <th scope="col">Évènement comptable</th>
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
               <th scope="col">Structure</th>

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferLocationSection/CollectiveOfferLocationSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferLocationSection/CollectiveOfferLocationSection.tsx
@@ -30,13 +30,13 @@ export default function CollectiveOfferLocationSection({
   }
 
   return (
-    <SummaryLayout.SubSection title="Lieu de l'événement">
+    <SummaryLayout.SubSection title="Lieu de l'évènement">
       <SummaryLayout.Row
         description={formatOfferEventAddress(offer.offerVenue, venue)}
       />
       {interventionAreas && (
         <SummaryLayout.Row
-          title="Zone de mobilité pour l'événement"
+          title="Zone de mobilité pour l'évènement"
           description={interventionAreas}
         />
       )}

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferLocationSection/__specs__/CollectiveOfferLocationSection.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferLocationSection/__specs__/CollectiveOfferLocationSection.spec.tsx
@@ -42,7 +42,7 @@ describe('CollectiveOfferLocationSection', () => {
     const loadingMessage = screen.queryByText(/Chargement en cours/)
     await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
 
-    expect(await screen.findByText("Lieu de l'événement")).toBeInTheDocument()
+    expect(await screen.findByText("Lieu de l'évènement")).toBeInTheDocument()
     expect(
       screen.getByText('Dans l’établissement scolaire')
     ).toBeInTheDocument()


### PR DESCRIPTION
Both forms are correct but we should use one consistently, not both.

See 55d5298c3207044ae78e6f65f2db0e14cfbb3780 and 206bede290a1a3135119c6c6eeb05be21f6b3247 for precedents.