### PR TITLE
(PC-26085): fix offerer stats total views for last 30 days

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
+++ b/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
@@ -67,3 +67,24 @@ class OffersData(BaseQuery):
         """
 
     model = TopOffersData
+
+
+class OffererTotalViewsLast30Days(pydantic_v1.BaseModel):
+    totalViews: int
+
+
+class OffererTotalViewsLast30DaysQuery(BaseQuery):
+    @property
+    def raw_query(self) -> str:
+        return f"""
+        SELECT
+            IFNULL(SUM(nb_daily_consult), 0) as totalViews
+        FROM
+            `{settings.BIG_QUERY_NOTIFICATIONS_TABLE_BASENAME}.{DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE}`
+        WHERE
+            offerer_id = @offerer_id
+        AND
+            day_seniority <= 30
+        """
+
+    model = OffererTotalViewsLast30Days

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -1098,6 +1098,7 @@ class IndividualOffererSubscription(PcObject, Base, Model):
 class OffererStatsData(typing.TypedDict, total=False):
     daily_views: list[OffererViewsModel]
     top_offers: list[TopOffersData]
+    total_views_last_30_days: int
 
 
 class OffererStats(PcObject, Base, Model):

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -285,15 +285,17 @@ def get_offerer_stats(offerer_id: int) -> offerers_serialize.GetOffererStatsResp
         return offerers_serialize.GetOffererStatsResponseModel(
             offererId=offerer_id,
             syncDate=None,
-            jsonData=offerers_serialize.OffererStatsDataModel(dailyViews=[], topOffers=[]),
+            jsonData=offerers_serialize.OffererStatsDataModel(dailyViews=[], topOffers=[], totalViewsLast30Days=0),
         )
     top_offers = next(el for el in stats if el.table == TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE)
     daily_offerer_views = next(el for el in stats if el.table == DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE)
     top_offers_data = top_offers.jsonData["top_offers"]
-    daily_offerer_viewsData = daily_offerer_views.jsonData["daily_views"]
+    total_views_last_30_days = top_offers.jsonData["total_views_last_30_days"]
+    daily_offerer_views_data = daily_offerer_views.jsonData["daily_views"]
     return offerers_serialize.GetOffererStatsResponseModel.build(
         offerer_id,
         min(top_offers.syncDate, daily_offerer_views.syncDate),
-        daily_offerer_viewsData,
+        daily_offerer_views_data,
         top_offers_data,
+        total_views_last_30_days,
     )

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -317,6 +317,7 @@ class TopOffersResponseData(offerers_models.TopOffersData):
 
 
 class OffererStatsDataModel(BaseModel):
+    totalViewsLast30Days: int
     topOffers: list[TopOffersResponseData]
     dailyViews: list[offerers_models.OffererViewsModel]
 
@@ -333,6 +334,7 @@ class GetOffererStatsResponseModel(BaseModel):
         syncDate: datetime,
         dailyViews: list[offerers_models.OffererViewsModel],
         topOffers: list[offerers_models.TopOffersData],
+        total_views_last_30_days: int,
     ) -> "GetOffererStatsResponseModel":
         top_offers_response = []
         if topOffers:
@@ -343,7 +345,9 @@ class GetOffererStatsResponseModel(BaseModel):
         return cls(
             offererId=offerer_id,
             syncDate=syncDate,
-            jsonData=OffererStatsDataModel(topOffers=top_offers_response, dailyViews=dailyViews),
+            jsonData=OffererStatsDataModel(
+                topOffers=top_offers_response, totalViewsLast30Days=total_views_last_30_days, dailyViews=dailyViews
+            ),
         )
 
 

--- a/api/tests/core/external/offerer_stats_test.py
+++ b/api/tests/core/external/offerer_stats_test.py
@@ -41,11 +41,12 @@ class OffererStatsTest:
             syncDate="2023-10-14",
             table=TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE,
             jsonData={
+                "total_views": 50,
                 "top_offers": [
                     {"numberOfViews": 7, "offerId": offer1.id},
                     {"numberOfViews": 6, "offerId": offer2.id},
                     {"numberOfViews": 4, "offerId": offer3.id},
-                ]
+                ],
             },
         )
 
@@ -54,6 +55,8 @@ class OffererStatsTest:
                 [
                     {"eventDate": "2023-10-16", "numberOfViews": 15},
                     {"eventDate": "2023-10-15", "numberOfViews": 10},
+                    {"eventDate": "2023-10-14", "numberOfViews": 3},
+                    {"eventDate": "2023-10-13", "numberOfViews": 2},
                 ]
             ),
             iter(
@@ -61,6 +64,11 @@ class OffererStatsTest:
                     {"offerId": offer1.id, "numberOfViews": 12},
                     {"offerId": offer2.id, "numberOfViews": 10},
                     {"offerId": offer3.id, "numberOfViews": 8},
+                ]
+            ),
+            iter(
+                [
+                    {"totalViews": 30},
                 ]
             ),
         ]
@@ -74,6 +82,8 @@ class OffererStatsTest:
             OffererStats.table == DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
         ).one()
         assert offerer_global_stats.jsonData["daily_views"] == [
+            {"eventDate": "2023-10-13", "numberOfViews": 2},
+            {"eventDate": "2023-10-14", "numberOfViews": 3},
             {"eventDate": "2023-10-15", "numberOfViews": 10},
             {"eventDate": "2023-10-16", "numberOfViews": 15},
         ]
@@ -87,6 +97,7 @@ class OffererStatsTest:
             {"offerId": offer2.id, "numberOfViews": 10},
             {"offerId": offer3.id, "numberOfViews": 8},
         ]
+        assert offerer_top_offers.jsonData["total_views_last_30_days"] == 30
 
     @patch("pcapi.connectors.big_query.TestingBackend.run_query")
     def test_create_offerer_stats_data(self, mock_run_query_with_params):
@@ -101,6 +112,7 @@ class OffererStatsTest:
                 [
                     {"eventDate": "2023-10-16", "numberOfViews": 15},
                     {"eventDate": "2023-10-15", "numberOfViews": 10},
+                    {"eventDate": "2023-10-14", "numberOfViews": 5},
                 ]
             ),
             iter(
@@ -108,6 +120,11 @@ class OffererStatsTest:
                     {"offerId": offer1.id, "numberOfViews": 12},
                     {"offerId": offer2.id, "numberOfViews": 10},
                     {"offerId": offer3.id, "numberOfViews": 8},
+                ]
+            ),
+            iter(
+                [
+                    {"totalViews": 30},
                 ]
             ),
         ]
@@ -123,6 +140,7 @@ class OffererStatsTest:
             OffererStats.table == DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
         ).one()
         assert offerer_global_stats.jsonData["daily_views"] == [
+            {"eventDate": "2023-10-14", "numberOfViews": 5},
             {"eventDate": "2023-10-15", "numberOfViews": 10},
             {"eventDate": "2023-10-16", "numberOfViews": 15},
         ]
@@ -136,3 +154,4 @@ class OffererStatsTest:
             {"offerId": offer2.id, "numberOfViews": 10},
             {"offerId": offer3.id, "numberOfViews": 8},
         ]
+        assert offerer_top_offers.jsonData["total_views_last_30_days"] == 30

--- a/api/tests/routes/pro/get_offerer_stats_test.py
+++ b/api/tests/routes/pro/get_offerer_stats_test.py
@@ -45,6 +45,7 @@ class OffererStatsTest:
             offerer=offerer,
             table=TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE,
             jsonData={
+                "total_views_last_30_days": 6,
                 "top_offers": [
                     {
                         "offerId": offer_1.id,
@@ -58,7 +59,7 @@ class OffererStatsTest:
                         "offerId": offer_3.id,
                         "numberOfViews": 3,
                     },
-                ]
+                ],
             },
         )
 
@@ -77,6 +78,7 @@ class OffererStatsTest:
                     {"image": None, "numberOfViews": 2, "offerId": offer_2.id, "offerName": offer_2.name},
                     {"image": None, "numberOfViews": 3, "offerId": offer_3.id, "offerName": offer_3.name},
                 ],
+                "totalViewsLast30Days": 6,
             },
             "offererId": offerer.id,
             "syncDate": "2021-01-01T00:00:00",

--- a/pro/src/apiClient/v1/models/OffererStatsDataModel.ts
+++ b/pro/src/apiClient/v1/models/OffererStatsDataModel.ts
@@ -9,5 +9,6 @@ import type { TopOffersResponseData } from './TopOffersResponseData';
 export type OffererStatsDataModel = {
   dailyViews: Array<OffererViewsModel>;
   topOffers: Array<TopOffersResponseData>;
+  totalViewsLast30Days: number;
 };
 

--- a/pro/src/pages/Home/StatisticsDashboard/MostViewedOffers.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/MostViewedOffers.tsx
@@ -1,29 +1,21 @@
 import cn from 'classnames'
 import React from 'react'
 
-import { OffererViewsModel, TopOffersResponseData } from 'apiClient/v1'
+import { TopOffersResponseData } from 'apiClient/v1'
 import { Thumb } from 'ui-kit'
 import { pluralizeString } from 'utils/pluralize'
 
 import styles from './MostViewedOffers.module.scss'
 
 export interface MostViewedOffersProps {
+  last30daysViews: number
   topOffers: TopOffersResponseData[]
-  dailyViews: OffererViewsModel[]
 }
 
 export const MostViewedOffers = ({
+  last30daysViews,
   topOffers,
-  dailyViews,
 }: MostViewedOffersProps) => {
-  const viewsToday = dailyViews.length
-    ? dailyViews[dailyViews.length - 1].numberOfViews
-    : 0
-  const last30daysViews =
-    dailyViews.length >= 30
-      ? viewsToday - dailyViews[dailyViews.length - 30].numberOfViews
-      : viewsToday
-
   return (
     <div className={styles['container']}>
       <div>

--- a/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
@@ -65,8 +65,8 @@ export const StatisticsDashboard = ({ offerer }: StatisticsDashboardProps) => {
             stats?.jsonData.dailyViews?.length ? (
               <div className={styles['data-container']}>
                 <MostViewedOffers
+                  last30daysViews={stats.jsonData.totalViewsLast30Days}
                   topOffers={stats.jsonData.topOffers}
-                  dailyViews={stats.jsonData.dailyViews}
                 />
 
                 <CumulatedViews dailyViews={stats.jsonData.dailyViews} />

--- a/pro/src/pages/Home/StatisticsDashboard/__specs__/MostViewedOffers.spec.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/__specs__/MostViewedOffers.spec.tsx
@@ -11,14 +11,14 @@ const renderCumulatedViews = (props: MostViewedOffersProps) =>
 describe('MostViewedOffers', () => {
   it('should render empty state when no views data', () => {
     renderCumulatedViews({
-      dailyViews: [{ eventDate: '2021-01-10', numberOfViews: 100 }],
       topOffers: [
         { offerId: 1, offerName: 'offer 1', numberOfViews: 100 },
         { offerId: 2, offerName: 'offer 2', numberOfViews: 200 },
         { offerId: 3, offerName: 'offer 3', numberOfViews: 300 },
       ],
+      last30daysViews: 1000,
     })
 
-    expect(screen.getByText(/100 fois/)).toBeInTheDocument()
+    expect(screen.getByText(/1 000 fois/)).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Home/StatisticsDashboard/__specs__/StatisticsDashboard.spec.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/__specs__/StatisticsDashboard.spec.tsx
@@ -29,7 +29,7 @@ const renderStatisticsDashboard = (
 describe('StatisticsDashboard', () => {
   it('should render empty state when no statistics', async () => {
     vi.spyOn(api, 'getOffererStats').mockResolvedValueOnce({
-      jsonData: { dailyViews: [], topOffers: [] },
+      jsonData: { dailyViews: [], topOffers: [], totalViewsLast30Days: 0 },
       syncDate: null,
       offererId: 1,
     })


### PR DESCRIPTION
## But de la pull request
Fixer le calcul des données de consultations des 30 derniers jours de l'offerer

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26085

## Vérifications

- [X] J'ai écrit les tests nécessaires
