### PR TITLE
(PC-26511)[PRO] fix adage search redirect with params

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
@@ -65,6 +65,9 @@ export const AdageHeaderMenu = ({
                   [styles['adage-header-link-active']]: isActive,
                 })
               }}
+              //  TODO : rework the facet filters + the formik context on the search page so that the search state can be
+              //  safely resetted based on the page url, and so that the facet filters are managed inside the router.
+              reloadDocument
               onClick={() => logAdageLinkClick(AdageHeaderLink.SEARCH)}
             >
               <SvgIcon src={strokeSearchIcon} alt="" width="20" />

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -52,7 +52,8 @@ export const OffersInstantSearch = ({
   const [venueFilterFromParam, setVenueFilterFromParam] =
     useState<VenueResponse | null>(null)
 
-  const notification = useNotification()
+  const { error } = useNotification()
+
   useEffect(() => {
     const getVenueById = async () => {
       try {
@@ -60,14 +61,15 @@ export const OffersInstantSearch = ({
         setVenueFilterFromParam(venueResponse)
         setFacetFilters([...facetFilters, [`venue.id:${venueId}`]])
       } catch {
-        notification.error('Lieu inconnu. Tous les résultats sont affichés.')
+        error('Lieu inconnu. Tous les résultats sont affichés.')
       }
     }
     if (venueId) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       getVenueById()
     }
-  }, [venueId])
+  }, [venueId, error])
+
   return (
     <InstantSearch
       indexName={ALGOLIA_COLLECTIVE_OFFERS_INDEX}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26511

**FF à activer**
WIP_ENABLE_DISCOVERY

**Objectif**
Corriger temporairement le routage de la page de la découverte adage vers la page de la recherche via le menu pour que la page se recharge et que le contexte des `facetFilters` précédent soit écrasé.

Dans l'idéal il faudrait pouvoir réinitialiser les `FacetFilters` au moment du routage sans recharger la page, mais c'est assez compliqué dans l'état actuel à cause du fait que les filtres sont géré en dehors du routage. Un chantier est planifié pour regarder ça en détail dans les prochaines semaines. Cette PR propose un correctif rapide!

**A noter**
Le premier commit contient juste du nettoyage des dépendances des useEffects.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques