### PR TITLE
(BSR)[API] fix: anomymize offerer_invitation

### DIFF
--- a/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
+++ b/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
@@ -292,3 +292,8 @@ UPDATE venue_provider SET "isActive" = false;
 UPDATE collective_offer_request
 SET
     "phoneNumber" =  pg_temp.fake_phone_number_from_id(id);
+
+UPDATE "offerer_invitation"
+SET
+    "email" = 'user' || "id" || '@anonymized.email'
+WHERE email NOT LIKE '%@passculture.app';


### PR DESCRIPTION
## But de la pull request

BSR : la table offerer_invitation en staging contient toujours les emails des pros invités à être rattachés à une structure en clair.

ça me semble compliqué de garder le lien `offerer_invitation.email -> user.email du compte pro créé` lors de l'anonymisation, mais ça pourrait se faire si le besoin est exprimé

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques