### PR TITLE
(PC-26551)[API] fix: Add `remove_duplicates_from_venue_indexation_queue` cronjob

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -846,3 +846,8 @@ def update_product_last_30_days_bookings() -> list[offers_models.Product]:
 def clean_processing_queues() -> None:
     backend = _get_backend()
     backend.clean_processing_queues()
+
+
+def remove_duplicates_from_venue_indexation_queue() -> None:
+    backend = _get_backend()
+    backend.remove_duplicates_from_venue_indexation_queue()

--- a/api/src/pcapi/core/search/backends/base.py
+++ b/api/src/pcapi/core/search/backends/base.py
@@ -118,3 +118,6 @@ class SearchBackend:
 
     def clean_processing_queues(self) -> None:
         raise NotImplementedError()
+
+    def remove_duplicates_from_venue_indexation_queue(self) -> None:
+        raise NotImplementedError()

--- a/api/src/pcapi/core/search/commands/indexation.py
+++ b/api/src/pcapi/core/search/commands/indexation.py
@@ -267,3 +267,8 @@ def index_offers_staging(
 @blueprint.cli.command("clean_indexation_processing_queues")
 def clean_indexation_processing_queues() -> None:
     search.clean_processing_queues()
+
+
+@blueprint.cli.command("remove_duplicates_from_venue_indexation_queue")
+def remove_duplicates_from_venue_indexation_queue() -> None:
+    search.remove_duplicates_from_venue_indexation_queue()


### PR DESCRIPTION
Every night (and sometimes during the day), we have a surge of offers
that are reindexed, when stocks are synchronized by partners. Whenever
an offer must be reindexed, we request the reindexation of the
corresponding venue because it may start or stop to be eligible for
search. Since each venue usually have many offers to reindex, we
usually request the reindexation of the same venue multiple times.

Until 25d3e964f20aef819aa6c50d2c3266a0543cefd7, that was not an issue
because the venue indexation queue was stored as a Redis set. Now it's
stored as a list [*]. Thus, requesting the indexation of the same
venue multiple times fills up the queue with duplicate venue ids. And
the queue grows very, very large.

Until we find a solution (most probably by moving back from lists to
sets, see [*]), we can regularly run a command that deduplicates the
content of the queue.

[*] We switched from sets to lists because we needed a Redis command
to atomically move items from a key to another key in
`AlgoliaBackend._pop_ids_from_queue`. `smove` is what we want, but it
appeared in Redis 6.2.0 and we're still on 5.0. We had to resort to
using `rpoplpush`, which operates on lists.