### PR TITLE
(PC-25794)[PRO] feat: redirect user on login page when his session has expired

### DIFF
--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -98,7 +98,7 @@ const routes: RouteConfig[] = [
   {
     element: <Unavailable />,
     path: UNAVAILABLE_ERROR_PAGE,
-    title: 'Erreur 404 - Page indisponible',
+    title: 'Page indisponible',
     meta: {
       public: true,
       withoutLayout: true,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25794

on modifie la customRequest pour intercepeter les `401 - Unauthrized` et rediriger vers le login dans ce cas

comme un appel à users/current est toujours fait en arrivant sur l'app on veut l'exclure de la redirection automatique (pour ne pas redirgier sur les pages publiques)

(supprimez vos cookies pour tester)


Pour adage, 
A vérifier, mais d'après ce que j'ai compris adage ne throw pas des 401 mais des 403 quand le token n'est pas bon, 
j'imagine qu'on voudrait rediriger vers une page d'erreur dans ce cas (si j'ai compris ça signifie que le token d'adage a changé, ça devrait être rare)

pas trop sûr de la repoduction mais j'ai vu deux types de pages d'erreur sur adage :

![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/9f81ea7c-707c-4b3c-8c3d-00ef04a876e6)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques