### PR TITLE
(PC-25588)[API] feat: add account creation through sso

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 d42246a7f9ba (pre) (head)
-197afaebf455 (post) (head)
+d158e4b24ff2 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231123T163324_d158e4b24ff2_alter_user_nullable_password.py
+++ b/api/src/pcapi/alembic/versions/20231123T163324_d158e4b24ff2_alter_user_nullable_password.py
@@ -1,0 +1,45 @@
+"""
+Make user password nullable.
+Add not null password or existing single sign-on trigger check.
+"""
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "d158e4b24ff2"
+down_revision = "197afaebf455"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("user", "password", existing_type=postgresql.BYTEA(), nullable=True)
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION ensure_password_or_sso_exists()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF NEW.password IS NULL THEN
+                IF NOT EXISTS (SELECT 1 FROM single_sign_on WHERE "userId" = NEW.id) THEN
+                    RAISE EXCEPTION 'missingLoginMethod' USING HINT = 'User must have either a password or a single sign-on';
+                END IF;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        DROP TRIGGER IF EXISTS ensure_password_or_sso_exists ON "user";
+        CREATE CONSTRAINT TRIGGER ensure_password_or_sso_exists
+        AFTER INSERT OR UPDATE OF password ON "user"
+        DEFERRABLE INITIALLY DEFERRED
+        FOR EACH ROW EXECUTE PROCEDURE ensure_password_or_sso_exists();
+        """
+    )
+
+
+def downgrade() -> None:
+    op.alter_column("user", "password", existing_type=postgresql.BYTEA(), nullable=False)
+    op.execute('drop trigger if exists ensure_password_or_sso_exists on "user"')
+    op.execute("drop function if exists ensure_password_or_sso_exists")

--- a/api/src/pcapi/connectors/google_oauth.py
+++ b/api/src/pcapi/connectors/google_oauth.py
@@ -1,0 +1,20 @@
+from flask import request
+import pydantic.v1 as pydantic_v1
+
+from pcapi.flask_app import oauth
+from pcapi.routes.serialization import ConfiguredBaseModel
+
+
+class GoogleUser(ConfiguredBaseModel):
+    sub: str
+    email: str
+    email_verified: bool
+
+
+def get_google_user(authorization_code: str) -> GoogleUser:
+    # postmessage is needed when the app uses a popup to fetch the authorization code
+    # see https://stackoverflow.com/questions/71968377
+    redirect_uri = "postmessage" if request.headers.get("platform") == "web" else None
+    token = oauth.google.fetch_access_token(code=authorization_code, redirect_uri=redirect_uri)
+    google_user = pydantic_v1.parse_obj_as(GoogleUser, oauth.google.parse_id_token(token))
+    return google_user

--- a/api/src/pcapi/core/users/exceptions.py
+++ b/api/src/pcapi/core/users/exceptions.py
@@ -91,3 +91,7 @@ class ExpiredToken(InvalidToken):
 
 class UserGenerationForbiddenException(Exception):
     pass
+
+
+class MissingLoginMethod(Exception):
+    pass

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -102,6 +102,7 @@ def clean_all_database(*args: typing.Any, **kwargs: typing.Any) -> None:
     users_models.Token.query.delete()
     offers_models.OfferValidationSubRule.query.delete()
     offers_models.OfferValidationRule.query.delete()
+    users_models.SingleSignOn.query.delete()
     users_models.User.query.delete()
     users_models.UserSession.query.delete()
     providers_models.Provider.query.delete()

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -38,9 +38,7 @@ class TrustedDevice(BaseModel):
         anystr_strip_whitespace = True
 
 
-class AccountRequest(BaseModel):
-    email: str
-    password: str
+class BaseAccountRequest(BaseModel):
     birthdate: datetime.date
     marketing_email_subscription: bool | None = False
     token: str
@@ -51,6 +49,15 @@ class AccountRequest(BaseModel):
 
     class Config:
         alias_generator = to_camel
+
+
+class AccountRequest(BaseAccountRequest):
+    email: str
+    password: str
+
+
+class GoogleAccountRequest(BaseAccountRequest):
+    authorization_code: str
 
 
 class NotificationSubscriptions(BaseModel):

--- a/api/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/api/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -53,9 +53,3 @@ class ValidateEmailResponse(ConfiguredBaseModel):
 
 class GoogleSigninRequest(ConfiguredBaseModel):
     authorization_code: str
-
-
-class GoogleUser(ConfiguredBaseModel):
-    sub: str
-    email: str
-    email_verified: bool

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -409,12 +409,12 @@ class AccountCreationTest:
         assert email_validation_token_exists
 
     @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
-    def test_too_young_account_creation(self, mocked_check_recaptcha_token_is_valid, client, app):
+    def test_too_young_account_creation(self, mocked_check_recaptcha_token_is_valid, client):
         assert users_models.User.query.first() is None
         data = {
             "email": "John.doe@example.com",
             "password": "Aazflrifaoi6@",
-            "birthdate": (datetime.utcnow() - relativedelta(years=15)).date(),
+            "birthdate": (datetime.utcnow() - relativedelta(years=15, days=-1)).date().isoformat(),
             "notifications": True,
             "token": "gnagna",
             "marketingEmailSubscription": True,
@@ -422,6 +422,7 @@ class AccountCreationTest:
 
         response = client.post("/native/v1/account", json=data)
         assert response.status_code == 400
+        assert "dateOfBirth" in response.json
         assert not push_testing.requests
 
     @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -13,6 +13,7 @@ import pytest
 from pcapi import settings
 from pcapi.connectors.dms import api as api_dms
 from pcapi.connectors.dms import models as dms_models
+from pcapi.connectors.google_oauth import GoogleUser
 from pcapi.core import token as token_utils
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.history import factories as history_factories
@@ -236,33 +237,19 @@ class SigninTest:
 
 
 class SSOSigninTest:
-    valid_user = {
-        "iss": "https://accounts.google.com",
-        "azp": "427121120704-5r71oe05dt37jlsbg2d19hmhtk79bqat.apps.googleusercontent.com",
-        "aud": "427121120704-5r71oe05dt37jlsbg2d19hmhtk79bqat.apps.googleusercontent.com",
-        "sub": "100428144463745704968",
-        "hd": "passculture.app",
-        "email": "docteur.cuesta@passculture.app",
-        "email_verified": True,
-        "at_hash": "i8lKXlAVDYjKc6Krwsledg",
-        "nonce": "k5Iy6eENx1AsYy20W405",
-        "name": "Docteur Cuesta",
-        "picture": "https://lh3.googleusercontent.com/a/ACg8ocKymVDJZjhFOcIEmgMMKs8h5hnzP3R6K64Qz3m4eEtf=s96-c",
-        "given_name": "Docteur",
-        "family_name": "Cuesta",
-        "locale": "fr",
-        "iat": 1697811815,
-        "exp": 1697815415,
-    }
+    valid_google_user = GoogleUser(
+        sub="100428144463745704968",
+        email="docteur.cuesta@passculture.app",
+        email_verified=True,
+    )
 
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_account_is_active(self, _mock_fetch_access_token, mock_parse_id_token, client, caplog):
+    def test_account_is_active(self, mocked_google_oauth, client, caplog):
         users_factories.SingleSignOnFactory(
-            ssoUserId=self.valid_user["sub"], user__email=self.valid_user["email"], user__isActive=True
+            ssoUserId=self.valid_google_user.sub, user__email=self.valid_google_user.email, user__isActive=True
         )
-        mock_parse_id_token.return_value = self.valid_user
+        mocked_google_oauth.return_value = self.valid_google_user
 
         with caplog.at_level(logging.INFO):
             response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
@@ -271,25 +258,23 @@ class SSOSigninTest:
         assert response.json["accountState"] == AccountState.ACTIVE.value
         assert "Successful authentication attempt" in caplog.messages
 
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_account_is_deleted(self, _mock_fetch_access_token, mock_parse_id_token, client):
-        user = users_factories.UserFactory(email=self.valid_user["email"], isActive=False)
-        users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_user["sub"])
+    def test_account_is_deleted(self, mocked_google_oauth, client):
+        user = users_factories.UserFactory(email=self.valid_google_user.email, isActive=False)
+        users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_google_user.sub)
         history_factories.SuspendedUserActionHistoryFactory(user=user, reason=users_constants.SuspensionReason.DELETED)
-        mock_parse_id_token.return_value = self.valid_user
+        mocked_google_oauth.return_value = self.valid_google_user
 
         response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
 
         assert response.status_code == 400
         assert response.json["code"] == "ACCOUNT_DELETED"
 
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_account_does_not_exist(self, _mock_fetch_access_token, mock_parse_id_token, client, caplog):
-        mock_parse_id_token.return_value = self.valid_user
+    def test_account_does_not_exist(self, mocked_google_oauth, client, caplog):
+        mocked_google_oauth.return_value = self.valid_google_user
 
         with caplog.at_level(logging.INFO):
             response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
@@ -298,72 +283,63 @@ class SSOSigninTest:
         assert response.json == {"email": "unknown"}
         assert "Failed authentication attempt" in caplog.messages
 
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_single_sign_on_ignores_email_if_found(self, _mock_fetch_access_token, mock_parse_id_token, client):
+    def test_single_sign_on_ignores_email_if_found(self, mocked_google_oauth, client):
         user = users_factories.UserFactory(email="another@email.com", isActive=True)
-        users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_user["sub"])
-        mock_parse_id_token.return_value = self.valid_user
+        users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_google_user.sub)
+        mocked_google_oauth.return_value = self.valid_google_user
 
         response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
 
         assert response.status_code == 200
 
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_single_sign_on_inserts_sso_method_if_email_found(
-        self, _mock_fetch_access_token, mock_parse_id_token, client
-    ):
-        user = users_factories.UserFactory(email=self.valid_user["email"], isActive=True)
-        mock_parse_id_token.return_value = self.valid_user
+    def test_single_sign_on_inserts_sso_method_if_email_found(self, mocked_google_oauth, client):
+        user = users_factories.UserFactory(email=self.valid_google_user.email, isActive=True)
+        mocked_google_oauth.return_value = self.valid_google_user
 
         response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
 
         assert response.status_code == 200
 
         created_sso = SingleSignOn.query.filter(SingleSignOn.user == user, SingleSignOn.ssoProvider == "google").one()
-        assert created_sso.ssoUserId == self.valid_user["sub"]
+        assert created_sso.ssoUserId == self.valid_google_user.sub
 
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_single_sign_on_raises_if_email_not_validated(self, _mock_fetch_access_token, mock_parse_id_token, client):
-        users_factories.UserFactory(email=self.valid_user["email"], isActive=True)
-        unvalidated_email_google_user = copy.deepcopy(self.valid_user)
-        unvalidated_email_google_user["email_verified"] = False
-        mock_parse_id_token.return_value = unvalidated_email_google_user
+    def test_single_sign_on_raises_if_email_not_validated(self, mocked_google_oauth, client):
+        users_factories.UserFactory(email=self.valid_google_user.email, isActive=True)
+        unvalidated_email_google_user = copy.deepcopy(self.valid_google_user)
+        unvalidated_email_google_user.email_verified = False
+        mocked_google_oauth.return_value = unvalidated_email_google_user
 
         response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
 
         assert response.status_code == 400
 
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_single_sign_on_does_not_duplicate_ssos(self, _mock_fetch_access_token, mock_parse_id_token, client):
-        single_sign_on = users_factories.SingleSignOnFactory(ssoUserId=self.valid_user["sub"])
-        mock_parse_id_token.return_value = self.valid_user
+    def test_single_sign_on_does_not_duplicate_ssos(self, mocked_google_oauth, client):
+        single_sign_on = users_factories.SingleSignOnFactory(ssoUserId=self.valid_google_user.sub)
+        mocked_google_oauth.return_value = self.valid_google_user
 
         response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
 
         assert response.status_code == 200
         assert SingleSignOn.query.filter(SingleSignOn.user == single_sign_on.user).count() == 1
 
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.parse_id_token")
-    @patch("pcapi.routes.native.v1.authentication.oauth.google.fetch_access_token")
+    @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_single_sign_on_raises_if_another_sso_is_already_configured(
-        self, _mock_fetch_access_token, mock_parse_id_token, client
-    ):
-        users_factories.SingleSignOnFactory(user__email=self.valid_user["email"])
-        mock_parse_id_token.return_value = self.valid_user
+    def test_single_sign_on_raises_if_another_sso_is_already_configured(self, mocked_google_oauth, client):
+        users_factories.SingleSignOnFactory(user__email=self.valid_google_user.email)
+        mocked_google_oauth.return_value = self.valid_google_user
 
         response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
 
         assert response.status_code == 400
-        assert SingleSignOn.query.filter(SingleSignOn.ssoUserId == self.valid_user["sub"]).count() == 0
+        assert SingleSignOn.query.filter(SingleSignOn.ssoUserId == self.valid_google_user.sub).count() == 0
 
     def test_sso_is_feature_flagged(self, client):
         response = client.post("/native/v1/oauth/google/authorize", json={"code": "4/google_code"})

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -29,7 +29,7 @@ def test_public_api(client):
                             "title": "TrustedDevice",
                         },
                     },
-                    "required": ["email", "password", "birthdate", "token"],
+                    "required": ["birthdate", "token", "email", "password"],
                     "title": "AccountRequest",
                     "type": "object",
                 },
@@ -733,6 +733,30 @@ def test_public_api(client):
                     },
                     "required": ["name", "values"],
                     "title": "GenreTypeModel",
+                    "type": "object",
+                },
+                "GoogleAccountRequest": {
+                    "properties": {
+                        "appsFlyerPlatform": {"nullable": True, "title": "Appsflyerplatform", "type": "string"},
+                        "appsFlyerUserId": {"nullable": True, "title": "Appsflyeruserid", "type": "string"},
+                        "authorizationCode": {"title": "Authorizationcode", "type": "string"},
+                        "birthdate": {"format": "date", "title": "Birthdate", "type": "string"},
+                        "firebasePseudoId": {"nullable": True, "title": "Firebasepseudoid", "type": "string"},
+                        "marketingEmailSubscription": {
+                            "default": False,
+                            "nullable": True,
+                            "title": "Marketingemailsubscription",
+                            "type": "boolean",
+                        },
+                        "token": {"title": "Token", "type": "string"},
+                        "trustedDevice": {
+                            "anyOf": [{"$ref": "#/components/schemas/TrustedDevice"}],
+                            "nullable": True,
+                            "title": "TrustedDevice",
+                        },
+                    },
+                    "required": ["birthdate", "token", "authorizationCode"],
+                    "title": "GoogleAccountRequest",
                     "type": "object",
                 },
                 "GoogleSigninRequest": {
@@ -2544,6 +2568,31 @@ def test_public_api(client):
                     },
                     "security": [{"JWTAuth": []}],
                     "summary": "delete_favorite <DELETE>",
+                    "tags": [],
+                }
+            },
+            "/native/v1/oauth/google/account": {
+                "post": {
+                    "description": "",
+                    "operationId": "post__native_v1_oauth_google_account",
+                    "parameters": [],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/components/schemas/GoogleAccountRequest"}}
+                        }
+                    },
+                    "responses": {
+                        "204": {"description": "No " "Content"},
+                        "400": {"description": "Bad " "Request"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable " "Entity",
+                        },
+                    },
+                    "summary": "create_account_with_google_sso " "<POST>",
                     "tags": [],
                 }
             },


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25588

## Implémentation

Le code de création de comptes a été repris avec quelques modifications : 
- la nouvelle route ne demande pas le mot de passe ni l'email de l'utilisateur
- l'email est récupéré du jeton Google que l'on reçoit
- le lien entre `User` et `SingleSignOn` est automatiquement créé dans `create_account`
- une contrainte en base de donnée a été rajoutée pour forcer la présence de soit `password` soit un `single_sign_on`

## Test fonctionnel

Sur une base de donnée propre, et la configuration en local pour utiliser l'oauth google :
```
pass-culture-main/api on  PC-25588-create-account-through-sso [⇡] via pass-culture-main 
➜ google_code="4/0AfJohXmzyj7UTUtRAY98ojUFWY7xwgADcsRCgGZFhr4sf3-VeAHqlVvrDASvAj4sq4Ea2Q"

pass-culture-main/api on  PC-25588-create-account-through-sso [⇡!] via pass-culture-main 
➜ http POST http://localhost:5001/native/v1/oauth/google/account platform:web authorizationCode="$google_code" birthdate="2000-01-01" token="abc"                                                             
HTTP/1.0 204 NO CONTENT
Content-Type: text/html; charset=utf-8
Date: Thu, 23 Nov 2023 16:13:04 GMT
Server: Werkzeug/2.0.3 Python/3.10.13
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block



pass-culture-main/api on  PC-25588-create-account-through-sso [⇡!] via pass-culture-main 
➜ pc pgcli                                                                                                                          
docker exec -it pc-api bash -c "bin/pgcli-wrapper.sh"
50eb49335207> select email from "user";
+----------------------------+
| email                      |
|----------------------------|
| dan.nguyen@passculture.app |
+----------------------------+
SELECT 1
Time: 0.010s



pass-culture-main/api on  PC-25588-create-account-through-sso [⇡!] via pass-culture-main 
➜ google_code="4/0AfJohXlLGk_p9z3CEGHw10hy1eWgURIpyJDWLt1uoKTZjPB4-uW76uc24uuFSqwqdfIq8w"

pass-culture-main/api on  PC-25588-create-account-through-sso [⇡] via pass-culture-main 
➜ http POST http://localhost:5001/native/v1/oauth/google/account platform:web authorizationCode="$google_code" birthdate="2000-01-01" token="abc"
HTTP/1.0 400 BAD REQUEST
Content-Length: 113
Content-Type: application/json
Date: Thu, 23 Nov 2023 16:30:18 GMT
Server: Werkzeug/2.0.3 Python/3.10.13
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block

{
    "email": [
        "Un compte existe déjà pour l'adresse mail Google dan.nguyen@passculture.app"
    ]
}

```