### PR TITLE
(PC-24362)[PRO] style: Both dialogs should have the same width.

### DIFF
--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
@@ -4,8 +4,13 @@
 @use "styles/variables/_colors.scss" as colors;
 @use "styles/variables/_size.scss" as size;
 
+$modal-width: rem.torem(592px);
+$modal-height: rem.torem(336px);
+
+
 .dialog {
-  width: rem.torem(592px);
+  height: $modal-height;
+  width: $modal-width;
 
   &-title {
     margin-bottom: rem.torem(16px);
@@ -18,7 +23,7 @@
   }
 
   &-checkboxes {
-    max-height: rem.torem(200px);
+    height: rem.torem(200px);
     overflow-y: auto
   }
 
@@ -48,4 +53,9 @@
     justify-content: flex-end;
     gap: rem.torem(24px);
   }
+}
+
+.discard-dialog {
+  width: $modal-width;
+  height: $modal-height;
 }

--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
@@ -182,6 +182,7 @@ const LinkVenuesDialog = ({
       </DialogBox>
       {showDiscardChangesDialog && (
         <ConfirmDialog
+          extraClassNames={styles['discard-dialog']}
           icon={strokeWarningIcon}
           onCancel={() => setShowDiscardChangesDialog(false)}
           title="Les informations non sauvegardées ne seront pas prises en compte"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24362

- La largeur des deux modals doit être identique.


### Avant
![image](https://github.com/pass-culture/pass-culture-main/assets/114910244/40892376-2e3f-46ed-83fb-052fa31779f1)


### Après 
![image](https://github.com/pass-culture/pass-culture-main/assets/114910244/999145ca-4f1a-49a3-94a5-351a7fa93381)
