### PR TITLE
(PC-26109)[PRO] feat: Make the venue playlist have a variable name ba…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useState } from 'react'
 
-import { LocalOfferersPlaylistOffer } from 'apiClient/adage'
+import {
+  InstitutionRuralLevel,
+  LocalOfferersPlaylistOffer,
+} from 'apiClient/adage'
 import { AdagePlaylistType } from 'apiClient/adage/models/AdagePlaylistType'
 import { apiAdage } from 'apiClient/api'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared/constants'
 import useNotification from 'hooks/useNotification'
+import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 
 import { TrackerElementArg } from '../AdageDiscovery'
 import styles from '../AdageDiscovery.module.scss'
@@ -21,12 +25,28 @@ type VenuePlaylistProps = {
   }: TrackerElementArg) => void
 }
 
+const institutionRuralLevelToPlaylistTitle: {
+  [key in InstitutionRuralLevel]: string
+} = {
+  'urbain dense': 'À moins 30 minutes à pieds de mon établissement',
+  'urbain densité intermédiaire':
+    'À moins de 30 minutes en transport de mon établissement',
+  "rural sous forte influence d'un pôle":
+    'À environ de 30 minutes de transport de mon établissement',
+  'rural autonome peu dense': 'À environs 1h de transport de mon établissement',
+  "rural sous faible influence d'un pôle":
+    'À environs 1h de transport de mon établissement',
+  'rural autonome très peu dense':
+    'À environs 1h de transport de mon établissement',
+}
+
 export const VenuePlaylist = ({
   onWholePlaylistSeen,
   trackPlaylistElementClicked,
 }: VenuePlaylistProps) => {
   const [venues, setVenues] = useState<LocalOfferersPlaylistOffer[]>([])
   const notify = useNotification()
+  const { adageUser } = useAdageUser()
 
   useEffect(() => {
     const getClassroomPlaylistOffer = async () => {
@@ -47,7 +67,11 @@ export const VenuePlaylist = ({
     <Carousel
       title={
         <h2 className={styles['section-title']}>
-          À moins de 30 minutes à pied de votre établissement
+          {adageUser.institutionRuralLevel
+            ? institutionRuralLevelToPlaylistTitle[
+                adageUser.institutionRuralLevel
+              ]
+            : 'À moins 30 minutes à pieds de mon établissement'}
         </h2>
       }
       onLastCarouselElementVisible={() =>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/__specs__/VenuePlaylist.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/__specs__/VenuePlaylist.spec.tsx
@@ -5,6 +5,7 @@ import { userEvent } from '@testing-library/user-event'
 import {
   AdageFrontRoles,
   AuthenticatedResponse,
+  InstitutionRuralLevel,
   LocalOfferersPlaylistOffer,
 } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
@@ -77,9 +78,7 @@ describe('AdageDiscover classRoomPlaylist', () => {
     renderNewOfferPlaylist(user)
 
     expect(
-      await screen.findByText(
-        'À moins de 30 minutes à pied de votre établissement'
-      )
+      await screen.findByText('À moins 30 minutes à pieds de mon établissement')
     ).toBeInTheDocument()
   })
 
@@ -105,4 +104,26 @@ describe('AdageDiscover classRoomPlaylist', () => {
 
     expect(mockTrackPlaylistElementClicked).toHaveBeenCalledTimes(1)
   })
+
+  it.each([
+    {
+      level: InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE,
+      title: 'À environs 1h de transport de mon établissement',
+    },
+    {
+      level: InstitutionRuralLevel.URBAIN_DENSIT_INTERM_DIAIRE,
+      title: 'À moins de 30 minutes en transport de mon établissement',
+    },
+    { level: null, title: 'À moins 30 minutes à pieds de mon établissement' },
+  ])(
+    'should display the playlist title based on the institution rural level',
+    async (ruralLevelParam) => {
+      renderNewOfferPlaylist({
+        ...user,
+        institutionRuralLevel: ruralLevelParam.level,
+      })
+
+      expect(await screen.findByText(ruralLevelParam.title)).toBeInTheDocument()
+    }
+  )
 })


### PR DESCRIPTION
…sed on the rural level of the institution in adage discovery.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26109

**FF à activer**
- WIP_ENABLE_DISCOVERY

**Objectif**
Avoir le titre de la dernière playlist (celle de la venue) qui change en fonction du niveau de ruralité de l'institution de l'utilisateur. L'indice est récupéré dans l'objet de l'utilisateur adage.

**A noter**
J'ai l'impression qu'en testing tous les comptes adage sont dans les zones urbaines denses.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques