### PR TITLE
(BSR)[API] fix: cast list to set

### DIFF
--- a/api/src/pcapi/scripts/provider/bulk_create_venue_provider.py
+++ b/api/src/pcapi/scripts/provider/bulk_create_venue_provider.py
@@ -20,7 +20,7 @@ def create_venue_provider(provider_id: int, venue_ids: list[int]) -> None:
         .all()
     )
 
-    missing = {venue_ids} - {venue.id for venue in venues}
+    missing = set(venue_ids) - {venue.id for venue in venues}
     if missing:
         print(f"Some venues were not found: {missing}")
         return


### PR DESCRIPTION
```
>>> test = [1, 2]
>>> set(test)
{1, 2}
>>> {test}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'list'
```