### PR TITLE
(PC-25696)[PRO] feat: Send a tracking event when a playlist is entire…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
@@ -124,6 +124,18 @@ export const AdageDiscovery = () => {
     getAllDomains()
   }, [])
 
+  function onWholePlaylistSeen(
+    playlistId: number,
+    playlistType: AdagePlaylistType
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    apiAdage.logHasSeenWholePlaylist({
+      iframeFrom: location.pathname,
+      playlistId,
+      playlistType,
+    })
+  }
+
   const colorAndMotifOrder = [
     { color: 'orange', src: squares },
     { color: 'purple', src: pills },
@@ -165,6 +177,9 @@ export const AdageDiscovery = () => {
               <h1 className={styles['section-title']}>
                 Les nouvelles offres publiées
               </h1>
+            }
+            onLastCarouselElementVisible={() =>
+              onWholePlaylistSeen(0, AdagePlaylistType.OFFER)
             }
             elements={[
               <CardOfferComponent
@@ -287,6 +302,9 @@ export const AdageDiscovery = () => {
                 Explorez les domaines artistiques
               </h1>
             }
+            onLastCarouselElementVisible={() =>
+              onWholePlaylistSeen(1, AdagePlaylistType.DOMAIN)
+            }
             elements={domainsOptions.map((elm, key) => {
               const colorAndMotif =
                 colorAndMotifOrder[key % colorAndMotifOrder.length]
@@ -317,6 +335,9 @@ export const AdageDiscovery = () => {
                 Ces interventions peuvent avoir lieu dans votre classe
               </h1>
             }
+            onLastCarouselElementVisible={() =>
+              onWholePlaylistSeen(2, AdagePlaylistType.OFFER)
+            }
             elements={[]}
           ></Carousel>
         </div>
@@ -326,6 +347,9 @@ export const AdageDiscovery = () => {
               <h1 className={styles['section-title']}>
                 À moins de 30 minutes à pieds
               </h1>
+            }
+            onLastCarouselElementVisible={() =>
+              onWholePlaylistSeen(3, AdagePlaylistType.VENUE)
             }
             elements={[
               <CardVenue

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
@@ -16,6 +16,7 @@ vi.mock('apiClient/api', () => ({
   apiAdage: {
     logHasSeenAllPlaylist: vi.fn(),
     logConsultPlaylistElement: vi.fn(),
+    logHasSeenWholePlaylist: vi.fn(),
   },
   api: {
     listEducationalDomains: vi.fn(() => [
@@ -147,5 +148,18 @@ describe('AdageDiscovery', () => {
       playlistId: 1,
       playlistType: 'domain',
     })
+  })
+
+  it('should trigger a log wheen the last element of a playlist is seen', async () => {
+    renderAdageDiscovery(user)
+
+    //  Once for the footer visibility, and twice for one playlist to reach the end of the scroll (first and last elements visibility used in Carousel)
+    vi.spyOn(useIsElementVisible, 'default').mockReturnValueOnce([true, true])
+    vi.spyOn(useIsElementVisible, 'default').mockReturnValueOnce([true, true])
+    vi.spyOn(useIsElementVisible, 'default').mockReturnValueOnce([true, true])
+
+    await waitFor(() => expect(api.listEducationalDomains).toHaveBeenCalled())
+
+    expect(apiAdage.logHasSeenWholePlaylist).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
…ly seen.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25696

**FF à activer**
WIP_ENABLE_DISCOVERY

**Objectif**
Appeler la route de logs adage dès qu'une playlist est vue en entier. Les carousels envoient déjà un événement quand le dernier élément est vu a 100%.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques