### PR TITLE
(PC-26307)[PRO] fix: Duplicate bookable offer test fix.

### DIFF
--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -14,7 +14,6 @@ import {
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { CollectiveOffer } from 'core/OfferEducational'
-import getCollectiveOfferAdapter from 'core/OfferEducational/adapters/getCollectiveOfferAdapter'
 import * as createFromTemplateUtils from 'core/OfferEducational/utils/createOfferFromTemplate'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
 import * as useNotification from 'hooks/useNotification'
@@ -239,12 +238,7 @@ describe('DuplicateOfferCell', () => {
 
       await userEvent.click(button)
 
-      const response = await getCollectiveOfferAdapter(offer.id)
-
-      expect(response.isOk).toBeFalsy()
-
-      expect(notifyError).toHaveBeenNthCalledWith(
-        1,
+      expect(notifyError).toHaveBeenCalledWith(
         'Une erreur est survenue lors de la récupération de votre offre'
       )
     })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26307

**Objectif**
Correction du timeout dans le test de la récupération de l'offre au moment de la duplication d'une offre réservable. `expect(response.isOk).toBeFalsy()` est déjà couvert puisque `getCollectiveOffer` retourne une erreur.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques