### PR TITLE
(BSR)[API] fix: Remove unwanted user id int-to-str conversion in `amplitude_tasks.track_event()`

### DIFF
--- a/api/src/pcapi/tasks/amplitude_tasks.py
+++ b/api/src/pcapi/tasks/amplitude_tasks.py
@@ -24,7 +24,7 @@ def track_event(
     event_properties = payload.event_properties
 
     backend().track_event(
-        user_id=str(user_id),
+        user_id=user_id,
         event_name=event_name,
         event_properties=event_properties,
     )

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -368,7 +368,7 @@ class BookOfferTest:
                 "price": 10.00,
                 "subcategory": "SUPPORT_PHYSIQUE_FILM",
             },
-            "user_id": str(beneficiary.id),
+            "user_id": beneficiary.id,
         }
 
     class WhenBookingWithActivationCodeTest:
@@ -1135,7 +1135,7 @@ class CancelByBeneficiaryTest:
                 "reason": BookingCancellationReasons.BENEFICIARY.value,
                 "subcategory": "SUPPORT_PHYSIQUE_FILM",
             },
-            "user_id": str(booking.userId),
+            "user_id": booking.userId,
         }
 
 
@@ -1352,7 +1352,7 @@ class MarkAsUsedTest:
                 "price": 10.10,
                 "subcategory": "SUPPORT_PHYSIQUE_FILM",
             },
-            "user_id": str(booking.userId),
+            "user_id": booking.userId,
         }
 
 

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -1258,5 +1258,5 @@ class ActivateUserTest:
             "event_properties": {
                 "from": fraud_check_type,
             },
-            "user_id": str(user.id),
+            "user_id": user.id,
         }

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -526,7 +526,7 @@ class EduconnectTest:
 
         client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
-        assert amplitude_testing.requests[0]["user_id"] == str(user.id)
+        assert amplitude_testing.requests[0]["user_id"] == user.id
         assert amplitude_testing.requests[0]["event_name"] == AmplitudeEventType.EDUCONNECT_ERROR.value
 
         assert (


### PR DESCRIPTION
All backends expect the user id to be an integer, which is what we get
from `payload.user_id`. So we should not convert it to a string here.
Only the real backend (that talks to Amplitude HTTP API) needs the
user id to a string, and it already converts it.

This did not cause any bug.