### PR TITLE
(PC-26278)[PRO] feat: V1 - Dans le bloc page partenaire, lorsque je clique sur l'image du lieu je peux en uploader une nouvelle

### DIFF
--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -14,6 +14,7 @@ import pcapi.core.offers.models as offers_models
 from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceMixin
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import finance_serialize
+from pcapi.routes.serialization.venues_serialize import BannerMetaModel
 from pcapi.routes.serialization.venues_serialize import DMSApplicationForEAC
 import pcapi.utils.date as date_utils
 from pcapi.utils.email import sanitize_email
@@ -43,7 +44,7 @@ class GetOffererVenueResponseModel(BaseModel, AccessibilityComplianceMixin):
     hasVenueProviders: bool
     isPermanent: bool
     bannerUrl: str | None
-    bannerMeta: dict | None
+    bannerMeta: BannerMetaModel | None
 
     @classmethod
     def from_orm(

--- a/pro/src/apiClient/v1/models/GetOffererVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererVenueResponseModel.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { BannerMetaModel } from './BannerMetaModel';
 import type { DMSApplicationForEAC } from './DMSApplicationForEAC';
 import type { VenueTypeCode } from './VenueTypeCode';
 
@@ -10,7 +11,7 @@ export type GetOffererVenueResponseModel = {
   adageInscriptionDate?: string | null;
   address?: string | null;
   audioDisabilityCompliant?: boolean | null;
-  bannerMeta?: Record<string, any> | null;
+  bannerMeta?: BannerMetaModel | null;
   bannerUrl?: string | null;
   bookingEmail?: string | null;
   city?: string | null;

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageAdd/ButtonImageAdd.module.scss
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageAdd/ButtonImageAdd.module.scss
@@ -17,7 +17,7 @@
   border-radius: rem.torem(4px);
 
   &.add-image-venue {
-    $height: rem.torem(176px);
+    $height: rem.torem(180px);
 
     width: math.div($height * 3, 2);
     height: $height;

--- a/pro/src/components/ImageUploader/ImageUploader.tsx
+++ b/pro/src/components/ImageUploader/ImageUploader.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import React from 'react'
 
 import { ButtonAppPreview } from './ButtonAppPreview'
@@ -9,24 +10,28 @@ import styles from './ImageUploader.module.scss'
 import { UploaderModeEnum } from './types'
 
 export interface ImageUploaderProps {
+  className?: string
   onImageUpload: (values: OnImageUploadArgs) => void
   onImageDelete: () => void
   initialValues?: UploadImageValues
   mode: UploaderModeEnum
   onClickButtonImageAdd?: () => void
+  hideActionButtons?: boolean
 }
 
 const ImageUploader = ({
+  className,
   onImageUpload,
   onImageDelete,
   initialValues = {},
   mode,
   onClickButtonImageAdd,
+  hideActionButtons = false,
 }: ImageUploaderProps) => {
   const { imageUrl, originalImageUrl, credit, cropParams } = initialValues
 
   return (
-    <div className={styles['image-uploader-image-container']}>
+    <div className={cn(className, styles['image-uploader-image-container'])}>
       {imageUrl && originalImageUrl ? (
         <>
           <ImagePreview
@@ -34,25 +39,27 @@ const ImageUploader = ({
             imageUrl={imageUrl}
             alt="Prévisualisation de l’image"
           />
-          <div className={styles['image-uploader-actions-container']}>
-            <div className={styles['actions-wrapper']}>
-              <ButtonImageEdit
-                mode={mode}
-                initialValues={{
-                  originalImageUrl,
-                  imageUrl,
-                  credit,
-                  cropParams,
-                }}
-                onImageUpload={onImageUpload}
-                onClickButtonImage={onClickButtonImageAdd}
-              />
-              {mode !== UploaderModeEnum.OFFER_COLLECTIVE && (
-                <ButtonAppPreview imageUrl={imageUrl} mode={mode} />
-              )}
-              <ButtonImageDelete onImageDelete={onImageDelete} />
+          {!hideActionButtons && (
+            <div className={styles['image-uploader-actions-container']}>
+              <div className={styles['actions-wrapper']}>
+                <ButtonImageEdit
+                  mode={mode}
+                  initialValues={{
+                    originalImageUrl,
+                    imageUrl,
+                    credit,
+                    cropParams,
+                  }}
+                  onImageUpload={onImageUpload}
+                  onClickButtonImage={onClickButtonImageAdd}
+                />
+                {mode !== UploaderModeEnum.OFFER_COLLECTIVE && (
+                  <ButtonAppPreview imageUrl={imageUrl} mode={mode} />
+                )}
+                <ButtonImageDelete onImageDelete={onImageDelete} />
+              </div>
             </div>
-          </div>
+          )}
         </>
       ) : (
         <ButtonImageEdit

--- a/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
+++ b/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
@@ -28,8 +28,8 @@ export interface VenueBannerMetaProps {
 }
 
 /* istanbul ignore next: DEBT, TO FIX */
-const buildInitialValues = (
-  bannerUrl?: string,
+export const buildInitialValues = (
+  bannerUrl?: string | null,
   bannerMeta?: VenueBannerMetaProps
 ): UploadImageValues => {
   let cropParams

--- a/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
+++ b/pro/src/components/VenueForm/ImageUploaderVenue/ImageUploaderVenue.tsx
@@ -79,8 +79,8 @@ const ImageUploaderVenue = ({ isCreatingVenue }: ImageUploaderProps) => {
         cropParams?.width
       )
 
-      setFieldValue('bannerUrl', editedVenue.bannerUrl)
-      setFieldValue('bannerMeta', editedVenue.bannerMeta)
+      await setFieldValue('bannerUrl', editedVenue.bannerUrl)
+      await setFieldValue('bannerMeta', editedVenue.bannerMeta)
       logEvent?.(VenueEvents.UPLOAD_IMAGE, {
         from: location.pathname,
         venueId: venueId,
@@ -99,8 +99,8 @@ const ImageUploaderVenue = ({ isCreatingVenue }: ImageUploaderProps) => {
     try {
       await api.deleteVenueBanner(venueId || 0)
 
-      setFieldValue('bannerUrl', undefined)
-      setFieldValue('bannerMeta', undefined)
+      await setFieldValue('bannerUrl', undefined)
+      await setFieldValue('bannerMeta', undefined)
 
       return Promise.resolve()
     } catch {

--- a/pro/src/components/VenueForm/VenueForm.tsx
+++ b/pro/src/components/VenueForm/VenueForm.tsx
@@ -106,7 +106,7 @@ const VenueForm = ({
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     loadCanOffererCreateCollectiveOffer()
-  }, [])
+  }, [offerer.id])
 
   return (
     <div>

--- a/pro/src/pages/Home/Offerers/PartnerPage.module.scss
+++ b/pro/src/pages/Home/Offerers/PartnerPage.module.scss
@@ -4,20 +4,18 @@
 @use "styles/variables/_colors.scss" as colors;
 
 .header {
-  display: grid;
-  grid-template-columns: 1fr;
+  display: flex;
+  flex-direction: column;
   gap: rem.torem(24px);
 
   @media (min-width: size.$tablet) {
-    grid-template-columns: rem.torem(292px) 1fr;
+    flex-direction: row;
     gap: rem.torem(32px);
   }
 }
 
-.image {
-  height: rem.torem(180px);
-  background-color: colors.$grey-light;
-  border-radius: rem.torem(6px);
+.image-uploader {
+  align-self: center;
 }
 
 .venue-type {

--- a/pro/src/pages/Home/Offerers/PartnerPage.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPage.tsx
@@ -103,6 +103,7 @@ export const PartnerPage = ({ offererId, venue }: PartnerPageProps) => {
             link={{
               to: `/structures/${offererId}/lieux/${venue.id}?modification`,
               isExternal: false,
+              'aria-label': `Gérer la page de ${venue.name}`,
             }}
             onClick={() =>
               logEvent?.(VenueEvents.CLICKED_VENUE_PUBLISHED_OFFERS_LINK, {

--- a/pro/src/pages/Home/Offerers/PartnerPage.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPage.tsx
@@ -1,9 +1,19 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useLoaderData } from 'react-router-dom'
 
+import { api } from 'apiClient/api'
 import { GetOffererVenueResponseModel } from 'apiClient/v1'
+import { ImageUploader, UploadImageValues } from 'components/ImageUploader'
+import { OnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageEdit'
+import { UploaderModeEnum } from 'components/ImageUploader/types'
+import {
+  VenueBannerMetaProps,
+  buildInitialValues,
+} from 'components/VenueForm/ImageUploaderVenue/ImageUploaderVenue'
 import { VenueEvents } from 'core/FirebaseEvents/constants'
 import useAnalytics from 'hooks/useAnalytics'
+import useNotification from 'hooks/useNotification'
+import { postImageToVenue } from 'repository/pcapi/pcapi'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -12,24 +22,76 @@ import { HomepageLoaderData } from '../Homepage'
 
 import styles from './PartnerPage.module.scss'
 
-interface PartnerPageProps {
+export interface PartnerPageProps {
   offererId: string
   venue: GetOffererVenueResponseModel
 }
 
 export const PartnerPage = ({ offererId, venue }: PartnerPageProps) => {
   const { logEvent } = useAnalytics()
+  const notify = useNotification()
   const { venueTypes } = useLoaderData() as HomepageLoaderData
   const venueType = venueTypes.find(
     (venueType) => venueType.id === venue.venueTypeCode
   )
+  const initialValues = buildInitialValues(
+    venue.bannerUrl,
+    // There would be a lot of refactoring to remove this "as"
+    // it would ask for a global typing refactor of the image uploads
+    // on the backend & frontend to synchronise BannerMetaModel with VenueBannerMetaProps
+    (venue.bannerMeta as VenueBannerMetaProps | null | undefined) || undefined
+  )
+  const [imageValues, setImageValues] =
+    useState<UploadImageValues>(initialValues)
+
+  const handleOnImageUpload = async ({
+    imageFile,
+    credit,
+    cropParams,
+  }: OnImageUploadArgs) => {
+    try {
+      const editedVenue = await postImageToVenue(
+        venue.id,
+        imageFile,
+        credit,
+        cropParams?.x,
+        cropParams?.y,
+        cropParams?.height,
+        cropParams?.width
+      )
+      setImageValues(
+        buildInitialValues(editedVenue.bannerUrl, editedVenue.bannerMeta)
+      )
+
+      notify.success('Vos modifications ont bien été prises en compte')
+    } catch {
+      notify.error(
+        'Une erreur est survenue lors de la sauvegarde de vos modifications.\n Merci de réessayer plus tard'
+      )
+    }
+  }
+
+  const handleOnImageDelete = async () => {
+    try {
+      await api.deleteVenueBanner(venue.id)
+
+      setImageValues(buildInitialValues())
+    } catch {
+      notify.error('Une erreur est survenue. Merci de réessayer plus tard.')
+    }
+  }
 
   return (
     <Card>
       <div className={styles['header']}>
-        <div className={styles['image']}>
-          Ajouter une image (TODO next ticket)
-        </div>
+        <ImageUploader
+          className={styles['image-uploader']}
+          onImageUpload={handleOnImageUpload}
+          onImageDelete={handleOnImageDelete}
+          initialValues={imageValues}
+          mode={UploaderModeEnum.VENUE}
+          hideActionButtons
+        />
 
         <div>
           <div className={styles['venue-type']}>{venueType?.label}</div>

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPage.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPage.spec.tsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+import * as router from 'react-router-dom'
+
+import { VenueTypeCode } from 'apiClient/v1'
+import { defaultGetOffererVenueResponseModel } from 'utils/apiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { PartnerPage, PartnerPageProps } from '../PartnerPage'
+
+const renderPartnerPages = (props: PartnerPageProps) => {
+  renderWithProviders(<PartnerPage {...props} />)
+}
+
+vi.mock('react-router-dom', async () => ({
+  ...((await vi.importActual('react-router-dom')) ?? {}),
+  useLoaderData: vi.fn(),
+}))
+
+describe('PartnerPages', () => {
+  beforeEach(() => {
+    vi.spyOn(router, 'useLoaderData').mockReturnValue({
+      venueTypes: [{ id: VenueTypeCode.FESTIVAL, label: 'Festival' }],
+    })
+  })
+
+  it('should display image upload if no image', () => {
+    renderPartnerPages({
+      venue: {
+        ...defaultGetOffererVenueResponseModel,
+        venueTypeCode: VenueTypeCode.FESTIVAL,
+      },
+      offererId: '1',
+    })
+
+    expect(screen.getByText(/Ajouter une image/)).toBeInTheDocument()
+  })
+
+  it('should display the image if its present', () => {
+    renderPartnerPages({
+      venue: {
+        ...defaultGetOffererVenueResponseModel,
+        venueTypeCode: VenueTypeCode.FESTIVAL,
+        bannerUrl: 'https://www.example.com/image.png',
+        bannerMeta: {
+          original_image_url: 'https://www.example.com/image.png',
+          image_credit: '',
+          crop_params: {
+            x_crop_percent: 0,
+            y_crop_percent: 0,
+            width_crop_percent: 0,
+            height_crop_percent: 0,
+          },
+        },
+      },
+      offererId: '1',
+    })
+
+    expect(screen.getByAltText('Prévisualisation de l’image')).toHaveAttribute(
+      'src',
+      'https://www.example.com/image.png'
+    )
+  })
+})

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -202,6 +202,7 @@ const Venue = ({
             link={{
               to: editVenueLink,
               isExternal: false,
+              'aria-label': `Gérer la page de ${name}`,
             }}
             onClick={() =>
               logEvent?.(

--- a/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
@@ -43,7 +43,7 @@ describe('venues', () => {
       renderVenue(props)
 
       expect(
-        screen.getByRole('link', { name: 'Gérer ma page' })
+        screen.getByRole('link', { name: `Gérer la page de My venue` })
       ).toHaveAttribute(
         'href',
         `/structures/${offererId}/lieux/${venueId}?modification`

--- a/pro/src/pages/Home/Venues/__specs__/Venue.tracker.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.tracker.spec.tsx
@@ -39,7 +39,9 @@ describe('venue create offer link', () => {
 
     renderVenue(props)
 
-    await userEvent.click(screen.getByRole('link', { name: 'Gérer ma page' }))
+    await userEvent.click(
+      screen.getByRole('link', { name: `Gérer la page de My venue` })
+    )
 
     expect(mockLogEvent).toHaveBeenCalledWith(
       VenueEvents.CLICKED_VENUE_PUBLISHED_OFFERS_LINK,
@@ -72,7 +74,9 @@ describe('venue create offer link', () => {
 
     renderVenue(props)
 
-    expect(screen.getByRole('link', { name: 'Gérer ma page' })).toHaveAttribute(
+    expect(
+      screen.getByRole('link', { name: `Gérer la page de My venue` })
+    ).toHaveAttribute(
       'href',
       `/structures/${offererId}/lieux/${venueId}?modification`
     )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26278

Derrière le FF WIP_PARTNER_PAGE, "Lieu non dit" est une structure avec un lieu permanent qui permet de voir le bloc pages partenaires

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/85a3cbe4-9d5d-42b7-aa1c-cee5f79a436c)
