### PR TITLE
(PC-26362)[API] feat: add route tracking search adage button show more

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -341,3 +341,25 @@ def log_has_seen_all_playlist(
         user_email=authenticated_information.email,
     )
     return
+
+
+@blueprint.adage_iframe.route("/logs/search-show-more", methods=["POST"])
+@spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
+@adage_jwt_required
+def log_search_show_more(
+    authenticated_information: AuthenticatedInformation,
+    body: serialization.TrackingShowMoreBody,
+) -> None:
+    institution = find_educational_institution_by_uai_code(authenticated_information.uai)
+    educational_utils.log_information_for_data_purpose(
+        event_name="SearchShowMore",
+        extra_data={
+            "source": body.source,
+            "from": body.iframeFrom,
+            "queryId": body.queryId,
+        },
+        uai=authenticated_information.uai,
+        user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
+        user_email=authenticated_information.email,
+    )
+    return

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -78,3 +78,7 @@ class SuggestionType(enum.Enum):
 class TrackingAutocompleteSuggestionBody(AdageBaseModel):
     suggestionType: SuggestionType
     suggestionValue: str
+
+
+class TrackingShowMoreBody(AdageBaseModel):
+    source: str

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -506,8 +506,9 @@ class LogsTest:
         assert caplog.records[0].message == "SearchShowMore"
         assert caplog.records[0].extra == {
             "analyticsSource": "adage",
+            "source": "partnersMap",
             "queryId": "1234a",
-            "from": "SearchShowMore",
+            "from": "for_my_institution",
             "uai": "EAU123",
             "user_role": AdageFrontRoles.READONLY,
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -484,3 +484,31 @@ class LogsTest:
             "user_role": AdageFrontRoles.READONLY,
             "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
         }
+
+    def test_log_search_show_more(self, client, caplog):
+        # given
+        adage_jwt_fake_valid_token = create_adage_valid_token_with_email(email="test@mail.com")
+        client.auth_header = {"Authorization": f"Bearer {adage_jwt_fake_valid_token}"}
+
+        # when
+        with caplog.at_level(logging.INFO):
+            response = client.post(
+                "/adage-iframe/logs/search-show-more",
+                json={
+                    "iframeFrom": "for_my_institution",
+                    "queryId": "1234a",
+                    "source": "partnersMap",
+                },
+            )
+
+        # then
+        assert response.status_code == 204
+        assert caplog.records[0].message == "SearchShowMore"
+        assert caplog.records[0].extra == {
+            "analyticsSource": "adage",
+            "queryId": "1234a",
+            "from": "SearchShowMore",
+            "uai": "EAU123",
+            "user_role": AdageFrontRoles.READONLY,
+            "userId": "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816",
+        }

--- a/pro/sonar-project.properties
+++ b/pro/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=pass-culture_pass-culture-main
 sonar.organization=pass-culture
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.coverage.exclusions=**/*.spec.*,**/*.stories.*,**/apiClient/v1/**/*,**/apiClient/v2/**/*,**/utils/collectiveApiFactories.ts,**/adage/services/DefaultService.ts,cypress/e2e/*
+sonar.coverage.exclusions=**/*.spec.*,**/*.stories.*,**/apiClient/v1/**/*,**/apiClient/v2/**/*,**/utils/collectiveApiFactories.ts,**/adage/services/DefaultService.ts,cypress/e2e/*,**/adage/models/*
 sonar.cpd.exclusions=**/apiClient/v1/**/*,**/apiClient/v2/**/*

--- a/pro/src/apiClient/adage/index.ts
+++ b/pro/src/apiClient/adage/index.ts
@@ -62,6 +62,7 @@ export { SuggestionType } from './models/SuggestionType';
 export type { TemplateDatesModel } from './models/TemplateDatesModel';
 export type { TrackingAutocompleteSuggestionBody } from './models/TrackingAutocompleteSuggestionBody';
 export type { TrackingFilterBody } from './models/TrackingFilterBody';
+export type { TrackingShowMoreBody } from './models/TrackingShowMoreBody';
 export type { ValidationError } from './models/ValidationError';
 export type { ValidationErrorElement } from './models/ValidationErrorElement';
 export type { VenueResponse } from './models/VenueResponse';

--- a/pro/src/apiClient/adage/models/TrackingShowMoreBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingShowMoreBody.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TrackingShowMoreBody = {
+  iframeFrom: string;
+  isFromNoResult?: boolean | null;
+  queryId?: string | null;
+  source: string;
+};
+

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -30,6 +30,7 @@ import type { SearchBody } from '../models/SearchBody';
 import type { StockIdBody } from '../models/StockIdBody';
 import type { TrackingAutocompleteSuggestionBody } from '../models/TrackingAutocompleteSuggestionBody';
 import type { TrackingFilterBody } from '../models/TrackingFilterBody';
+import type { TrackingShowMoreBody } from '../models/TrackingShowMoreBody';
 import type { VenueResponse } from '../models/VenueResponse';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
@@ -595,6 +596,28 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'POST',
       url: '/adage-iframe/logs/search-button',
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        403: `Forbidden`,
+        404: `Not Found`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * log_search_show_more <POST>
+   * @param requestBody
+   * @returns void
+   * @throws ApiError
+   */
+  public logSearchShowMore(
+    requestBody?: TrackingShowMoreBody,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/adage-iframe/logs/search-show-more',
       body: requestBody,
       mediaType: 'application/json',
       errors: {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -4,8 +4,10 @@ import {
   useInstantSearch,
   useStats,
 } from 'react-instantsearch'
+import { useParams } from 'react-router-dom'
 
 import { AdageFrontRoles } from 'apiClient/adage'
+import { apiAdage } from 'apiClient/api'
 import useActiveFeature from 'hooks/useActiveFeature'
 import fullGoTop from 'icons/full-go-top.svg'
 import { getCollectiveOfferAdapter } from 'pages/AdageIframe/app/adapters/getCollectiveOfferAdapter'
@@ -54,6 +56,10 @@ export const Offers = ({
   const { hits, isLastPage, showMore } = useInfiniteHits()
   const { nbHits } = useStats()
   const { scopedResults, results: nonScopedResult } = useInstantSearch()
+  const { siret, venueId } = useParams<{
+    siret: string
+    venueId: string
+  }>()
 
   const results = indexId
     ? scopedResults.find((res) => res.indexId === indexId)?.results
@@ -74,6 +80,16 @@ export const Offers = ({
     isSatisfactionSurveyActive &&
     !adageUser.preferences?.feedback_form_closed &&
     adageUser.role !== AdageFrontRoles.READONLY
+
+  const showMoreAndTrack = async () => {
+    showMore()
+
+    await apiAdage.logSearchShowMore({
+      iframeFrom: location.pathname,
+      source: siret || venueId ? 'partnersMap' : 'homepage',
+      queryId: results?.queryID,
+    })
+  }
 
   useEffect(() => {
     setQueriesAreLoading(true)
@@ -179,7 +195,10 @@ export const Offers = ({
                   <Spinner />
                 </div>
               ) : (
-                <Button onClick={showMore} variant={ButtonVariant.SECONDARY}>
+                <Button
+                  onClick={showMoreAndTrack}
+                  variant={ButtonVariant.SECONDARY}
+                >
                   Voir plus d’offres
                 </Button>
               ))}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26362

Ajouter une route de tracking pour pouvoir l'utiliser côté front sur le bouton "Voir plus" sur adage


## Vérifications

- [x] J'ai écrit les tests nécessaires