### PR TITLE
(BSR)[API] chore: Delete unused `CollectiveBooking.bookingId` column

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 d42246a7f9ba (pre) (head)
-e447c5675466 (post) (head)
+e0e253e1dca7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231122T173518_e0e253e1dca7_delete_collective_booking_booking_id.py
+++ b/api/src/pcapi/alembic/versions/20231122T173518_e0e253e1dca7_delete_collective_booking_booking_id.py
@@ -1,0 +1,20 @@
+"""Delete `collective_booking.bookingId` column
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "e0e253e1dca7"
+down_revision = "e447c5675466"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("collective_booking", "bookingId")
+
+
+def downgrade() -> None:
+    op.add_column("collective_booking", sa.Column("bookingId", sa.BIGINT(), autoincrement=False, nullable=True))

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1044,8 +1044,6 @@ class EducationalRedactor(PcObject, Base, Model):
 class CollectiveBooking(PcObject, Base, Model):
     __tablename__ = "collective_booking"
 
-    bookingId = sa.Column(sa.BigInteger)
-
     dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
     Index("ix_collective_booking_date_created", dateCreated)
 


### PR DESCRIPTION
This column was used to ease the migration from the former
`EducationalBooking` model. The column is not used anymore.