### PR TITLE
(PC-26246)[API] feat: change quantity when updating existing stock

### DIFF
--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -45,7 +45,7 @@ def _stock_exists(
             )
             and stock.priceCategoryId == stock_to_create.price_category_id
             and (stock.price == stock_to_create.price if not stock.priceCategoryId else True)
-            and stock.quantity == stock_to_create.quantity
+            and (stock.quantity == stock_to_create.quantity if not stock.priceCategoryId else True)
         ):
             return True
     return False
@@ -62,7 +62,6 @@ def _get_existing_stocks_by_fields(
             offers_models.Stock.beginningDatetime == stock.beginning_datetime,
             offers_models.Stock.bookingLimitDatetime == stock.booking_limit_datetime,
             offers_models.Stock.priceCategoryId == stock.price_category_id,
-            offers_models.Stock.quantity == stock.quantity,
         )
         for stock in stock_payload
     ]


### PR DESCRIPTION
Quand on update/edit un stock, si le stock existe déjà dans l'offre mais qu'on a une quantité différente, on ajoute cette quantité plutôt que de ne rien faire.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26246
## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques