### PR TITLE
(BSR)[API] Meilleurs logs en cas d'erreur d'indexation

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -63,7 +63,7 @@ def _get_backend() -> base.SearchBackend:
     return backend_class()
 
 
-def _log(
+def _log_async_request(
     resource_type: str,
     ids: Iterable[int],
     reason: IndexationReason,
@@ -95,7 +95,7 @@ def async_index_offer_ids(
     This function returns quickly. The "real" reindexation will be
     done later through a cron job.
     """
-    _log("offers", offer_ids, reason, log_extra)
+    _log_async_request("offers", offer_ids, reason, log_extra)
     backend = _get_backend()
     try:
         backend.enqueue_offer_ids(offer_ids)
@@ -116,7 +116,7 @@ def async_index_collective_offer_ids(
     This function returns quickly. The "real" reindexation will be
     done later through a cron job.
     """
-    _log("collective offers", collective_offer_ids, reason, log_extra)
+    _log_async_request("collective offers", collective_offer_ids, reason, log_extra)
     backend = _get_backend()
     try:
         backend.enqueue_collective_offer_ids(collective_offer_ids)
@@ -142,7 +142,7 @@ def async_index_collective_offer_template_ids(
     This function returns quickly. The "real" reindexation will be
     done later through a cron job.
     """
-    _log("collective offer templates", collective_offer_template_ids, reason, log_extra)
+    _log_async_request("collective offer templates", collective_offer_template_ids, reason, log_extra)
     backend = _get_backend()
     try:
         backend.enqueue_collective_offer_template_ids(collective_offer_template_ids)
@@ -168,7 +168,7 @@ def async_index_venue_ids(
     This function returns quickly. The "real" reindexation will be
     done later through a cron job.
     """
-    _log("venues", venue_ids, reason, log_extra)
+    _log_async_request("venues", venue_ids, reason, log_extra)
     backend = _get_backend()
     try:
         backend.enqueue_venue_ids(venue_ids)
@@ -189,7 +189,7 @@ def async_index_offers_of_venue_ids(
     This function returns quickly. The "real" reindexation will be
     done later through a cron job.
     """
-    _log("offers of venues", venue_ids, reason, log_extra)
+    _log_async_request("offers of venues", venue_ids, reason, log_extra)
     backend = _get_backend()
     try:
         backend.enqueue_venue_ids_for_offers(venue_ids)

--- a/api/src/pcapi/core/search/commands/indexation.py
+++ b/api/src/pcapi/core/search/commands/indexation.py
@@ -123,9 +123,7 @@ def _partially_index(
     batch_size: int = 10000,
     starting_page: int = 1,
     last_page: int | None = None,
-    indexation_callback_kwargs: dict | None = None,
 ) -> None:
-    backend = search._get_backend()
     page = starting_page
     while True:
         if last_page and page > last_page:
@@ -135,10 +133,8 @@ def _partially_index(
             break
         indexation_callback_arguments = [ids]
         if "backend" in indexation_callback.__annotations__:
-            indexation_callback_arguments.insert(0, backend)
-        if indexation_callback_kwargs is None:
-            indexation_callback_kwargs = {}
-        indexation_callback(*indexation_callback_arguments, **indexation_callback_kwargs)
+            indexation_callback_arguments.insert(0, search._get_backend())
+        indexation_callback(*indexation_callback_arguments)
         logger.info("Indexed %d %s from page %d", len(ids), what, page)
         page += 1
 


### PR DESCRIPTION
**Commits à relire séparément** (j'en ai profité pour faire un peu de nettoyage).

Message du commit principal ::

    We have two queues for each kind of resource to index (individual
    offers, venues, collective offers, collective offer templates): the
    main queue and an error queue. For each kind of resource, we regularly
    pop from the main queue and try to send an indexation command to
    Algolia. If it fails (network issue or, more commonly, an error when
    trying to serialize our object for Algolia), we move the resource to
    the error queue. We regularly do the same for items in the error
    queue.

    Until now, when an error occurred when processing the error queue, we
    only log a warning, which was not visible in Sentry. We do monitor the
    size of the queues, but it only tells us that there has been an issue,
    not what the issue was. With this commit, we now log an exception,
    which will be visible in Sentry and can be acted upon.