### PR TITLE
PC 25882 adage add venue ids offerer name

### DIFF
--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -164,6 +164,14 @@ def confirm_collective_booking(educational_booking_id: int) -> educational_model
         db.session.add(collective_booking)
         db.session.commit()
 
+    # re-fetch collective booking with some joinedload that will
+    # very-likely be useful later
+    collective_booking = educational_repository.find_collective_booking_by_id(collective_booking.id)
+    if not collective_booking:
+        # this should not happen
+        logger.exception("Confirmed booking not found", extra={"booking": educational_booking_id})
+        raise exceptions.EducationalBookingNotFound()
+
     logger.info(
         "Head of institution confirmed an educational offer",
         extra={
@@ -205,6 +213,14 @@ def refuse_collective_booking(educational_booking_id: int) -> educational_models
             raise exception
 
         repository.save(collective_booking)
+
+    # re-fetch collective booking with some joinedload that will
+    # very-likely be useful later
+    collective_booking = educational_repository.find_collective_booking_by_id(educational_booking_id)
+    if collective_booking is None:
+        # this should not happen
+        logger.exception("Refused booking not found", extra={"booking": educational_booking_id})
+        raise exceptions.EducationalBookingNotFound()
 
     logger.info(
         "Collective Booking has been cancelled",

--- a/api/tests/routes/adage/v1/confirm_prebooking_test.py
+++ b/api/tests/routes/adage/v1/confirm_prebooking_test.py
@@ -118,6 +118,8 @@ class Returns200Test:
             "interventionArea": offer.interventionArea,
             "imageUrl": None,
             "imageCredit": None,
+            "venueId": venue.id,
+            "offererName": venue.managingOfferer.name,
         }
         assert (
             CollectiveBooking.query.filter(CollectiveBooking.id == booking.id).one().status

--- a/api/tests/routes/adage/v1/conftest.py
+++ b/api/tests/routes/adage/v1/conftest.py
@@ -1,0 +1,62 @@
+from pcapi.core.educational import models
+from pcapi.core.offers.utils import offer_app_link
+from pcapi.routes.adage.v1.serialization.prebooking import _get_educational_offer_accessibility
+from pcapi.utils.date import format_into_utc_date
+
+
+def expected_serialized_prebooking(booking: models.CollectiveBooking) -> dict:
+    stock = booking.collectiveStock
+    offer = stock.collectiveOffer
+    venue = offer.venue
+    redactor = booking.educationalRedactor
+
+    return {
+        "address": offer.offerVenue["otherAddress"],
+        "accessibility": _get_educational_offer_accessibility(offer),
+        "beginningDatetime": format_into_utc_date(stock.beginningDatetime),
+        "cancellationDate": None,
+        "cancellationLimitDate": format_into_utc_date(booking.cancellationLimitDate),
+        "city": venue.city,
+        "confirmationDate": format_into_utc_date(booking.confirmationDate) if booking.confirmationDate else None,
+        "confirmationLimitDate": format_into_utc_date(booking.confirmationLimitDate),
+        "contact": {"email": offer.contactEmail, "phone": offer.contactPhone},
+        "coordinates": {
+            "latitude": float(venue.latitude),
+            "longitude": float(venue.longitude),
+        },
+        "creationDate": format_into_utc_date(booking.dateCreated),
+        "description": offer.description,
+        "durationMinutes": offer.durationMinutes,
+        "expirationDate": None,
+        "id": booking.id,
+        "isDigital": False,
+        "venueName": venue.name,
+        "name": offer.name,
+        "numberOfTickets": stock.numberOfTickets,
+        "participants": [students.value for students in offer.students],
+        "priceDetail": stock.priceDetail,
+        "postalCode": venue.postalCode,
+        "price": float(stock.price),
+        "quantity": 1,
+        "redactor": {
+            "email": redactor.email,
+            "redactorFirstName": redactor.firstName,
+            "redactorLastName": redactor.lastName,
+            "redactorCivility": redactor.civility,
+        },
+        "UAICode": booking.educationalInstitution.institutionId,
+        "yearId": int(booking.educationalYearId),
+        "status": booking.status.value,
+        "subcategoryLabel": offer.subcategory.app_label,
+        "venueTimezone": venue.timezone,
+        "totalAmount": float(stock.price),
+        "url": offer_app_link(offer),
+        "withdrawalDetails": None,
+        "domainIds": [domain.id for domain in offer.domains],
+        "domainLabels": [domain.name for domain in offer.domains],
+        "interventionArea": offer.interventionArea,
+        "imageUrl": offer.imageUrl,
+        "imageCredit": offer.imageCredit,
+        "venueId": venue.id,
+        "offererName": venue.managingOfferer.name,
+    }

--- a/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
+++ b/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
@@ -3,7 +3,7 @@ import pytest
 from pcapi.core.educational.factories import CollectiveBookingFactory
 from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalYearFactory
-from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.core.testing import assert_num_queries
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -33,7 +33,7 @@ class Returns200Test:
         client = client.with_eac_token()
         adage_id = booking1.educationalYear.adageId
 
-        with assert_no_duplicated_queries():
+        with assert_num_queries(1):
             response = client.get(f"/adage/v1/years/{adage_id}/prebookings")
 
         assert response.status_code == 200

--- a/api/tests/routes/adage/v1/get_educational_bookings_test.py
+++ b/api/tests/routes/adage/v1/get_educational_bookings_test.py
@@ -7,6 +7,8 @@ from pcapi.core.offers.utils import offer_app_link
 from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.utils.date import format_into_utc_date
 
+from tests.routes.adage.v1.conftest import expected_serialized_prebooking
+
 
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
@@ -410,61 +412,4 @@ class Returns200Test:
         )
 
         assert response.status_code == 200
-        stock1 = booking1.collectiveStock
-        offer1 = stock1.collectiveOffer
-        venue1 = offer1.venue
-
-        assert response.json == {
-            "prebookings": [
-                {
-                    "address": offer1.offerVenue["otherAddress"],
-                    "accessibility": "Non accessible",
-                    "beginningDatetime": format_into_utc_date(stock1.beginningDatetime),
-                    "cancellationDate": None,
-                    "cancellationLimitDate": format_into_utc_date(booking1.cancellationLimitDate),
-                    "city": venue1.city,
-                    "confirmationDate": format_into_utc_date(booking1.confirmationDate),
-                    "confirmationLimitDate": format_into_utc_date(booking1.confirmationLimitDate),
-                    "contact": {"email": offer1.contactEmail, "phone": offer1.contactPhone},
-                    "coordinates": {
-                        "latitude": float(venue1.latitude),
-                        "longitude": float(venue1.longitude),
-                    },
-                    "creationDate": format_into_utc_date(booking1.dateCreated),
-                    "description": offer1.description,
-                    "durationMinutes": offer1.durationMinutes,
-                    "expirationDate": None,
-                    "id": booking1.id,
-                    "isDigital": False,
-                    "venueName": venue1.name,
-                    "name": offer1.name,
-                    "numberOfTickets": stock1.numberOfTickets,
-                    "participants": [students.value for students in offer1.students],
-                    "priceDetail": stock1.priceDetail,
-                    "postalCode": venue1.postalCode,
-                    "price": float(stock1.price),
-                    "quantity": 1,
-                    "redactor": {
-                        "email": booking1.educationalRedactor.email,
-                        "redactorFirstName": booking1.educationalRedactor.firstName,
-                        "redactorLastName": booking1.educationalRedactor.lastName,
-                        "redactorCivility": booking1.educationalRedactor.civility,
-                    },
-                    "UAICode": booking1.educationalInstitution.institutionId,
-                    "yearId": int(booking1.educationalYearId),
-                    "status": "CONFIRMED",
-                    "subcategoryLabel": offer1.subcategory.app_label,
-                    "venueTimezone": venue1.timezone,
-                    "totalAmount": float(stock1.price),
-                    "url": offer_app_link(offer1),
-                    "withdrawalDetails": None,
-                    "domainIds": [domain.id for domain in offer1.domains],
-                    "domainLabels": [domain.name for domain in offer1.domains],
-                    "interventionArea": offer1.interventionArea,
-                    "imageUrl": None,
-                    "imageCredit": None,
-                    "venueId": venue1.id,
-                    "offererName": venue1.managingOfferer.name,
-                }
-            ]
-        }
+        assert response.json == {"prebookings": [expected_serialized_prebooking(booking1)]}

--- a/api/tests/routes/adage/v1/get_educational_bookings_test.py
+++ b/api/tests/routes/adage/v1/get_educational_bookings_test.py
@@ -89,6 +89,8 @@ class Returns200Test:
                     "interventionArea": offer1.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue1.id,
+                    "offererName": venue1.managingOfferer.name,
                 },
                 {
                     "address": offer2.offerVenue["otherAddress"],
@@ -137,6 +139,8 @@ class Returns200Test:
                     "interventionArea": offer2.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue2.id,
+                    "offererName": venue2.managingOfferer.name,
                 },
             ]
         }
@@ -216,6 +220,8 @@ class Returns200Test:
                     "interventionArea": offer1.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue1.id,
+                    "offererName": venue1.managingOfferer.name,
                 }
             ]
         }
@@ -295,6 +301,8 @@ class Returns200Test:
                     "interventionArea": offer1.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue1.id,
+                    "offererName": venue1.managingOfferer.name,
                 }
             ]
         }
@@ -374,6 +382,8 @@ class Returns200Test:
                     "interventionArea": offer1.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue1.id,
+                    "offererName": venue1.managingOfferer.name,
                 }
             ]
         }
@@ -453,6 +463,8 @@ class Returns200Test:
                     "interventionArea": offer1.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue1.id,
+                    "offererName": venue1.managingOfferer.name,
                 }
             ]
         }

--- a/api/tests/routes/adage/v1/get_educational_institution_test.py
+++ b/api/tests/routes/adage/v1/get_educational_institution_test.py
@@ -114,6 +114,8 @@ class Returns200Test:
                     "interventionArea": offer.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue.id,
+                    "offererName": venue.managingOfferer.name,
                 }
             ],
         }

--- a/api/tests/routes/adage/v1/get_educational_institution_test.py
+++ b/api/tests/routes/adage/v1/get_educational_institution_test.py
@@ -8,7 +8,7 @@ from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
 from pcapi.core.offers.utils import offer_app_link
-from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.core.testing import assert_num_queries
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -155,8 +155,13 @@ class Returns200Test:
         adage_id = educational_year.adageId
         institution_id = educational_institution.institutionId
 
-        with assert_no_duplicated_queries():
-            client.with_eac_token().get(f"/adage/v1/years/{adage_id}/educational_institution/{institution_id}")
+        dst = f"/adage/v1/years/{adage_id}/educational_institution/{institution_id}"
+
+        # fetch the institution (1 query)
+        # fetch the prebookings (1 query)
+        # fetch the deposit (1 query)
+        with assert_num_queries(3):
+            client.with_eac_token().get(dst)
 
     def test_get_educational_institution_without_deposit(self, client: Any) -> None:
         educational_year = EducationalYearFactory()

--- a/api/tests/routes/adage/v1/get_educational_institution_test.py
+++ b/api/tests/routes/adage/v1/get_educational_institution_test.py
@@ -7,9 +7,9 @@ from pcapi.core.educational.factories import EducationalDepositFactory
 from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
-from pcapi.core.offers.utils import offer_app_link
 from pcapi.core.testing import assert_num_queries
-from pcapi.utils.date import format_into_utc_date
+
+from tests.routes.adage.v1.conftest import expected_serialized_prebooking
 
 
 @pytest.mark.usefixtures("db_session")
@@ -57,67 +57,10 @@ class Returns200Test:
         )
 
         assert response.status_code == 200
-
-        stock = booking.collectiveStock
-        offer = stock.collectiveOffer
-        venue = offer.venue
         assert response.json == {
             "credit": 2000,
             "isFinal": True,
-            "prebookings": [
-                {
-                    "address": offer.offerVenue["otherAddress"],
-                    "accessibility": "Non accessible",
-                    "beginningDatetime": format_into_utc_date(stock.beginningDatetime),
-                    "cancellationDate": None,
-                    "cancellationLimitDate": format_into_utc_date(booking.cancellationLimitDate),
-                    "city": venue.city,
-                    "confirmationDate": format_into_utc_date(booking.confirmationDate)
-                    if booking.confirmationDate
-                    else None,
-                    "confirmationLimitDate": format_into_utc_date(booking.confirmationLimitDate),
-                    "contact": {"email": offer.contactEmail, "phone": offer.contactPhone},
-                    "coordinates": {
-                        "latitude": float(venue.latitude),
-                        "longitude": float(venue.longitude),
-                    },
-                    "creationDate": format_into_utc_date(booking.dateCreated),
-                    "description": offer.description,
-                    "durationMinutes": offer.durationMinutes,
-                    "expirationDate": None,
-                    "id": booking.id,
-                    "isDigital": False,
-                    "venueName": venue.name,
-                    "name": offer.name,
-                    "numberOfTickets": stock.numberOfTickets,
-                    "participants": [students.value for students in offer.students],
-                    "priceDetail": stock.priceDetail,
-                    "postalCode": venue.postalCode,
-                    "price": float(stock.price),
-                    "quantity": 1,
-                    "redactor": {
-                        "email": "jean.doux@example.com",
-                        "redactorFirstName": "Jean",
-                        "redactorLastName": "Doudou",
-                        "redactorCivility": "M.",
-                    },
-                    "UAICode": booking.educationalInstitution.institutionId,
-                    "yearId": int(booking.educationalYearId),
-                    "status": "CONFIRMED",
-                    "subcategoryLabel": offer.subcategory.app_label,
-                    "venueTimezone": venue.timezone,
-                    "totalAmount": float(stock.price),
-                    "url": offer_app_link(offer),
-                    "withdrawalDetails": None,
-                    "domainIds": [domain.id for domain in offer.domains],
-                    "domainLabels": [domain.name for domain in offer.domains],
-                    "interventionArea": offer.interventionArea,
-                    "imageUrl": None,
-                    "imageCredit": None,
-                    "venueId": venue.id,
-                    "offererName": venue.managingOfferer.name,
-                }
-            ],
+            "prebookings": [expected_serialized_prebooking(booking)],
         }
 
     def test_get_educational_institution_num_queries(self, client: Any) -> None:
@@ -174,7 +117,6 @@ class Returns200Test:
         )
 
         assert response.status_code == 200
-
         assert response.json == {
             "credit": 0,
             "isFinal": False,

--- a/api/tests/routes/adage/v1/get_prebookings_test.py
+++ b/api/tests/routes/adage/v1/get_prebookings_test.py
@@ -7,9 +7,9 @@ from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
 from pcapi.core.educational.models import StudentLevels
-from pcapi.core.offers.utils import offer_app_link
 from pcapi.core.testing import assert_num_queries
-from pcapi.utils.date import format_into_utc_date
+
+from tests.routes.adage.v1.conftest import expected_serialized_prebooking
 
 
 @pytest.mark.usefixtures("db_session")
@@ -56,69 +56,7 @@ class Returns200Test:
             response = client.with_eac_token().get(dst)
 
         assert response.status_code == 200
-
-        stock = booking.collectiveStock
-        offer = stock.collectiveOffer
-        venue = offer.venue
-        assert response.json == {
-            "prebookings": [
-                {
-                    "accessibility": "Auditif, Visuel",
-                    "address": "1 rue des polissons, Paris 75017",
-                    "beginningDatetime": format_into_utc_date(stock.beginningDatetime),
-                    "cancellationDate": None,
-                    "cancellationLimitDate": format_into_utc_date(booking.cancellationLimitDate),
-                    "city": venue.city,
-                    "confirmationDate": format_into_utc_date(booking.confirmationDate),
-                    "confirmationLimitDate": format_into_utc_date(booking.confirmationLimitDate),
-                    "contact": {"email": "miss.rond@point.com", "phone": "0101010101"},
-                    "coordinates": {
-                        "latitude": float(venue.latitude),
-                        "longitude": float(venue.longitude),
-                    },
-                    "creationDate": format_into_utc_date(booking.dateCreated),
-                    "description": offer.description,
-                    "durationMinutes": offer.durationMinutes,
-                    "expirationDate": None,
-                    "id": booking.id,
-                    "isDigital": False,
-                    "venueName": venue.name,
-                    "name": offer.name,
-                    "numberOfTickets": stock.numberOfTickets,
-                    "participants": [
-                        "CAP - 1re ann\u00e9e",
-                        "CAP - 2e ann\u00e9e",
-                        "Lyc\u00e9e - Seconde",
-                        "Lyc\u00e9e - Premi\u00e8re",
-                    ],
-                    "priceDetail": stock.priceDetail,
-                    "postalCode": venue.postalCode,
-                    "price": float(stock.price),
-                    "quantity": 1,
-                    "redactor": {
-                        "email": "jean.doux@example.com",
-                        "redactorFirstName": "Jean",
-                        "redactorLastName": "Doudou",
-                        "redactorCivility": "M.",
-                    },
-                    "UAICode": booking.educationalInstitution.institutionId,
-                    "yearId": int(booking.educationalYearId),
-                    "status": "CONFIRMED",
-                    "subcategoryLabel": offer.subcategory.app_label,
-                    "venueTimezone": venue.timezone,
-                    "totalAmount": float(stock.price),
-                    "url": offer_app_link(offer),
-                    "withdrawalDetails": None,
-                    "domainIds": [domain.id for domain in offer.domains],
-                    "domainLabels": [domain.name for domain in offer.domains],
-                    "interventionArea": offer.interventionArea,
-                    "imageUrl": None,
-                    "imageCredit": None,
-                    "venueId": venue.id,
-                    "offererName": venue.managingOfferer.name,
-                }
-            ],
-        }
+        assert response.json == {"prebookings": [expected_serialized_prebooking(booking)]}
 
     def test_get_prebookings_with_query_params(self, client: Any) -> None:
         redactor = EducationalRedactorFactory(
@@ -155,63 +93,4 @@ class Returns200Test:
             response = client.with_eac_token().get(dst)
 
         assert response.status_code == 200
-        stock = booking.collectiveStock
-        offer = stock.collectiveOffer
-        venue = offer.venue
-        assert response.json == {
-            "prebookings": [
-                {
-                    "accessibility": "Non accessible",
-                    "address": "1 rue des polissons, Paris 75017",
-                    "beginningDatetime": format_into_utc_date(stock.beginningDatetime),
-                    "cancellationDate": None,
-                    "cancellationLimitDate": format_into_utc_date(booking.cancellationLimitDate),
-                    "city": venue.city,
-                    "confirmationDate": format_into_utc_date(booking.confirmationDate),
-                    "confirmationLimitDate": format_into_utc_date(booking.confirmationLimitDate),
-                    "contact": {
-                        "email": offer.contactEmail,
-                        "phone": offer.contactPhone,
-                    },
-                    "coordinates": {
-                        "latitude": float(venue.latitude),
-                        "longitude": float(venue.longitude),
-                    },
-                    "creationDate": format_into_utc_date(booking.dateCreated),
-                    "description": offer.description,
-                    "durationMinutes": offer.durationMinutes,
-                    "expirationDate": None,
-                    "id": booking.id,
-                    "isDigital": False,
-                    "venueName": venue.name,
-                    "name": offer.name,
-                    "numberOfTickets": stock.numberOfTickets,
-                    "participants": [student.value for student in offer.students],
-                    "priceDetail": stock.priceDetail,
-                    "postalCode": venue.postalCode,
-                    "price": float(stock.price),
-                    "quantity": 1,
-                    "redactor": {
-                        "email": "jean.doux@example.com",
-                        "redactorFirstName": "Jean",
-                        "redactorLastName": "Doudou",
-                        "redactorCivility": "M.",
-                    },
-                    "UAICode": booking.educationalInstitution.institutionId,
-                    "yearId": int(booking.educationalYearId),
-                    "status": "PENDING",
-                    "subcategoryLabel": "Séance de cinéma",
-                    "venueTimezone": venue.timezone,
-                    "totalAmount": float(stock.price),
-                    "url": offer_app_link(offer),
-                    "withdrawalDetails": None,
-                    "domainIds": [domain.id for domain in offer.domains],
-                    "domainLabels": [domain.name for domain in offer.domains],
-                    "interventionArea": offer.interventionArea,
-                    "imageUrl": None,
-                    "imageCredit": None,
-                    "venueId": venue.id,
-                    "offererName": venue.managingOfferer.name,
-                }
-            ],
-        }
+        assert response.json == {"prebookings": [expected_serialized_prebooking(booking)]}

--- a/api/tests/routes/adage/v1/get_prebookings_test.py
+++ b/api/tests/routes/adage/v1/get_prebookings_test.py
@@ -114,6 +114,8 @@ class Returns200Test:
                     "interventionArea": offer.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue.id,
+                    "offererName": venue.managingOfferer.name,
                 }
             ],
         }
@@ -208,6 +210,8 @@ class Returns200Test:
                     "interventionArea": offer.interventionArea,
                     "imageUrl": None,
                     "imageCredit": None,
+                    "venueId": venue.id,
+                    "offererName": venue.managingOfferer.name,
                 }
             ],
         }

--- a/api/tests/routes/adage/v1/get_prebookings_test.py
+++ b/api/tests/routes/adage/v1/get_prebookings_test.py
@@ -8,6 +8,7 @@ from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offers.utils import offer_app_link
+from pcapi.core.testing import assert_num_queries
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -49,9 +50,10 @@ class Returns200Test:
         CollectiveBookingFactory(educationalYear=other_educational_year)
         CollectiveBookingFactory(educationalInstitution=other_educational_institution)
 
-        response = client.with_eac_token().get(
-            f"/adage/v1/years/{booking.educationalYear.adageId}/educational_institution/{booking.educationalInstitution.institutionId}/prebookings"
-        )
+        dst = f"/adage/v1/years/{booking.educationalYear.adageId}/educational_institution/{booking.educationalInstitution.institutionId}/prebookings"
+
+        with assert_num_queries(1):
+            response = client.with_eac_token().get(dst)
 
         assert response.status_code == 200
 
@@ -145,9 +147,10 @@ class Returns200Test:
             collectiveStock__collectiveOffer__subcategoryId="SEANCE_CINE",
         )
 
-        response = client.with_eac_token().get(
-            f"/adage/v1/years/{booking.educationalYear.adageId}/educational_institution/{booking.educationalInstitution.institutionId}/prebookings?redactorEmail={redactor.email}"
-        )
+        dst = f"/adage/v1/years/{booking.educationalYear.adageId}/educational_institution/{booking.educationalInstitution.institutionId}/prebookings?redactorEmail={redactor.email}"
+
+        with assert_num_queries(1):
+            response = client.with_eac_token().get(dst)
 
         assert response.status_code == 200
         stock = booking.collectiveStock


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25882 

api adage (v1)

ajout de deux informations aux réponses des routes concernant les pré-réservations : 1. identifiant du lieu et 2. nom de la structure.

## Au passage

Amélioration et factorisations de fonctions qui vont chercher des réservations en base de données.
Factorisation de code de test : ajout (principalement) de fonctions qui permettent de générer le `dict` attendu dans la réponse. Cela évite d'avoir plein de fois le même objet dans plein de fichier de tests différents. Cela permettra à l'avenir de n'avoir à mettre à jour qu'un fonction de test, au lieu d'aller chercher toutes les fonctions de tests qui vérifient en détail le JSON de la réponse.