### PR TITLE
(PC-26091)[API] fix: typo in id_check_blocked_other

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -62,7 +62,7 @@ class FraudReasonCode(enum.Enum):
     DOCUMENT_DAMAGED = "document_damaged"
     ELIGIBILITY_CHANGED = "eligibility_changed"  # The user's eligibility detected by ubble is different from the eligibility declared by the user
     ID_CHECK_BLOCKED_OTHER = (
-        "id_check_bocked_other"  # Default reason code when the user's ID check is blocked for an unhandled reason
+        "id_check_blocked_other"  # Default reason code when the user's ID check is blocked for an unhandled reason
     )
     ID_CHECK_DATA_MATCH = "id_check_data_match"  # Ubble check did not match the data declared in the app (profile step)
     ID_CHECK_EXPIRED = "id_check_expired"


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-26091

On stocke `FraudReasonCode.name` dans la base de données, donc aucun impact sur les données.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques