### PR TITLE
(PC-26113)[PRO] fix: Flaky test in AdageDiscovery.spec.tsx

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
@@ -55,8 +55,10 @@ describe('AdageDiscovery', () => {
     }))
   })
 
-  it('should render adage discovery', () => {
+  it('should render adage discovery', async () => {
     renderAdageDiscovery(user)
+
+    await waitFor(() => expect(api.listEducationalDomains).toHaveBeenCalled())
 
     expect(
       screen.getByText('Les nouvelles offres publiées')
@@ -87,16 +89,20 @@ describe('AdageDiscovery', () => {
     expect(notifyError).toHaveBeenNthCalledWith(1, GET_DATA_ERROR_MESSAGE)
   })
 
-  it('should not call tracker when footer suggestion is not visible', () => {
+  it('should not call tracker when footer suggestion is not visible', async () => {
     renderAdageDiscovery(user)
+
+    await waitFor(() => expect(api.listEducationalDomains).toHaveBeenCalled())
 
     expect(apiAdage.logHasSeenAllPlaylist).toHaveBeenCalledTimes(0)
   })
 
-  it('should call tracker when footer suggestion is visible', () => {
+  it('should call tracker when footer suggestion is visible', async () => {
     vi.spyOn(useIsElementVisible, 'default').mockReturnValueOnce([true])
 
     renderAdageDiscovery(user)
+
+    await waitFor(() => expect(api.listEducationalDomains).toHaveBeenCalled())
 
     expect(apiAdage.logHasSeenAllPlaylist).toHaveBeenCalledTimes(1)
   })
@@ -151,15 +157,23 @@ describe('AdageDiscovery', () => {
   })
 
   it('should trigger a log wheen the last element of a playlist is seen', async () => {
-    renderAdageDiscovery(user)
+    //  Once for the footer visibility and twice for each playlist (4*2+1=9)
+    vi.spyOn(useIsElementVisible, 'default')
+      .mockReturnValueOnce([true, true])
+      .mockReturnValueOnce([true, true])
+      .mockReturnValueOnce([true, true])
+      .mockReturnValueOnce([true, true])
+      .mockReturnValueOnce([true, true])
+      .mockReturnValueOnce([true, true])
+      .mockReturnValueOnce([true, true])
+      .mockReturnValueOnce([true, true])
+      .mockReturnValueOnce([true, true])
 
-    //  Once for the footer visibility, and twice for one playlist to reach the end of the scroll (first and last elements visibility used in Carousel)
-    vi.spyOn(useIsElementVisible, 'default').mockReturnValueOnce([true, true])
-    vi.spyOn(useIsElementVisible, 'default').mockReturnValueOnce([true, true])
-    vi.spyOn(useIsElementVisible, 'default').mockReturnValueOnce([true, true])
+    renderAdageDiscovery(user)
 
     await waitFor(() => expect(api.listEducationalDomains).toHaveBeenCalled())
 
-    expect(apiAdage.logHasSeenWholePlaylist).toHaveBeenCalledTimes(1)
+    //  Log called once for each playlist
+    expect(apiAdage.logHasSeenWholePlaylist).toHaveBeenCalledTimes(4)
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26113

**Objectif**
Le test sur l'appel au log data quand on atteint la fin d'une playlist dans la découverte semble ne pas fonctionner parfois dans la ci. J'ai changé le mock du hook de visibilité des éléments pour couvrir l'ensemble des appels à useIsElementVisible de la page découverte.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques