### PR TITLE
(PC-26266)[PRO] adage offer responsive

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.module.scss
@@ -30,6 +30,7 @@
     padding: 0;
     border-radius: rem.torem(8px) rem.torem(8px) 0 0;
     box-shadow: 0 rem.torem(2px) rem.torem(4px) 0 rgb(0 0 0 / 25%);
+    overflow-x: auto;
 
     &-brand {
       width: rem.torem(120px);

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.module.scss
@@ -1,5 +1,12 @@
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_size.scss" as size;
 
 .app-layout-content {
-  padding: 0 rem.torem(24px);
+  padding: 0 rem.torem(8px);
+}
+
+@media (min-width: size.$tablet) {
+  .app-layout-content {
+    padding: 0 rem.torem(24px);
+  }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.module.scss
@@ -1,6 +1,7 @@
 @use "styles/variables/_colors.scss" as colors;
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/variables/_size.scss" as size;
 
 $offer-image-height: rem.torem(264px);
 $offer-image-width: rem.torem(176px);
@@ -15,6 +16,9 @@ $offer-image-width: rem.torem(176px);
 
   &-container {
     display: flex;
+    flex-wrap: wrap;
+    padding: rem.torem(16px);
+    gap: rem.torem(16px);
   }
 
   &-geoloc {
@@ -44,7 +48,6 @@ $offer-image-width: rem.torem(176px);
   &-image-container {
     border-radius: rem.torem(3px);
     object-fit: cover;
-    margin: rem.torem(16px);
   }
 
   &-image {
@@ -89,6 +92,7 @@ $offer-image-width: rem.torem(176px);
 
     &-row {
       display: flex;
+      flex-wrap: wrap;
       justify-content: space-between;
       gap: rem.torem(12px);
       align-items: flex-start;
@@ -170,5 +174,17 @@ $offer-image-width: rem.torem(176px);
         transform: rotate(180deg);
       }
     }
+  }
+}
+
+@media (min-width: size.$tablet) {
+  .offer-container {
+    flex-wrap: unset;
+  }
+}
+
+@media (min-width: size.$mobile) {
+  .offer-header-row {
+    flex-wrap: unset;
   }
 }

--- a/pro/src/styles/variables/_size.scss
+++ b/pro/src/styles/variables/_size.scss
@@ -2,9 +2,9 @@
 @use "styles/variables/_forms.scss" as forms;
 @use "styles/mixins/_fonts.scss" as fonts;
 
-$desktop: 1440px;
-$tablet: 744px;
-$mobile: 380px;
+$desktop: rem.torem(1440px);
+$tablet: rem.torem(744px);
+$mobile: rem.torem(380px);
 $main-content-width: rem.torem(874px);
 $main-content-padding: rem.torem(24px);
 $checkbox-size: rem.torem(20px);


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26266

**Objectif**
Faire le minimum vital pour que les offres de la recherche adage ne sortent pas de l'écran sur les plus petites tailles. Et ajout d'un scroll dans le header pour contenir la largeur de l'écran quelle que soit la taille de l'appareil.

**A noter**
J'ai mis les breakpoints des `size` en rem dans le premier commit.


<img width="385" alt="Capture d’écran 2023-12-18 à 11 30 31" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/f9a6c4c0-4a1f-4834-b8a0-310929e068ab">
<img width="408" alt="Capture d’écran 2023-12-18 à 11 30 53" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/3130d5d5-d3f5-40f4-809a-b5d36f487432">

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques