### PR TITLE
(BSR)[API] chore: Fix docstring of Alembic migration (single line)

### DIFF
--- a/api/src/pcapi/alembic/versions/20231123T163324_d158e4b24ff2_alter_user_nullable_password.py
+++ b/api/src/pcapi/alembic/versions/20231123T163324_d158e4b24ff2_alter_user_nullable_password.py
@@ -1,6 +1,4 @@
-"""
-Make user password nullable.
-Add not null password or existing single sign-on trigger check.
+"""Add NOT NULL contraint and contraint trigger on `user.password`
 """
 from alembic import op
 from sqlalchemy.dialects import postgresql


### PR DESCRIPTION
It should be a single line, otherwise it breaks the output of `alembic
history` (among other commands).