### PR TITLE
PC-25874 upsertion of movies catalogue

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-34eb58880f79 (pre) (head)
+98681bf3c6b2 (pre) (head)
 2e4475aaf41d (post) (head)

--- a/api/src/pcapi/alembic/versions/20231128T192124_98681bf3c6b2_add_allocine_id_as_product_index.py
+++ b/api/src/pcapi/alembic/versions/20231128T192124_98681bf3c6b2_add_allocine_id_as_product_index.py
@@ -1,0 +1,32 @@
+"""Create index on extraData["allocineId"] for the table "Product"
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "98681bf3c6b2"
+down_revision = "34eb58880f79"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.create_index(
+        "product_allocineId_idx",
+        "product",
+        [sa.text("(\"jsonData\" -> 'allocineId')")],
+        unique=True,
+        postgresql_where=sa.text("(\"jsonData\" -> 'allocineId') IS NOT NULL"),
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "product_allocineId_idx",
+        table_name="product",
+        postgresql_where=sa.text("(\"jsonData\" -> 'allocineId') IS NOT NULL"),
+    )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -77,13 +77,24 @@ class OfferExtraData(typing.TypedDict, total=False):
     visa: str | None
 
     # allocine
-    cast: str | None
+    allocineId: int | None
+    backlink: str | None
+    cast: list[str] | None
     companies: list[dict] | None
-    countries: str | None
+    countries: list[str] | None
+    credits: list[dict] | None
     diffusionVersion: str | None
+    eidr: str | None
     genres: list[str] | None
+    originalTitle: str | None
+    posterUrl: str | None
+    productionYear: int | None
     releaseDate: str | None
+    releases: list[dict] | None
+    runtime: int | None
+    synopsis: str | None
     theater: dict | None
+    title: str | None
     type: str | None
 
     # titelive prior gtl (csr)
@@ -129,6 +140,7 @@ class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
     url = sa.Column(sa.String(255), nullable=True)
 
     sa.Index("product_ean_idx", extraData["ean"].astext)
+    sa.Index("product_allocineId_idx", extraData["allocineId"].cast(sa.Integer))
 
     @property
     def subcategory(self) -> subcategories_v2.Subcategory:

--- a/api/src/pcapi/core/providers/allocine_movie_list.py
+++ b/api/src/pcapi/core/providers/allocine_movie_list.py
@@ -1,0 +1,60 @@
+from sqlalchemy import Integer
+
+from pcapi.connectors.serialization.allocine_serializers import AllocineMovie
+from pcapi.core.categories.subcategories_v2 import SEANCE_CINE
+from pcapi.core.offers.models import OfferExtraData
+from pcapi.core.offers.models import Product
+from pcapi.domain import allocine as allocine_domain
+from pcapi.models import db
+from pcapi.repository import transaction
+
+
+def synchronize_products() -> None:
+    movies = allocine_domain.get_movie_list()
+    allocine_ids = [movie.internalId for movie in movies]
+    products_query = Product.query.filter(Product.extraData["allocineId"].cast(Integer).in_(allocine_ids))
+    products_by_allocine_id = {product.extraData["allocineId"]: product for product in products_query}
+    with transaction():
+        for movie in movies:
+            _upsert_product(products_by_allocine_id, movie)
+
+
+def _upsert_product(products_by_allocine_id: dict[int, Product], movie: AllocineMovie) -> None:
+    allocine_id = movie.internalId
+    product = products_by_allocine_id.get(allocine_id)
+    movie_data = _build_movie_data(movie)
+    if not product:
+        product = Product(
+            description=movie.synopsis,
+            extraData=movie_data,
+            idAtProviders=str(allocine_id),
+            name=movie.title,
+            subcategoryId=SEANCE_CINE.id,
+        )
+    else:
+        if product.extraData is None:
+            product.extraData = OfferExtraData()
+        product.extraData.update(movie_data)
+
+    db.session.add(product)
+
+
+def _build_movie_data(movie: AllocineMovie) -> OfferExtraData:
+    return OfferExtraData(
+        allocineId=movie.internalId,
+        backlink=str(movie.backlink.url),
+        cast=[f"{item.actor.firstName} {item.actor.lastName}" for item in movie.cast.items if item.actor],
+        companies=[company.model_dump() for company in movie.companies],
+        countries=[country.name for country in movie.countries],
+        credits=[credit.model_dump() for credit in movie.credits],
+        eidr=movie.data.eidr,
+        genres=[genre.name for genre in movie.genres],
+        originalTitle=movie.originalTitle,
+        posterUrl=str(movie.poster.url) if movie.poster else None,
+        productionYear=movie.data.productionYear,
+        releases=[release.model_dump() for release in movie.releases],
+        runtime=movie.runtime,
+        synopsis=movie.synopsis,
+        title=movie.title,
+        type=movie.type,
+    )

--- a/api/tests/domain/allocine_test.py
+++ b/api/tests/domain/allocine_test.py
@@ -6,18 +6,18 @@ from pcapi.domain.allocine import get_movie_list
 from pcapi.domain.allocine import get_movie_poster
 from pcapi.domain.allocine import get_movies_showtimes
 
-from tests.domain.fixtures import ALLOCINE_MOVIE_LIST_PAGES
+from tests.domain import fixtures
 
 
 class GetMovieListFromAllocineTest:
     def _configure_api_responses(self, requests_mock):
         requests_mock.get(
             f"{ALLOCINE_API_URL}/movieList?after=",
-            json=ALLOCINE_MOVIE_LIST_PAGES[""],
+            json=fixtures.ALLOCINE_MOVIE_LIST_PAGE_1,
         )
         requests_mock.get(
             f"{ALLOCINE_API_URL}/movieList?after=YXJyYXljb25uZWN0aW9uOjQ5",
-            json=ALLOCINE_MOVIE_LIST_PAGES["YXJyYXljb25uZWN0aW9uOjQ5"],
+            json=fixtures.ALLOCINE_MOVIE_LIST_PAGE_2,
         )
 
     def test_get_all_pages(self, requests_mock):

--- a/api/tests/domain/fixtures.py
+++ b/api/tests/domain/fixtures.py
@@ -1,3 +1,6 @@
+import copy
+
+
 ALLOCINE_MOVIE_LIST_PAGE_1 = {
     "movieList": {
         "totalCount": 4,
@@ -134,6 +137,9 @@ ALLOCINE_MOVIE_LIST_PAGE_1 = {
         ],
     }
 }
+
+ALLOCINE_MOVIE_LIST_PAGE_1_UPDATED = copy.deepcopy(ALLOCINE_MOVIE_LIST_PAGE_1)
+ALLOCINE_MOVIE_LIST_PAGE_1_UPDATED["movieList"]["edges"][0]["node"]["title"] = "Nouveau titre pour ceux de chez nous"
 
 ALLOCINE_MOVIE_LIST_PAGE_2 = {
     "movieList": {
@@ -282,9 +288,4 @@ ALLOCINE_MOVIE_LIST_PAGE_2 = {
             },
         ],
     }
-}
-
-ALLOCINE_MOVIE_LIST_PAGES = {
-    "": ALLOCINE_MOVIE_LIST_PAGE_1,
-    "YXJyYXljb25uZWN0aW9uOjQ5": ALLOCINE_MOVIE_LIST_PAGE_2,
 }

--- a/api/tests/providers/allocine_movie_list_test.py
+++ b/api/tests/providers/allocine_movie_list_test.py
@@ -1,0 +1,86 @@
+import pytest
+
+from pcapi.connectors.api_allocine import ALLOCINE_API_URL
+from pcapi.core.offers.models import Product
+from pcapi.core.providers.allocine_movie_list import synchronize_products
+
+from tests.domain import fixtures
+
+
+@pytest.mark.usefixtures("db_session")
+class AllocineMovieListTest:
+    def _configure_api_responses(self, requests_mock):
+        requests_mock.get(f"{ALLOCINE_API_URL}/movieList?after=", json=fixtures.ALLOCINE_MOVIE_LIST_PAGE_1)
+        requests_mock.get(
+            f"{ALLOCINE_API_URL}/movieList?after=YXJyYXljb25uZWN0aW9uOjQ5",
+            json=fixtures.ALLOCINE_MOVIE_LIST_PAGE_2,
+        )
+
+    def test_synchronize_products_creates_products(self, requests_mock):
+        # Given
+        self._configure_api_responses(requests_mock)
+        assert Product.query.count() == 0
+
+        # When
+        synchronize_products()
+
+        # Then
+        catalogue = Product.query.order_by(Product.id).all()
+        assert len(catalogue) == 4
+
+        movie_data = catalogue[0].extraData
+        expected_data = fixtures.ALLOCINE_MOVIE_LIST_PAGE_1["movieList"]["edges"][0]["node"]
+        assert movie_data["allocineId"] == expected_data["internalId"]
+        assert movie_data["backlink"] == expected_data["backlink"]["url"]
+        assert movie_data["cast"] == [
+            f"{item['node']['actor']['firstName']} {item['node']['actor']['lastName']}"
+            for item in expected_data["cast"]["edges"]
+        ]
+        assert movie_data["companies"] == [
+            {"activity": company["activity"], "name": company["company"]["name"]}
+            for company in expected_data["companies"]
+        ]
+        assert movie_data["countries"] == [country["name"] for country in expected_data["countries"]]
+        assert movie_data["credits"] == [expected_data["credits"]["edges"][0]["node"]]
+        assert movie_data["eidr"] == expected_data["data"]["eidr"]
+        assert movie_data["productionYear"] == expected_data["data"]["productionYear"]
+        assert "diffusionVersion" not in movie_data
+        assert movie_data["genres"] == expected_data["genres"]
+        assert movie_data["originalTitle"] == expected_data["originalTitle"]
+        assert movie_data["posterUrl"] == expected_data["poster"]["url"]
+        assert movie_data["releases"] == expected_data["releases"]
+        assert movie_data["runtime"] == 21
+        assert movie_data["synopsis"] == expected_data["synopsis"]
+        assert "theater" not in movie_data
+        assert movie_data["title"] == expected_data["title"]
+        assert movie_data["type"] == expected_data["type"]
+
+    def test_synchronize_products_updates_products(self, requests_mock):
+        # Given
+        self._configure_api_responses(requests_mock)
+        assert Product.query.count() == 0
+        synchronize_products()
+        requests_mock.get(f"{ALLOCINE_API_URL}/movieList?after=", json=fixtures.ALLOCINE_MOVIE_LIST_PAGE_1_UPDATED)
+
+        # When
+        synchronize_products()
+
+        # Then
+        updated_product = Product.query.order_by(Product.id).all()[0]
+        assert updated_product.extraData["title"] == "Nouveau titre pour ceux de chez nous"
+
+    def test_synchronize_products_is_idempotent(self, requests_mock):
+        # Given
+        self._configure_api_responses(requests_mock)
+        assert Product.query.count() == 0
+
+        # When
+        synchronize_products()
+        old_catalogue = Product.query.order_by(Product.id).all()
+        synchronize_products()
+        new_catalogue = Product.query.order_by(Product.id).all()
+
+        # Then
+        assert all(
+            [new_product.__dict__ == old_catalogue[idx].__dict__ for idx, new_product in enumerate(new_catalogue)]
+        )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25874


Dans la classe `OfferExtraData`, les champs `cast` et `countries` étaient typés en `str` et passent en `list[str]`. Cependant, en base ils sont déjà tous enregistrés au format `list[str]` (au moins en staging).

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques