### PR TITLE
(BSR)[BO] fix: handle favicon in bo error pages

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/base.html
@@ -11,9 +11,10 @@
     <meta name="csrf-token"
           content="{{ csrf_token.current_token }}">
     <title>Backoffice</title>
+    {% set icon_path = get_setting("BACKOFFICE_FAVICON_PATH") if get_setting else "favicon_default.ico" %}
     <link rel="icon"
           type="image/x-icon"
-          href="{{ url_for('static', filename='backoffice/favicon/' + get_setting("BACKOFFICE_FAVICON_PATH") ) }}" />
+          href="{{ url_for('static', filename='backoffice/favicon/' + icon_path ) }}" />
     <!-- Bootstrap icons -->
     <link href="{{ url_for('static', filename='backoffice/css/bootstrap-icons@1.9.1/font/bootstrap-icons.css') }}"
           rel="stylesheet"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : fix la favicon du BO quand on affiche une page d'erreur

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques