### PR TITLE
(PC-25999)[API] feat: make banId non nullable for permanent venues

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 7049d737cb3f (pre) (head)
-faed981725fd (post) (head)
+c0c6a91a03cb (post) (head)

--- a/api/src/pcapi/alembic/versions/20231208T130817_c0c6a91a03cb_make_ban_id_non_nullable_for_permanent_ids.py
+++ b/api/src/pcapi/alembic/versions/20231208T130817_c0c6a91a03cb_make_ban_id_non_nullable_for_permanent_ids.py
@@ -1,0 +1,31 @@
+"""
+Check that Ban ID is not null for permanent venues
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "c0c6a91a03cb"
+down_revision = "faed981725fd"
+branch_labels = None
+depends_on = None
+
+
+CONSTRAINT_CHECK_IS_PERMANENT_AND_HAS_BAN_ID_OR_IS_VIRTUAL = """
+    ("isPermanent" IS FALSE)
+    OR ("isVirtual" IS True) 
+    OR ("isPermanent" IS TRUE AND "isVirtual" IS FALSE AND "banId" IS NOT NULL)
+"""
+
+
+def upgrade() -> None:
+    op.create_check_constraint(
+        constraint_name="check_non_virtual_permanent_venues_have_ban_id",
+        table_name="venue",
+        condition=(CONSTRAINT_CHECK_IS_PERMANENT_AND_HAS_BAN_ID_OR_IS_VIRTUAL),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("check_non_virtual_permanent_venues_have_ban_id", "venue", type_="check")

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -93,6 +93,14 @@ class VenueModelConstraintsTest:
             repository.save(venue3)
         assert err.value.errors["isVirtual"] == ["Un lieu pour les offres numériques existe déjà pour cette structure"]
 
+    def test_permanent_venue_must_have_a_ban_id(self):
+        venue = factories.VenueFactory(isPermanent=True)
+        with pytest.raises(IntegrityError) as err:
+            venue.banId = None
+            db.session.add(venue)
+            db.session.flush()
+        assert "check_non_virtual_permanent_venues_have_ban_id" in str(err.value)
+
 
 class VenueTimezonePropertyTest:
     def test_europe_paris_is_default_timezone(self):

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -921,6 +921,7 @@ class UpdateVenueTest(PostEndpointHelper):
             "city": "Umeå",
             "postal_code": "90325",
             "address": "Skolgatan 31A",
+            "ban_id": "12345_5678_91011",
             "booking_email": venue.bookingEmail + ".update",
             "phone_number": "+33102030456",
             "is_permanent": True,


### PR DESCRIPTION
## But de la pull request

Une fois que le script pour ajouter les id BAN aura tourné en prod, et qu'on aura bien vérifié qu'il n'y aura plus aucun lieu permanent qui n'a pas de banId, on pourra merger cette PR pour ajouter la contrainte suivante:

Si on a un lieu permanent, la colonne banId doit être non nullable

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25999

*EDIT* : On abandonne cette contrainte car certains lieux n'ont pas de banId (cf ticket Jira pour plus d'info)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques