### PR TITLE
(PC-25631)[PRO] feat: track click on follow up bank account click

### DIFF
--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -61,6 +61,15 @@ const ReimbursementBankAccount = ({
               to: '', // TODO: change when link is available.
               isExternal: true,
             }}
+            onClick={() => {
+              logEvent?.(
+                BankAccountEvents.CLICKED_BANK_DETAILS_RECORD_FOLLOW_UP,
+                {
+                  from: location.pathname,
+                  offererId: offererId,
+                }
+              )
+            }}
             icon={fullLinkIcon}
             className={styles['ds-link-button']}
           >

--- a/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
+++ b/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
@@ -248,6 +248,27 @@ describe('ReimbursementBankAccount', () => {
         }
       )
     })
+
+    it('should track follow up bank account link click', async () => {
+      renderReimbursementBankAccount(
+        {
+          ...bankAccount,
+          status: BankAccountApplicationStatus.EN_CONSTRUCTION,
+        },
+        1,
+        2
+      )
+      await userEvent.click(
+        screen.getByRole('link', { name: 'Suivre le dossier' })
+      )
+      expect(mockLogEvent).toHaveBeenCalledWith(
+        BankAccountEvents.CLICKED_BANK_DETAILS_RECORD_FOLLOW_UP,
+        {
+          from: '/remboursements/informations-bancaires',
+          offererId: 0,
+        }
+      )
+    })
   })
 
   it('should call the onUpdateButtonClick function when clicking the action button', async () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25631

Ajouter un tracker au clic sur le bouton "Suivre le dossier" de la page Informations bancaires

![Capture d’écran 2023-11-29 à 10 01 55](https://github.com/pass-culture/pass-culture-main/assets/71768799/a3bc0280-6fea-4b3d-b867-0d38e4c35e9a)
