### PR TITLE
(PC-26190)[PRO] feat: add studentLevel for marseille in offer edition…

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
@@ -1,8 +1,10 @@
 import { useFormikContext } from 'formik'
 import React from 'react'
 
+import { StudentLevels } from 'apiClient/adage'
 import FormLayout from 'components/FormLayout'
 import { OfferEducationalFormValues } from 'core/OfferEducational'
+import useActiveFeature from 'hooks/useActiveFeature'
 import { CheckboxGroup, InfoBox } from 'ui-kit'
 
 import useParticipantsOptions from './useParticipantsOptions'
@@ -23,19 +25,35 @@ const FormParticipants = ({
     isTemplate
   )
 
+  const isMarseilleEnabled = useActiveFeature('WIP_ENABLE_MARSEILLE')
+
+  const filteredParticipantsOptions = isMarseilleEnabled
+    ? defaultPartipantsOptions
+    : defaultPartipantsOptions.filter(
+        (option) =>
+          option.name !==
+            `participants.${StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE}` &&
+          option.name !==
+            `participants.${StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_PRIMAIRE}`
+      )
+
   return (
     <FormLayout.Section title="Participants">
       <FormLayout.Row
         sideComponent={
           <InfoBox>
-            Le pass Culture à destination du public scolaire s’adresse aux
+            {isMarseilleEnabled
+              ? `Dans le cadre du projet Marseille en Grand, les écoles primaires
+            innovantes du territoire marseillais bénéficient d’un budget pour
+            financer des projets d’EAC avec leurs élèves.`
+              : `Le pass Culture à destination du public scolaire s’adresse aux
             élèves de la sixième à la terminale des établissements publics et
-            privés sous contrat.
+            privés sous contrat.`}
           </InfoBox>
         }
       >
         <CheckboxGroup
-          group={defaultPartipantsOptions}
+          group={filteredParticipantsOptions}
           groupName="participants"
           legend="Cette offre s'adresse aux élèves de :"
           disabled={disableForm}


### PR DESCRIPTION
… and creation

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26190

Ajouter les deux nouvelles classes côté pro dans l'edition et la création d'une offre lorsque le ff est activé (WIP_ENABLE_MARSEILLE)