### PR TITLE
(BSR)[API] build: run index_offers_staging in rebuild_staging

### DIFF
--- a/api/rebuild_staging.sh
+++ b/api/rebuild_staging.sh
@@ -14,3 +14,4 @@ flask sandbox --name beneficiaries --clean false
 flask add_permissions_to_staging_specific_roles
 
 flask disable_external_bookings
+flask index_offers_staging


### PR DESCRIPTION
This command is designed to find and reindex a variety of offers to always have relevant stuff in staging research

Testé en staging. Malheureusement c'est long (30 min)
En revanche ça répond à un besoin PM et QA important. 

Proposition si c'est trop long: retirer la réindexation qui est faite actuellement (dans le script rebuild du repo infra) et la remplacer par celle-ci, qui est plus complète


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques