### PR TITLE
(PC-26596)[API] fix: return offers without showSubType

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -262,14 +262,19 @@ def serialize_extra_data(offer: offers_models.Offer) -> CategoryRelatedFields:
     # Convert musicSubType (resp showSubType) code to musicType slug (resp showType slug)
     music_sub_type = serialized_data.pop(subcategories.ExtraDataFieldEnum.MUSIC_SUB_TYPE.value, None)
 
-    # fixme (mageoffray, 2023-12-14): some historical offers have no musicSubType and only musicType.
+    # FIXME (mageoffray, 2023-12-14): some historical offers have no musicSubType and only musicType.
     # We should migrate our musicType|musicSubType to titelive music types. This migration will include
     # offers without musicSubType
     music_type = serialized_data.pop(subcategories.ExtraDataFieldEnum.MUSIC_TYPE.value, None)
     if music_type and not music_sub_type:
         music_sub_type = "-1"  # Use 'Other' when not filled
 
+    # FIXME (mageoffray, 2023-12-14): some historical offers have no showSubType and only showType.
     show_sub_type = serialized_data.pop(subcategories.ExtraDataFieldEnum.SHOW_SUB_TYPE.value, None)
+    show_type = serialized_data.pop(subcategories.ExtraDataFieldEnum.SHOW_TYPE.value, None)
+    if show_type and not show_sub_type:
+        show_sub_type = "-1"  # Use 'Other' when not filled
+
     if music_sub_type:
         serialized_data["musicType"] = MusicTypeEnum(music_types.MUSIC_SUB_TYPES_BY_CODE[int(music_sub_type)].slug)
     if show_sub_type:

--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -86,26 +86,6 @@ class GetEventTest:
         assert response.status_code == 200
         assert response.json["categoryRelatedFields"] == {"category": "DECOUVERTE_METIERS", "speaker": None}
 
-    def test_get_event_without_music_type(self, client):
-        venue, _ = utils.create_offerer_provider_linked_to_venue()
-        event_offer = offers_factories.EventOfferFactory(
-            subcategoryId=subcategories.CONCERT.id,
-            venue=venue,
-            extraData={"musicType": "800"},
-        )
-
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-            f"/public/offers/v1/events/{event_offer.id}"
-        )
-        assert response.status_code == 200
-        print(response.json["categoryRelatedFields"])
-        assert response.json["categoryRelatedFields"] == {
-            "author": None,
-            "musicType": "OTHER",
-            "performer": None,
-            "category": "CONCERT",
-        }
-
     def test_get_event_without_ticket(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         event_offer = offers_factories.EventOfferFactory(

--- a/api/tests/routes/public/individual_offers/v1/get_events_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_events_test.py
@@ -52,6 +52,24 @@ class GetEventsTest:
         assert response.status_code == 200
         assert len(response.json["events"]) == 2
 
+    def test_get_events_without_sub_types(self, client):
+        venue, _ = utils.create_offerer_provider_linked_to_venue()
+        offers_factories.EventOfferFactory(
+            subcategoryId=subcategories.CONCERT.id,
+            venue=venue,
+            extraData={"musicType": "800"},
+        )
+        offers_factories.EventOfferFactory(
+            subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
+            venue=venue,
+            extraData={"showType": "800"},
+        )
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            f"/public/offers/v1/events?limit=5&venueId={venue.id}"
+        )
+        assert response.status_code == 200
+        assert len(response.json["events"]) == 2
+
     def test_404_when_venue_id_not_tied_to_api_key(self, client):
         utils.create_offerer_provider_linked_to_venue()
         unrelated_venue = offerers_factories.VenueFactory()


### PR DESCRIPTION
New item added to the list of "clean offer table".

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26596

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques