### PR TITLE
(PC-26051)[PRO] style: move ReimbursementsTabs to avoid gap and margin bottom

### DIFF
--- a/pro/src/pages/Reimbursements/Reimbursements.tsx
+++ b/pro/src/pages/Reimbursements/Reimbursements.tsx
@@ -28,8 +28,8 @@ const Reimbursements = (): JSX.Element => {
       <div className={styles['reimbursements-container']}>
         <h1 className={styles['title']}>Remboursements</h1>
         <ReimbursementsBanners />
-        <ReimbursementsTabs />
         <div>
+          <ReimbursementsTabs />
           <Routes>
             {routes.map(({ path, element }) => (
               <Route key={path} path={path} element={element} />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26051

Espacement entre tabs et contenu 64px -> 32px

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/bfe54f14-b02e-46d7-9996-07c5d8223ce8)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques