### PR TITLE
(PC-26100)[BO] feat: rm categories filters

### DIFF
--- a/api/src/pcapi/routes/backoffice/bookings/collective_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/collective_bookings_blueprint.py
@@ -59,7 +59,7 @@ def _get_collective_bookings(
             .load_only(
                 educational_models.CollectiveOffer.id,
                 educational_models.CollectiveOffer.name,
-                educational_models.CollectiveOffer.subcategoryId,
+                educational_models.CollectiveOffer.formats,
             ),
             sa.orm.joinedload(educational_models.CollectiveBooking.educationalInstitution).load_only(
                 educational_models.EducationalInstitution.id, educational_models.EducationalInstitution.name

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
@@ -9,7 +9,6 @@ from flask_login import current_user
 import sqlalchemy as sa
 
 from pcapi.core import search
-from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.mails import transactional as transactional_mails
 from pcapi.core.offerers import models as offerers_models
@@ -72,12 +71,10 @@ def _get_collective_offer_templates(
         to_datetime = date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time())
         base_query = base_query.filter(educational_models.CollectiveOfferTemplate.dateCreated <= to_datetime)
 
-    if form.category.data:
+    if form.formats.data:
         base_query = base_query.filter(
-            educational_models.CollectiveOfferTemplate.subcategoryId.in_(
-                subcategory.id
-                for subcategory in subcategories.ALL_SUBCATEGORIES
-                if subcategory.category.id in form.category.data
+            educational_models.CollectiveOfferTemplate.formats.overlap(
+                sa.dialects.postgresql.array((fmt for fmt in form.formats.data))
             )
         )
 

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -9,7 +9,6 @@ from flask_login import current_user
 import sqlalchemy as sa
 
 from pcapi.core import search
-from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import adage_backends as adage_client
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.adage_backends.serialize import serialize_collective_offer
@@ -79,12 +78,10 @@ def _get_collective_offers(
         to_datetime = date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time())
         base_query = base_query.filter(educational_models.CollectiveOffer.dateCreated <= to_datetime)
 
-    if form.category.data:
+    if form.formats.data:
         base_query = base_query.filter(
-            educational_models.CollectiveOffer.subcategoryId.in_(
-                subcategory.id
-                for subcategory in subcategories.ALL_SUBCATEGORIES
-                if subcategory.category.id in form.category.data
+            educational_models.CollectiveOffer.formats.overlap(
+                sa.dialects.postgresql.array((fmt for fmt in form.formats.data))
             )
         )
 

--- a/api/src/pcapi/routes/backoffice/collective_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/forms.py
@@ -4,7 +4,7 @@ import typing
 from flask_wtf import FlaskForm
 import wtforms
 
-from pcapi.core.categories import categories
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.routes.backoffice import filters
 from pcapi.routes.backoffice.forms import fields
@@ -46,9 +46,7 @@ class GetCollectiveOffersListForm(GetOffersBaseFields):
     to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
     only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des structures validées")
     q = fields.PCOptSearchField("ID, nom de l'offre")
-    category = fields.PCSelectMultipleField(
-        "Catégories", choices=utils.choices_from_enum(categories.CategoryIdLabelEnum)
-    )
+    formats = fields.PCSelectMultipleField("Formats", choices=utils.choices_from_enum(subcategories.EacFormat))
     offerer = fields.PCTomSelectField(
         "Structures",
         multiple=True,
@@ -79,7 +77,7 @@ class GetCollectiveOffersListForm(GetOffersBaseFields):
         # 'only_validated_offerers', 'sort' must be combined with other filters
         return not any(
             (
-                self.category.data,
+                self.formats.data,
                 self.venue.data,
                 self.offerer.data,
                 self.status.data,

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -1,5 +1,5 @@
 {% from "components/bookings/extra_row.html" import build_booking_toggle_extra_row_button with context %}
-{% from "components/bookings/extra_row.html" import build_booking_extra_row with context %}
+{% from "components/bookings/extra_row.html" import build_collective_booking_extra_row with context %}
 {% import "components/forms.html" as forms with context %}
 {% import "components/links.html" as links %}
 {% import "components/clipboard.html" as clipboard %}
@@ -189,7 +189,7 @@
                 <td>{{ links.build_offerer_name_to_details_link(collective_booking.offerer) }}</td>
                 <td>{{ links.build_venue_name_to_details_link(collective_booking.venue) }}</td>
               </tr>
-              {{ build_booking_extra_row(collective_booking, collective_booking.collectiveStock, collective_offer) }}
+              {{ build_collective_booking_extra_row(collective_booking, collective_booking.collectiveStock, collective_offer) }}
             {% endfor %}
           </tbody>
         </table>

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -26,12 +26,6 @@
             <div class="col-4">
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Catégorie :</span> {{ collective_offer.subcategoryId | format_offer_category }}
-                </p>
-                <p class="mb-1">
-                  <span class="fw-bold">Sous-catégorie :</span> {{ collective_offer.subcategoryId | format_offer_subcategory }}
-                </p>
-                <p class="mb-1">
                   <span class="fw-bold">Formats :</span> {{ collective_offer.formats | format_collective_offer_formats }}
                 </p>
                 <p class="mb-1">

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
@@ -29,7 +29,6 @@
                     data-use-confirmation-modal="true"
                     data-modal-selector="#batch-reject-modal">Rejeter</button>
           </div>
-          <div></div>
         </div>
         <table class="table mb-4"
                data-table-multi-select-id="table-container-collective-offer-validation">
@@ -43,8 +42,6 @@
               <th scope="col"></th>
               <th scope="col">ID</th>
               <th scope="col">Nom de l'offre</th>
-              <th scope="col">Catégorie</th>
-              <th scope="col">Sous-catégorie</th>
               <th scope="col">Formats</th>
               {% if has_permission("PRO_FRAUD_ACTIONS") %}<th scope="col">Règles de conformité</th>{% endif %}
               <th scope="col">État</th>
@@ -102,8 +99,6 @@
                 </td>
                 <td>{{ links.build_collective_offer_details_link(collective_offer) }}</td>
                 <td>{{ links.build_offer_name_to_pc_pro_link(collective_offer) }}</td>
-                <td>{{ collective_offer.subcategoryId | format_offer_category }}</td>
-                <td>{{ collective_offer.subcategoryId | format_offer_subcategory }}</td>
                 <td>{{ collective_offer.formats | format_collective_offer_formats }}</td>
                 {% if has_permission("PRO_FRAUD_ACTIONS") %}
                   <td>{{ collective_offer.flaggingValidationRules | format_offer_validation_rule_list }}</td>

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
@@ -29,7 +29,6 @@
                     data-use-confirmation-modal="true"
                     data-modal-selector="#batch-reject-modal">Rejeter</button>
           </div>
-          <div></div>
         </div>
         <table class="table mb-4"
                data-table-multi-select-id="table-container-collective-offer-template-validation">
@@ -43,8 +42,6 @@
               <th scope="col"></th>
               <th scope="col">ID</th>
               <th scope="col">Nom de l'offre</th>
-              <th scope="col">Catégorie</th>
-              <th scope="col">Sous-catégorie</th>
               <th scope="col">Formats</th>
               {% if has_permission("PRO_FRAUD_ACTIONS") %}<th scope="col">Règles de conformité</th>{% endif %}
               <th scope="col">État</th>
@@ -101,8 +98,6 @@
                 </td>
                 <td>{{ collective_offer_template.id }}</td>
                 <td>{{ links.build_offer_name_to_pc_pro_link(collective_offer_template) }}</td>
-                <td>{{ collective_offer_template.subcategoryId | format_offer_category }}</td>
-                <td>{{ collective_offer_template.subcategoryId | format_offer_subcategory }}</td>
                 <td>{{ collective_offer_template.formats | format_collective_offer_formats }}</td>
                 {% if has_permission("PRO_FRAUD_ACTIONS") %}
                   <td>{{ collective_offer_template.flaggingValidationRules | format_offer_validation_rule_list }}</td>

--- a/api/src/pcapi/routes/backoffice/templates/components/bookings/extra_row.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/bookings/extra_row.html
@@ -5,6 +5,20 @@
     <i class="bi bi-chevron-right"></i>
   </button>
 {% endmacro %}
+
+{% macro build_collective_booking_extra_row(booking, stock, offer) %}
+    {% call build_booking_extra_row(booking, stock, offer) %}
+      <li>Formats : {{ offer.formats | format_collective_offer_formats }}</li>
+    {% endcall %}
+{% endmacro %}
+
+{% macro build_individual_booking_extra_row(booking, stock, offer) %}
+    {% call build_booking_extra_row(booking, stock, offer) %}
+      <li>Catégorie : {{ offer.subcategoryId | format_offer_category }}</li>
+      <li>Sous-catégorie : {{ offer.subcategoryId | format_offer_subcategory }}</li>
+    {% endcall %}
+{% endmacro %}
+
 {% macro build_booking_extra_row(booking, stock, offer) %}
   <tr class="collapse accordion-collapse pc-booking-{{ booking.id }}">
     <td colspan="100%">
@@ -12,8 +26,7 @@
         <div class="col-6">
           <div class="card shadow-sm p-4 mx-2">
             <ul>
-              <li>Catégorie : {{ offer.subcategoryId | format_offer_category }}</li>
-              <li>Sous-catégorie : {{ offer.subcategoryId | format_offer_subcategory }}</li>
+              {{ caller() }}
               {% if booking.dateUsed %}
                 <li>
                   Date de validation :

--- a/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
@@ -1,5 +1,5 @@
 {% from "components/bookings/extra_row.html" import build_booking_toggle_extra_row_button with context %}
-{% from "components/bookings/extra_row.html" import build_booking_extra_row with context %}
+{% from "components/bookings/extra_row.html" import build_individual_booking_extra_row with context %}
 {% import "components/forms.html" as forms with context %}
 {% import "components/links.html" as links %}
 {% import "components/clipboard.html" as clipboard %}
@@ -218,7 +218,7 @@
                 <td>{{ links.build_offerer_name_to_details_link(booking.offerer) }}</td>
                 <td>{{ links.build_venue_name_to_details_link(booking.venue) }}</td>
               </tr>
-              {{ build_booking_extra_row(booking, booking.stock, offer) }}
+              {{ build_individual_booking_extra_row(booking, booking.stock, offer) }}
             {% endfor %}
           </tbody>
         </table>


### PR DESCRIPTION
Replace them by formats.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26100

Suppression des filtres Catégories sur le backoffice : pages des offres collective et vitrines, ainsi que sur la page des réservations collectives.

Les tests ont en toute logique été mis à jour : les offres créées n'ont plus de sous-catégories, que des formats.