### PR TITLE
(PC-26313)[PRO] fix: update conditional wording rendering

### DIFF
--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -30,7 +30,7 @@ const ReimbursementBankAccount = ({
   offererId,
   managedVenues,
 }: ReimbursementBankAccountProps): JSX.Element => {
-  const hasLinkedVenuesWithPaidOffer = bankAccount.linkedVenues.length > 0
+  const hasLinkedVenues = bankAccount.linkedVenues.length > 0
   const { logEvent } = useAnalytics()
   const location = useLocation()
   const venuesNotLinkedToBankAccount = managedVenues.filter(
@@ -83,8 +83,7 @@ const ReimbursementBankAccount = ({
         <div className={styles['linked-venues-section']}>
           <div className={styles['linked-venues-section-title']}>
             Lieu(x) rattaché(s) à ce compte bancaire
-            {(bankAccount.linkedVenues.length === 0 ||
-              venuesNotLinkedToBankAccount > 0) && (
+            {(!hasLinkedVenues || venuesNotLinkedToBankAccount > 0) && (
               <SvgIcon
                 src={fullErrorIcon}
                 alt="Une action est requise"
@@ -94,20 +93,19 @@ const ReimbursementBankAccount = ({
             )}
           </div>
           <div className={styles['linked-venues-content']}>
-            {bankAccount.linkedVenues.length === 0 && (
+            {!hasLinkedVenues && (
               <div className={styles['issue-text']}>
                 Aucun lieu n’est rattaché à ce compte bancaire.
                 {venuesNotLinkedToBankAccount === 0 &&
                   ' Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire.'}
               </div>
             )}
-            {bankAccount.linkedVenues.length > 0 &&
-              venuesNotLinkedToBankAccount > 0 && (
-                <div className={styles['issue-text']}>
-                  Certains de vos lieux ne sont pas rattachés
-                </div>
-              )}
-            {hasLinkedVenuesWithPaidOffer && (
+            {hasLinkedVenues && venuesNotLinkedToBankAccount > 0 && (
+              <div className={styles['issue-text']}>
+                Certains de vos lieux ne sont pas rattachés
+              </div>
+            )}
+            {hasLinkedVenues && (
               <>
                 <div className={styles['linked-venues']}>
                   {bankAccount.linkedVenues.map((venue) => (
@@ -133,23 +131,22 @@ const ReimbursementBankAccount = ({
                 </Button>
               </>
             )}
-            {!hasLinkedVenuesWithPaidOffer &&
-              venuesNotLinkedToBankAccount > 0 && (
-                <Button
-                  onClick={() => {
-                    logEvent?.(
-                      BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
-                      {
-                        from: location.pathname,
-                        offererId,
-                      }
-                    )
-                    onUpdateButtonClick?.(bankAccount.id)
-                  }}
-                >
-                  Rattacher un lieu
-                </Button>
-              )}
+            {!hasLinkedVenues && venuesNotLinkedToBankAccount > 0 && (
+              <Button
+                onClick={() => {
+                  logEvent?.(
+                    BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
+                    {
+                      from: location.pathname,
+                      offererId,
+                    }
+                  )
+                  onUpdateButtonClick?.(bankAccount.id)
+                }}
+              >
+                Rattacher un lieu
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom'
 import {
   BankAccountApplicationStatus,
   BankAccountResponseModel,
+  ManagedVenues,
 } from 'apiClient/v1'
 import { BankAccountEvents } from 'core/FirebaseEvents/constants'
 import useAnalytics from 'hooks/useAnalytics'
@@ -18,22 +19,23 @@ import styles from './ReimbursementBankAccount.module.scss'
 
 interface ReimbursementBankAccountProps {
   bankAccount: BankAccountResponseModel
-  venuesNotLinkedLength: number
-  bankAccountsNumber: number
+  managedVenues: ManagedVenues[]
   onUpdateButtonClick?: (id: number) => void
   offererId?: number
 }
 
 const ReimbursementBankAccount = ({
   bankAccount,
-  venuesNotLinkedLength,
-  bankAccountsNumber,
   onUpdateButtonClick,
   offererId,
+  managedVenues,
 }: ReimbursementBankAccountProps): JSX.Element => {
-  const hasLinkedVenues = bankAccount.linkedVenues.length > 0
+  const hasLinkedVenuesWithPaidOffer = bankAccount.linkedVenues.length > 0
   const { logEvent } = useAnalytics()
   const location = useLocation()
+  const venuesNotLinkedToBankAccount = managedVenues.filter(
+    (venue) => !venue.bankAccountId
+  ).length
 
   return (
     <div className={styles['bank-account']}>
@@ -81,8 +83,8 @@ const ReimbursementBankAccount = ({
         <div className={styles['linked-venues-section']}>
           <div className={styles['linked-venues-section-title']}>
             Lieu(x) rattaché(s) à ce compte bancaire
-            {(!hasLinkedVenues ||
-              (hasLinkedVenues && venuesNotLinkedLength > 0)) && (
+            {(bankAccount.linkedVenues.length === 0 ||
+              venuesNotLinkedToBankAccount > 0) && (
               <SvgIcon
                 src={fullErrorIcon}
                 alt="Une action est requise"
@@ -92,22 +94,20 @@ const ReimbursementBankAccount = ({
             )}
           </div>
           <div className={styles['linked-venues-content']}>
-            {!hasLinkedVenues && (
+            {bankAccount.linkedVenues.length === 0 && (
               <div className={styles['issue-text']}>
                 Aucun lieu n’est rattaché à ce compte bancaire.
-                {venuesNotLinkedLength === 0 &&
-                  bankAccountsNumber > 1 &&
+                {venuesNotLinkedToBankAccount === 0 &&
                   ' Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire.'}
               </div>
             )}
-            {hasLinkedVenues && venuesNotLinkedLength > 0 && (
-              <div className={styles['issue-text']}>
-                {venuesNotLinkedLength > 1
-                  ? 'Certains de vos lieux ne sont pas rattachés'
-                  : 'Un de vos lieux n’est pas rattaché.'}
-              </div>
-            )}
-            {hasLinkedVenues && (
+            {bankAccount.linkedVenues.length > 0 &&
+              venuesNotLinkedToBankAccount > 0 && (
+                <div className={styles['issue-text']}>
+                  Certains de vos lieux ne sont pas rattachés
+                </div>
+              )}
+            {hasLinkedVenuesWithPaidOffer && (
               <>
                 <div className={styles['linked-venues']}>
                   {bankAccount.linkedVenues.map((venue) => (
@@ -133,22 +133,23 @@ const ReimbursementBankAccount = ({
                 </Button>
               </>
             )}
-            {!hasLinkedVenues && venuesNotLinkedLength > 0 && (
-              <Button
-                onClick={() => {
-                  logEvent?.(
-                    BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
-                    {
-                      from: location.pathname,
-                      offererId,
-                    }
-                  )
-                  onUpdateButtonClick?.(bankAccount.id)
-                }}
-              >
-                Rattacher un lieu
-              </Button>
-            )}
+            {!hasLinkedVenuesWithPaidOffer &&
+              venuesNotLinkedToBankAccount > 0 && (
+                <Button
+                  onClick={() => {
+                    logEvent?.(
+                      BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
+                      {
+                        from: location.pathname,
+                        offererId,
+                      }
+                    )
+                    onUpdateButtonClick?.(bankAccount.id)
+                  }}
+                >
+                  Rattacher un lieu
+                </Button>
+              )}
           </div>
         </div>
       )}

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -179,13 +179,6 @@ const BankInformations = (): JSX.Element => {
             {selectedOffererBankAccounts?.bankAccounts.map((bankAccount) => (
               <ReimbursementBankAccount
                 bankAccount={bankAccount}
-                venuesNotLinkedLength={
-                  selectedOfferer?.venuesWithNonFreeOffersWithoutBankAccounts
-                    .length ?? 0
-                }
-                bankAccountsNumber={
-                  selectedOffererBankAccounts?.bankAccounts.length
-                }
                 offererId={selectedOfferer?.id}
                 key={bankAccount.id}
                 onUpdateButtonClick={(bankAccountId) => {
@@ -195,6 +188,7 @@ const BankInformations = (): JSX.Element => {
                     ) ?? null
                   )
                 }}
+                managedVenues={selectedOffererBankAccounts.managedVenues}
               />
             ))}
           </div>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26313

- Si aucun lieu (physique - avec ou sans offre - ou numérique - avec offre) n’est rattaché au compte bancaire en question → affichage de la phrase “Aucun lieu n’est rattaché à ce compte bancaire.”

 - Si 1 ou plusieurs lieux (physique - avec ou sans offre - ou numérique - avec offre) n’est pas rattaché au compte bancaire en question → affichage de la phrase “Certains de vos lieux ne sont pas rattachés”

- Si tous les lieux (physique - avec ou sans offre - ou numérique - avec offre) de la structure sont déjà rattachés à un ou plusieurs comptes bancaires, autres que le compte bancaire en question → affichage de la phrase “Aucun lieu n’est rattaché à ce compte bancaire. Désélectionnez un lieu déjà rattaché et ajoutez-le à ce compte bancaire.”

- Si tous les lieux d’une structure sont rattachés au compte bancaire en question → affichage des lieux rattachés, pas de wording

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques