### PR TITLE
(BSR)[API] fix: make titelive music sync more robust

### DIFF
--- a/api/src/pcapi/connectors/serialization/titelive_serializers.py
+++ b/api/src/pcapi/connectors/serialization/titelive_serializers.py
@@ -36,7 +36,7 @@ class TiteliveArticle(BaseModel):
     contenu_explicite: str
     dateparution: datetime.date | None
     distributeur: str | None
-    editeur: str
+    editeur: str | None
     if typing.TYPE_CHECKING:
         gencod: str
     else:

--- a/api/src/pcapi/connectors/titelive.py
+++ b/api/src/pcapi/connectors/titelive.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 def get_jwt_token() -> str:
     TITELIVE_JWT_CACHE_KEY = "api:titelive_jwt:cache"
-    TITELIVE_JWT_CACHE_TIMEOUT = 5 * 60  # 5 minutes
+    TITELIVE_JWT_CACHE_TIMEOUT = 5 * 60 - 15  # a little less than 5 minutes
     url = f"{settings.TITELIVE_EPAGINE_API_AUTH_URL}/login/{settings.TITELIVE_EPAGINE_API_USERNAME}/token"
     payload = {"password": settings.TITELIVE_EPAGINE_API_PASSWORD}
 

--- a/api/src/pcapi/scheduled_tasks/titelive_commands.py
+++ b/api/src/pcapi/scheduled_tasks/titelive_commands.py
@@ -44,7 +44,13 @@ def synchronize_titelive_thing_thumbs() -> None:
     type=click.DateTime(),
     default=None,
 )
+@click.option(
+    "--from-page",
+    help="page to sync from, defaults to 1",
+    type=int,
+    default=1,
+)
 @log_cron_with_transaction
 @cron_require_feature(FeatureToggle.SYNCHRONIZE_TITELIVE_API_MUSIC_PRODUCTS)
-def synchronize_titelive_music_products(from_date: datetime.datetime | None) -> None:
-    TiteliveMusicSearch().synchronize_products(from_date.date() if from_date else None)
+def synchronize_titelive_music_products(from_date: datetime.datetime | None, from_page: int) -> None:
+    TiteliveMusicSearch().synchronize_products(from_date.date() if from_date else None, from_page)

--- a/api/tests/providers/titelive_search_test.py
+++ b/api/tests/providers/titelive_search_test.py
@@ -41,10 +41,7 @@ class TiteliveSearchTest:
     def test_titelive_music_sync(self, requests_mock):
         self._configure_login_and_images(requests_mock)
         requests_mock.get("https://catsearch.epagine.fr/v1/search?page=1", json=fixtures.MUSIC_SEARCH_FIXTURE)
-        requests_mock.get(
-            "https://catsearch.epagine.fr/v1/search?page=2",
-            json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE,
-        )
+        requests_mock.get("https://catsearch.epagine.fr/v1/search?page=2", json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE)
         titelive_epagine_provider = providers_repository.get_provider_by_name(
             providers_constants.TITELIVE_EPAGINE_PROVIDER_NAME
         )
@@ -140,10 +137,7 @@ class TiteliveSearchTest:
     @freezegun.freeze_time("2023-01-01")
     def test_titelive_sync_event(self, requests_mock):
         self._configure_login_and_images(requests_mock)
-        requests_mock.get(
-            "https://catsearch.epagine.fr/v1/search",
-            json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE,
-        )
+        requests_mock.get("https://catsearch.epagine.fr/v1/search", json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE)
         titelive_epagine_provider = providers_repository.get_provider_by_name(
             providers_constants.TITELIVE_EPAGINE_PROVIDER_NAME
         )
@@ -207,10 +201,7 @@ class TiteliveSearchTest:
     def test_sync_skips_products_already_synced_by_other_provider(self, requests_mock):
         self._configure_login_and_images(requests_mock)
         requests_mock.get("https://catsearch.epagine.fr/v1/search?page=1", json=fixtures.MUSIC_SEARCH_FIXTURE)
-        requests_mock.get(
-            "https://catsearch.epagine.fr/v1/search?page=2",
-            json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE,
-        )
+        requests_mock.get("https://catsearch.epagine.fr/v1/search?page=2", json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE)
         other_provider = providers_factories.ProviderFactory()
         offers_factories.ProductFactory(extraData={"ean": "3700187679323"}, lastProvider=other_provider)
 
@@ -232,10 +223,7 @@ class TiteliveSearchTest:
     def test_sync_thumbnails(self, requests_mock):
         self._configure_login_and_images(requests_mock)
         requests_mock.get("https://catsearch.epagine.fr/v1/search?page=1", json=fixtures.MUSIC_SEARCH_FIXTURE)
-        requests_mock.get(
-            "https://catsearch.epagine.fr/v1/search?page=2",
-            json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE,
-        )
+        requests_mock.get("https://catsearch.epagine.fr/v1/search?page=2", json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE)
 
         TiteliveMusicSearch().synchronize_products(datetime.date(2022, 12, 1))
 
@@ -246,10 +234,7 @@ class TiteliveSearchTest:
     def test_sync_thumbnails_failure_is_silent(self, requests_mock):
         self._configure_login_and_images(requests_mock)
         requests_mock.get("https://catsearch.epagine.fr/v1/search?page=1", json=fixtures.MUSIC_SEARCH_FIXTURE)
-        requests_mock.get(
-            "https://catsearch.epagine.fr/v1/search?page=2",
-            json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE,
-        )
+        requests_mock.get("https://catsearch.epagine.fr/v1/search?page=2", json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE)
         requests_mock.get("https://images.epagine.fr/323/3700187679324.jpg", exc=requests.exceptions.RequestException)
 
         assert TiteliveMusicSearch().synchronize_products(datetime.date(2022, 12, 1)) is None
@@ -279,3 +264,12 @@ class TiteliveSearchTest:
 
         synced_product = offers_models.Product.query.one()
         assert synced_product.idAtProviders == "3700187679323"
+
+    def test_titelive_music_sync_from_page(self, requests_mock):
+        self._configure_login_and_images(requests_mock)
+        requests_mock.get("https://catsearch.epagine.fr/v1/search?page=1", json=fixtures.MUSIC_SEARCH_FIXTURE)
+        requests_mock.get("https://catsearch.epagine.fr/v1/search?page=2", json=fixtures.EMPTY_MUSIC_SEARCH_FIXTURE)
+
+        TiteliveMusicSearch().synchronize_products(datetime.date(2022, 12, 1), 2)
+
+        assert offers_models.Product.query.count() == 0


### PR DESCRIPTION
## But de la pull request

Faciliter le rattrapage de la synchro Titelive musique et acceptation d'un nouveau champ nullable

## Vérifications

- [X] J'ai écrit les tests nécessaires