### PR TITLE
(PC-26104)[PRO] fix: display warning pop in on dialog dismiss

### DIFF
--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -75,6 +75,7 @@ const BankInformations = (): JSX.Element => {
       searchParams.delete('structure')
       setSearchParams(searchParams)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
@@ -97,6 +98,7 @@ const BankInformations = (): JSX.Element => {
     }
 
     selectedOfferer && void getSelectedOffererBankAccounts(selectedOfferer.id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedOfferer])
 
   if (isOffererBankAccountsLoading || isOffererLoading) {

--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
@@ -51,6 +51,14 @@ const LinkVenuesDialog = ({
     (venue) => selectedVenuesIds.indexOf(venue.id) >= 0
   )
 
+  function onCancel() {
+    if (isEqual(selectedVenuesIds, initialVenuesIds)) {
+      closeDialog()
+    } else {
+      setShowDiscardChangesDialog(true)
+    }
+  }
+
   async function submitForm(hasUncheckedVenue = false) {
     try {
       await api.linkVenueToBankAccount(offererId, selectedBankAccount.id, {
@@ -100,9 +108,7 @@ const LinkVenuesDialog = ({
         labelledBy="link-venues-dialog"
         extraClassNames={styles['dialog']}
         hasCloseButton={true}
-        onDismiss={() => {
-          closeDialog()
-        }}
+        onDismiss={onCancel}
       >
         <h3 className={styles['dialog-title']}>
           Compte bancaire : {selectedBankAccount.label}
@@ -161,13 +167,7 @@ const LinkVenuesDialog = ({
             <div className={styles['dialog-actions']}>
               <Button
                 variant={ButtonVariant.SECONDARY}
-                onClick={() => {
-                  if (isEqual(selectedVenuesIds, initialVenuesIds)) {
-                    closeDialog()
-                  } else {
-                    setShowDiscardChangesDialog(true)
-                  }
-                }}
+                onClick={onCancel}
               >
                 Annuler
               </Button>

--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
@@ -165,10 +165,7 @@ const LinkVenuesDialog = ({
               })}
             </div>
             <div className={styles['dialog-actions']}>
-              <Button
-                variant={ButtonVariant.SECONDARY}
-                onClick={onCancel}
-              >
+              <Button variant={ButtonVariant.SECONDARY} onClick={onCancel}>
                 Annuler
               </Button>
               <SubmitButton

--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
@@ -52,6 +52,7 @@ const Validation = (): JSX.Element => {
     if (activity === null || activity == DEFAULT_ACTIVITY_VALUES) {
       navigate('/parcours-inscription/activite')
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activity, offerer])
 
   if (isLoadingVenueTypes) {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26104

Page informations bancaires
Si je décoche un lieu ou que j’en coche un nouveau mais que l’AC n’enregistre pas : 

    Au clic sur la croix 

    Au clic en dehors de la pop in 

-> la pop in warning s’affiche

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques