### PR TITLE
(BSR)[PRO] ci: Remove unused export of `ENVIRONMENT_NAME` environment variable

### DIFF
--- a/.github/workflows/deploy-pro-pr-version-generic.yml
+++ b/.github/workflows/deploy-pro-pr-version-generic.yml
@@ -68,10 +68,7 @@ jobs:
           restore-keys: |
             v1-yarn-pro-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --immutable
-      - run: |
-          set -a; 
-          source ../config/run_envs/${{ inputs.ENV }};
-          yarn build:${{ inputs.ENV }};
+      - run: yarn build:${{ inputs.ENV }}
         env:
           # By default NodeJS processes are limited to 512MB of memory
           # This is not enough for the build process when compiling sourcemaps

--- a/config/run_envs/integration
+++ b/config/run_envs/integration
@@ -1,1 +1,0 @@
-ENVIRONMENT_NAME="integration"

--- a/config/run_envs/production
+++ b/config/run_envs/production
@@ -1,1 +1,0 @@
-ENVIRONMENT_NAME="production"

--- a/config/run_envs/staging
+++ b/config/run_envs/staging
@@ -1,1 +1,0 @@
-ENVIRONMENT_NAME="staging"


### PR DESCRIPTION
It's not used anymore.

---

J'ai du mal à voir quand on a arrêté d'utiliser cette variable... En
tout cas, je ne trouve pas où elle est utilisée actuellement.