### PR TITLE
(PC-26226)[PRO] feat: If no coordinates, get the municipality centroid.

### DIFF
--- a/pro/src/components/VenueForm/Informations/__specs__/Informations.spec.tsx
+++ b/pro/src/components/VenueForm/Informations/__specs__/Informations.spec.tsx
@@ -30,7 +30,7 @@ vi.mock('apiClient/adresse', async () => {
   return {
     ...((await vi.importActual('apiClient/adresse')) ?? {}),
     default: {
-      getDataFromAddress: vi.fn(),
+      getDataFromAddressParts: vi.fn(),
     },
   }
 })
@@ -106,7 +106,9 @@ describe('components | Informations', () => {
       ape_code: '95.07A',
       legal_category_code: '1000',
     })
-    vi.spyOn(apiAdresse, 'getDataFromAddress').mockResolvedValue(mockAdressData)
+    vi.spyOn(apiAdresse, 'getDataFromAddressParts').mockResolvedValue(
+      mockAdressData
+    )
 
     const { buttonSubmit } = renderInformations({
       initialValues,

--- a/pro/src/core/Venue/adapters/getSiretDataAdapter.ts
+++ b/pro/src/core/Venue/adapters/getSiretDataAdapter.ts
@@ -65,8 +65,12 @@ const getSiretDataAdapter: GetSiretDataAdapter = async (humanSiret: string) => {
       }
     }
     const { street, city, postalCode } = response.address
-    const address = `${street} ${city} ${postalCode}`
-    const addressData = await apiAdresse.getDataFromAddress(address, 1)
+    const addressData = await apiAdresse.getDataFromAddressParts(
+      street,
+      city,
+      postalCode,
+      1
+    )
     /* istanbul ignore next: DEBT, TO FIX */
     if (addressData.length == 0) {
       return {

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -29,7 +29,7 @@ vi.spyOn(sirenApiValidate, 'default').mockResolvedValue(undefined)
 // Appel fait dans apiAdresse.getDataFromAddress
 vi.mock('apiClient/adresse', () => ({
   apiAdresse: {
-    getDataFromAddress: () =>
+    getDataFromAddressParts: () =>
       Promise.resolve([
         {
           address: 'name',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26226

-  si la géolocalisation de l’adresse du SIRET n’est pas trouvée via API Adresse, on refait une requête pour récupérer le géocodage du centroïde de la commune aka les coordonnées du centre de la commune, et on crée le Venue avec ces informations

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques