### PR TITLE
(PC-26655)[API] feat: offerFactory takes into consideration the subcategory for extradata

### DIFF
--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -1,15 +1,19 @@
 import datetime
 import decimal
+import random
 import typing
 import uuid
 
 import factory
+from factory.faker import faker
 
 from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.factories import BaseFactory
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.models as offers_models
 import pcapi.core.users.factories as users_factories
+from pcapi.domain import music_types
+from pcapi.domain import show_types
 from pcapi.models.offer_mixin import OfferValidationType
 
 from . import models
@@ -44,6 +48,69 @@ class ThingProductFactory(ProductFactory):
     subcategoryId = subcategories.SUPPORT_PHYSIQUE_FILM.id
 
 
+def build_extra_data_from_subcategory(subcategory_id: str, set_all_fields: bool) -> offers_models.OfferExtraData:
+    fake = faker.Faker(locale="fr_FR")
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT.get(subcategory_id)
+    if not subcategory:
+        raise ValueError(f"Unknown subcategory {subcategory_id}")
+    extradata: offers_models.OfferExtraData = {}
+    name_fields = [
+        subcategories.ExtraDataFieldEnum.AUTHOR.value,
+        subcategories.ExtraDataFieldEnum.PERFORMER.value,
+        subcategories.ExtraDataFieldEnum.SPEAKER.value,
+        subcategories.ExtraDataFieldEnum.STAGE_DIRECTOR.value,
+    ]
+    conditional_fields = (
+        sorted(  # we sort to ensure MUSIC_SUB_TYPE and SHOW_SUB_TYPE is always after MUSIC_TYPE and SHOW_TYPE
+            subcategory.conditional_fields,
+            key=lambda field: (
+                1
+                if field
+                in [
+                    subcategories.ExtraDataFieldEnum.MUSIC_SUB_TYPE.value,
+                    subcategories.ExtraDataFieldEnum.SHOW_SUB_TYPE.value,
+                ]
+                else 0
+            ),
+        )
+    )
+    for field in conditional_fields:
+        if (
+            not set_all_fields
+            and not subcategory.conditional_fields[field].is_required_in_internal_form
+            and random.choice([True, False])
+        ):
+            continue
+        match field:
+            case item if item in name_fields:
+                extradata[field] = fake.name()  # type: ignore [literal-required]
+            case subcategories.ExtraDataFieldEnum.EAN.value:
+                extradata[field] = fake.ean13()
+            case subcategories.ExtraDataFieldEnum.GTL_ID.value:
+                # GTLS are only for synchronized books thus it's handeled by product factory
+                continue
+            case subcategories.ExtraDataFieldEnum.VISA.value:
+                extradata[field] = fake.ean()
+            case subcategories.ExtraDataFieldEnum.MUSIC_TYPE.value:
+                extradata[field] = str(random.choice(music_types.music_types).code)
+            case subcategories.ExtraDataFieldEnum.MUSIC_SUB_TYPE.value:
+                music_type_code = extradata.get(subcategories.ExtraDataFieldEnum.MUSIC_TYPE.value)
+                assert music_type_code
+                music_type = music_types.MUSIC_TYPES_BY_CODE.get(int(music_type_code))
+                assert music_type
+                extradata[field] = str(random.choice(music_type.children).code)
+            case subcategories.ExtraDataFieldEnum.SHOW_TYPE.value:
+                extradata[field] = str(random.choice(show_types.show_types).code)
+            case subcategories.ExtraDataFieldEnum.SHOW_SUB_TYPE.value:
+                show_type_code = extradata.get(subcategories.ExtraDataFieldEnum.SHOW_TYPE.value)
+                assert show_type_code
+                show_type = show_types.SHOW_TYPES_BY_CODE.get(int(show_type_code))
+                assert show_type
+                extradata[field] = str(random.choice(show_type.children).code)
+
+    return offers_models.OfferExtraData(**extradata)
+
+
 class OfferFactory(BaseFactory):
     class Meta:
         model = models.Offer
@@ -57,7 +124,6 @@ class OfferFactory(BaseFactory):
     motorDisabilityCompliant = False
     visualDisabilityCompliant = False
     lastValidationType = OfferValidationType.AUTO
-    extraData = None
 
     @classmethod
     def _create(
@@ -75,6 +141,15 @@ class OfferFactory(BaseFactory):
                 models.OfferValidationStatus.REJECTED,
                 models.OfferValidationStatus.PENDING,
             )
+        if "extraData" not in kwargs:
+            product = kwargs.get("product")
+            if product:
+                kwargs["extraData"] = product.extraData
+            subcategory_id = kwargs.get("subcategoryId")
+            assert isinstance(
+                subcategory_id, str
+            )  # if the subcategoryId was not given in the factory, it will get the default subcategoryId
+            kwargs["extraData"] = build_extra_data_from_subcategory(subcategory_id, kwargs.pop("set_all_fields", False))
 
         return super()._create(model_class, *args, **kwargs)
 

--- a/api/src/pcapi/domain/music_types.py
+++ b/api/src/pcapi/domain/music_types.py
@@ -345,6 +345,7 @@ music_types = [
     ),
 ]
 
+MUSIC_TYPES_BY_CODE = {music_type.code: music_type for music_type in music_types}
 MUSIC_TYPES_LABEL_BY_CODE = {music_type.code: music_type.label for music_type in music_types}
 MUSIC_TYPES_BY_SLUG = {
     music_sub_type.slug: music_type for music_type in music_types for music_sub_type in music_type.children
@@ -355,7 +356,7 @@ MUSIC_SUB_TYPES_LABEL_BY_CODE = {
 }
 MUSIC_SUB_TYPES_BY_CODE = {
     music_sub_type.code: music_sub_type for music_type in music_types for music_sub_type in music_type.children
-}
+}  # WARNING: for code -1, the sub type is not unique, it returns the one with the slug CHANSON_VARIETE-OTHER
 MUSIC_SUB_TYPES_BY_SLUG = {
     music_sub_type.slug: music_sub_type for music_type in music_types for music_sub_type in music_type.children
 }

--- a/api/src/pcapi/domain/show_types.py
+++ b/api/src/pcapi/domain/show_types.py
@@ -176,6 +176,7 @@ show_types = [
     ),
 ]
 
+SHOW_TYPES_BY_CODE = {show_type.code: show_type for show_type in show_types}
 SHOW_TYPES_LABEL_BY_CODE = {show_type.code: show_type.label for show_type in show_types}
 SHOW_TYPES_BY_SLUG = {show_sub_type.slug: show_type for show_type in show_types for show_sub_type in show_type.children}
 
@@ -184,7 +185,7 @@ SHOW_SUB_TYPES_LABEL_BY_CODE = {
 }
 SHOW_SUB_TYPES_BY_CODE = {
     show_sub_type.code: show_sub_type for show_type in show_types for show_sub_type in show_type.children
-}
+}  # WARNING: for code -1, the sub type is not unique, it returns the one with the one with the slug OPERA-OTHER
 SHOW_SUB_TYPES_BY_SLUG = {
     show_sub_type.slug: show_sub_type for show_type in show_types for show_sub_type in show_type.children
 }

--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -113,7 +113,6 @@ def create_offers_with_gtl_id(gtl_id: str, size_per_gtl: int, venue: offerers_mo
         description=product.description,
         size=size_per_gtl,
         venue=venue,
-        extraData={"gtl_id": gtl_id, "author": Fake.name(), "ean": ean, "editeur": Fake.name()},
     )
     for offer in offers:
         offers_factories.StockFactory(offer=offer)
@@ -148,10 +147,6 @@ def create_offers_with_same_ean() -> None:
                     city=venue_data["city"],
                     departementCode=venue_data["departementCode"],
                 ),
-                extraData={
-                    "ean": ean,
-                    "author": author,
-                },
             )
         )
         for offer in offers:
@@ -174,7 +169,6 @@ def create_offer_with_ean(ean: str, venue: offerers_models.Venue, author: str) -
         name=product.name,
         subcategoryId=product.subcategoryId,
         description=product.description,
-        extraData={"ean": ean, "author": author},
         venue=venue,
     )
     offers_factories.StockFactory(quantity=random.randint(10, 100), offer=offer)
@@ -303,7 +297,6 @@ def create_book_in_multiple_venues(venues: list[offerers_models.Venue]) -> None:
             name=product.name,
             description=product.description,
             subcategoryId=product.subcategoryId,
-            extraData={"ean": ean, "author": author},
             venue=venue,
         )
         offers_factories.StockFactory(quantity=random.randint(10, 100), offer=offer)
@@ -325,7 +318,6 @@ def create_books_with_the_same_author_duplicated_in_multiple_venues(venues: list
                 name=product.name,
                 subcategoryId=product.subcategoryId,
                 description=product.description,
-                extraData={"ean": ean, "author": author},
                 venue=venue,
             )
             offers_factories.StockFactory(quantity=random.randint(10, 100), offer=offer)
@@ -342,7 +334,6 @@ def create_books_with_the_same_author_duplicated_in_multiple_venues(venues: list
             name=product.name,
             subcategoryId=product.subcategoryId,
             description=product.description,
-            extraData={"ean": ean, "author": author},
             venue=venues[3],
         )
         offers_factories.StockFactory(quantity=random.randint(10, 100), offer=offer)
@@ -362,7 +353,6 @@ def create_multiauthors_books(venues: list[offerers_models.Venue]) -> None:
         name=product.name,
         subcategoryId=product.subcategoryId,
         description=product.description,
-        extraData={"ean": ean, "author": ", ".join(authors)},
         venue=venues[0],
     )
     offers_factories.StockFactory(quantity=random.randint(10, 100), offer=offer)
@@ -371,7 +361,6 @@ def create_multiauthors_books(venues: list[offerers_models.Venue]) -> None:
         for _ in range(4):
             create_offer_with_ean(Fake.ean13(), random.choice(venues), author=author)
 
-    # author "collectif"
     author = "collectif"
     for _ in range(3):
         create_offer_with_ean(Fake.ean13(), random.choice(venues), author=author)

--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -49,7 +49,6 @@ def save_test_cases_sandbox() -> None:
     create_specific_invoice()
     create_specific_cashflow_batch_without_invoice()
     create_venue_labels(sandbox=True)
-    create_offers_with_more_extra_data()
     create_venues_with_gmaps_image()
     create_app_beneficiary()
     create_venues_with_practical_info_graphical_edge_cases()
@@ -376,113 +375,6 @@ def create_multiauthors_books(venues: list[offerers_models.Venue]) -> None:
     author = "collectif"
     for _ in range(3):
         create_offer_with_ean(Fake.ean13(), random.choice(venues), author=author)
-
-
-def create_offers_with_more_extra_data() -> None:
-    venue_data = random.choice(venues_mock.venues)
-    venue = offerers_factories.VenueFactory(
-        name="extra_data " + str(venue_data["name"]),
-        venueTypeCode=offerers_models.VenueTypeCode.BOOKSTORE,
-        latitude=venue_data["latitude"],
-        longitude=venue_data["longitude"],
-        address=venue_data["address"],
-        postalCode=venue_data["postalCode"],
-        city=venue_data["city"],
-        departementCode=venue_data["departementCode"],
-    )
-    for _ in range(2):
-        create_offers_with_gtl_id(gtl_id=random.choice(list(GTLS)), size_per_gtl=1, venue=venue)
-        creat_cine_offer_with_cast(venue)
-        create_music_offers(venue)
-        create_event_offers(venue)
-
-
-def create_music_offers(venue: offerers_models.Venue) -> None:
-    for subcategory in filter(
-        lambda subcategory: subcategories_v2.ExtraDataFieldEnum.MUSIC_TYPE in subcategory.conditional_fields,
-        list(subcategories_v2.ALL_SUBCATEGORIES),
-    ):
-        music_type = random.choice(music_types)
-        create_offers_with_extradata(
-            venue=venue,
-            extra_data={
-                "musicType": str(music_type.code),
-                "musicSubType": str(random.choice(music_type.children).code),
-                "performer": Fake.name(),
-            },
-            subcategory=subcategory,
-        )
-
-
-def create_event_offers(venue: offerers_models.Venue) -> None:
-    for subcategory in subcategories_v2.EVENT_SUBCATEGORIES.values():
-        show_type = random.choice(list(show_types))
-        create_offers_with_extradata(
-            venue=venue,
-            extra_data={
-                "showType": str(show_type.code),
-                "showSubType": str(random.choice(show_type.children).code),
-                "performer": Fake.name(),
-                "stageDirector": Fake.name(),
-                "speaker": Fake.name(),
-            },
-            subcategory=subcategory,
-        )
-
-
-def creat_cine_offer_with_cast(venue: offerers_models.Venue) -> None:
-    create_offers_with_extradata(
-        venue=venue,
-        extra_data={
-            "cast": [Fake.name() for _ in range(random.randint(1, 10))],
-            "releaseDate": Fake.date(),
-            "genres": [random.choice(movie_types).name for _ in range(random.randint(1, 4))],
-            "stageDirector": Fake.name(),
-        },
-        subcategory=subcategories_v2.SEANCE_CINE,
-    )
-
-
-def create_offers_with_extradata(
-    venue: offerers_models.Venue,
-    subcategory: subcategories_v2.Subcategory | None = None,
-    extra_data: dict | None = None,
-    should_create_product: bool = False,
-    name: str | None = None,
-    description: str | None = None,
-) -> None:
-    if not subcategory:
-        subcategory = random.choice(subcategories_v2.ALL_SUBCATEGORIES)
-    offer_adapted_factory = (
-        offers_factories.EventOfferFactory if subcategory.is_event else offers_factories.OfferFactory
-    )
-    if should_create_product:
-        product = offers_factories.ProductFactory(
-            name=name if name else "product with extradata" + Fake.sentence(nb_words=3, variable_nb_words=True)[:-1],
-            subcategoryId=subcategory.id,
-            lastProvider=providers_factory.PublicApiProviderFactory(name="BookProvider"),
-            extraData=extra_data,
-            description=description if description else Fake.paragraph(nb_sentences=5, variable_nb_sentences=True),
-        )
-        offer = offer_adapted_factory(
-            product=product,
-            name=product.name,
-            subcategoryId=product.subcategoryId,
-            description=product.description,
-            venue=venue,
-            extraData=product.extraData,
-        )
-    else:
-        offer = offer_adapted_factory(
-            name=name if name else "offer with extradata" + Fake.sentence(nb_words=3, variable_nb_words=True)[:-1],
-            subcategoryId=subcategory.id,
-            description=description if description else Fake.paragraph(nb_sentences=5, variable_nb_sentences=True),
-            venue=venue,
-            extraData=extra_data,
-        )
-    offers_factories.StockFactory(
-        offer=offer,
-    )
 
 
 def create_venues_with_gmaps_image() -> None:

--- a/api/tests/core/offers/test_factories.py
+++ b/api/tests/core/offers/test_factories.py
@@ -1,0 +1,80 @@
+import pytest
+
+from pcapi.core.categories import subcategories_v2 as subcategories
+from pcapi.core.offers.factories import OfferFactory
+from pcapi.core.offers.models import OfferExtraData
+from pcapi.domain import music_types
+from pcapi.domain import show_types
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class OfferFactoryTest:
+    def test_default(self):
+        offer = OfferFactory(set_all_fields=True)
+        assert offer.extraData
+
+    def test_extradata_is_none(self):
+        offer = OfferFactory(extraData=None)
+        assert offer.extraData is None
+
+    def test_keeps_extra_data(self):
+        extra_data = OfferExtraData(author="Dan Nguyen")
+
+        offer = OfferFactory(extraData=extra_data)
+
+        assert offer.extraData == {"author": "Dan Nguyen"}
+
+    def test_generate_book_extra_data_does_not_set_gtl_id(self):
+        book_offer = OfferFactory(subcategoryId=subcategories.LIVRE_PAPIER.id, set_all_fields=True)
+        assert book_offer.extraData.get("gtl_id") is None
+
+    def test_generate_cinema_extra_data(self):
+        cinema_offer = OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id, set_all_fields=True)
+
+        assert cinema_offer.extraData is not None
+        assert isinstance(cinema_offer.extraData.get("author"), str)
+        assert isinstance(cinema_offer.extraData.get("visa"), str)
+        assert isinstance(cinema_offer.extraData.get("stageDirector"), str)
+
+    def test_generate_book_extra_data(self):
+        book_offer = OfferFactory(subcategoryId=subcategories.LIVRE_PAPIER.id, set_all_fields=True)
+        import re
+
+        assert book_offer.extraData is not None
+        assert isinstance(book_offer.extraData.get("author"), str)
+        assert re.match(r"\d{13}", book_offer.extraData.get("ean"))
+
+    def test_generate_concert_extra_data(self):
+        concert_offer = OfferFactory(subcategoryId=subcategories.CONCERT.id, set_all_fields=True)
+
+        assert concert_offer.extraData is not None
+        assert isinstance(concert_offer.extraData.get("author"), str)
+        assert isinstance(concert_offer.extraData.get("performer"), str)
+
+        music_type_code = int(concert_offer.extraData.get("musicType"))
+        music_type = music_types.MUSIC_TYPES_BY_CODE.get(music_type_code)
+        assert music_type_code in music_types.MUSIC_TYPES_BY_CODE
+
+        music_sub_type_code = int(concert_offer.extraData.get("musicSubType"))
+        music_sub_type = music_types.MUSIC_SUB_TYPES_BY_CODE.get(music_sub_type_code)
+
+        assert music_sub_type_code == -1 or music_sub_type in music_type.children
+
+    def test_generate_spectacle_representation_extra_data(self):
+        concert_offer = OfferFactory(subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id, set_all_fields=True)
+
+        assert concert_offer.extraData is not None
+        assert isinstance(concert_offer.extraData.get("author"), str)
+        assert isinstance(concert_offer.extraData.get("stageDirector"), str)
+        assert isinstance(concert_offer.extraData.get("performer"), str)
+
+        show_type_code = int(concert_offer.extraData.get("showType"))
+        show_type = show_types.SHOW_TYPES_BY_CODE.get(show_type_code)
+        assert show_type_code in show_types.SHOW_TYPES_BY_CODE
+
+        show_sub_type_code = int(concert_offer.extraData.get("showSubType"))
+        show_sub_type = show_types.SHOW_SUB_TYPES_BY_CODE.get(show_sub_type_code)
+
+        assert show_sub_type_code == -1 or show_sub_type in show_type.children

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -703,6 +703,7 @@ class GetBookingsTest:
             dateUsed=datetime(2023, 3, 2),
             stock__offer__url=OFFER_URL,
             stock__features=["VO"],
+            stock__offer__extraData=None,
             cancellation_limit_date=datetime(2023, 3, 2),
         )
 

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -120,6 +120,7 @@ class Returns200Test:
             name="Derrick",
             description="Tatort, but slower",
             durationMinutes=60,
+            extraData=None,
             mentalDisabilityCompliant=True,
             externalTicketOfficeUrl="http://example.net",
             withdrawalDetails="Veuillez chercher votre billet au guichet",

--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -29,6 +29,7 @@ class GetEventTest:
         event_offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.SEANCE_CINE.id,
             venue=venue,
+            extraData=None,
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
             product=product,
@@ -84,7 +85,7 @@ class GetEventTest:
         )
 
         assert response.status_code == 200
-        assert response.json["categoryRelatedFields"] == {"category": "DECOUVERTE_METIERS", "speaker": None}
+        assert response.json["categoryRelatedFields"]["category"] == "DECOUVERTE_METIERS"
 
     def test_get_event_without_ticket(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
@@ -104,6 +105,7 @@ class GetEventTest:
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         event_offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.CONCERT.id,
+            extraData=None,
             venue=venue,
         )
 

--- a/api/tests/routes/public/individual_offers/v1/get_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_test.py
@@ -53,8 +53,7 @@ class GetProductTest:
     def test_books_can_be_retrieved(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            venue=venue, subcategoryId=subcategories.LIVRE_PAPIER.id, extraData=None
         )
         # This overpriced stock can be removed once all stocks have a price under 300 €
         offers_factories.StockFactory(offer=product_offer, price=decimal.Decimal("400.12"))


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26655
L'objectif de cette modification est de rendre la sandbox plus réaliste.
on n'a plus besoins de create offers with extra data car c'est ce qui ce passe par defaut dans create_offers_for_each_subcategory()
## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques