### PR TITLE
(PC-25692)[API] feat: backoffice allow searching ids or name of venue to filter venue in the action page

### DIFF
--- a/api/src/pcapi/routes/backoffice/venues/forms.py
+++ b/api/src/pcapi/routes/backoffice/venues/forms.py
@@ -118,6 +118,7 @@ class GetVenuesListForm(utils.PCForm):
     class Meta:
         csrf = False
 
+    q = fields.PCOptSearchField("ID ou liste d'ID de lieu, nom du lieu")
     type = fields.PCSelectMultipleField("Type de lieu", choices=utils.choices_from_enum(offerers_models.VenueTypeCode))
     venue_label = fields.PCQuerySelectMultipleField(
         "Label",
@@ -151,6 +152,7 @@ class GetVenuesListForm(utils.PCForm):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
+        self._fields.move_to_end("q", last=False)
         if self.is_empty():
             # default value checked does not work in wtforms.BooleanField
             self.only_validated_offerers.data = True
@@ -158,6 +160,7 @@ class GetVenuesListForm(utils.PCForm):
     def is_empty(self) -> bool:
         return not any(
             (
+                self.q.data,
                 self.type.data,
                 self.venue_label.data,
                 self.criteria.data,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25692

test en local : 
AVEC id : 
<img width="362" alt="Capture d’écran 2023-12-19 à 13 55 04" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/7380f56c-cbaf-4f92-9dc6-881dafcdebda">

AVEC ids:
<img width="313" alt="Capture d’écran 2023-12-19 à 13 55 32" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/f7344830-de61-42d8-ab4b-0a2de1fbffc1">

avec nom:
<img width="363" alt="Capture d’écran 2023-12-19 à 13 56 09" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/9e4ed078-4f9d-4842-a9ac-efa651fcdcff">
