### PR TITLE
(PC-26326) count published and pending collective offers

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -433,11 +433,13 @@ class CollectiveOffer(
 
     @isSoldOut.expression  # type: ignore[no-redef]
     def isSoldOut(cls) -> Exists:  # pylint: disable=no-self-argument
+        aliased_collective_stock = sa.orm.aliased(CollectiveStock)
+        aliased_collective_booking = sa.orm.aliased(CollectiveBooking)
         return (
             sa.exists()
-            .where(CollectiveStock.collectiveOfferId == cls.id)
-            .where(CollectiveBooking.collectiveStockId == CollectiveStock.id)
-            .where(CollectiveBooking.status != CollectiveBookingStatus.CANCELLED)
+            .where(aliased_collective_stock.collectiveOfferId == cls.id)
+            .where(aliased_collective_booking.collectiveStockId == aliased_collective_stock.id)
+            .where(aliased_collective_booking.status != CollectiveBookingStatus.CANCELLED)
         )
 
     @property

--- a/api/tests/routes/pro/get_offerer_stats_v2_test.py
+++ b/api/tests/routes/pro/get_offerer_stats_v2_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 import pcapi.core.educational.factories as educational_factories
+from pcapi.core.educational.models import CollectiveBookingStatus
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
@@ -22,15 +23,36 @@ def test_get_offerer_stats(client):
     for _ in range(3):
         offers_factories.StockFactory(offer=offer)
 
-    for _ in range(2):
-        educational_factories.CollectiveOfferFactory(
-            venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.APPROVED
-        )
+    collective_offer = educational_factories.CollectiveOfferFactory(
+        venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.APPROVED
+    )
+    collective_stock = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+    educational_factories.CollectiveBookingFactory(
+        collectiveStock=collective_stock, status=CollectiveBookingStatus.PENDING
+    )
+
+    collective_offer2 = educational_factories.CollectiveOfferFactory(
+        venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.APPROVED
+    )
+    collective_stock2 = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer2)
+
+    educational_factories.CollectiveBookingFactory(
+        collectiveStock=collective_stock2, status=CollectiveBookingStatus.CONFIRMED
+    )
+
+    collective_offer3 = educational_factories.CollectiveOfferFactory(
+        venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.APPROVED
+    )
+    collective_stock3 = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer3)
+    educational_factories.CollectiveBookingFactory(
+        collectiveStock=collective_stock3, status=CollectiveBookingStatus.REIMBURSED
+    )
+
     for _ in range(3):
         offers_factories.OfferFactory(
             venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.PENDING
         )
-    for _ in range(4):
+    for _ in range(2):
         educational_factories.CollectiveOfferFactory(
             venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.PENDING
         )
@@ -51,15 +73,19 @@ def test_get_offerer_stats(client):
         "publishedPublicOffers": 1,
         "publishedEducationalOffers": 3,
         "pendingPublicOffers": 3,
-        "pendingEducationalOffers": 5,
+        "pendingEducationalOffers": 3,
     }
 
 
 def test_get_offerer_stats_with_no_public_offers(client):
     user_offerer = offerers_factories.UserOffererFactory()
     for _ in range(2):
-        educational_factories.CollectiveOfferFactory(
+        collective_offer = educational_factories.CollectiveOfferFactory(
             venue__managingOfferer=user_offerer.offerer, validation=OfferValidationStatus.APPROVED
+        )
+        collective_stock = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        educational_factories.CollectiveBookingFactory(
+            collectiveStock=collective_stock, status=CollectiveBookingStatus.PENDING
         )
     for _ in range(2):
         educational_factories.CollectiveOfferFactory(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26326

On veut compter comme offre publié les offres: Publiés, pré-réservées et réservées, pour les offres en attentes, on comptes les offres en statut en attente
![image](https://github.com/pass-culture/pass-culture-main/assets/56326095/7fce41be-91b4-4d7b-9cef-b4036df6415e)

Le OfferStatus dans le flux est calculé avec une hybrid property dans la table CollectiveOffer