### PR TITLE
(PC-24841)[BO] feat: Force debit note button

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -53,6 +53,7 @@ class ActionType(enum.Enum):
     FINANCE_INCIDENT_USER_RECREDIT = "Compte re-crédité suite à un incident"
     FINANCE_INCIDENT_WAIT_FOR_PAYMENT = "Attente de la prochaine échéance de remboursement"
     FINANCE_INCIDENT_GENERATE_DEBIT_NOTE = "Une note de débit va être générée"
+    FINANCE_INCIDENT_CHOOSE_DEBIT_NOTE = "Choix note de débit"
     # Bank accounts changes:
     LINK_VENUE_BANK_ACCOUNT_DEPRECATED = "Lieu dissocié d'un compte bancaire"
     LINK_VENUE_BANK_ACCOUNT_CREATED = "Lieu associé à un compte bancaire"

--- a/api/src/pcapi/core/mails/transactional/finance_incidents/finance_incident_notification.py
+++ b/api/src/pcapi/core/mails/transactional/finance_incidents/finance_incident_notification.py
@@ -1,0 +1,47 @@
+from pcapi.core import mails
+from pcapi.core.bookings import models as bookings_models
+from pcapi.core.finance import models as finance_models
+from pcapi.core.mails import models as mails_models
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.offers import models as offers_models
+
+
+def send_finance_incident_emails(
+    finance_incident: finance_models.FinanceIncident,
+) -> bool:
+    venue = finance_incident.venue
+
+    if not venue.current_reimbursement_point or not venue.current_reimbursement_point.bookingEmail:
+        return True
+
+    offers = set()
+    for booking_finance_incident in finance_incident.booking_finance_incidents:
+        # this email refers to a cancelled booking (which is the case in total overpayment incidents only)
+        if booking_finance_incident.is_partial:
+            continue
+
+        booking = booking_finance_incident.booking or booking_finance_incident.collectiveBooking
+        if isinstance(booking, bookings_models.Booking):
+            offer = booking.stock.offer
+        else:
+            offer = booking.collectiveStock.collectiveOffer
+
+        offers.add(offer)
+
+    for offer in offers:
+        if isinstance(offer, offers_models.Offer):
+            template = TransactionalEmail.RETRIEVE_INCIDENT_AMOUNT_ON_INDIVIDUAL_BOOKINGS
+        else:
+            template = TransactionalEmail.RETRIEVE_INCIDENT_AMOUNT_ON_COLLECTIVE_BOOKINGS
+
+        data = mails_models.TransactionalEmailData(
+            template=template.value,
+            params={"OFFER_NAME": offer.name, "VENUE_NAME": venue.common_name},
+        )
+
+        mails.send(
+            recipients=[venue.current_reimbursement_point.bookingEmail],
+            data=data,
+        )
+
+    return True

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -204,3 +204,7 @@ class TransactionalEmail(Enum):
     BANK_ACCOUNT_VALIDATED = models.TemplatePro(
         id_prod=1095, id_not_prod=149, tags=["pro_cordonnées_bancaire_validées"]
     )
+
+    # Finance incidents
+    RETRIEVE_INCIDENT_AMOUNT_ON_INDIVIDUAL_BOOKINGS = models.Template(id_prod=1111, id_not_prod=150)
+    RETRIEVE_INCIDENT_AMOUNT_ON_COLLECTIVE_BOOKINGS = models.Template(id_prod=1112, id_not_prod=151)

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -525,6 +525,8 @@ def format_modified_info_values(modified_info: typing.Any, name: str | None = No
 
 def format_modified_info_name(info_name: str) -> str:
     match info_name:
+        case "force_debit_note":
+            return "Génération d'une note de débit"
         case "comment":
             return "Commentaire"
         case "email":

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general.html
@@ -16,8 +16,8 @@
             {% endif %}
           </div>
           <div class="h5 me-1 align-middle">{{ incident.kind | format_finance_incident_type | safe }}</div>
-          {% if has_permission("MANAGE_INCIDENTS") and incident.status.value == 'created' %}
-            <div class="d-flex justify-content-end flex-grow-1 gap-2">
+          <div class="d-flex justify-content-end flex-grow-1 gap-2">
+            {% if has_permission("MANAGE_INCIDENTS") and incident.status.value == 'created' %}
               <button class="btn btn-outline-primary"
                       data-bs-toggle="modal"
                       data-bs-target="#reject-finance-incident-modal-{{ incident.id }}">Annuler l'incident</button>
@@ -26,8 +26,22 @@
                       data-bs-toggle="modal"
                       data-bs-target="#finance-incident-validation-modal-{{ incident.id }}">Valider l'incident</button>
               {{ build_lazy_modal(url_for('backoffice_web.finance_incidents.get_finance_incident_validation_form', finance_incident_id=incident.id), "finance-incident-validation-modal-" + incident.id|string) }}
-            </div>
-          {% endif %}
+            {% elif has_permission("MANAGE_INCIDENTS") and incident.status.value == 'validated' and not incident.isClosed %}
+              {% if incident.forceDebitNote %}
+                <button class="btn btn-outline-primary"
+                        data-bs-toggle="modal"
+                        data-bs-target="#finance-incident-cancel-debit-note-modal-{{ incident.id }}">
+                  Annuler la note de débit, récupérer l'argent sur les justificatifs
+                </button>
+                {{ build_lazy_modal(url_for('backoffice_web.finance_incidents.get_finance_incident_cancel_debit_note_form', finance_incident_id=incident.id), "finance-incident-cancel-debit-note-modal-" + incident.id|string) }}
+              {% else %}
+                <button class="btn btn-outline-primary"
+                        data-bs-toggle="modal"
+                        data-bs-target="#finance-incident-force-debit-note-modal-{{ incident.id }}">Demander la note de débit</button>
+                {{ build_lazy_modal(url_for('backoffice_web.finance_incidents.get_finance_incident_force_debit_note_form', finance_incident_id=incident.id), "finance-incident-force-debit-note-modal-" + incident.id|string) }}
+              {% endif %}
+            {% endif %}
+          </div>
         </div>
         <h6 class="card-subtitle text-muted">ID : {{ incident.id }}</h6>
         <div class="d-flex justify-content-start">


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24841

:warning: Le mail concerne à chaque fois une offre de l'incident, si ce dernier porte sur 3 offres alors 3 mails seront envoyés à l'acteur :warning: 
Nous avons soumis l'idée de lister ces offres dans un seul mail, Nine étudie cette possibilité
Aussi le template fait mention de l'annulation d'un événement, il ne concerne donc pour l'instant que les trop perçus totaux

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/b2cb69e3-928b-4c4f-a8a1-878e553096e1)


Ajout du bouton sur la note de débit (annulation ou activation)

Envoi de mail conditionnel

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques