### PR TITLE
(PC-26549)[API] feat: migrate banId column from String to Text

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 7049d737cb3f (pre) (head)
-562ae6d8be2f (post) (head)
+faed981725fd (post) (head)

--- a/api/src/pcapi/alembic/versions/20231219T173827_faed981725fd_change_ban_id_to_text.py
+++ b/api/src/pcapi/alembic/versions/20231219T173827_faed981725fd_change_ban_id_to_text.py
@@ -1,0 +1,23 @@
+"""
+Change banId column from String to Text
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "faed981725fd"
+down_revision = "562ae6d8be2f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("venue", "banId")
+    op.add_column("venue", sa.Column("banId", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("venue", "banId")
+    op.add_column("venue", sa.Column("banId", sa.String(20), nullable=True))

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -271,7 +271,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, Accessibility
     # banId is a unique interoperability key for French addresses registered in the
     # Base Adresse Nationale. See "cle_interop" here:
     # https://doc.adresse.data.gouv.fr/mettre-a-jour-sa-base-adresse-locale/le-format-base-adresse-locale
-    banId = Column(String(20), nullable=True)
+    banId = Column(Text(), nullable=True)
 
     timezone = Column(String(50), nullable=False, default=METROPOLE_TIMEZONE, server_default=METROPOLE_TIMEZONE)
 

--- a/api/src/pcapi/routes/serialization/base.py
+++ b/api/src/pcapi/routes/serialization/base.py
@@ -81,7 +81,7 @@ class VenueAddress(RequiredStrippedString):
 
 class VenueBanId(pydantic_v1.ConstrainedStr):
     strip_whitespace = True
-    max_length = 20
+    max_length = 50
 
 
 class VenueCity(RequiredStrippedString):

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -30,7 +30,7 @@ def create_valid_venue_data(user=None):
         "siret": f"{user_offerer.offerer.siren}10045",
         "address": "75 Rue Charles Fourier, 75013 Paris",
         "postalCode": "75200",
-        "banId": "75113_1834_00007",
+        "banId": "75113_1834_00007_ter_a",
         "bookingEmail": "toto@example.com",
         "city": "Paris",
         "managingOffererId": user_offerer.offerer.id,


### PR DESCRIPTION
## But de la pull request

Migration de la colonne banId dans Venue, comme la taille du ban Id est indéterminée, on utilise désormais un champ Text()

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26549

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques