### PR TITLE
(PC-23795)[BO] fix: permit to use coma in edit stock  price

### DIFF
--- a/api/src/pcapi/routes/backoffice/offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offers/forms.py
@@ -396,8 +396,12 @@ class EditOfferVenueForm(FlaskForm):
 
 
 class EditStockForm(FlaskForm):
+    class Meta:
+        locales = ["fr_FR", "fr"]
+
     price = fields.PCDecimalField(
         "Prix",
+        use_locale=True,
         validators=[
             wtforms.validators.NumberRange(min=0, max=300, message="Le prix doit être positif et inférieur à 300 €.")
         ],


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23795

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques