### PR TITLE
(PC-26186)[API] fix: fill the gaps in the stats provided from big query

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
+++ b/api/src/pcapi/connectors/big_query/queries/offerer_stats.py
@@ -29,6 +29,8 @@ class OffererViewsPerDay(BaseQuery):
             `{settings.BIG_QUERY_TABLE_BASENAME}.{DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE}`
         WHERE
             offerer_id = @offerer_id
+        AND
+            DATE(event_date) >= DATE_SUB(CURRENT_DATE(), INTERVAL 180 DAY)
         ORDER BY event_date DESC
         LIMIT 180
         """

--- a/api/tests/core/external/offerer_stats_test.py
+++ b/api/tests/core/external/offerer_stats_test.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import freezegun
 import pytest
 
 from pcapi.connectors.big_query.queries.offerer_stats import DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE
@@ -16,6 +17,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 
 class OffererStatsTest:
+    @freezegun.freeze_time("2023-10-25")
     @patch("pcapi.connectors.big_query.TestingBackend.run_query")
     def test_update_offerer_stats_data(self, mock_run_query_with_params):
         offerer = OffererFactory()
@@ -53,10 +55,10 @@ class OffererStatsTest:
         mock_run_query_with_params.side_effect = [
             iter(
                 [
-                    {"eventDate": "2023-10-16", "numberOfViews": 15},
+                    {"eventDate": "2023-10-18", "numberOfViews": 15},
                     {"eventDate": "2023-10-15", "numberOfViews": 10},
                     {"eventDate": "2023-10-14", "numberOfViews": 3},
-                    {"eventDate": "2023-10-13", "numberOfViews": 2},
+                    {"eventDate": "2023-10-10", "numberOfViews": 2},
                 ]
             ),
             iter(
@@ -82,10 +84,21 @@ class OffererStatsTest:
             OffererStats.table == DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
         ).one()
         assert offerer_global_stats.jsonData["daily_views"] == [
+            {"eventDate": "2023-10-10", "numberOfViews": 2},
+            {"eventDate": "2023-10-11", "numberOfViews": 2},
+            {"eventDate": "2023-10-12", "numberOfViews": 2},
             {"eventDate": "2023-10-13", "numberOfViews": 2},
             {"eventDate": "2023-10-14", "numberOfViews": 3},
             {"eventDate": "2023-10-15", "numberOfViews": 10},
-            {"eventDate": "2023-10-16", "numberOfViews": 15},
+            {"eventDate": "2023-10-16", "numberOfViews": 10},
+            {"eventDate": "2023-10-17", "numberOfViews": 10},
+            {"eventDate": "2023-10-18", "numberOfViews": 15},
+            {"eventDate": "2023-10-19", "numberOfViews": 15},
+            {"eventDate": "2023-10-20", "numberOfViews": 15},
+            {"eventDate": "2023-10-21", "numberOfViews": 15},
+            {"eventDate": "2023-10-22", "numberOfViews": 15},
+            {"eventDate": "2023-10-23", "numberOfViews": 15},
+            {"eventDate": "2023-10-24", "numberOfViews": 15},
         ]
 
         offerer_top_offers = OffererStats.query.filter(
@@ -99,6 +112,7 @@ class OffererStatsTest:
         ]
         assert offerer_top_offers.jsonData["total_views_last_30_days"] == 30
 
+    @freezegun.freeze_time("2023-10-25")
     @patch("pcapi.connectors.big_query.TestingBackend.run_query")
     def test_create_offerer_stats_data(self, mock_run_query_with_params):
         offerer = OffererFactory()
@@ -111,8 +125,8 @@ class OffererStatsTest:
             iter(
                 [
                     {"eventDate": "2023-10-16", "numberOfViews": 15},
-                    {"eventDate": "2023-10-15", "numberOfViews": 10},
-                    {"eventDate": "2023-10-14", "numberOfViews": 5},
+                    {"eventDate": "2023-10-10", "numberOfViews": 10},
+                    {"eventDate": "2023-10-05", "numberOfViews": 5},
                 ]
             ),
             iter(
@@ -140,9 +154,26 @@ class OffererStatsTest:
             OffererStats.table == DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
         ).one()
         assert offerer_global_stats.jsonData["daily_views"] == [
-            {"eventDate": "2023-10-14", "numberOfViews": 5},
+            {"eventDate": "2023-10-05", "numberOfViews": 5},
+            {"eventDate": "2023-10-06", "numberOfViews": 5},
+            {"eventDate": "2023-10-07", "numberOfViews": 5},
+            {"eventDate": "2023-10-08", "numberOfViews": 5},
+            {"eventDate": "2023-10-09", "numberOfViews": 5},
+            {"eventDate": "2023-10-10", "numberOfViews": 10},
+            {"eventDate": "2023-10-11", "numberOfViews": 10},
+            {"eventDate": "2023-10-12", "numberOfViews": 10},
+            {"eventDate": "2023-10-13", "numberOfViews": 10},
+            {"eventDate": "2023-10-14", "numberOfViews": 10},
             {"eventDate": "2023-10-15", "numberOfViews": 10},
             {"eventDate": "2023-10-16", "numberOfViews": 15},
+            {"eventDate": "2023-10-17", "numberOfViews": 15},
+            {"eventDate": "2023-10-18", "numberOfViews": 15},
+            {"eventDate": "2023-10-19", "numberOfViews": 15},
+            {"eventDate": "2023-10-20", "numberOfViews": 15},
+            {"eventDate": "2023-10-21", "numberOfViews": 15},
+            {"eventDate": "2023-10-22", "numberOfViews": 15},
+            {"eventDate": "2023-10-23", "numberOfViews": 15},
+            {"eventDate": "2023-10-24", "numberOfViews": 15},
         ]
 
         offerer_top_offers = OffererStats.query.filter(


### PR DESCRIPTION
## But de la pull request
La data nous renvoie une donnée par jour pour les jours où l'offerer a eu des vues, dans cette PR on remplie les trous afin d'afficher les stats corrects pour l'offerer
EX:
Si la data nous renvoie:
09/09/23: 10 vues
09/11/23: 100 vues
le graph fait une interpolation et lisse la courbe, affichant alors des données fausses, en plus le graph s'arrête au 09/11/23
Après cette PR le graph s'arretera tous le temps à la veille de la mise à jour (car les données de la data sont toujours décalés d'un jour)
on aura alors:
09/09/23: 10 vues
10/09/23: 10 vues
.
.
.
09/11/23: 100 vues
10/11/23: 100 vues
.
.
. 
yesterday: 100 vues

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26186

## Vérifications

- [X] J'ai écrit les tests nécessaires