### PR TITLE
(PC-25032)[API] fix: open api to new categories

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -241,6 +241,8 @@ def edit_event(event_id: int, body: serialization.EventOfferEdition) -> serializ
                 withdrawalDetails=update_body.get("withdrawal_details", offers_api.UNCHANGED),
                 **utils.compute_accessibility_edition_fields(update_body.get("accessibility")),
             )
+            if body.image:
+                utils.save_image(body.image, offer)
     except (offers_exceptions.OfferCreationBaseException, offers_exceptions.OfferEditionBaseException) as error:
         raise api_errors.ApiErrors(error.errors, status_code=400)
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -451,20 +451,10 @@ class InAppDetails(serialization.ConfiguredBaseModel):
 class ProductOfferCreation(OfferCreationBase):
     category_related_fields: product_category_creation_fields
     stock: StockCreation | None
+    location: PhysicalLocation | DigitalLocation = LOCATION_FIELD
 
     class Config:
         extra = "forbid"
-
-
-class BatchProductOfferCreation(serialization.ConfiguredBaseModel):
-    product_offers: list[ProductOfferCreation]
-    location: PhysicalLocation | DigitalLocation = LOCATION_FIELD
-
-    @pydantic_v1.validator("product_offers")
-    def validate_product_offer_list(cls, product_offers: list[ProductOfferCreation]) -> list[ProductOfferCreation]:
-        if len(product_offers) > 50:
-            raise ValueError("Maximum number of product offers is 50")
-        return product_offers
 
 
 class ProductOfferByEanCreation(serialization.ConfiguredBaseModel):
@@ -559,6 +549,7 @@ class OfferEditionBase(serialization.ConfiguredBaseModel):
     )
     is_duo: bool | None = IS_DUO_BOOKINGS_FIELD
     withdrawal_details: str | None = WITHDRAWAL_DETAILS_FIELD
+    image: ImageBody | None
 
     class Config:
         extra = "forbid"
@@ -579,16 +570,6 @@ class ProductOfferEdition(OfferEditionBase):
 
     class Config:
         extra = "forbid"
-
-
-class BatchProductOfferEdition(serialization.ConfiguredBaseModel):
-    product_offers: list[ProductOfferEdition]
-
-    @pydantic_v1.validator("product_offers")
-    def validate_product_offer_list(cls, product_offers: list[ProductOfferEdition]) -> list[ProductOfferEdition]:
-        if len(product_offers) > 50:
-            raise ValueError("Maximum number of product offers is 50")
-        return product_offers
 
 
 class ProductOfferByEanEdition(serialization.ConfiguredBaseModel):
@@ -768,14 +749,6 @@ class ProductOfferResponse(OfferResponse):
             stock=ProductStockResponse.build_product_stock(active_stock) if active_stock else None,
             **base_offer_response.dict(),
         )
-
-
-class BatchProductOfferResponse(serialization.ConfiguredBaseModel):
-    product_offers: list[ProductOfferResponse]
-
-    @classmethod
-    def build_product_offers(cls, offers: list[offers_models.Offer]) -> "BatchProductOfferResponse":
-        return cls(product_offers=[ProductOfferResponse.build_product_offer(offer) for offer in offers])
 
 
 def _serialize_has_ticket(

--- a/api/src/pcapi/routes/public/individual_offers/v1/utils.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/utils.py
@@ -91,10 +91,6 @@ def retrieve_offer_query(offer_id: int) -> sqla_orm.Query:
     return _retrieve_offer_tied_to_user_query().filter(offers_models.Offer.id == offer_id)
 
 
-def retrieve_offers_query(offer_ids: list[int]) -> sqla_orm.Query:
-    return _retrieve_offer_tied_to_user_query().filter(offers_models.Offer.id.in_(offer_ids))
-
-
 def _retrieve_offer_tied_to_user_query() -> sqla_orm.Query:
     return (
         offers_models.Offer.query.join(offerers_models.Venue)

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -1,9 +1,13 @@
 import pytest
 
+from pcapi import settings
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.testing import override_features
+from pcapi.utils import human_ids
+
+from tests.routes import image_data
 
 from . import utils
 
@@ -137,6 +141,7 @@ class PatchEventTest:
                 "eventDuration": 40,
                 "enableDoubleBookings": "true",
                 "itemCollectionDetails": "Here !",
+                "image": {"file": image_data.GOOD_IMAGE},
             },
         )
 
@@ -147,6 +152,12 @@ class PatchEventTest:
         assert event_offer.bookingContact == "test@myemail.com"
         assert event_offer.bookingEmail == "test@myemail.com"
         assert event_offer.withdrawalDetails == "Here !"
+
+        assert offers_models.Mediation.query.one()
+        assert (
+            event_offer.image.url
+            == f"{settings.OBJECT_STORAGE_URL}/thumbs/mediations/{human_ids.humanize(event_offer.activeMediation.id)}"
+        )
 
     def test_cannot_edit_event_with_ticket_if_FF_not_active(self, client):
         # This test can be deleted with FF WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API


### PR DESCRIPTION
## But de la pull request
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25032

Release product API now we know what we want to do.
There was problems with having a bulk creation/edition route. The payload can become really big in case images are uploaded, we also had a bad error management. If an error occurs after pydantic validation it would not be specific (the user don't know wich offer caused the error). 
Keep it simple until users complains.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques