### PR TITLE
(BSR)[BO] chore: all flash messages in BO have 'warning' color

### DIFF
--- a/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
@@ -325,13 +325,13 @@ def _batch_individual_bookings_action(
         try:
             booking_callback(booking)
         except bookings_exceptions.BookingIsAlreadyCancelled:
-            flash("Au moins une des réservations a déjà été annulée", "error")
+            flash("Au moins une des réservations a déjà été annulée", "warning")
             return _redirect_after_individual_booking_action()
         except bookings_exceptions.BookingIsAlreadyUsed:
-            flash("Au moins une des réservations a déjà été validée", "error")
+            flash("Au moins une des réservations a déjà été validée", "warning")
             return _redirect_after_individual_booking_action()
         except bookings_exceptions.BookingIsAlreadyRefunded:
-            flash("Au moins une des réservations a déjà été remboursée", "error")
+            flash("Au moins une des réservations a déjà été remboursée", "warning")
             return _redirect_after_individual_booking_action()
 
     flash(success_message, "success")

--- a/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
@@ -271,7 +271,7 @@ def batch_validate_offerer() -> utils.BackofficeResponse:
             BatchForm,
         )
     except offerers_exceptions.OffererAlreadyValidatedException:
-        flash("Au moins une des structures a déjà été validée", "error")
+        flash("Au moins une des structures a déjà été validée", "warning")
         return _redirect_after_offerer_validation_action()
 
 
@@ -343,7 +343,7 @@ def batch_reject_offerer() -> utils.BackofficeResponse:
             offerer_forms.BatchOptionalCommentForm,
         )
     except offerers_exceptions.OffererAlreadyRejectedException:
-        flash("Une des structures a déjà été rejetée", "error")
+        flash("Une des structures a déjà été rejetée", "warning")
         return _redirect_after_offerer_validation_action()
 
 
@@ -639,7 +639,7 @@ def batch_reject_user_offerer() -> utils.BackofficeResponse:
             offerers_api.reject_offerer_attachment, "Les rattachements sélectionnés ont été rejetés avec succès"
         )
     except offerers_exceptions.UserOffererAlreadyValidatedException:
-        flash("Au moins un des rattachements est déjà rejeté", "error")
+        flash("Au moins un des rattachements est déjà rejeté", "warning")
         return _redirect_after_user_offerer_validation_action_list()
 
 

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/cgr.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/cgr.py
@@ -45,7 +45,7 @@ class CGRContext(PivotContext):
     def create_pivot(cls, form: forms.EditCGRForm) -> bool:
         cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
         if not cgr_provider:
-            flash("Provider CGR n'existe pas.", "error")
+            flash("Provider CGR n'existe pas.", "warning")
             return False
 
         venue_id = form.venue_id.data

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/ems.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/ems.py
@@ -46,7 +46,7 @@ class EMSContext(PivotContext):
     def create_pivot(cls, form: forms.EditEMSForm) -> bool:
         ems_provider = providers_repository.get_provider_by_local_class("EMSStocks")
         if not ems_provider:
-            flash("Provider EMS n'existe pas", "error")
+            flash("Provider EMS n'existe pas", "warning")
             return False
 
         venue_id = form.venue_id.data

--- a/api/src/pcapi/routes/backoffice/pivots/forms.py
+++ b/api/src/pcapi/routes/backoffice/pivots/forms.py
@@ -129,7 +129,7 @@ class EditEMSForm(EditPivotForm):
 
         ems_provider = providers_repository.get_provider_by_local_class("EMSStocks")
         if not ems_provider:
-            flash("Provider EMS n'existe pas.", "error")
+            flash("Provider EMS n'existe pas.", "warning")
             return False
 
         pivot = providers_repository.get_pivot_for_id_at_provider(

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -592,7 +592,7 @@ def update_venue(venue_id: int) -> utils.BackofficeResponse:
 
         try:
             if not sirene.siret_is_active(new_siret):
-                flash("Ce SIRET n'est plus actif, on ne peut pas l'attribuer à ce lieu", "error")
+                flash("Ce SIRET n'est plus actif, on ne peut pas l'attribuer à ce lieu", "warning")
                 return render_venue_details(venue, form), 400
         except sirene.SireneException:
             unavailable_sirene = True


### PR DESCRIPTION
## But de la pull request

Les messages flash d'erreurs dans la backoffice sont tous en "warning" (couleur orange).
Cette PR homogénéise en changeant les quelques-uns restés en "error".

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques