### PR TITLE
(PC-26380)[PRO] fix: Set minimumFractionDigits in formatnumber adage …

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
@@ -40,6 +40,7 @@ export default function AdageHeaderBudget({
           style: 'currency',
           currency: 'EUR',
           maximumFractionDigits: 0,
+          minimumFractionDigits: 0, //  Some browsers need the minimum to be explicit since the defaut min value for currency is 2, in what case min > max
         }).format(institutionBudget)}
       </div>
     </div>


### PR DESCRIPTION
…header for IE.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26380

**Objectif**
Corriger le bug de crash de l'app quand on affiche le budget dans le header d'adage.

**A noter**
Ce serait parce que le `minimumFractionDigits` est par défaut à 2 pour les unités monétaires. Et certaine navigateurs ne comprendrait pas pourquoi maximumFractionDigits < minimumFractionDigits quand `minimumFractionDigits` n'est pas explicitement fixé.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques