### PR TITLE
(BSR)[API] ci: Do not run mypy-cop on master branch

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -70,7 +70,7 @@ jobs:
   run-mypy-cop:
     name: "MyPy cop"
     needs: check-api
-    if: needs.check-api.outputs.folder_changed == 'true'
+    if: github.ref != 'refs/head/master' && needs.check-api.outputs.folder_changed == 'true'
     uses: ./.github/workflows/dev_on_workflow_mypy_cop.yml
 
   update-api-client-template:


### PR DESCRIPTION
It's supposed to be run on feature branches only to warn when the
number of mypy's "type: ignore" comments increases in the related pull
requests.