### PR TITLE
(PC-26550)[PRO] feat: Replace instantsearch fetch by offerCount in he…

### DIFF
--- a/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
@@ -240,7 +240,7 @@ describe('app', () => {
       await screen.findByRole('button', { name: 'Rechercher' })
 
       expect(Configure).toHaveBeenNthCalledWith(
-        2,
+        1,
         expect.objectContaining({
           aroundLatLng: '48.856614, 2.3522219',
           aroundRadius: DEFAULT_GEO_RADIUS,

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -28,18 +28,6 @@ export const AdageHeader = () => {
 
   const isDiscoveryPage = pathname === '/adage-iframe'
 
-  const getEducationalInstitutionBudget = async () => {
-    const { isOk, payload, message } =
-      await getEducationalInstitutionWithBudgetAdapter()
-
-    if (!isOk) {
-      return notify.error(message)
-    }
-
-    setInstitutionBudget(payload.budget)
-    setIsLoading(false)
-  }
-
   function logAdageLinkClick(headerLinkName: AdageHeaderLink) {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     apiAdage.logHeaderLinkClick({
@@ -49,11 +37,23 @@ export const AdageHeader = () => {
   }
 
   useEffect(() => {
+    async function getEducationalInstitutionBudget() {
+      const { isOk, payload, message } =
+        await getEducationalInstitutionWithBudgetAdapter()
+
+      if (!isOk) {
+        return notify.error(message)
+      }
+
+      setInstitutionBudget(payload.budget)
+      setIsLoading(false)
+    }
+
     if (adageUser.role !== AdageFrontRoles.READONLY) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       getEducationalInstitutionBudget()
     }
-  }, [adageUser.role])
+  }, [adageUser.role, notify])
 
   return (
     <div
@@ -70,10 +70,7 @@ export const AdageHeader = () => {
             viewBox="0 0 71 24"
           />
         </div>
-        <AdageHeaderMenu
-          adageUser={adageUser}
-          logAdageLinkClick={logAdageLinkClick}
-        />
+        <AdageHeaderMenu logAdageLinkClick={logAdageLinkClick} />
         {!isLoading && (
           <AdageHeaderBudget
             institutionBudget={institutionBudget}

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
@@ -1,12 +1,7 @@
 import cn from 'classnames'
-import { useStats } from 'react-instantsearch'
 import { NavLink } from 'react-router-dom'
 
-import {
-  AdageFrontRoles,
-  AdageHeaderLink,
-  AuthenticatedResponse,
-} from 'apiClient/adage'
+import { AdageFrontRoles, AdageHeaderLink } from 'apiClient/adage'
 import useActiveFeature from 'hooks/useActiveFeature'
 import strokePassIcon from 'icons/stroke-pass.svg'
 import strokeSearchIcon from 'icons/stroke-search.svg'
@@ -18,26 +13,25 @@ import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import styles from './AdageHeaderMenu.module.scss'
 
 type AdageHeaderMenuProps = {
-  adageUser: AuthenticatedResponse
   logAdageLinkClick: (link: AdageHeaderLink) => void
 }
 
 export const AdageHeaderMenu = ({
-  adageUser,
   logAdageLinkClick,
 }: AdageHeaderMenuProps) => {
   const params = new URLSearchParams(location.search)
   const adageAuthToken = params.get('token')
 
-  const { favoritesCount } = useAdageUser()
-
-  const { nbHits } = useStats()
+  const {
+    favoritesCount,
+    adageUser: { role, offersCount },
+  } = useAdageUser()
 
   const isDiscoveryActive = useActiveFeature('WIP_ENABLE_DISCOVERY')
 
   return (
     <ul className={styles['adage-header-menu']}>
-      {adageUser.role !== AdageFrontRoles.READONLY && (
+      {role !== AdageFrontRoles.READONLY && (
         <>
           {isDiscoveryActive && (
             <li className={styles['adage-header-menu-item']}>
@@ -89,7 +83,9 @@ export const AdageHeaderMenu = ({
                 className={styles['adage-header-link-icon']}
               />
               Pour mon établissement
-              <div className={styles['adage-header-nb-hits']}>{nbHits}</div>
+              <div className={styles['adage-header-nb-hits']}>
+                {offersCount ?? 0}
+              </div>
             </NavLink>
           </li>
 

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -1,15 +1,7 @@
-import algoliasearch from 'algoliasearch/lite'
-import * as React from 'react'
-import { Configure, InstantSearch } from 'react-instantsearch'
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 
 import { AdageFrontRoles, VenueResponse } from 'apiClient/adage'
 import useActiveFeature from 'hooks/useActiveFeature'
-import {
-  ALGOLIA_API_KEY,
-  ALGOLIA_APP_ID,
-  ALGOLIA_COLLECTIVE_OFFERS_INDEX,
-} from 'utils/config'
 
 import useAdageUser from '../../hooks/useAdageUser'
 import { AdageDiscovery } from '../AdageDiscovery/AdageDiscovery'
@@ -36,22 +28,7 @@ export const AppLayout = ({
 
   return (
     <div>
-      <InstantSearch
-        searchClient={algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY)}
-        indexName={ALGOLIA_COLLECTIVE_OFFERS_INDEX}
-      >
-        <Configure
-          attributesToHighlight={[]}
-          attributesToRetrieve={[]}
-          clickAnalytics
-          facetFilters={[
-            `offer.educationalInstitutionUAICode:${adageUser.uai}`,
-          ]}
-          hitsPerPage={8}
-          distinct={false}
-        />
-        <AdageHeader />
-      </InstantSearch>
+      <AdageHeader />
       <main
         className={isDiscoveryPage ? '' : styles['app-layout-content']}
         id="content"

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/__specs__/AppLayout.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/__specs__/AppLayout.spec.tsx
@@ -79,7 +79,9 @@ vi.mock('pages/AdageIframe/repository/pcapi/pcapi', () => ({
 
 const renderAppLayout = (initialRoute = '/') => {
   renderWithProviders(
-    <AdageUserContextProvider adageUser={defaultAdageUser}>
+    <AdageUserContextProvider
+      adageUser={{ ...defaultAdageUser, offersCount: 1 }}
+    >
       <FiltersContextProvider>
         <AlgoliaQueryContextProvider>
           <AppLayout venueFilter={null} />


### PR DESCRIPTION
…ader institution count.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26550

**Objectif**
Jusqu'à maintenant sur adage on faisait une requete à algolia (via react-instantsearch wrappé autour du header) pour savoir combien il y a d'offres liées au l'établissement de l'utilisateur. Désormais on a directement l'info sur le user via la valuer de `offersCount`. Cette PR clean donc l'ancienne implémentation et ajoute le nouveau compteur dans le header.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques