### PR TITLE
(BSR)[API] fix: Handle 404 when fetching movie posters

### DIFF
--- a/api/src/pcapi/connectors/ems.py
+++ b/api/src/pcapi/connectors/ems.py
@@ -11,9 +11,12 @@ import sentry_sdk
 
 from pcapi import settings
 from pcapi.connectors.serialization import ems_serializers
-from pcapi.core.external_bookings.ems.exceptions import EMSAPIException
 from pcapi.core.external_bookings.exceptions import ExternalBookingSoldOutError
 from pcapi.utils import requests
+
+
+class EMSAPIException(Exception):
+    pass
 
 
 class AbstractEMSConnector:

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -194,7 +194,17 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
         return showtime_details.data
 
     def get_movie_poster(self, image_url: str) -> bytes:
-        return boost.get_movie_poster_from_api(image_url)
+        try:
+            return boost.get_movie_poster_from_api(image_url)
+        except exceptions.BoostAPIException:
+            logger.info(
+                "Could not fetch movie poster",
+                extra={
+                    "provider": "boost",
+                    "url": image_url,
+                },
+            )
+            return bytes()
 
     def get_cinemas_attributs(self) -> list[boost_serializers.CinemaAttribut]:
         json_data = boost.get_resource(

--- a/api/src/pcapi/core/external_bookings/ems/exceptions.py
+++ b/api/src/pcapi/core/external_bookings/ems/exceptions.py
@@ -1,2 +1,0 @@
-class EMSAPIException(Exception):
-    pass

--- a/api/tests/domain/allocine_test.py
+++ b/api/tests/domain/allocine_test.py
@@ -97,6 +97,11 @@ class GetMoviePosterTest:
         requests_mock.get(url, content=b"poster data")
         assert get_movie_poster(url) == b"poster data"
 
+    def test_handle_error_on_movie_poster(self, requests_mock):
+        url = "https://allocine.example.com/movie/poster.jpg"
+        requests_mock.get(url, status_code=404)
+        assert get_movie_poster(url) == b""
+
 
 class RemoveMovieShowsWithSpecialEventTypeTest:
     def test_should_remove_movie_shows_with_special_event_type(self):

--- a/api/tests/domain/allocine_test.py
+++ b/api/tests/domain/allocine_test.py
@@ -1,4 +1,3 @@
-from unittest.mock import MagicMock
 from unittest.mock import Mock
 
 from pcapi.domain.allocine import _exclude_movie_showtimes_with_special_event_type
@@ -93,17 +92,10 @@ class GetMovieShowtimeListFromAllocineTest:
 
 
 class GetMoviePosterTest:
-    def test_should_call_api_with_correct_poster_url(self):
-        # Given
-        poster_url = "http://url.com"
-        mock_get_movie_poster_from_allocine = MagicMock(return_value=bytes())
-
-        # When
-        movie_poster = get_movie_poster(poster_url, get_movie_poster_from_api=mock_get_movie_poster_from_allocine)
-
-        # Then
-        mock_get_movie_poster_from_allocine.assert_called_once_with("http://url.com")
-        assert movie_poster == bytes()
+    def test_call_allocine_api_with_correct_poster_url(self, requests_mock):
+        url = "https://allocine.example.com/movie/poster.jpg"
+        requests_mock.get(url, content=b"poster data")
+        assert get_movie_poster(url) == b"poster data"
 
 
 class RemoveMovieShowsWithSpecialEventTypeTest:

--- a/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
@@ -398,6 +398,39 @@ class CDSStocksTest:
         assert cds_stocks.erroredThumbs == 0
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")
+    @patch("pcapi.settings.CDS_API_URL", "fakeUrl/")
+    def test_handle_error_on_movie_poster(self, mock_get_venue_movies, mock_get_shows, requests_mock):
+        # Given
+        cds_details, venue_provider = setup_cinema()
+        requests_mock.get(
+            "https://account_id.fakeurl/cinemas?api_token=token",
+            json=[fixtures.CINEMA_WITH_INTERNET_SALE_GAUGE_ACTIVE_TRUE],
+        )
+        requests_mock.get("https://account_id.fakeurl/mediaoptions?api_token=token", json=fixtures.MEDIA_OPTIONS)
+        mocked_movies = [fixtures.MOVIE_1, fixtures.MOVIE_2]
+        mock_get_venue_movies.return_value = mocked_movies
+
+        mocked_shows = [
+            {"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5, "price_label": "pass Culture"},
+            {"show_information": fixtures.MOVIE_2_SHOW_1, "price": 6, "price_label": "pass Culture"},
+        ]
+        mock_get_shows.return_value = mocked_shows
+
+        # Simulate 404 on movie poster URLs
+        requests_mock.get("https://example.com/coupez.png", status_code=404)
+        requests_mock.get("https://example.com/topgun.png", status_code=404)
+
+        cds_stocks = CDSStocks(venue_provider=venue_provider)
+
+        # When
+        cds_stocks.updateObjects()
+
+        # Then
+        offers = Offer.query.all()
+        assert {offer.thumbUrl for offer in offers} == {None}
+
+    @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_movie_poster")
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")
     @patch("pcapi.settings.CDS_API_URL", "fakeUrl/")


### PR DESCRIPTION
Failing to fetch a movie poster should not break anything. Just log
and continue as if there was no movie poster.