### PR TITLE
(BSR)[PRO] feat: display same offer count in stats as in offer list

### DIFF
--- a/pro/src/pages/Home/StatisticsDashboard/OfferStats.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/OfferStats.tsx
@@ -11,6 +11,7 @@ import fullLinkIcon from 'icons/full-link.svg'
 import fullShowIcon from 'icons/full-show.svg'
 import strokePhoneIcon from 'icons/stroke-phone.svg'
 import strokeTeacherIcon from 'icons/stroke-teacher.svg'
+import { getOffersCountToDisplay } from 'pages/Offers/domain/getOffersCountToDisplay'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -43,7 +44,10 @@ const StatBlock = ({ icon, count, label, link, linkLabel }: StatBlockProps) => (
 
     <div className={styles['stat-block-text']}>
       <p>
-        <span className={styles['stat-block-count']}>{count}</span> {label}
+        <span className={styles['stat-block-count']}>
+          {getOffersCountToDisplay(count)}
+        </span>{' '}
+        {label}
       </p>
       <ButtonLink
         variant={ButtonVariant.QUATERNARY}

--- a/pro/src/pages/Home/StatisticsDashboard/__specs__/OfferStats.spec.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/__specs__/OfferStats.spec.tsx
@@ -86,4 +86,17 @@ describe('OfferStats', () => {
       '5 à destination de groupes scolaires'
     )
   })
+
+  it('should render when the count is too high', async () => {
+    vi.spyOn(api, 'getOffererV2Stats').mockResolvedValueOnce({
+      publishedPublicOffers: 10000,
+      publishedEducationalOffers: 0,
+      pendingPublicOffers: 0,
+      pendingEducationalOffers: 0,
+    })
+
+    renderOfferStats()
+
+    expect(await screen.findByText('500+')).toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/Offers/domain/getOffersCountToDisplay.ts
+++ b/pro/src/pages/Offers/domain/getOffersCountToDisplay.ts
@@ -1,4 +1,6 @@
 import { MAX_OFFERS_TO_DISPLAY } from 'core/Offers/constants'
 
 export const getOffersCountToDisplay = (offersCount: number) =>
-  offersCount <= MAX_OFFERS_TO_DISPLAY ? offersCount.toString() : '500+'
+  offersCount <= MAX_OFFERS_TO_DISPLAY
+    ? offersCount.toString()
+    : `${MAX_OFFERS_TO_DISPLAY}+`


### PR DESCRIPTION
## But de la pull request

Cf https://passcultureteam.slack.com/archives/C02BSV8DHU0/p1703856412196479

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques