### PR TITLE
(PC-26604)[PRO] fix: adjust heigt when dialog has banner

### DIFF
--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
@@ -69,6 +69,10 @@ $banner-height: rem.torem(124px);
   @media (min-width: size.$tablet) {
     height: $modal-height;
     width: $modal-width;
+
+    &-with-banner {
+      height: $modal-height + $banner-height;
+    }
   }
 }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26604

Adjuster la taille de la pop-in de rattachement quand il y une bannière 

![Capture d’écran 2024-01-05 à 13 09 39](https://github.com/pass-culture/pass-culture-main/assets/71768799/5d5b96dd-e2ec-4e0b-aa59-8db123b0b94f)
