### PR TITLE
(PC-26056)[API] feat: backoffice add information on collective offer

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1081,6 +1081,12 @@ class EducationalRedactor(PcObject, Base, Model):
         back_populates="educationalRedactorsFavorite",
     )
 
+    @property
+    def full_name(self) -> str:
+        # full_name is used for display and should never be empty, which would be confused with no user.
+        # We use the email as a fallback because it is the most human-readable way to identify a single user
+        return (f"{self.firstName or ''} {self.lastName or ''}".strip()) or self.email
+
 
 class CollectiveBooking(PcObject, Base, Model):
     __tablename__ = "collective_booking"

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -372,6 +372,16 @@ def get_collective_offer_details(collective_offer_id: int) -> utils.BackofficeRe
         sa.orm.joinedload(educational_models.CollectiveOffer.lastValidationAuthor).load_only(
             users_models.User.firstName, users_models.User.lastName
         ),
+        sa.orm.joinedload(educational_models.CollectiveOffer.teacher).load_only(
+            educational_models.EducationalRedactor.firstName,
+            educational_models.EducationalRedactor.lastName,
+        ),
+        sa.orm.joinedload(educational_models.CollectiveOffer.institution).load_only(
+            educational_models.EducationalInstitution.name
+        ),
+        sa.orm.joinedload(educational_models.CollectiveOffer.template).load_only(
+            educational_models.CollectiveOfferTemplate.name,
+        ),
     )
     collective_offer = collective_offer_query.one_or_none()
     if not collective_offer:

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -66,6 +66,16 @@
                   <span class="fw-bold">Places :</span>
                   {% if collective_offer.collectiveStock %}{{ collective_offer.collectiveStock.numberOfTickets }}{% endif %}
                 </p>
+                {% if collective_offer.institution %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Établissement :</span> {{ collective_offer.institution.name }}
+                  </p>
+                {% endif %}
+                {% if collective_offer.teacher %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Enseignant :</span> {{ collective_offer.teacher.full_name }}
+                  </p>
+                {% endif %}
               </div>
             </div>
             <div class="col-4">
@@ -79,6 +89,13 @@
                   <span class="fw-bold">Lieu :</span> {{ links.build_venue_name_to_details_link(collective_offer.venue) }}
                 </p>
               </div>
+              {% if collective_offer.template %}
+                <div class="fs-6">
+                  <p class="mb-1">
+                    <span class="fw-bold">Offre vitrine liée :</span> {{ links.build_collective_offer_template_details_link(collective_offer.template) }}
+                  </p>
+                </div>
+              {% endif %}
             </div>
           </div>
         </div>

--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -60,6 +60,11 @@
      class="link-primary"
      title="Page de l'offre">{{ offer.id }}</a>
 {% endmacro %}
+{% macro build_collective_offer_template_details_link(offer) %}
+  <a href="{{ url_for('backoffice_web.collective_offer_template.list_collective_offer_templates', q=offer.id) }}" {# !TODO: need to create function in blueprint in PC-26057 #}
+    class="link-primary"
+  title="Page de l'offre vitrine">{{ offer.name }}</a>
+{% endmacro %}
 {% macro build_bank_account_name_to_details_link(bank_account, text_attr="label") %}
   <a href="{{ url_for('backoffice_web.bank_account.get', bank_account_id=bank_account.id) }}"
      class="link-primary"

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -528,6 +528,15 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         event_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         collective_booking = educational_factories.CollectiveBookingFactory(
             collectiveStock__beginningDatetime=event_date,
+            collectiveStock__collectiveOffer__teacher=educational_factories.EducationalRedactorFactory(
+                firstName="Pacôme", lastName="De Champignac"
+            ),
+            collectiveStock__collectiveOffer__institution=educational_factories.EducationalInstitutionFactory(
+                name="Ecole de Marcinelle"
+            ),
+            collectiveStock__collectiveOffer__template=educational_factories.CollectiveOfferTemplateFactory(
+                name="offre Vito Cortizone pour lieu que l'on ne peut refuser"
+            ),
         )
         url = url_for(self.endpoint, collective_offer_id=collective_booking.collectiveStock.collectiveOffer.id)
         with assert_num_queries(4):
@@ -540,6 +549,9 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         assert "État : Validée" in content_as_text
         assert "Utilisateur de la dernière validation" not in content_as_text
         assert "Date de dernière validation de l’offre" not in content_as_text
+        assert "Enseignant : Pacôme De Champignac" in content_as_text
+        assert "Établissement : Ecole de Marcinelle" in content_as_text
+        assert "Offre vitrine liée : offre Vito Cortizone pour lieu que l'on ne peut refuser" in content_as_text
 
     def test_processed_pricing(self, legit_user, authenticated_client):
         pricing = finance_factories.CollectivePricingFactory(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26056

## Vérifications

l'image de l'exemple ne montre pas l'enseignant car l'offre en question n'en a pas, cependant dans une utre offre on peut voir le nom et prenom de l'enseignant
<img width="1310" alt="Capture d’écran 2024-01-02 à 14 53 14" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/c9663080-006f-4c85-a336-4c98c946da5d">


