### PR TITLE
(PC-25824)[API] link ban id to correct field in front

### DIFF
--- a/pro/src/components/Address/Address.tsx
+++ b/pro/src/components/Address/Address.tsx
@@ -101,7 +101,7 @@ export const handleAddressSelect = (
   setFieldValue('city', selectedItem?.extraData.city)
   setFieldValue('latitude', selectedItem?.extraData.latitude)
   setFieldValue('longitude', selectedItem?.extraData.longitude)
-  setFieldValue('banId', selectedItem?.extraData.banId)
+  setFieldValue('banId', selectedItem?.value)
 }
 
 export default AddressSelect

--- a/pro/src/components/Address/__specs__/Address.spec.tsx
+++ b/pro/src/components/Address/__specs__/Address.spec.tsx
@@ -106,6 +106,7 @@ describe('AddressSelect', () => {
           address: '12 rue des tournesols',
           addressAutocomplete: '12 rue des tournesols 75003 Paris',
           city: 'Paris',
+          banId: '2',
           latitude: 22.2,
           longitude: -2.22,
           postalCode: '75003',


### PR DESCRIPTION
## But de la pull request

Petite correction du front pour récupérer le bon champ de BAN ID

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25824

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques