### PR TITLE
(PC-26279)[PRO] feat: ajout des nouvelles étapes au bloc page partenaire

### DIFF
--- a/pro/src/pages/Home/Offerers/PartnerPage.module.scss
+++ b/pro/src/pages/Home/Offerers/PartnerPage.module.scss
@@ -35,3 +35,8 @@
 .venue-address {
   margin-bottom: rem.torem(16px);
 }
+
+.venue-offer-steps {
+  margin-top: rem.torem(32px);
+  max-width: rem.torem(500px);
+}

--- a/pro/src/pages/Home/Offerers/PartnerPage.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPage.tsx
@@ -19,6 +19,7 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 
 import { Card } from '../Card'
 import { HomepageLoaderData } from '../Homepage'
+import { VenueOfferSteps } from '../VenueOfferSteps/VenueOfferSteps'
 
 import styles from './PartnerPage.module.scss'
 
@@ -114,6 +115,10 @@ export const PartnerPage = ({ offererId, venue }: PartnerPageProps) => {
             Gérer ma page
           </ButtonLink>
         </div>
+      </div>
+
+      <div className={styles['venue-offer-steps']}>
+        <VenueOfferSteps venue={venue} hasVenue isInsidePartnerBlock />
       </div>
     </Card>
   )

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.module.scss
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.module.scss
@@ -3,12 +3,15 @@
 
 .card-wrapper {
   margin-left: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: rem.torem(16px);
 
   &.no-shadow {
     box-shadow: none;
   }
 
-  .venue-offer-steps {
+  & .venue-offer-steps {
     display: flex;
     flex-direction: column;
     gap: rem.torem(8px);
@@ -43,7 +46,21 @@
 
 .card-title {
   display: block;
-  margin-bottom: rem.torem(24px);
+  margin-bottom: rem.torem(8px);
 
   @include fonts.title4;
+}
+
+.inside-partner-block {
+  &.card-wrapper {
+    border: none;
+    padding: 0;
+    gap: rem.torem(8px);
+  }
+
+  .card-title {
+    margin-bottom: 0;
+
+    @include fonts.button;
+  }
 }

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -25,10 +25,11 @@ import { shouldDisplayEACInformationSectionForVenue } from '../venueUtils'
 import styles from './VenueOfferSteps.module.scss'
 
 export interface VenueOfferStepsProps {
-  hasVenue: boolean
   offerer?: GetOffererResponseModel | null
   venue?: GetOffererVenueResponseModel
+  hasVenue: boolean
   isFirstVenue?: boolean
+  isInsidePartnerBlock?: boolean
 }
 
 export const VenueOfferSteps = ({
@@ -36,6 +37,7 @@ export const VenueOfferSteps = ({
   venue,
   hasVenue = false,
   isFirstVenue = false,
+  isInsidePartnerBlock = false,
 }: VenueOfferStepsProps) => {
   const { logEvent } = useAnalytics()
   const isVenueCreationAvailable = useActiveFeature('API_SIRENE_AVAILABLE')
@@ -75,7 +77,8 @@ export const VenueOfferSteps = ({
   return (
     <Card
       className={cn(styles['card-wrapper'], {
-        [styles['no-shadow']]: hasVenue,
+        [styles['no-shadow']]: hasVenue || isInsidePartnerBlock,
+        [styles['inside-partner-block']]: isInsidePartnerBlock,
       })}
       data-testid={hasVenue ? 'venue-offer-steps' : 'home-offer-steps'}
     >

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -20,6 +20,7 @@ import useActiveFeature from '../../../hooks/useActiveFeature'
 import useAnalytics from '../../../hooks/useAnalytics'
 import { UNAVAILABLE_ERROR_PAGE } from '../../../utils/routes'
 import { Card } from '../Card'
+import { shouldDisplayEACInformationSectionForVenue } from '../venueUtils'
 
 import styles from './VenueOfferSteps.module.scss'
 
@@ -27,7 +28,6 @@ export interface VenueOfferStepsProps {
   hasVenue: boolean
   offerer?: GetOffererResponseModel | null
   venue?: GetOffererVenueResponseModel
-  shouldDisplayEACInformationSection?: boolean
   isFirstVenue?: boolean
 }
 
@@ -35,17 +35,19 @@ export const VenueOfferSteps = ({
   offerer,
   venue,
   hasVenue = false,
-  shouldDisplayEACInformationSection = false,
   isFirstVenue = false,
 }: VenueOfferStepsProps) => {
+  const { logEvent } = useAnalytics()
   const isVenueCreationAvailable = useActiveFeature('API_SIRENE_AVAILABLE')
   const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
+
   const venueCreationUrl = isVenueCreationAvailable
     ? `/structures/${offerer?.id}/lieux/creation`
     : UNAVAILABLE_ERROR_PAGE
-  const { logEvent } = useAnalytics()
+  const shouldDisplayEACInformationSection =
+    venue && shouldDisplayEACInformationSectionForVenue(venue)
 
   /* Condition linked to add bank account banner
     display button if this is the first venue and the offerer has no offer at all,

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
@@ -5,6 +5,7 @@ import {
   VenueOfferSteps,
   VenueOfferStepsProps,
 } from 'pages/Home/VenueOfferSteps/VenueOfferSteps'
+import * as venueUtils from 'pages/Home/venueUtils'
 import {
   defaultGetOffererResponseModel,
   defaultGetOffererVenueResponseModel,
@@ -35,6 +36,13 @@ describe('VenueOfferSteps', () => {
     hasValidBankAccount: false,
     hasNonFreeOffer: false,
   }
+
+  beforeEach(() => {
+    vi.spyOn(
+      venueUtils,
+      'shouldDisplayEACInformationSectionForVenue'
+    ).mockReturnValue(false)
+  })
 
   it('should display venue creation link if user has no venue', () => {
     props.hasVenue = false
@@ -149,8 +157,14 @@ describe('VenueOfferSteps', () => {
   })
 
   it('should display eac dms link when condition to display it is true', () => {
-    props.shouldDisplayEACInformationSection = true
+    vi.spyOn(
+      venueUtils,
+      'shouldDisplayEACInformationSectionForVenue'
+    ).mockReturnValue(true)
+    props.venue = { ...defaultGetOffererVenueResponseModel }
+
     renderVenueOfferSteps(props)
+
     expect(screen.getByText('Démarche en cours :')).toBeInTheDocument()
     expect(
       screen.getByText('Suivre ma demande de référencement ADAGE')
@@ -158,7 +172,6 @@ describe('VenueOfferSteps', () => {
   })
 
   it('should display bank information status follow link when condition to display it is true', () => {
-    props.shouldDisplayEACInformationSection = false
     props.venue = {
       ...defaultGetOffererVenueResponseModel,
       hasPendingBankInformationApplication: true,
@@ -194,7 +207,6 @@ describe('VenueOfferSteps', () => {
       hasPendingBankInformationApplication: true,
       demarchesSimplifieesApplicationId: null,
     }
-    props.shouldDisplayEACInformationSection = false
     renderVenueOfferSteps(props)
     expect(
       screen.getByRole('link', {
@@ -204,12 +216,17 @@ describe('VenueOfferSteps', () => {
   })
 
   it('should display link for eac informations if has adage id and already created offer', () => {
+    vi.spyOn(
+      venueUtils,
+      'shouldDisplayEACInformationSectionForVenue'
+    ).mockReturnValue(true)
     props.venue = {
       ...defaultGetOffererVenueResponseModel,
       hasAdageId: true,
     }
-    props.shouldDisplayEACInformationSection = true
+
     renderVenueOfferSteps(props)
+
     expect(
       screen.getByText(
         'Renseigner mes informations à destination des enseignants'
@@ -218,12 +235,18 @@ describe('VenueOfferSteps', () => {
   })
 
   it('should display disabled link to eac informations if venue doesnt have adage id', () => {
+    vi.spyOn(
+      venueUtils,
+      'shouldDisplayEACInformationSectionForVenue'
+    ).mockReturnValue(true)
+    props.venue = { ...defaultGetOffererVenueResponseModel }
     props.venue = {
       ...defaultGetOffererVenueResponseModel,
       hasAdageId: false,
     }
-    props.shouldDisplayEACInformationSection = true
+
     renderVenueOfferSteps(props)
+
     const eacInformationsLink = screen.getByRole('link', {
       name: 'Renseigner mes informations à destination des enseignants',
     })
@@ -233,8 +256,9 @@ describe('VenueOfferSteps', () => {
 
   it('should not display dms link if condition to display it is false', () => {
     props.hasVenue = false
-    props.shouldDisplayEACInformationSection = false
+
     renderVenueOfferSteps(props)
+
     expect(
       screen.queryByText('Suivre ma demande de référencement ADAGE')
     ).not.toBeInTheDocument()
@@ -246,20 +270,27 @@ describe('VenueOfferSteps', () => {
       hasCreatedOffer: true,
       hasPendingBankInformationApplication: false,
     }
-    props.shouldDisplayEACInformationSection = false
+
     renderVenueOfferSteps(props)
+
     expect(screen.queryByText('Prochaines étapes :')).not.toBeInTheDocument()
     expect(screen.queryByTestId('venue-offer-steps')).not.toBeInTheDocument()
     expect(screen.queryByTestId('home-offer-steps')).not.toBeInTheDocument()
   })
 
   it('should display venueOfferSteps if condition to display it', () => {
+    vi.spyOn(
+      venueUtils,
+      'shouldDisplayEACInformationSectionForVenue'
+    ).mockReturnValue(true)
+    props.venue = { ...defaultGetOffererVenueResponseModel }
     props.venue = {
       ...defaultGetOffererVenueResponseModel,
       hasCreatedOffer: true,
     }
-    props.shouldDisplayEACInformationSection = true
+
     renderVenueOfferSteps(props)
+
     expect(screen.getByText('Prochaines étapes :')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
@@ -13,6 +13,7 @@ import {
 
 import { Events, VenueEvents } from '../../../../core/FirebaseEvents/constants'
 import * as useAnalytics from '../../../../hooks/useAnalytics'
+import * as venueUtils from '../../venueUtils'
 import { VenueOfferSteps, VenueOfferStepsProps } from '../VenueOfferSteps'
 
 const mockLogEvent = vi.fn()
@@ -47,7 +48,12 @@ describe('VenueOfferSteps', () => {
     vi.spyOn(useAnalytics, 'default').mockImplementation(() => ({
       logEvent: mockLogEvent,
     }))
+    vi.spyOn(
+      venueUtils,
+      'shouldDisplayEACInformationSectionForVenue'
+    ).mockReturnValue(true)
   })
+
   it('should track creation venue', async () => {
     renderVenueOfferSteps()
 
@@ -130,7 +136,6 @@ describe('VenueOfferSteps', () => {
     renderVenueOfferSteps({
       venue: { ...venue, hasPendingBankInformationApplication: true },
       hasVenue: true,
-      shouldDisplayEACInformationSection: true,
     })
 
     await userEvent.click(

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -1,9 +1,7 @@
 import cn from 'classnames'
-import { addDays, isBefore } from 'date-fns'
 import React, { useState } from 'react'
 
 import {
-  DMSApplicationstatus,
   GetOffererResponseModel,
   GetOffererVenueResponseModel,
 } from 'apiClient/v1'
@@ -19,10 +17,10 @@ import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { Tag, TagVariant } from 'ui-kit/Tag/Tag'
-import { getLastCollectiveDmsApplication } from 'utils/getLastCollectiveDmsApplication'
 
 import { Card } from '../Card'
 import { VenueOfferSteps } from '../VenueOfferSteps/VenueOfferSteps'
+import { shouldDisplayEACInformationSectionForVenue } from '../venueUtils'
 
 import styles from './Venue.module.scss'
 
@@ -33,30 +31,8 @@ export interface VenueProps {
 }
 
 export const Venue = ({ offerer, venue, isFirstVenue }: VenueProps) => {
-  const dmsInformations = getLastCollectiveDmsApplication(
-    venue.collectiveDmsApplications
-  )
-  const hasAdageIdForMoreThan30Days =
-    venue.hasAdageId &&
-    !!venue.adageInscriptionDate &&
-    isBefore(new Date(venue.adageInscriptionDate), addDays(new Date(), -30))
-
-  const hasRefusedApplicationForMoreThan30Days =
-    (dmsInformations?.state == DMSApplicationstatus.REFUSE ||
-      dmsInformations?.state == DMSApplicationstatus.SANS_SUITE) &&
-    dmsInformations.processingDate &&
-    isBefore(
-      new Date(dmsInformations?.processingDate),
-      addDays(new Date(), -30)
-    )
-
-  const shouldDisplayEACInformationSection =
-    Boolean(dmsInformations) &&
-    !hasAdageIdForMoreThan30Days &&
-    !hasRefusedApplicationForMoreThan30Days
-
   const shouldShowVenueOfferSteps =
-    shouldDisplayEACInformationSection ||
+    shouldDisplayEACInformationSectionForVenue(venue) ||
     !venue.hasCreatedOffer ||
     venue.hasPendingBankInformationApplication
 
@@ -200,11 +176,8 @@ export const Venue = ({ offerer, venue, isFirstVenue }: VenueProps) => {
           <VenueOfferSteps
             offerer={offerer}
             venue={venue}
-            hasVenue={true}
+            hasVenue
             isFirstVenue={isFirstVenue}
-            shouldDisplayEACInformationSection={
-              shouldDisplayEACInformationSection
-            }
           />
         </div>
       )}

--- a/pro/src/pages/Home/venueUtils.ts
+++ b/pro/src/pages/Home/venueUtils.ts
@@ -1,7 +1,11 @@
+import { isBefore, addDays } from 'date-fns'
+
 import {
+  DMSApplicationstatus,
   GetOffererResponseModel,
   GetOffererVenueResponseModel,
 } from 'apiClient/v1'
+import { getLastCollectiveDmsApplication } from 'utils/getLastCollectiveDmsApplication'
 
 export const getVirtualVenueFromOfferer = (
   offerer?: GetOffererResponseModel | null
@@ -22,3 +26,31 @@ export const hasOffererAtLeastOnePhysicalVenue = (
   offerer?: GetOffererResponseModel | null
 ): boolean =>
   offerer?.managedVenues?.some((venue) => !venue.isVirtual && venue.id) ?? false
+
+export const shouldDisplayEACInformationSectionForVenue = (
+  venue: GetOffererVenueResponseModel
+): boolean => {
+  const dmsInformations = getLastCollectiveDmsApplication(
+    venue.collectiveDmsApplications
+  )
+
+  const hasAdageIdForMoreThan30Days =
+    venue.hasAdageId &&
+    !!venue.adageInscriptionDate &&
+    isBefore(new Date(venue.adageInscriptionDate), addDays(new Date(), -30))
+
+  const hasRefusedApplicationForMoreThan30Days =
+    (dmsInformations?.state == DMSApplicationstatus.REFUSE ||
+      dmsInformations?.state == DMSApplicationstatus.SANS_SUITE) &&
+    dmsInformations.processingDate &&
+    isBefore(
+      new Date(dmsInformations?.processingDate),
+      addDays(new Date(), -30)
+    )
+
+  return (
+    Boolean(dmsInformations) &&
+    !hasAdageIdForMoreThan30Days &&
+    !hasRefusedApplicationForMoreThan30Days
+  )
+}

--- a/pro/src/ui-kit/Button/Button.tsx
+++ b/pro/src/ui-kit/Button/Button.tsx
@@ -3,7 +3,6 @@
 import cn from 'classnames'
 import React from 'react'
 
-import fullRightIcon from 'icons/full-right.svg'
 import strokePassIcon from 'icons/stroke-pass.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import Tooltip from 'ui-kit/Tooltip'
@@ -69,14 +68,6 @@ const Button = ({
           src={icon}
           alt=""
           className={styles['button-icon']}
-          width="20"
-        />
-      )}
-      {!isLoading && variant === ButtonVariant.BOX && (
-        <SvgIcon
-          src={fullRightIcon}
-          alt=""
-          className={cn(styles['button-icon'], styles['button-icon-arrow'])}
           width="20"
         />
       )}

--- a/pro/src/ui-kit/Button/ButtonLink.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.tsx
@@ -2,7 +2,6 @@ import cn from 'classnames'
 import React, { FocusEventHandler, MouseEventHandler } from 'react'
 import { Link } from 'react-router-dom'
 
-import fullRightIcon from 'icons/full-right.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './Button.module.scss'
@@ -77,17 +76,6 @@ const ButtonLink = ({
       ) : (
         <>{children}</>
       )}
-      {
-        /* istanbul ignore next: graphic variation */ variant ===
-          ButtonVariant.BOX && (
-          <SvgIcon
-            src={fullRightIcon}
-            alt={svgAlt}
-            className={cn(styles['button-icon'], styles['button-icon-arrow'])}
-            width="22"
-          />
-        )
-      }
     </>
   )
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26279

Il n'y a pas de lieu permanent avec des next steps dans la sandbox (on a un ticket back pour changer la sandbox), ma reco est de checkout en local et manuellement changer un lieu qui a des next steps en permanent en settant isPermanent = true

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/e055807a-f301-4ad6-adcf-14c7dad74e27)