### PR TITLE
(PC-26456)[API] fix : public individual API get_event(s) routes

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -772,11 +772,10 @@ class BatchProductOfferResponse(serialization.ConfiguredBaseModel):
 def _serialize_has_ticket(
     offer: offers_models.Offer,
 ) -> bool:
-    if offer.withdrawalType is None or offer.withdrawalType == offers_models.WithdrawalTypeEnum.NO_TICKET:
-        return False
+    # hasTicket is True only if the bookings are linked to an externalBooking
+    # This is the case for offers with withdrawalType IN_APP.
     if offer.withdrawalType == offers_models.WithdrawalTypeEnum.IN_APP:
         return True
-    logger.error("Unknown withdrawal type %s for offer %s", offer.withdrawalType, offer.id)
     return False
 
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -262,6 +262,14 @@ def serialize_extra_data(offer: offers_models.Offer) -> CategoryRelatedFields:
 
     # Convert musicSubType (resp showSubType) code to musicType slug (resp showType slug)
     music_sub_type = serialized_data.pop(subcategories.ExtraDataFieldEnum.MUSIC_SUB_TYPE.value, None)
+
+    # fixme (mageoffray, 2023-12-14): some historical offers have no musicSubType and only musicType.
+    # We should migrate our musicType|musicSubType to titelive music types. This migration will include
+    # offers without musicSubType
+    music_type = serialized_data.pop(subcategories.ExtraDataFieldEnum.MUSIC_TYPE.value, None)
+    if music_type and not music_sub_type:
+        music_sub_type = "-1"  # Use 'Other' when not filled
+
     show_sub_type = serialized_data.pop(subcategories.ExtraDataFieldEnum.SHOW_SUB_TYPE.value, None)
     if music_sub_type:
         serialized_data["musicType"] = MusicTypeEnum(music_types.MUSIC_SUB_TYPES_BY_CODE[int(music_sub_type)].slug)
@@ -288,7 +296,6 @@ def deserialize_extra_data(
             extra_data["showType"] = str(show_types.SHOW_TYPES_BY_SLUG[field_value].code)
         else:
             extra_data[field_name] = field_value
-
     return extra_data
 
 

--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -106,6 +106,20 @@ class GetEventTest:
             "category": "CONCERT",
         }
 
+    def test_get_event_without_ticket(self, client):
+        venue, _ = utils.create_offerer_provider_linked_to_venue()
+        event_offer = offers_factories.EventOfferFactory(
+            subcategoryId=subcategories.CONCERT.id,
+            venue=venue,
+            withdrawalType=offers_models.WithdrawalTypeEnum.ON_SITE,
+        )
+
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            f"/public/offers/v1/events/{event_offer.id}"
+        )
+        assert response.status_code == 200
+        assert response.json["hasTicket"] is False
+
     def test_get_music_offer_without_music_type(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         event_offer = offers_factories.EventOfferFactory(

--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -86,23 +86,24 @@ class GetEventTest:
         assert response.status_code == 200
         assert response.json["categoryRelatedFields"] == {"category": "DECOUVERTE_METIERS", "speaker": None}
 
-    def test_get_show_offer_without_show_type(self, client):
+    def test_get_event_without_music_type(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         event_offer = offers_factories.EventOfferFactory(
-            subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
+            subcategoryId=subcategories.CONCERT.id,
             venue=venue,
+            extraData={"musicType": "800"},
         )
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
             f"/public/offers/v1/events/{event_offer.id}"
         )
         assert response.status_code == 200
+        print(response.json["categoryRelatedFields"])
         assert response.json["categoryRelatedFields"] == {
             "author": None,
-            "category": "SPECTACLE_REPRESENTATION",
+            "musicType": "OTHER",
             "performer": None,
-            "showType": None,
-            "stageDirector": None,
+            "category": "CONCERT",
         }
 
     def test_get_music_offer_without_music_type(self, client):

--- a/api/tests/routes/public/individual_offers/v1/get_events_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_events_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pcapi.core import testing
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 
@@ -9,11 +10,9 @@ from . import utils
 
 @pytest.mark.usefixtures("db_session")
 class GetEventsTest:
-    ENDPOINT_URL = "http://localhost/public/offers/v1/events"
-
     def test_get_first_page(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
-        offers = offers_factories.EventOfferFactory.create_batch(12, venue=venue)
+        offers = offers_factories.EventOfferFactory.create_batch(6, venue=venue)
         offers_factories.ThingOfferFactory.create_batch(3, venue=venue)  # not returned
 
         with testing.assert_no_duplicated_queries():
@@ -23,6 +22,18 @@ class GetEventsTest:
 
         assert response.status_code == 200
         assert [event["id"] for event in response.json["events"]] == [offer.id for offer in offers[0:5]]
+
+    def test_get_offers_without_music_sub_type(self, client):
+        venue, _ = utils.create_offerer_provider_linked_to_venue()
+        offers_factories.EventOfferFactory(
+            venue=venue, subcategoryId=subcategories.CONCERT.id, extraData={"musicType": "800"}
+        )
+
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            f"/public/offers/v1/events?limit=5&venueId={venue.id}"
+        )
+
+        assert response.status_code == 200
 
     def test_404_when_venue_id_not_tied_to_api_key(self, client):
         utils.create_offerer_provider_linked_to_venue()


### PR DESCRIPTION
Some data were missing from offers (musicSubType), fallback to 'OTHER' in this case. 
We also had a bug for offers not created from this API, withdrawalType is either None or IN_APP for offers created from apis.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26456
