### PR TITLE
(PC-25745)[BO] feat: Search by id offerer or id venue in autocompletion

### DIFF
--- a/api/src/pcapi/routes/backoffice/autocomplete.py
+++ b/api/src/pcapi/routes/backoffice/autocomplete.py
@@ -53,13 +53,21 @@ def prefill_offerers_choices(autocomplete_field: fields.PCTomSelectField) -> Non
 def autocomplete_offerers() -> AutocompleteResponse:
     query_string = request.args.get("q", "").strip()
 
-    if len(query_string) < 2:
+    is_numeric_query = query_string.isnumeric()
+    if not is_numeric_query and len(query_string) < 2:
         return AutocompleteResponse(items=[])
 
-    filters = sa.func.unaccent(offerers_models.Offerer.name).ilike(f"%{clean_accents(query_string)}%")
+    if is_numeric_query and len(query_string) == 1:
+        filters = offerers_models.Offerer.id == int(query_string)
+    else:
+        filters = sa.func.unaccent(offerers_models.Offerer.name).ilike(f"%{clean_accents(query_string)}%")
 
-    if query_string.isnumeric() and len(query_string) <= 9:
-        filters = sa.or_(filters, offerers_models.Offerer.siren.like(f"{query_string}%"))
+        if is_numeric_query and len(query_string) <= 9:
+            filters = sa.or_(
+                filters,
+                offerers_models.Offerer.id == int(query_string),
+                offerers_models.Offerer.siren.like(f"{query_string}%"),
+            )
 
     offerers = _get_offerers_base_query().filter(filters).limit(NUM_RESULTS)
 
@@ -97,13 +105,21 @@ def prefill_venues_choices(autocomplete_field: fields.PCTomSelectField) -> None:
 def autocomplete_venues() -> AutocompleteResponse:
     query_string = request.args.get("q", "").strip()
 
-    if not query_string or len(query_string) < 2:
+    is_numeric_query = query_string.isnumeric()
+    if not is_numeric_query and len(query_string) < 2:
         return AutocompleteResponse(items=[])
 
-    filters = sa.func.unaccent(offerers_models.Venue.name).ilike(f"%{clean_accents(query_string)}%")
+    if is_numeric_query and len(query_string) == 1:
+        filters = offerers_models.Venue.id == int(query_string)
+    else:
+        filters = sa.func.unaccent(offerers_models.Venue.name).ilike(f"%{clean_accents(query_string)}%")
 
-    if query_string.isnumeric() and len(query_string) <= 14:
-        filters = sa.or_(filters, offerers_models.Venue.siret.like(f"{query_string}%"))
+        if is_numeric_query and len(query_string) <= 14:
+            filters = sa.or_(
+                filters,
+                offerers_models.Venue.id == int(query_string),
+                offerers_models.Venue.siret.like(f"{query_string}%"),
+            )
 
     venues = _get_venues_base_query().filter(filters).limit(NUM_RESULTS)
 

--- a/api/src/pcapi/static/backoffice/js/addons/pc-tom-select-field.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-tom-select-field.js
@@ -105,6 +105,7 @@ class PcTomSelectField extends PcAddOn {
     return {
       valueField: 'id',
       labelField: 'text',
+      searchField: ['id','text'],
       load: (query, callback) => {
         const url = `${tomselectAutocompleteUrl}?q=${encodeURIComponent(query)}`;
         fetch(url)

--- a/api/tests/routes/backoffice/autocomplete_test.py
+++ b/api/tests/routes/backoffice/autocomplete_test.py
@@ -16,7 +16,7 @@ pytestmark = [
 
 def _test_autocomplete(authenticated_client, endpoint: str, search_query: str, expected_texts: list[str]):
     # user + session + data requested
-    expected_num_queries = 3 if len(search_query) >= 2 else 2
+    expected_num_queries = 3 if search_query.isnumeric() or len(search_query) >= 2 else 2
 
     with assert_num_queries(expected_num_queries):
         response = authenticated_client.get(url_for(endpoint, q=search_query))
@@ -34,7 +34,7 @@ class AutocompleteOffererTest:
         "search_query, expected_texts",
         [
             ("", set()),
-            ("1", set()),
+            ("1", {"La scène (100200000)"}),
             ("12", {"Le Cinéma (123456789)", "La Librairie (123444556)"}),
             ("1234", {"Le Cinéma (123456789)", "La Librairie (123444556)"}),
             ("12345", {"Le Cinéma (123456789)"}),
@@ -44,13 +44,17 @@ class AutocompleteOffererTest:
             ("ciné", {"Le Cinéma (123456789)", "Cinéma concurrent (561234789)"}),
             ("cinema", {"Le Cinéma (123456789)", "Cinéma concurrent (561234789)"}),
             ("ciné théâtre", set()),
+            ("666666", set()),
+            ("666666001", {"Le Théâtre (100200300)"}),
+            ("12344", {"Cinéma concurrent (561234789)", "La Librairie (123444556)"}),
         ],
     )
     def test_autocomplete_offerers(self, authenticated_client, search_query, expected_texts):
-        offerers_factories.OffererFactory(siren="100200300", name="Le Théâtre")
-        offerers_factories.OffererFactory(siren="123456789", name="Le Cinéma")
-        offerers_factories.OffererFactory(siren="123444556", name="La Librairie")
-        offerers_factories.OffererFactory(siren="561234789", name="Cinéma concurrent")
+        offerers_factories.OffererFactory(id=1, siren="100200000", name="La scène")
+        offerers_factories.OffererFactory(id=666666001, siren="100200300", name="Le Théâtre")
+        offerers_factories.OffererFactory(id=666666002, siren="123456789", name="Le Cinéma")
+        offerers_factories.OffererFactory(id=666666003, siren="123444556", name="La Librairie")
+        offerers_factories.OffererFactory(id=12344, siren="561234789", name="Cinéma concurrent")
 
         _test_autocomplete(authenticated_client, "backoffice_web.autocomplete_offerers", search_query, expected_texts)
 
@@ -60,7 +64,7 @@ class AutocompleteVenueTest:
         "search_query, expected_texts",
         [
             ("", set()),
-            ("1", set()),
+            ("1", {"La scène (10020030000000)"}),
             ("12", {"Le Cinéma (12345678900018)", "La Librairie (12344455600012)", "La Médiathèque (12345678900011)"}),
             (
                 "1234",
@@ -74,14 +78,18 @@ class AutocompleteVenueTest:
             ("ciné", {"Le Cinéma (12345678900018)", "Cinéma concurrent (56123478900023)"}),
             ("cinema", {"Le Cinéma (12345678900018)", "Cinéma concurrent (56123478900023)"}),
             ("ciné théâtre", set()),
+            ("666666", set()),
+            ("666666001", {"Le Théâtre (10020030000021)"}),
+            ("12344", {"Cinéma concurrent (56123478900023)", "La Librairie (12344455600012)"}),
         ],
     )
     def test_autocomplete_venues(self, authenticated_client, search_query, expected_texts):
-        offerers_factories.VenueFactory(siret="10020030000021", name="Le Théâtre")
-        offerers_factories.VenueFactory(siret="12345678900018", name="Le Cinéma")
-        offerers_factories.VenueFactory(siret="12344455600012", name="La Librairie")
-        offerers_factories.VenueFactory(siret="12345678900011", name="La Médiathèque")
-        offerers_factories.VenueFactory(siret="56123478900023", name="Cinéma concurrent")
+        offerers_factories.VenueFactory(id=1, siret="10020030000000", name="La scène")
+        offerers_factories.VenueFactory(id=666666001, siret="10020030000021", name="Le Théâtre")
+        offerers_factories.VenueFactory(id=666666002, siret="12345678900018", name="Le Cinéma")
+        offerers_factories.VenueFactory(id=666666003, siret="12344455600012", name="La Librairie")
+        offerers_factories.VenueFactory(id=666666004, siret="12345678900011", name="La Médiathèque")
+        offerers_factories.VenueFactory(id=12344, siret="56123478900023", name="Cinéma concurrent")
 
         _test_autocomplete(authenticated_client, "backoffice_web.autocomplete_venues", search_query, expected_texts)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-25745

Cette structure à l'id 207, mais un nom et siren ne contenant pas 207 :
![image](https://github.com/pass-culture/pass-culture-main/assets/124259391/c2159af2-2276-4101-958b-bb22f122638a)

J'ai été obligé de modifier la déclaration tom-select en cas d'auto-complète, car le composant refait une recherche par défaut sur le label de l'option. Même si ça s'applique à tous les écrans utilisant un auto-complète, ça ne me semble pas problématique dans la plupart des cas.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques