### PR TITLE
(PC-26652)[ADAGE] feat: display dist from user to offer's venue in playlists

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -4,9 +4,13 @@ import { NavLink, useSearchParams } from 'react-router-dom'
 import { CollectiveOfferTemplateResponseModel } from 'apiClient/adage'
 import { OfferAddressType } from 'apiClient/v1'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
+import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { Tag, TagVariant } from 'ui-kit/Tag/Tag'
-import { humanizeDistance } from 'utils/getDistance'
+import {
+  humanizeDistance,
+  getHumanizeRelativeDistance,
+} from 'utils/getDistance'
 
 import OfferFavoriteButton from '../../OffersInstantSearch/OffersSearch/Offers/OfferFavoriteButton/OfferFavoriteButton'
 
@@ -25,6 +29,7 @@ const OfferCardComponent = ({
 }: CardComponentProps) => {
   const [searchParams] = useSearchParams()
   const adageAuthToken = searchParams.get('token')
+  const { adageUser } = useAdageUser()
 
   const tagInfos = {
     [OfferAddressType.SCHOOL]: [{ logo: logoSchool, text: 'En classe' }],
@@ -100,13 +105,23 @@ const OfferCardComponent = ({
 
         <div className="offer-venue">
           <div className={styles['offer-venue-name']}>{offer.venue.name}</div>
-          {(offer.venue.distance || offer.venue.distance === 0) && (
-            <div
-              className={styles['offer-venue-distance']}
-            >{`à ${humanizeDistance(Number(offer.venue.distance) * 1000)} - ${
-              offer.venue.city
-            }`}</div>
-          )}
+          {offer.venue.coordinates.latitude &&
+            offer.venue.coordinates.longitude &&
+            (adageUser.lat || adageUser.lat === 0) &&
+            (adageUser.lon || adageUser.lon === 0) && (
+              <div
+                className={styles['offer-venue-distance']}
+              >{`à ${getHumanizeRelativeDistance(
+                {
+                  latitude: offer.venue.coordinates.latitude,
+                  longitude: offer.venue.coordinates.longitude,
+                },
+                {
+                  latitude: adageUser.lat,
+                  longitude: adageUser.lon,
+                }
+              )} - ${offer.venue.city}`}</div>
+            )}
         </div>
       </NavLink>
       <OfferFavoriteButton

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/__specs__/OfferCard.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/__specs__/OfferCard.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import * as router from 'react-router-dom'
 
-import { OfferAddressType } from 'apiClient/adage'
+import { AuthenticatedResponse, OfferAddressType } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
 import { defaultAdageUser, defaultCollectiveOffer } from 'utils/adageFactories'
@@ -29,12 +29,18 @@ const mockOffer = {
   isTemplate: false,
 }
 
+const adageUser: AuthenticatedResponse = {
+  ...defaultAdageUser,
+  lat: 48.86543326111946,
+  lon: 2.321135886028998,
+}
+
 const renderOfferCardComponent = ({
   offer,
   handlePlaylistElementTracking,
 }: CardComponentProps) => {
   renderWithProviders(
-    <AdageUserContextProvider adageUser={defaultAdageUser}>
+    <AdageUserContextProvider adageUser={adageUser}>
       <OfferCardComponent
         offer={offer}
         handlePlaylistElementTracking={handlePlaylistElementTracking}
@@ -83,6 +89,26 @@ describe('OfferCard component', () => {
 
     expect(screen.getByText('Sortie')).toBeInTheDocument()
     expect(screen.getByText('Lieu à définir')).toBeInTheDocument()
+  })
+
+  it('should display the distance when it is available', () => {
+    const offer = {
+      ...mockOffer,
+      offerVenue: {
+        ...mockOffer.offerVenue,
+        addressType: OfferAddressType.OFFERER_VENUE,
+      },
+      venue: {
+        ...mockOffer.venue,
+        coordinates: {
+          latitude: 48.869440910282734,
+          longitude: 2.3087717501609233,
+        },
+      },
+    }
+    renderOfferCardComponent({ offer, handlePlaylistElementTracking: vi.fn() })
+
+    expect(screen.getByText('à 1 km - Paris')).toBeInTheDocument()
   })
 
   it('should redirect on click in offer card', async () => {


### PR DESCRIPTION
To be consistent with what's in the detailed offer page.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-26652

<img width="227" alt="Capture d’écran 2024-01-04 à 16 45 15" src="https://github.com/pass-culture/pass-culture-main/assets/2340654/20a13679-66ed-4d42-b856-2f29c43ad5fd">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques