### PR TITLE
(PC-26212)[BO] fix: add format column to the collective offer template page

### DIFF
--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
@@ -42,6 +42,7 @@ def _get_collective_offer_templates(
             educational_models.CollectiveOfferTemplate.id,
             educational_models.CollectiveOfferTemplate.name,
             educational_models.CollectiveOfferTemplate.subcategoryId,
+            educational_models.CollectiveOfferTemplate.formats,
             educational_models.CollectiveOfferTemplate.dateCreated,
             educational_models.CollectiveOfferTemplate.validation,
         ),

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
@@ -45,6 +45,7 @@
               <th scope="col">Nom de l'offre</th>
               <th scope="col">Catégorie</th>
               <th scope="col">Sous-catégorie</th>
+              <th scope="col">Formats</th>
               {% if has_permission("PRO_FRAUD_ACTIONS") %}<th scope="col">Règles de conformité</th>{% endif %}
               <th scope="col">État</th>
               <th scope="col">
@@ -101,6 +102,7 @@
                 <td>{{ links.build_offer_name_to_pc_pro_link(collective_offer_template) }}</td>
                 <td>{{ collective_offer_template.subcategoryId | format_offer_category }}</td>
                 <td>{{ collective_offer_template.subcategoryId | format_offer_subcategory }}</td>
+                <td>{{ collective_offer_template.formats | format_collective_offer_formats }}</td>
                 {% if has_permission("PRO_FRAUD_ACTIONS") %}
                   <td>{{ collective_offer_template.flaggingValidationRules | format_offer_validation_rule_list }}</td>
                 {% endif %}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26212
Ajout de la colonne de format à la liste des offres vitrine dans le backoffice.

<img width="1448" alt="Capture d’écran 2023-12-06 à 09 52 57" src="https://github.com/pass-culture/pass-culture-main/assets/2340654/48e3bbd7-c3fa-43b1-9a2e-65d64c7286dd">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques