### PR TITLE
(PC-26271)[ADAGE] fix: various fixes on adage's playlist

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
+++ b/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
@@ -6,14 +6,14 @@ from .base import BaseQuery
 
 
 class ClassroomPlaylistModel(pydantic_v1.BaseModel):
-    offer_id: str
+    collective_offer_id: str
     distance_in_km: float
 
 
 class ClassroomPlaylistQuery(BaseQuery):
     raw_query = f"""
         SELECT
-            offer_id,
+            distinct collective_offer_id,
             distance_in_km
         FROM
             `{settings.BIG_QUERY_TABLE_BASENAME}.adage_home_playlist_moving_offerers`

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -67,7 +67,7 @@ def generate_fake_adage_token(readonly: bool) -> None:
 @click.option("--final", type=bool, is_flag=True, default=False, help="Flag deposits as final.")
 def import_deposit_csv(path: str, year: int, ministry: str, conflict: str, final: bool) -> None:
     """
-    import CSV depostis and update institution according to adage data.
+    import CSV deposits and update institution according to adage data.
 
     CSV format change every time we try to work with it.
     """

--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -27,8 +27,8 @@ class GetClassroomPlaylistTest:
         mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
         with patch(mock_path) as mock_run_query:
             mock_run_query.return_value = [
-                {"offer_id": str(offers[0].id), "distance_in_km": expected_distance},
-                {"offer_id": str(offers[1].id), "distance_in_km": expected_distance},
+                {"collective_offer_id": str(offers[0].id), "distance_in_km": expected_distance},
+                {"collective_offer_id": str(offers[1].id), "distance_in_km": expected_distance},
             ]
 
             # fetch institution (1 query)
@@ -130,7 +130,7 @@ class GetNewTemplateOffersPlaylistTest:
 
                 for idx, response_offer in enumerate(response_offers):
                     assert response_offer["id"] == offers[idx].id
-                    assert response_offer["venue"]["distance"] == None
+                    assert response_offer["venue"]["distance"] == expected_distance
                     assert response_offer["offerVenue"]["distance"] == expected_distance
                     assert response_offer["isFavorite"] == bool(idx)
 


### PR DESCRIPTION
- `institution_id` are string in BigQuery model. We need to cast them to str to avoid malformed queries
- `collective_offer_id` is used by data instead of `offer_id`.
- small typo
- We need the distance to the venue to be returned in any case for new template collective offers but only add the distance from the offer and the institution if it is performed at the offerer's venue.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26271

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques