### PR TITLE
(PC-26505)[PRO] fix: Add a min-width to the side section in the offer…

### DIFF
--- a/pro/src/components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/components/SummaryLayout/SummaryLayout.module.scss
@@ -18,6 +18,7 @@
 
   &-side {
     width: rem.torem(231px);
+    min-width: rem.torem(231px);
     margin: 0 auto;
     margin-bottom: rem.torem(32px);
   }


### PR DESCRIPTION
… summary page.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26505

**Objectif**
Dans la page de résumé d'une offre, quand la description d'une offre est suffisamment longue il faut préciser la `min-width` du container de l'image sinon sa taille se réduit.

<img width="909" alt="Capture d’écran 2023-12-18 à 16 06 38" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/72f705e7-ae7e-4c72-8bdf-c752c30cf06f">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques