### PR TITLE
(PC-26731)[API] fix: delete legacy columns from stock

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 71effb72345c (pre) (head)
-b9f04189f351 (post) (head)
+2b2059710c60 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240105T113037_2b2059710c60_delete_unused_stock_columns.py
+++ b/api/src/pcapi/alembic/versions/20240105T113037_2b2059710c60_delete_unused_stock_columns.py
@@ -1,0 +1,21 @@
+"""Delete legacy collective columns from stock table."""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "2b2059710c60"
+down_revision = "b9f04189f351"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("stock", "numberOfTickets")
+    op.drop_column("stock", "educationalPriceDetail")
+
+
+def downgrade() -> None:
+    op.add_column("stock", sa.Column("educationalPriceDetail", sa.TEXT(), autoincrement=False, nullable=True))
+    op.add_column("stock", sa.Column("numberOfTickets", sa.INTEGER(), autoincrement=False, nullable=True))

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -186,8 +186,6 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     )
     dateModified: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
     dnBookedQuantity: int = sa.Column(sa.BigInteger, nullable=False, server_default=sa.text("0"))
-    educationalPriceDetail = sa.Column(sa.Text, nullable=True)
-    numberOfTickets = sa.Column(sa.Integer, nullable=True)
     offer: sa_orm.Mapped["Offer"] = sa.orm.relationship("Offer", backref="stocks")
     offerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id"), index=True, nullable=False)
     price: decimal.Decimal = sa.Column(
@@ -198,6 +196,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     )
     priceCategory: sa_orm.Mapped["PriceCategory | None"] = sa.orm.relationship("PriceCategory", back_populates="stocks")
     quantity: int | None = sa.Column(sa.Integer, nullable=True)
+    # FIXME: mageoffray (2024-01-05) : remove this column when Provider API is not used anymore
     rawProviderQuantity = sa.Column(sa.Integer, nullable=True)
     features: list[str] = sa.Column(postgresql.ARRAY(sa.Text), nullable=False, server_default=sa.text("'{}'::text[]"))
 


### PR DESCRIPTION
Delete `numberOfTickets`, `educationalPriceDetail` and `rawProviderQuantity`  from `stock` table

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26731
