### PR TITLE
(PC-23423)[PRO] style: Modals have now the same size.

### DIFF
--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
@@ -59,3 +59,8 @@ $modal-height: rem.torem(336px);
   width: $modal-width;
   height: $modal-height;
 }
+
+.unlink-dialog {
+  width: $modal-width;
+  height: $modal-height;
+}

--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
@@ -196,6 +196,7 @@ const LinkVenuesDialog = ({
       )}
       {showUnlinkVenuesDialog && (
         <ConfirmDialog
+          extraClassNames={styles['unlink-dialog']}
           icon={strokeWarningIcon}
           onCancel={() => setShowUnlinkVenuesDialog(false)}
           title="Attention : le ou les lieux désélectionnés ne seront plus remboursés sur ce compte bancaire"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23423

- La taille des deux dialogs sont maintenant identiques.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques