### PR TITLE
(PC-24834)[PRO] fix: move new window info to svg alt

### DIFF
--- a/pro/src/components/Banner/OfferRefundWarning.tsx
+++ b/pro/src/components/Banner/OfferRefundWarning.tsx
@@ -8,9 +8,9 @@ const OfferRefundWarning = () => {
       links={[
         {
           href: 'https://aide.passculture.app/hc/fr/articles/6043184068252',
+          svgAlt: 'Nouvelle fenêtre',
           linkTitle:
             'Quelles sont les offres numériques éligibles au remboursement ?',
-          'aria-label': 'Nouvelle fenêtre',
         },
       ]}
       type="attention"

--- a/pro/src/components/Banner/WithdrawalReminder.tsx
+++ b/pro/src/components/Banner/WithdrawalReminder.tsx
@@ -10,7 +10,7 @@ const WithdrawalReminder = () => {
         {
           href: CGU_URL,
           linkTitle: "Consulter les Conditions Générales d'Utilisation",
-          'aria-label': 'Nouvelle fenêtre',
+          svgAlt: 'Nouvelle fenêtre',
         },
       ]}
       type="notification-info"

--- a/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
+++ b/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
@@ -180,8 +180,8 @@ const Categories = ({
               text: 'Quelles catégories choisir ?',
               target: '_blank',
               rel: 'noopener noreferrer',
-              'aria-label': 'Nouvelle fenêtre',
             }}
+            svgAlt="Nouvelle fenêtre"
           >
             Une sélection précise de vos catégories permettra au grand public de
             facilement trouver votre offre. Une fois validées, vous ne pourrez

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
@@ -79,12 +79,11 @@ const UsefulInformations = ({
             link={{
               isExternal: true,
               to: 'https://aide.passculture.app/hc/fr/articles/4413389597329--Acteurs-Culturels-Quelles-modalit%C3%A9s-de-retrait-indiquer-pour-ma-structure-',
-              text: 'En savoir plus',
-              'aria-label':
-                'en savoir plus sur les modalités de retrait (nouvelle fenêtre)',
+              text: 'Quelles modalités de retrait choisir ?',
               target: '_blank',
               rel: 'noopener noreferrer',
             }}
+            svgAlt="Nouvelle fenêtre"
           >
             {isVenueVirtual
               ? 'Indiquez ici tout ce qui peut être utile au bénéficiaire pour le retrait de l’offre.'

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
@@ -438,7 +438,9 @@ describe('IndividualOffer section: UsefulInformations', () => {
         const infoBox = screen.getByText(
           'Indiquez ici tout ce qui peut être utile au bénéficiaire pour le retrait de l’offre. En renseignant ces informations depuis votre page lieu, elles s’appliqueront par défaut à toutes vos offres.'
         )
-        const infoLink = screen.getByText('En savoir plus')
+        const infoLink = screen.getByText(
+          'Quelles modalités de retrait choisir ?'
+        )
         expect(infoBox).toBeInTheDocument()
         expect(infoLink).toHaveAttribute(
           'href',
@@ -459,7 +461,9 @@ describe('IndividualOffer section: UsefulInformations', () => {
         const infoBoxWithdrawal = screen.getByText(
           'Indiquez ici tout ce qui peut être utile au bénéficiaire pour le retrait de l’offre.'
         )
-        const infoLinkWithdrawal = screen.getByText('En savoir plus')
+        const infoLinkWithdrawal = screen.getByText(
+          'Quelles modalités de retrait choisir ?'
+        )
         expect(infoBoxWithdrawal).toBeInTheDocument()
         expect(infoLinkWithdrawal).toHaveAttribute(
           'href',

--- a/pro/src/ui-kit/InfoBox/InfoBox.tsx
+++ b/pro/src/ui-kit/InfoBox/InfoBox.tsx
@@ -16,9 +16,10 @@ interface InfoBoxLinkProps extends LinkProps {
 interface InfoBoxProps {
   children: ReactNode
   link?: InfoBoxLinkProps
+  svgAlt?: string
 }
 
-const InfoBox = ({ children, link }: InfoBoxProps): JSX.Element => {
+const InfoBox = ({ children, link, svgAlt }: InfoBoxProps): JSX.Element => {
   return (
     <div className={cn(styles['info-box'])}>
       <div className={styles['info-box-header']}>
@@ -41,6 +42,7 @@ const InfoBox = ({ children, link }: InfoBoxProps): JSX.Element => {
           link={link}
           icon={fullLinkIcon}
           className={styles['info-box-link']}
+          svgAlt={svgAlt || ''}
         >
           {link.text}
         </ButtonLink>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24834

Enlever les aria-label indiquant "Nouvelle fenêtre" pour mettre ces informations dans le alt du svg 
(sur la page création d'offre)
