### PR TITLE
(PC-26070)[API] feat: add csrf attack prevention for google sso

### DIFF
--- a/api/src/pcapi/core/token/__init__.py
+++ b/api/src/pcapi/core/token/__init__.py
@@ -27,6 +27,7 @@ class TokenType(enum.Enum):
     SUSPENSION_SUSPICIOUS_LOGIN = "suspension_suspicious_login"
     RESET_PASSWORD = "reset_password"
     ACCOUNT_CREATION = "account_creation"
+    OAUTH_STATE = "oauth_state"
 
 
 T = typing.TypeVar("T", bound="AbstractToken")
@@ -239,7 +240,7 @@ class UUIDToken(AbstractToken):
         payload: dict[str, typing.Any] = {
             "token_type": type_.value,
             "uuid": random_uuid,
-            "data": data,
+            "data": data or {},
         }
         if ttl:
             payload["exp"] = (datetime.utcnow() + ttl).timestamp()

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -911,6 +911,14 @@ def create_user_refresh_token(user: models.User, device_info: "account_serializa
     return create_refresh_token(identity=user.email, expires_delta=duration)
 
 
+def create_oauth_state_token() -> str:
+    token = token_utils.UUIDToken.create(
+        token_utils.TokenType.OAUTH_STATE,
+        users_constants.OAUTH_STATE_TOKEN_LIFE_TIME,
+    )
+    return token.encoded_token
+
+
 def create_account_creation_token(google_user: "google_oauth.GoogleUser") -> str:
     token = token_utils.UUIDToken.create(
         token_utils.TokenType.ACCOUNT_CREATION,

--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -5,6 +5,7 @@ from pcapi import settings
 
 
 ACCOUNT_CREATION_TOKEN_LIFE_TIME = datetime.timedelta(hours=1)
+OAUTH_STATE_TOKEN_LIFE_TIME = datetime.timedelta(hours=1)
 RESET_PASSWORD_TOKEN_LIFE_TIME = datetime.timedelta(hours=24)
 EMAIL_VALIDATION_TOKEN_LIFE_TIME = datetime.timedelta(minutes=30)
 EMAIL_CHANGE_TOKEN_LIFE_TIME = datetime.timedelta(seconds=settings.EMAIL_CHANGE_TOKEN_LIFE_TIME)

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -190,6 +190,15 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
     return response
 
 
+@blueprint.native_v1.route("/oauth/state", methods=["GET"])
+@spectree_serialize(response_model=authentication.OauthStateResponse, on_success_status=200, api=blueprint.api)
+@ip_rate_limiter()
+@feature_required(FeatureToggle.WIP_ENABLE_GOOGLE_SSO)
+def google_oauth_state() -> authentication.OauthStateResponse:
+    encoded_oauth_state_token = users_api.create_oauth_state_token()
+    return authentication.OauthStateResponse(oauth_state_token=encoded_oauth_state_token)
+
+
 @blueprint.native_v1.route("/oauth/google/authorize", methods=["POST"])
 @spectree_serialize(
     response_model=authentication.SigninResponse,
@@ -200,6 +209,20 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
 @ip_rate_limiter()
 @feature_required(FeatureToggle.WIP_ENABLE_GOOGLE_SSO)
 def google_auth(body: authentication.GoogleSigninRequest) -> authentication.SigninResponse:
+    try:
+        oauth_state_token = token_utils.UUIDToken.load_and_check(
+            body.oauth_state_token, token_utils.TokenType.OAUTH_STATE
+        )
+    except (users_exceptions.ExpiredToken, users_exceptions.InvalidToken) as e:
+        raise ApiErrors(
+            {
+                "code": "SSO_LOGIN_TIMEOUT",
+                "general": ["La demande de connexion a mis trop de temps."],
+            },
+            status_code=400,
+        ) from e
+    oauth_state_token.expire()
+
     google_user = google_oauth.get_google_user(body.authorization_code)
     email = google_user.email
     sso_user_id = google_user.sub

--- a/api/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/api/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -51,6 +51,11 @@ class ValidateEmailResponse(ConfiguredBaseModel):
     refresh_token: str
 
 
+class OauthStateResponse(ConfiguredBaseModel):
+    oauth_state_token: str
+
+
 class GoogleSigninRequest(ConfiguredBaseModel):
     authorization_code: str
+    oauth_state_token: str
     device_info: TrustedDevice | None = None

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -249,10 +249,16 @@ class SSOSigninTest:
         users_factories.SingleSignOnFactory(
             ssoUserId=self.valid_google_user.sub, user__email=self.valid_google_user.email, user__isActive=True
         )
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
         mocked_google_oauth.return_value = self.valid_google_user
 
         with caplog.at_level(logging.INFO):
-            response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
+            response = client.post(
+                "/native/v1/oauth/google/authorize",
+                json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+            )
 
         assert response.status_code == 200
         assert response.json["accountState"] == AccountState.ACTIVE.value
@@ -264,9 +270,15 @@ class SSOSigninTest:
         user = users_factories.UserFactory(email=self.valid_google_user.email, isActive=False)
         users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_google_user.sub)
         history_factories.SuspendedUserActionHistoryFactory(user=user, reason=users_constants.SuspensionReason.DELETED)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
         mocked_google_oauth.return_value = self.valid_google_user
 
-        response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
 
         assert response.status_code == 400
         assert response.json["code"] == "ACCOUNT_DELETED"
@@ -274,10 +286,16 @@ class SSOSigninTest:
     @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_account_creation_token_if_account_does_not_exist(self, mocked_google_oauth, client, caplog):
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
         mocked_google_oauth.return_value = self.valid_google_user
 
         with caplog.at_level(logging.INFO):
-            response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
+            response = client.post(
+                "/native/v1/oauth/google/authorize",
+                json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+            )
 
         assert response.status_code == 401
         assert set(["code", "accountCreationToken", "general"]) == response.json.keys()
@@ -297,9 +315,15 @@ class SSOSigninTest:
     def test_single_sign_on_ignores_email_if_found(self, mocked_google_oauth, client):
         user = users_factories.UserFactory(email="another@email.com", isActive=True)
         users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_google_user.sub)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
         mocked_google_oauth.return_value = self.valid_google_user
 
-        response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
 
         assert response.status_code == 200
 
@@ -307,9 +331,15 @@ class SSOSigninTest:
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_inserts_sso_method_if_email_found(self, mocked_google_oauth, client):
         user = users_factories.UserFactory(email=self.valid_google_user.email, isActive=True)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
         mocked_google_oauth.return_value = self.valid_google_user
 
-        response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
 
         assert response.status_code == 200
 
@@ -320,11 +350,17 @@ class SSOSigninTest:
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_raises_if_email_not_validated(self, mocked_google_oauth, client):
         users_factories.UserFactory(email=self.valid_google_user.email, isActive=True)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
         unvalidated_email_google_user = copy.deepcopy(self.valid_google_user)
         unvalidated_email_google_user.email_verified = False
         mocked_google_oauth.return_value = unvalidated_email_google_user
 
-        response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
 
         assert response.status_code == 400
 
@@ -332,9 +368,15 @@ class SSOSigninTest:
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_does_not_duplicate_ssos(self, mocked_google_oauth, client):
         single_sign_on = users_factories.SingleSignOnFactory(ssoUserId=self.valid_google_user.sub)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
         mocked_google_oauth.return_value = self.valid_google_user
 
-        response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
 
         assert response.status_code == 200
         assert SingleSignOn.query.filter(SingleSignOn.user == single_sign_on.user).count() == 1
@@ -342,13 +384,97 @@ class SSOSigninTest:
     @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
     def test_single_sign_on_raises_if_another_sso_is_already_configured(self, mocked_google_oauth, client):
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
         users_factories.SingleSignOnFactory(user__email=self.valid_google_user.email)
         mocked_google_oauth.return_value = self.valid_google_user
 
-        response = client.post("/native/v1/oauth/google/authorize", json={"authorizationCode": "4/google_code"})
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
 
         assert response.status_code == 400
         assert SingleSignOn.query.filter(SingleSignOn.ssoUserId == self.valid_google_user.sub).count() == 0
+
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
+    def test_oauth_state_token_past_expiration_date(self, client):
+        with freeze_time("2022-01-01"):
+            oauth_state_token = token_utils.UUIDToken.create(
+                token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+            )
+
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
+
+        assert response.status_code == 400, response.json
+        assert response.json["code"] == "SSO_LOGIN_TIMEOUT"
+
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
+    def test_oauth_state_token_expired(self, client):
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        oauth_state_token.expire()
+
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
+
+        assert response.status_code == 400, response.json
+        assert response.json["code"] == "SSO_LOGIN_TIMEOUT"
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
+    def test_authorization_expires_oauth_state_token(self, mocked_google_oauth, client):
+        users_factories.SingleSignOnFactory(
+            ssoUserId=self.valid_google_user.sub, user__email=self.valid_google_user.email, user__isActive=True
+        )
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_google_user
+
+        response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
+
+        assert response.status_code == 200, response.json
+        assert not token_utils.UUIDToken.token_exists(token_utils.TokenType.OAUTH_STATE, oauth_state_token.key_suffix)
+
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
+    def test_oauth_state_token_creation(self, client):
+        response = client.get("/native/v1/oauth/state")
+
+        assert response.status_code == 200, response.json
+
+        oauth_state_token = token_utils.UUIDToken.load_without_checking(response.json["oauthStateToken"])
+        assert uuid.UUID(oauth_state_token.key_suffix)
+        assert not oauth_state_token.check(token_utils.TokenType.OAUTH_STATE, oauth_state_token.key_suffix)
+
+    @override_features(WIP_ENABLE_GOOGLE_SSO=True)
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_oauth_state_token_roundtrip(self, mocked_google_oauth, client):
+        users_factories.SingleSignOnFactory(
+            ssoUserId=self.valid_google_user.sub, user__email=self.valid_google_user.email, user__isActive=True
+        )
+        mocked_google_oauth.return_value = self.valid_google_user
+
+        oauth_state_token_response = client.get("/native/v1/oauth/state")
+        authorization_response = client.post(
+            "/native/v1/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token_response.json["oauthStateToken"],
+            },
+        )
+
+        assert authorization_response.status_code == 200, authorization_response.json
 
     def test_sso_is_feature_flagged(self, client):
         response = client.post("/native/v1/oauth/google/authorize", json={"code": "4/google_code"})
@@ -376,6 +502,7 @@ class TrustedDeviceFeatureTest:
                 "oauth/google/authorize",
                 {
                     "authorizationCode": "4/google_code",
+                    "oauth_state_token": "eyJhbG.real.jwt.token",
                     "deviceInfo": {
                         "deviceId": "2E429592-2446-425F-9A62-D6983F375B3B",
                         "source": "iPhone 13",
@@ -395,15 +522,24 @@ class TrustedDeviceFeatureTest:
             email_verified=True,
         )
 
+        def setup_method(self):
+            self.valid_oauth_state_token = token_utils.UUIDToken.create(token_utils.TokenType.OAUTH_STATE, ttl=None)
+
+        def teardown_method(self):
+            self.valid_oauth_state_token.expire()
+
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(WIP_ENABLE_GOOGLE_SSO=True, WIP_ENABLE_TRUSTED_DEVICE=True)
         def test_save_login_device_history_on_signin(
             self,
             mocked_google_oauth,
+            mocked_load_and_check_oauth_token,
             client,
             signin_route,
             data,
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True)
 
@@ -416,11 +552,13 @@ class TrustedDeviceFeatureTest:
             assert login_device.os == "iOS"
             assert login_device.location == "Paris, France"
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(WIP_ENABLE_GOOGLE_SSO=True, WIP_ENABLE_TRUSTED_DEVICE=True)
         def should_not_save_login_device_history_on_signin_when_no_device_info(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True)
 
@@ -428,11 +566,13 @@ class TrustedDeviceFeatureTest:
 
             assert LoginDeviceHistory.query.count() == 0
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(WIP_ENABLE_GOOGLE_SSO=True, WIP_ENABLE_TRUSTED_DEVICE=False)
         def should_not_save_login_device_history_when_feature_flag_is_disabled(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True)
 
@@ -440,11 +580,13 @@ class TrustedDeviceFeatureTest:
 
             assert LoginDeviceHistory.query.count() == 0
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(WIP_ENABLE_GOOGLE_SSO=True, WIP_ENABLE_TRUSTED_DEVICE=True)
         def test_save_login_device_as_trusted_device_on_second_signin_with_same_device(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             user = users_factories.UserFactory(
                 email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True
@@ -456,11 +598,13 @@ class TrustedDeviceFeatureTest:
             trusted_device = TrustedDevice.query.filter(TrustedDevice.deviceId == data["deviceInfo"]["deviceId"]).one()
             assert user.trusted_devices == [trusted_device]
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(WIP_ENABLE_GOOGLE_SSO=True, WIP_ENABLE_TRUSTED_DEVICE=False)
         def should_not_save_login_device_as_trusted_device_on_second_signin_when_feature_flag_is_inactive(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             user = users_factories.UserFactory(
                 email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True
@@ -472,11 +616,13 @@ class TrustedDeviceFeatureTest:
             assert TrustedDevice.query.count() == 0
             assert user.trusted_devices == []
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(WIP_ENABLE_GOOGLE_SSO=True, WIP_ENABLE_TRUSTED_DEVICE=True)
         def should_not_save_login_device_as_trusted_device_on_second_signin_when_using_different_devices(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             first_device = {
                 "deviceId": "2E429592-2446-425F-9A62-D6983F375B3B",
@@ -498,13 +644,17 @@ class TrustedDeviceFeatureTest:
             assert TrustedDevice.query.count() == 0
             assert user.trusted_devices == []
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(
             WIP_ENABLE_GOOGLE_SSO=True,
             WIP_ENABLE_TRUSTED_DEVICE=True,
             WIP_ENABLE_SUSPICIOUS_EMAIL_SEND=True,
         )
-        def should_send_email_when_login_is_suspicious(self, mocked_google_oauth, client, signin_route, data):
+        def should_send_email_when_login_is_suspicious(
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
+        ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True)
 
@@ -519,6 +669,7 @@ class TrustedDeviceFeatureTest:
             assert mails_testing.outbox[0].sent_data["params"]["LOGIN_TIME"]
             assert mails_testing.outbox[0].sent_data["params"]["ACCOUNT_SECURING_LINK"]
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(
             WIP_ENABLE_GOOGLE_SSO=True,
@@ -526,7 +677,7 @@ class TrustedDeviceFeatureTest:
             WIP_ENABLE_SUSPICIOUS_EMAIL_SEND=True,
         )
         def should_send_limited_number_of_emails_when_login_is_suspicious(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
             mocked_google_oauth.return_value = self.valid_google_user
             users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True)
@@ -538,6 +689,7 @@ class TrustedDeviceFeatureTest:
 
             assert len(mails_testing.outbox) == users_constants.MAX_SUSPICIOUS_LOGIN_EMAILS
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(
             WIP_ENABLE_GOOGLE_SSO=True,
@@ -545,8 +697,9 @@ class TrustedDeviceFeatureTest:
             WIP_ENABLE_SUSPICIOUS_EMAIL_SEND=True,
         )
         def should_send_suspicious_login_email_to_user_suspended_upon_request(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             user = users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD)
             history_factories.SuspendedUserActionHistoryFactory(
@@ -558,6 +711,7 @@ class TrustedDeviceFeatureTest:
             assert len(mails_testing.outbox) == 1
             assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(
             WIP_ENABLE_GOOGLE_SSO=True,
@@ -574,8 +728,9 @@ class TrustedDeviceFeatureTest:
             ],
         )
         def should_not_send_suspicious_login_email_to_suspended_user(
-            self, mocked_google_oauth, client, signin_route, data, reason
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data, reason
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             user = users_factories.UserFactory(
                 email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=False
@@ -586,6 +741,7 @@ class TrustedDeviceFeatureTest:
 
             assert len(mails_testing.outbox) == 0
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(
             WIP_ENABLE_GOOGLE_SSO=True,
@@ -593,8 +749,9 @@ class TrustedDeviceFeatureTest:
             WIP_ENABLE_SUSPICIOUS_EMAIL_SEND=True,
         )
         def should_extend_refresh_token_lifetime_when_logging_in_with_a_trusted_device(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             user = users_factories.UserFactory(
                 email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True
@@ -610,6 +767,7 @@ class TrustedDeviceFeatureTest:
 
             assert refresh_token_lifetime == settings.JWT_REFRESH_TOKEN_EXTENDED_EXPIRES
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(
             WIP_ENABLE_GOOGLE_SSO=True,
@@ -617,8 +775,9 @@ class TrustedDeviceFeatureTest:
             WIP_ENABLE_SUSPICIOUS_EMAIL_SEND=True,
         )
         def should_not_extend_refresh_token_lifetime_when_logging_in_from_unknown_device(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True)
 
@@ -631,11 +790,13 @@ class TrustedDeviceFeatureTest:
 
             assert refresh_token_lifetime == settings.JWT_REFRESH_TOKEN_EXPIRES
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(WIP_ENABLE_GOOGLE_SSO=True, WIP_ENABLE_TRUSTED_DEVICE=True)
         def should_not_send_email_when_logging_in_from_a_trusted_device(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             user = users_factories.UserFactory(
                 email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True
@@ -646,9 +807,13 @@ class TrustedDeviceFeatureTest:
 
             assert len(mails_testing.outbox) == 0
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(WIP_ENABLE_GOOGLE_SSO=True, WIP_ENABLE_TRUSTED_DEVICE=False)
-        def should_not_send_email_when_feature_flag_is_inactive(self, mocked_google_oauth, client, signin_route, data):
+        def should_not_send_email_when_feature_flag_is_inactive(
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
+        ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True)
 
@@ -656,6 +821,7 @@ class TrustedDeviceFeatureTest:
 
             assert len(mails_testing.outbox) == 0
 
+        @patch("pcapi.core.token.UUIDToken.load_and_check")
         @patch("pcapi.connectors.google_oauth.get_google_user")
         @override_features(
             WIP_ENABLE_GOOGLE_SSO=True,
@@ -663,8 +829,9 @@ class TrustedDeviceFeatureTest:
             WIP_ENABLE_SUSPICIOUS_EMAIL_SEND=False,
         )
         def should_not_send_email_when_feature_flag_is_active_but_email_is_inactive(
-            self, mocked_google_oauth, client, signin_route, data
+            self, mocked_google_oauth, mocked_load_and_check_oauth_token, client, signin_route, data
         ):
+            mocked_load_and_check_oauth_token.return_value = self.valid_oauth_state_token
             mocked_google_oauth.return_value = self.valid_google_user
             users_factories.UserFactory(email="user@test.com", password=settings.TEST_DEFAULT_PASSWORD, isActive=True)
 

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -767,8 +767,9 @@ def test_public_api(client):
                             "nullable": True,
                             "title": "TrustedDevice",
                         },
+                        "oauthStateToken": {"title": "Oauthstatetoken", "type": "string"},
                     },
-                    "required": ["authorizationCode"],
+                    "required": ["authorizationCode", "oauthStateToken"],
                     "title": "GoogleSigninRequest",
                     "type": "object",
                 },
@@ -899,6 +900,12 @@ def test_public_api(client):
                     },
                     "required": ["marketingEmail", "marketingPush"],
                     "title": "NotificationSubscriptions",
+                    "type": "object",
+                },
+                "OauthStateResponse": {
+                    "properties": {"oauthStateToken": {"title": "Oauthstatetoken", "type": "string"}},
+                    "required": ["oauthStateToken"],
+                    "title": "OauthStateResponse",
                     "type": "object",
                 },
                 "OfferAccessibilityResponse": {
@@ -2631,6 +2638,30 @@ def test_public_api(client):
                         },
                     },
                     "summary": "google_auth <POST>",
+                    "tags": [],
+                }
+            },
+            "/native/v1/oauth/state": {
+                "get": {
+                    "description": "",
+                    "operationId": "get__native_v1_oauth_state",
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/OauthStateResponse"}}
+                            },
+                            "description": "OK",
+                        },
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable " "Entity",
+                        },
+                    },
+                    "summary": "google_oauth_state " "<GET>",
                     "tags": [],
                 }
             },


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26070

## Comportement voulu
![image](https://github.com/pass-culture/pass-culture-main/assets/26348504/be1ee1ea-6ab8-4c41-ae23-191ae5ca15b7)
<details>
<summary>Code source</summary>

```
sequenceDiagram
    participant Google
    participant App
    participant Backend

    App ->>+ Backend: GET /oauth/state
    Backend ->> Backend: Génération et sauvegarde du token de state oauth
    Backend -->>- App: Envoi du state
    Note over App: L'app ne stocke pas le state
    App ->>+ Google: Connexion SSO (manuelle)<br/>Envoi du state reçu
    Google -->>- App: Envoi du code d'autorisation<br/>Envoi du state reçu
    App ->>+ Backend: Envoi du code d'autorisation (POST /google/authorize)<br/>Envoi du state reçu
    Note over App: Le state envoyé est celui reçu de Google
    Backend ->> Backend: Validation du state
    Backend ->>+ Google: Validation du code d'autorisation
    Google -->>- Backend: Envoi des informations de l'utilisateur
    Backend ->> Backend: Recherche de l'utilisateur

    alt Utilisateur trouvé
        Backend -->>- App: Connexion
    else Utilisateur non trouvé
        Note over App, Backend: Processus de création de compte
    end
```
</details>
