### PR TITLE
(PC-25708)[API] fix: duplication for price category

### DIFF
--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -1,4 +1,3 @@
-import decimal
 import logging
 
 from flask_login import current_user
@@ -37,9 +36,7 @@ def _stock_exists(
 ) -> bool:
     for stock in existing_stocks:
         if (
-            # pylint: disable=too-many-boolean-expressions
             stock.offerId == offer_id
-            and stock.price == (stock_to_create.price or decimal.Decimal(0))
             and stock.beginningDatetime
             == (stock_to_create.beginning_datetime.replace(tzinfo=None) if stock_to_create.beginning_datetime else None)
             and stock.bookingLimitDatetime
@@ -64,7 +61,6 @@ def _get_existing_stocks_by_fields(
             offers_models.Stock.isSoftDeleted == False,
             offers_models.Stock.beginningDatetime == stock.beginning_datetime,
             offers_models.Stock.bookingLimitDatetime == stock.booking_limit_datetime,
-            offers_models.Stock.price == (stock.price or decimal.Decimal(0)),
             offers_models.Stock.priceCategoryId == stock.price_category_id,
             offers_models.Stock.quantity == stock.quantity,
         )

--- a/api/tests/routes/pro/post_stocks_test.py
+++ b/api/tests/routes/pro/post_stocks_test.py
@@ -616,14 +616,13 @@ class Returns201Test:
             offer=offer, priceCategoryLabel=price_cat_label_1, price=10
         )
         price_category_2 = offers_factories.PriceCategoryFactory(
-            offer=offer, priceCategoryLabel=price_cat_label_2, price=10
+            offer=offer, priceCategoryLabel=price_cat_label_2, price=20
         )
         offers_factories.EventStockFactory(
             offer=offer,
             beginningDatetime=format_into_utc_date(beginning),
             bookingLimitDatetime=format_into_utc_date(beginning),
             priceCategory=price_category_1,
-            price=10,
             quantity=10,
         )
         offers_factories.EventStockFactory(
@@ -631,7 +630,6 @@ class Returns201Test:
             beginningDatetime=format_into_utc_date(beginning_later),
             bookingLimitDatetime=format_into_utc_date(beginning_later),
             priceCategory=price_category_2,
-            price=20,
             quantity=20,
         )
         offerers_factories.UserOffererFactory(
@@ -644,28 +642,24 @@ class Returns201Test:
             "stocks": [
                 {
                     "priceCategoryId": price_category_1.id,
-                    "price": 10,
                     "quantity": 10,
                     "beginningDatetime": format_into_utc_date(beginning),
                     "bookingLimitDatetime": format_into_utc_date(beginning),
                 },
                 {
                     "priceCategoryId": price_category_1.id,
-                    "price": 10,
                     "quantity": 10,
                     "beginningDatetime": format_into_utc_date(beginning_later),
                     "bookingLimitDatetime": format_into_utc_date(beginning_later),
                 },
                 {
                     "priceCategoryId": price_category_2.id,
-                    "price": 20,
                     "quantity": 10,
                     "beginningDatetime": format_into_utc_date(beginning),
                     "bookingLimitDatetime": format_into_utc_date(beginning),
                 },
                 {
                     "priceCategoryId": price_category_2.id,
-                    "price": 20,
                     "quantity": 20,
                     "beginningDatetime": format_into_utc_date(beginning_later),
                     "bookingLimitDatetime": format_into_utc_date(beginning_later),
@@ -675,7 +669,6 @@ class Returns201Test:
 
         # When
         response = client.with_session_auth("user@example.com").post("/stocks/bulk/", json=stock_data)
-
         # Then
         assert response.status_code == 201
         assert response.json["stocks"] == 2


### PR DESCRIPTION

## But de la pull request

Fix suite à la revue PM, la duplication d'offres datées n'est plus possibles avec une catégorie de prix non nulle 

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25708

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques