### PR TITLE
(BSR)[PRO] ci: Change the e2e videos path for more usability.

### DIFF
--- a/.github/workflows/tests-pro-e2e.yml
+++ b/.github/workflows/tests-pro-e2e.yml
@@ -49,6 +49,10 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      - name: 'Move cypress videos'
+        run: |
+          mkdir -p cypress/videos/${{ github.ref }}/${{ github.sha }} && \
+          mv cypress/videos/*.mp4 cypress/videos/${{ github.ref }}/${{ github.sha }}/
       - name: Archive E2E results
         if: always()
         uses: google-github-actions/upload-cloud-storage@v1


### PR DESCRIPTION
## But de la pull request

- Les vidéos sont maintenant dans des dossiers par branche et par commit.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques