### PR TITLE
(PC-26365)[API] fix: N+1 issues

### DIFF
--- a/api/src/pcapi/core/educational/api/venue.py
+++ b/api/src/pcapi/core/educational/api/venue.py
@@ -2,6 +2,7 @@ from operator import or_
 
 import sqlalchemy as sa
 
+from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
 from pcapi.utils.clean_accents import clean_accents
@@ -61,6 +62,11 @@ def get_all_venues(page: int | None, per_page: int | None) -> list[offerers_mode
         .options(sa.orm.joinedload(offerers_models.Venue.contact))
         .options(sa.orm.joinedload(offerers_models.Venue.venueLabel))
         .options(sa.orm.joinedload(offerers_models.Venue.managingOfferer))
+        .options(
+            sa.orm.joinedload(offerers_models.Venue.collectiveDomains).load_only(
+                educational_models.EducationalDomain.id, educational_models.EducationalDomain.name
+            )
+        )
         .all()
     )
 

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -307,6 +307,12 @@ def get_paginated_collective_bookings_for_educational_year(
                 educational_models.CollectiveBooking.collectiveStockId,
                 educational_models.CollectiveBooking.status,
                 educational_models.CollectiveBooking.confirmationLimitDate,
+                educational_models.CollectiveBooking.dateCreated,
+                educational_models.CollectiveBooking.dateUsed,
+                educational_models.CollectiveBooking.offererId,
+                educational_models.CollectiveBooking.cancellationDate,
+                educational_models.CollectiveBooking.cancellationLimitDate,
+                educational_models.CollectiveBooking.cancellationReason,
             )
             .joinedload(educational_models.CollectiveBooking.collectiveStock, innerjoin=True)
             .load_only(
@@ -317,7 +323,7 @@ def get_paginated_collective_bookings_for_educational_year(
             .joinedload(educational_models.CollectiveStock.collectiveOffer, innerjoin=True)
             .load_only(educational_models.CollectiveOffer.name)
             .joinedload(educational_models.CollectiveOffer.venue, innerjoin=True)
-            .load_only(offerers_models.Venue.timezone)
+            .load_only(offerers_models.Venue.timezone, offerers_models.Venue.id)
         )
         .options(
             sa.orm.joinedload(educational_models.CollectiveBooking.collectiveStock, innerjoin=True)

--- a/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
+++ b/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
@@ -13,7 +13,7 @@ class Returns200Test:
         educationalYear = EducationalYearFactory()
         educationalInstitution = EducationalInstitutionFactory()
         other_educational_institution = EducationalInstitutionFactory(institutionId="institutionId")
-        other_educational_year = EducationalYearFactory(adageId="adageId")
+        EducationalYearFactory(adageId="adageId")
         booking1 = CollectiveBookingFactory(
             educationalYear=educationalYear,
             educationalInstitution=educationalInstitution,
@@ -24,7 +24,11 @@ class Returns200Test:
             educationalInstitution=other_educational_institution,
             status="PENDING",
         )
-        CollectiveBookingFactory(educationalYear=other_educational_year)
+        booking3 = CollectiveBookingFactory(
+            educationalYear=educationalYear,
+            educationalInstitution=other_educational_institution,
+            status="PENDING",
+        )
 
         client = client.with_eac_token()
         adage_id = booking1.educationalYear.adageId
@@ -61,6 +65,19 @@ class Returns200Test:
                     "redactorEmail": booking2.educationalRedactor.email,
                     "domainIds": [domain.id for domain in booking2.collectiveStock.collectiveOffer.domains],
                     "domainLabels": [domain.name for domain in booking2.collectiveStock.collectiveOffer.domains],
+                },
+                {
+                    "id": booking3.id,
+                    "UAICode": other_educational_institution.institutionId,
+                    "status": "PENDING",
+                    "confirmationLimitDate": format_into_utc_date(booking3.confirmationLimitDate),
+                    "totalAmount": booking3.collectiveStock.price,
+                    "beginningDatetime": format_into_utc_date(booking3.collectiveStock.beginningDatetime),
+                    "venueTimezone": booking3.collectiveStock.collectiveOffer.venue.timezone,
+                    "name": booking3.collectiveStock.collectiveOffer.name,
+                    "redactorEmail": booking3.educationalRedactor.email,
+                    "domainIds": [domain.id for domain in booking3.collectiveStock.collectiveOffer.domains],
+                    "domainLabels": [domain.name for domain in booking3.collectiveStock.collectiveOffer.domains],
                 },
             ],
         }

--- a/api/tests/routes/adage/v1/get_all_venues_test.py
+++ b/api/tests/routes/adage/v1/get_all_venues_test.py
@@ -1,4 +1,5 @@
 from pcapi.core.offerers import factories as offerer_factories
+from pcapi.core.testing import assert_no_duplicated_queries
 
 
 class Returns200Test:
@@ -65,7 +66,8 @@ class Returns200Test:
         last_venues = offerer_factories.VenueFactory.create_batch(8, isPermanent=True)
 
         client.with_eac_token()
-        response = client.get("/adage/v1/venues?per_page=2")
+        with assert_no_duplicated_queries():
+            response = client.get("/adage/v1/venues?per_page=2")
         assert response.status_code == 200
         assert len(response.json["venues"]) == 2
         assert {venue["id"] for venue in response.json["venues"]} == {first_venues[0].id, first_venues[1].id}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26365

`/adage/v1/years/9/prebookings` :  [sentry](https://sentry.passculture.team/organizations/sentry/performance/api:d6ac9aa83b1845a09a108919d4b2f2a3/?environment=production&project=5&query=transaction.duration%3A%3C15m+http.method%3AGET&statsPeriod=7d&transaction=adage_v1.get_all_bookings_per_year&unselectedSeries=p100%28%29#request)

`/adage/v1/venues`: [sentry](https://sentry.passculture.team/organizations/sentry/performance/api:95ef4487f22f43418b1964b69559d785/?environment=production&project=5&query=transaction.duration%3A%3C15m+http.method%3AGET&statsPeriod=7d&transaction=adage_v1.get_all_venues&unselectedSeries=p100%28%29)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques