### PR TITLE
(BSR)[API] fix: deactivate cinema venueProvider by default

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_venue_provider_and_external_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_venue_provider_and_external_bookings.py
@@ -133,7 +133,7 @@ def create_offerers_with_cinema_venue_providers_and_external_bookings() -> None:
 
         cinema_details_factory(cinemaProviderPivot=cinema_provider_pivot)
         providers_factories.VenueProviderFactory(
-            venue=venue, provider=cinema_provider, venueIdAtOfferProvider=cinema_id_at_provider
+            venue=venue, provider=cinema_provider, venueIdAtOfferProvider=cinema_id_at_provider, isActive=False
         )
         logger.info("created 3 ExternalBookings for synced offers (%s)", local_class)
 


### PR DESCRIPTION
They looks like the last errors on testing related to sandbox data.