### PR TITLE
(PC-26524)[ADAGE] fix: filter local offerers per density

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
+++ b/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
@@ -59,12 +59,12 @@ class LocalOfferersModel(pydantic_v1.BaseModel):
 class LocalOfferersQuery(BaseQuery):
     raw_query = f"""
         SELECT
-            venue_id,
+            distinct venue_id,
             distance_in_km
         FROM
             `{settings.BIG_QUERY_TABLE_BASENAME}.adage_home_playlist_local_offerers`
         WHERE
-            distance_in_km <= 60
+            distance_in_km <= @range
             and institution_id = @institution_id
         LIMIT
             10

--- a/api/src/pcapi/core/educational/api/institution.py
+++ b/api/src/pcapi/core/educational/api/institution.py
@@ -184,7 +184,7 @@ def create_educational_institution_from_adage(institution: AdageEducationalInsti
 
 def get_institution_rural_level(
     institution: EducationalInstitution | None,
-) -> educational_models.InstitutionRuralLevel | None:
+) -> str | None:
     if not institution:
         return None
 

--- a/api/src/pcapi/routes/adage_iframe/authentication.py
+++ b/api/src/pcapi/routes/adage_iframe/authentication.py
@@ -1,3 +1,5 @@
+import typing
+
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.educational.api import favorites as educational_api_favorite
@@ -34,7 +36,9 @@ def authenticate(authenticated_information: AuthenticatedInformation) -> Authent
         preferences = _get_preferences(redactor)
         favorites_count = _get_favorites_count(redactor)
         offer_count = get_offers_count(authenticated_information)
-        institution_rural_level = institution_api.get_institution_rural_level(institution)
+        institution_rural_level = typing.cast(
+            educational_models.InstitutionRuralLevel | None, institution_api.get_institution_rural_level(institution)
+        )
 
         return AuthenticatedResponse(
             role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,

--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -166,11 +166,15 @@ class GetLocalOfferersPlaylistTest(SharedPlaylistsErrorTests):
         iframe_client = _get_iframe_client(client)
 
         mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
-        with patch(mock_path) as mock_run_query:
+        with (
+            patch(mock_path) as mock_run_query,
+            patch("pcapi.routes.adage_iframe.playlists._get_max_range_for_local_venues") as mock_max_range,
+        ):
             mock_run_query.return_value = [
                 {"venue_id": venues[0].id, "distance_in_km": expected_distance},
                 {"venue_id": venues[1].id, "distance_in_km": expected_distance},
             ]
+            mock_max_range.return_value = 60
 
             # fetch the institution (1 query)
             # fetch venues data (1 query)


### PR DESCRIPTION
We want to filter more strongly on institution that are inside big cities where there are more offers than on country side.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-26524

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques