### PR TITLE
(PC-26204)[PRO] fix: Dont show card hover style when favorite button …

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.module.scss
@@ -11,7 +11,9 @@ $offer-image-width: rem.torem(216px);
   flex-direction: column;
   width: $offer-image-width;
   gap: rem.torem(16px);
+}
 
+.offer-link {
   &:active {
     opacity: 0.64;
 
@@ -38,12 +40,10 @@ $offer-image-width: rem.torem(216px);
     }
   }
 
-  &-link {
-    &:focus-visible {
-      outline: rem.torem(1px) solid colors.$input-text-color;
-      outline-offset: rem.torem(4px);
-      border-radius: rem.torem(18px);
-    }
+  &:focus-visible {
+    outline: rem.torem(1px) solid colors.$input-text-color;
+    outline-offset: rem.torem(4px);
+    border-radius: rem.torem(18px);
   }
 }
 

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/CardOffer/CardOffer.tsx
@@ -55,6 +55,7 @@ const CardOfferComponent = ({
   return (
     <div className={styles['container']}>
       <NavLink
+        className={styles['offer-link']}
         data-testid="card-offer-link"
         to={`/adage-iframe/decouverte/offre/${offer.id}?token=${adageAuthToken}`}
         onClick={() => {

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -20,6 +20,9 @@
   &:disabled,
   &.button-disabled {
     cursor: default;
+  }
+
+  &.button-disabled {
     pointer-events: none;
   }
 


### PR DESCRIPTION
…is clicked.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26204

**FF à activer**
WIP_ENABLE_DISCOVERY

**Objectif**
Dans la page découverte d'adage, ne pas avoir les styles de hover/active/focus de la carte d'une offre quand on clic sur le bouton favoris.

**Réalisation**
- Appliquer les styles de focus/hover/active sur le lien et pas sur le container de la carte en entier
- Garder le pointer-event par défaut sur els boutons disabled (pour le style hover au clic)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques