### PR TITLE
(BSR)[API] chore: trade pylint ignore against dataclasses

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -229,7 +229,8 @@ class Booking(PcObject, Base, Model):
         return self.cancellationLimitDate is not None and self.cancellationLimitDate <= datetime.utcnow()
 
     @isConfirmed.expression  # type: ignore [no-redef]
-    def isConfirmed(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
+    @classmethod
+    def isConfirmed(cls) -> BooleanClauseList:
         return and_(cls.cancellationLimitDate.is_not(None), cls.cancellationLimitDate <= datetime.utcnow())
 
     @hybrid_property
@@ -237,7 +238,8 @@ class Booking(PcObject, Base, Model):
         return self.status in [BookingStatus.USED, BookingStatus.REIMBURSED]
 
     @is_used_or_reimbursed.expression  # type: ignore [no-redef]
-    def is_used_or_reimbursed(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def is_used_or_reimbursed(cls) -> bool:
         return cls.status.in_([BookingStatus.USED, BookingStatus.REIMBURSED])
 
     @hybrid_property
@@ -245,7 +247,8 @@ class Booking(PcObject, Base, Model):
         return self.status == BookingStatus.REIMBURSED
 
     @isReimbursed.expression  # type: ignore [no-redef]
-    def isReimbursed(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def isReimbursed(cls) -> bool:
         return cls.status == BookingStatus.REIMBURSED
 
     @hybrid_property
@@ -253,7 +256,8 @@ class Booking(PcObject, Base, Model):
         return self.status == BookingStatus.CANCELLED
 
     @isCancelled.expression  # type: ignore [no-redef]
-    def isCancelled(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def isCancelled(cls) -> bool:
         return cls.status == BookingStatus.CANCELLED
 
     @property
@@ -277,7 +281,8 @@ class Booking(PcObject, Base, Model):
         return any(externalBooking.id for externalBooking in self.externalBookings)
 
     @isExternal.expression  # type: ignore [no-redef]
-    def isExternal(cls) -> Label:  # pylint: disable=no-self-argument
+    @classmethod
+    def isExternal(cls) -> Label:
         return select(
             [
                 case(
@@ -331,7 +336,8 @@ class Booking(PcObject, Base, Model):
         )
 
     @display_even_if_used.expression  # type: ignore [no-redef]
-    def display_even_if_used(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
+    @classmethod
+    def display_even_if_used(cls) -> BooleanClauseList:
         return and_(
             offers_models.Offer.subcategoryId.in_(offers_models.Stock.AUTOMATICALLY_USED_SUBCATEGORIES),
             cls.amount == 0,

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -130,7 +130,8 @@ class HasImageMixin:
         return self.imageId is not None
 
     @hasImage.expression  # type: ignore[no-redef]
-    def hasImage(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasImage(cls) -> bool:
         return cls.imageId is not None
 
     def _get_image_storage_id(self, original: bool = False) -> str:
@@ -241,7 +242,8 @@ class StatusMixin:
         return offer_mixin.OfferStatus.ACTIVE
 
     @status.expression  # type: ignore [no-redef]
-    def status(cls) -> sa.sql.elements.Case:  # pylint: disable=no-self-argument
+    @classmethod
+    def status(cls) -> sa.sql.elements.Case:
         return sa.case(
             [
                 (
@@ -422,7 +424,8 @@ class CollectiveOffer(
         return False
 
     @hasEndDatePassed.expression  # type: ignore[no-redef]
-    def hasEndDatePassed(cls) -> False_:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasEndDatePassed(cls) -> False_:
         return sa.sql.expression.false()
 
     @hybrid_property
@@ -432,7 +435,8 @@ class CollectiveOffer(
         return True
 
     @isSoldOut.expression  # type: ignore[no-redef]
-    def isSoldOut(cls) -> Exists:  # pylint: disable=no-self-argument
+    @classmethod
+    def isSoldOut(cls) -> Exists:
         return (
             sa.exists()
             .where(CollectiveStock.collectiveOfferId == cls.id)
@@ -470,7 +474,8 @@ class CollectiveOffer(
         return self.collectiveStock.hasBookingLimitDatetimePassed
 
     @hasBookingLimitDatetimesPassed.expression  # type: ignore[no-redef]
-    def hasBookingLimitDatetimesPassed(cls) -> Exists:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasBookingLimitDatetimesPassed(cls) -> Exists:
         aliased_collective_stock = sa.orm.aliased(CollectiveStock)
         return (
             sa.exists()
@@ -485,7 +490,8 @@ class CollectiveOffer(
         return self.collectiveStock.hasBeginningDatetimePassed
 
     @hasBeginningDatetimePassed.expression  # type: ignore[no-redef]
-    def hasBeginningDatetimePassed(cls) -> Exists:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasBeginningDatetimePassed(cls) -> Exists:
         aliased_collective_stock = sa.orm.aliased(CollectiveStock)
         return (
             sa.exists()
@@ -530,7 +536,8 @@ class CollectiveOffer(
         return self.subcategory.is_event
 
     @isEvent.expression  # type: ignore [no-redef]
-    def isEvent(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def isEvent(cls) -> bool:
         return cls.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES)
 
     @property
@@ -715,7 +722,8 @@ class CollectiveOfferTemplate(
         return self.end <= datetime.combine(datetime.utcnow(), time.max)
 
     @hasEndDatePassed.expression  # type: ignore[no-redef]
-    def hasEndDatePassed(cls) -> Exists:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasEndDatePassed(cls) -> Exists:
         today = datetime.combine(datetime.utcnow(), time.max)
         return cls.dateRange.contained_by(psycopg2.extras.DateTimeRange(upper=today))
 
@@ -725,7 +733,8 @@ class CollectiveOfferTemplate(
         return False
 
     @hasBookingLimitDatetimesPassed.expression  # type: ignore[no-redef]
-    def hasBookingLimitDatetimesPassed(cls) -> False_:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasBookingLimitDatetimesPassed(cls) -> False_:
         # this property is here for compatibility reasons
         return sa.sql.expression.false()
 
@@ -735,7 +744,8 @@ class CollectiveOfferTemplate(
         return False
 
     @hasBeginningDatetimePassed.expression  # type: ignore[no-redef]
-    def hasBeginningDatetimePassed(cls) -> False_:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasBeginningDatetimePassed(cls) -> False_:
         # this property is here for compatibility reasons
         return sa.sql.expression.false()
 
@@ -745,7 +755,8 @@ class CollectiveOfferTemplate(
         return False
 
     @isSoldOut.expression  # type: ignore[no-redef]
-    def isSoldOut(cls) -> False_:  # pylint: disable=no-self-argument
+    @classmethod
+    def isSoldOut(cls) -> False_:
         # this property is here for compatibility reasons
         return sa.sql.expression.false()
 
@@ -788,7 +799,8 @@ class CollectiveOfferTemplate(
         return self.subcategory.is_event
 
     @isEvent.expression  # type: ignore [no-redef]
-    def isEvent(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def isEvent(cls) -> bool:
         return cls.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES)
 
     @property
@@ -886,7 +898,8 @@ class CollectiveStock(PcObject, Base, Model):
         return self.bookingLimitDatetime <= datetime.utcnow()
 
     @hasBookingLimitDatetimePassed.expression  # type: ignore[no-redef]
-    def hasBookingLimitDatetimePassed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasBookingLimitDatetimePassed(cls) -> BinaryExpression:
         return cls.bookingLimitDatetime <= sa.func.now()
 
     @hybrid_property
@@ -894,7 +907,8 @@ class CollectiveStock(PcObject, Base, Model):
         return self.beginningDatetime <= datetime.utcnow()
 
     @hasBeginningDatetimePassed.expression  # type: ignore[no-redef]
-    def hasBeginningDatetimePassed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def hasBeginningDatetimePassed(cls) -> BinaryExpression:
         return cls.beginningDatetime <= sa.func.now()
 
     @hybrid_property
@@ -902,7 +916,8 @@ class CollectiveStock(PcObject, Base, Model):
         return self.beginningDatetime <= datetime.utcnow()
 
     @isEventExpired.expression  # type: ignore[no-redef]
-    def isEventExpired(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def isEventExpired(cls):
         return cls.beginningDatetime <= sa.func.now()
 
     @property
@@ -1170,7 +1185,8 @@ class CollectiveBooking(PcObject, Base, Model):
         return self.cancellationLimitDate <= datetime.utcnow()
 
     @isConfirmed.expression  # type: ignore[no-redef]
-    def isConfirmed(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def isConfirmed(cls) -> bool:
         return cls.cancellationLimitDate <= datetime.utcnow()
 
     @hybrid_property
@@ -1178,7 +1194,8 @@ class CollectiveBooking(PcObject, Base, Model):
         return self.status in [CollectiveBookingStatus.USED, CollectiveBookingStatus.REIMBURSED]
 
     @is_used_or_reimbursed.expression  # type: ignore[no-redef]
-    def is_used_or_reimbursed(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def is_used_or_reimbursed(cls) -> bool:
         return cls.status.in_([CollectiveBookingStatus.USED, CollectiveBookingStatus.REIMBURSED])
 
     @hybrid_property
@@ -1186,7 +1203,8 @@ class CollectiveBooking(PcObject, Base, Model):
         return self.status == CollectiveBookingStatus.REIMBURSED
 
     @isReimbursed.expression  # type: ignore [no-redef]
-    def isReimbursed(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def isReimbursed(cls) -> bool:
         return cls.status == CollectiveBookingStatus.REIMBURSED
 
     @hybrid_property
@@ -1194,7 +1212,8 @@ class CollectiveBooking(PcObject, Base, Model):
         return self.status == CollectiveBookingStatus.CANCELLED
 
     @isCancelled.expression  # type: ignore [no-redef]
-    def isCancelled(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def isCancelled(cls) -> bool:
         return cls.status == CollectiveBookingStatus.CANCELLED
 
     @property
@@ -1423,7 +1442,8 @@ class CollectiveOfferRequest(PcObject, Base, Model):
             self._phoneNumber = ParsedPhoneNumber(value).phone_number
 
     @phoneNumber.expression  # type: ignore [no-redef]
-    def phoneNumber(cls) -> str | None:  # pylint: disable=no-self-argument
+    @classmethod
+    def phoneNumber(cls) -> str | None:
         return cls._phoneNumber
 
 

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -425,7 +425,8 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, Accessibility
         self._bannerUrl = value
 
     @bannerUrl.expression  # type: ignore [no-redef]
-    def bannerUrl(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def bannerUrl(cls):
         return cls._bannerUrl
 
     @property
@@ -479,7 +480,8 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, Accessibility
         return self.last_collective_dms_application.state if self.last_collective_dms_application else None
 
     @dms_adage_status.expression  # type: ignore [no-redef]
-    def dms_adage_status(cls) -> str | None:  # pylint: disable=no-self-argument
+    @classmethod
+    def dms_adage_status(cls) -> str | None:
         return (
             db.session.query(educational_models.CollectiveDmsApplication.state)
             .select_from(educational_models.CollectiveDmsApplication)
@@ -593,7 +595,8 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, Accessibility
         )
 
     @current_reimbursement_point_id.expression  # type: ignore [no-redef]
-    def current_reimbursement_point_id(cls) -> int | None:  # pylint: disable=no-self-argument # type: ignore[no-redef]
+    @classmethod
+    def current_reimbursement_point_id(cls) -> int | None:
         now = datetime.utcnow()
 
         return (
@@ -667,7 +670,8 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, Accessibility
         return self.publicName or self.name
 
     @common_name.expression  # type: ignore [no-redef]
-    def common_name(cls) -> str:  # pylint: disable=no-self-argument
+    @classmethod
+    def common_name(cls) -> str:
         return sqla_func.coalesce(func.nullif(cls.publicName, ""), cls.name)
 
     @property
@@ -914,7 +918,8 @@ class Offerer(
         return postal_code_utils.PostalCode(self.postalCode).get_departement_code()
 
     @departementCode.expression  # type: ignore [no-redef]
-    def departementCode(cls) -> Case:  # pylint: disable=no-self-argument
+    @classmethod
+    def departementCode(cls) -> Case:
         return case(
             [
                 (

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -376,7 +376,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return None
 
     @birth_date.expression  # type: ignore [no-redef]
-    def birth_date(cls) -> date | None:  # pylint: disable=no-self-argument
+    @classmethod
+    def birth_date(cls) -> date | None:
         return sa.case(
             [
                 (cls.validatedBirthDate.is_not(None), cls.validatedBirthDate),
@@ -428,7 +429,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return (f"{self.firstName or ''} {self.lastName or ''}".strip()) or self.email
 
     @full_name.expression  # type: ignore [no-redef]
-    def full_name(cls) -> str:  # pylint: disable=no-self-argument
+    @classmethod
+    def full_name(cls) -> str:
         return sa.func.coalesce(
             sa.func.nullif(
                 sa.func.trim(
@@ -564,7 +566,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return self.has_beneficiary_role or self.has_underage_beneficiary_role
 
     @is_beneficiary.expression  # type: ignore [no-redef]
-    def is_beneficiary(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
+    @classmethod
+    def is_beneficiary(cls) -> BooleanClauseList:
         return expression.or_(
             cls.roles.contains([UserRole.BENEFICIARY]), cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
         )
@@ -590,7 +593,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
             self._phoneNumber = ParsedPhoneNumber(value).phone_number
 
     @phoneNumber.expression  # type: ignore [no-redef]
-    def phoneNumber(cls) -> str | None:  # pylint: disable=no-self-argument
+    @classmethod
+    def phoneNumber(cls) -> str | None:
         return cls._phoneNumber
 
     @hybrid_property
@@ -598,7 +602,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return self.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
 
     @is_phone_validated.expression  # type: ignore [no-redef]
-    def is_phone_validated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def is_phone_validated(cls) -> BinaryExpression:
         return cls.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
 
     @hybrid_property
@@ -606,7 +611,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return self.phoneValidationStatus == PhoneValidationStatusType.SKIPPED_BY_SUPPORT
 
     @is_phone_validation_skipped.expression  # type: ignore [no-redef]
-    def is_phone_validation_skipped(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def is_phone_validation_skipped(cls):
         return cls.phoneValidationStatus == PhoneValidationStatusType.SKIPPED_BY_SUPPORT
 
     @hybrid_property
@@ -614,7 +620,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.ADMIN in self.roles
 
     @has_admin_role.expression  # type: ignore [no-redef]
-    def has_admin_role(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def has_admin_role(cls) -> bool:
         return cls.roles.contains([UserRole.ADMIN])
 
     @hybrid_property
@@ -622,7 +629,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.BENEFICIARY in self.roles
 
     @has_beneficiary_role.expression  # type: ignore [no-redef]
-    def has_beneficiary_role(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def has_beneficiary_role(cls) -> bool:
         return cls.roles.contains([UserRole.BENEFICIARY])
 
     @hybrid_property
@@ -630,7 +638,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.PRO in self.roles
 
     @has_pro_role.expression  # type: ignore [no-redef]
-    def has_pro_role(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def has_pro_role(cls) -> bool:
         return cls.roles.contains([UserRole.PRO])
 
     @hybrid_property
@@ -638,7 +647,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.NON_ATTACHED_PRO in self.roles
 
     @has_non_attached_pro_role.expression  # type: ignore [no-redef]
-    def has_non_attached_pro_role(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def has_non_attached_pro_role(cls) -> bool:
         return cls.roles.contains([UserRole.NON_ATTACHED_PRO])
 
     @hybrid_property
@@ -646,7 +656,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.UNDERAGE_BENEFICIARY in self.roles
 
     @has_underage_beneficiary_role.expression  # type: ignore [no-redef]
-    def has_underage_beneficiary_role(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def has_underage_beneficiary_role(cls) -> bool:
         return cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
 
     @hybrid_property
@@ -654,7 +665,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.TEST in self.roles
 
     @has_test_role.expression  # type: ignore [no-redef]
-    def has_test_role(cls) -> bool:  # pylint: disable=no-self-argument
+    @classmethod
+    def has_test_role(cls) -> bool:
         return cls.roles.contains([UserRole.TEST])
 
 
@@ -813,7 +825,8 @@ class UserEmailHistory(PcObject, Base, Model):
         return f"{self.oldUserEmail}@{self.oldDomainEmail}"
 
     @oldEmail.expression  # type: ignore [no-redef]
-    def oldEmail(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def oldEmail(cls):
         return func.concat(cls.oldUserEmail, "@", cls.oldDomainEmail)
 
     @hybrid_property
@@ -821,7 +834,8 @@ class UserEmailHistory(PcObject, Base, Model):
         return f"{self.newUserEmail}@{self.newDomainEmail}"
 
     @newEmail.expression  # type: ignore [no-redef]
-    def newEmail(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def newEmail(cls):
         return func.concat(cls.newUserEmail, "@", cls.newDomainEmail)
 
 

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -58,7 +58,8 @@ class BeneficiaryImport(PcObject, Base, Model):
         return self._last_status().status
 
     @currentStatus.expression  # type: ignore [no-redef]
-    def currentStatus(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def currentStatus(cls):
         return cls._query_last_status(BeneficiaryImportStatus.status)
 
     @hybrid_property
@@ -66,7 +67,8 @@ class BeneficiaryImport(PcObject, Base, Model):
         return self._last_status().date
 
     @updatedAt.expression  # type: ignore [no-redef]
-    def updatedAt(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def updatedAt(cls):
         return cls._query_last_status(BeneficiaryImportStatus.date)
 
     @hybrid_property
@@ -74,7 +76,8 @@ class BeneficiaryImport(PcObject, Base, Model):
         return self._last_status().detail
 
     @detail.expression  # type: ignore [no-redef]
-    def detail(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def detail(cls):
         return cls._query_last_status(BeneficiaryImportStatus.detail)
 
     @hybrid_property
@@ -83,7 +86,8 @@ class BeneficiaryImport(PcObject, Base, Model):
         return author.email or None
 
     @authorEmail.expression  # type: ignore [no-redef]
-    def authorEmail(cls):  # pylint: disable=no-self-argument
+    @classmethod
+    def authorEmail(cls):
         return cls._query_last_status(BeneficiaryImportStatus.author)
 
     @property

--- a/api/src/pcapi/models/needs_validation_mixin.py
+++ b/api/src/pcapi/models/needs_validation_mixin.py
@@ -18,5 +18,6 @@ class NeedsValidationMixin:
         return self.validationToken is None
 
     @isValidated.expression  # type: ignore [no-redef]
-    def isValidated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def isValidated(cls) -> BinaryExpression:
         return cls.validationToken.is_(None)

--- a/api/src/pcapi/models/validation_status_mixin.py
+++ b/api/src/pcapi/models/validation_status_mixin.py
@@ -25,7 +25,8 @@ class ValidationStatusMixin:
         return self.validationStatus == ValidationStatus.NEW
 
     @isNew.expression  # type: ignore [no-redef]
-    def isNew(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def isNew(cls) -> BinaryExpression:
         return cls.validationStatus == ValidationStatus.NEW
 
     @sqla_hybrid.hybrid_property
@@ -33,7 +34,8 @@ class ValidationStatusMixin:
         return self.validationStatus == ValidationStatus.PENDING
 
     @isPending.expression  # type: ignore [no-redef]
-    def isPending(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def isPending(cls) -> BinaryExpression:
         return cls.validationStatus == ValidationStatus.PENDING
 
     @sqla_hybrid.hybrid_property
@@ -41,7 +43,8 @@ class ValidationStatusMixin:
         return self.validationStatus in (ValidationStatus.NEW, ValidationStatus.PENDING)
 
     @isWaitingForValidation.expression  # type: ignore [no-redef]
-    def isWaitingForValidation(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def isWaitingForValidation(cls) -> BinaryExpression:
         return cls.validationStatus.in_([ValidationStatus.NEW, ValidationStatus.PENDING])
 
     @sqla_hybrid.hybrid_property
@@ -49,7 +52,8 @@ class ValidationStatusMixin:
         return self.validationStatus == ValidationStatus.VALIDATED
 
     @isValidated.expression  # type: ignore [no-redef]
-    def isValidated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def isValidated(cls) -> BinaryExpression:
         return cls.validationStatus == ValidationStatus.VALIDATED
 
     @sqla_hybrid.hybrid_property
@@ -57,7 +61,8 @@ class ValidationStatusMixin:
         return self.validationStatus == ValidationStatus.REJECTED
 
     @isRejected.expression  # type: ignore [no-redef]
-    def isRejected(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def isRejected(cls) -> BinaryExpression:
         # sqla.not_(isRejected) works only if we check None separately.
         return cls.validationStatus == ValidationStatus.REJECTED
 
@@ -66,6 +71,7 @@ class ValidationStatusMixin:
         return self.validationStatus == ValidationStatus.DELETED
 
     @isDeleted.expression  # type: ignore [no-redef]
-    def isDeleted(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+    @classmethod
+    def isDeleted(cls) -> BinaryExpression:
         # sqla.not_(isDeleted) works only if we check None separately.
         return cls.validationStatus == ValidationStatus.DELETED


### PR DESCRIPTION
https://docs.sqlalchemy.org/en/20/orm/extensions/hybrid.html#defining-expression-behavior-distinct-from-attribute-behavior mentions that the use of

> The use of @classmethod is optional, and is strictly to give typing tools a hint
> that cls in this case is expected to be the Interval class, and not an instance of Interval.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques