### PR TITLE
(PC-26002)[API] fix: CDS synchro - use venue id in movie uuid instead of venue siret

### DIFF
--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -261,7 +261,7 @@ def _get_showtimes_uuid_by_idAtProvider(id_at_provider: str) -> str:
 
 def _build_movie_uuid(movie_information_id: str, venue: Venue) -> str:
     """This must be unique, among all Providers and Venues"""
-    return f"{movie_information_id}%{venue.siret}%CDS"
+    return f"{movie_information_id}%{venue.id}%CDS"
 
 
 def _build_showtime_uuid(showtime_details: ShowCDS) -> str:

--- a/api/src/pcapi/utils/cinema_providers.py
+++ b/api/src/pcapi/utils/cinema_providers.py
@@ -3,7 +3,7 @@ from re import search as re_search
 
 def get_cds_show_id_from_uuid(uuid: str | None) -> int | None:
     """
-    Parses the uuid with this pattern: "<movie.id>%<venue.siret>#<show.id>/<showtime>"
+    Parses the uuid with this pattern: "<movie.id>%<venue.id>#<show.id>/<showtime>"
     and returns the show_id as int, or None if it cannot
     """
     if uuid:

--- a/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
@@ -87,12 +87,12 @@ class CDSStocksTest:
         stock_providable_info = providable_infos[1]
 
         assert offer_providable_info.type == Offer
-        assert offer_providable_info.id_at_providers == f"123%{venue_provider.venue.siret}%CDS"
-        assert offer_providable_info.new_id_at_provider == f"123%{venue_provider.venue.siret}%CDS"
+        assert offer_providable_info.id_at_providers == f"123%{venue_provider.venue.id}%CDS"
+        assert offer_providable_info.new_id_at_provider == f"123%{venue_provider.venue.id}%CDS"
 
         assert stock_providable_info.type == Stock
-        assert stock_providable_info.id_at_providers == f"123%{venue_provider.venue.siret}%CDS#1/2022-06-20 11:00:00"
-        assert stock_providable_info.new_id_at_provider == f"123%{venue_provider.venue.siret}%CDS#1/2022-06-20 11:00:00"
+        assert stock_providable_info.id_at_providers == f"123%{venue_provider.venue.id}%CDS#1/2022-06-20 11:00:00"
+        assert stock_providable_info.new_id_at_provider == f"123%{venue_provider.venue.id}%CDS#1/2022-06-20 11:00:00"
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26002

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques