### PR TITLE
(BSR) Add permission to allow dependabot to build storybook

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: [self-hosted, linux, x64]


### PR DESCRIPTION
## But de la pull request

Currently dependabot is not able to deploy [storybook](https://github.com/pass-culture/pass-culture-main/actions/runs/7337863246/job/19981100599). If we refers to this [section ](https://github.com/JamesIves/github-pages-deploy-action) we should allow content: write to let him deploy