### PR TITLE
(BSR)[BO] feat: offer link directly to details page

### DIFF
--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -721,7 +721,7 @@ def _batch_reject_offers(offer_ids: list[int]) -> None:
         )
 
 
-@list_offers_blueprint.route("/<int:offer_id>/details", methods=["GET"])
+@list_offers_blueprint.route("/<int:offer_id>", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.READ_OFFERS)
 def get_offer_details(offer_id: int) -> utils.BackofficeResponse:
     offer_query = offers_models.Offer.query.filter(offers_models.Offer.id == offer_id).options(

--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -34,7 +34,7 @@
      target="_top">{{ venue[text_attr] }}</a>
 {% endmacro %}
 {% macro build_offer_name_to_details_link(offer, text_attr="name") %}
-  <a href="{{ url_for('backoffice_web.offer.list_offers', q=offer.id) }}"
+  <a href="{{ url_for('backoffice_web.offer.get_offer_details', offer_id=offer.id) }}"
      class="link-primary"
      target="_top">{{ offer[text_attr] }}</a>
 {% endmacro %}


### PR DESCRIPTION
## But de la pull request

Lorsqu'on clique sur un id d'offre dans la page de réservation, aller directement à la page de détails de l'offre, plutôt que la recherche filtrée par cet id (c'était bien quand on n'avait pas la page offre :)).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques