### PR TITLE
(PC-26110)[PRO] refactor: Remove WIP_ENABLE_LIKE_IN_ADAGE ff.

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 ce93f52f9f59 (pre) (head)
-a006ff4ea0bf (post) (head)
+1ce7e6391919 (post) (head)

--- a/api/src/pcapi/alembic/versions/20231207T101155_1ce7e6391919_delete_adage_favorite_ff.py
+++ b/api/src/pcapi/alembic/versions/20231207T101155_1ce7e6391919_delete_adage_favorite_ff.py
@@ -1,0 +1,35 @@
+"""
+Remove FF WIP_ENABLE_LIKE_IN_ADAGE
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "1ce7e6391919"
+down_revision = "a006ff4ea0bf"
+branch_labels = None
+depends_on = None
+
+
+def get_flag():  # type:ignore[no-untyped-def]
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="WIP_ENABLE_LIKE_IN_ADAGE",
+        isActive=True,
+        description="Active la possibilité de liker une offre sur adage",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -95,7 +95,6 @@ class FeatureToggle(enum.Enum):
     # For features under construction, a temporary feature flag must be named with the `WIP_` prefix
     WIP_BEHIND_L7_LOAD_BALANCER = "À activer/désactiver en même temps que le load balancer L7"
     WIP_ENABLE_OFFER_CREATION_API_V1 = "Active la création d'offres via l'API v1"
-    WIP_ENABLE_LIKE_IN_ADAGE = "Active la possibilité de liker une offre sur adage"
     WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY = "Changer le template d'email de confirmation de réservation"
     WIP_ENABLE_TRUSTED_DEVICE = "Active la fonctionnalité d'appareil de confiance"
     WIP_ENABLE_SUSPICIOUS_EMAIL_SEND = "Active l'envoie d'email lors de la détection d'une connexion suspicieuse"
@@ -173,7 +172,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ENABLE_COMPLIANCE_CALL,
     FeatureToggle.WIP_ENABLE_DIFFUSE_HELP,
     FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API,
-    FeatureToggle.WIP_ENABLE_LIKE_IN_ADAGE,
     FeatureToggle.WIP_ENABLE_MOCK_UBBLE,
     FeatureToggle.WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY,
     FeatureToggle.WIP_ENABLE_DOUBLE_MODEL_WRITING,

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
@@ -33,7 +33,6 @@ export const AdageHeaderMenu = ({
 
   const { nbHits } = useStats()
 
-  const areFavoritesActive = useActiveFeature('WIP_ENABLE_LIKE_IN_ADAGE')
   const isDiscoveryActive = useActiveFeature('WIP_ENABLE_DISCOVERY')
 
   return (
@@ -94,29 +93,27 @@ export const AdageHeaderMenu = ({
             </NavLink>
           </li>
 
-          {areFavoritesActive && (
-            <li className={styles['adage-header-menu-item']}>
-              <NavLink
-                to={`/adage-iframe/mes-favoris?token=${adageAuthToken}`}
-                className={({ isActive }) => {
-                  return cn(styles['adage-header-link'], {
-                    [styles['adage-header-link-active']]: isActive,
-                  })
-                }}
-                onClick={() => logAdageLinkClick(AdageHeaderLink.MY_FAVORITES)}
-              >
-                <SvgIcon
-                  src={strokeStarIcon}
-                  alt=""
-                  className={styles['adage-header-link-icon']}
-                />
-                Mes Favoris
-                <div className={styles['adage-header-nb-hits']}>
-                  {favoritesCount ?? 0}
-                </div>
-              </NavLink>
-            </li>
-          )}
+          <li className={styles['adage-header-menu-item']}>
+            <NavLink
+              to={`/adage-iframe/mes-favoris?token=${adageAuthToken}`}
+              className={({ isActive }) => {
+                return cn(styles['adage-header-link'], {
+                  [styles['adage-header-link-active']]: isActive,
+                })
+              }}
+              onClick={() => logAdageLinkClick(AdageHeaderLink.MY_FAVORITES)}
+            >
+              <SvgIcon
+                src={strokeStarIcon}
+                alt=""
+                className={styles['adage-header-link-icon']}
+              />
+              Mes Favoris
+              <div className={styles['adage-header-nb-hits']}>
+                {favoritesCount ?? 0}
+              </div>
+            </NavLink>
+          </li>
         </>
       )}
     </ul>

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
@@ -34,18 +34,6 @@ const renderAdageHeader = (
   )
 }
 
-const isFavoritesActive = {
-  features: {
-    list: [
-      {
-        nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE',
-        isActive: true,
-      },
-    ],
-    initialized: true,
-  },
-}
-
 const isDiscoveryActive = {
   features: {
     list: [
@@ -219,20 +207,10 @@ describe('AdageHeader', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should not display favorites tab if the feature flag is disabled', () => {
+  it('should display a favorites tab in the header', () => {
     vi.spyOn(apiAdage, 'getEducationalInstitutionWithBudget')
 
     renderAdageHeader(user)
-
-    expect(
-      screen.queryByRole('link', { name: /Mes Favoris/ })
-    ).not.toBeInTheDocument()
-  })
-
-  it('should display favorites tab if the feature flag is enabled', () => {
-    vi.spyOn(apiAdage, 'getEducationalInstitutionWithBudget')
-
-    renderAdageHeader(user, isFavoritesActive)
 
     expect(
       screen.queryByRole('link', { name: /Mes Favoris/ })
@@ -242,10 +220,7 @@ describe('AdageHeader', () => {
   it('should display the user favorite count after the favorite tab name', () => {
     vi.spyOn(apiAdage, 'getEducationalInstitutionWithBudget')
 
-    renderAdageHeader(
-      { ...user, favoritesCount: 10 } as AuthenticatedResponse,
-      isFavoritesActive
-    )
+    renderAdageHeader({ ...user, favoritesCount: 10 })
 
     expect(
       screen.queryByRole('link', { name: /Mes Favoris (10)/ })

--- a/pro/src/pages/AdageIframe/app/components/OffersFavorites/__specs__/OffersFavorites.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersFavorites/__specs__/OffersFavorites.spec.tsx
@@ -18,10 +18,7 @@ const mockOffer: CollectiveOfferTemplateResponseModel = {
   ...defaultCollectiveTemplateOffer,
 }
 
-const renderAdageFavoritesOffers = (
-  user: AuthenticatedResponse,
-  storeOverrides?: any
-) => {
+const renderAdageFavoritesOffers = (user: AuthenticatedResponse) => {
   renderWithProviders(
     <Routes>
       <Route path="/adage-iframe" element={<h1>Accueil</h1>} />
@@ -34,20 +31,8 @@ const renderAdageFavoritesOffers = (
         }
       />
     </Routes>,
-    { storeOverrides, initialRouterEntries: ['/adage-iframe/mes-favoris'] }
+    { initialRouterEntries: ['/adage-iframe/mes-favoris'] }
   )
-}
-
-const isFavoritesActive = {
-  features: {
-    list: [
-      {
-        nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE',
-        isActive: true,
-      },
-    ],
-    initialized: true,
-  },
 }
 
 describe('OffersFavorites', () => {
@@ -60,7 +45,7 @@ describe('OffersFavorites', () => {
   }
 
   it('should render favorites title', async () => {
-    renderAdageFavoritesOffers(user, isFavoritesActive)
+    renderAdageFavoritesOffers(user)
 
     const loadingMessage = screen.queryByText(/Chargement en cours/)
     await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
@@ -71,7 +56,7 @@ describe('OffersFavorites', () => {
   })
 
   it('should display no results message whenever favorites list is empty', async () => {
-    renderAdageFavoritesOffers(user, isFavoritesActive)
+    renderAdageFavoritesOffers(user)
 
     const loadingMessage = screen.queryByText(/Chargement en cours/)
     await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
@@ -89,7 +74,7 @@ describe('OffersFavorites', () => {
       favoritesTemplate: [mockOffer],
     })
 
-    renderAdageFavoritesOffers(user, isFavoritesActive)
+    renderAdageFavoritesOffers(user)
 
     const loadingMessage = screen.queryByText(/Chargement en cours/)
     await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
@@ -102,7 +87,7 @@ describe('OffersFavorites', () => {
   it('should not display the list of favorites if the favorite cannot be fetched', async () => {
     vi.spyOn(apiAdage, 'getCollectiveFavorites').mockRejectedValueOnce({})
 
-    renderAdageFavoritesOffers(user, isFavoritesActive)
+    renderAdageFavoritesOffers(user)
 
     const loadingMessage = screen.queryByText(/Chargement en cours/)
     await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
@@ -117,7 +102,7 @@ describe('OffersFavorites', () => {
   it('should redirect to main adage page when clicking the catalogue button', async () => {
     vi.spyOn(apiAdage, 'getCollectiveFavorites').mockRejectedValueOnce({})
 
-    renderAdageFavoritesOffers(user, isFavoritesActive)
+    renderAdageFavoritesOffers(user)
 
     await waitFor(() =>
       expect(screen.queryByText(/Chargement en cours/)).not.toBeInTheDocument()

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -49,14 +49,11 @@ const Offer = ({
   openDetails = false,
 }: OfferProps): JSX.Element => {
   const [displayDetails, setDisplayDetails] = useState(openDetails)
-  const isLikeActive = useActiveFeature('WIP_ENABLE_LIKE_IN_ADAGE')
   const isGeolocationActive = useActiveFeature('WIP_ENABLE_ADAGE_GEO_LOCATION')
   const { adageUser } = useAdageUser()
 
   const canAddOfferToFavorites =
-    isLikeActive &&
-    offer.isTemplate &&
-    adageUser.role !== AdageFrontRoles.READONLY
+    offer.isTemplate && adageUser.role !== AdageFrontRoles.READONLY
 
   const openOfferDetails = (
     offer: HydratedCollectiveOffer | HydratedCollectiveOfferTemplate

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -326,29 +326,23 @@ describe('offer', () => {
   })
 
   it('should display the add to favorite button on offers that are not favorite yet', () => {
-    renderOffer(
-      {
-        ...offerProps,
-        offer: { ...defaultCollectiveTemplateOffer, isTemplate: true },
-      },
-      [{ nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE', isActive: true }]
-    )
+    renderOffer({
+      ...offerProps,
+      offer: { ...defaultCollectiveTemplateOffer, isTemplate: true },
+    })
 
     expect(screen.getByText('Enregistrer en favoris')).toBeInTheDocument()
   })
 
   it('should display the remove from favorite button on offers that are already favorite', () => {
-    renderOffer(
-      {
-        ...offerProps,
-        offer: {
-          ...defaultCollectiveTemplateOffer,
-          isFavorite: true,
-          isTemplate: true,
-        },
+    renderOffer({
+      ...offerProps,
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        isFavorite: true,
+        isTemplate: true,
       },
-      [{ nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE', isActive: true }]
-    )
+    })
 
     expect(screen.getByText('Supprimer des favoris')).toBeInTheDocument()
   })
@@ -357,13 +351,10 @@ describe('offer', () => {
     vi.spyOn(apiAdage, 'postCollectiveOfferFavorites').mockResolvedValue()
     vi.spyOn(apiAdage, 'deleteFavoriteForCollectiveOffer').mockResolvedValue()
 
-    renderOffer(
-      {
-        ...offerProps,
-        offer: { ...defaultCollectiveTemplateOffer, isTemplate: true },
-      },
-      [{ nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE', isActive: true }]
-    )
+    renderOffer({
+      ...offerProps,
+      offer: { ...defaultCollectiveTemplateOffer, isTemplate: true },
+    })
 
     const toFavoriteButton = screen.getByRole('button', {
       name: 'Enregistrer en favoris',
@@ -389,18 +380,15 @@ describe('offer', () => {
       'deleteFavoriteForCollectiveOfferTemplate'
     ).mockResolvedValue()
 
-    renderOffer(
-      {
-        ...offerProps,
-        offer: {
-          ...offerProps.offer,
-          dates: { end: '', start: '' },
-          isTemplate: true,
-        },
-        afterFavoriteChange: () => {},
+    renderOffer({
+      ...offerProps,
+      offer: {
+        ...offerProps.offer,
+        dates: { end: '', start: '' },
+        isTemplate: true,
       },
-      [{ nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE', isActive: true }]
-    )
+      afterFavoriteChange: () => {},
+    })
 
     const toFavoriteButton = screen.getByRole('button', {
       name: 'Enregistrer en favoris',
@@ -424,16 +412,13 @@ describe('offer', () => {
       null
     )
 
-    renderOffer(
-      {
-        ...offerProps,
-        offer: {
-          ...defaultCollectiveTemplateOffer,
-          isTemplate: true,
-        },
+    renderOffer({
+      ...offerProps,
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        isTemplate: true,
       },
-      [{ nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE', isActive: true }]
-    )
+    })
 
     const toFavoriteButton = screen.getByRole('button', {
       name: 'Enregistrer en favoris',
@@ -444,23 +429,20 @@ describe('offer', () => {
     expect(screen.getByText('Enregistrer en favoris')).toBeInTheDocument()
   })
 
-  it('should not change favorite status when set to favorite request fails', async () => {
+  it('should not change favorite status when remove from favorite request fails', async () => {
     vi.spyOn(
       apiAdage,
       'deleteFavoriteForCollectiveOfferTemplate'
     ).mockRejectedValue(null)
 
-    renderOffer(
-      {
-        ...offerProps,
-        offer: {
-          ...defaultCollectiveTemplateOffer,
-          isFavorite: true,
-          isTemplate: true,
-        },
+    renderOffer({
+      ...offerProps,
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        isFavorite: true,
+        isTemplate: true,
       },
-      [{ nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE', isActive: true }]
-    )
+    })
 
     const toFavoriteButton = screen.getByRole('button', {
       name: 'Supprimer des favoris',
@@ -480,7 +462,7 @@ describe('offer', () => {
           isTemplate: true,
         },
       },
-      [{ nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE', isActive: true }],
+      undefined,
       { ...user, role: AdageFrontRoles.READONLY }
     )
 
@@ -488,12 +470,9 @@ describe('offer', () => {
   })
 
   it('should not display favorite button when offer is bookable', () => {
-    renderOffer(
-      {
-        ...offerProps,
-      },
-      [{ nameKey: 'WIP_ENABLE_LIKE_IN_ADAGE', isActive: true }]
-    )
+    renderOffer({
+      ...offerProps,
+    })
 
     expect(screen.queryByText('Enregistrer en favoris')).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26110

**Objectif**
Suppression du FF qui autorise l'affichage des favoris dans adage (onglet du header, bouton favoris sur les offres, page des favoris)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques