### PR TITLE
(BSR)[API] ci: Do not run mypy-cop on master branch (for real)

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -70,7 +70,7 @@ jobs:
   run-mypy-cop:
     name: "MyPy cop"
     needs: check-api
-    if: github.ref != 'refs/head/master' && needs.check-api.outputs.folder_changed == 'true'
+    if: github.ref != 'refs/heads/master' && needs.check-api.outputs.folder_changed == 'true'
     uses: ./.github/workflows/dev_on_workflow_mypy_cop.yml
 
   update-api-client-template:


### PR DESCRIPTION
Follow-up of 5eeac027859c1c4900c9369809, this time without the typo.