### PR TITLE
(PC-25032)[API] fix: subcategories ean conditional_fields

### DIFF
--- a/api/src/pcapi/core/categories/subcategories_v2.py
+++ b/api/src/pcapi/core/categories/subcategories_v2.py
@@ -817,7 +817,7 @@ LIVRE_AUDIO_PHYSIQUE = Subcategory(
     is_event=False,
     conditional_fields={
         ExtraDataFieldEnum.AUTHOR.value: FieldCondition(),
-        ExtraDataFieldEnum.EAN.value: FieldCondition(),
+        ExtraDataFieldEnum.EAN.value: FieldCondition(is_required_in_external_form=True),
     },
     can_expire=True,
     can_be_duo=False,
@@ -1258,7 +1258,7 @@ TELECHARGEMENT_MUSIQUE = Subcategory(
             is_required_in_external_form=True, is_required_in_internal_form=True
         ),
         ExtraDataFieldEnum.PERFORMER.value: FieldCondition(),
-        ExtraDataFieldEnum.EAN.value: FieldCondition(is_required_in_external_form=True),
+        ExtraDataFieldEnum.EAN.value: FieldCondition(),
     },
     can_expire=False,
     can_be_duo=False,


### PR DESCRIPTION
ean is required for LIVRE_AUDIO_PHYSIQUE but not for TELECHARGEMENT_MUSIQUE

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25032
