### PR TITLE
(PC-26124) offerer stats top 3 offres

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
+++ b/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
@@ -61,9 +61,9 @@ class OffersData(BaseQuery):
         WHERE
             offerer_id = @offerer_id
         AND
-            DATE(execution_date) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+            DATE(execution_date) > DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+        QUALIFY RANK() OVER(PARTITION BY offerer_id ORDER BY execution_date DESC) = 1
         ORDER BY numberOfViews DESC
-        LIMIT 3
         """
 
     model = TopOffersData


### PR DESCRIPTION
## But de la pull request
Fix du bug de la requête sur le 3 offres, il se peut qu'on ait un jour sans aucune entrée dans la table, la condition dans le where ne doit pas être une égalité strict

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26124

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques