### PR TITLE
(BSR)[ADAGE] fix: returns empty results for the fake BigQuery backend

### DIFF
--- a/api/src/pcapi/connectors/big_query/testing_backend.py
+++ b/api/src/pcapi/connectors/big_query/testing_backend.py
@@ -9,4 +9,4 @@ TestingRowIterator = typing.Generator[TestingRow, None, None]
 
 class TestingBackend(BaseBackend):
     def run_query(self, query: str, page_size: int, **parameters: typing.Any) -> TestingRowIterator:
-        yield
+        yield from ()


### PR DESCRIPTION
with:

```
def foo():
    yield
```


list(foo()) is [None] where an empty list was expected.

## But de la pull request

Corriger un plantage de backend de simulation BigQuery en environnement de développement

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques