### PR TITLE
(BSR)[API] fix: don't create marseille en grand if it already exists

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -326,6 +326,7 @@ class EducationalRedactorWithFavoriteCollectiveOfferTemplate(EducationalRedactor
 class EducationalInstitutionProgramFactory(BaseFactory):
     class Meta:
         model = models.EducationalInstitutionProgram
+        sqlalchemy_get_or_create = ["name"]
 
     # some programs are inserted by default.
     # since the id sequence starts at 0, this will trigger a unique


### PR DESCRIPTION
Since it is added in the migration, that should not be also created in the sandbox unless it does not already exists.
Linked to commit 70cbd97

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques