### PR TITLE
(PC-26678)[API] fix: [DO NOT MERGE] delete unused products

### DIFF
--- a/api/src/pcapi/scripts/offer/delete_unused_products.py
+++ b/api/src/pcapi/scripts/offer/delete_unused_products.py
@@ -1,0 +1,49 @@
+import logging
+
+from sqlalchemy.orm import joinedload
+
+from pcapi.core.offers import models as offers_models
+from pcapi.models import db
+from pcapi.repository import transaction
+
+
+logger = logging.getLogger(__name__)
+
+
+CHUNK_SIZE = 500
+
+
+def get_products_to_delete(from_id: int):
+    query = (
+        offers_models.Product.query.filter(
+            offers_models.Product.owningOffererId.is_not(None),
+            offers_models.Product.idAtProviders.is_(None),
+            offers_models.Product.lastProviderId.is_(None),
+            offers_models.Product.id.between(from_id, from_id + CHUNK_SIZE),
+        )
+        # For products with an owningOfferer this is a 1-1 relationship
+        .options(joinedload(offers_models.Product.offers))
+    )
+    logger.info("Batch from id : %s", from_id)
+    for product in query:
+        yield product
+
+
+def execute_request(start_id: int, stop_id: int, dry_run: bool = True):
+    for id in range(start_id, stop_id, CHUNK_SIZE):
+        with transaction():
+            product_to_delete = get_products_to_delete(id)
+            products_id_to_delete = []
+            for product in product_to_delete:
+                for offer in product.offers:
+                    offer.productId = None
+
+                logger.info("Updating offers ids : %s", [offer.id for offer in product.offers])
+                db.session.add_all(product.offers)
+                products_id_to_delete.append(product.id)
+            logger.info("Deleting products ids : %s", products_id_to_delete)
+            offers_models.Product.query.filter(offers_models.Product.id.in_(products_id_to_delete)).delete(
+                synchronize_session=False
+            )
+            if dry_run:
+                db.session.rollback()


### PR DESCRIPTION
Supprimer les produits créés historiquement pour les offres créées manuellement. Pour chaque offre, un produit inutilisé a été créé. Supprimons les et retirons le productId de l'offre.

Le script supprimera environ 1 800 000 produits (29 % des 6 183 920 lignes) et modifiera 1 800 000 offres (1,5 % des 117 292 133 lignes). 
Nous pourrions diviser ce script en deux avec un VACUUM manuel, mais je ne pense pas que cela soit nécessaire, la table product a assez peu d'écriture par jour, l'autovacuum récupérera la place ensuite. Pour les offres la quantité d'offre modifiée est assez petite par rapport à la quantité de donnée de la table. 

Le prochain script devra passer sur les 99.5% des offres restantes pour supprimer la description, nom, ..., tout ce qui est dupliqué depuis le produit. A ce moment là il pourra être intéressant de fractionner avec des VACUUM manuels.

Performances : 
avec CHUNK = 500 si 500 products sont à supprimer (worst case), 1.6s pour le delete et 2.2s pour le traitement entier (select, update des offres et delete)

AVEC CHUNK = 200 si 200 products sont à supprimer (worst case), 0.9s pour le delete et 1.1s pour le traitement entier 

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26678


