### PR TITLE
(BSR)[API] feat: Log queue name for rq-based asynchronous jobs

### DIFF
--- a/api/src/pcapi/workers/logger.py
+++ b/api/src/pcapi/workers/logger.py
@@ -3,6 +3,7 @@ from rq.job import Job
 
 def job_extra_description(job: Job) -> dict:
     return {
+        "queue": job.origin,
         "job": job.id,
         "function": job.func_name,
         "call_args": str(job.args),  # args is a reserved word for logging


### PR DESCRIPTION
We seem to have issues on the "low" queue. Being able to filter
related logs would be helpful.