### PR TITLE
(PC-26499)[API] fix: update Batch attributes even if marketing push is disabled

### DIFF
--- a/api/src/pcapi/core/external/attributes/api.py
+++ b/api/src/pcapi/core/external/attributes/api.py
@@ -41,8 +41,7 @@ def update_external_user(
     else:
         user_attributes = get_user_attributes(user)
 
-        update_batch = user.has_enabled_push_notifications()
-        if not skip_batch and update_batch:
+        if not skip_batch:
             update_batch_user(user.id, user_attributes, cultural_survey_answers=cultural_survey_answers)
 
         if not skip_sendinblue:

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -51,7 +51,6 @@ from pcapi.repository import repository
 from pcapi.repository import transaction
 from pcapi.routes.serialization.users import ImportUserFromCsvModel
 from pcapi.routes.serialization.users import ProUserCreationBodyV2Model
-from pcapi.tasks import batch_tasks
 from pcapi.utils.clean_accents import clean_accents
 import pcapi.utils.date as date_utils
 import pcapi.utils.email as email_utils
@@ -940,10 +939,6 @@ def update_notification_subscription(
     }
 
     repository.save(user)
-
-    if not subscriptions.marketing_push:
-        payload = batch_tasks.DeleteBatchUserAttributesRequest(user_id=user.id)
-        batch_tasks.delete_user_attributes_task.delay(payload)
 
 
 def reset_recredit_amount_to_show(user: models.User) -> None:

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -307,10 +307,6 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
             ).exists()
         ).scalar()
 
-    def has_enabled_push_notifications(self) -> bool:
-        subscriptions = self.get_notification_subscriptions()
-        return subscriptions.marketing_push
-
     @property
     def is_authenticated(self) -> bool:  # required by flask-login
         return True


### PR DESCRIPTION
User may receive transactional push notifications, which must use up-to-date information

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-26499

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques