### PR TITLE
(PC-26756)[PRO] fix: Dont display the MEG levels in adage filters unl…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -30,6 +30,7 @@ interface OfferFiltersProps {
   categoriesOptions: Option<string[]>[]
   domainsOptions: Option<number>[]
   isFormatEnabled: boolean
+  shouldDisplayMarseilleStudentOptions: boolean
 }
 
 export const OfferFilters = ({
@@ -39,6 +40,7 @@ export const OfferFilters = ({
   categoriesOptions,
   domainsOptions,
   isFormatEnabled,
+  shouldDisplayMarseilleStudentOptions,
 }: OfferFiltersProps): JSX.Element => {
   const [modalOpenStatus, setModalOpenStatus] = useState<{
     [key: string]: boolean
@@ -142,6 +144,14 @@ export const OfferFilters = ({
       value: OfferAddressType.SCHOOL,
     },
   ]
+
+  const studentsOptionsFiltered = shouldDisplayMarseilleStudentOptions
+    ? studentsOptions
+    : studentsOptions.filter(
+        ({ value }) =>
+          value !== 'Écoles innovantes Marseille en Grand : maternelle' &&
+          value !== 'Écoles innovantes Marseille en Grand : élémentaire'
+      )
 
   return (
     <FormikProvider value={formik}>
@@ -403,7 +413,7 @@ export const OfferFilters = ({
                     placeholder="Ex: Collège"
                     name="students"
                     label="Niveau scolaire"
-                    options={studentsOptions}
+                    options={studentsOptionsFiltered}
                     isOpen={modalOpenStatus['students']}
                     sortOptions={(options, selectedOptions) => {
                       //  Implement custom sort to not sort results alphabetically

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -39,6 +39,7 @@ const renderOfferFilters = ({
             { value: 2, label: 'Architecture' },
             { value: 3, label: 'Arts' },
           ]}
+          shouldDisplayMarseilleStudentOptions={true}
           isFormatEnabled={isFormatEnabled}
         />
       </Formik>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -225,6 +225,9 @@ export const OffersSearch = ({
             categoriesOptions={categoriesOptions}
             domainsOptions={domainsOptions}
             isFormatEnabled={isFormatEnabled}
+            shouldDisplayMarseilleStudentOptions={
+              isMarseilleEnabled && isUserInMarseilleProgram
+            }
           />
         </div>
 

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
@@ -203,4 +203,19 @@ describe('FormParticipants', () => {
       })
     ).toBeInTheDocument()
   })
+
+  it('should not display new student level for MeG when ff is not active', () => {
+    renderFormParticipants(participants, false)
+
+    expect(
+      screen.queryByRole('checkbox', {
+        name: StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE,
+      })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('checkbox', {
+        name: StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE,
+      })
+    ).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
…ess ff is active and user is on program.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26756

**FF à activer/désactiver**
WIP_ENABLED_MARSEILLE

**Objectif**
Quand le FF est désactivé ou quand l'utilisateur n'est pas sur le programme Marseille en Grand (MeG) on ne souhaite pas voir les options des niveaux scolaires élémentaire et maternelle dans la liste des filtres de la recherche adage.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques