### PR TITLE
(BSR)[API] test: Fix assert_num_queries

### DIFF
--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -615,11 +615,11 @@ class GetCollectiveOfferPriceFormTest(GetEndpointHelper):
     endpoint_kwargs = {"collective_offer_id": 1}
     needed_permission = perm_models.Permissions.ADVANCED_PRO_SUPPORT
 
-    # session + current user + stock
-    expected_num_queries = 3
+    # session + current user + offer + stock
+    expected_num_queries = 4
 
     def test_get_collective_offer_price_form(self, legit_user, authenticated_client):
-        collective_offer_id = educational_factories.CollectiveStockFactory().collectiveOffer.id
+        collective_offer_id = educational_factories.CollectiveStockFactory().collectiveOfferId
 
         with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, collective_offer_id=collective_offer_id))


### PR DESCRIPTION
Accessing the offer in the test setup put it in SQLAlchemy session.
Then when the route tried to load it, no SQL query was performed, so
that made 3 SQL queries. In reality, the offer is fetched from the
database, so 4 SQL queries are made.

Note that this test passed when it was run on its own, but failed when
all module tests were run. And it did not fail before a2410a7dad64351,
which does not look related). I don't know why.