### PR TITLE
(PC-26650)[PRO] feat: Wording on adage discovery playlist names.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/VenuePlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/VenuePlaylist.tsx
@@ -30,16 +30,15 @@ type VenuePlaylistProps = {
 const institutionRuralLevelToPlaylistTitle: {
   [key in InstitutionRuralLevel]: string
 } = {
-  'urbain dense': 'À moins 30 minutes à pieds de mon établissement',
+  'urbain dense': 'À moins de 30 minutes à pied de mon établissement',
   'urbain densité intermédiaire':
     'À moins de 30 minutes en transport de mon établissement',
   "rural sous forte influence d'un pôle":
     'À environ de 30 minutes de transport de mon établissement',
-  'rural autonome peu dense': 'À environs 1h de transport de mon établissement',
+  'rural autonome peu dense': 'À environ 1h de route de mon établissement',
   "rural sous faible influence d'un pôle":
-    'À environs 1h de transport de mon établissement',
-  'rural autonome très peu dense':
-    'À environs 1h de transport de mon établissement',
+    'À environ 1h de route de mon établissement',
+  'rural autonome très peu dense': 'À environ 1h de route de mon établissement',
 }
 
 export const VenuePlaylist = ({
@@ -77,7 +76,7 @@ export const VenuePlaylist = ({
             ? institutionRuralLevelToPlaylistTitle[
                 adageUser.institutionRuralLevel
               ]
-            : 'À moins 30 minutes à pieds de mon établissement'}
+            : 'À moins de 30 minutes à pied de mon établissement'}
         </h2>
       }
       className={classNames(styles['playlist-carousel'], {

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/__specs__/VenuePlaylist.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/__specs__/VenuePlaylist.spec.tsx
@@ -82,7 +82,9 @@ describe('AdageDiscover classRoomPlaylist', () => {
     renderNewOfferPlaylist(user)
 
     expect(
-      await screen.findByText('À moins 30 minutes à pieds de mon établissement')
+      await screen.findByText(
+        'À moins de 30 minutes à pied de mon établissement'
+      )
     ).toBeInTheDocument()
   })
 
@@ -116,13 +118,13 @@ describe('AdageDiscover classRoomPlaylist', () => {
   it.each([
     {
       level: InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE,
-      title: 'À environs 1h de transport de mon établissement',
+      title: 'À environ 1h de route de mon établissement',
     },
     {
       level: InstitutionRuralLevel.URBAIN_DENSIT_INTERM_DIAIRE,
       title: 'À moins de 30 minutes en transport de mon établissement',
     },
-    { level: null, title: 'À moins 30 minutes à pieds de mon établissement' },
+    { level: null, title: 'À moins de 30 minutes à pied de mon établissement' },
   ])(
     'should display the playlist title based on the institution rural level',
     async (ruralLevelParam) => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26650

**FF à activer**
WIP_ENABLE_DISCOVERY

**Objectif**
Modifier les noms des playlists de la page découverte d'adage.

<img width="1431" alt="Capture d’écran 2024-01-03 à 09 22 05" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/13dacdb9-a9f4-438b-8a86-8a8fe99f6e99">
<img width="1434" alt="Capture d’écran 2024-01-03 à 09 22 42" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/1703a5a9-4f98-4177-a90c-6798fa189e98">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques