### PR TITLE
(PC-22771)[BO] fix: can't move event offer when database has at least…

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1537,7 +1537,7 @@ def check_can_move_event_offer(offer: models.Offer) -> list[offerers_models.Venu
 
     count_past_stocks = (
         models.Stock.query.with_entities(models.Stock.id)
-        .filter(models.Stock.beginningDatetime < datetime.datetime.utcnow())
+        .filter(models.Stock.offerId == offer.id, models.Stock.beginningDatetime < datetime.datetime.utcnow())
         .count()
     )
     if count_past_stocks > 0:

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -1389,6 +1389,10 @@ class EditOfferVenueTest(PostEndpointHelper):
             finance_factories.PricingFactory(event=finance_event2_1, booking=booking2_1)
         booking2_2 = bookings_factories.CancelledBookingFactory(stock=stock2)
 
+        # other objects to validate queries filters
+        offers_factories.EventStockFactory(beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=7))
+        bookings_factories.ReimbursedBookingFactory()
+
         response = self.post_to_endpoint(
             authenticated_client,
             offer_id=offer.id,


### PR DESCRIPTION
… one event in the past

## But de la pull request

Correction suite au ticket Jira : https://passculture.atlassian.net/browse/PC-22771

Il était impossible de déplacer le moindre évènement dès lors qu'il y avait au moins un évènement passé en base de données (n'importe quelle structure)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques