### PR TITLE
(PC-26749)[PRO] fix: Fix types when spying on usenotification.

### DIFF
--- a/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
+++ b/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
@@ -180,8 +180,11 @@ describe('OfferEducationalActions', () => {
 
   it('should display error message when trying to activate offer with booking limit date time in the past', async () => {
     const notifyError = vi.fn()
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: notifyError,
     }))
     renderOfferEducationalActions({
@@ -204,11 +207,16 @@ describe('OfferEducationalActions', () => {
   it('should activate offer with booking limit date time in the future', async () => {
     const notifyError = vi.fn()
     const offerId = 12
+
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       success: vi.fn(),
       error: notifyError,
     }))
+
     const bookingLimitDateTomorrow = new Date()
     bookingLimitDateTomorrow.setDate(bookingLimitDateTomorrow.getDate() + 1)
     renderOfferEducationalActions({

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/ClassroomPlaylist/__specs__/ClassroomPlaylist.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/ClassroomPlaylist/__specs__/ClassroomPlaylist.spec.tsx
@@ -48,14 +48,17 @@ const renderNewOfferPlaylist = () => {
 describe('AdageDiscover classRoomPlaylist', () => {
   const notifyError = vi.fn()
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.spyOn(apiAdage, 'logConsultPlaylistElement')
     vi.spyOn(apiAdage, 'getClassroomPlaylist').mockResolvedValue({
       collectiveOffers: [defaultCollectiveOffer],
     })
 
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: notifyError,
     }))
 

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/NewOfferPlaylist/__specs__/NewOfferPlaylist.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/NewOfferPlaylist/__specs__/NewOfferPlaylist.spec.tsx
@@ -47,14 +47,17 @@ describe('AdageDiscovery', () => {
     institutionCity: 'ALES',
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.spyOn(apiAdage, 'logConsultPlaylistElement')
     vi.spyOn(apiAdage, 'newTemplateOffersPlaylist').mockResolvedValue({
       collectiveOffers: [defaultCollectiveTemplateOffer],
     })
 
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: notifyError,
     }))
 

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/__specs__/VenuePlaylist.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/__specs__/VenuePlaylist.spec.tsx
@@ -60,14 +60,17 @@ describe('AdageDiscover classRoomPlaylist', () => {
     institutionCity: 'ALES',
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.spyOn(apiAdage, 'logConsultPlaylistElement')
     vi.spyOn(apiAdage, 'getLocalOfferersPlaylist').mockResolvedValue({
       venues: [mockLocalOfferersPlaylistOffer],
     })
 
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: notifyError,
     }))
 

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
@@ -50,9 +50,12 @@ describe('AdageDiscovery', () => {
     institutionCity: 'ALES',
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: notifyError,
     }))
   })

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
@@ -49,9 +49,12 @@ describe('AdageHeader', () => {
     institutionCity: 'ALES',
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: notifyError,
     }))
     vi.spyOn(apiAdage, 'getEducationalInstitutionWithBudget').mockResolvedValue(

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
@@ -37,8 +37,12 @@ describe('SurveySatisfaction', () => {
 
   it('should fail close survey satisfaction', async () => {
     const notifyError = vi.fn()
-    // @ts-expect-error
+
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
+      ...notifsImport,
       error: notifyError,
     }))
 

--- a/pro/src/pages/CollectiveOfferFromRequest/__specs__/CollectiveOfferFromRequest.spec.tsx
+++ b/pro/src/pages/CollectiveOfferFromRequest/__specs__/CollectiveOfferFromRequest.spec.tsx
@@ -47,9 +47,12 @@ describe('CollectiveOfferFromRequest', () => {
     postalCode: '75000',
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: mockNotifyError,
     }))
 

--- a/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
@@ -80,10 +80,15 @@ describe('CollectiveOfferStockCreation', () => {
       payload: null,
     })
     const notifyError = vi.fn()
-    // @ts-expect-error
+
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
+      ...notifsImport,
       error: notifyError,
     }))
+
     renderCollectiveStockCreation('/offre/A1/collectif/stocks', props)
     expect(
       await screen.findByRole('heading', {

--- a/pro/src/pages/OffererStats/__specs__/OffererStats.spec.tsx
+++ b/pro/src/pages/OffererStats/__specs__/OffererStats.spec.tsx
@@ -87,8 +87,12 @@ describe('OffererStatsScreen', () => {
 
   it('should display error message if api call fail', async () => {
     const notifyError = vi.fn()
-    // @ts-expect-error
+
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
+      ...notifsImport,
       error: notifyError,
     }))
     vi.spyOn(api, 'listOfferersNames').mockRejectedValueOnce('')

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -173,12 +173,15 @@ describe('DuplicateOfferCell', () => {
     const mockNavigate = vi.fn()
     const notifyError = vi.fn()
 
-    beforeEach(() => {
+    beforeEach(async () => {
       offer = collectiveOfferFactory()
       offerDuplicate = collectiveOfferFactory()
 
+      const notifsImport = (await vi.importActual(
+        'hooks/useNotification'
+      )) as ReturnType<typeof useNotification.default>
       vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-        ...vi.importActual('hooks/useNotification'),
+        ...notifsImport,
         error: notifyError,
       }))
 

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/LinkVenuesDialog.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/LinkVenuesDialog.spec.tsx
@@ -121,8 +121,12 @@ describe('LinkVenueDialog', () => {
   it('should display error message when attach pricing point fail', async () => {
     vi.spyOn(api, 'linkVenueToPricingPoint').mockRejectedValue({})
     const mockNotifyError = vi.fn()
+
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: mockNotifyError,
     }))
     const managedVenues = [

--- a/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
@@ -71,7 +71,7 @@ describe('CollectiveOfferSummary', () => {
   const mockLogEvent = vi.fn()
   const notifyError = vi.fn()
 
-  beforeEach(() => {
+  beforeEach(async () => {
     offer = collectiveOfferTemplateFactory({ isTemplate: true })
     categories = {
       educationalCategories: categoriesFactory([{ id: 'CAT_1' }]),
@@ -80,8 +80,11 @@ describe('CollectiveOfferSummary', () => {
       ]),
     }
 
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: notifyError,
     }))
 

--- a/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -217,8 +217,12 @@ describe('CollectiveOfferVisibility', () => {
       .fn()
       .mockResolvedValue({ isOk: false, message: 'Ooops' })
     const notifyError = vi.fn()
-    // @ts-expect-error
+
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
+      ...notifsImport,
       error: notifyError,
     }))
     renderVisibilityStep({ ...props, patchInstitution: spyPatch })
@@ -406,8 +410,11 @@ describe('CollectiveOfferVisibility', () => {
     it('should display error message on api error getting requested info', async () => {
       const notifyError = vi.fn()
 
+      const notifsImport = (await vi.importActual(
+        'hooks/useNotification'
+      )) as ReturnType<typeof useNotification.default>
       vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-        ...vi.importActual('hooks/useNotification'),
+        ...notifsImport,
         error: notifyError,
       }))
 

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -369,8 +369,11 @@ describe('OfferType', () => {
   it('should display error message if trying to duplicate without template offer', async () => {
     vi.spyOn(api, 'canOffererCreateEducationalOffer').mockResolvedValue()
     const notifyError = vi.fn()
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: notifyError,
     }))
 

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -93,7 +93,7 @@ describe('screen Offers', () => {
 
   const mockNotifyError = vi.fn()
   const mockNotifyPending = vi.fn()
-  beforeEach(() => {
+  beforeEach(async () => {
     currentUser = {
       id: 'EY',
       isAdmin: false,
@@ -121,8 +121,12 @@ describe('screen Offers', () => {
         ({ id, proLabel }) => ({ value: id, label: proLabel })
       ),
     } as OffersProps
+
+    const notifsImport = (await vi.importActual(
+      'hooks/useNotification'
+    )) as ReturnType<typeof useNotification.default>
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
-      ...vi.importActual('hooks/useNotification'),
+      ...notifsImport,
       error: mockNotifyError,
       pending: mockNotifyPending,
     }))


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26749

**Objectif**
Corriger l'erreur de type dans les fichiers de tests au moment du mock du hook useNotification.

**A noter**
Problème du type retourné par `...vi.importActual('hooks/useNotification')` dans le cas d'un hook qui retourne un `useMemo`.
L'erreur est apparue entre la version v1.1.0 et v1.1.3 de vitest. J'ai ajouté un "as" pour forcer le type retourné par importActual. Et j'ai retiré les // ts-expect-error qu'on avait à certains autres endroits.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques