### PR TITLE
(BSR)[PRO] refactor: extract AppLayout from RouteWrapper

### DIFF
--- a/pro/src/app/AppLayout.tsx
+++ b/pro/src/app/AppLayout.tsx
@@ -5,59 +5,49 @@ import DomainNameBanner from 'components/DomainNameBanner'
 import Header from 'components/Header/Header'
 import SkipLinks from 'components/SkipLinks'
 
-import { LayoutConfig } from './AppRouter/routesMap'
-
 export interface AppLayoutProps {
   children?: React.ReactNode
-  layoutConfig?: LayoutConfig
+  pageName?: string
+  fullscreen?: boolean
   className?: string
 }
 
-const AppLayout = ({ children, layoutConfig, className }: AppLayoutProps) => {
-  const defaultConfig: LayoutConfig = {
-    fullscreen: false,
-    pageName: 'Accueil',
-  }
+export const AppLayout = ({
+  children,
+  className,
+  pageName = 'Accueil',
+  fullscreen = false,
+}: AppLayoutProps) => (
+  <>
+    {!fullscreen && (
+      <>
+        <SkipLinks />
+        <Header />
+      </>
+    )}
 
-  const { fullscreen, pageName } = {
-    ...defaultConfig,
-    ...layoutConfig,
-  }
-
-  return (
-    <>
-      {!fullscreen && (
-        <>
-          <SkipLinks />
-          <Header />
-        </>
+    <main
+      id="content"
+      className={classnames(
+        {
+          page: true,
+          [`${pageName}-page`]: true,
+          container: !fullscreen,
+          fullscreen,
+        },
+        className
       )}
-
-      <main
-        id="content"
-        className={classnames(
-          {
-            page: true,
-            [`${pageName}-page`]: true,
-            container: !fullscreen,
-            fullscreen,
-          },
-          className
-        )}
-      >
-        {fullscreen ? (
-          children
-        ) : (
-          <div className="page-content">
-            <div className={classnames('after-notification-content')}>
-              <DomainNameBanner />
-              {children}
-            </div>
+    >
+      {fullscreen ? (
+        children
+      ) : (
+        <div className="page-content">
+          <div className={classnames('after-notification-content')}>
+            <DomainNameBanner />
+            {children}
           </div>
-        )}
-      </main>
-    </>
-  )
-}
-
-export default AppLayout
+        </div>
+      )}
+    </main>
+  </>
+)

--- a/pro/src/app/AppRouter/RouteWrapper.tsx
+++ b/pro/src/app/AppRouter/RouteWrapper.tsx
@@ -1,7 +1,6 @@
 import React, { ComponentType, ReactNode } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 
-import AppLayout from 'app/AppLayout'
 import { RouteConfig } from 'app/AppRouter/routesMap'
 import useCurrentUser from 'hooks/useCurrentUser'
 
@@ -15,14 +14,6 @@ export const RouteWrapper = ({ children, routeMeta }: RouteWrapperProps) => {
   const location = useLocation()
   const fromUrl = encodeURIComponent(`${location.pathname}${location.search}`)
   let jsx: ReactNode = children
-
-  if (!routeMeta?.withoutLayout) {
-    jsx = (
-      <AppLayout layoutConfig={routeMeta && routeMeta.layoutConfig}>
-        {jsx}
-      </AppLayout>
-    )
-  }
 
   if (!routeMeta?.public && currentUser === null) {
     const loginUrl = fromUrl.includes('logout')

--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -40,15 +40,8 @@ import { VenueEdition } from 'pages/VenueEdition'
 import CollectiveOfferSelectionDuplication from 'screens/CollectiveOfferSelectionDuplication'
 import { UNAVAILABLE_ERROR_PAGE } from 'utils/routes'
 
-export interface LayoutConfig {
-  pageName?: string
-  fullscreen?: boolean
-}
-
 interface RouteMeta {
   public?: boolean
-  layoutConfig?: LayoutConfig
-  withoutLayout?: boolean
 }
 
 export interface RouteConfig {
@@ -70,14 +63,12 @@ const routes: RouteConfig[] = [
   {
     element: <RedirectToConnexionComponent />,
     path: '/',
-    meta: { withoutLayout: true },
   },
   {
     element: <AdageIframe />,
     path: '/adage-iframe/*',
     meta: {
       public: true,
-      withoutLayout: true,
     },
   },
   {
@@ -86,14 +77,12 @@ const routes: RouteConfig[] = [
     title: 'Créer un compte',
     meta: {
       public: true,
-      withoutLayout: true,
     },
   },
   {
     element: <CsvTable />,
     path: '/remboursements-details',
     title: 'Remboursements',
-    meta: { withoutLayout: true },
   },
   {
     element: <Unavailable />,
@@ -101,7 +90,6 @@ const routes: RouteConfig[] = [
     title: 'Page indisponible',
     meta: {
       public: true,
-      withoutLayout: true,
     },
   },
   {
@@ -130,20 +118,13 @@ const routes: RouteConfig[] = [
     title: 'Se connecter',
     meta: {
       public: true,
-      withoutLayout: true,
     },
   },
   {
     element: <EmailChangeValidation />,
     path: '/email_validation',
     title: 'Valider l’adresse email',
-    meta: {
-      public: true,
-      layoutConfig: {
-        fullscreen: true,
-        pageName: 'sign-in',
-      },
-    },
+    meta: { public: true },
   },
   {
     element: <OffererCreation />,
@@ -269,19 +250,13 @@ const routes: RouteConfig[] = [
     element: <ResetPassword />,
     path: '/mot-de-passe-perdu',
     title: 'Définir un nouveau mot de passe',
-    meta: {
-      public: true,
-      withoutLayout: true,
-    },
+    meta: { public: true },
   },
   {
     element: <LostPassword />,
     path: '/demande-mot-de-passe',
     title: 'Demander un nouveau mot de passe',
-    meta: {
-      public: true,
-      withoutLayout: true,
-    },
+    meta: { public: true },
   },
   {
     path: '/offre/individuelle/:offerId/*',
@@ -292,11 +267,6 @@ const routes: RouteConfig[] = [
     element: <Reimbursements />,
     path: '/remboursements/*',
     title: 'Remboursements',
-    meta: {
-      layoutConfig: {
-        pageName: 'reimbursements',
-      },
-    },
   },
   {
     element: <UserProfile />,
@@ -313,7 +283,6 @@ const routes: RouteConfig[] = [
     element: <SignupJourneyRoutes />,
     path: '/parcours-inscription/*',
     title: 'Parcours de souscription',
-    meta: { withoutLayout: true },
   },
 ]
 

--- a/pro/src/app/__specs__/AppLayout.spec.tsx
+++ b/pro/src/app/__specs__/AppLayout.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'
 
-import AppLayout, { AppLayoutProps } from '../AppLayout'
+import { AppLayout, AppLayoutProps } from '../AppLayout'
 
 const renderApp = (props: AppLayoutProps, storeOverrides: any, url = '/') =>
   renderWithProviders(

--- a/pro/src/app/__specs__/AppRouter.spec.tsx
+++ b/pro/src/app/__specs__/AppRouter.spec.tsx
@@ -39,12 +39,12 @@ describe('AppRouter', () => {
                     <Link to={{ pathname: '/offers' }}>Go to private page</Link>
                   </p>
                 ),
-                meta: { public: true, withoutLayout: true },
+                meta: { public: true },
               },
               {
                 path: '/connexion',
                 element: <p>Login page</p>,
-                meta: { public: true, withoutLayout: true },
+                meta: { public: true },
               },
               { path: '/offers', element: <p>Offers page</p> },
             ]}

--- a/pro/src/pages/Bookings/Bookings.tsx
+++ b/pro/src/pages/Bookings/Bookings.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 
+import { AppLayout } from 'app/AppLayout'
 import { getVenuesAdapter } from 'core/Bookings/adapters'
 import { Audience } from 'core/shared'
 import BookingsScreen from 'screens/Bookings'
@@ -16,15 +17,17 @@ const Bookings = (): JSX.Element => {
   const location = useLocation()
 
   return (
-    <BookingsScreen
-      audience={Audience.INDIVIDUAL}
-      getBookingsCSVFileAdapter={getBookingsCSVFileAdapter}
-      getBookingsXLSFileAdapter={getBookingsXLSFileAdapter}
-      getFilteredBookingsRecapAdapter={getFilteredBookingsRecapAdapter}
-      getUserHasBookingsAdapter={getUserHasBookingsAdapter}
-      getVenuesAdapter={getVenuesAdapter}
-      locationState={location.state}
-    />
+    <AppLayout>
+      <BookingsScreen
+        audience={Audience.INDIVIDUAL}
+        getBookingsCSVFileAdapter={getBookingsCSVFileAdapter}
+        getBookingsXLSFileAdapter={getBookingsXLSFileAdapter}
+        getFilteredBookingsRecapAdapter={getFilteredBookingsRecapAdapter}
+        getUserHasBookingsAdapter={getUserHasBookingsAdapter}
+        getVenuesAdapter={getVenuesAdapter}
+        locationState={location.state}
+      />
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveBookings/CollectiveBookings.tsx
+++ b/pro/src/pages/CollectiveBookings/CollectiveBookings.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 
+import { AppLayout } from 'app/AppLayout'
 import { getVenuesAdapter } from 'core/Bookings/adapters'
 import { Audience } from 'core/shared'
 import BookingsScreen from 'screens/Bookings'
@@ -16,17 +17,19 @@ const CollectiveBookings = (): JSX.Element => {
   const location = useLocation()
 
   return (
-    <BookingsScreen
-      audience={Audience.COLLECTIVE}
-      getBookingsCSVFileAdapter={getCollectiveBookingsCSVFileAdapter}
-      getBookingsXLSFileAdapter={getCollectiveBookingsXLSFileAdapter}
-      getFilteredBookingsRecapAdapter={
-        getFilteredCollectiveBookingsRecapAdapter
-      }
-      getUserHasBookingsAdapter={getUserHasCollectiveBookingsAdapter}
-      getVenuesAdapter={getVenuesAdapter}
-      locationState={location.state}
-    />
+    <AppLayout>
+      <BookingsScreen
+        audience={Audience.COLLECTIVE}
+        getBookingsCSVFileAdapter={getCollectiveBookingsCSVFileAdapter}
+        getBookingsXLSFileAdapter={getCollectiveBookingsXLSFileAdapter}
+        getFilteredBookingsRecapAdapter={
+          getFilteredCollectiveBookingsRecapAdapter
+        }
+        getUserHasBookingsAdapter={getUserHasCollectiveBookingsAdapter}
+        getVenuesAdapter={getVenuesAdapter}
+        locationState={location.state}
+      />
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
+++ b/pro/src/pages/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { AppLayout } from 'app/AppLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import CollectiveOfferConfirmationScreen from 'screens/CollectiveOfferConfirmation'
 import {
@@ -25,7 +26,7 @@ const CollectiveOfferConfirmation = ({
   }
 
   return (
-    <>
+    <AppLayout>
       <CollectiveOfferConfirmationScreen
         isShowcase={offer.isTemplate}
         offerStatus={offer?.status}
@@ -33,7 +34,7 @@ const CollectiveOfferConfirmation = ({
         institutionDisplayName={getInstitutionDisplayName()}
       />
       <RouteLeavingGuardCollectiveOfferCreation />
-    </>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
+++ b/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 
+import { AppLayout } from 'app/AppLayout'
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import { Mode, isCollectiveOffer } from 'core/OfferEducational'
@@ -27,30 +28,33 @@ export const CollectiveOfferCreation = ({
     offer
   )
 
-  if (!isReady) {
-    return <Spinner />
-  }
   return (
-    <CollectiveOfferLayout
-      subTitle={offer?.name}
-      isCreation
-      isTemplate={isTemplate}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
-      requestId={requestId}
-    >
-      <OfferEducationalScreen
-        categories={offerEducationalFormData.categories}
-        userOfferers={offerEducationalFormData.offerers}
-        domainsOptions={offerEducationalFormData.domains}
-        nationalPrograms={offerEducationalFormData.nationalPrograms}
-        offer={offer}
-        setOffer={setOffer}
-        getIsOffererEligible={canOffererCreateCollectiveOfferAdapter}
-        mode={Mode.CREATION}
-        isTemplate={isTemplate}
-      />
-      <RouteLeavingGuardCollectiveOfferCreation />
-    </CollectiveOfferLayout>
+    <AppLayout>
+      {!isReady ? (
+        <Spinner />
+      ) : (
+        <CollectiveOfferLayout
+          subTitle={offer?.name}
+          isCreation
+          isTemplate={isTemplate}
+          isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+          requestId={requestId}
+        >
+          <OfferEducationalScreen
+            categories={offerEducationalFormData.categories}
+            userOfferers={offerEducationalFormData.offerers}
+            domainsOptions={offerEducationalFormData.domains}
+            nationalPrograms={offerEducationalFormData.nationalPrograms}
+            offer={offer}
+            setOffer={setOffer}
+            getIsOffererEligible={canOffererCreateCollectiveOfferAdapter}
+            mode={Mode.CREATION}
+            isTemplate={isTemplate}
+          />
+          <RouteLeavingGuardCollectiveOfferCreation />
+        </CollectiveOfferLayout>
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferEdition/CollectiveOfferEdition.tsx
+++ b/pro/src/pages/CollectiveOfferEdition/CollectiveOfferEdition.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { AppLayout } from 'app/AppLayout'
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import { Mode } from 'core/OfferEducational'
 import OfferEducationalScreen from 'screens/OfferEducational'
@@ -21,28 +22,30 @@ const CollectiveOfferEdition = ({
     offer
   )
 
-  if (!isReady || !offer) {
-    return <Spinner />
-  }
-
   return (
-    <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
-      <OfferEducationalScreen
-        categories={offerEducationalFormData.categories}
-        userOfferers={offerEducationalFormData.offerers}
-        domainsOptions={offerEducationalFormData.domains}
-        nationalPrograms={offerEducationalFormData.nationalPrograms}
-        offer={offer}
-        setOffer={setOffer}
-        isOfferActive={offer?.isActive}
-        isOfferBooked={
-          offer?.isTemplate ? false : offer?.collectiveStock?.isBooked
-        }
-        mode={offer?.isEditable ? Mode.EDITION : Mode.READ_ONLY}
-        reloadCollectiveOffer={reloadCollectiveOffer}
-        isTemplate={offer.isTemplate}
-      />
-    </CollectiveOfferLayout>
+    <AppLayout>
+      {!isReady || !offer ? (
+        <Spinner />
+      ) : (
+        <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+          <OfferEducationalScreen
+            categories={offerEducationalFormData.categories}
+            userOfferers={offerEducationalFormData.offerers}
+            domainsOptions={offerEducationalFormData.domains}
+            nationalPrograms={offerEducationalFormData.nationalPrograms}
+            offer={offer}
+            setOffer={setOffer}
+            isOfferActive={offer?.isActive}
+            isOfferBooked={
+              offer?.isTemplate ? false : offer?.collectiveStock?.isBooked
+            }
+            mode={offer?.isEditable ? Mode.EDITION : Mode.READ_ONLY}
+            reloadCollectiveOffer={reloadCollectiveOffer}
+            isTemplate={offer.isTemplate}
+          />
+        </CollectiveOfferLayout>
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferFromRequest/CollectiveOfferFromRequest.tsx
+++ b/pro/src/pages/CollectiveOfferFromRequest/CollectiveOfferFromRequest.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { GetCollectiveOfferRequestResponseModel } from 'apiClient/v1'
+import { AppLayout } from 'app/AppLayout'
 import ActionsBarSticky from 'components/ActionsBarSticky'
 import { SummaryLayout } from 'components/SummaryLayout'
 import { Events } from 'core/FirebaseEvents/constants'
@@ -89,91 +90,93 @@ const CollectiveOfferFromRequest = (): JSX.Element => {
     fetchData()
   }, [])
 
-  if (isLoading) {
-    return <Spinner />
-  }
-
   return (
-    <>
-      <div className={styles['eac-section']}>
-        <Title level={1}>Récapitulatif de la demande</Title>
-      </div>
-      <div className={styles['eac-section']}>
-        Vous avez reçu une demande de création d’offres de la part d’un
-        établissement scolaire. Vous pouvez créer une offre à partir des
-        informations saisies par l’enseignant. Toutes les informations sont
-        modifiables.
-        <br /> L’offre sera visible par l’enseignant sur Adage.
-      </div>
-      <SummaryLayout.Section title="Détails de la demande">
-        <div className={styles['eac-section']}>
-          <SummaryLayout.Row
-            title="Demande reçue le"
-            description={
-              informations?.dateCreated
-                ? getDateToFrenchText(informations?.dateCreated)
-                : '-'
-            }
-          />
-          <SummaryLayout.Row
-            title="Offre concernée"
-            description={offerTemplate?.name}
-          />
-        </div>
-        <div className={styles['eac-section']}>
-          <SummaryLayout.Row
-            title="Etablissement scolaire"
-            description={
-              <div>
-                {`${informations?.institution.institutionType} ${informations?.institution.name}`.trim()}
-                <br />
-                {`${informations?.institution.postalCode} ${informations?.institution.city}`}
-              </div>
-            }
-          />
-          <SummaryLayout.Row
-            title="Prénom et nom de l’enseignant"
-            description={`${informations?.redactor.firstName} ${informations?.redactor.lastName} `}
-          />
-          <SummaryLayout.Row
-            title="Téléphone"
-            description={informations?.phoneNumber ?? '-'}
-          />
-          <SummaryLayout.Row
-            title="Email"
-            description={informations?.redactor.email}
-          />
-        </div>
+    <AppLayout>
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <>
+          <div className={styles['eac-section']}>
+            <Title level={1}>Récapitulatif de la demande</Title>
+          </div>
+          <div className={styles['eac-section']}>
+            Vous avez reçu une demande de création d’offres de la part d’un
+            établissement scolaire. Vous pouvez créer une offre à partir des
+            informations saisies par l’enseignant. Toutes les informations sont
+            modifiables.
+            <br /> L’offre sera visible par l’enseignant sur Adage.
+          </div>
+          <SummaryLayout.Section title="Détails de la demande">
+            <div className={styles['eac-section']}>
+              <SummaryLayout.Row
+                title="Demande reçue le"
+                description={
+                  informations?.dateCreated
+                    ? getDateToFrenchText(informations?.dateCreated)
+                    : '-'
+                }
+              />
+              <SummaryLayout.Row
+                title="Offre concernée"
+                description={offerTemplate?.name}
+              />
+            </div>
+            <div className={styles['eac-section']}>
+              <SummaryLayout.Row
+                title="Etablissement scolaire"
+                description={
+                  <div>
+                    {`${informations?.institution.institutionType} ${informations?.institution.name}`.trim()}
+                    <br />
+                    {`${informations?.institution.postalCode} ${informations?.institution.city}`}
+                  </div>
+                }
+              />
+              <SummaryLayout.Row
+                title="Prénom et nom de l’enseignant"
+                description={`${informations?.redactor.firstName} ${informations?.redactor.lastName} `}
+              />
+              <SummaryLayout.Row
+                title="Téléphone"
+                description={informations?.phoneNumber ?? '-'}
+              />
+              <SummaryLayout.Row
+                title="Email"
+                description={informations?.redactor.email}
+              />
+            </div>
 
-        <SummaryLayout.Row
-          title="Nombre d'élèves"
-          description={informations?.totalStudents ?? '-'}
-        />
-        <SummaryLayout.Row
-          title="Nombre d'accompagnateurs"
-          description={informations?.totalTeachers ?? '-'}
-        />
-        <SummaryLayout.Row
-          title="Date souhaitée"
-          description={
-            informations?.requestedDate
-              ? getDateToFrenchText(informations?.requestedDate)
-              : '-'
-          }
-        />
-        <SummaryLayout.Row
-          title="Descriptif de la demande"
-          description={informations?.comment}
-        />
-      </SummaryLayout.Section>
-      <ActionsBarSticky>
-        <ActionsBarSticky.Right>
-          <Button onClick={handleButtonClick}>
-            Créer l’offre pour l’enseignant
-          </Button>
-        </ActionsBarSticky.Right>
-      </ActionsBarSticky>
-    </>
+            <SummaryLayout.Row
+              title="Nombre d'élèves"
+              description={informations?.totalStudents ?? '-'}
+            />
+            <SummaryLayout.Row
+              title="Nombre d'accompagnateurs"
+              description={informations?.totalTeachers ?? '-'}
+            />
+            <SummaryLayout.Row
+              title="Date souhaitée"
+              description={
+                informations?.requestedDate
+                  ? getDateToFrenchText(informations?.requestedDate)
+                  : '-'
+              }
+            />
+            <SummaryLayout.Row
+              title="Descriptif de la demande"
+              description={informations?.comment}
+            />
+          </SummaryLayout.Section>
+          <ActionsBarSticky>
+            <ActionsBarSticky.Right>
+              <Button onClick={handleButtonClick}>
+                Créer l’offre pour l’enseignant
+              </Button>
+            </ActionsBarSticky.Right>
+          </ActionsBarSticky>
+        </>
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { GetCollectiveOfferRequestResponseModel } from 'apiClient/v1/models/GetCollectiveOfferRequestResponseModel'
+import { AppLayout } from 'app/AppLayout'
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import {
@@ -153,22 +154,24 @@ export const CollectiveOfferStockCreation = ({
   }
 
   return (
-    <CollectiveOfferLayout
-      subTitle={offer?.name}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
-      isTemplate={isTemplate}
-      isCreation={isCreation}
-      requestId={requestId}
-    >
-      <OfferEducationalStockScreen
-        initialValues={initialValues}
-        mode={Mode.CREATION}
-        offer={offer}
-        onSubmit={handleSubmitStock}
+    <AppLayout>
+      <CollectiveOfferLayout
+        subTitle={offer?.name}
+        isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+        isTemplate={isTemplate}
+        isCreation={isCreation}
         requestId={requestId}
-      />
-      <RouteLeavingGuardCollectiveOfferCreation />
-    </CollectiveOfferLayout>
+      >
+        <OfferEducationalStockScreen
+          initialValues={initialValues}
+          mode={Mode.CREATION}
+          offer={offer}
+          onSubmit={handleSubmitStock}
+          requestId={requestId}
+        />
+        <RouteLeavingGuardCollectiveOfferCreation />
+      </CollectiveOfferLayout>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferStockEdition/CollectiveOfferStockEdition.tsx
+++ b/pro/src/pages/CollectiveOfferStockEdition/CollectiveOfferStockEdition.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { AppLayout } from 'app/AppLayout'
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import {
   Mode,
@@ -69,19 +70,21 @@ const CollectiveOfferStockEdition = ({
   }
 
   return (
-    <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
-      <OfferEducationalStockScreen
-        initialValues={initialValues}
-        mode={
-          offer.collectiveStock?.isEducationalStockEditable
-            ? Mode.EDITION
-            : Mode.READ_ONLY
-        }
-        offer={offer}
-        onSubmit={handleSubmitStock}
-        reloadCollectiveOffer={reloadCollectiveOffer}
-      />
-    </CollectiveOfferLayout>
+    <AppLayout>
+      <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+        <OfferEducationalStockScreen
+          initialValues={initialValues}
+          mode={
+            offer.collectiveStock?.isEducationalStockEditable
+              ? Mode.EDITION
+              : Mode.READ_ONLY
+          }
+          offer={offer}
+          onSubmit={handleSubmitStock}
+          reloadCollectiveOffer={reloadCollectiveOffer}
+        />
+      </CollectiveOfferLayout>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { AppLayout } from 'app/AppLayout'
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import {
@@ -33,22 +34,26 @@ export const CollectiveOfferSummaryCreation = ({
     return <></>
   }
 
-  return isLoading ? (
-    <Spinner />
-  ) : (
-    <CollectiveOfferLayout
-      subTitle={offer?.name}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
-      isTemplate={isTemplate}
-      isCreation={true}
-    >
-      <CollectiveOfferSummaryCreationScreen
-        offer={offer}
-        categories={categories}
-        setOffer={setOffer}
-      />
-      <RouteLeavingGuardCollectiveOfferCreation />
-    </CollectiveOfferLayout>
+  return (
+    <AppLayout>
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <CollectiveOfferLayout
+          subTitle={offer?.name}
+          isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+          isTemplate={isTemplate}
+          isCreation={true}
+        >
+          <CollectiveOfferSummaryCreationScreen
+            offer={offer}
+            categories={categories}
+            setOffer={setOffer}
+          />
+          <RouteLeavingGuardCollectiveOfferCreation />
+        </CollectiveOfferLayout>
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
+import { AppLayout } from 'app/AppLayout'
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import {
   getEducationalCategoriesAdapter,
@@ -42,17 +43,21 @@ const CollectiveOfferSummaryEdition = ({
 
   const isReady = offer !== null && categories !== null
 
-  return !isReady ? (
-    <Spinner />
-  ) : (
-    <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
-      <CollectiveOfferSummaryEditionScreen
-        offer={offer}
-        categories={categories}
-        reloadCollectiveOffer={reloadCollectiveOffer}
-        mode={Mode.EDITION}
-      />
-    </CollectiveOfferLayout>
+  return (
+    <AppLayout>
+      {!isReady ? (
+        <Spinner />
+      ) : (
+        <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+          <CollectiveOfferSummaryEditionScreen
+            offer={offer}
+            categories={categories}
+            reloadCollectiveOffer={reloadCollectiveOffer}
+            mode={Mode.EDITION}
+          />
+        </CollectiveOfferLayout>
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { EducationalInstitutionResponseModel } from 'apiClient/v1'
+import { AppLayout } from 'app/AppLayout'
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import {
@@ -73,25 +74,27 @@ export const CollectiveOfferVisibility = ({
     : DEFAULT_VISIBILITY_FORM_VALUES
 
   return (
-    <CollectiveOfferLayout
-      subTitle={offer?.name}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
-      isTemplate={isTemplate}
-      isCreation={isCreation}
-      requestId={requestId}
-    >
-      <CollectiveOfferVisibilityScreen
-        mode={Mode.CREATION}
-        patchInstitution={patchEducationalInstitutionAdapter}
-        initialValues={initialValues}
-        onSuccess={onSuccess}
-        institutions={institutions}
-        isLoadingInstitutions={isLoadingInstitutions}
-        offer={offer}
+    <AppLayout>
+      <CollectiveOfferLayout
+        subTitle={offer?.name}
+        isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+        isTemplate={isTemplate}
+        isCreation={isCreation}
         requestId={requestId}
-      />
-      <RouteLeavingGuardCollectiveOfferCreation />
-    </CollectiveOfferLayout>
+      >
+        <CollectiveOfferVisibilityScreen
+          mode={Mode.CREATION}
+          patchInstitution={patchEducationalInstitutionAdapter}
+          initialValues={initialValues}
+          onSuccess={onSuccess}
+          institutions={institutions}
+          isLoadingInstitutions={isLoadingInstitutions}
+          offer={offer}
+          requestId={requestId}
+        />
+        <RouteLeavingGuardCollectiveOfferCreation />
+      </CollectiveOfferLayout>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
+import { AppLayout } from 'app/AppLayout'
 import { filterEducationalCategories } from 'core/OfferEducational'
 import { getOffererAdapter } from 'core/Offers/adapters'
 import { DEFAULT_PAGE, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
@@ -156,26 +157,28 @@ const CollectiveOffers = (): JSX.Element => {
     dispatch(savePageNumber(currentPageNumber))
   }, [dispatch, currentPageNumber, urlSearchFilters])
 
-  if (!initialSearchFilters) {
-    return <Spinner />
-  }
-
   return (
-    <OffersScreen
-      audience={Audience.COLLECTIVE}
-      categories={categories}
-      currentPageNumber={currentPageNumber}
-      currentUser={currentUser}
-      initialSearchFilters={initialSearchFilters}
-      isLoading={isLoading}
-      loadAndUpdateOffers={loadAndUpdateOffers}
-      offerer={offerer}
-      offers={offers}
-      redirectWithUrlFilters={redirectWithUrlFilters}
-      setOfferer={setOfferer}
-      urlSearchFilters={urlSearchFilters}
-      venues={venues}
-    />
+    <AppLayout>
+      {!initialSearchFilters ? (
+        <Spinner />
+      ) : (
+        <OffersScreen
+          audience={Audience.COLLECTIVE}
+          categories={categories}
+          currentPageNumber={currentPageNumber}
+          currentUser={currentUser}
+          initialSearchFilters={initialSearchFilters}
+          isLoading={isLoading}
+          loadAndUpdateOffers={loadAndUpdateOffers}
+          offerer={offerer}
+          offers={offers}
+          redirectWithUrlFilters={redirectWithUrlFilters}
+          setOfferer={setOfferer}
+          urlSearchFilters={urlSearchFilters}
+          venues={venues}
+        />
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/Desk/Desk.module.scss
+++ b/pro/src/pages/Desk/Desk.module.scss
@@ -2,24 +2,22 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
 
-.desk-screen {
-  .desk-form {
-    border-radius: rem.torem(8px);
-    box-shadow: 0 0 rem.torem(5px) colors.$black-shadow;
-    display: flex;
-    flex-direction: column;
-    padding: rem.torem(25px);
-    text-align: center;
+.desk-form {
+  border-radius: rem.torem(8px);
+  box-shadow: 0 0 rem.torem(5px) colors.$black-shadow;
+  display: flex;
+  flex-direction: column;
+  padding: rem.torem(25px);
+  text-align: center;
 
-    .desk-form-input {
-      margin: rem.torem(10px) auto rem.torem(15px);
-      width: rem.torem(328px);
-    }
+  .desk-form-input {
+    margin: rem.torem(10px) auto rem.torem(15px);
+    width: rem.torem(328px);
+  }
 
-    .desk-form-label {
-      margin: 0 auto;
-      width: rem.torem(328px);
-    }
+  .desk-form-label {
+    margin: 0 auto;
+    width: rem.torem(328px);
   }
 }
 

--- a/pro/src/pages/Desk/Desk.tsx
+++ b/pro/src/pages/Desk/Desk.tsx
@@ -3,6 +3,7 @@ import { FormikProvider, useFormik } from 'formik'
 import React, { useState } from 'react'
 
 import { GetBookingResponse } from 'apiClient/v2'
+import { AppLayout } from 'app/AppLayout'
 import { Banner, SubmitButton, TextInput } from 'ui-kit'
 import Titles from 'ui-kit/Titles/Titles'
 
@@ -122,7 +123,7 @@ const Desk = (): JSX.Element => {
   }
 
   return (
-    <div className={styles['desk-screen']}>
+    <AppLayout>
       <Titles title="Guichet" />
       <p className="advice">
         Saisissez les contremarques présentées par les bénéficiaires afin de les
@@ -185,7 +186,7 @@ const Desk = (): JSX.Element => {
           </Banner>
         </form>
       </FormikProvider>
-    </div>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/EmailChangeValidation/EmailChangeValidation.tsx
+++ b/pro/src/pages/EmailChangeValidation/EmailChangeValidation.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
+import { AppLayout } from 'app/AppLayout'
 import { EmailChangeValidationScreen } from 'screens/EmailChangeValidation'
 import { resetIsInitialized } from 'store/user/actions'
 import { parse } from 'utils/query-string'
@@ -32,7 +33,12 @@ const EmailChangeValidation = (): JSX.Element => {
   if (isSuccess === undefined) {
     return <></>
   }
-  return <EmailChangeValidationScreen isSuccess={isSuccess} />
+
+  return (
+    <AppLayout fullscreen pageName="sign-in">
+      <EmailChangeValidationScreen isSuccess={isSuccess} />
+    </AppLayout>
+  )
 }
 
 export default EmailChangeValidation

--- a/pro/src/pages/Home/Homepage.tsx
+++ b/pro/src/pages/Home/Homepage.tsx
@@ -5,6 +5,7 @@ import {
   GetOffererResponseModel,
   GetOfferersNamesResponseModel,
 } from 'apiClient/v1'
+import { AppLayout } from 'app/AppLayout'
 import AddBankAccountCallout from 'components/Callout/AddBankAccountCallout'
 import LinkVenueCallout from 'components/Callout/LinkVenueCallout'
 import PendingBankAccountCallout from 'components/Callout/PendingBankAccountCallout'
@@ -131,7 +132,7 @@ const Homepage = (): JSX.Element => {
     ) ?? false
 
   return (
-    <>
+    <AppLayout>
       <div className="homepage">
         <h1>Bienvenue dans l’espace acteurs culturels</h1>
 
@@ -201,7 +202,7 @@ const Homepage = (): JSX.Element => {
         </section>
       </div>
       <TutorialDialog />
-    </>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/IndividualOfferWizard/IndividualOfferWizard.tsx
+++ b/pro/src/pages/IndividualOfferWizard/IndividualOfferWizard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useLocation, Route, Routes, useParams } from 'react-router-dom'
 
+import { AppLayout } from 'app/AppLayout'
 import { withRouteWrapper } from 'app/AppRouter/RouteWrapper'
 import { routesIndividualOfferWizard } from 'app/AppRouter/subroutesIndividualOfferWizardMap'
 import { IndividualOfferContextProvider } from 'context/IndividualOfferContext'
@@ -15,18 +16,20 @@ export const IndividualOfferWizard = () => {
     parse(search)
 
   return (
-    <IndividualOfferContextProvider
-      isUserAdmin={currentUser.isAdmin}
-      offerId={offerId === 'creation' ? undefined : offerId}
-      queryOffererId={offererId}
-      querySubcategoryId={querySubcategoryId}
-    >
-      <Routes>
-        {routesIndividualOfferWizard.map(({ path, element }) => (
-          <Route key={path} path={path} element={element} />
-        ))}
-      </Routes>
-    </IndividualOfferContextProvider>
+    <AppLayout>
+      <IndividualOfferContextProvider
+        isUserAdmin={currentUser.isAdmin}
+        offerId={offerId === 'creation' ? undefined : offerId}
+        queryOffererId={offererId}
+        querySubcategoryId={querySubcategoryId}
+      >
+        <Routes>
+          {routesIndividualOfferWizard.map(({ path, element }) => (
+            <Route key={path} path={path} element={element} />
+          ))}
+        </Routes>
+      </IndividualOfferContextProvider>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/LostPassword/LostPassword.tsx
+++ b/pro/src/pages/LostPassword/LostPassword.tsx
@@ -2,7 +2,7 @@ import { Formik } from 'formik'
 import React, { useState } from 'react'
 
 import { api } from 'apiClient/api'
-import AppLayout from 'app/AppLayout'
+import { AppLayout } from 'app/AppLayout'
 import SkipLinks from 'components/SkipLinks'
 import useInitReCaptcha from 'hooks/useInitReCaptcha'
 import useNotification from 'hooks/useNotification'
@@ -40,6 +40,7 @@ const LostPassword = (): JSX.Element => {
   return (
     <>
       <SkipLinks displayMenu={false} />
+
       <div className={styles['lost-password']}>
         <header className={styles['logo-side']}>
           <SvgIcon
@@ -50,12 +51,8 @@ const LostPassword = (): JSX.Element => {
             width="135"
           />
         </header>
-        <AppLayout
-          layoutConfig={{
-            fullscreen: true,
-            pageName: 'lost-password',
-          }}
-        >
+
+        <AppLayout fullscreen pageName="lost-password">
           <div className={styles['content']}>
             {mailSent ? (
               <Hero

--- a/pro/src/pages/OfferType/OfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
 
+import { AppLayout } from 'app/AppLayout'
 import OfferTypeScreen from 'screens/OfferType'
 
 const OfferType = (): JSX.Element => {
-  return <OfferTypeScreen />
+  return (
+    <AppLayout>
+      <OfferTypeScreen />
+    </AppLayout>
+  )
 }
 
 export default OfferType

--- a/pro/src/pages/OffererStats/OffererStats.tsx
+++ b/pro/src/pages/OffererStats/OffererStats.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { AppLayout } from 'app/AppLayout'
 import { useGetOffererNames } from 'core/Offerers/adapters'
 import useNotification from 'hooks/useNotification'
 import { OffererStatsScreen } from 'screens/OffererStats'
@@ -9,21 +10,28 @@ import { sortByLabel } from 'utils/strings'
 const OffererStats = (): JSX.Element | null => {
   const notify = useNotification()
   const { isLoading, error, data: offererNames } = useGetOffererNames({})
-  if (isLoading) {
-    return <Spinner />
-  }
+
   if (error) {
     notify.error(error.message)
     return null
   }
 
   const offererOptions = sortByLabel(
-    offererNames.map((offerer) => ({
+    offererNames?.map((offerer) => ({
       value: offerer.id.toString(),
       label: offerer.name,
-    }))
+    })) ?? []
   )
-  return <OffererStatsScreen offererOptions={offererOptions} />
+
+  return (
+    <AppLayout>
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <OffererStatsScreen offererOptions={offererOptions} />
+      )}
+    </AppLayout>
+  )
 }
 
 export default OffererStats

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/OffererDetails.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/OffererDetails.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { GetOffererVenueResponseModel } from 'apiClient/v1'
+import { AppLayout } from 'app/AppLayout'
 import fullBackIcon from 'icons/full-back.svg'
 import { HTTP_STATUS } from 'repository/pcapi/pcapiClient'
 import { ButtonLink } from 'ui-kit'
@@ -80,64 +81,70 @@ const OffererDetails = () => {
     return <Spinner />
   }
 
-  return offerer ? (
-    <div className={styles['offerer-page']}>
-      <ButtonLink
-        link={{
-          to: `/accueil?structure=${offerer.id}`,
-          isExternal: false,
-        }}
-        variant={ButtonVariant.TERNARY}
-        icon={fullBackIcon}
-        className={styles['offerer-page-go-back-link']}
-      >
-        Accueil
-      </ButtonLink>
+  return (
+    <AppLayout>
+      {offerer ? (
+        <div className={styles['offerer-page']}>
+          <ButtonLink
+            link={{
+              to: `/accueil?structure=${offerer.id}`,
+              isExternal: false,
+            }}
+            variant={ButtonVariant.TERNARY}
+            icon={fullBackIcon}
+            className={styles['offerer-page-go-back-link']}
+          >
+            Accueil
+          </ButtonLink>
 
-      <div className={styles['offerer-form-heading']}>
-        <div className={styles['title-page']}>
-          <h1>Structure</h1>
-        </div>
-        <h2 className={styles['offerer-name']}>{offerer.name}</h2>
-        <div className={styles['description']}>
-          Détails de la structure rattachée, des collaborateurs, des lieux et
-          des fournisseurs de ses offres
-        </div>
-      </div>
-
-      <div className={styles['offerer-page-container']}>
-        <div className={styles['section']}>
-          <h2 className={styles['main-list-title']}>Informations structure</h2>
-          <div className={styles['op-detail']}>
-            <span>{'SIREN : '}</span>
-            <span>{formatSiren(offerer.siren)}</span>
+          <div className={styles['offerer-form-heading']}>
+            <div className={styles['title-page']}>
+              <h1>Structure</h1>
+            </div>
+            <h2 className={styles['offerer-name']}>{offerer.name}</h2>
+            <div className={styles['description']}>
+              Détails de la structure rattachée, des collaborateurs, des lieux
+              et des fournisseurs de ses offres
+            </div>
           </div>
-          <div className={styles['op-detail']}>
-            <span>{'Désignation : '}</span>
-            <span>{offerer.name}</span>
-          </div>
-          <div className={styles['op-detail']}>
-            <span>{'Siège social : '}</span>
-            <span>
-              {`${offerer.address} - ${offerer.postalCode} ${offerer.city}`}
-            </span>
+
+          <div className={styles['offerer-page-container']}>
+            <div className={styles['section']}>
+              <h2 className={styles['main-list-title']}>
+                Informations structure
+              </h2>
+              <div className={styles['op-detail']}>
+                <span>{'SIREN : '}</span>
+                <span>{formatSiren(offerer.siren)}</span>
+              </div>
+              <div className={styles['op-detail']}>
+                <span>{'Désignation : '}</span>
+                <span>{offerer.name}</span>
+              </div>
+              <div className={styles['op-detail']}>
+                <span>{'Siège social : '}</span>
+                <span>
+                  {`${offerer.address} - ${offerer.postalCode} ${offerer.city}`}
+                </span>
+              </div>
+            </div>
+
+            <AttachmentInvitations offererId={offerer.id} />
+
+            <ApiKey
+              maxAllowedApiKeys={offerer.apiKey.maxAllowed}
+              offererId={offerer.id}
+              reloadOfferer={loadOfferer}
+              savedApiKeys={offerer.apiKey.savedApiKeys}
+            />
+
+            <Venues offererId={offerer.id} venues={physicalVenues} />
           </div>
         </div>
-
-        <AttachmentInvitations offererId={offerer.id} />
-
-        <ApiKey
-          maxAllowedApiKeys={offerer.apiKey.maxAllowed}
-          offererId={offerer.id}
-          reloadOfferer={loadOfferer}
-          savedApiKeys={offerer.apiKey.savedApiKeys}
-        />
-
-        <Venues offererId={offerer.id} venues={physicalVenues} />
-      </div>
-    </div>
-  ) : (
-    <></>
+      ) : (
+        <></>
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataEdition.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataEdition.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { GetCollectiveVenueResponseModel } from 'apiClient/v1'
+import { AppLayout } from 'app/AppLayout'
 import MandatoryInfo from 'components/FormLayout/FormLayoutMandatoryInfo'
 import {
   EducationalCategories,
@@ -125,7 +126,7 @@ const CollectiveDataEdition = (): JSX.Element | null => {
     return null
   }
   return (
-    <div>
+    <AppLayout>
       <ButtonLink
         link={{
           to: `/structures/${offererId}/lieux/${venueId}#venue-collective-data`,
@@ -162,7 +163,7 @@ const CollectiveDataEdition = (): JSX.Element | null => {
           categories={categories}
         />
       )}
-    </div>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/Offerers/OffererCreation/OffererCreation.tsx
+++ b/pro/src/pages/Offerers/OffererCreation/OffererCreation.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { api } from 'apiClient/api'
 import { isErrorAPIError } from 'apiClient/helpers'
 import { CreateOffererQueryModel } from 'apiClient/v1'
+import { AppLayout } from 'app/AppLayout'
 import FormLayout from 'components/FormLayout/FormLayout'
 import { getSirenDataAdapter } from 'core/Offerers/adapters'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -69,62 +70,64 @@ const OffererCreation = (): JSX.Element => {
   })
 
   return (
-    <div className={styles['offerer-page']}>
-      <ButtonLink
-        link={{ to: '/accueil', isExternal: false }}
-        variant={ButtonVariant.TERNARY}
-        icon={fullBackIcon}
-        className={styles['offerer-page-go-back-link']}
-      >
-        Accueil
-      </ButtonLink>
-      <Titles title="Structure" />
-      {isEntrepriseApiDisabled ? (
-        <OffererCreationUnavailable />
-      ) : (
-        <FormikProvider value={formik}>
-          <form onSubmit={formik.handleSubmit}>
-            <FormLayout.Row>
-              <SirenInput label="SIREN" onValidSiren={getSirenAPIData} />
-            </FormLayout.Row>
-            <FormLayout.Row>
-              <div className={styles['op-detail-creation-form']}>
-                <span>Siège social : </span>
-                {offerer?.postalCode && (
-                  <span>
-                    {`${offerer?.address} - ${offerer?.postalCode} ${offerer?.city}`}
-                  </span>
-                )}
+    <AppLayout>
+      <div className={styles['offerer-page']}>
+        <ButtonLink
+          link={{ to: '/accueil', isExternal: false }}
+          variant={ButtonVariant.TERNARY}
+          icon={fullBackIcon}
+          className={styles['offerer-page-go-back-link']}
+        >
+          Accueil
+        </ButtonLink>
+        <Titles title="Structure" />
+        {isEntrepriseApiDisabled ? (
+          <OffererCreationUnavailable />
+        ) : (
+          <FormikProvider value={formik}>
+            <form onSubmit={formik.handleSubmit}>
+              <FormLayout.Row>
+                <SirenInput label="SIREN" onValidSiren={getSirenAPIData} />
+              </FormLayout.Row>
+              <FormLayout.Row>
+                <div className={styles['op-detail-creation-form']}>
+                  <span>Siège social : </span>
+                  {offerer?.postalCode && (
+                    <span>
+                      {`${offerer?.address} - ${offerer?.postalCode} ${offerer?.city}`}
+                    </span>
+                  )}
+                </div>
+              </FormLayout.Row>
+              <FormLayout.Row>
+                <div className={styles['op-detail-creation-form']}>
+                  <span>Désignation : </span>
+                  {offerer?.name && <span>{offerer?.name}</span>}
+                </div>
+              </FormLayout.Row>
+              <div className={styles['offerer-form-validation']}>
+                <div>
+                  <ButtonLink
+                    variant={ButtonVariant.SECONDARY}
+                    link={{
+                      to: '/accueil',
+                      isExternal: false,
+                    }}
+                  >
+                    Retour
+                  </ButtonLink>
+                </div>
+                <div>
+                  <SubmitButton variant={ButtonVariant.PRIMARY}>
+                    Créer
+                  </SubmitButton>
+                </div>
               </div>
-            </FormLayout.Row>
-            <FormLayout.Row>
-              <div className={styles['op-detail-creation-form']}>
-                <span>Désignation : </span>
-                {offerer?.name && <span>{offerer?.name}</span>}
-              </div>
-            </FormLayout.Row>
-            <div className={styles['offerer-form-validation']}>
-              <div>
-                <ButtonLink
-                  variant={ButtonVariant.SECONDARY}
-                  link={{
-                    to: '/accueil',
-                    isExternal: false,
-                  }}
-                >
-                  Retour
-                </ButtonLink>
-              </div>
-              <div>
-                <SubmitButton variant={ButtonVariant.PRIMARY}>
-                  Créer
-                </SubmitButton>
-              </div>
-            </div>
-          </form>
-        </FormikProvider>
-      )}
-    </div>
+            </form>
+          </FormikProvider>
+        )}
+      </div>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
+import { AppLayout } from 'app/AppLayout'
 import { getOffererAdapter } from 'core/Offers/adapters'
 import { DEFAULT_PAGE, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQuerySearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
@@ -158,26 +159,28 @@ const OffersRoute = (): JSX.Element => {
     loadAllVenuesByProUser()
   }, [offerer?.id])
 
-  if (!initialSearchFilters) {
-    return <Spinner />
-  }
-
   return (
-    <OffersScreen
-      audience={Audience.INDIVIDUAL}
-      categories={categories}
-      currentPageNumber={currentPageNumber}
-      currentUser={currentUser}
-      initialSearchFilters={initialSearchFilters}
-      isLoading={isLoading}
-      loadAndUpdateOffers={loadAndUpdateOffers}
-      offerer={offerer}
-      offers={offers}
-      redirectWithUrlFilters={redirectWithUrlFilters}
-      setOfferer={setOfferer}
-      urlSearchFilters={urlSearchFilters}
-      venues={venues}
-    />
+    <AppLayout>
+      {!initialSearchFilters ? (
+        <Spinner />
+      ) : (
+        <OffersScreen
+          audience={Audience.INDIVIDUAL}
+          categories={categories}
+          currentPageNumber={currentPageNumber}
+          currentUser={currentUser}
+          initialSearchFilters={initialSearchFilters}
+          isLoading={isLoading}
+          loadAndUpdateOffers={loadAndUpdateOffers}
+          offerer={offerer}
+          offers={offers}
+          redirectWithUrlFilters={redirectWithUrlFilters}
+          setOfferer={setOfferer}
+          urlSearchFilters={urlSearchFilters}
+          venues={venues}
+        />
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/Reimbursements/Reimbursements.tsx
+++ b/pro/src/pages/Reimbursements/Reimbursements.tsx
@@ -3,6 +3,7 @@ import './Reimbursement.scss'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
+import { AppLayout } from 'app/AppLayout'
 import {
   oldRoutesReimbursements,
   routesReimbursements,
@@ -24,20 +25,22 @@ const Reimbursements = (): JSX.Element => {
     : oldRoutesReimbursements
 
   return (
-    <ReimbursementContextProvider>
-      <div className={styles['reimbursements-container']}>
-        <h1 className={styles['title']}>Remboursements</h1>
-        <ReimbursementsBanners />
-        <div>
-          <ReimbursementsTabs />
-          <Routes>
-            {routes.map(({ path, element }) => (
-              <Route key={path} path={path} element={element} />
-            ))}
-          </Routes>
+    <AppLayout pageName="reimbursements">
+      <ReimbursementContextProvider>
+        <div className={styles['reimbursements-container']}>
+          <h1 className={styles['title']}>Remboursements</h1>
+          <ReimbursementsBanners />
+          <div>
+            <ReimbursementsTabs />
+            <Routes>
+              {routes.map(({ path, element }) => (
+                <Route key={path} path={path} element={element} />
+              ))}
+            </Routes>
+          </div>
         </div>
-      </div>
-    </ReimbursementContextProvider>
+      </ReimbursementContextProvider>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/ResetPassword/ResetPassword.tsx
+++ b/pro/src/pages/ResetPassword/ResetPassword.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import AppLayout from 'app/AppLayout'
+import { AppLayout } from 'app/AppLayout'
 import useRedirectLoggedUser from 'hooks/useRedirectLoggedUser'
 import logoPassCultureProFullIcon from 'icons/logo-pass-culture-pro-full.svg'
 import Hero from 'ui-kit/Hero'
@@ -50,12 +50,8 @@ const ResetPassword = (): JSX.Element => {
           width="135"
         />
       </header>
-      <AppLayout
-        layoutConfig={{
-          fullscreen: true,
-          pageName: 'reset-password',
-        }}
-      >
+
+      <AppLayout fullscreen pageName="reset-password">
         <div className={styles['content']}>
           {passwordChanged && !isBadToken && (
             <Hero

--- a/pro/src/pages/SignIn/SignIn.tsx
+++ b/pro/src/pages/SignIn/SignIn.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { HTTP_STATUS, isErrorAPIError } from 'apiClient/helpers'
-import AppLayout from 'app/AppLayout'
+import { AppLayout } from 'app/AppLayout'
 import SkipLinks from 'components/SkipLinks'
 import useNotification from 'hooks/useNotification'
 import useRedirectLoggedUser from 'hooks/useRedirectLoggedUser'
@@ -89,6 +89,7 @@ const SignIn = (): JSX.Element => {
   return (
     <>
       <SkipLinks displayMenu={false} />
+
       <div className={styles['sign-in']}>
         <header className={styles['logo-side']}>
           <SvgIcon
@@ -99,12 +100,8 @@ const SignIn = (): JSX.Element => {
             width="135"
           />
         </header>
-        <AppLayout
-          layoutConfig={{
-            fullscreen: true,
-            pageName: 'sign-in',
-          }}
-        >
+
+        <AppLayout fullscreen pageName="sign-in">
           <section className={styles['content']}>
             <h1>Bienvenue sur l’espace dédié aux acteurs culturels</h1>
             <div className={styles['mandatory']}>

--- a/pro/src/pages/Signup/Signup.tsx
+++ b/pro/src/pages/Signup/Signup.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
-import AppLayout from 'app/AppLayout'
+import { AppLayout } from 'app/AppLayout'
 import { routesSignup } from 'app/AppRouter/subroutesSignupMap'
 import SkipLinks from 'components/SkipLinks'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -18,6 +18,7 @@ const Signup = () => {
   return (
     <>
       <SkipLinks displayMenu={false} />
+
       <div className={styles['sign-up']}>
         <header className={styles['logo-side']}>
           <SvgIcon
@@ -28,12 +29,8 @@ const Signup = () => {
             width="135"
           />
         </header>
-        <AppLayout
-          layoutConfig={{
-            fullscreen: true,
-            pageName: 'sign-up',
-          }}
-        >
+
+        <AppLayout fullscreen pageName="sign-up">
           {isProAccountCreationEnabled ? (
             <Routes>
               {routesSignup.map(({ path, element }) => (

--- a/pro/src/pages/SignupJourneyRoutes/SignupJourneyRoutes.tsx
+++ b/pro/src/pages/SignupJourneyRoutes/SignupJourneyRoutes.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { Route, Routes, useLocation } from 'react-router-dom'
 
-import AppLayout from 'app/AppLayout'
+import { AppLayout } from 'app/AppLayout'
 import { routesSignupJourney } from 'app/AppRouter/subroutesSignupJourneyMap'
 import { SignupJourneyFormLayout } from 'components/SignupJourneyFormLayout'
 import SkipLinks from 'components/SkipLinks'
@@ -42,6 +42,7 @@ const SignupJourneyRoutes = () => {
   return (
     <>
       <SkipLinks displayMenu={false} />
+
       <header className={styles['header']}>
         <div className={styles['header-content']}>
           <SvgIcon
@@ -59,11 +60,10 @@ const SignupJourneyRoutes = () => {
           </Button>
         </div>
       </header>
+
       <AppLayout
-        layoutConfig={{
-          fullscreen: true,
-          pageName: 'sign-up-journey',
-        }}
+        fullscreen
+        pageName="sign-up-journey"
         className={styles['sign-up-journey']}
       >
         <SignupJourneyContextProvider>

--- a/pro/src/pages/User/UserProfile.tsx
+++ b/pro/src/pages/User/UserProfile.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { AppLayout } from 'app/AppLayout'
 import useCurrentUser from 'hooks/useCurrentUser'
 import { UserProfile as UserProfileScreen } from 'screens/UserProfile'
 
@@ -13,11 +14,13 @@ const Profile = (): JSX.Element => {
   const { currentUser } = useCurrentUser()
 
   return (
-    <UserProfileScreen
-      userIdentityInitialValues={serializeUserIdentity(currentUser)}
-      userPhoneInitialValues={serializeUserPhone(currentUser)}
-      userEmailInitialValues={serializeUserEmail(currentUser)}
-    />
+    <AppLayout>
+      <UserProfileScreen
+        userIdentityInitialValues={serializeUserIdentity(currentUser)}
+        userPhoneInitialValues={serializeUserPhone(currentUser)}
+        userEmailInitialValues={serializeUserEmail(currentUser)}
+      />
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/VenueCreation/VenueCreation.tsx
+++ b/pro/src/pages/VenueCreation/VenueCreation.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useParams } from 'react-router-dom'
 
+import { AppLayout } from 'app/AppLayout'
 import { setDefaultInitialFormValues } from 'components/VenueForm'
 import useGetOfferer from 'core/Offerers/getOffererAdapter/useGetOfferer'
 import { useGetVenueLabels } from 'core/Venue/adapters/getVenueLabelsAdapter'
@@ -13,7 +14,6 @@ const VenueCreation = (): JSX.Element | null => {
   const homePath = '/accueil'
   const { offererId } = useParams<{ offererId: string }>()
   const notify = useNotification()
-  const navigate = useNavigate()
 
   const initialValues = setDefaultInitialFormValues()
 
@@ -33,29 +33,30 @@ const VenueCreation = (): JSX.Element | null => {
     data: venueLabels,
   } = useGetVenueLabels()
 
-  if (isLoadingOfferer || isLoadingVenueTypes || isLoadingVenueLabels) {
-    return <Spinner />
-  }
-
   if (errorOfferer || errorVenueTypes || errorVenueLabels) {
     const loadingError = [errorOfferer, errorVenueTypes, errorVenueLabels].find(
       (error) => error !== undefined
     )
     if (loadingError !== undefined) {
-      navigate(homePath)
       notify.error(loadingError.message)
     }
-    return null
+    return <Navigate to={homePath} />
   }
 
   return (
-    <VenueFormScreen
-      initialValues={initialValues}
-      isCreatingVenue
-      offerer={offerer}
-      venueTypes={venueTypes}
-      venueLabels={venueLabels}
-    />
+    <AppLayout>
+      {isLoadingOfferer || isLoadingVenueTypes || isLoadingVenueLabels ? (
+        <Spinner />
+      ) : (
+        <VenueFormScreen
+          initialValues={initialValues}
+          isCreatingVenue
+          offerer={offerer}
+          venueTypes={venueTypes}
+          venueLabels={venueLabels}
+        />
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/VenueCreation/__specs__/VenueCreation.spec.tsx
+++ b/pro/src/pages/VenueCreation/__specs__/VenueCreation.spec.tsx
@@ -6,7 +6,6 @@ import { api } from 'apiClient/api'
 import { GetOffererResponseModel } from 'apiClient/v1'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
-import AppLayout from '../../../app/AppLayout'
 import VenueCreation from '../VenueCreation'
 
 const renderVenueCreation = async (offererId: string) => {
@@ -25,15 +24,10 @@ const renderVenueCreation = async (offererId: string) => {
     },
   }
 
-  renderWithProviders(
-    <AppLayout>
-      <VenueCreation />
-    </AppLayout>,
-    {
-      storeOverrides,
-      initialRouterEntries: [`/structures/${offererId}/lieux/creation`],
-    }
-  )
+  renderWithProviders(<VenueCreation />, {
+    storeOverrides,
+    initialRouterEntries: [`/structures/${offererId}/lieux/creation`],
+  })
   await waitFor(() => {
     expect(api.canOffererCreateEducationalOffer).toHaveBeenCalled()
   })

--- a/pro/src/pages/VenueEdition/VenueEdition.tsx
+++ b/pro/src/pages/VenueEdition/VenueEdition.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useParams } from 'react-router-dom'
 
 import { OfferStatus } from 'apiClient/v1'
+import { AppLayout } from 'app/AppLayout'
 import { setInitialFormValues } from 'components/VenueForm'
 import useGetOfferer from 'core/Offerers/getOffererAdapter/useGetOfferer'
 import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
@@ -24,7 +25,6 @@ import { offerHasBookingQuantity } from './utils'
 
 const VenueEdition = (): JSX.Element | null => {
   const homePath = '/accueil'
-  const navigate = useNavigate()
   const { offererId, venueId } = useParams<{
     offererId: string
     venueId: string
@@ -75,18 +75,6 @@ const VenueEdition = (): JSX.Element | null => {
   const hasBookingQuantity = offerHasBookingQuantity(venueOffers?.offers)
 
   if (
-    isLoadingVenue ||
-    isLoadingVenueTypes ||
-    isLoadingVenueLabels ||
-    isLoadingProviders ||
-    isLoadingVenueProviders ||
-    isLoadingOfferer ||
-    isLoadingVenueOffers
-  ) {
-    return <Spinner />
-  }
-
-  if (
     errorOfferer ||
     errorVenue ||
     errorVenueTypes ||
@@ -101,27 +89,37 @@ const VenueEdition = (): JSX.Element | null => {
       errorVenueLabels,
     ].find((error) => error !== undefined)
     if (loadingError !== undefined) {
-      navigate(homePath)
       notify.error(loadingError.message)
-      return null
+      return <Navigate to={homePath} />
     }
     /* istanbul ignore next: Never */
     return null
   }
 
-  const initialValues = setInitialFormValues(venue)
   return (
-    <VenueFormScreen
-      initialValues={initialValues}
-      isCreatingVenue={false}
-      offerer={offerer}
-      venueTypes={venueTypes}
-      venueLabels={venueLabels}
-      providers={providers}
-      venue={venue}
-      venueProviders={venueProviders}
-      hasBookingQuantity={venue?.id ? hasBookingQuantity : false}
-    />
+    <AppLayout>
+      {isLoadingVenue ||
+      isLoadingVenueTypes ||
+      isLoadingVenueLabels ||
+      isLoadingProviders ||
+      isLoadingVenueProviders ||
+      isLoadingOfferer ||
+      isLoadingVenueOffers ? (
+        <Spinner />
+      ) : (
+        <VenueFormScreen
+          initialValues={setInitialFormValues(venue)}
+          isCreatingVenue={false}
+          offerer={offerer}
+          venueTypes={venueTypes}
+          venueLabels={venueLabels}
+          providers={providers}
+          venue={venue}
+          venueProviders={venueProviders}
+          hasBookingQuantity={venue?.id ? hasBookingQuantity : false}
+        />
+      )}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/VenueEdition/__specs__/VenueEdition.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEdition.spec.tsx
@@ -1,7 +1,6 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
-import * as router from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import {
@@ -175,7 +174,7 @@ describe('route VenueEdition', () => {
     ).not.toBeChecked()
   })
 
-  it('should not render reimbursement fields when FF bank details is enable and venue has no siret', async () => {
+  it('should not render reimbursement fields when FF bank details is enabled and venue has no siret', async () => {
     vi.spyOn(api, 'getVenue').mockResolvedValueOnce({
       ...venue,
       siret: '11111111111111',
@@ -193,7 +192,9 @@ describe('route VenueEdition', () => {
       name: 'Cinéma des iles',
     })
 
-    expect(screen.queryByText(/Remboursement/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Barème de remboursement/)
+    ).not.toBeInTheDocument()
   })
 
   it('should return to home when not able to get venue informations', async () => {
@@ -209,15 +210,11 @@ describe('route VenueEdition', () => {
         ''
       )
     )
-    const mockNavigate = vi.fn()
-    vi.spyOn(router, 'useNavigate').mockReturnValue(mockNavigate)
-    // When
     renderVenueEdition(venue.id, offerer.id)
 
     await waitForElementToBeRemoved(screen.getByTestId('spinner'))
-    // Then
     expect(api.getVenue).toHaveBeenCalledTimes(1)
 
-    expect(mockNavigate).toHaveBeenCalledWith('/accueil')
+    expect(await screen.findByText('Home')).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
@@ -3,6 +3,7 @@ import { Form, FormikProvider, useFormik } from 'formik'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { AppLayout } from 'app/AppLayout'
 import ActionsBarSticky from 'components/ActionsBarSticky'
 import { createOfferFromTemplate } from 'core/OfferEducational'
 import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
@@ -98,96 +99,98 @@ const CollectiveOfferSelectionDuplication = (): JSX.Element => {
   }
 
   return (
-    <div className="container">
-      <Titles title="Créer une offre réservable" />
-      <Title as="h3" className="sub-title" level={4}>
-        Séléctionner l’offre vitrine à dupliquer
-      </Title>
+    <AppLayout>
+      <div className="container">
+        <Titles title="Créer une offre réservable" />
+        <Title as="h3" className="sub-title" level={4}>
+          Séléctionner l’offre vitrine à dupliquer
+        </Title>
 
-      <div className={styles['search-container']}>
-        <FormikProvider value={formikSearch}>
-          <Form className={styles['search-input-container']}>
-            <TextInput
-              label="Offre vitrine à dupliquer"
-              isLabelHidden
-              name="searchFilter"
-              placeholder="Rechercher une offre vitrine"
-              className={styles['search-input']}
-            />
-            <SubmitButton
-              className={styles['search-button']}
-              isLoading={isLoading}
-              aria-label="Button de recherche"
-              icon={strokeSearchIcon}
-            >
-              Rechercher
-            </SubmitButton>
-          </Form>
-        </FormikProvider>
-        <FormikProvider value={formikSelection}>
-          <Form>
-            <p className={styles['offer-info']}>
-              {showAll
-                ? 'Les dernières offres vitrines créées'
-                : `${pluralize(offers.length, 'offre')} vitrine`}
-            </p>
-            {offers?.slice(0, 5).map((offer) => (
-              <div
-                key={offer.id}
-                className={cn(styles['offer-selection'], {
-                  [styles['offer-selected']]:
-                    formikSelection.values.templateOfferId ===
-                    offer.id.toString(),
-                })}
+        <div className={styles['search-container']}>
+          <FormikProvider value={formikSearch}>
+            <Form className={styles['search-input-container']}>
+              <TextInput
+                label="Offre vitrine à dupliquer"
+                isLabelHidden
+                name="searchFilter"
+                placeholder="Rechercher une offre vitrine"
+                className={styles['search-input']}
+              />
+              <SubmitButton
+                className={styles['search-button']}
+                isLoading={isLoading}
+                aria-label="Button de recherche"
+                icon={strokeSearchIcon}
               >
-                <RadioButton
-                  name="templateOfferId"
-                  value={offer.id.toString()}
-                  label={
-                    <div className={styles['offer-selection-label']}>
-                      <Thumb
-                        url={offer.thumbUrl}
-                        className={styles['img-offer']}
-                      />
-                      <p className={styles['offer-title']}>
-                        <strong>{offer.name}</strong>
-                        {offer.venue.name}
-                      </p>
-                    </div>
-                  }
-                />
-              </div>
-            ))}
-            {offers?.length < 1 && (
-              <div className={styles['search-no-results']}>
-                <SvgIcon
-                  src={strokeSearchIcon}
-                  alt="Illustration de recherche"
-                  className={styles['search-no-results-icon']}
-                  width="124"
-                />
-                <p className={styles['search-no-results-text']}>
-                  Aucune offre trouvée pour votre recherche
-                </p>
-              </div>
-            )}
-            <ActionsBarSticky>
-              <ActionsBarSticky.Left>
-                <ButtonLink
-                  variant={ButtonVariant.SECONDARY}
-                  link={{ isExternal: false, to: computeOffersUrl({}) }}
+                Rechercher
+              </SubmitButton>
+            </Form>
+          </FormikProvider>
+          <FormikProvider value={formikSelection}>
+            <Form>
+              <p className={styles['offer-info']}>
+                {showAll
+                  ? 'Les dernières offres vitrines créées'
+                  : `${pluralize(offers.length, 'offre')} vitrine`}
+              </p>
+              {offers?.slice(0, 5).map((offer) => (
+                <div
+                  key={offer.id}
+                  className={cn(styles['offer-selection'], {
+                    [styles['offer-selected']]:
+                      formikSelection.values.templateOfferId ===
+                      offer.id.toString(),
+                  })}
                 >
-                  Annuler et quitter
-                </ButtonLink>
-              </ActionsBarSticky.Left>
-              <ActionsBarSticky.Right>
-                <SubmitButton disabled={false}>Étape suivante</SubmitButton>
-              </ActionsBarSticky.Right>
-            </ActionsBarSticky>
-          </Form>
-        </FormikProvider>
+                  <RadioButton
+                    name="templateOfferId"
+                    value={offer.id.toString()}
+                    label={
+                      <div className={styles['offer-selection-label']}>
+                        <Thumb
+                          url={offer.thumbUrl}
+                          className={styles['img-offer']}
+                        />
+                        <p className={styles['offer-title']}>
+                          <strong>{offer.name}</strong>
+                          {offer.venue.name}
+                        </p>
+                      </div>
+                    }
+                  />
+                </div>
+              ))}
+              {offers?.length < 1 && (
+                <div className={styles['search-no-results']}>
+                  <SvgIcon
+                    src={strokeSearchIcon}
+                    alt="Illustration de recherche"
+                    className={styles['search-no-results-icon']}
+                    width="124"
+                  />
+                  <p className={styles['search-no-results-text']}>
+                    Aucune offre trouvée pour votre recherche
+                  </p>
+                </div>
+              )}
+              <ActionsBarSticky>
+                <ActionsBarSticky.Left>
+                  <ButtonLink
+                    variant={ButtonVariant.SECONDARY}
+                    link={{ isExternal: false, to: computeOffersUrl({}) }}
+                  >
+                    Annuler et quitter
+                  </ButtonLink>
+                </ActionsBarSticky.Left>
+                <ActionsBarSticky.Right>
+                  <SubmitButton disabled={false}>Étape suivante</SubmitButton>
+                </ActionsBarSticky.Right>
+              </ActionsBarSticky>
+            </Form>
+          </FormikProvider>
+        </div>
       </div>
-    </div>
+    </AppLayout>
   )
 }
 

--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -6,6 +6,7 @@ import {
   EducationalRedactor,
   GetCollectiveOfferRequestResponseModel,
 } from 'apiClient/v1'
+import { AppLayout } from 'app/AppLayout'
 import ActionsBarSticky from 'components/ActionsBarSticky'
 import BannerPublicApi from 'components/Banner/BannerPublicApi'
 import FormLayout from 'components/FormLayout'
@@ -228,9 +229,11 @@ const CollectiveOfferVisibility = ({
         )
       )
   }
+
   return (
-    <>
+    <AppLayout>
       <FormLayout.MandatoryInfo />
+
       <OfferEducationalActions
         reloadCollectiveOffer={reloadCollectiveOffer}
         className={styles.actions}
@@ -238,6 +241,7 @@ const CollectiveOfferVisibility = ({
         offer={offer}
         mode={mode}
       />
+
       <FormikProvider value={formik}>
         <form onSubmit={formik.handleSubmit}>
           <FormLayout>
@@ -335,7 +339,7 @@ const CollectiveOfferVisibility = ({
           </FormLayout>
         </form>
       </FormikProvider>
-    </>
+    </AppLayout>
   )
 }
 

--- a/pro/src/screens/EmailChangeValidation/EmailChangeValidation.tsx
+++ b/pro/src/screens/EmailChangeValidation/EmailChangeValidation.tsx
@@ -1,7 +1,7 @@
 // react hooks and usages doc : https://reactjs.org/docs/hooks-intro.html
 import React from 'react'
 
-import AppLayout from 'app/AppLayout'
+import { AppLayout } from 'app/AppLayout'
 import SkipLinks from 'components/SkipLinks'
 import logoPassCultureProFullIcon from 'icons/logo-pass-culture-pro-full.svg'
 import { ButtonLink } from 'ui-kit'
@@ -20,6 +20,7 @@ const EmailChangeValidation = ({
   return (
     <>
       <SkipLinks displayMenu={false} />
+
       <div className={styles['email-validation']}>
         <header className={styles['logo-side']}>
           <SvgIcon
@@ -30,12 +31,8 @@ const EmailChangeValidation = ({
             width="135"
           />
         </header>
-        <AppLayout
-          layoutConfig={{
-            fullscreen: true,
-            pageName: 'sign-up',
-          }}
-        >
+
+        <AppLayout fullscreen pageName="sign-up">
           {isSuccess && (
             <section className={styles['content']}>
               <h1>Et voilà !</h1>


### PR DESCRIPTION
## But de la pull request

Le but est d'éliminer le composant `<RouteWrapper>` afin de simplifier la gestion du router. Le composant fait deux choses aujourd'hui : 

- appliquer `<AppLayout>`
- faire la redirection si on est pas loggé

Cette PR s'occupe du layout en mettant le composant au niveau de chaque page. On ne peut pas utiliser le mécanisme de layout du router car on a des pages sans layout et des pages avec des configs de layout différentes.