### PR TITLE
(PC-26300)[API] fix: Recredit user registered at 14 and credited at 15

### DIFF
--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -2531,7 +2531,9 @@ class UserRecreditTest:
             ("2005-07-01", datetime.datetime(2021, 5, 1), True),
         ],
     )
-    def test_has_celebrated_birthday_since_registration(self, birth_date, registration_datetime, expected_result):
+    def test_has_celebrated_birthday_since_credit_or_registration(
+        self, birth_date, registration_datetime, expected_result
+    ):
         user = users_factories.BeneficiaryGrant18Factory(
             dateOfBirth=birth_date,
         )
@@ -2543,7 +2545,7 @@ class UserRecreditTest:
             dateCreated=registration_datetime,
             eligibilityType=users_models.EligibilityType.UNDERAGE,
         )
-        assert api._has_celebrated_birthday_since_registration(user) == expected_result
+        assert api._has_celebrated_birthday_since_credit_or_registration(user) == expected_result
 
     def test_can_be_recredited(self):
         with freezegun.freeze_time("2020-05-02"):


### PR DESCRIPTION
## But de la pull request
Ticket Jira : https://passculture.atlassian.net/browse/PC-26300
Permettra peut-être de corriger à [cette erreur Sentry](https://sentry.passculture.team/organizations/sentry/issues/377455/?project=5&query=is%3Aunresolved+no+registration+date&statsPeriod=14d)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques