### PR TITLE
(BSR)[API] feat: Log when requesting an asynchronous indexation 

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -584,9 +584,7 @@ def cancel_booking_by_offerer(booking: Booking) -> None:
 
 
 def cancel_bookings_from_stock_by_offerer(stock: offers_models.Stock) -> list[Booking]:
-    cancelled_bookings = _cancel_bookings_from_stock(stock, BookingCancellationReasons.OFFERER)
-    search.async_index_offer_ids([stock.offerId])
-    return cancelled_bookings
+    return _cancel_bookings_from_stock(stock, BookingCancellationReasons.OFFERER)
 
 
 def cancel_bookings_from_rejected_offer(offer: offers_models.Offer) -> list[Booking]:

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -316,7 +316,10 @@ def book_offer(
     if not transactional_mails.send_individual_booking_confirmation_email_to_beneficiary(booking):
         logger.warning("Could not send booking=%s confirmation email to beneficiary", booking.id)
 
-    search.async_index_offer_ids([stock.offerId])
+    search.async_index_offer_ids(
+        [stock.offerId],
+        reason=search.IndexationReason.BOOKING_CREATION,
+    )
 
     update_external_user(booking.user)
     update_external_pro(stock.offer.venue.bookingEmail)
@@ -434,7 +437,10 @@ def _cancel_booking(
 
     update_external_user(booking.user)
     update_external_pro(booking.venue.bookingEmail)
-    search.async_index_offer_ids([booking.stock.offerId])
+    search.async_index_offer_ids(
+        [booking.stock.offerId],
+        reason=search.IndexationReason.BOOKING_CANCELLATION,
+    )
     return True
 
 

--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -88,7 +88,10 @@ def book_collective_offer(
             extra={"booking": booking.id},
         )
 
-    search.async_index_collective_offer_ids([stock.collectiveOfferId])
+    search.async_index_collective_offer_ids(
+        [stock.collectiveOfferId],
+        reason=search.IndexationReason.BOOKING_CREATION,
+    )
 
     try:
         adage_client.notify_prebooking(data=prebooking.serialize_collective_booking(booking))
@@ -212,7 +215,10 @@ def refuse_collective_booking(educational_booking_id: int) -> educational_models
 
     send_eac_booking_cancellation_email(collective_booking)
 
-    search.async_index_collective_offer_ids([collective_booking.collectiveStock.collectiveOfferId])
+    search.async_index_collective_offer_ids(
+        [collective_booking.collectiveStock.collectiveOfferId],
+        reason=search.IndexationReason.BOOKING_CANCELLATION,
+    )
 
     return collective_booking
 
@@ -278,7 +284,10 @@ def cancel_collective_offer_booking(offer_id: int) -> None:
     # Offer is reindexed in the end of this function
     cancelled_booking = _cancel_collective_booking_by_offerer(collective_stock)
 
-    search.async_index_collective_offer_ids([offer_id])
+    search.async_index_collective_offer_ids(
+        [offer_id],
+        reason=search.IndexationReason.BOOKING_CANCELLATION,
+    )
 
     logger.info(
         "Cancelled collective booking from offer",
@@ -383,7 +392,10 @@ def cancel_collective_booking(
             )
 
         db.session.commit()
-    search.async_index_collective_offer_ids([collective_booking.collectiveStock.collectiveOfferId])
+    search.async_index_collective_offer_ids(
+        [collective_booking.collectiveStock.collectiveOfferId],
+        reason=search.IndexationReason.BOOKING_CANCELLATION,
+    )
     logger.info(
         "CollectiveBooking has been cancelled by %s %s",
         reason.value.lower(),
@@ -408,7 +420,10 @@ def uncancel_collective_booking(
             )
         db.session.commit()
 
-    search.async_index_collective_offer_ids([collective_booking.collectiveStock.collectiveOfferId])
+    search.async_index_collective_offer_ids(
+        [collective_booking.collectiveStock.collectiveOfferId],
+        reason=search.IndexationReason.BOOKING_UNCANCELLATION,
+    )
     logger.info(
         "CollectiveBooking has been uncancelled by support",
         extra={

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -439,7 +439,10 @@ def update_collective_offer_educational_institution(
             raise exceptions.EducationalRedactorNotFound()
 
     db.session.commit()
-    search.async_index_collective_offer_ids([offer_id])
+    search.async_index_collective_offer_ids(
+        [offer_id],
+        reason=search.IndexationReason.OFFER_UPDATE,
+    )
     if educational_institution_id is not None and offer.validation == offer_mixin.OfferValidationStatus.APPROVED:
         adage_client.notify_institution_association(serialize_collective_offer(offer))
 
@@ -537,7 +540,10 @@ def create_collective_offer_public(
     db.session.add(collective_offer)
     db.session.add(collective_stock)
     db.session.commit()
-    search.async_index_collective_offer_ids([collective_offer.id])
+    search.async_index_collective_offer_ids(
+        [collective_offer.id],
+        reason=search.IndexationReason.OFFER_CREATION,
+    )
     logger.info(
         "Collective offer has been created",
         extra={"offerId": collective_offer.id},
@@ -639,7 +645,10 @@ def edit_collective_offer_public(
 
     db.session.commit()
 
-    search.async_index_collective_offer_ids([offer.id])
+    search.async_index_collective_offer_ids(
+        [offer.id],
+        reason=search.IndexationReason.OFFER_UPDATE,
+    )
 
     notify_educational_redactor_on_collective_offer_or_stock_edit(
         offer.id,
@@ -655,7 +664,10 @@ def publish_collective_offer(
 
     if offer.validation == offer_mixin.OfferValidationStatus.DRAFT:
         update_offer_fraud_information(offer, user)
-        search.async_index_collective_offer_ids([offer.id])
+        search.async_index_collective_offer_ids(
+            [offer.id],
+            reason=search.IndexationReason.OFFER_PUBLICATION,
+        )
         db.session.commit()
 
     return offer
@@ -668,7 +680,10 @@ def publish_collective_offer_template(
 
     if offer_template.validation == offer_mixin.OfferValidationStatus.DRAFT:
         update_offer_fraud_information(offer_template, user)
-        search.async_index_collective_offer_template_ids([offer_template.id])
+        search.async_index_collective_offer_template_ids(
+            [offer_template.id],
+            reason=search.IndexationReason.OFFER_PUBLICATION,
+        )
         db.session.commit()
 
     return offer_template

--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -72,7 +72,10 @@ def create_collective_stock(
         extra={"collective_offer": collective_offer.id, "collective_stock_id": collective_stock.id},
     )
 
-    search.async_index_collective_offer_ids([collective_offer.id])
+    search.async_index_collective_offer_ids(
+        [collective_offer.id],
+        reason=search.IndexationReason.STOCK_CREATION,
+    )
 
     return collective_stock
 
@@ -142,7 +145,10 @@ def edit_collective_stock(
         db.session.commit()
 
     logger.info("Stock has been updated", extra={"stock": stock.id})
-    search.async_index_collective_offer_ids([stock.collectiveOfferId])
+    search.async_index_collective_offer_ids(
+        [stock.collectiveOfferId],
+        reason=search.IndexationReason.STOCK_UPDATE,
+    )
 
     notify_educational_redactor_on_collective_offer_or_stock_edit(
         stock.collectiveOffer.id,

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -714,6 +714,7 @@ def _delete_stock(stock: models.Stock) -> None:
             )
 
         push_notification_job.send_cancel_booking_notification.delay([booking.id for booking in cancelled_bookings])
+    search.async_index_offer_ids([stock.offerId])
 
 
 def delete_stock(stock: models.Stock) -> None:

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -832,7 +832,7 @@ def add_criteria_to_offers(
     offer_ids_query = models.Offer.query.filter(
         models.Offer.productId.in_(p.id for p in products), models.Offer.isActive.is_(True)
     ).with_entities(models.Offer.id)
-    offer_ids = [offer_id for offer_id, in offer_ids_query.all()]
+    offer_ids = {offer_id for offer_id, in offer_ids_query.all()}
 
     if not offer_ids:
         return False

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -65,7 +65,10 @@ def create_venue_provider(
     ):
         venue.isPermanent = True
         repository.save(venue)
-        search.async_index_venue_ids([venue.id])
+        search.async_index_venue_ids(
+            [venue.id],
+            reason=search.IndexationReason.VENUE_PROVIDER_CREATION,
+        )
 
     logger.info(
         "La synchronisation d'offre a été activée",
@@ -310,9 +313,17 @@ def synchronize_stocks(
 
     db.session.commit()
 
-    search.async_index_offer_ids(offer_ids)
+    search.async_index_offer_ids(
+        offer_ids,
+        reason=search.IndexationReason.STOCK_SYNCHRONIZATION,
+        log_extra={"provider_id": provider_id},
+    )
 
-    return {"new_offers": len(new_offers), "new_stocks": len(new_stocks), "updated_stocks": len(update_stock_mapping)}
+    return {
+        "new_offers": len(new_offers),
+        "new_stocks": len(new_stocks),
+        "updated_stocks": len(update_stock_mapping),
+    }
 
 
 def _build_new_offers_from_stock_details(

--- a/api/src/pcapi/local_providers/cinema_providers/ems/ems_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/ems/ems_stocks.py
@@ -94,7 +94,11 @@ class EMSStocks:
         offer_ids = set()
         for offer in self.created_offers:
             offer_ids.add(offer.id)
-        search.async_index_offer_ids(offer_ids)
+        search.async_index_offer_ids(
+            offer_ids,
+            reason=search.IndexationReason.STOCK_SYNCHRONIZATION,
+            log_extra={"provider": "ems"},
+        )
 
         logger.info(
             "Synchronization of objects of venue=%s, created=%d, updated=%d, errors=%s",

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
@@ -245,7 +245,10 @@ def _batch_validate_or_reject_collective_offer_templates(
             collective_offer_template, old_validation_status, new_validation_status, recipients
         )
 
-    search.async_index_collective_offer_template_ids(collective_offer_template_update_succeed_ids)
+    search.async_index_collective_offer_template_ids(
+        collective_offer_template_update_succeed_ids,
+        reason=search.IndexationReason.OFFER_BATCH_VALIDATION,
+    )
 
     if len(collective_offer_template_update_succeed_ids) == 1:
         flash(

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -221,7 +221,10 @@ def _batch_validate_or_reject_collective_offers(
         if collective_offer.institutionId is not None:
             adage_client.notify_institution_association(serialize_collective_offer(collective_offer))
 
-    search.async_index_collective_offer_ids(collective_offer_update_succeed_ids)
+    search.async_index_collective_offer_ids(
+        collective_offer_update_succeed_ids,
+        reason=search.IndexationReason.OFFER_BATCH_VALIDATION,
+    )
 
     if len(collective_offer_update_succeed_ids) == 1:
         flash(

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -544,7 +544,10 @@ def batch_edit_offer() -> utils.BackofficeResponse:
 
         repository.save(offer)
 
-    search.async_index_offer_ids(form.object_ids_list)
+    search.async_index_offer_ids(
+        form.object_ids_list,
+        reason=search.IndexationReason.OFFER_BATCH_UPDATE,
+    )
 
     flash("Les offres ont été modifiées avec succès", "success")
     return redirect(request.referrer or url_for("backoffice_web.offer.list_offers"), 303)
@@ -655,7 +658,10 @@ def _batch_validate_offers(offer_ids: list[int]) -> None:
                 offer, old_validation, new_validation, recipients
             )
 
-    search.async_index_offer_ids(offer_ids)
+    search.async_index_offer_ids(
+        offer_ids,
+        reason=search.IndexationReason.OFFER_BATCH_VALIDATION,
+    )
 
 
 def _batch_reject_offers(offer_ids: list[int]) -> None:
@@ -699,7 +705,10 @@ def _batch_reject_offers(offer_ids: list[int]) -> None:
     if len(offer_ids) > 0:
         favorites = users_models.Favorite.query.filter(users_models.Favorite.offerId.in_(offer_ids)).all()
         repository.delete(*favorites)
-        search.async_index_offer_ids(offer_ids)
+        search.async_index_offer_ids(
+            offer_ids,
+            reason=search.IndexationReason.OFFER_BATCH_VALIDATION,
+        )
 
 
 @list_offers_blueprint.route("/<int:offer_id>/details", methods=["GET"])
@@ -738,7 +747,10 @@ def get_offer_details(offer_id: int) -> utils.BackofficeResponse:
 @list_offers_blueprint.route("/<int:offer_id>/reindex", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.ADVANCED_PRO_SUPPORT)
 def reindex(offer_id: int) -> utils.BackofficeResponse:
-    search.async_index_offer_ids({offer_id})
+    search.async_index_offer_ids(
+        {offer_id},
+        reason=search.IndexationReason.OFFER_MANUAL_REINDEXATION,
+    )
 
     flash("La resynchronisation de l'offre a été demandée.", "success")
 

--- a/api/src/pcapi/routes/backoffice/titelive/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/titelive/blueprint.py
@@ -140,7 +140,11 @@ def add_product_whitelist(ean: str, title: str) -> utils.BackofficeResponse:
                         synchronize_session=False,
                     )
                     db.session.commit()
-                    search.async_index_offer_ids(offer_ids)
+                    search.async_index_offer_ids(
+                        offer_ids,
+                        reason=search.IndexationReason.PRODUCT_WHITELIST_ADDITION,
+                        log_extra={"ean": ean},
+                    )
 
     return redirect(url_for(".search_titelive", ean=ean), code=303)
 

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -687,7 +687,10 @@ def batch_edit_venues() -> utils.BackofficeResponse:
     updated_venues = list(set(updated_criteria_venues + updated_permanent_venues))
 
     repository.save(*updated_venues)
-    search.async_index_venue_ids([v.id for v in updated_venues])
+    search.async_index_venue_ids(
+        [v.id for v in updated_venues],
+        reason=search.IndexationReason.VENUE_BATCH_UPDATE,
+    )
 
     flash("Les lieux ont été modifiés avec succès", "success")
     return redirect(request.referrer or url_for(".list_venues"), code=303)

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -316,7 +316,11 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
             logger.exception("Error while creating offer by ean", extra={"exc": exc})
             continue
     db.session.commit()
-    search.async_index_offer_ids(offers_to_index)
+    search.async_index_offer_ids(
+        offers_to_index,
+        reason=search.IndexationReason.OFFER_UPDATE,
+        log_extra={"venue_id": venue_id, "source": "offers_public_api"},
+    )
 
 
 def _get_existing_products(ean_to_create: set[str]) -> list[offers_models.Product]:

--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_search_objects.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_search_objects.py
@@ -30,7 +30,10 @@ def create_data_search_indexed_objects() -> None:
                 educational_models.CollectiveOffer.id
             )
         ]
-        search.async_index_collective_offer_ids(collective_offer_ids)
+        search.async_index_collective_offer_ids(
+            collective_offer_ids,
+            reason=search.IndexationReason.OFFER_CREATION,
+        )
 
         collective_offer_template_ids = [
             collective_offer_template_id
@@ -38,4 +41,7 @@ def create_data_search_indexed_objects() -> None:
                 educational_models.CollectiveOfferTemplate.id
             )
         ]
-        search.async_index_collective_offer_template_ids(collective_offer_template_ids)
+        search.async_index_collective_offer_template_ids(
+            collective_offer_template_ids,
+            reason=search.IndexationReason.OFFER_CREATION,
+        )

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_search_objects.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_search_objects.py
@@ -30,7 +30,10 @@ def create_industrial_search_indexed_objects() -> None:
                 educational_models.CollectiveOffer.id
             )
         ]
-        search.async_index_collective_offer_ids(collective_offer_ids)
+        search.async_index_collective_offer_ids(
+            collective_offer_ids,
+            reason=search.IndexationReason.OFFER_CREATION,
+        )
 
         collective_offer_template_ids = [
             collective_offer_template_id
@@ -38,4 +41,7 @@ def create_industrial_search_indexed_objects() -> None:
                 educational_models.CollectiveOfferTemplate.id
             )
         ]
-        search.async_index_collective_offer_template_ids(collective_offer_template_ids)
+        search.async_index_collective_offer_template_ids(
+            collective_offer_template_ids,
+            reason=search.IndexationReason.OFFER_CREATION,
+        )

--- a/api/src/pcapi/scripts/offer/tag_many.py
+++ b/api/src/pcapi/scripts/offer/tag_many.py
@@ -60,6 +60,9 @@ def create_missing_mappings(offer_ids: Ids, criterion_names: CriterionNames, dry
 
     if not dry_run:
         db.session.commit()
-        search.async_index_offer_ids(offer_ids)
+        search.async_index_offer_ids(
+            offer_ids,
+            reason=search.IndexationReason.CRITERIA_LINK,
+        )
     else:
         db.session.rollback()

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -16,6 +16,7 @@ from sqlalchemy.sql import text
 
 from pcapi.analytics.amplitude.backends.amplitude_connector import AmplitudeEventType
 import pcapi.analytics.amplitude.testing as amplitude_testing
+from pcapi.core import search
 from pcapi.core.bookings import api
 from pcapi.core.bookings import exceptions
 from pcapi.core.bookings import factories as bookings_factories
@@ -179,7 +180,10 @@ class BookOfferTest:
         assert booking.priceCategoryLabel is None
         assert stock.dnBookedQuantity == 7
 
-        mocked_async_index_offer_ids.assert_called_once_with([stock.offer.id])
+        mocked_async_index_offer_ids.assert_called_once_with(
+            [stock.offer.id],
+            reason=search.IndexationReason.BOOKING_CREATION,
+        )
 
         assert len(mails_testing.outbox) == 2
         email_data1 = mails_testing.outbox[0].sent_data

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -11,6 +11,7 @@ import pytest
 import sqlalchemy as sa
 
 from pcapi.connectors import sirene
+from pcapi.core import search
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.criteria import factories as criteria_factories
@@ -400,7 +401,11 @@ class EditVenueTest:
         offerers_api.update_venue(venue, author=user, **json_data)
 
         # Then
-        mocked_async_index_offers_of_venue_ids.assert_called_once_with([venue.id])
+        mocked_async_index_offers_of_venue_ids.assert_called_once_with(
+            [venue.id],
+            reason=search.IndexationReason.VENUE_UPDATE,
+            log_extra={"changes": {"publicName"}},
+        )
 
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def when_changes_on_city_algolia_indexing_is_triggered(self, mocked_async_index_offers_of_venue_ids):
@@ -417,7 +422,11 @@ class EditVenueTest:
         offerers_api.update_venue(venue, author=user, **json_data)
 
         # Then
-        mocked_async_index_offers_of_venue_ids.assert_called_once_with([venue.id])
+        mocked_async_index_offers_of_venue_ids.assert_called_once_with(
+            [venue.id],
+            reason=search.IndexationReason.VENUE_UPDATE,
+            log_extra={"changes": {"city"}},
+        )
 
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def when_changes_are_not_on_algolia_fields_it_should_not_trigger_indexing(
@@ -1815,7 +1824,10 @@ class VenueBannerTest:
                 "updated_at": "2020-10-15T00:00:00",
             }
 
-            mock_search_async_index_venue_ids.assert_called_once_with([venue.id])
+            mock_search_async_index_venue_ids.assert_called_once_with(
+                [venue.id],
+                reason=search.IndexationReason.VENUE_BANNER_UPDATE,
+            )
 
     @freeze_time("2020-10-15 00:00:00")
     @patch("pcapi.core.search.async_index_venue_ids")
@@ -1841,7 +1853,10 @@ class VenueBannerTest:
                 "updated_at": "2020-10-15T00:00:00",
             }
 
-            mock_search_async_index_venue_ids.assert_called_once_with([venue.id])
+            mock_search_async_index_venue_ids.assert_called_once_with(
+                [venue.id],
+                reason=search.IndexationReason.VENUE_BANNER_UPDATE,
+            )
 
     @patch("pcapi.core.search.async_index_venue_ids")
     def test_replace_venue_banner(self, mock_search_async_index_venue_ids, tmpdir):

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -400,7 +400,7 @@ class EditVenueTest:
         offerers_api.update_venue(venue, author=user, **json_data)
 
         # Then
-        mocked_async_index_offers_of_venue_ids.called_once_with([venue.id])
+        mocked_async_index_offers_of_venue_ids.assert_called_once_with([venue.id])
 
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def when_changes_on_city_algolia_indexing_is_triggered(self, mocked_async_index_offers_of_venue_ids):

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1103,7 +1103,7 @@ class AddCriterionToOffersTest:
         assert set(offer21.criteria) == {criterion1, criterion2}
         assert not inactive_offer.criteria
         assert not unmatched_offer.criteria
-        mocked_async_index_offer_ids.called_once_with([offer11.id, offer12.id, offer21.id])
+        mocked_async_index_offer_ids.assert_called_once_with({offer11.id, offer12.id, offer21.id})
 
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_add_criteria_from_ean_when_one_has_criteria(self, mocked_async_index_offer_ids):
@@ -1129,7 +1129,7 @@ class AddCriterionToOffersTest:
         assert set(offer21.criteria) == {criterion1, criterion2}
         assert not inactive_offer.criteria
         assert not unmatched_offer.criteria
-        mocked_async_index_offer_ids.called_once_with([offer11.id, offer12.id, offer21.id])
+        mocked_async_index_offer_ids.assert_called_once_with({offer11.id, offer12.id, offer21.id})
 
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_add_criteria_from_visa(self, mocked_async_index_offer_ids):
@@ -1155,7 +1155,7 @@ class AddCriterionToOffersTest:
         assert set(offer21.criteria) == {criterion1, criterion2}
         assert not inactive_offer.criteria
         assert not unmatched_offer.criteria
-        mocked_async_index_offer_ids.called_once_with([offer11.id, offer12.id, offer21.id])
+        mocked_async_index_offer_ids.assert_called_once_with({offer11.id, offer12.id, offer21.id})
 
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_add_criteria_when_no_offers_is_found(self, mocked_async_index_offer_ids):

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from freezegun.api import freeze_time
 import pytest
 
+from pcapi.core import search
 from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.factories import CancelledBookingFactory
 from pcapi.core.categories import subcategories_v2 as subcategories
@@ -206,7 +207,9 @@ class SynchronizeStocksTest:
 
         # Test offer reindexation
         mock_async_index_offer_ids.assert_called_with(
-            {stock.offer.id, offer.id, stock_with_booking.offer.id, created_offer.id, second_created_offer.id}
+            {stock.offer.id, offer.id, stock_with_booking.offer.id, created_offer.id, second_created_offer.id},
+            reason=search.IndexationReason.STOCK_SYNCHRONIZATION,
+            log_extra={"provider_id": provider.id},
         )
 
     def test_build_new_offers_from_stock_details(self, db_session):

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -58,12 +58,12 @@ def fail(*args, **kwargs):
 
 
 def test_async_index_offer_ids(app):
-    search.async_index_offer_ids({1, 2})
+    search.async_index_offer_ids({1, 2}, reason=search.IndexationReason.OFFER_UPDATE)
     assert app.redis_client.smembers("search:algolia:offer_ids") == {"1", "2"}
 
 
 def test_async_index_offers_of_venue_ids(app):
-    search.async_index_offers_of_venue_ids({1, 2})
+    search.async_index_offers_of_venue_ids({1, 2}, reason=search.IndexationReason.VENUE_UPDATE)
     assert app.redis_client.smembers("search:algolia:venue_ids_for_offers") == {"1", "2"}
 
 
@@ -75,7 +75,10 @@ def test_async_index_venue_ids(app):
     permanent_venue = offerers_factories.VenueFactory(isPermanent=True)
     other_venue = offerers_factories.VenueFactory(isPermanent=False)
 
-    search.async_index_venue_ids([permanent_venue.id, other_venue.id])
+    search.async_index_venue_ids(
+        [permanent_venue.id, other_venue.id],
+        search.IndexationReason.VENUE_CREATION,
+    )
 
     enqueued_ids = app.redis_client.smembers("search:algolia:venue-ids-to-index")
     enqueued_ids = {int(venue_id) for venue_id in enqueued_ids}

--- a/api/tests/core/search/test_integration.py
+++ b/api/tests/core/search/test_integration.py
@@ -17,7 +17,7 @@ def test_offer_indexation_on_booking_cycle(app):
     offer = stock.offer
     assert search_testing.search_store["offers"] == {}
 
-    search.async_index_offer_ids([offer.id])
+    search.async_index_offer_ids([offer.id], reason=search.IndexationReason.OFFER_UPDATE)
     assert search_testing.search_store["offers"] == {}
 
     search.index_offers_in_queue()
@@ -38,7 +38,7 @@ def test_offer_indexation_on_venue_cycle(app):
     venue = offer.venue
     assert search_testing.search_store["offers"] == {}
 
-    search.async_index_offers_of_venue_ids([venue.id])
+    search.async_index_offers_of_venue_ids([venue.id], reason=search.IndexationReason.VENUE_UPDATE)
     assert search_testing.search_store["offers"] == {}
 
     search.index_offers_of_venues_in_queue()
@@ -49,7 +49,7 @@ def test_venue_indexation_cycle(app):
     venue = offerers_factories.VenueFactory(isPermanent=True)
     assert search_testing.search_store["venues"] == {}
 
-    search.async_index_venue_ids([venue.id])
+    search.async_index_venue_ids([venue.id], search.IndexationReason.VENUE_CREATION)
     assert search_testing.search_store["venues"] == {}
 
     search.index_venues_in_queue()

--- a/api/tests/local_providers/synchronize_provider_api_test.py
+++ b/api/tests/local_providers/synchronize_provider_api_test.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
+import itertools
 from unittest import mock
 
 from freezegun.api import freeze_time
@@ -172,10 +173,14 @@ class ProviderAPICronTest:
         assert stock.offer.lastProviderId == provider.id
 
         # Test it adds offer in redis
-        assert mocked_async_index_offer_ids.mock_calls == [
-            mock.call({offer.id, created_offer.id, stock.offer.id}),
-            mock.call({stock_with_booking.offer.id, second_created_offer.id}),
-        ]
+        reindexed = itertools.chain.from_iterable(call.args[0] for call in mocked_async_index_offer_ids.mock_calls)
+        assert set(reindexed) == {
+            offer.id,
+            created_offer.id,
+            stock.offer.id,
+            stock_with_booking.offer.id,
+            second_created_offer.id,
+        }
 
         # Ensure next synchronisation is done with modifiedSince parameter
         with requests_mock.Mocker() as request_mock:

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -7,6 +7,7 @@ from flask import g
 from flask import url_for
 import pytest
 
+from pcapi.core import search
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import categories
@@ -979,7 +980,10 @@ class BatchEditOfferTest(PostEndpointHelper):
             assert criteria[0] in offer.criteria
             assert criteria[2] not in offer.criteria
 
-        mock_async_index.assert_called_once_with([offer.id for offer in offers])
+        mock_async_index.assert_called_once_with(
+            [offer.id for offer in offers],
+            reason=search.IndexationReason.OFFER_BATCH_UPDATE,
+        )
 
 
 class ValidateOfferTest(PostEndpointHelper):

--- a/api/tests/routes/backoffice/pro_users_test.py
+++ b/api/tests/routes/backoffice/pro_users_test.py
@@ -429,7 +429,7 @@ class DeleteProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.search_pro", _external=True)
 
-        mails_api.delete_contact.called_once_with(user.email)
+        mails_api.delete_contact.assert_called_once_with(user.email)
         DeleteBatchUserAttributesRequest.assert_called_once_with(user_id=user_id)
         delete_user_attributes_task.delay.assert_called_once_with("canary")
         assert users_models.User.query.filter(users_models.User.id == user_id).count() == 0

--- a/api/tests/routes/backoffice/titelive_test.py
+++ b/api/tests/routes/backoffice/titelive_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from flask import url_for
 import pytest
 
+from pcapi.core import search
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.fraud.factories import ProductWhitelistFactory
 from pcapi.core.offers import factories as offers_factories
@@ -211,7 +212,11 @@ class AddProductWhitelistTest(PostEndpointHelper):
             ).strftime("%d/%m/%Y")
             assert not offer.lastValidationType == OfferValidationType.MANUAL
 
-        mocked_async_index_offer_ids.assert_called_once_with([o.id for o in offers_to_restore])
+        mocked_async_index_offer_ids.assert_called_once_with(
+            [o.id for o in offers_to_restore],
+            reason=search.IndexationReason.PRODUCT_WHITELIST_ADDITION,
+            log_extra={"ean": "9782070455379"},
+        )
 
     @patch("pcapi.routes.backoffice.titelive.blueprint.get_by_ean13")
     @patch("pcapi.routes.backoffice.titelive.blueprint.offers_api.whitelist_product")
@@ -306,7 +311,11 @@ class AddProductWhitelistTest(PostEndpointHelper):
         assert offer.lastValidationDate.strftime("%d/%m/%Y") == datetime.date.today().strftime("%d/%m/%Y")
         assert offer.lastValidationType == OfferValidationType.MANUAL
         assert offer.lastValidationAuthor == legit_user
-        mocked_async_index_offer_ids.assert_called_once_with([offer.id])
+        mocked_async_index_offer_ids.assert_called_once_with(
+            [offer.id],
+            reason=search.IndexationReason.PRODUCT_WHITELIST_ADDITION,
+            log_extra={"ean": "9782070455379"},
+        )
 
 
 class DeleteProductWhitelistTest(GetEndpointHelper):

--- a/api/tests/routes/pro/delete_thumbnail_test.py
+++ b/api/tests/routes/pro/delete_thumbnail_test.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+from pcapi.core import search
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Mediation
@@ -28,7 +29,10 @@ class OfferMediationTest:
         assert mock_delete_public_object.call_args_list == [
             (("thumbs", expected_thumb_path),),
         ]
-        mock_search_async_index_offer_ids.assert_called_once_with([offer.id])
+        mock_search_async_index_offer_ids.assert_called_once_with(
+            [offer.id],
+            reason=search.IndexationReason.MEDIATION_DELETION,
+        )
 
     @patch("pcapi.core.object_storage.backends.local.LocalBackend.delete_public_object")
     def test_delete_no_mediation(self, mock_delete_public_object, client):

--- a/api/tests/routes/pro/delete_venue_banner_test.py
+++ b/api/tests/routes/pro/delete_venue_banner_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from pcapi import settings
+from pcapi.core import search
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.utils.human_ids import humanize
 
@@ -32,7 +33,10 @@ class VenueBannerTest:
             (("thumbs", expected_original_thumb_base_path),),
         ]
 
-        mock_search_async_index_venue_ids.assert_called_once_with([venue.id])
+        mock_search_async_index_venue_ids.assert_called_once_with(
+            [venue.id],
+            reason=search.IndexationReason.VENUE_BANNER_DELETION,
+        )
 
     @patch("pcapi.core.object_storage.backends.local.LocalBackend.delete_public_object")
     @patch("pcapi.core.search.async_index_venue_ids")
@@ -51,7 +55,10 @@ class VenueBannerTest:
 
         mock_delete_public_object.assert_called_once_with("thumbs", expected_thumb_base_path)
 
-        mock_search_async_index_venue_ids.assert_called_once_with([venue.id])
+        mock_search_async_index_venue_ids.assert_called_once_with(
+            [venue.id],
+            reason=search.IndexationReason.VENUE_BANNER_DELETION,
+        )
 
     @patch("pcapi.core.object_storage.backends.local.LocalBackend.delete_public_object")
     def test_delete_no_banner(self, mock_delete_public_object, client):


### PR DESCRIPTION
**Commits indépendants, à relire séparément.**

Le "gros" de la pull request consiste en un ajout de logs aux fonctions de réindexation asynchrones, telle `search.async_index_offer_ids()`. Ces logs devraient nous aider à mieux comprendre pourquoi la file d'indexation se remplit parfois très vite.