### PR TITLE
(BSR)[EAC] feat: playlists: format distances

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/playlists.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import logging
 import random
 import typing
@@ -91,12 +92,18 @@ def get_classroom_playlist(
     )
 
 
+def format_distance(distance: float | None) -> Decimal | None:
+    if not distance:
+        return None
+    return Decimal.from_float(distance).quantize(Decimal("1.0"))
+
+
 def serialize_collective_offer(
     offer: educational_models.CollectiveOffer,
     serializer: type[serializers.CollectiveOfferResponseModel] | type[serializers.CollectiveOfferTemplateResponseModel],
     is_favorite: bool,
-    venue_distance: int | None = None,
-    event_distance: int | None = None,
+    venue_distance: float | None = None,
+    event_distance: float | None = None,
 ) -> serializers.CollectiveOfferResponseModel | serializers.CollectiveOfferTemplateResponseModel:
     offer_venue_id = offer.offerVenue.get("venueId")
     if offer_venue_id:
@@ -105,8 +112,9 @@ def serialize_collective_offer(
         offer_venue = None
 
     serialized_offer = serializer.build(offer=offer, offerVenue=offer_venue, is_favorite=is_favorite)
-    serialized_offer.venue.distance = venue_distance
-    serialized_offer.offerVenue.distance = event_distance
+
+    serialized_offer.venue.distance = format_distance(venue_distance)
+    serialized_offer.offerVenue.distance = format_distance(event_distance)
 
     return serialized_offer
 
@@ -204,7 +212,7 @@ def get_local_offerers_playlist(
                 img_url=venue.bannerUrl,
                 public_name=venue.publicName,
                 name=venue.name,
-                distance=rows[str(venue.id)],
+                distance=format_distance(rows[str(venue.id)]),
                 city=venue.city,
                 id=venue.id,
             )

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -1,5 +1,6 @@
 from datetime import date
 from datetime import datetime
+from decimal import Decimal
 import enum
 import logging
 import typing
@@ -63,7 +64,7 @@ class OfferVenueResponse(BaseModel):
     coordinates: common_models.Coordinates
     managingOfferer: OfferManagingOffererResponse
     adageId: str | None
-    distance: float | None
+    distance: Decimal | None
 
     class Config:
         orm_mode = True
@@ -120,7 +121,7 @@ class CollectiveOfferOfferVenue(BaseModel):
     address: str | None
     postalCode: str | None
     city: str | None
-    distance: float | None
+    distance: Decimal | None
 
     _validated_venue_id = validator("venueId", pre=True, allow_reuse=True)(validate_venue_id)
 

--- a/api/src/pcapi/routes/adage_iframe/serialization/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/playlists.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import typing
 
 from pcapi.routes.serialization import BaseModel
@@ -7,7 +8,7 @@ from pcapi.serialization.utils import to_camel
 class LocalOfferersPlaylistOffer(BaseModel):
     id: int
     name: str
-    distance: float
+    distance: Decimal | None
     img_url: str | None
     public_name: str | None
     city: str | None

--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -41,9 +41,10 @@ class GetClassroomPlaylistTest(SharedPlaylistsErrorTests):
 
         mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
         with patch(mock_path) as mock_run_query:
+            # add some decimal digits and ensure that the response removed them
             mock_run_query.return_value = [
-                {"collective_offer_id": str(offers[0].id), "distance_in_km": expected_distance},
-                {"collective_offer_id": str(offers[1].id), "distance_in_km": expected_distance},
+                {"collective_offer_id": str(offers[0].id), "distance_in_km": expected_distance + 0.001234},
+                {"collective_offer_id": str(offers[1].id), "distance_in_km": expected_distance + 0.001234},
             ]
 
             # fetch institution (1 query)

--- a/pro/src/apiClient/adage/models/LocalOfferersPlaylistOffer.ts
+++ b/pro/src/apiClient/adage/models/LocalOfferersPlaylistOffer.ts
@@ -5,7 +5,7 @@
 
 export type LocalOfferersPlaylistOffer = {
   city?: string | null;
-  distance: number;
+  distance?: number | null;
   id: number;
   imgUrl?: string | null;
   name: string;


### PR DESCRIPTION
## But de la pull request

Renvoyer une distance avec un seul chiffre après la virgule.

Il y a deux possibilités : soit formater la valeur au niveau de la réponse de la requête Big query, soit au niveau du contrôleur. La seconde option a été choisie puisqu'il y perte d'informations et que les deux sont comparables en terme de complexité (la première était sûrement un tout petit peu plus simple).