### PR TITLE
(PC-26202)[PRO] Champs de date limite, style

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.module.scss
@@ -5,10 +5,10 @@
   padding-bottom: rem.torem(24px);
 }
 
-.siret-banner {
+.siret-callout{
   margin-top: rem.torem(58px);
 }
 
-.banner-content-info {
+.callout-content-info {
   margin-top: rem.torem(8px);
 }

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { BannerInvisibleSiren } from 'components/Banner'
+import Callout from 'components/Callout/Callout'
 import FormLayout from 'components/FormLayout'
 import { OnboardingFormNavigationAction } from 'components/SignupJourneyFormLayout/constants'
 import { SIGNUP_JOURNEY_STEP_IDS } from 'components/SignupJourneyStepper/constants'
@@ -15,7 +16,6 @@ import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
 import { MAYBE_APP_USER_APE_CODE } from 'pages/Signup/SignupContainer/constants'
 import MaybeAppUserDialog from 'pages/Signup/SignupContainer/MaybeAppUserDialog'
-import { Banner } from 'ui-kit'
 
 import { ActionBar } from '../ActionBar'
 
@@ -131,9 +131,8 @@ const Offerer = (): JSX.Element => {
             {showInvisibleBanner && (
               <BannerInvisibleSiren isNewOnboarding={true} />
             )}
-            <Banner
-              type="notification-info"
-              className={styles['siret-banner']}
+            <Callout
+              className={styles['siret-callout']}
               links={[
                 {
                   href: 'https://aide.passculture.app/hc/fr/articles/4633420022300--Acteurs-Culturels-Collectivit%C3%A9-Lieu-rattach%C3%A9-%C3%A0-une-collectivit%C3%A9-S-inscrire-et-param%C3%A9trer-son-compte-pass-Culture-',
@@ -145,11 +144,11 @@ const Offerer = (): JSX.Element => {
                 Vous êtes un équipement d’une collectivité ou d'un établissement
                 public ?
               </strong>
-              <p className={styles['banner-content-info']}>
+              <p className={styles['callout-content-info']}>
                 Renseignez le SIRET de la structure à laquelle vous êtes
                 rattaché.
               </p>
-            </Banner>
+            </Callout>
             <ActionBar
               onClickNext={handleNextStep}
               isDisabled={formik.isSubmitting}


### PR DESCRIPTION
## But de la pull request - Modifier la taille de champs de la création d'offre.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26202
Branche: PC-26202-champs-date-limite

Testes:

<img width="950" alt="Capture d’écran 2023-12-04 à 13 46 23" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/14701a2a-24c4-4155-b6d4-9e64c3da3411">

<img width="742" alt="Capture d’écran 2023-12-04 à 13 45 16" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/fdabcb5f-09e7-4640-9dd5-0d914867e4a6">

Il y a cela aussi: 

<img width="944" alt="Capture d’écran 2023-12-04 à 13 49 22" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/7f7e06e3-1935-48e2-88c1-cba42262fc52">



