### PR TITLE
(BSR)[ADAGE] feat: always return valid data for playlists in testing

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/playlists.py
@@ -68,7 +68,7 @@ def get_classroom_playlist(
     except queries_base.MalformedRow:
         return serializers.ListCollectiveOffersResponseModel(collectiveOffers=[])
 
-    if (settings.IS_TESTING or settings.IS_DEV) and not rows:
+    if (settings.IS_TESTING or settings.IS_DEV) and not settings.IS_RUNNING_TESTS:
         rows = get_random_results(educational_models.CollectiveOffer)
 
     offer_ids = typing.cast(set[int], set(rows))
@@ -153,7 +153,7 @@ def new_template_offers_playlist(
     except queries_base.MalformedRow:
         return serializers.ListCollectiveOfferTemplateResponseModel(collectiveOffers=[])
 
-    if (settings.IS_TESTING or settings.IS_DEV) and not rows:
+    if (settings.IS_TESTING or settings.IS_DEV) and not settings.IS_RUNNING_TESTS:
         rows = get_random_results(educational_models.CollectiveOfferTemplate)
 
     offer_ids = typing.cast(set[int], set(rows))
@@ -201,7 +201,7 @@ def get_local_offerers_playlist(
     except queries_base.MalformedRow:
         return playlists_serializers.LocalOfferersPlaylist(venues=[])
 
-    if (settings.IS_TESTING or settings.IS_DEV) and not rows:
+    if (settings.IS_TESTING or settings.IS_DEV) and not settings.IS_RUNNING_TESTS:
         rows = get_random_results(offerers_models.Venue)
 
     venues = offerers_api.get_venues_by_ids(set(rows))


### PR DESCRIPTION
## But de la pull request

and for devel.
Since we can't get data from BigQuery that matches the testing sandbox, we'll skip the condition about BigQuery returning empty set.

Longer reason is that BigQuery has the staging's ids and they don't match the collective offers / templates / venues found in testing. Bottom line, objects are not found and nothing is returned, but since we had ids the previous condition failed us.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques