### PR TITLE
(PC-26450)[PRO] fix: playlist domains on redirect data not filtered

### DIFF
--- a/pro/src/pages/AdageIframe/app/App.tsx
+++ b/pro/src/pages/AdageIframe/app/App.tsx
@@ -28,6 +28,7 @@ export const App = (): JSX.Element => {
   const [venueFilter, setVenueFilter] = useState<VenueResponse | null>(null)
 
   const notification = useNotification()
+  const domainId = Number(params.get('domain'))
 
   useEffect(() => {
     const siret = params.get('siret')
@@ -97,7 +98,11 @@ export const App = (): JSX.Element => {
   return (
     <AdageUserContextProvider adageUser={user}>
       <FiltersContextProvider venueFilter={venueFilter}>
-        <FacetFiltersContextProvider uai={user?.uai} venueFilter={venueFilter}>
+        <FacetFiltersContextProvider
+          uai={user?.uai}
+          venueFilter={venueFilter}
+          domainFilter={domainId}
+        >
           {user?.role &&
           [AdageFrontRoles.READONLY, AdageFrontRoles.REDACTOR].includes(
             user.role

--- a/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInfos/OffersInfos.tsx
@@ -13,7 +13,6 @@ export const OffersInfos = () => {
     state: { offer: offer },
   } = useLocation()
 
-  console.log('ici', useLocation())
   const [searchParams] = useSearchParams()
   const adageAuthToken = searchParams.get('token')
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -94,8 +94,8 @@ export const OffersSearch = ({
         const domainFromPath = result.find((elm) => elm.id === domainId)
 
         if (domainFromPath) {
-          await formik.setFieldValue('domains', [domainFromPath.id])
-          formik.handleSubmit()
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          formik.setFieldValue('domains', [domainFromPath.id])
         }
 
         return setDomainsOptions(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26450

Lorsqu’on clique sur un domaine artistique dans la page découverte, on est bien redirigé avec le bon tag, mais la recherche ne correspond pas au tag choisi, on veut avoir directement les bons résultats sans cliquer sur rechercher après la redirection
