### PR TITLE
(PC-25885)[BO] feat: only New status on offerer page to be validated

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
@@ -59,7 +59,7 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
 
     # new and pending attachements by default
     if not form.status.data:
-        form.status.data = [ValidationStatus.NEW.value, ValidationStatus.PENDING.value]
+        form.status.data = [ValidationStatus.NEW.value]
 
     offerers = validation_repository.list_offerers_to_be_validated(
         form.q.data,
@@ -387,7 +387,7 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
 
     # new and pending attachements by default
     if not form.status.data:
-        form.status.data = [ValidationStatus.NEW.value, ValidationStatus.PENDING.value]
+        form.status.data = [ValidationStatus.NEW.value]
 
     users_offerers = validation_repository.list_users_offerers_to_be_validated(
         form.q.data,


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-25885

- Sur la page structure à valider, mettre par défaut le filtre à “nouveau”
 retirer “en attente”

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/ed7eb156-8b9a-4279-a22b-cbf29cfce344)


- Sur les rattachements à valider, mettre par défaut le filtre à “nouveau”
 retirer “en attente"

![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/f0cb31d9-d778-457f-9c1b-afdc847339de)


## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques