### PR TITLE
(PC-26068)[PRO] feat: Display redirect dialog after offer publishing.

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_users_and_offerers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_users_and_offerers.py
@@ -100,4 +100,11 @@ def create_users_offerers() -> list[offerers_models.Offerer]:
     )
     offerers.append(user_offerer.offerer)
 
+    user_offerer = offerers_factories.UserOffererFactory(
+        user__email="eac_with_no_offers@example.com",
+        offerer__name="eac_with_no_offers",
+        offerer__siren="956513147",
+    )
+    offerers.append(user_offerer.offerer)
+
     return offerers

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
@@ -314,6 +314,17 @@ def create_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         state="refuse",
     )
 
+    # eac_with_no_offers
+    offerer = next(offerer_iterator)
+    venue_with_accepted_dms_status = create_venue(
+        managingOfferer=offerer,
+        name=f"Lieu {offerer.name}",
+        venueEducationalStatusId=next(educational_status_iterator),
+        collectiveInterventionArea=ALL_INTERVENTION_AREA,
+        siret="95651314700192",
+        adageId="98764",
+    )
+
 
 def create_venue(*, reimbursement: bool = False, **kwargs: typing.Any) -> offerers_models.Venue:
     venue = offerers_factories.VenueFactory(**kwargs)

--- a/pro/src/components/Callout/__specs__/AddBankAccountCallout.spec.tsx
+++ b/pro/src/components/Callout/__specs__/AddBankAccountCallout.spec.tsx
@@ -123,7 +123,7 @@ describe('AddBankAccountCallout', () => {
         BankAccountEvents.CLICKED_ADD_BANK_ACCOUNT,
         {
           from: '/accueil',
-          offererId: 0,
+          offererId: 1,
         }
       )
     })

--- a/pro/src/components/Callout/__specs__/LinkVenueCallout.spec.tsx
+++ b/pro/src/components/Callout/__specs__/LinkVenueCallout.spec.tsx
@@ -168,7 +168,7 @@ describe('LinkVenueCallout', () => {
         BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
         {
           from: '/accueil',
-          offererId: 0,
+          offererId: 1,
         }
       )
     })

--- a/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/__specs__/utils.spec.ts
+++ b/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/__specs__/utils.spec.ts
@@ -119,6 +119,13 @@ describe('components | RouteLeavingGuardCollectiveOfferCreation', () => {
       nextLocation: '/offre/collectif/AE/creation',
       expectedShouldBlock: false,
     },
+    {
+      description:
+        'should not block when going from summary to bank account url',
+      currentLocation: '/offre/AE/collectif/creation/recapitulatif',
+      nextLocation: '/remboursements/informations-bancaires?structure=1E',
+      expectedShouldBlock: false,
+    },
   ]
 
   cases.forEach(

--- a/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/utils/index.ts
+++ b/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/utils/index.ts
@@ -76,5 +76,14 @@ export const shouldBlockNavigation: BlockerFunction = ({
     return false
   }
 
+  if (
+    from === STEP_RECAP &&
+    nextLocation.pathname.startsWith(
+      '/remboursements/informations-bancaires?structure='
+    )
+  ) {
+    return false
+  }
+
   return true
 }

--- a/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
@@ -36,6 +36,7 @@ const defaultProps = {
   setOffer: vi.fn(),
   reloadCollectiveOffer: vi.fn(),
   isTemplate: false,
+  offerer: undefined,
 }
 
 describe('CollectiveOfferStockCreation', () => {

--- a/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -20,6 +20,7 @@ export const CollectiveOfferSummaryCreation = ({
   offer,
   setOffer,
   isTemplate,
+  offerer,
 }: MandatoryCollectiveOfferFromParamsProps) => {
   const notify = useNotification()
 
@@ -49,6 +50,7 @@ export const CollectiveOfferSummaryCreation = ({
             offer={offer}
             categories={categories}
             setOffer={setOffer}
+            offerer={offerer}
           />
           <RouteLeavingGuardCollectiveOfferCreation />
         </CollectiveOfferLayout>

--- a/pro/src/pages/CollectiveOfferVisibility/__specs__/CollectiveOfferCreationVisibility.spec.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/__specs__/CollectiveOfferCreationVisibility.spec.tsx
@@ -31,6 +31,7 @@ const defaultProps = {
   setOffer: vi.fn(),
   reloadCollectiveOffer: vi.fn(),
   isTemplate: false,
+  offerer: undefined,
 }
 
 describe('CollectiveOfferVisibility', () => {

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -301,7 +301,7 @@ describe('BankInformations page', () => {
       BankAccountEvents.CLICKED_ADD_BANK_ACCOUNT,
       {
         from: '/remboursements/informations-bancaires',
-        offererId: 0,
+        offererId: 1,
       }
     )
   })

--- a/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
+import { GetOffererResponseModel } from 'apiClient/v1'
 import ActionsBarSticky from 'components/ActionsBarSticky'
 import CollectiveOfferSummary from 'components/CollectiveOfferSummary'
 import {
@@ -9,7 +10,9 @@ import {
   EducationalCategories,
 } from 'core/OfferEducational'
 import { computeURLCollectiveOfferId } from 'core/OfferEducational/utils/computeURLCollectiveOfferId'
+import useActiveFeature from 'hooks/useActiveFeature'
 import useNotification from 'hooks/useNotification'
+import { RedirectToBankAccountDialog } from 'screens/Offers/RedirectToBankAccountDialog'
 import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -21,26 +24,34 @@ interface CollectiveOfferSummaryCreationProps {
   offer: CollectiveOfferTemplate | CollectiveOffer
   categories: EducationalCategories
   setOffer: (offer: CollectiveOffer | CollectiveOfferTemplate) => void
+  offerer: GetOffererResponseModel | undefined
 }
 
 const CollectiveOfferSummaryCreation = ({
   offer,
   categories,
   setOffer,
+  offerer,
 }: CollectiveOfferSummaryCreationProps) => {
+  const [displayRedirectDialog, setDisplayRedirectDialog] = useState(false)
+
   const notify = useNotification()
   const navigate = useNavigate()
 
   const { requete: requestId } = useParams()
 
-  const publishOffer = async () => {
-    const confirmationUrl = offer.isTemplate
-      ? `/offre/${offer.id}/collectif/vitrine/confirmation`
-      : `/offre/${computeURLCollectiveOfferId(
-          offer.id,
-          offer.isTemplate
-        )}/collectif/confirmation`
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
+    'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
+  )
 
+  const confirmationUrl = offer.isTemplate
+    ? `/offre/${offer.id}/collectif/vitrine/confirmation`
+    : `/offre/${computeURLCollectiveOfferId(
+        offer.id,
+        offer.isTemplate
+      )}/collectif/confirmation`
+
+  const publishOffer = async () => {
     if (offer.isTemplate) {
       const response = await publishCollectiveOfferTemplateAdapter(offer.id)
       if (!response.isOk) {
@@ -55,7 +66,19 @@ const CollectiveOfferSummaryCreation = ({
       return notify.error(response.message)
     }
     setOffer(response.payload)
-    return navigate(confirmationUrl)
+    const shouldDisplayRedirectDialog =
+      isNewBankDetailsJourneyEnabled &&
+      response.payload.isNonFreeOffer &&
+      offerer &&
+      !offerer.hasNonFreeOffer &&
+      !offerer.hasValidBankAccount &&
+      !offerer.hasPendingBankAccount
+
+    if (shouldDisplayRedirectDialog) {
+      setDisplayRedirectDialog(true)
+    } else {
+      navigate(confirmationUrl)
+    }
   }
   const backRedirectionUrl = offer.isTemplate
     ? `/offre/collectif/vitrine/${offer.id}/creation`
@@ -64,33 +87,42 @@ const CollectiveOfferSummaryCreation = ({
       }`
 
   return (
-    <div className={styles['summary']}>
-      <CollectiveOfferSummary
-        offer={offer}
-        categories={categories}
-        offerEditLink={`/offre/collectif${offer.isTemplate ? '/vitrine' : ''}/${
-          offer.id
-        }/creation`}
-        stockEditLink={`/offre/${offer.id}/collectif/stocks`}
-        visibilityEditLink={`/offre/${offer.id}/collectif/visibilite`}
-      />
-      <ActionsBarSticky>
-        <ActionsBarSticky.Left>
-          <ButtonLink
-            variant={ButtonVariant.SECONDARY}
-            link={{
-              to: backRedirectionUrl,
-              isExternal: false,
-            }}
-          >
-            Étape précédente
-          </ButtonLink>
-        </ActionsBarSticky.Left>
-        <ActionsBarSticky.Right>
-          <Button onClick={publishOffer}>Publier l’offre</Button>{' '}
-        </ActionsBarSticky.Right>
-      </ActionsBarSticky>
-    </div>
+    <>
+      <div className={styles['summary']}>
+        <CollectiveOfferSummary
+          offer={offer}
+          categories={categories}
+          offerEditLink={`/offre/collectif${
+            offer.isTemplate ? '/vitrine' : ''
+          }/${offer.id}/creation`}
+          stockEditLink={`/offre/${offer.id}/collectif/stocks`}
+          visibilityEditLink={`/offre/${offer.id}/collectif/visibilite`}
+        />
+        <ActionsBarSticky>
+          <ActionsBarSticky.Left>
+            <ButtonLink
+              variant={ButtonVariant.SECONDARY}
+              link={{
+                to: backRedirectionUrl,
+                isExternal: false,
+              }}
+            >
+              Étape précédente
+            </ButtonLink>
+          </ActionsBarSticky.Left>
+          <ActionsBarSticky.Right>
+            <Button onClick={publishOffer}>Publier l’offre</Button>{' '}
+          </ActionsBarSticky.Right>
+        </ActionsBarSticky>
+      </div>
+      {displayRedirectDialog && offerer?.id && (
+        <RedirectToBankAccountDialog
+          cancelRedirectUrl={confirmationUrl}
+          offerId={offerer?.id}
+          venueId={offer.venue.id}
+        />
+      )}
+    </>
   )
 }
 

--- a/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import RedirectDialog from 'components/Dialog/RedirectDialog'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { OfferAppPreview } from 'components/OfferAppPreview'
 import { SummaryLayout } from 'components/SummaryLayout'
@@ -11,7 +10,6 @@ import {
   Events,
   OFFER_FORM_NAVIGATION_MEDIUM,
   OFFER_FORM_NAVIGATION_OUT,
-  VenueEvents,
 } from 'core/FirebaseEvents/constants'
 import { serializeOfferApi } from 'core/Offers/adapters/getIndividualOfferAdapter/serializers'
 import { publishIndividualOffer } from 'core/Offers/adapters/publishIndividualOffer'
@@ -21,9 +19,8 @@ import { useOfferWizardMode } from 'hooks'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
-import fullWaitIcon from 'icons/full-wait.svg'
-import strokePartyIcon from 'icons/stroke-party.svg'
 import phoneStrokeIcon from 'icons/stroke-phone.svg'
+import { RedirectToBankAccountDialog } from 'screens/Offers/RedirectToBankAccountDialog'
 import Banner from 'ui-kit/Banners/Banner/Banner'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -203,55 +200,12 @@ const SummaryScreen = () => {
         isDisabled={isDisabled}
       />
 
-      {displayRedirectDialog && (
-        <RedirectDialog
-          icon={strokePartyIcon}
-          onCancel={() => {
-            logEvent?.(
-              Events.CLICKED_SEE_LATER_FROM_SUCCESS_OFFER_CREATION_MODAL,
-              {
-                from: OFFER_WIZARD_STEP_IDS.SUMMARY,
-              }
-            )
-            navigate(offerConfirmationStepUrl)
-          }}
-          title="Félicitations, vous avez créé votre offre !"
-          redirectText={
-            isNewBankDetailsJourneyEnabled
-              ? 'Ajouter un compte bancaire'
-              : 'Renseigner des coordonnées bancaires'
-          }
-          redirectLink={{
-            to: isNewBankDetailsJourneyEnabled
-              ? `remboursements/informations-bancaires?structure=${offerOfferer?.id}`
-              : `/structures/${offerOfferer?.id}/lieux/${venueId}?modification#remboursement`,
-            isExternal: false,
-          }}
-          onRedirect={() =>
-            logEvent?.(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
-              venue_id: venueId,
-              from: OFFER_WIZARD_STEP_IDS.SUMMARY,
-            })
-          }
-          cancelText="Plus tard"
-          cancelIcon={fullWaitIcon}
-          withRedirectLinkIcon={false}
-        >
-          <p>
-            Vous pouvez dès à présent{' '}
-            {isNewBankDetailsJourneyEnabled
-              ? 'ajouter un compte bancaire'
-              : 'renseigner des coordonnées bancaires'}
-            .
-          </p>
-          <p>
-            Vos remboursements seront rétroactifs une fois{' '}
-            {isNewBankDetailsJourneyEnabled
-              ? 'votre compte bancaire validé'
-              : 'vos coordonnées bancaires validées'}
-            .
-          </p>
-        </RedirectDialog>
+      {displayRedirectDialog && offerOfferer?.id && venueId && (
+        <RedirectToBankAccountDialog
+          cancelRedirectUrl={offerConfirmationStepUrl}
+          offerId={offerOfferer?.id}
+          venueId={venueId}
+        />
       )}
     </>
   )

--- a/pro/src/screens/Offers/RedirectToBankAccountDialog.tsx
+++ b/pro/src/screens/Offers/RedirectToBankAccountDialog.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import RedirectDialog from 'components/Dialog/RedirectDialog'
+import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
+import { Events, VenueEvents } from 'core/FirebaseEvents/constants'
+import useActiveFeature from 'hooks/useActiveFeature'
+import useAnalytics from 'hooks/useAnalytics'
+import fullWaitIcon from 'icons/full-wait.svg'
+import strokePartyIcon from 'icons/stroke-party.svg'
+
+export interface RedirectToBankAccountDialogProps {
+  cancelRedirectUrl: string
+  offerId: number
+  venueId: number
+}
+
+export const RedirectToBankAccountDialog = ({
+  cancelRedirectUrl,
+  offerId,
+  venueId,
+}: RedirectToBankAccountDialogProps): JSX.Element => {
+  const navigate = useNavigate()
+  const { logEvent } = useAnalytics()
+
+  const isNewBankDetailsJourneyEnabled = useActiveFeature(
+    'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
+  )
+
+  return (
+    <RedirectDialog
+      icon={strokePartyIcon}
+      onCancel={() => {
+        logEvent?.(Events.CLICKED_SEE_LATER_FROM_SUCCESS_OFFER_CREATION_MODAL, {
+          from: OFFER_WIZARD_STEP_IDS.SUMMARY,
+        })
+        navigate(cancelRedirectUrl)
+      }}
+      title="Félicitations, vous avez créé votre offre !"
+      redirectText={
+        isNewBankDetailsJourneyEnabled
+          ? 'Ajouter un compte bancaire'
+          : 'Renseigner des coordonnées bancaires'
+      }
+      redirectLink={{
+        to: isNewBankDetailsJourneyEnabled
+          ? `/remboursements/informations-bancaires?structure=${offerId}`
+          : `/structures/${offerId}/lieux/${venueId}?modification#remboursement`,
+        isExternal: false,
+      }}
+      onRedirect={() =>
+        logEvent?.(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
+          venue_id: venueId,
+          from: OFFER_WIZARD_STEP_IDS.SUMMARY,
+        })
+      }
+      cancelText="Plus tard"
+      cancelIcon={fullWaitIcon}
+      withRedirectLinkIcon={false}
+    >
+      <p>
+        Vous pouvez dès à présent{' '}
+        {isNewBankDetailsJourneyEnabled
+          ? 'ajouter un compte bancaire'
+          : 'renseigner des coordonnées bancaires'}
+        .
+      </p>
+      <p>
+        Vos remboursements seront rétroactifs une fois{' '}
+        {isNewBankDetailsJourneyEnabled
+          ? 'votre compte bancaire validé'
+          : 'vos coordonnées bancaires validées'}
+        .
+      </p>
+    </RedirectDialog>
+  )
+}

--- a/pro/src/screens/Offers/__specs__/RedirectToBankAccountDialog.tracker.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/RedirectToBankAccountDialog.tracker.spec.tsx
@@ -1,0 +1,55 @@
+import { screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import React from 'react'
+
+import * as useAnalytics from 'hooks/useAnalytics'
+import {
+  RedirectToBankAccountDialog,
+  RedirectToBankAccountDialogProps,
+} from 'screens/Offers/RedirectToBankAccountDialog'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+const mockLogEvent = vi.fn()
+const renderDialog = (props: RedirectToBankAccountDialogProps) => {
+  renderWithProviders(<RedirectToBankAccountDialog {...props} />)
+}
+
+describe('screen Offers', () => {
+  let props: RedirectToBankAccountDialogProps
+  beforeEach(() => {
+    props = {
+      cancelRedirectUrl: '/url',
+      offerId: 1,
+      venueId: 2,
+    }
+
+    vi.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+      logEvent: mockLogEvent,
+    }))
+  })
+
+  it('should track event on cancel', async () => {
+    renderDialog(props)
+
+    await userEvent.click(screen.getByText('Plus tard'))
+
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      'hasClickedSeeLaterFromSuccessOfferCreationModal',
+      {
+        from: 'recapitulatif',
+      }
+    )
+  })
+  it('should track event on redirect', async () => {
+    renderDialog(props)
+
+    await userEvent.click(
+      screen.getByText('Renseigner des coordonnées bancaires')
+    )
+
+    expect(mockLogEvent).toHaveBeenCalledWith('hasClickedVenueAddRibButton', {
+      from: 'recapitulatif',
+      venue_id: 2,
+    })
+  })
+})

--- a/pro/src/utils/apiFactories.ts
+++ b/pro/src/utils/apiFactories.ts
@@ -3,15 +3,20 @@ import {
   BankAccountApplicationStatus,
   BankAccountResponseModel,
   BookingRecapResponseModel,
+  type CollectiveOfferOfferVenueResponseModel,
+  type GetCollectiveOfferManagingOffererResponseModel,
+  GetCollectiveOfferResponseModel,
+  type GetCollectiveOfferVenueResponseModel,
   GetIndividualOfferResponseModel,
-  GetOfferManagingOffererResponseModel,
-  GetOfferVenueResponseModel,
   GetOffererResponseModel,
   GetOffererVenueResponseModel,
+  GetOfferManagingOffererResponseModel,
+  GetOfferVenueResponseModel,
   ListOffersOfferResponseModel,
   ListOffersStockResponseModel,
   ListOffersVenueResponseModel,
   ManagedVenues,
+  OfferAddressType,
   OfferStatus,
   SubcategoryIdEnum,
   VenueListItemResponseModel,
@@ -206,7 +211,7 @@ export const defaultGetOffererResponseModel: GetOffererResponseModel = {
   isValidated: false,
   managedVenues: [],
   name: 'Ma super structure',
-  id: 0,
+  id: 1,
   postalCode: '00000',
 }
 
@@ -323,3 +328,45 @@ export const defaultManagedVenues: ManagedVenues = {
   siret: '123456789',
   hasPricingPoint: true,
 }
+
+const defaultCollectiveOfferOfferVenueResponseModel: CollectiveOfferOfferVenueResponseModel =
+  {
+    addressType: OfferAddressType.OFFERER_VENUE,
+    otherAddress: 'other',
+  }
+
+const defaultGetCollectiveOfferManagingOffererResponseModel: GetCollectiveOfferManagingOffererResponseModel =
+  {
+    id: 1,
+    name: 'nom',
+  }
+
+const defaultGetCollectiveOfferVenueResponseModel: GetCollectiveOfferVenueResponseModel =
+  {
+    id: 1,
+    managingOfferer: defaultGetCollectiveOfferManagingOffererResponseModel,
+    name: 'nom',
+  }
+
+export const defaultGetCollectiveOfferResponseModel: GetCollectiveOfferResponseModel =
+  {
+    bookingEmails: [],
+    contactEmail: 'contact@contact.contact',
+    dateCreated: '10/18/2000',
+    description: 'description',
+    domains: [],
+    hasBookingLimitDatetimesPassed: false,
+    id: 1,
+    interventionArea: [],
+    isActive: false,
+    isBookable: false,
+    isCancellable: false,
+    isEditable: false,
+    isPublicApi: false,
+    isVisibilityEditable: false,
+    name: 'offre',
+    offerVenue: defaultCollectiveOfferOfferVenueResponseModel,
+    status: OfferStatus.ACTIVE,
+    students: [],
+    venue: defaultGetCollectiveOfferVenueResponseModel,
+  }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26068

- Afficher la pop in de redirection à la fin du parcours de création d'offres collectives.


**Pour tester :** 

- Activer le FF `WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY`
- Sélectionner la structure 'eac_with_no_offer' (relancer la sandbox pour générer cette structure)
- Créer une offre collective gratuite (prix = 0) -> la pop-in ne doit pas s'afficher
- Créer une offre collective payante (prix > 0) -> la pop-in devrait s'afficher
- Créer une deuxième offre collective payante -> la pop-in ne s'affiche plus 
