### PR TITLE
(PC-23442)[API/PRO] chore: Remove WIP_ENABLE_NEW_USER_OFFERER_LINK FF.

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 d42246a7f9ba (pre) (head)
-5ff88862400b (post) (head)
+76109536b81c (post) (head)

--- a/api/src/pcapi/alembic/versions/20231201T105425_76109536b81c_remove_feature_flag_enable_new_user_offerer_link.py
+++ b/api/src/pcapi/alembic/versions/20231201T105425_76109536b81c_remove_feature_flag_enable_new_user_offerer_link.py
@@ -1,0 +1,36 @@
+"""
+Remove FF WIP_ENABLE_NEW_USER_OFFERER_LINK
+"""
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "76109536b81c"
+down_revision = "5ff88862400b"
+branch_labels = None
+depends_on = None
+
+
+def get_flag():  # type:ignore[no-untyped-def]
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="WIP_ENABLE_NEW_USER_OFFERER_LINK",
+        isActive=True,
+        description="Activer le nouvel ajout des collaborateurs",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1190,8 +1190,7 @@ def validate_pro_user_email(user: users_models.User, author_user: users_models.U
     else:
         repository.save(user)
 
-    if feature.FeatureToggle.WIP_ENABLE_NEW_USER_OFFERER_LINK.is_active():
-        offerers_api.accept_offerer_invitation_if_exists(user)
+    offerers_api.accept_offerer_invitation_if_exists(user)
 
 
 def save_firebase_flags(user: models.User, firebase_value: dict) -> None:

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -102,7 +102,6 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_SATISFACTION_SURVEY = "Activer l'affichage du questionnaire de satisfaction adage"
     WIP_MANDATORY_BOOKING_CONTACT = "Rend obligatoire offer.bookingContact pour les offres retirables"
     WIP_ENABLE_BOOST_PREFIXED_EXTERNAL_BOOKING = "Active les réservations externes boost avec préfixe"
-    WIP_ENABLE_NEW_USER_OFFERER_LINK = "Activer le nouvel ajout des collaborateurs"
     WIP_ENABLE_DIFFUSE_HELP = "Activer l'affichage de l'aide diffuse adage"
     WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API = "Activer la création d'évènements avec tickets dans l'API publique"
     WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY = "Activer le nouveau parcours de dépôt de coordonnées bancaires"
@@ -176,7 +175,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ENABLE_LIKE_IN_ADAGE,
     FeatureToggle.WIP_ENABLE_MOCK_UBBLE,
     FeatureToggle.WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY,
-    FeatureToggle.WIP_ENABLE_NEW_USER_OFFERER_LINK,
     FeatureToggle.WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY,
     FeatureToggle.WIP_ENABLE_SATISFACTION_SURVEY,
     FeatureToggle.WIP_ENABLE_SEARCH_HISTORY_ADAGE,
@@ -204,7 +202,6 @@ if settings.IS_TESTING:
         FeatureToggle.WIP_CATEGORY_SELECTION,
         FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API,
         FeatureToggle.WIP_ENABLE_OFFER_CREATION_API_V1,
-        FeatureToggle.WIP_ENABLE_NEW_USER_OFFERER_LINK,
     }
 
     FEATURES_DISABLED_BY_DEFAULT = tuple(testing_features_disabled_by_default - features_to_enable)

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -17,14 +17,12 @@ from pcapi.core.offerers import api
 from pcapi.core.offerers import repository
 import pcapi.core.offerers.exceptions as offerers_exceptions
 import pcapi.core.offerers.models as offerers_models
-from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ResourceNotFoundError
 from pcapi.repository import transaction
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import offerers_serialize
 from pcapi.serialization.decorator import spectree_serialize
-from pcapi.utils.feature import feature_required
 from pcapi.utils.rest import check_user_has_access_to_offerer
 
 from . import blueprint
@@ -92,7 +90,6 @@ def get_offerer(offerer_id: int) -> offerers_serialize.GetOffererResponseModel:
 
 
 @private_api.route("/offerers/<int:offerer_id>/invite", methods=["POST"])
-@feature_required(feature.FeatureToggle.WIP_ENABLE_NEW_USER_OFFERER_LINK)
 @login_required
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
 def invite_member(offerer_id: int, body: offerers_serialize.InviteMemberQueryModel) -> None:
@@ -107,7 +104,6 @@ def invite_member(offerer_id: int, body: offerers_serialize.InviteMemberQueryMod
 
 
 @private_api.route("/offerers/<int:offerer_id>/members", methods=["GET"])
-@feature_required(feature.FeatureToggle.WIP_ENABLE_NEW_USER_OFFERER_LINK)
 @login_required
 @spectree_serialize(response_model=offerers_serialize.GetOffererMembersResponseModel, api=blueprint.pro_private_schema)
 def get_offerer_members(offerer_id: int) -> offerers_serialize.GetOffererMembersResponseModel:

--- a/api/tests/routes/pro/get_offerer_members_test.py
+++ b/api/tests/routes/pro/get_offerer_members_test.py
@@ -2,14 +2,12 @@ import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
-from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 from pcapi.models.validation_status_mixin import ValidationStatus
 
 
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
-    @override_features(WIP_ENABLE_NEW_USER_OFFERER_LINK=True)
     def test_get_offerer_members_by_pro(self, client):
         pro = users_factories.ProFactory(email="offerer@example.com")
         offerer = offerers_factories.OffererFactory()
@@ -39,7 +37,6 @@ class Returns200Test:
 
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:
-    @override_features(WIP_ENABLE_NEW_USER_OFFERER_LINK=True)
     def test_access_by_unauthorized_pro_user(self, client):
         pro_user = users_factories.ProFactory()
         offerer = offerers_factories.OffererFactory()

--- a/api/tests/routes/pro/post_offerer_invite_member_test.py
+++ b/api/tests/routes/pro/post_offerer_invite_member_test.py
@@ -2,13 +2,11 @@ import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
-from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 
 
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
-    @override_features(WIP_ENABLE_NEW_USER_OFFERER_LINK=True)
     def test_post_invite_member(self, client):
         pro_user = users_factories.ProFactory(email="pro.user@example.com")
         offerer = offerers_factories.OffererFactory()
@@ -27,7 +25,6 @@ class Returns200Test:
 
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:
-    @override_features(WIP_ENABLE_NEW_USER_OFFERER_LINK=True)
     def test_inivitation_already_exists(self, client):
         pro_user = users_factories.ProFactory(email="pro.user@example.com")
         offerer = offerers_factories.OffererFactory()

--- a/pro/src/pages/Home/Offerers/OffererDetails.tsx
+++ b/pro/src/pages/Home/Offerers/OffererDetails.tsx
@@ -30,9 +30,6 @@ const OffererDetails = ({
 }: OffererDetailsProps) => {
   const { logEvent } = useAnalytics()
   const isStatisticsDashboardEnabled = useActiveFeature('WIP_HOME_STATS')
-  const isNewOffererLinkEnabled = useActiveFeature(
-    'WIP_ENABLE_NEW_USER_OFFERER_LINK'
-  )
 
   const hasMissingReimbursementPoints = useMemo(() => {
     if (!selectedOfferer) {
@@ -83,27 +80,25 @@ const OffererDetails = ({
             />
           </div>
 
-          {isNewOffererLinkEnabled && (
-            <>
-              <div className="od-separator vertical" />
-              <ButtonLink
-                variant={ButtonVariant.TERNARY}
-                link={{
-                  to: `/structures/${selectedOfferer.id}`,
-                  isExternal: false,
-                }}
-                icon={fullAddUserIcon}
-                isDisabled={!isUserOffererValidated}
-                onClick={() => {
-                  logEvent?.(OffererLinkEvents.CLICKED_INVITE_COLLABORATOR, {
-                    offererId: selectedOfferer.id,
-                  })
-                }}
-              >
-                Inviter
-              </ButtonLink>
-            </>
-          )}
+          <>
+            <div className="od-separator vertical" />
+            <ButtonLink
+              variant={ButtonVariant.TERNARY}
+              link={{
+                to: `/structures/${selectedOfferer.id}`,
+                isExternal: false,
+              }}
+              icon={fullAddUserIcon}
+              isDisabled={!isUserOffererValidated}
+              onClick={() => {
+                logEvent?.(OffererLinkEvents.CLICKED_INVITE_COLLABORATOR, {
+                  offererId: selectedOfferer.id,
+                })
+              }}
+            >
+              Inviter
+            </ButtonLink>
+          </>
 
           <div className="od-separator vertical" />
           <ButtonLink

--- a/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.tsx
@@ -82,11 +82,6 @@ describe('offererDetailsLegacy', () => {
         },
         initialized: true,
       },
-      features: {
-        list: [
-          { isActive: false, nameKey: 'WIP_ENABLE_NEW_USER_OFFERER_LINK' },
-        ],
-      },
     }
 
     virtualVenue = {
@@ -221,28 +216,11 @@ describe('offererDetailsLegacy', () => {
 
     const secondOfflineVenueTitle = screen.getByText('Le deuxième Sous-sol')
     expect(secondOfflineVenueTitle).toBeInTheDocument()
-  })
-
-  it('should display invite member button if FF is enable and track', async () => {
-    const storeOverrides = {
-      ...store,
-      features: {
-        list: [{ isActive: true, nameKey: 'WIP_ENABLE_NEW_USER_OFFERER_LINK' }],
-      },
-    }
-    await renderHomePage(storeOverrides)
-
     expect(screen.getByText('Inviter')).toBeInTheDocument()
   })
 
   it('should trigger an event when clicking on "Inviter" for offerers', async () => {
-    const storeOverrides = {
-      ...store,
-      features: {
-        list: [{ isActive: true, nameKey: 'WIP_ENABLE_NEW_USER_OFFERER_LINK' }],
-      },
-    }
-    await renderHomePage(storeOverrides)
+    await renderHomePage(store)
 
     await userEvent.click(screen.getByText('Inviter'))
 

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/OffererDetails.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/OffererDetails.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { GetOffererVenueResponseModel } from 'apiClient/v1'
-import useActiveFeature from 'hooks/useActiveFeature'
 import fullBackIcon from 'icons/full-back.svg'
 import { HTTP_STATUS } from 'repository/pcapi/pcapiClient'
 import { ButtonLink } from 'ui-kit'
@@ -33,10 +32,6 @@ const OffererDetails = () => {
     setOfferer(null)
     setPhysicalVenues([])
   }, [])
-
-  const isNewOffererLinkEnabled = useActiveFeature(
-    'WIP_ENABLE_NEW_USER_OFFERER_LINK'
-  )
 
   const loadOfferer = useCallback(
     async (id: number) => {
@@ -129,9 +124,7 @@ const OffererDetails = () => {
           </div>
         </div>
 
-        {isNewOffererLinkEnabled && (
-          <AttachmentInvitations offererId={offerer.id} />
-        )}
+        <AttachmentInvitations offererId={offerer.id} />
 
         <ApiKey
           maxAllowedApiKeys={offerer.apiKey.maxAllowed}

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetails.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetails.spec.tsx
@@ -66,6 +66,7 @@ describe('src | components | pages | Offerer | OffererDetails', () => {
 
       expect(screen.getByText('Lieux')).toBeInTheDocument()
       expect(screen.getByText('fake venue')).toBeInTheDocument()
+      expect(screen.getByText('Collaborateurs')).toBeInTheDocument()
     })
 
     it("shouldn't render anything if venues won't load", async () => {
@@ -80,25 +81,6 @@ describe('src | components | pages | Offerer | OffererDetails', () => {
           /Détails de la structure rattachée, des collaborateurs, des lieux et des fournisseurs de ses offres/
         )
       ).not.toBeInTheDocument()
-    })
-
-    it('Should show invite section if the FF is enabled', async () => {
-      renderWithProviders(<OffererDetails />, {
-        storeOverrides: {
-          features: {
-            list: [
-              {
-                nameKey: 'WIP_ENABLE_NEW_USER_OFFERER_LINK',
-                isActive: true,
-              },
-            ],
-            initialized: true,
-          },
-        },
-      })
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-      expect(screen.getByText('Collaborateurs')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23442

- Retrait du FF pour le nouveau parcours d'invitation.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques