### PR TITLE
(PC-26651)[API] perf: bump beamer and brevo delay to 12 hours

### DIFF
--- a/api/src/pcapi/core/external/attributes/api.py
+++ b/api/src/pcapi/core/external/attributes/api.py
@@ -57,12 +57,10 @@ def update_external_pro(email: str | None) -> None:
 
     if email:
         now = datetime.utcnow()
-        update_sib_pro_attributes_task.delay(
-            UpdateProAttributesRequest(email=email, time_id=f"{now.hour}:{now.minute // 15}")
-        )
+        update_sib_pro_attributes_task.delay(UpdateProAttributesRequest(email=email, time_id=f"{now.hour // 12}"))
         if FeatureToggle.ENABLE_BEAMER.is_active():
             update_beamer_pro_attributes_task.delay(
-                UpdateProAttributesRequest(email=email, time_id=f"{now.hour}:{now.minute // 15}")
+                UpdateProAttributesRequest(email=email, time_id=f"{now.hour // 12}")
             )
 
 

--- a/api/src/pcapi/tasks/beamer_tasks.py
+++ b/api/src/pcapi/tasks/beamer_tasks.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 BEAMER_PRO_QUEUE_NAME = settings.GCP_BEAMER_PRO_QUEUE_NAME
 
 
-@task(BEAMER_PRO_QUEUE_NAME, "/beamer/update_pro_attributes", True, 900)  # type: ignore [arg-type]
+# Deduplicate and delay by 12 hours.
+# See api/src/pcapi/tasks/sendinblue_tasks.py comment for more details
+@task(BEAMER_PRO_QUEUE_NAME, "/beamer/update_pro_attributes", True, 43_200)  # type: ignore [arg-type]
 def update_beamer_pro_attributes_task(payload: UpdateProAttributesRequest) -> None:
     from pcapi.connectors import beamer
     from pcapi.core.external.attributes.api import get_pro_attributes

--- a/api/src/pcapi/tasks/sendinblue_tasks.py
+++ b/api/src/pcapi/tasks/sendinblue_tasks.py
@@ -32,7 +32,7 @@ def send_transactional_email_secondary_task(payload: SendTransactionalEmailReque
     send_transactional_email(payload)
 
 
-# De-duplicate and delay by 15 minutes, to avoid collecting pro attributes and making an update request to Sendinblue
+# De-duplicate and delay by 12 hours, to avoid collecting pro attributes and making an update request to Sendinblue
 # several times in a short time when a user managing an offerer makes several changes.
 #
 # Deduplication of Google tasks is based on identical payload in src.pcapi.tasks.cloud_task.enqueue_internal_task,
@@ -41,8 +41,8 @@ def send_transactional_email_secondary_task(payload: SendTransactionalEmailReque
 # Reference: https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks/create
 #
 # So time_id parameter in UpdateProAttributesRequest helps to generate different hashes, so different task ids, every
-# 15 minutes. Keep delayed_seconds below consistent with time_id generation.
-@task(SENDINBLUE_PRO_QUEUE_NAME, "/sendinblue/update_pro_attributes", True, 900)  # type: ignore [arg-type]
+# 12 hours. Keep delayed_seconds below consistent with time_id generation.
+@task(SENDINBLUE_PRO_QUEUE_NAME, "/sendinblue/update_pro_attributes", True, 43_200)  # type: ignore [arg-type]
 def update_sib_pro_attributes_task(payload: UpdateProAttributesRequest) -> None:
     from pcapi.core.external.attributes.api import get_pro_attributes
     from pcapi.core.external.sendinblue import update_contact_attributes


### PR DESCRIPTION
The marketing team is ok to have 12 hours old data. It will greatly reduce our calls to Brevo and Beamer.
This will only impact pro attributes.

10 // 12 ->> 0
13 // 12 ->> 1

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26651

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques