### PR TITLE
(PC-26662)[BO] fix: IntegrityError when object deletion is faster than another action

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -776,7 +776,11 @@ def get_public_account(user_id: int) -> utils.BackofficeResponse:
 @public_accounts_blueprint.route("/<int:user_id>/update", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT)
 def update_public_account(user_id: int) -> utils.BackofficeResponse:
-    user = users_models.User.query.get_or_404(user_id)
+    user = (
+        users_models.User.query.filter_by(id=user_id).populate_existing().with_for_update(key_share=True).one_or_none()
+    )
+    if not user:
+        raise NotFound()
 
     form = account_forms.EditAccountForm()
     if not form.validate():
@@ -838,7 +842,12 @@ def resend_validation_email(user_id: int) -> utils.BackofficeResponse:
 @public_accounts_blueprint.route("/<int:user_id>/validate-phone-number", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT)
 def manually_validate_phone_number(user_id: int) -> utils.BackofficeResponse:
-    user = users_models.User.query.get_or_404(user_id)
+    user = (
+        users_models.User.query.filter_by(id=user_id).populate_existing().with_for_update(key_share=True).one_or_none()
+    )
+    if not user:
+        raise NotFound()
+
     if not user.phoneNumber:
         flash("L'utilisateur n'a pas de numéro de téléphone", "warning")
         return redirect(get_public_account_link(user_id), code=303)
@@ -860,7 +869,11 @@ def manually_validate_phone_number(user_id: int) -> utils.BackofficeResponse:
 @public_accounts_blueprint.route("/<int:user_id>/send-validation-code", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT)
 def send_validation_code(user_id: int) -> utils.BackofficeResponse:
-    user = users_models.User.query.get_or_404(user_id)
+    user = (
+        users_models.User.query.filter_by(id=user_id).populate_existing().with_for_update(key_share=True).one_or_none()
+    )
+    if not user:
+        raise NotFound()
 
     if not user.phoneNumber:
         flash("L'utilisateur n'a pas de numéro de téléphone", "warning")
@@ -900,7 +913,11 @@ def send_validation_code(user_id: int) -> utils.BackofficeResponse:
 @public_accounts_blueprint.route("/<int:user_id>/review", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS)
 def review_public_account(user_id: int) -> utils.BackofficeResponse:
-    user = users_models.User.query.get_or_404(user_id)
+    user = (
+        users_models.User.query.filter_by(id=user_id).populate_existing().with_for_update(key_share=True).one_or_none()
+    )
+    if not user:
+        raise NotFound()
 
     form = account_forms.ManualReviewForm()
     if not form.validate():
@@ -943,7 +960,14 @@ def review_public_account(user_id: int) -> utils.BackofficeResponse:
 @public_accounts_blueprint.route("/<int:user_id>/comment", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT)
 def comment_public_account(user_id: int) -> utils.BackofficeResponse:
-    user = users_models.User.query.get_or_404(user_id)
+    user = (
+        users_models.User.query.filter_by(id=user_id)
+        .populate_existing()
+        .with_for_update(key_share=True, read=True)
+        .one_or_none()
+    )
+    if not user:
+        raise NotFound()
 
     form = account_forms.CommentForm()
     if not form.validate():

--- a/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
@@ -141,7 +141,7 @@ def get_bo_user(user_id: int) -> utils.BackofficeResponse:
 @bo_users_blueprint.route("/<int:user_id>", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_ADMIN_ACCOUNTS)
 def update_bo_user(user_id: int) -> utils.BackofficeResponse:
-    user = _get_bo_user_query(user_id).one_or_none()
+    user = _get_bo_user_query(user_id).populate_existing().with_for_update(key_share=True).one_or_none()
 
     if not user:
         raise NotFound()

--- a/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
@@ -111,7 +111,14 @@ def get_history(bank_account_id: int) -> utils.BackofficeResponse:
 @bank_blueprint.route("/<int:bank_account_id>", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PRO_ENTITY)
 def update_bank_account(bank_account_id: int) -> utils.BackofficeResponse:
-    bank_account = finance_models.BankAccount.query.get_or_404(bank_account_id)
+    bank_account = (
+        finance_models.BankAccount.query.filter_by(id=bank_account_id)
+        .populate_existing()
+        .with_for_update(key_share=True)
+        .one_or_none()
+    )
+    if not bank_account:
+        raise NotFound()
 
     form = forms.EditBankAccountForm()
     if not form.validate():

--- a/api/src/pcapi/routes/backoffice/pro_users/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro_users/blueprint.py
@@ -118,7 +118,9 @@ def get_details(user_id: int) -> utils.BackofficeResponse:
 @pro_user_blueprint.route("/update", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PRO_ENTITY)
 def update_pro_user(user_id: int) -> utils.BackofficeResponse:
-    user = users_api.get_pro_account_base_query(user_id).one_or_none()
+    user = (
+        users_api.get_pro_account_base_query(user_id).populate_existing().with_for_update(key_share=True).one_or_none()
+    )
     if not user:
         raise NotFound()
 
@@ -160,7 +162,7 @@ def update_pro_user(user_id: int) -> utils.BackofficeResponse:
 @pro_user_blueprint.route("/delete", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PRO_ENTITY)
 def delete(user_id: int) -> utils.BackofficeResponse:
-    user = users_api.get_pro_account_base_query(user_id).one_or_none()
+    user = users_api.get_pro_account_base_query(user_id).populate_existing().with_for_update().one_or_none()
     if not user:
         raise NotFound()
 
@@ -194,7 +196,12 @@ def delete(user_id: int) -> utils.BackofficeResponse:
 @pro_user_blueprint.route("/comment", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PRO_ENTITY)
 def comment_pro_user(user_id: int) -> utils.BackofficeResponse:
-    user = users_api.get_pro_account_base_query(user_id).one_or_none()
+    user = (
+        users_api.get_pro_account_base_query(user_id)
+        .populate_existing()
+        .with_for_update(key_share=True, read=True)
+        .one_or_none()
+    )
     if not user:
         raise NotFound()
 
@@ -212,7 +219,9 @@ def comment_pro_user(user_id: int) -> utils.BackofficeResponse:
 @pro_user_blueprint.route("/validate-email", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PRO_ENTITY)
 def validate_pro_user_email(user_id: int) -> utils.BackofficeResponse:
-    user = users_api.get_pro_account_base_query(user_id).one_or_none()
+    user = (
+        users_api.get_pro_account_base_query(user_id).populate_existing().with_for_update(key_share=True).one_or_none()
+    )
     if not user:
         raise NotFound()
 

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -497,7 +497,10 @@ def get_invoices(venue_id: int) -> utils.BackofficeResponse:
 @venue_blueprint.route("/<int:venue_id>/delete", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.DELETE_PRO_ENTITY)
 def delete_venue(venue_id: int) -> utils.BackofficeResponse:
-    venue = offerers_models.Venue.query.get_or_404(venue_id)
+    venue = offerers_models.Venue.query.filter_by(id=venue_id).populate_existing().with_for_update().one_or_none()
+    if not venue:
+        raise NotFound()
+
     venue_name = venue.name
 
     emails = offerers_repository.get_emails_by_venue(venue)
@@ -644,7 +647,9 @@ def update_venue(venue_id: int) -> utils.BackofficeResponse:
 @venue_blueprint.route("/<int:venue_id>/comment", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PRO_ENTITY)
 def comment_venue(venue_id: int) -> utils.BackofficeResponse:
-    venue = offerers_models.Venue.query.get_or_404(venue_id)
+    venue = offerers_models.Venue.query.fitler_by(id=venue_id).with_for_update(key_share=True, read=True).one_or_none()
+    if not venue:
+        raise NotFound()
 
     form = forms.CommentForm()
     if not form.validate():
@@ -698,7 +703,12 @@ def batch_edit_venues() -> utils.BackofficeResponse:
         flash(utils.build_form_error_msg(form), "warning")
         return redirect(request.referrer or url_for(".list_venues"), code=303)
 
-    venues = offerers_models.Venue.query.filter(offerers_models.Venue.id.in_(form.object_ids_list)).all()
+    venues = (
+        offerers_models.Venue.query.filter(offerers_models.Venue.id.in_(form.object_ids_list))
+        .populate_existing()
+        .with_for_update(key_share=True)
+        .all()
+    )
 
     updated_criteria_venues = _update_venues_criteria(venues=venues, criteria_ids=form.criteria.data)
     updated_permanent_venues = []

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -1792,7 +1792,7 @@ class GetRejectOffererFormTest(GetEndpointHelper):
         offerer = offerers_factories.NotValidatedOffererFactory()
 
         url = url_for(self.endpoint, offerer_id=offerer.id)
-        with assert_num_queries(2):  # session + current user
+        with assert_num_queries(3):  # session + current user + offerer
             response = authenticated_client.get(url)
             # Rendering is not checked, but at least the fetched frame does not crash
             assert response.status_code == 200


### PR DESCRIPTION
An exception was reported in production when offerer deletion was initiated one second after user_offerer soft deletion request: `Unexpected database error on method=POST url=https://backoffice.passculture.team/pro/offerer/34633/users/46617/delete: IntegrityError('(psycopg2.errors.ForeignKeyViolation) insert or update on table "action_history" violates foreign key constraint "action_history_offererId_fkey"\nDETAIL:  Key (offererId)=(34633) is not present in table "offerer".\n')`

So this commit ensures that concurrent actions on Offerer, Venue, User do not cause exception in the slowest. Not all potential exceptions are covered, but only these objects which have "Delete" button in BO.

Fix verified locally with temporary sleep() in user_offerer soft deletion request.

See: https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-26662
Erreur Sentry : https://sentry.passculture.team/organizations/sentry/issues/1248852/events/cd5e6d7e02324e9980893493a7d2acb2/?project=5

J'ai fait l'économie du test auto particulièrement contraignant (appel de deux API dans deux threads différents).
Mais testé en local avant/après dans le backoffice.

A priori, à la fin de chaque route on nettoie la session, donc on aura un `rollback()` en cas de retour anticipé. N'hésitez pas à m'alerter si je me trompe !

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques