### PR TITLE
(PC-26314)[PRO] refactor: no bank information if no venue

### DIFF
--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -86,7 +86,7 @@ const ReimbursementBankAccount = ({
         <div className={styles['linked-venues-section']}>
           <div className={styles['linked-venues-section-title']}>
             Lieu(x) rattaché(s) à ce compte bancaire
-            {hasWarning && (
+            {hasWarning && managedVenues.length > 0 && (
               <SvgIcon
                 src={fullErrorIcon}
                 alt="Une action est requise"
@@ -95,62 +95,64 @@ const ReimbursementBankAccount = ({
               />
             )}
           </div>
-          <div className={styles['linked-venues-content']}>
-            {!hasLinkedVenues && (
-              <div className={styles['issue-text']}>
-                Aucun lieu n’est rattaché à ce compte bancaire.
-                {venuesNotLinkedToBankAccount === 0 &&
-                  ' Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire.'}
-              </div>
-            )}
-            {hasLinkedVenues && venuesNotLinkedToBankAccount > 0 && (
-              <div className={styles['issue-text']}>
-                Certains de vos lieux ne sont pas rattachés
-              </div>
-            )}
-            {hasLinkedVenues && (
-              <>
-                <div className={styles['linked-venues']}>
-                  {bankAccount.linkedVenues.map((venue) => (
-                    <div className={styles['linked-venue']} key={venue.id}>
-                      {venue.commonName}
-                    </div>
-                  ))}
+          {managedVenues.length > 0 && (
+            <div className={styles['linked-venues-content']}>
+              {!hasLinkedVenues && (
+                <div className={styles['issue-text']}>
+                  Aucun lieu n’est rattaché à ce compte bancaire.
+                  {venuesNotLinkedToBankAccount === 0 &&
+                    ' Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire.'}
                 </div>
+              )}
+              {hasLinkedVenues && venuesNotLinkedToBankAccount > 0 && (
+                <div className={styles['issue-text']}>
+                  Certains de vos lieux ne sont pas rattachés.
+                </div>
+              )}
+              {hasLinkedVenues && (
+                <>
+                  <div className={styles['linked-venues']}>
+                    {bankAccount.linkedVenues.map((venue) => (
+                      <div className={styles['linked-venue']} key={venue.id}>
+                        {venue.commonName}
+                      </div>
+                    ))}
+                  </div>
+                  <Button
+                    variant={ButtonVariant.SECONDARY}
+                    onClick={() => {
+                      onUpdateButtonClick?.(bankAccount.id)
+                      logEvent?.(
+                        BankAccountEvents.CLICKED_CHANGE_VENUE_TO_BANK_ACCOUNT,
+                        {
+                          from: location.pathname,
+                          offererId,
+                        }
+                      )
+                    }}
+                  >
+                    Modifier
+                  </Button>
+                </>
+              )}
+              {!hasLinkedVenues && venuesNotLinkedToBankAccount > 0 && (
                 <Button
-                  variant={ButtonVariant.SECONDARY}
                   onClick={() => {
-                    onUpdateButtonClick?.(bankAccount.id)
                     logEvent?.(
-                      BankAccountEvents.CLICKED_CHANGE_VENUE_TO_BANK_ACCOUNT,
+                      BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
                       {
                         from: location.pathname,
                         offererId,
                       }
                     )
+                    onUpdateButtonClick?.(bankAccount.id)
                   }}
                 >
-                  Modifier
+                  Rattacher un lieu
                 </Button>
-              </>
-            )}
-            {!hasLinkedVenues && venuesNotLinkedToBankAccount > 0 && (
-              <Button
-                onClick={() => {
-                  logEvent?.(
-                    BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
-                    {
-                      from: location.pathname,
-                      offererId,
-                    }
-                  )
-                  onUpdateButtonClick?.(bankAccount.id)
-                }}
-              >
-                Rattacher un lieu
-              </Button>
-            )}
-          </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
+++ b/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
@@ -140,7 +140,7 @@ describe('ReimbursementBankAccount', () => {
 
   it('should render without venues linked to bank account and with all venues linked to another account', () => {
     bankAccount.linkedVenues = []
-    renderReimbursementBankAccount(bankAccount, [], 2)
+    renderReimbursementBankAccount(bankAccount, managedVenues, 2)
 
     expect(
       screen.getByText(
@@ -168,7 +168,7 @@ describe('ReimbursementBankAccount', () => {
     ).not.toBeInTheDocument()
 
     expect(
-      screen.getByText('Certains de vos lieux ne sont pas rattachés')
+      screen.getByText('Certains de vos lieux ne sont pas rattachés.')
     ).toBeInTheDocument()
     expect(screen.getByText('Le Petit Rintintin')).toBeInTheDocument()
 
@@ -185,7 +185,7 @@ describe('ReimbursementBankAccount', () => {
     renderReimbursementBankAccount(bankAccount, managedVenues)
 
     expect(
-      screen.getByText('Certains de vos lieux ne sont pas rattachés')
+      screen.getByText('Certains de vos lieux ne sont pas rattachés.')
     ).toBeInTheDocument()
   })
 
@@ -222,11 +222,7 @@ describe('ReimbursementBankAccount', () => {
     ).not.toBeInTheDocument()
 
     expect(
-      screen.queryByText('Un de vos lieux n’est pas rattaché.')
-    ).not.toBeInTheDocument()
-
-    expect(
-      screen.queryByText('Certains de vos lieux ne sont pas rattachés')
+      screen.queryByText('Certains de vos lieux ne sont pas rattachés.')
     ).not.toBeInTheDocument()
   })
 
@@ -305,5 +301,36 @@ describe('ReimbursementBankAccount', () => {
       screen.getByRole('button', { name: 'Rattacher un lieu' })
     )
     expect(mockUpdateButtonClick).toHaveBeenCalled()
+  })
+
+  it('should not display bank any wording or button under bank account card if offerer has no venue', () => {
+    bankAccount.linkedVenues = []
+    renderReimbursementBankAccount(bankAccount, [])
+
+    expect(
+      screen.getByText('Lieu(x) rattaché(s) à ce compte bancaire')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: 'Rattacher un lieu' })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('img', { name: 'Une action est requise' })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText('Aucun lieu n’est rattaché à ce compte bancaire.')
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText(
+        'Aucun lieu n’est rattaché à ce compte bancaire. Désélectionnez un lieu déjà rattaché et rattachez-le à ce compte bancaire.'
+      )
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText('Certains de vos lieux ne sont pas rattachés.')
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26314

edge case:
Lorsque la structure n'a pas de lieu, et que l'utilisateur a créé un compte bancaire, ne pas afficher de message ou de bouton de rattachement d'un lieu.

Censé rendre ça:
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/97b960ba-9cb2-466d-b0c4-ad6c038b9e90)

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques