### PR TITLE
(BSR)[ADAGE] fix: use camel case in adage playlist

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/serialization/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/playlists.py
@@ -1,6 +1,7 @@
 import typing
 
 from pcapi.routes.serialization import BaseModel
+from pcapi.serialization.utils import to_camel
 
 
 class LocalOfferersPlaylistOffer(BaseModel):
@@ -10,6 +11,9 @@ class LocalOfferersPlaylistOffer(BaseModel):
     img_url: str | None
     public_name: str | None
     city: str | None
+
+    class Config:
+        alias_generator = to_camel
 
 
 class LocalOfferersPlaylist(BaseModel):

--- a/pro/src/apiClient/adage/models/LocalOfferersPlaylistOffer.ts
+++ b/pro/src/apiClient/adage/models/LocalOfferersPlaylistOffer.ts
@@ -7,8 +7,8 @@ export type LocalOfferersPlaylistOffer = {
   city?: string | null;
   distance: number;
   id: number;
-  img_url?: string | null;
+  imgUrl?: string | null;
   name: string;
-  public_name?: string | null;
+  publicName?: string | null;
 };
 


### PR DESCRIPTION
## But de la pull request

passer la serialization en camel case pour la dernière route de playlist pour la page découverte d'Adage.
