### PR TITLE
(PC-25964)[API] feat: also check non public SIREN when checking every active offerers

### DIFF
--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -23,9 +23,8 @@ class CheckOffererSirenRequest(BaseModel):
 @task(settings.GCP_CHECK_OFFERER_SIREN_QUEUE_NAME, "/offerers/check_offerer_is_active", task_request_timeout=3 * 60)  # type: ignore [arg-type]
 def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
     try:
-        siren_info = sirene.get_siren(payload.siren)
+        siren_info = sirene.get_siren(payload.siren, with_address=False, raise_if_non_public=False)
     except sirene.SireneException as exc:
-        # This exception includes SIREN marked as "non diffusibles"
         logger.info("Could not fetch info from Sirene API", extra={"siren": payload.siren, "exc": exc})
         return
 

--- a/api/tests/connectors/sirene_test.py
+++ b/api/tests/connectors/sirene_test.py
@@ -84,6 +84,24 @@ def test_get_siren_with_non_public_data():
 
 
 @override_settings(SIRENE_BACKEND="pcapi.connectors.sirene.InseeBackend")
+def test_get_siren_with_non_public_data_do_not_raise():
+    siren = "123456789"
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            f"https://api.insee.fr/entreprises/sirene/V3/siren/{siren}",
+            json=sirene_test_data.RESPONSE_SIREN_COMPANY_WITH_NON_PUBLIC_DATA,
+        )
+        mock.get(
+            f"https://api.insee.fr/entreprises/sirene/V3/siret/{siren}00001",
+            json=sirene_test_data.RESPONSE_SIRET_COMPANY_WITH_NON_PUBLIC_DATA,
+        )
+        siren_info = sirene.get_siren(siren, raise_if_non_public=False)
+        assert siren_info.siren == siren
+        assert siren_info.name == "[ND]"
+        assert siren_info.active is True
+
+
+@override_settings(SIRENE_BACKEND="pcapi.connectors.sirene.InseeBackend")
 def test_get_siret():
     siret = "12345678900017"
     with requests_mock.Mocker() as mock:

--- a/api/tests/core/offerers/test_commands.py
+++ b/api/tests/core/offerers/test_commands.py
@@ -26,4 +26,4 @@ class CheckActiveOfferersTest:
             run_command(app, "check_active_offerers")
 
         # Only check that the task is called; its behavior is tested in test_api.py
-        mock_get_siren.assert_called_once_with(offerer.siren)
+        mock_get_siren.assert_called_once_with(offerer.siren, with_address=False, raise_if_non_public=False)


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-25964

Lorsqu'on vérifie si les structure sont encore actives, vérifier aussi les structures non diffusibles

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques