### PR TITLE
(BSR)[API] test: Fix flaky tests/core/finance/test_api.py::PriceEventTest::test_accrue_revenue

### DIFF
--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -146,7 +146,7 @@ class PriceEventTest:
         return models.FinanceEvent.query.filter_by(booking=booking).one()
 
     def _make_collective_event(self, price=None, user=None, stock=None, venue=None):
-        booking_kwargs = {}
+        booking_kwargs = {"dateUsed": datetime.datetime.utcnow()}
         if user:
             booking_kwargs["user"] = user
         if stock:


### PR DESCRIPTION
This test failed when run at the beginning of the year, because the
"used date" of a collective was set to a few days before, possibly the
previous year. The calculated revenue of pricings would be wrong.