### PR TITLE
(PC-25991)[API] refactor: optimise get offer by id query

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -64,8 +64,16 @@ def list_offers(query: offers_serialize.ListOffersQueryModel) -> offers_serializ
     api=blueprint.pro_private_schema,
 )
 def get_offer(offer_id: int) -> offers_serialize.GetIndividualOfferResponseModel:
+    load_all: offers_repository.OFFER_LOAD_OPTIONS = [
+        "stock",
+        "mediations",
+        "product",
+        "price_category",
+        "venue",
+        "bookings_count",
+    ]
     try:
-        offer = offers_repository.get_offer_by_id(offer_id)
+        offer = offers_repository.get_offer_by_id(offer_id, load_options=load_all)
     except exceptions.OfferNotFound:
         raise api_errors.ApiErrors(
             errors={


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25991

Lié au ticket jira 24965, lorsqu'on va retirer les stocks de la route GET offers, on n'aura plus besoin de la jointure sur les stocks (?)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques