### PR TITLE
(PC-25762)[PRO] feat: Mise à jour du style des champs de stock

### DIFF
--- a/pro/src/screens/IndividualOffer/StocksThing/StockThing.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksThing/StockThing.module.scss
@@ -2,13 +2,13 @@
 
 .input-price,
 .input-quantity {
-  flex: 1 0 rem.torem(146px);
-  max-width: 146px;
+  flex: 1 0 rem.torem(102px);
+  max-width: 102px;
 }
 
 .input-booking-limit-datetime {
-  flex: 1 1 rem.torem(316px);
-  max-width: 316px;
+  flex: 1 1 rem.torem(170px);
+  min-width: 162px;
 
   svg {
     width: rem.torem(20px);
@@ -16,7 +16,8 @@
 }
 
 .input-activation-code {
-  flex: 1 0 rem.torem(160px);
+  flex: 1 0 rem.torem(122px);
+  max-width: 122px;
 }
 
 .field-layout-footer {

--- a/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
@@ -322,9 +322,7 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                   smallLabel
                   name="price"
                   label="Prix"
-                  className={cn({
-                    [styles['input-price']]: !showExpirationDate,
-                  })}
+                  className={styles['input-price']}
                   classNameFooter={styles['field-layout-footer']}
                   disabled={readOnlyFields.includes('price')}
                   type="number"
@@ -336,10 +334,7 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                   smallLabel
                   name="bookingLimitDatetime"
                   label="Date limite de réservation"
-                  className={cn({
-                    [styles['input-booking-limit-datetime']]:
-                      !showExpirationDate,
-                  })}
+                  className={styles['input-booking-limit-datetime']}
                   classNameFooter={styles['field-layout-footer']}
                   minDate={today}
                   maxDate={getMaximumBookingDatetime(maxDateTime)}
@@ -361,9 +356,7 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                   name="quantity"
                   label="Quantité"
                   placeholder="Illimité"
-                  className={cn({
-                    [styles['input-quantity']]: !showExpirationDate,
-                  })}
+                  className={styles['input-quantity']}
                   classNameFooter={styles['field-layout-footer']}
                   disabled={readOnlyFields.includes('quantity')}
                   type="number"


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25762
Branche: PC-25762-style-onglet-stock

## But de la pull request

Bien aligné l’ensemble des champs :

- Réduire la taille du champ quantité.
- Réduire la taille du champ date d’expiration.
- Jusqu'à avoir assez de place pour faire tenir “date limite de réservation” sur une ligne.



<img width="666" alt="Capture d’écran 2023-11-28 à 21 52 27" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/30ffb0f2-3674-4eca-b922-d486e2ca2b3e">

<img width="1512" alt="Capture d’écran 2023-11-28 à 21 32 55" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/7c124eea-1d4f-4f00-8a82-6572b3a90b6e">

<img width="956" alt="Capture d’écran 2023-11-29 à 09 44 11" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/d6e0138a-7539-43f2-849c-2ea1a4997da3">



