### PR TITLE
(BSR)[API] chore: Avoid mypy warnings about `app.generate_error_response()`

### DIFF
--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -53,7 +53,7 @@ with app.app_context():
     install_routes(app)
     app.register_blueprint(backoffice_web, url_prefix="/")
 
-    app.generate_error_response = generate_error_response  # type: ignore [attr-defined]
+    app.generate_error_response = generate_error_response
 
     setup_metrics(app)
 

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -201,13 +201,15 @@ oauth.register(
 app.url_map.strict_slashes = False
 
 
-def generate_error_response(errors: dict, backoffice_template_name: str = "errors/generic.html") -> Response:
+# The argument `backoffice_template_name` is not used, but it is needed
+# to have the same signature as `backoffice_app.generate_error_response()`.
+def generate_error_response(errors: dict, backoffice_template_name: str = "not used") -> Response:
     return jsonify(errors)
 
 
 with app.app_context():
     app.redis_client = redis.from_url(url=settings.REDIS_URL, decode_responses=True)
-    app.generate_error_response = generate_error_response  # type: ignore [attr-defined]
+    app.generate_error_response = generate_error_response
 
 
 @app.shell_context_processor

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import time
+import typing
 
 from authlib.integrations.flask_client import OAuth
 from flask import Flask
@@ -31,6 +32,11 @@ from pcapi.scripts.install import install_commands
 from pcapi.utils.json_encoder import EnumJSONEncoder
 from pcapi.utils.rate_limiting import rate_limiter
 from pcapi.utils.sentry import init_sentry_sdk
+
+
+if typing.TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 monkeypatches.install_monkey_patches()
@@ -143,7 +149,11 @@ class ProxyFix(werkzeug.middleware.proxy_fix.ProxyFix):
     traffic to go through our L7 load balancer.
     """
 
-    def __call__(self, environ, start_response):  # type: ignore [no-untyped-def]
+    def __call__(
+        self,
+        environ: "WSGIEnvironment",
+        start_response: "StartResponse",
+    ) -> typing.Iterable[bytes]:
         import sqlalchemy
 
         from pcapi.models.feature import FeatureToggle

--- a/api/src/pcapi/routes/adage/security.py
+++ b/api/src/pcapi/routes/adage/security.py
@@ -1,6 +1,7 @@
 from functools import wraps
+import typing
 
-from flask import request
+import flask
 
 from pcapi import settings
 from pcapi.models.api_errors import ForbiddenError
@@ -8,13 +9,13 @@ from pcapi.routes.adage.v1.blueprint import EAC_API_KEY_AUTH
 from pcapi.serialization.spec_tree import add_security_scheme
 
 
-def adage_api_key_required(route_function):  # type: ignore [no-untyped-def]
+def adage_api_key_required(route_function: typing.Callable) -> typing.Callable:
     add_security_scheme(route_function, EAC_API_KEY_AUTH)
 
     @wraps(route_function)
-    def wrapper(*args, **kwds):  # type: ignore [no-untyped-def]
+    def wrapper(*args: typing.Any, **kwds: typing.Any) -> flask.Response:
         mandatory_authorization_type = "Bearer "
-        authorization_header = request.headers.get("Authorization")
+        authorization_header = flask.request.headers.get("Authorization")
 
         if authorization_header and mandatory_authorization_type in authorization_header:
             adage_api_key = authorization_header.replace(mandatory_authorization_type, "")

--- a/api/src/pcapi/routes/adage_iframe/security.py
+++ b/api/src/pcapi/routes/adage_iframe/security.py
@@ -1,7 +1,8 @@
 from functools import wraps
 import logging
+import typing
 
-from flask import request
+import flask
 from jwt import ExpiredSignatureError
 from jwt import InvalidSignatureError
 from jwt import InvalidTokenError
@@ -16,13 +17,13 @@ from pcapi.serialization.spec_tree import add_security_scheme
 logger = logging.getLogger(__name__)
 
 
-def adage_jwt_required(route_function):  # type: ignore [no-untyped-def]
+def adage_jwt_required(route_function: typing.Callable) -> typing.Callable:
     add_security_scheme(route_function, JWT_AUTH)
 
     @wraps(route_function)
-    def wrapper(*args, **kwargs):  # type: ignore [no-untyped-def]
+    def wrapper(*args: typing.Any, **kwargs: typing.Any) -> flask.Response:
         mandatory_authorization_type = "Bearer "
-        authorization_header = request.headers.get("Authorization")
+        authorization_header = flask.request.headers.get("Authorization")
 
         if authorization_header and mandatory_authorization_type in authorization_header:
             adage_jwt = authorization_header.replace(mandatory_authorization_type, "")

--- a/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
@@ -9,6 +9,7 @@ from pcapi.models import api_errors
 JsonResponse = tuple[Response, int]
 
 
+# mypy does not like us using `@app.errorhandler` more than once.
 @app.errorhandler(exceptions.OfferIsAlreadyBooked)  # type: ignore [arg-type]
 @app.errorhandler(exceptions.QuantityIsInvalid)
 @app.errorhandler(exceptions.StockIsNotBookable)
@@ -18,23 +19,23 @@ JsonResponse = tuple[Response, int]
 @app.errorhandler(exceptions.DigitalExpenseLimitHasBeenReached)
 @app.errorhandler(exceptions.OfferCategoryNotBookableByUser)
 def handle_book_an_offer(exception: ClientError) -> JsonResponse:
-    return app.generate_error_response(exception.errors), 400  # type: ignore [attr-defined]
+    return app.generate_error_response(exception.errors), 400
 
 
 @app.errorhandler(exceptions.CannotCancelConfirmedBooking)
 def handle_cancel_a_booking(exception: ClientError) -> JsonResponse:
-    return app.generate_error_response(exception.errors), 400  # type: ignore [attr-defined]
+    return app.generate_error_response(exception.errors), 400
 
 
 @app.errorhandler(exceptions.BookingDoesntExist)
 def handle_cancel_a_booking_not_found(exception: exceptions.BookingDoesntExist) -> JsonResponse:
-    return app.generate_error_response(exception.errors), 404  # type: ignore [attr-defined]
+    return app.generate_error_response(exception.errors), 404
 
 
 @app.errorhandler(exceptions.BookingIsAlreadyRefunded)
 def handle_booking_is_already_refunded(exception: exceptions.BookingIsAlreadyRefunded) -> JsonResponse:
     error = {"payment": ["Cette réservation a été remboursée"]}
-    return app.generate_error_response(error), api_errors.ForbiddenError.status_code  # type: ignore [attr-defined]
+    return app.generate_error_response(error), api_errors.ForbiddenError.status_code
 
 
 @app.errorhandler(exceptions.BookingRefused)
@@ -44,22 +45,22 @@ def handle_booking_refused(exception: exceptions.BookingRefused) -> JsonResponse
             "Cette réservation pour une offre éducationnelle a été refusée par le chef d'établissement"
         )
     }
-    return app.generate_error_response(error), api_errors.ForbiddenError.status_code  # type: ignore [attr-defined]
+    return app.generate_error_response(error), api_errors.ForbiddenError.status_code
 
 
 @app.errorhandler(exceptions.BookingIsNotConfirmed)
 def handle_booking_is_not_confirmed(exception: exceptions.BookingIsNotConfirmed) -> JsonResponse:
     error = {"booking": [str(exception)]}
-    return app.generate_error_response(error), api_errors.ForbiddenError.status_code  # type: ignore [attr-defined]
+    return app.generate_error_response(error), api_errors.ForbiddenError.status_code
 
 
 @app.errorhandler(exceptions.BookingIsAlreadyUsed)
 def handle_booking_is_already_used(exception: exceptions.BookingIsAlreadyUsed) -> JsonResponse:
     error = {"booking": ["Cette réservation a déjà été validée"]}
-    return app.generate_error_response(error), api_errors.ResourceGoneError.status_code  # type: ignore [attr-defined]
+    return app.generate_error_response(error), api_errors.ResourceGoneError.status_code
 
 
 @app.errorhandler(exceptions.BookingIsAlreadyCancelled)
 def handle_booking_is_already_cancelled(exception: exceptions.BookingIsAlreadyCancelled) -> JsonResponse:
     error = {"booking_cancelled": ["Cette réservation a été annulée"]}
-    return app.generate_error_response(error), api_errors.ResourceGoneError.status_code  # type: ignore [attr-defined]
+    return app.generate_error_response(error), api_errors.ResourceGoneError.status_code

--- a/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -30,17 +30,17 @@ ApiErrorResponse = tuple[dict | Response, int]
 
 @app.errorhandler(NotFound)
 def restize_not_found_route_errors(error: NotFound) -> ApiErrorResponse | HtmlErrorResponse:
-    return app.generate_error_response({}, backoffice_template_name="errors/not_found.html"), 404  # type: ignore [attr-defined]
+    return app.generate_error_response({}, backoffice_template_name="errors/not_found.html"), 404
 
 
 @app.errorhandler(ApiErrors)
 def restize_api_errors(error: ApiErrors) -> ApiErrorResponse:
-    return app.generate_error_response(error.errors), error.status_code or 400  # type: ignore [attr-defined]
+    return app.generate_error_response(error.errors), error.status_code or 400
 
 
 @app.errorhandler(offers_exceptions.TooLateToDeleteStock)
 def restize_too_late_to_delete_stock(error: offers_exceptions.TooLateToDeleteStock) -> ApiErrorResponse:
-    return app.generate_error_response(error.errors), 400  # type: ignore [attr-defined]
+    return app.generate_error_response(error.errors), 400
 
 
 @app.errorhandler(Exception)
@@ -51,7 +51,7 @@ def internal_error(error: Exception) -> ApiErrorResponse | HTTPException:
     logger.exception("Unexpected error on method=%s url=%s: %s", request.method, request.url, error)
     errors = ApiErrors()
     errors.add_error("global", "Il semble que nous ayons des problèmes techniques :(" + " On répare ça au plus vite.")
-    return app.generate_error_response(errors.errors), 500  # type: ignore [attr-defined]
+    return app.generate_error_response(errors.errors), 500
 
 
 @app.errorhandler(UnauthorizedError)
@@ -69,7 +69,7 @@ def method_not_allowed(error: MethodNotAllowed) -> ApiErrorResponse:
     api_errors = ApiErrors()
     api_errors.add_error("global", "La méthode que vous utilisez n'existe pas sur notre serveur")
     logger.warning("405 %s", error)
-    return app.generate_error_response(api_errors.errors), 405  # type: ignore [attr-defined]
+    return app.generate_error_response(api_errors.errors), 405
 
 
 @app.errorhandler(DecimalCastError)
@@ -78,7 +78,7 @@ def decimal_cast_error(error: DecimalCastError) -> ApiErrorResponse:
     logger.warning(json.dumps(error.errors))
     for field in error.errors.keys():
         api_errors.add_error(field, "Saisissez un nombre valide")
-    return app.generate_error_response(api_errors.errors), 400  # type: ignore [attr-defined]
+    return app.generate_error_response(api_errors.errors), 400
 
 
 @app.errorhandler(DateTimeCastError)
@@ -87,13 +87,13 @@ def date_time_cast_error(error: DateTimeCastError) -> ApiErrorResponse:
     logger.warning(json.dumps(error.errors))
     for field in error.errors.keys():
         api_errors.add_error(field, "Format de date invalide")
-    return app.generate_error_response(api_errors.errors), 400  # type: ignore [attr-defined]
+    return app.generate_error_response(api_errors.errors), 400
 
 
 @app.errorhandler(finance_exceptions.DepositTypeAlreadyGrantedException)
 def already_activated_exception(error: finance_exceptions.DepositTypeAlreadyGrantedException) -> ApiErrorResponse:
     logger.error(json.dumps(error.errors))
-    return app.generate_error_response(error.errors), 405  # type: ignore [attr-defined]
+    return app.generate_error_response(error.errors), 405
 
 
 @app.errorhandler(429)
@@ -123,7 +123,7 @@ def ratelimit_handler(error: Exception) -> ApiErrorResponse:
     logger.warning("Requests ratelimit exceeded on routes url=%s", request.url, extra=extra)
     api_errors = ApiErrors()
     api_errors.add_error("global", "Nombre de tentatives de connexion dépassé, veuillez réessayer dans une minute")
-    return app.generate_error_response(api_errors.errors), 429  # type: ignore [attr-defined]
+    return app.generate_error_response(api_errors.errors), 429
 
 
 @app.errorhandler(DatabaseError)
@@ -147,38 +147,38 @@ def database_error_handler(error: DatabaseError) -> ApiErrorResponse:
     logger.exception("Unexpected database error on method=%s url=%s: %s", request.method, request.url, error)
     errors = ApiErrors()
     errors.add_error("global", "Il semble que nous ayons des problèmes techniques :(" + " On répare ça au plus vite.")
-    return app.generate_error_response(errors.errors), 500  # type: ignore [attr-defined]
+    return app.generate_error_response(errors.errors), 500
 
 
 @app.errorhandler(ImageRatioError)
 def handle_ratio_error(error: ImageRatioError) -> ApiErrorResponse:
     logger.info("Image ratio error: %s", error)
-    return app.generate_error_response({"code": "BAD_IMAGE_RATIO", "extra": str(error)}), 400  # type: ignore [attr-defined]
+    return app.generate_error_response({"code": "BAD_IMAGE_RATIO", "extra": str(error)}), 400
 
 
 @app.errorhandler(sirene.UnknownEntityException)
 def handle_unknown_entity_exception(error: sirene.UnknownEntityException) -> ApiErrorResponse:
     msg = "Le SIREN n’existe pas."
     err = {"global": [msg]}
-    return app.generate_error_response(err), 400  # type: ignore [attr-defined]
+    return app.generate_error_response(err), 400
 
 
 @app.errorhandler(sirene.InvalidFormatException)
 def handle_sirene_invalid_format_exception(error: sirene.InvalidFormatException) -> ApiErrorResponse:
     msg = "Le format de ce SIREN ou SIRET est incorrect."
     err = {"global": [msg]}
-    return app.generate_error_response(err), 400  # type: ignore [attr-defined]
+    return app.generate_error_response(err), 400
 
 
 @app.errorhandler(sirene.NonPublicDataException)
 def handle_sirene_non_public_data_exception(error: sirene.NonPublicDataException) -> ApiErrorResponse:
     msg = "Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles."
     err = {"global": [msg]}
-    return app.generate_error_response(err), 400  # type: ignore [attr-defined]
+    return app.generate_error_response(err), 400
 
 
 @app.errorhandler(sirene.SireneApiException)
 def handle_sirene_api_exception(error: sirene.SireneApiException) -> ApiErrorResponse:
     msg = "Les informations relatives à ce SIREN ou SIRET n'ont pas pu être vérifiées, veuillez réessayer plus tard."
     err = {"global": [msg]}
-    return app.generate_error_response(err), 500  # type: ignore [attr-defined]
+    return app.generate_error_response(err), 500

--- a/api/src/pcapi/routes/error_handlers/thumbnails_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/thumbnails_error_handlers.py
@@ -17,4 +17,4 @@ def handle_create_a_thumbnail(exception: Exception) -> tuple[Response, int]:
         exception.__class__.__name__,
         error_message,
     )
-    return app.generate_error_response({"errors": [error_message]}), 400  # type: ignore [attr-defined]
+    return app.generate_error_response({"errors": [error_message]}), 400

--- a/api/stubs/flask/app.pyi
+++ b/api/stubs/flask/app.pyi
@@ -4,7 +4,9 @@
 #   - a `redis_client` attribute has been added. Since we set this
 #     attribute when building the `app` object, accessing it from
 #     many parts of our code causes mypy warnings.
-#   - `name` had to be typed somewhat incorrectly to please mypy.
+#   - ditto for `generate_error_response`.
+#   - cached properties had to be typed somewhat incorrectly to please
+#     mypy: `name`, `logger` and `jinja_env`.
 # All changes appear between `<change>` and `</change>` tags.
 
 import logging
@@ -55,6 +57,13 @@ from werkzeug.routing import Map, MapAdapter as MapAdapter, Rule
 
 iscoroutinefunction: Incomplete
 
+# <change>
+class GenerateErrorResponse(t.Protocol):
+    def __call__(self, errors: dict, backoffice_template_name: str = ...) -> Response:
+        pass
+
+# </change>
+
 class Flask(Scaffold):
     request_class = Request
     response_class = Response
@@ -88,6 +97,7 @@ class Flask(Scaffold):
     subdomain_matching: Incomplete
     # <change>
     redis_client: redis.Redis
+    generate_error_response: GenerateErrorResponse
     # </change>
 
     def __init__(


### PR DESCRIPTION
We set a `generate_error_response()` function on each app (the
"regular" app and the "back-office" app). This helps with the
implementation of error handlers. But mypy does not like that.
By declaring this attribute in the typing stub for `Flask`,
mypy accepts our setting and accessing the attribute.

(This is similar to what was done for `app.redis_client` in 0524dbd392863353305e7ac3dea4d198a3b7dd14.)