### PR TITLE
(BSR)[PRO] refactor: remove venueId from IndividualOffer

### DIFF
--- a/pro/src/components/IndividualOfferForm/utils/setInitialFormValues.ts
+++ b/pro/src/components/IndividualOfferForm/utils/setInitialFormValues.ts
@@ -37,7 +37,7 @@ const setInitialFormValues = (
     name: offer.name,
     description: offer.description,
     offererId: offer.offererId.toString(),
-    venueId: offer.venueId.toString(),
+    venueId: offer.venue.id.toString(),
     isNational: offer.isNational,
     isDuo: offer.isDuo,
     categoryId: subcategory.categoryId,

--- a/pro/src/context/IndividualOfferContext/IndividualOfferContext.tsx
+++ b/pro/src/context/IndividualOfferContext/IndividualOfferContext.tsx
@@ -23,7 +23,6 @@ export interface IndividualOfferContextValues {
   setSubcategory: (p?: SubcategoryResponseModel) => void
   offererNames: OffererName[]
   venueList: IndividualOfferVenueItem[]
-  venueId?: number | undefined
   offerOfferer?: OffererName | null
   showVenuePopin: Record<string, boolean>
 }
@@ -67,7 +66,6 @@ export function IndividualOfferContextProvider({
   )
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [offerOfferer, setOfferOfferer] = useState<OffererName | null>(null)
-  const [venueId, setVenueId] = useState<number>()
 
   const [offer, setOfferState] = useState<IndividualOffer | null>(null)
   const [categories, setCategories] = useState<CategoryResponseModel[]>([])
@@ -91,7 +89,6 @@ export function IndividualOfferContextProvider({
       const response = await getIndividualOfferAdapter(Number(offerId))
       if (response.isOk) {
         setOffer(response.payload)
-        setVenueId(response.payload.venueId)
       } else {
         navigate('/accueil')
         notify.error(
@@ -164,7 +161,6 @@ export function IndividualOfferContextProvider({
         subCategories,
         offererNames,
         venueList,
-        venueId,
         offerOfferer,
         showVenuePopin: showVenuePopin,
         subcategory,

--- a/pro/src/core/Offers/adapters/getIndividualOfferAdapter/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/getIndividualOfferAdapter/__specs__/serializers.spec.ts
@@ -252,7 +252,6 @@ describe('serializer', () => {
         postalCode: '11100',
         publicName: 'Mon Lieu',
       },
-      venueId: 1,
       visa: '',
       withdrawalDelay: null,
       withdrawalDetails: '',

--- a/pro/src/core/Offers/adapters/getIndividualOfferAdapter/serializers.ts
+++ b/pro/src/core/Offers/adapters/getIndividualOfferAdapter/serializers.ts
@@ -102,7 +102,6 @@ export const serializeOfferApi = (
     subcategoryId: apiOffer.subcategoryId,
     url: apiOffer.url || '',
     externalTicketOfficeUrl: apiOffer.externalTicketOfficeUrl || '',
-    venueId: apiOffer.venue.id,
     venue: apiOffer.venue,
     withdrawalDetails: apiOffer.withdrawalDetails || '',
     withdrawalDelay:

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -148,7 +148,6 @@ export interface IndividualOffer {
   image?: IndividualOfferImage
   url: string
   externalTicketOfficeUrl: string
-  venueId: number
   venue: GetOfferVenueResponseModel
   visa: string
   withdrawalDetails: string | null

--- a/pro/src/pages/IndividualOfferWizard/Confirmation/__specs__/Confirmation.spec.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Confirmation/__specs__/Confirmation.spec.tsx
@@ -83,8 +83,8 @@ describe('Confirmation', () => {
       },
     }
     offer = individualOfferFactory({
-      venueId: venueId,
       venue: offerVenueFactory({
+        id: venueId,
         managingOfferer: {
           id: offererId,
           name: 'Offerer name',

--- a/pro/src/pages/IndividualOfferWizard/Offer/__specs__/Offer.spec.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Offer/__specs__/Offer.spec.tsx
@@ -9,6 +9,7 @@ import {
   RenderWithProvidersOptions,
   renderWithProviders,
 } from 'utils/renderWithProviders'
+
 import { Offer } from '../Offer'
 
 const renderOfferPage = (options?: RenderWithProvidersOptions) =>

--- a/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
@@ -153,7 +153,6 @@ describe('screens:IndividualOffer::Informations::creation', () => {
       image: undefined,
       url: 'https://offer.example.com',
       externalTicketOfficeUrl: 'https://external.example.com',
-      venueId: 1,
       visa: '',
       withdrawalDetails: 'Offer withdrawalDetails',
       withdrawalDelay: 140,

--- a/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.edition.spec.tsx
@@ -23,6 +23,7 @@ import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
 import { AccessiblityEnum } from 'core/shared'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 import * as pcapi from 'repository/pcapi/pcapi'
+import { offerVenueFactory } from 'utils/apiFactories'
 import {
   individualOfferCategoryFactory,
   individualOfferContextFactory,
@@ -167,7 +168,6 @@ describe('screens:IndividualOffer::Informations:edition', () => {
       image: undefined,
       url: 'https://offer.example.com',
       externalTicketOfficeUrl: 'https://external.example.com',
-      venueId: 1,
       visa: '',
       withdrawalDetails: 'Offer withdrawalDetails',
       withdrawalDelay: 140,
@@ -255,7 +255,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
   it('should submit minimal virtual offer and redirect to summary', async () => {
     contextOverride.offer = {
       ...offer,
-      venueId: virtualVenueId,
+      venue: offerVenueFactory({ id: virtualVenueId }),
       subcategoryId: 'SCID virtual',
       isEvent: false,
       withdrawalDelay: undefined,
@@ -429,7 +429,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
     it('should submit when user click onCancel button, but should not send mail', async () => {
       contextOverride.offer = {
         ...offer,
-        venueId: virtualVenueId,
+        venue: offerVenueFactory({ id: virtualVenueId }),
         subcategoryId: 'SCID virtual',
         isEvent: false,
       }
@@ -497,7 +497,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
     it('should not submit when user click on close withdrawal dialog button', async () => {
       contextOverride.offer = {
         ...offer,
-        venueId: virtualVenueId,
+        venue: offerVenueFactory({ id: virtualVenueId }),
         subcategoryId: 'SCID virtual',
         isEvent: false,
       }
@@ -579,7 +579,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
       async (condition) => {
         contextOverride.offer = {
           ...offer,
-          venueId: virtualVenueId,
+          venue: offerVenueFactory({ id: virtualVenueId }),
           subcategoryId: 'SCID virtual',
           isEvent: true,
           withdrawalDelay: undefined,
@@ -638,7 +638,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
     it('should not open widthdrawal dialog if offer is not active', async () => {
       contextOverride.offer = {
         ...offer,
-        venueId: virtualVenueId,
+        venue: offerVenueFactory({ id: virtualVenueId }),
         subcategoryId: 'SCID virtual',
         isEvent: true,
         withdrawalDelay: undefined,
@@ -714,7 +714,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
       async (withdrawalInformations) => {
         contextOverride.offer = {
           ...offer,
-          venueId: virtualVenueId,
+          venue: offerVenueFactory({ id: virtualVenueId }),
           subcategoryId: 'SCID virtual',
           isEvent: false,
           withdrawalType: WithdrawalTypeEnum.ON_SITE,

--- a/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/__specs__/serializer.spec.ts
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/__specs__/serializer.spec.ts
@@ -51,7 +51,6 @@ describe('routes::Summary::serializers', () => {
         subcategoryId: 'SCID',
         url: 'https://offer.example.com',
         externalTicketOfficeUrl: 'https://external.example.com',
-        venueId: 1,
         visa: '',
         withdrawalDetails: 'Offer withdrawalDetails',
         withdrawalDelay: 140,

--- a/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -43,14 +43,8 @@ const SummaryScreen = () => {
   const notification = useNotification()
   const mode = useOfferWizardMode()
   const navigate = useNavigate()
-  const {
-    setOffer,
-    venueId,
-    offerOfferer,
-    showVenuePopin,
-    offer,
-    subCategories,
-  } = useIndividualOfferContext()
+  const { setOffer, offerOfferer, showVenuePopin, offer, subCategories } =
+    useIndividualOfferContext()
   const { logEvent } = useAnalytics()
 
   if (offer === null) {
@@ -90,7 +84,8 @@ const SummaryScreen = () => {
           !offererResponse.hasNonFreeOffer &&
           !offererResponse.hasValidBankAccount &&
           !offererResponse.hasPendingBankAccount) ||
-        (!isNewBankDetailsJourneyEnabled && showVenuePopin[venueId || ''])
+        (!isNewBankDetailsJourneyEnabled &&
+          showVenuePopin[offer.venue.id || ''])
 
       if (shouldDisplayRedirectDialog) {
         setDisplayRedirectDialog(true)
@@ -200,11 +195,11 @@ const SummaryScreen = () => {
         isDisabled={isDisabled}
       />
 
-      {displayRedirectDialog && offerOfferer?.id && venueId && (
+      {displayRedirectDialog && offerOfferer?.id && offer.venue.id && (
         <RedirectToBankAccountDialog
           cancelRedirectUrl={offerConfirmationStepUrl}
           offerId={offerOfferer?.id}
-          venueId={venueId}
+          venueId={offer.venue.id}
         />
       )}
     </>

--- a/pro/src/screens/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
@@ -336,12 +336,14 @@ describe('Summary', () => {
     })
 
     it('should display redirect modal if first offer', async () => {
+      const venueId = 1
       const context = {
-        offer: individualOfferFactory(),
-        venueId: 1,
+        offer: individualOfferFactory({
+          venue: offerVenueFactory({ id: venueId }),
+        }),
         offerOfferer: { name: 'offerOffererName', id: 1 },
         showVenuePopin: {
-          1: true,
+          [venueId]: true,
         },
       }
 
@@ -380,7 +382,6 @@ describe('Summary', () => {
           individualStockFactory({ price: 2, quantity: null })
         ),
         offerOfferer: { name: 'offerOffererName', id: 1 },
-        venueId: 1,
         venueList: [individualOfferVenueItemFactory()],
       }
 
@@ -433,7 +434,6 @@ describe('Summary', () => {
           individualStockFactory({ price: 2, quantity: null })
         ),
         offerOfferer: { name: 'offerOffererName', id: 1 },
-        venueId: 1,
         venueList: [individualOfferVenueItemFactory()],
       }
 
@@ -476,7 +476,6 @@ describe('Summary', () => {
     it('should not display redirect modal if offer is free', async () => {
       const context = {
         offer: individualOfferFactory(),
-        venueId: 1,
         venueList: [individualOfferVenueItemFactory()],
       }
 
@@ -509,7 +508,6 @@ describe('Summary', () => {
     it('should not display redirect modal if venue hasNonFreeOffers', async () => {
       const context = {
         offer: individualOfferFactory(),
-        venueId: 1,
         venueList: [individualOfferVenueItemFactory()],
       }
 

--- a/pro/src/screens/IndividualOfferConfirmationScreen/IndividualOfferConfirmationScreen.tsx
+++ b/pro/src/screens/IndividualOfferConfirmationScreen/IndividualOfferConfirmationScreen.tsx
@@ -28,7 +28,7 @@ const IndividualOfferConfirmationScreen = ({
 }: IndividualOfferConfirmationScreenProps): JSX.Element => {
   const { logEvent } = useAnalytics()
   const isPendingOffer = offer.status === OFFER_STATUS_PENDING
-  const queryString = `?structure=${offer.venue.managingOfferer.id}&lieu=${offer.venueId}`
+  const queryString = `?structure=${offer.venue.managingOfferer.id}&lieu=${offer.venue.id}`
   const title = isPendingOffer
     ? 'Offre en cours de validation'
     : 'Offre publiée !'

--- a/pro/src/utils/individualApiFactories.ts
+++ b/pro/src/utils/individualApiFactories.ts
@@ -76,7 +76,6 @@ export const individualOfferFactory = (
     isActivable: true,
     status: OfferStatus.ACTIVE,
     subcategoryId: SubcategoryIdEnum.CINE_PLEIN_AIR,
-    venueId: customVenue.id,
     priceCategories: [priceCategoryFactory()],
     ...customOffer,
   }


### PR DESCRIPTION
## But de la pull request

On enlève un champ qui est redondant avec `offer.venue.id`

Check fonctionnel : sur la création d'offre indiv, si on crée la 1ère offre payante sur une structure qui n'a pas de compte bancaire, on voit la modale qui propose de rediriger vers le compte bancaire s'afficher