### PR TITLE
(PC-26123)[PRO] feat: Create fallback images on venue and offers card…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
@@ -362,7 +362,7 @@ export const AdageDiscovery = () => {
                     ...mockOffer.offerVenue,
                     addressType: OfferAddressType.OFFERER_VENUE,
                   },
-                  imageUrl: 'https://picsum.photos/201/',
+                  imageUrl: null,
                 }}
               />,
               <CardOfferComponent
@@ -485,6 +485,21 @@ export const AdageDiscovery = () => {
                   })
                 }
                 venue={{ ...mockVenue, imageUrl: 'https://picsum.photos/201/' }}
+              />,
+              <CardVenue
+                key="card-venue-1"
+                handlePlaylistElementTracking={() =>
+                  trackPlaylistElementClicked({
+                    playlistId: 3,
+                    playlistType: AdagePlaylistType.VENUE,
+                    elementId: 1, // TODO: change elementId with real value
+                  })
+                }
+                venue={{
+                  ...mockVenue,
+                  publicName: 'Mon super 2eme lieu',
+                  imageUrl: null,
+                }}
               />,
             ]}
           ></Carousel>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.module.scss
@@ -56,6 +56,14 @@ $offer-image-width: rem.torem(216px);
   height: $offer-image-height;
   border-radius: rem.torem(16px);
   border: rem.torem(1px) solid colors.$white;
+
+  &.offer-image-fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: colors.$grey-light;
+    color: colors.$grey-semi-dark;
+  }
 }
 
 .offer-favorite-button {

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.tsx
@@ -71,8 +71,10 @@ const CardOfferComponent = ({
               src={offer.imageUrl}
             />
           ) : (
-            <div className={styles['offer-image']}>
-              <SvgIcon src={strokeOfferIcon} alt="" />
+            <div
+              className={`${styles['offer-image']} ${styles['offer-image-fallback']}`}
+            >
+              <SvgIcon src={strokeOfferIcon} alt="" width="80" />
             </div>
           )}
         </div>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardVenue/CardVenue.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardVenue/CardVenue.module.scss
@@ -21,7 +21,6 @@ $venue-image-width: rem.torem(276px);
       box-shadow: none;
     }
 
-
     .venue-infos-name,
     .venue-infos-distance {
       text-decoration: none;
@@ -52,6 +51,14 @@ $venue-image-width: rem.torem(276px);
   height: $venue-image-height;
   border-radius: rem.torem(16px);
   object-fit: cover;
+
+  &.venue-image-fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: colors.$grey-light;
+    color: colors.$grey-semi-dark;
+  }
 }
 
 .venue-infos {

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardVenue/CardVenue.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardVenue/CardVenue.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { useSearchParams } from 'react-router-dom'
 
+import strokeVenueIcon from 'icons/stroke-venue.svg'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+
 import styles from './CardVenue.module.scss'
 
 interface CardVenueModel {
-  imageUrl: string
+  imageUrl?: string | null
   name: string
   publicName?: string
   distance: number
@@ -31,12 +34,20 @@ const CardVenue = ({
       href={`/adage-iframe/venue/${venue.id}?token=${adageAuthToken}`}
       onClick={() => handlePlaylistElementTracking()}
     >
-      <img
-        alt=""
-        className={styles['venue-image']}
-        loading="lazy"
-        src={venue.imageUrl}
-      />
+      {venue.imageUrl ? (
+        <img
+          alt=""
+          className={styles['venue-image']}
+          loading="lazy"
+          src={venue.imageUrl}
+        />
+      ) : (
+        <div
+          className={`${styles['venue-image']} ${styles['venue-image-fallback']}`}
+        >
+          <SvgIcon src={strokeVenueIcon} width="80" alt="" />
+        </div>
+      )}
       <div className={styles['venue-infos']}>
         <div className={styles['venue-infos-name']}>
           {venue.publicName || venue.name}


### PR DESCRIPTION
…s in discovery.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26123


**FF à activer**
- WIP_ENABLE_DISCOVERY

**Objectif**
Avoir une image de repli dans le cas ou la venue ou l'offre n'a pas d'image dans la nouvelle page de découverte sur adage

**A noter**
Dans `AdageDiscovery.tsx` je ne fais que créer des fausses données avec des `imageUrl` vides.

<img width="597" alt="Capture d’écran 2023-12-01 à 17 42 19" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/e3e62e6c-0ec7-4e3c-9f93-bd2743091da1">
<img width="713" alt="Capture d’écran 2023-12-01 à 17 43 50" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/1eb9d9ae-3bbc-4899-9cd2-fa889f6b66ec">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques