### PR TITLE
Pc 26191 adage marseille redirect

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -26,7 +26,7 @@ export const AdageHeader = () => {
   const [institutionBudget, setInstitutionBudget] = useState(0)
   const { pathname } = useLocation()
 
-  const isDiscoveryPage = pathname === '/adage-iframe'
+  const isDiscoveryPage = pathname === '/adage-iframe/decouverte'
 
   function logAdageLinkClick(headerLinkName: AdageHeaderLink) {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
@@ -36,7 +36,7 @@ export const AdageHeaderMenu = ({
           {isDiscoveryActive && (
             <li className={styles['adage-header-menu-item']}>
               <NavLink
-                to={`/adage-iframe?token=${adageAuthToken}`}
+                to={`/adage-iframe/decouverte?token=${adageAuthToken}`}
                 end
                 className={({ isActive }) => {
                   return cn(styles['adage-header-link'], {

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { AdageFrontRoles, VenueResponse } from 'apiClient/adage'
 import useActiveFeature from 'hooks/useActiveFeature'
 
+import { MARSEILLE_EN_GRAND } from '../../constants'
 import useAdageUser from '../../hooks/useAdageUser'
 import { AdageDiscovery } from '../AdageDiscovery/AdageDiscovery'
 import { AdageHeader } from '../AdageHeader/AdageHeader'
@@ -26,16 +27,16 @@ export const AppLayout = ({
   const isDiscoveryActive = useActiveFeature('WIP_ENABLE_DISCOVERY')
   const isMarseilleEnabled = useActiveFeature('WIP_ENABLE_MARSEILLE')
   const isUserInMarseilleProgram = (adageUser.programs ?? []).some(
-    (prog) => prog.name === 'marseille_en_grand'
+    (prog) => prog.name === MARSEILLE_EN_GRAND
   )
-  const recirectToMarseilleSearch =
+  const redirectToMarseilleSearch =
     isMarseilleEnabled && isUserInMarseilleProgram
   const venueId = params.get('venue')
 
   const redirectToSearch =
     !isDiscoveryActive ||
     venueId ||
-    recirectToMarseilleSearch ||
+    redirectToMarseilleSearch ||
     adageUser.role === AdageFrontRoles.READONLY
 
   return (
@@ -53,7 +54,7 @@ export const AppLayout = ({
                 <Navigate
                   to={`recherche${search}${
                     //  To apply marseille student level filters only when redirecting to search from '/'
-                    recirectToMarseilleSearch ? '&program=marseille' : ''
+                    redirectToMarseilleSearch ? '&program=marseille' : ''
                   }`}
                 />
               ) : (

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -22,9 +22,19 @@ export const AppLayout = ({
   const { pathname, search } = useLocation()
   const params = new URLSearchParams(search)
 
-  const isDiscoveryPage = pathname === '/adage-iframe'
+  const isDiscoveryPage = pathname === '/adage-iframe/decouverte'
   const isDiscoveryActive = useActiveFeature('WIP_ENABLE_DISCOVERY')
+  const isMarseilleEnabled = useActiveFeature('WIP_ENABLE_MARSEILLE')
+  const isUserInMarseilleProgram = (adageUser.programs ?? []).some(
+    (prog) => prog.name === 'marseille_en_grand'
+  )
   const venueId = params.get('venue')
+
+  const redirectToSearch =
+    !isDiscoveryActive ||
+    venueId ||
+    (isMarseilleEnabled && isUserInMarseilleProgram) ||
+    adageUser.role === AdageFrontRoles.READONLY
 
   return (
     <div>
@@ -37,15 +47,14 @@ export const AppLayout = ({
           <Route
             path=""
             element={
-              adageUser.role === AdageFrontRoles.REDACTOR &&
-              isDiscoveryActive &&
-              !venueId ? (
-                <AdageDiscovery />
-              ) : (
+              redirectToSearch ? (
                 <Navigate to={`recherche${search}`} />
+              ) : (
+                <Navigate to={`decouverte${search}`} />
               )
             }
           />
+          <Route path="decouverte" element={<AdageDiscovery />} />
           <Route
             path="recherche"
             element={<OffersInstantSearch venueFilter={venueFilter} />}

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -28,12 +28,14 @@ export const AppLayout = ({
   const isUserInMarseilleProgram = (adageUser.programs ?? []).some(
     (prog) => prog.name === 'marseille_en_grand'
   )
+  const recirectToMarseilleSearch =
+    isMarseilleEnabled && isUserInMarseilleProgram
   const venueId = params.get('venue')
 
   const redirectToSearch =
     !isDiscoveryActive ||
     venueId ||
-    (isMarseilleEnabled && isUserInMarseilleProgram) ||
+    recirectToMarseilleSearch ||
     adageUser.role === AdageFrontRoles.READONLY
 
   return (
@@ -48,7 +50,12 @@ export const AppLayout = ({
             path=""
             element={
               redirectToSearch ? (
-                <Navigate to={`recherche${search}`} />
+                <Navigate
+                  to={`recherche${search}${
+                    //  To apply marseille student level filters only when redirecting to search from '/'
+                    recirectToMarseilleSearch ? '&program=marseille' : ''
+                  }`}
+                />
               ) : (
                 <Navigate to={`decouverte${search}`} />
               )

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/__specs__/AppLayout.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/__specs__/AppLayout.spec.tsx
@@ -1,19 +1,21 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
 
-import { FeatureResponseModel } from 'apiClient/adage'
+import { MARSEILLE_EN_GRAND } from 'pages/AdageIframe/app/constants'
 import {
   AlgoliaQueryContextProvider,
   FiltersContextProvider,
 } from 'pages/AdageIframe/app/providers'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
-import { RootState } from 'store/rootReducer'
 import {
   defaultAdageUser,
   defaultCategories,
   defaultUseInfiniteHitsReturn,
 } from 'utils/adageFactories'
-import { renderWithProviders } from 'utils/renderWithProviders'
+import {
+  RenderWithProvidersOptions,
+  renderWithProviders,
+} from 'utils/renderWithProviders'
 
 import { AppLayout } from '../AppLayout'
 
@@ -99,8 +101,7 @@ vi.mock('pages/AdageIframe/repository/pcapi/pcapi', () => ({
 }))
 
 const renderAppLayout = (
-  initialRoute = '/',
-  storeOverrides: Partial<RootState> = {},
+  options?: RenderWithProvidersOptions,
   user = defaultAdageUser
 ) => {
   renderWithProviders(
@@ -111,24 +112,12 @@ const renderAppLayout = (
         </AlgoliaQueryContextProvider>
       </FiltersContextProvider>
     </AdageUserContextProvider>,
-
-    { storeOverrides, initialRouterEntries: [initialRoute] }
+    options
   )
 }
 
-const store = {
-  features: {
-    list: [
-      {
-        isActive: true,
-        nameKey: 'WIP_ENABLE_MARSEILLE',
-      },
-      {
-        isActive: true,
-        nameKey: 'WIP_ENABLE_DISCOVERY',
-      },
-    ] as FeatureResponseModel[],
-  },
+const featureOverrides = {
+  features: ['WIP_ENABLE_MARSEILLE', 'WIP_ENABLE_DISCOVERY'],
 }
 
 describe('AppLayout', () => {
@@ -141,16 +130,16 @@ describe('AppLayout', () => {
   })
 
   it('should redirect to the search page if the user is in Marseille en Grand and if the FF is active', () => {
-    renderAppLayout('', store, {
+    renderAppLayout(featureOverrides, {
       ...defaultAdageUser,
-      programs: [{ label: '', name: 'marseille_en_grand' }],
+      programs: [{ label: '', name: MARSEILLE_EN_GRAND }],
     })
 
     expect(screen.getByRole('link', { name: 'Rechercher' })).toBeInTheDocument()
   })
 
   it('should redirect to the discovery page if the user is not in Marseille en Grand and if the FF is active', async () => {
-    renderAppLayout('', store, {
+    renderAppLayout(featureOverrides, {
       ...defaultAdageUser,
       programs: [],
     })

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -57,7 +57,7 @@ export const OfferInfos = () => {
                   title: 'Découvrir',
                   link: {
                     isExternal: false,
-                    to: `/adage-iframe?token=${adageAuthToken}`,
+                    to: `/adage-iframe/decouverte?token=${adageAuthToken}`,
                   },
                   icon: strokePassIcon,
                 },

--- a/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavoritesNoResult/OffersFavoritesNoResult.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavoritesNoResult/OffersFavoritesNoResult.tsx
@@ -28,7 +28,7 @@ export const OffersFavoritesNoResult = () => {
         </p>
         <ButtonLink
           link={{
-            to: `/adage-iframe?token=${adageAuthToken}`,
+            to: `/adage-iframe/recherche?token=${adageAuthToken}`,
             isExternal: false,
           }}
           variant={ButtonVariant.PRIMARY}

--- a/pro/src/pages/AdageIframe/app/components/OffersFavorites/__specs__/OffersFavorites.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersFavorites/__specs__/OffersFavorites.spec.tsx
@@ -21,7 +21,7 @@ const mockOffer: CollectiveOfferTemplateResponseModel = {
 const renderAdageFavoritesOffers = (user: AuthenticatedResponse) => {
   renderWithProviders(
     <Routes>
-      <Route path="/adage-iframe" element={<h1>Accueil</h1>} />
+      <Route path="/adage-iframe/recherche" element={<h1>Accueil</h1>} />
       <Route
         path="/adage-iframe/mes-favoris"
         element={

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -53,6 +53,7 @@ export const OffersInstantSearch = ({
     useState<VenueResponse | null>(null)
 
   const notification = useNotification()
+
   useEffect(() => {
     const getVenueById = async () => {
       try {
@@ -68,6 +69,7 @@ export const OffersInstantSearch = ({
       getVenueById()
     }
   }, [venueId])
+
   return (
     <InstantSearch
       indexName={ALGOLIA_COLLECTIVE_OFFERS_INDEX}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/ModalFilterLayout/ModalFilterLayout.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/ModalFilterLayout/ModalFilterLayout.module.scss
@@ -4,7 +4,7 @@
 
 .modal-content {
     padding: rem.torem(24px);
-    width: rem.torem(416px);
+    min-width: rem.torem(416px);
 
 
     &-title {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -373,7 +373,9 @@ describe('OfferFilters', () => {
     expect(options[0]).toHaveAccessibleName('Collège - 5e')
 
     //  Verify that non-selected options aren't sorted alphabetically
-    expect(options[1]).toHaveAccessibleName('Collège - 6e')
+    expect(options[1]).toHaveAccessibleName(
+      'Écoles innovantes Marseille en Grand : maternelle'
+    )
     expect(options[options.length - 1]).toHaveAccessibleName('CAP - 2e année')
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/studentsOptions.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/studentsOptions.ts
@@ -1,4 +1,12 @@
 export const studentsOptions = [
+  {
+    label: 'Écoles innovantes Marseille en Grand : maternelle',
+    value: 'Écoles innovantes Marseille en Grand : maternelle',
+  },
+  {
+    label: 'Écoles innovantes Marseille en Grand : élémentaire',
+    value: 'Écoles innovantes Marseille en Grand : élémentaire',
+  },
   { label: 'Collège - 6e', value: 'Collège - 6e' },
   { label: 'Collège - 5e', value: 'Collège - 5e' },
   { label: 'Collège - 4e', value: 'Collège - 4e' },
@@ -11,6 +19,14 @@ export const studentsOptions = [
 ]
 
 export const studentsForData = [
+  {
+    label: 'Écoles innovantes Marseille en Grand : maternelle',
+    value: 'Écoles innovantes Marseille en Grand : maternelle',
+  },
+  {
+    label: 'Écoles innovantes Marseille en Grand : élémentaire',
+    value: 'Écoles innovantes Marseille en Grand : élémentaire',
+  },
   { label: 'Collège - 6e', valueForData: 'Collège sixième' },
   { label: 'Collège - 5e', valueForData: 'Collège cinquième' },
   { label: 'Collège - 4e', valueForData: 'Collège quatrième' },

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -9,6 +9,7 @@ import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useIsElementVisible from 'hooks/useIsElementVisible'
 import useNotification from 'hooks/useNotification'
+import { MARSEILLE, MARSEILLE_EN_GRAND } from 'pages/AdageIframe/app/constants'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { FacetFiltersContext } from 'pages/AdageIframe/app/providers'
 import { Option } from 'pages/AdageIframe/app/types'
@@ -80,12 +81,12 @@ export const OffersSearch = ({
 
   const isMarseilleEnabled = useActiveFeature('WIP_ENABLE_MARSEILLE')
   const isUserInMarseilleProgram = (adageUser.programs ?? []).some(
-    (prog) => prog.name === 'marseille_en_grand'
+    (prog) => prog.name === MARSEILLE_EN_GRAND
   )
   const filterOnMarseilleStudents =
     isMarseilleEnabled &&
     isUserInMarseilleProgram &&
-    params.get('program') === 'marseille'
+    params.get('program') === MARSEILLE
 
   useEffect(() => {
     const getAllCategories = async () => {
@@ -123,17 +124,15 @@ export const OffersSearch = ({
     if (filterOnMarseilleStudents) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       formik.setFieldValue('students', [
-        //  TODO Replace enum values with the Marseille levels when they'll be created
-        StudentLevels.LYC_E_TERMINALE,
-        StudentLevels.LYC_E_SECONDE,
+        StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE,
+        StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_PRIMAIRE,
       ])
 
       setFacetFilters([
         ...facetFilters,
         [
-          //  TODO Replace enum values with the Marseille levels when they'll be created
-          `offer.students:${StudentLevels.LYC_E_TERMINALE}`,
-          `offer.students:${StudentLevels.LYC_E_SECONDE}`,
+          `offer.students:${StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE}`,
+          `offer.students:${StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_PRIMAIRE}`,
         ],
       ])
     }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -449,4 +449,43 @@ describe('offersSearch component', () => {
 
     expect(screen.getByTestId('suggestions-header')).toBeInTheDocument()
   })
+
+  it('should filter on student levels when the institution is in MeG and redirected from "/"', async () => {
+    vi.spyOn(URLSearchParams.prototype, 'get').mockImplementation(
+      () => 'marseille'
+    )
+    renderOffersSearchComponent(
+      props,
+      {
+        ...user,
+        programs: [{ label: '', name: 'marseille_en_grand' }],
+      },
+      {
+        features: {
+          list: [
+            {
+              isActive: true,
+              nameKey: 'WIP_ENABLE_MARSEILLE',
+            },
+          ],
+        },
+      }
+    )
+
+    const loadingMessage = screen.queryByText(/Chargement en cours/)
+    await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
+
+    //  TODO Replace StudentLevel filters values with the correct MeG ones when they exist
+    expect(
+      screen.getByRole('button', {
+        name: /Lycée - Terminale/,
+      })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', {
+        name: /Lycée - Seconde/,
+      })
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -5,6 +5,7 @@ import { AdageFrontRoles, AuthenticatedResponse } from 'apiClient/adage'
 import { apiAdage, api } from 'apiClient/api'
 import Notification from 'components/Notification/Notification'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
+import { MARSEILLE, MARSEILLE_EN_GRAND } from 'pages/AdageIframe/app/constants'
 import {
   AlgoliaQueryContextProvider,
   FiltersContextProvider,
@@ -14,7 +15,10 @@ import {
   defaultUseInfiniteHitsReturn,
   defaultUseStatsReturn,
 } from 'utils/adageFactories'
-import { renderWithProviders } from 'utils/renderWithProviders'
+import {
+  RenderWithProvidersOptions,
+  renderWithProviders,
+} from 'utils/renderWithProviders'
 
 import { MAIN_INDEX_ID } from '../../OffersInstantSearch'
 import { OffersSearch, SearchProps } from '../OffersSearch'
@@ -103,7 +107,7 @@ vi.mock('apiClient/api', () => ({
 const renderOffersSearchComponent = (
   props: SearchProps,
   user: AuthenticatedResponse,
-  storeOverrides?: unknown
+  options?: RenderWithProvidersOptions
 ) => {
   renderWithProviders(
     <>
@@ -116,9 +120,7 @@ const renderOffersSearchComponent = (
       </AdageUserContextProvider>
       <Notification />
     </>,
-    {
-      storeOverrides: storeOverrides,
-    }
+    options
   )
 }
 
@@ -452,39 +454,29 @@ describe('offersSearch component', () => {
 
   it('should filter on student levels when the institution is in MeG and redirected from "/"', async () => {
     vi.spyOn(URLSearchParams.prototype, 'get').mockImplementation(
-      () => 'marseille'
+      () => MARSEILLE
     )
     renderOffersSearchComponent(
       props,
       {
         ...user,
-        programs: [{ label: '', name: 'marseille_en_grand' }],
+        programs: [{ label: '', name: MARSEILLE_EN_GRAND }],
       },
-      {
-        features: {
-          list: [
-            {
-              isActive: true,
-              nameKey: 'WIP_ENABLE_MARSEILLE',
-            },
-          ],
-        },
-      }
+      { features: ['WIP_ENABLE_MARSEILLE'] }
     )
 
     const loadingMessage = screen.queryByText(/Chargement en cours/)
     await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
 
-    //  TODO Replace StudentLevel filters values with the correct MeG ones when they exist
     expect(
       screen.getByRole('button', {
-        name: /Lycée - Terminale/,
+        name: /Écoles innovantes Marseille en Grand : maternelle/,
       })
     ).toBeInTheDocument()
 
     expect(
       screen.getByRole('button', {
-        name: /Lycée - Seconde/,
+        name: /Écoles innovantes Marseille en Grand : primaire/,
       })
     ).toBeInTheDocument()
   })

--- a/pro/src/pages/AdageIframe/app/constants.tsx
+++ b/pro/src/pages/AdageIframe/app/constants.tsx
@@ -10,3 +10,6 @@ export const INITIAL_FILTERS: Filters = {
   onlyInMySchool: false,
   onlyInMyDpt: true,
 }
+
+export const MARSEILLE_EN_GRAND = 'marseille_en_grand'
+export const MARSEILLE = 'marseille'

--- a/pro/src/pages/AdageIframe/app/providers/FacetFiltersContextProvider.tsx
+++ b/pro/src/pages/AdageIframe/app/providers/FacetFiltersContextProvider.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, ReactNode, useMemo, useState } from 'react'
+import React, {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useMemo,
+  useState,
+} from 'react'
 
 import { VenueResponse } from 'apiClient/adage'
 import { getDefaultFacetFilterUAICodeValue } from 'utils/facetFilters'
@@ -7,7 +14,7 @@ import { Facets } from '../types'
 
 type FacetFiltersContextType = {
   facetFilters: Facets
-  setFacetFilters: (facets: Facets) => void
+  setFacetFilters: Dispatch<SetStateAction<Facets>>
 }
 
 const facetFiltersContextInitialValues: FacetFiltersContextType = {

--- a/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
+++ b/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
@@ -8,6 +8,7 @@
   flex-direction: column;
   gap: rem.torem(24px);
   height: rem.torem(250px);
+  width: max-content;
 }
 
 .search-list {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26191

Si le FF : WIP_ENABLE_MARSEILLE est activé et que le compte sur lequel on est connecté appartient au programme de Marseille en Grand, on redirige vers la page de recherche au lieu de la page découverte et on pré-filtre le niveau scolaire sur les deux nouveaux niveaux

Pour tester : 

- aller sur adage en testing, choisir un directeur d'école à marseille, prendre son token et l'ajouter à la fin du lien généré dans la pr


## Vérifications

- [ ] J'ai écrit les tests nécessaires