### PR TITLE
(PC-26665)[PRO] fix: During the build prevent small svgs from being i…

### DIFF
--- a/pro/vite.config.ts
+++ b/pro/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(({ mode }) => {
       outDir: '../build',
       sourcemap: true,
       emptyOutDir: true,
+      assetsInlineLimit: 0,
     },
     resolve: {
       alias: {


### PR DESCRIPTION
…nlined.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26665

**Objectif**
Corriger l'affichage des icons dans l'app après un build autre que local.
[Les navigateurs modernes interdisent l'affichage des tags de svg `<use>`](https://developer.chrome.com/blog/migrate-way-from-data-urls-in-svg-use?hl=en) avec le contenu inlined. Or Vite 5 rend inline par défaut tous les svg de moins de 4Ko au moment du build. `assetsInlineLimit: 0` permet de désactiver ce comportement de vite.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques