### PR TITLE
(PC-26500)[API] perf: search offer by ean if a string with 13 digit is provided

### DIFF
--- a/api/src/pcapi/routes/backoffice/multiple_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/multiple_offers/forms.py
@@ -1,7 +1,7 @@
 from flask_wtf import FlaskForm
 import wtforms
 
-from pcapi.routes.backoffice import utils as bo_utils
+from pcapi.utils import string as string_utils
 
 from ..forms import fields
 
@@ -13,9 +13,9 @@ class SearchEanForm(FlaskForm):
     ean = fields.PCSearchField("EAN-13")
 
     def validate_ean(self, ean: fields.PCSearchField) -> fields.PCSearchField:
-        if ean.data and not bo_utils.is_ean_valid(ean.data):
+        if ean.data and not string_utils.is_ean_valid(ean.data):
             raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un EAN-13")
-        ean.data = bo_utils.format_ean_or_visa(ean.data)
+        ean.data = string_utils.format_ean_or_visa(ean.data)
         return ean
 
 

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -39,6 +39,7 @@ from pcapi.routes.backoffice import search_utils
 from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.utils import date as date_utils
+from pcapi.utils import string as string_utils
 from pcapi.workers import push_notification_job
 
 from . import forms
@@ -76,7 +77,7 @@ SEARCH_FIELD_TO_PYTHON = {
     "EAN": {
         "field": "string",
         "column": offers_models.Offer.extraData["ean"].astext,
-        "special": utils.format_ean_or_visa,
+        "special": string_utils.format_ean_or_visa,
     },
     "EVENT_DATE": {
         "field": "date",
@@ -138,7 +139,7 @@ SEARCH_FIELD_TO_PYTHON = {
     "VISA": {
         "field": "string",
         "column": offers_models.Offer.extraData["visa"].astext,
-        "special": utils.format_ean_or_visa,
+        "special": string_utils.format_ean_or_visa,
     },
 }
 
@@ -224,12 +225,14 @@ def _get_offer_ids_query(form: forms.InternalSearchForm) -> BaseQuery:
             search_query = form.q.data
             or_filters = []
 
-            if utils.is_ean_valid(search_query):
-                or_filters.append(offers_models.Offer.extraData["ean"].astext == utils.format_ean_or_visa(search_query))
+            if string_utils.is_ean_valid(search_query):
+                or_filters.append(
+                    offers_models.Offer.extraData["ean"].astext == string_utils.format_ean_or_visa(search_query)
+                )
 
             if utils.is_visa_valid(search_query):
                 or_filters.append(
-                    offers_models.Offer.extraData["visa"].astext == utils.format_ean_or_visa(search_query)
+                    offers_models.Offer.extraData["visa"].astext == string_utils.format_ean_or_visa(search_query)
                 )
 
             if search_query.isnumeric():

--- a/api/src/pcapi/routes/backoffice/titelive/forms.py
+++ b/api/src/pcapi/routes/backoffice/titelive/forms.py
@@ -2,7 +2,7 @@ from flask_wtf import FlaskForm
 import wtforms
 from wtforms import validators
 
-from pcapi.routes.backoffice import utils as bo_utils
+from pcapi.utils import string as string_utils
 
 from ..forms import fields
 
@@ -21,9 +21,9 @@ class SearchEanForm(FlaskForm):
 
     def validate_ean(self, ean: fields.PCSearchField) -> fields.PCSearchField:
         if ean.data:
-            if not bo_utils.is_ean_valid(ean.data):
+            if not string_utils.is_ean_valid(ean.data):
                 raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un EAN-13")
-            ean.data = bo_utils.format_ean_or_visa(ean.data)
+            ean.data = string_utils.format_ean_or_visa(ean.data)
         return ean
 
     def is_empty(self) -> bool:

--- a/api/src/pcapi/routes/backoffice/utils.py
+++ b/api/src/pcapi/routes/backoffice/utils.py
@@ -24,6 +24,7 @@ from pcapi.core.history import models as history_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
+from pcapi.utils import string as string_utils
 from pcapi.utils.regions import get_all_regions
 
 from . import blueprint
@@ -156,17 +157,8 @@ def random_hash() -> str:
     return format(random.getrandbits(128), "x")
 
 
-def format_ean_or_visa(ean: str) -> str:
-    return ean.replace("-", "").replace(" ", "")
-
-
-def is_ean_valid(ean: str) -> bool:
-    ean = format_ean_or_visa(ean)
-    return ean.isdigit() and len(ean) == 13
-
-
 def is_visa_valid(visa: str) -> bool:
-    visa = format_ean_or_visa(visa)
+    visa = string_utils.format_ean_or_visa(visa)
     return visa.isdigit() and len(visa) <= 10
 
 

--- a/api/src/pcapi/utils/string.py
+++ b/api/src/pcapi/utils/string.py
@@ -5,4 +5,13 @@ def to_camelcase(s: str) -> str:
     return re.sub(r"(?!^)_([a-zA-Z])", lambda m: m.group(1).upper(), s)
 
 
+def is_ean_valid(ean: str) -> bool:
+    ean = format_ean_or_visa(ean)
+    return ean.isdigit() and len(ean) == 13
+
+
+def format_ean_or_visa(ean: str) -> str:
+    return ean.replace("-", "").replace(" ", "")
+
+
 u_nbsp = "\u00A0"


### PR DESCRIPTION
Improve offer search by EAN
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26500

It should improve theses cases : https://sentry.passculture.team/organizations/sentry/issues/423864/events/563bcb3ff7d942ea9aa981ed396f10c7/?environment=production&project=5&statsPeriod=90d or https://sentry.passculture.team/organizations/sentry/issues/423864/events/e0924dc894464c9fbc94f09b692f2b91/?environment=production&project=5&statsPeriod=90d

In staging a 13 digits search took around 150.200s (for a cultura user). 
It is now around 3s

The full text search is improving, but might still timeout. It wen from 130s to 70s (for same user and keyword `guitare shiver` )
