### PR TITLE
(BSR)[BO] fix: avoid N+1 request in current_user

### DIFF
--- a/api/src/pcapi/core/users/backoffice/api.py
+++ b/api/src/pcapi/core/users/backoffice/api.py
@@ -30,6 +30,10 @@ def fetch_user_with_profile(user_id: int) -> models.User | None:
             .joinedload(perm_models.BackOfficeUserProfile.roles)
             .joinedload(perm_models.Role.permissions)
         )
-        .options(orm.load_only(models.User.id, models.User.email, models.User.roles))
+        .options(
+            orm.load_only(
+                models.User.id, models.User.email, models.User.firstName, models.User.lastName, models.User.roles
+            )
+        )
         .one_or_none()
     )

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -447,7 +447,7 @@ class GetIncidentCreationFormTest(PostEndpointHelper):
 
     error_message = "Seules les réservations ayant le statut 'remboursée' et correspondant au même lieu peuvent faire l'objet d'un incident"
 
-    expected_num_queries = 7
+    expected_num_queries = 6
 
     def test_get_incident_creation_for_one_booking_form(self, authenticated_client, invoiced_pricing):
         venue = offerers_factories.VenueFactory()
@@ -533,7 +533,7 @@ class GetCollectiveBookingIncidentFormTest(PostEndpointHelper):
     endpoint_kwargs = {"collective_booking_id": 1}
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
-    expected_num_queries = 11
+    expected_num_queries = 10
 
     def test_get_form(self, authenticated_client, invoiced_collective_pricing):
         collective_booking = educational_factories.ReimbursedCollectiveBookingFactory(

--- a/api/tests/routes/backoffice/helpers/post.py
+++ b/api/tests/routes/backoffice/helpers/post.py
@@ -14,7 +14,7 @@ class PostEndpointWithoutPermissionHelper(base.BaseHelper):
 
     # Number of queries to fetch csrf token from homepage
     # Same as expected_num_queries in HomePageTest
-    fetch_csrf_num_queries = 4
+    fetch_csrf_num_queries = 3
 
     @property
     def method(self) -> str:

--- a/api/tests/routes/backoffice/home_test.py
+++ b/api/tests/routes/backoffice/home_test.py
@@ -19,9 +19,8 @@ pytestmark = [
 class HomePageTest:
     # - session
     # - authenticated user
-    # - user again to show the name
     # - data inserted in cards (stats got in a single request)
-    expected_num_queries = 4
+    expected_num_queries = 3
 
     def test_view_home_page_as_anonymous(self, client):
         response = client.get(url_for("backoffice_web.home"))


### PR DESCRIPTION
## But de la pull request

Éviter une requête N+1 dans les cas où l'on récupère le nom de l'utilisateur authentifié dans le BO (`curent_user`)

## Vérifications

- [x] J'ai mis à jour les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques