### PR TITLE
(PC-26281)[PRO] feat: V2 - Dans le bloc "page partenaire", je vois le bloc "enseignant" avec les statuts ("Référencé"/"référencement en cours"/"non référencé")

### DIFF
--- a/pro/src/pages/Home/Offerers/PartnerPage.module.scss
+++ b/pro/src/pages/Home/Offerers/PartnerPage.module.scss
@@ -22,6 +22,7 @@
   @include fonts.body-important;
 
   color: colors.$grey-dark;
+  text-transform: uppercase;
   margin-top: rem.torem(16px);
 }
 

--- a/pro/src/pages/Home/Offerers/PartnerPage.module.scss
+++ b/pro/src/pages/Home/Offerers/PartnerPage.module.scss
@@ -41,3 +41,25 @@
   margin-top: rem.torem(32px);
   max-width: rem.torem(500px);
 }
+
+.details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.details-title {
+  @include fonts.title4;
+
+  margin-top: rem.torem(32px);
+  display: inline-block;
+  margin-right: rem.torem(8px);
+}
+
+.details-description {
+  margin-top: rem.torem(8px);
+}
+
+.details-link {
+  margin-top: rem.torem(16px);
+}

--- a/pro/src/pages/Home/Offerers/PartnerPage.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPage.tsx
@@ -106,7 +106,9 @@ export const PartnerPage = ({ offererId, venue }: PartnerPageProps) => {
         <div>
           <div className={styles['venue-type']}>{venueType?.label}</div>
           <div className={styles['venue-name']}>{venue.name}</div>
-          <address className={styles['venue-address']}>{venue.address}</address>
+          <address className={styles['venue-address']}>
+            {venue.address}, {venue.postalCode} {venue.city}
+          </address>
 
           <ButtonLink
             variant={ButtonVariant.SECONDARY}

--- a/pro/src/pages/Home/Offerers/PartnerPage.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPage.tsx
@@ -13,9 +13,15 @@ import {
 import { Events } from 'core/FirebaseEvents/constants'
 import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
+import fullDuplicateIcon from 'icons/full-duplicate.svg'
+import fullInfoIcon from 'icons/full-info.svg'
+import fullLinkIcon from 'icons/full-link.svg'
 import { postImageToVenue } from 'repository/pcapi/pcapi'
-import { ButtonLink } from 'ui-kit'
+import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
+import { copyTextToClipboard } from 'ui-kit/CopyLink/CopyLink'
+import { Tag, TagVariant } from 'ui-kit/Tag/Tag'
+import { WEBAPP_URL } from 'utils/config'
 
 import { Card } from '../Card'
 import { HomepageLoaderData } from '../Homepage'
@@ -90,6 +96,8 @@ export const PartnerPage = ({ offererId, venue }: PartnerPageProps) => {
     })
   }
 
+  const venuePreviewLink = `${WEBAPP_URL}/lieu/${venue.id}`
+
   return (
     <Card>
       <div className={styles['header']}>
@@ -126,6 +134,133 @@ export const PartnerPage = ({ offererId, venue }: PartnerPageProps) => {
       <div className={styles['venue-offer-steps']}>
         <VenueOfferSteps venue={venue} hasVenue isInsidePartnerBlock />
       </div>
+
+      {/* TODO handle not visible case (https://passculture.atlassian.net/browse/PC-26280) */}
+      <section className={styles['details']}>
+        <div>
+          <h4 className={styles['details-title']}>Grand public</h4>
+          <Tag variant={TagVariant.LIGHT_GREEN}>Visible</Tag>
+        </div>
+
+        <p className={styles['details-description']}>
+          Votre page partenaire est visible sur l’application pass Culture.
+        </p>
+
+        <ButtonLink
+          variant={ButtonVariant.TERNARY}
+          icon={fullLinkIcon}
+          link={{
+            to: venuePreviewLink,
+            isExternal: true,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          }}
+          svgAlt="Nouvelle fenêtre"
+          className={styles['details-link']}
+        >
+          Voir ma page dans l’application
+        </ButtonLink>
+
+        <Button
+          variant={ButtonVariant.TERNARY}
+          icon={fullDuplicateIcon}
+          className={styles['details-link']}
+          onClick={async () => {
+            await copyTextToClipboard(venuePreviewLink)
+            notify.success('Lien copié !')
+          }}
+        >
+          Copier le lien de la page
+        </Button>
+      </section>
+
+      {!venue.hasAdageId && !venue.demarchesSimplifieesApplicationId && (
+        <section className={styles['details']}>
+          <div>
+            <h4 className={styles['details-title']}>Enseignants</h4>
+            <Tag variant={TagVariant.LIGHT_BLUE}>Non référencé sur ADAGE</Tag>
+          </div>
+
+          <p className={styles['details-description']}>
+            Pour pouvoir adresser des offres aux enseignants, vous devez être
+            référencé sur ADAGE, l’application du ministère de l’Education
+            nationale et de la Jeunesse dédiée à l’EAC.
+          </p>
+
+          <ButtonLink
+            variant={ButtonVariant.TERNARY}
+            icon={fullLinkIcon}
+            link={{
+              to: 'https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage',
+              isExternal: true,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            }}
+            svgAlt="Nouvelle fenêtre"
+            className={styles['details-link']}
+          >
+            Demander à être référencé sur Adage
+          </ButtonLink>
+
+          <ButtonLink
+            variant={ButtonVariant.TERNARY}
+            icon={fullInfoIcon}
+            link={{
+              to: 'https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires',
+              isExternal: true,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            }}
+            svgAlt="Nouvelle fenêtre"
+            className={styles['details-link']}
+          >
+            En savoir plus sur le pass Culture à destination des scolaires
+          </ButtonLink>
+        </section>
+      )}
+
+      {!venue.hasAdageId && venue.demarchesSimplifieesApplicationId && (
+        <section className={styles['details']}>
+          <div>
+            <h4 className={styles['details-title']}>Enseignants</h4>
+            <Tag variant={TagVariant.LIGHT_YELLOWN}>Référencement en cours</Tag>
+          </div>
+
+          <p className={styles['details-description']}>
+            Votre démarche de référencement est en cours de traitement par
+            ADAGE.
+          </p>
+
+          <ButtonLink
+            variant={ButtonVariant.TERNARY}
+            icon={fullInfoIcon}
+            link={{
+              to: 'https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires',
+              isExternal: true,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            }}
+            svgAlt="Nouvelle fenêtre"
+            className={styles['details-link']}
+          >
+            En savoir plus sur le pass Culture à destination des scolaires
+          </ButtonLink>
+        </section>
+      )}
+
+      {venue.hasAdageId && (
+        <section className={styles['details']}>
+          <div>
+            <h4 className={styles['details-title']}>Enseignants</h4>
+            <Tag variant={TagVariant.LIGHT_GREEN}>Référencé sur ADAGE</Tag>
+          </div>
+
+          <p className={styles['details-description']}>
+            Vos offres collectives sont visibles par les enseignants, de même
+            que les informations renseignées sur votre activité.
+          </p>
+        </section>
+      )}
     </Card>
   )
 }

--- a/pro/src/pages/Home/Offerers/PartnerPages.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPages.tsx
@@ -21,9 +21,8 @@ export const PartnerPages = ({ venues, offererId }: PartnerPagesProps) => {
   const [selectedVenueId, setSelectedVenueId] = useState<string>(
     venues.length > 0 ? venues[0].id.toString() : ''
   )
-  const selectedVenue = venues.find(
-    (venue) => venue.id.toString() === selectedVenueId
-  )
+  const selectedVenue =
+    venues.find((venue) => venue.id.toString() === selectedVenueId) ?? venues[0]
 
   return (
     <section className={styles['section']}>

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPage.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPage.spec.tsx
@@ -78,4 +78,43 @@ describe('PartnerPages', () => {
       'https://www.example.com/image.png'
     )
   })
+
+  it('should display the EAC section when no adage', () => {
+    renderPartnerPages({
+      venue: {
+        ...defaultGetOffererVenueResponseModel,
+        hasAdageId: false,
+        demarchesSimplifieesApplicationId: null,
+      },
+      offererId: '1',
+    })
+
+    expect(screen.getByText('Non référencé sur ADAGE')).toBeInTheDocument()
+  })
+
+  it('should display the EAC section when adage application in progress', () => {
+    renderPartnerPages({
+      venue: {
+        ...defaultGetOffererVenueResponseModel,
+        hasAdageId: false,
+        demarchesSimplifieesApplicationId: 10,
+      },
+      offererId: '1',
+    })
+
+    expect(screen.getByText('Référencement en cours')).toBeInTheDocument()
+  })
+
+  it('should display the EAC section when adage application accepted', () => {
+    renderPartnerPages({
+      venue: {
+        ...defaultGetOffererVenueResponseModel,
+        hasAdageId: true,
+        demarchesSimplifieesApplicationId: 10,
+      },
+      offererId: '1',
+    })
+
+    expect(screen.getByText('Référencé sur ADAGE')).toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPages.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPages.spec.tsx
@@ -35,7 +35,9 @@ describe('PartnerPages', () => {
       offererId: '1',
     })
 
-    expect(screen.getByText(/Votre page partenaire/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Votre page partenaire' })
+    ).toBeInTheDocument()
     expect(
       screen.queryByLabelText(/Sélectionnez votre page partenaire/)
     ).not.toBeInTheDocument()
@@ -53,7 +55,9 @@ describe('PartnerPages', () => {
       offererId: '1',
     })
 
-    expect(screen.getByText(/Vos pages partenaire/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Vos pages partenaire' })
+    ).toBeInTheDocument()
     expect(
       screen.queryByLabelText(/Sélectionnez votre page partenaire/)
     ).toBeInTheDocument()

--- a/pro/src/ui-kit/CopyLink/CopyLink.tsx
+++ b/pro/src/ui-kit/CopyLink/CopyLink.tsx
@@ -10,16 +10,16 @@ export interface CopyLinkProps {
   textToCopy: string
 }
 
+export const copyTextToClipboard = async (text: string) => {
+  if ('clipboard' in navigator) {
+    await navigator.clipboard.writeText(text)
+  } else {
+    document.execCommand('copy', true, text)
+  }
+}
+
 const CopyLink = ({ textToCopy }: CopyLinkProps): JSX.Element => {
   const [isClicked, setIsClicked] = useState(false)
-
-  const copyTextToClipboard = async (text: string) => {
-    if ('clipboard' in navigator) {
-      return await navigator.clipboard.writeText(text).then()
-    } else {
-      return document.execCommand('copy', true, text)
-    }
-  }
 
   return (
     <div

--- a/pro/src/ui-kit/Tag/Tag.module.scss
+++ b/pro/src/ui-kit/Tag/Tag.module.scss
@@ -59,4 +59,16 @@
     background-color: colors.$green-valid;
     color: colors.$white;
   }
+
+  &.light-green {
+    background-color: colors.$callout-success-background;
+  }
+
+  &.light-yellow {
+    background-color: colors.$callout-warning-background;
+  }
+
+  &.light-blue {
+    background-color: colors.$callout-info-background;
+  }
 }

--- a/pro/src/ui-kit/Tag/Tag.tsx
+++ b/pro/src/ui-kit/Tag/Tag.tsx
@@ -12,6 +12,9 @@ export enum TagVariant {
   LIGHT_PURPLE = 'light-purple',
   RED = 'red',
   GREEN = 'green',
+  LIGHT_GREEN = 'light-green',
+  LIGHT_YELLOWN = 'light-yellow',
+  LIGHT_BLUE = 'light-blue',
 }
 
 const classByVariant: Record<TagVariant, string> = {
@@ -23,6 +26,9 @@ const classByVariant: Record<TagVariant, string> = {
   [TagVariant.LIGHT_PURPLE]: styles['light-purple'],
   [TagVariant.RED]: styles['red'],
   [TagVariant.GREEN]: styles['green'],
+  [TagVariant.LIGHT_GREEN]: styles['light-green'],
+  [TagVariant.LIGHT_YELLOWN]: styles['light-yellow'],
+  [TagVariant.LIGHT_BLUE]: styles['light-blue'],
 }
 
 interface TagProps {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26281

Besoin du FF WIP_PARTNER_PAGE
Données de test : 

- Non référence : structure Club dorothy
- référencement en cours : structure Bar des amis
- référencé : pas dispo dans la sandbox, il faut passer un lieu référencé sur Adage comme eac_lieu_1 en lieu permanent (soit via le backoffice en testing, soit en changeant `isPermanent = true` sur la venue en local)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/193455fc-dbe1-419d-ab9b-7933f65a2825)

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/0fff1d66-c1d1-4f18-98ca-3ca10c9af882)

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/764ae2f6-906f-42d5-adcf-ab262e5e0be7)
