### PR TITLE
(BSR)[API] fix: Remove useless join

### DIFF
--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -555,8 +555,7 @@ def get_offerer_and_extradata(offerer_id: int) -> models.Offerer | None:
     has_valid_bank_account_subquery = (
         sqla.select(1)
         .select_from(finance_models.BankAccount)
-        .join(
-            models.Offerer,
+        .where(
             sqla.and_(
                 finance_models.BankAccount.offererId == models.Offerer.id,
                 finance_models.BankAccount.isActive.is_(True),
@@ -570,8 +569,7 @@ def get_offerer_and_extradata(offerer_id: int) -> models.Offerer | None:
     has_pending_bank_account_subquery = (
         sqla.select(1)
         .select_from(finance_models.BankAccount)
-        .join(
-            models.Offerer,
+        .where(
             sqla.and_(
                 finance_models.BankAccount.offererId == models.Offerer.id,
                 finance_models.BankAccount.isActive.is_(True),


### PR DESCRIPTION
It’s useless here and moreover, the `correlate` instruction is ignore, thus we end up joining over all bankAccounts and all Offerers

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques