### PR TITLE
(PC-25834)[API] fix: use less memory per batch in cron

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -791,8 +791,10 @@ def unindex_all_venues() -> None:
 
 
 def get_last_30_days_bookings_for_eans() -> dict[str, int]:
+    logger.info("Getting eans with bookings in the last 30 days")
     rows: Iterable[Last30DaysBookingsModel] = big_query_queries.Last30DaysBookings().execute()
     ean_booking_count = {row.ean: row.booking_count for row in rows if row.ean}
+    logger.info("Got %s eans with bookings in the last 30 days", len(ean_booking_count))
     return ean_booking_count
 
 

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -821,7 +821,7 @@ def update_product_last_30_days_bookings() -> list[offers_models.Product]:
     updated_eans = []
     current_product_batch = []
 
-    batch_size = 1000
+    batch_size = 100
     for batch in range(0, len(booking_count_by_ean), batch_size):
         ean_batch = list(booking_count_by_ean.keys())[batch : batch + batch_size]
         for product in db.session.query(offers_models.Product).filter(


### PR DESCRIPTION
We used python's tracemalloc profiler to track down our memory usage in this function Turns out loading 1_000 products can easily take 400M of memory. Tuning it down at 100 (40M) makes it much more managable for our cron job

We followed the doc here for the profiling: https://docs.python.org/3/library/tracemalloc.html#record-the-current-and-peak-size-of-all-traced-memory-blocks

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25834

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques