### PR TITLE
(PC-26635)[API] [MERGE AFTER MEP v262] feat: Remove Cashflow.bankAccount foreign key

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-ea0a25aef628 (pre) (head)
+71effb72345c (pre) (head)
 48e05c743111 (post) (head)

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 71effb72345c (pre) (head)
-48e05c743111 (post) (head)
+b9f04189f351 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240103T140021_b9f04189f351_remove_cashflow_foreign_key_bank_account.py
+++ b/api/src/pcapi/alembic/versions/20240103T140021_b9f04189f351_remove_cashflow_foreign_key_bank_account.py
@@ -1,0 +1,24 @@
+"""Remove Cashflow.bankAccount foreignkey
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "b9f04189f351"
+down_revision = "48e05c743111"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_cashflow_bankAccountId", table_name="cashflow")
+    op.drop_constraint("cashflow_bankAccountId_fkey", "cashflow", type_="foreignkey")
+    op.drop_column("cashflow", "bankAccountId")
+
+
+def downgrade() -> None:
+    op.add_column("cashflow", sa.Column("bankAccountId", sa.BIGINT(), autoincrement=False, nullable=True))
+    op.create_foreign_key("cashflow_bankAccountId_fkey", "cashflow", "bank_information", ["bankAccountId"], ["id"])
+    op.create_index("ix_cashflow_bankAccountId", "cashflow", ["bankAccountId"], unique=False)

--- a/api/src/pcapi/alembic/versions/20240104T075421_71effb72345c_make_cashflow_bank_account_column_nullable.py
+++ b/api/src/pcapi/alembic/versions/20240104T075421_71effb72345c_make_cashflow_bank_account_column_nullable.py
@@ -1,0 +1,20 @@
+"""Make Cashflow.bankAccountId nullable
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "71effb72345c"
+down_revision = "16ebdf83377e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("cashflow", "bankAccountId", existing_type=sa.BIGINT(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("cashflow", "bankAccountId", existing_type=sa.BIGINT(), nullable=False)

--- a/api/src/pcapi/alembic/versions/20240104T075421_71effb72345c_make_cashflow_bank_account_column_nullable.py
+++ b/api/src/pcapi/alembic/versions/20240104T075421_71effb72345c_make_cashflow_bank_account_column_nullable.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 # pre/post deployment: pre
 # revision identifiers, used by Alembic.
 revision = "71effb72345c"
-down_revision = "16ebdf83377e"
+down_revision = "ea0a25aef628"
 branch_labels = None
 depends_on = None
 

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -656,7 +656,7 @@ class Cashflow(Base, Model):
     # change. Here we want to store the bank account that was used at
     # the time the cashflow was created.
     _bankAccountId: int = sqla.Column(
-        "bankAccountId", sqla.BigInteger, sqla.ForeignKey("bank_information.id"), index=True, nullable=False
+        "bankAccountId", sqla.BigInteger, sqla.ForeignKey("bank_information.id"), index=True, nullable=True
     )
     _bankAccount: BankInformation = sqla_orm.relationship(BankInformation, foreign_keys=[_bankAccountId])
     _bankInformationId: int = sqla.Column(

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -901,8 +901,7 @@ class GenerateCashflowsTest:
         assert len(pricing2.cashflows) == 1
         assert pricing11.cashflows[0].amount == -2500
         assert pricing11.cashflows[0].bankInformation == bank_info1
-        assert pricing11.cashflows[0]._bankInformationId == bank_info1.id
-        assert pricing11.cashflows[0]._bankAccountId == bank_info1.id
+        assert pricing11.cashflows[0].bankInformationId == bank_info1.id
         assert pricing2.cashflows[0].amount == -3000
 
         assert not pricing_future_event.cashflows


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26635

Étape 2/3 ([étape 1/3](https://github.com/pass-culture/pass-culture-main/pull/9847)) qui sera mergée après la MEP v272

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques