### PR TITLE
(BSR)[API] test: Do not use `commit()` when not necessary

### DIFF
--- a/api/tests/core/bookings/test_models.py
+++ b/api/tests/core/bookings/test_models.py
@@ -35,24 +35,27 @@ def test_reimbursement_rate():
 
 
 def test_save_cancellation_date_postgresql_function():
-    # In this test, we manually COMMIT so that save_cancellation_date
-    # PotsgreSQL function is triggered.
+    # In this test, we manually perform an `INSERT` so that the
+    # `save_cancellation_date` PotsgreSQL function is triggered.
     booking = factories.BookingFactory()
     assert booking.cancellationDate is None
 
     booking.status = BookingStatus.CANCELLED
-    db.session.commit()
+    db.session.flush()
+    db.session.refresh(booking)
     assert booking.cancellationDate is not None
 
     # `cancellationDate` should not be changed when another attribute
     # is updated.
     previous = booking.cancellationDate
     booking.cancellationReason = "FRAUD"
-    db.session.commit()
+    db.session.flush()
+    db.session.refresh(booking)
     assert booking.cancellationDate == previous
 
     booking.status = BookingStatus.CONFIRMED
-    db.session.commit()
+    db.session.flush()
+    db.session.refresh(booking)
     assert booking.cancellationDate is None
 
 

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -666,7 +666,8 @@ class GetPricingPointLinkTest:
             datetime.datetime.utcnow() - datetime.timedelta(days=5),
             datetime.datetime.utcnow() - datetime.timedelta(days=2),
         )
-        db.session.commit()
+        db.session.flush()
+        db.session.refresh(link)  # otherwise `link.timespan.lower` is seen as a string
 
         with pytest.raises(ValueError):
             api._get_pricing_point_link(booking)
@@ -683,7 +684,8 @@ class GetPricingPointLinkTest:
             link.timespan.lower,
             datetime.datetime.utcnow(),
         )
-        db.session.commit()
+        db.session.flush()
+        db.session.refresh(link)  # otherwise `link.timespan.lower` is seen as a string
 
         with pytest.raises(ValueError):
             api._get_pricing_point_link(booking)

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -31,7 +31,7 @@ class VenueModelConstraintsTest:
         with pytest.raises(IntegrityError) as err:
             venue.address = "1 test address"
             db.session.add(venue)
-            db.session.commit()
+            db.session.flush()
         assert "check_is_virtual_xor_has_address" in str(err.value)
 
     def test_virtual_venue_cannot_have_siret(self):
@@ -39,7 +39,7 @@ class VenueModelConstraintsTest:
         with pytest.raises(IntegrityError) as err:
             venue.siret = "siret"
             db.session.add(venue)
-            db.session.commit()
+            db.session.flush()
         assert "check_has_siret_xor_comment_xor_isVirtual" in str(err.value)
 
     def test_non_virtual_with_siret_can_have_null_address(self):
@@ -52,7 +52,7 @@ class VenueModelConstraintsTest:
         venue.city = None
         with pytest.raises(IntegrityError) as err:
             db.session.add(venue)
-            db.session.commit()
+            db.session.flush()
         assert "check_is_virtual_xor_has_address" in str(err.value)
 
     def test_non_virtual_without_siret_must_have_full_address(self):
@@ -62,7 +62,7 @@ class VenueModelConstraintsTest:
         venue.city = None
         with pytest.raises(IntegrityError) as err:
             db.session.add(venue)
-            db.session.commit()
+            db.session.flush()
         assert "check_is_virtual_xor_has_address" in str(err.value)
 
     def test_non_virtual_without_siret_must_have_comment(self):
@@ -70,7 +70,7 @@ class VenueModelConstraintsTest:
         with pytest.raises(IntegrityError) as err:
             venue.comment = None
             db.session.add(venue)
-            db.session.commit()
+            db.session.flush()
         assert "check_has_siret_xor_comment_xor_isVirtual" in str(err.value)
 
     def test_at_most_one_virtual_venue_per_offerer(self):

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -795,8 +795,7 @@ class UpdateOfferTest:
         )
 
         offer = api.update_offer(offer, isDuo=True, bookingEmail="new@example.com")
-        # update_offer does not commit. This helps pytest-flask to rollback the transaction
-        db.session.commit()
+        db.session.flush()
 
         assert offer.isDuo
         assert offer.bookingEmail == "new@example.com"
@@ -836,8 +835,7 @@ class UpdateOfferTest:
         )
 
         offer = api.update_offer(offer, name="New name", description="new Description")
-        # update_offer does not commit. This helps pytest-flask to rollback the transaction
-        db.session.commit()
+        db.session.flush()
 
         assert offer.name == "New name"
         assert offer.description == "new Description"
@@ -855,8 +853,7 @@ class UpdateOfferTest:
             description="new Description",
             extraData={"ean": "1234567890124", "musicType": 520, "musicSubType": 524},
         )
-        # update_offer does not commit. This helps pytest-flask to rollback the transaction
-        db.session.commit()
+        db.session.flush()
 
         assert offer.name == "New name"
         assert offer.description == "new Description"

--- a/api/tests/core/reference/test_models.py
+++ b/api/tests/core/reference/test_models.py
@@ -26,7 +26,7 @@ class ReferenceSchemeTest:
         scheme = factories.ReferenceSchemeFactory()
         scheme.nextNumber = 1
         db.session.add(scheme)
-        db.session.commit()
+        db.session.flush()
 
         scheme.increment_after_use()
         db.session.refresh(scheme)
@@ -37,11 +37,11 @@ class ReferenceSchemeTest:
         scheme = factories.ReferenceSchemeFactory(name="x", year=2023)
         scheme.nextNumber = 1
         db.session.add(scheme)
-        db.session.commit()
+        db.session.flush()
 
         scheme = models.ReferenceScheme.get_and_lock("x", 2023)
         scheme.increment_after_use()
-        db.session.commit()
+        db.session.flush()
 
         db.session.refresh(scheme)
         assert scheme.nextNumber == 2
@@ -51,7 +51,7 @@ class ReferenceSchemeTest:
         scheme = factories.ReferenceSchemeFactory()
         scheme.nextNumber = 1
         db.session.add(scheme)
-        db.session.commit()
+        db.session.flush()
 
         # Simulate another transaction locking the reference.
         engine = sqla.create_engine(app.config["SQLALCHEMY_DATABASE_URI"])

--- a/api/tests/core/users/backoffice/test_api.py
+++ b/api/tests/core/users/backoffice/test_api.py
@@ -37,7 +37,7 @@ def roles_fixture(permissions) -> list[perm_models.Roles]:
     roles[2].permissions = [permissions[0], permissions[1]]
 
     db.session.bulk_save_objects(roles)
-    db.session.commit()
+    db.session.flush()
 
     return roles
 

--- a/api/tests/models/feature_test.py
+++ b/api/tests/models/feature_test.py
@@ -101,7 +101,7 @@ def test_install_feature_flags(app, caplog):
 
     db.session.add(declared_and_installed)
     db.session.add(not_declared_but_installed)
-    db.session.commit()
+    db.session.flush()
 
     install_feature_flags()
 

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -157,7 +157,7 @@ def roles_with_permissions_fixture():
         role.permissions = [perms_in_db[perm.name] for perm in perms]
         db.session.add(role)
 
-    db.session.commit()
+    db.session.flush()
     return roles
 
 
@@ -172,7 +172,7 @@ def legit_user_fixture(roles_with_permissions: None) -> users_models.User:
     user.backoffice_profile = perm_models.BackOfficeUserProfile(user=user)
     backoffice_api.upsert_roles(user, list(perm_models.Roles))
 
-    db.session.commit()
+    db.session.flush()
 
     return user
 
@@ -187,7 +187,7 @@ def read_only_bo_user_fixture(roles_with_permissions: None) -> users_models.User
     user = users_factories.UserFactory(roles=["ADMIN"])
     user.backoffice_profile = perm_models.BackOfficeUserProfile(user=user)
     backoffice_api.upsert_roles(user, {perm_models.Roles.LECTURE_SEULE})
-    db.session.commit()
+    db.session.flush()
     return user
 
 

--- a/api/tests/routes/backoffice/users_test.py
+++ b/api/tests/routes/backoffice/users_test.py
@@ -29,7 +29,7 @@ def beneficiary_fraud_admin_fixture(roles_with_permissions: None) -> users_model
     user = users_factories.UserFactory(roles=["ADMIN"])
     user.backoffice_profile = perm_models.BackOfficeUserProfile(user=user)
     backoffice_api.upsert_roles(user, {perm_models.Roles.FRAUDE_JEUNES})
-    db.session.commit()
+    db.session.flush()
     return user
 
 
@@ -38,7 +38,7 @@ def pro_fraud_admin_fixture(roles_with_permissions: None) -> users_models.User:
     user = users_factories.UserFactory(roles=["ADMIN"])
     user.backoffice_profile = perm_models.BackOfficeUserProfile(user=user)
     backoffice_api.upsert_roles(user, {perm_models.Roles.FRAUDE_CONFORMITE})
-    db.session.commit()
+    db.session.flush()
     return user
 
 
@@ -47,7 +47,7 @@ def fraude_jeunes_admin_fixture(roles_with_permissions: None) -> users_models.Us
     user = users_factories.UserFactory(roles=["ADMIN"])
     user.backoffice_profile = perm_models.BackOfficeUserProfile(user=user)
     backoffice_api.upsert_roles(user, {perm_models.Roles.FRAUDE_JEUNES})
-    db.session.commit()
+    db.session.flush()
     return user
 
 
@@ -56,7 +56,7 @@ def support_n2_fixture(roles_with_permissions: None) -> users_models.User:
     user = users_factories.UserFactory(roles=["ADMIN"])
     user.backoffice_profile = perm_models.BackOfficeUserProfile(user=user)
     backoffice_api.upsert_roles(user, {perm_models.Roles.SUPPORT_N2})
-    db.session.commit()
+    db.session.flush()
     return user
 
 
@@ -65,7 +65,7 @@ def super_admin_fixture(roles_with_permissions: None) -> users_models.User:
     user = users_factories.UserFactory(roles=["ADMIN"])
     user.backoffice_profile = perm_models.BackOfficeUserProfile(user=user)
     backoffice_api.upsert_roles(user, {perm_models.Roles.ADMIN})
-    db.session.commit()
+    db.session.flush()
     return user
 
 

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -52,7 +52,6 @@ class GetOffererTest:
 
         offerer_id = offerer.id
         client = client.with_session_auth(pro.email)
-        db.session.commit()
 
         with testing.assert_no_duplicated_queries():
             response = client.get(f"/offerers/{offerer_id}")


### PR DESCRIPTION
Most of the time, we only need to tell SQLAlchemy to perform an UPDATE
or INSERT queries, not a COMMIT.