### PR TITLE
(PC-24281)[PRO] fix: fix conditions to display first offer modal

### DIFF
--- a/pro/src/screens/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
@@ -424,10 +424,11 @@ describe('Summary', () => {
         ...defaultGetOffererResponseModel,
         hasValidBankAccount: false,
         hasPendingBankAccount: false,
+        hasNonFreeOffer: false,
       })
 
       vi.spyOn(api, 'patchPublishOffer').mockResolvedValue(
-        GetIndividualOfferFactory({ isNonFreeOffer: false })
+        GetIndividualOfferFactory({ isNonFreeOffer: true })
       )
 
       renderSummary(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24281 

Fix l'affichage de la pop-in lors de la création d'une première offre individuelle

![Capture d’écran 2023-11-28 à 17 20 48](https://github.com/pass-culture/pass-culture-main/assets/71768799/896857b8-00d4-49ae-bce9-56a124eeb9ee)


On veut afficher la pop-in selon les conditions suivantes quand le FF WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY est actif : 

- La structure n'a pas encore d'offre payantes 
- La structure n'a pas de compte bancaire (validé ou en cours) 
- L'offre entrain d'être créée est payante 

