### PR TITLE
(PC-25706)[API] fix: count distinct offers

### DIFF
--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -667,6 +667,7 @@ def get_venues_with_non_free_offers_without_bank_accounts(offerer_id: int) -> li
 def get_number_of_bookable_offers_for_offerer(offerer_id: int) -> int:
     return (
         offers_models.Offer.query.with_entities(offers_models.Offer.id)
+        .distinct()
         .join(models.Venue)
         .join(offers_models.Stock)
         .filter(

--- a/api/tests/routes/pro/get_offerer_stats_v2_test.py
+++ b/api/tests/routes/pro/get_offerer_stats_v2_test.py
@@ -19,7 +19,9 @@ def test_get_offerer_stats(client):
     offer = offers_factories.OfferFactory(
         venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.APPROVED
     )
-    offers_factories.StockFactory(offer=offer)
+    for _ in range(3):
+        offers_factories.StockFactory(offer=offer)
+
     for _ in range(2):
         educational_factories.CollectiveOfferFactory(
             venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.APPROVED


### PR DESCRIPTION
## But de la pull request
Avec le join sur la table stock, sans le distinct on se retrouve à compter le nombre de stocks

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25706
