### PR TITLE
(PC-26658)[API] feat: don't use BigQuery to get the institution rurality level

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-945ba5efc72f (pre) (head)
+232786daf672 (pre) (head)
 3467ee234047 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240108T101350_232786daf672_add_rurality_level_to_institution.py
+++ b/api/src/pcapi/alembic/versions/20240108T101350_232786daf672_add_rurality_level_to_institution.py
@@ -1,0 +1,23 @@
+"""add rurality_level to EductionInstitution
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi.core.educational.models import InstitutionRuralLevel
+from pcapi.utils.db import MagicEnum
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "232786daf672"
+down_revision = "945ba5efc72f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("educational_institution", sa.Column("ruralLevel", MagicEnum(InstitutionRuralLevel), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("educational_institution", "ruralLevel")

--- a/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
+++ b/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
@@ -74,7 +74,8 @@ class LocalOfferersQuery(BaseQuery):
 
 
 class InstitutionRuralLevelModel(pydantic_v1.BaseModel):
-    institution_rural_level: educational_models.InstitutionRuralLevel
+    institution_id: int
+    institution_rural_level: educational_models.InstitutionRuralLevel | None
 
     class Config:
         use_enum_values = True
@@ -83,13 +84,9 @@ class InstitutionRuralLevelModel(pydantic_v1.BaseModel):
 class InstitutionRuralLevelQuery(BaseQuery):
     raw_query = f"""
         SELECT
-            institution_rural_level,
+            DISTINCT institution_id, institution_rural_level,
         FROM
             `{settings.BIG_QUERY_TABLE_BASENAME}.adage_home_playlist_moving_offerers`
-        WHERE
-            institution_id = @institution_id
-        LIMIT
-            1
     """
 
     model = InstitutionRuralLevelModel

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -38,6 +38,7 @@ from pcapi.models import db
 from pcapi.models import offer_mixin
 from pcapi.models.accessibility_mixin import AccessibilityMixin
 from pcapi.models.pc_object import PcObject
+from pcapi.utils.db import MagicEnum
 from pcapi.utils.image_conversion import CropParams
 from pcapi.utils.image_conversion import ImageRatio
 from pcapi.utils.image_conversion import process_original_image
@@ -120,6 +121,15 @@ class CollectiveBookingStatusFilter(enum.Enum):
     BOOKED = "booked"
     VALIDATED = "validated"
     REIMBURSED = "reimbursed"
+
+
+class InstitutionRuralLevel(enum.Enum):
+    URBAIN_DENSITE_INTERMEDIAIRE = "urbain densité intermédiaire"
+    RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE = "rural sous forte influence d'un pôle"
+    URBAIN_DENSE = "urbain dense"
+    RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE = "rural sous faible influence d'un pôle"
+    RURAL_AUTONOME_TRES_PEU_DENSE = "rural autonome très peu dense"
+    RURAL_AUTONOME_PEU_DENSE = "rural autonome peu dense"
 
 
 @sa.orm.declarative_mixin
@@ -983,6 +993,8 @@ class EducationalInstitution(PcObject, Base, Model):
         back_populates="institutions",
     )
 
+    ruralLevel: InstitutionRuralLevel = sa.Column(MagicEnum(InstitutionRuralLevel), nullable=True, default=None)
+
     @property
     def full_name(self) -> str:
         return f"{self.institutionType} {self.name}".strip()
@@ -1567,15 +1579,6 @@ class CollectiveOfferTemplateEducationalRedactor(PcObject, Base, Model):
     __table_args__ = (
         UniqueConstraint("educationalRedactorId", "collectiveOfferTemplateId", name="unique_redactorId_template"),
     )
-
-
-class InstitutionRuralLevel(enum.Enum):
-    URBAIN_DENSITE_INTERMEDIAIRE = "urbain densité intermédiaire"
-    RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE = "rural sous forte influence d'un pôle"
-    URBAIN_DENSE = "urbain dense"
-    RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE = "rural sous faible influence d'un pôle"
-    RURAL_AUTONOME_TRES_PEU_DENSE = "rural autonome très peu dense"
-    RURAL_AUTONOME_PEU_DENSE = "rural autonome peu dense"
 
 
 class EducationalInstitutionProgramAssociation(Base, Model):

--- a/api/src/pcapi/routes/adage_iframe/authentication.py
+++ b/api/src/pcapi/routes/adage_iframe/authentication.py
@@ -1,9 +1,6 @@
-import typing
-
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.educational.api import favorites as educational_api_favorite
-from pcapi.core.educational.api import institution as institution_api
 from pcapi.core.educational.api.institution import get_educational_institution_department_code
 from pcapi.core.educational.exceptions import MissingRequiredRedactorInformation
 from pcapi.core.educational.repository import find_educational_institution_by_uai_code
@@ -38,9 +35,6 @@ def authenticate(authenticated_information: AuthenticatedInformation) -> Authent
         preferences = _get_preferences(redactor)
         favorites_count = _get_favorites_count(redactor)
         offer_count = get_offers_count(authenticated_information)
-        institution_rural_level = typing.cast(
-            educational_models.InstitutionRuralLevel | None, institution_api.get_institution_rural_level(institution)
-        )
         programs = _get_programs(institution)
 
         return AuthenticatedResponse(
@@ -55,7 +49,7 @@ def authenticate(authenticated_information: AuthenticatedInformation) -> Authent
             lon=authenticated_information.lon,
             favoritesCount=favorites_count,
             offersCount=offer_count,
-            institution_rural_level=institution_rural_level,
+            institution_rural_level=institution.ruralLevel if institution else None,
             programs=programs,
         )
     return AuthenticatedResponse(role=AdageFrontRoles.READONLY)

--- a/api/src/pcapi/routes/adage_iframe/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/playlists.py
@@ -12,7 +12,6 @@ from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository
 import pcapi.core.educational.api.favorites as favorites_api
-import pcapi.core.educational.api.institution as institution_api
 import pcapi.core.offerers.api as offerers_api
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.offerers.repository import get_venue_by_id
@@ -183,16 +182,15 @@ def new_template_offers_playlist(
 
 
 def _get_max_range_for_local_venues(institution: educational_models.EducationalInstitution) -> int:
-    institution_rural_level = institution_api.get_institution_rural_level(institution)
     return {
-        educational_models.InstitutionRuralLevel.URBAIN_DENSE.value: 3,
-        educational_models.InstitutionRuralLevel.URBAIN_DENSITE_INTERMEDIAIRE.value: 10,
-        educational_models.InstitutionRuralLevel.RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE.value: 15,
-        educational_models.InstitutionRuralLevel.RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE.value: 60,
-        educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE.value: 60,
-        educational_models.InstitutionRuralLevel.RURAL_AUTONOME_TRES_PEU_DENSE.value: 60,
+        educational_models.InstitutionRuralLevel.URBAIN_DENSE: 3,
+        educational_models.InstitutionRuralLevel.URBAIN_DENSITE_INTERMEDIAIRE: 10,
+        educational_models.InstitutionRuralLevel.RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE: 15,
+        educational_models.InstitutionRuralLevel.RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE: 60,
+        educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE: 60,
+        educational_models.InstitutionRuralLevel.RURAL_AUTONOME_TRES_PEU_DENSE: 60,
         None: 60,
-    }.get(institution_rural_level, 60)
+    }.get(institution.ruralLevel, 60)
 
 
 @blueprint.adage_iframe.route("/playlists/local-offerers", methods=["GET"])

--- a/api/tests/routes/adage_iframe/get_authenticate_test.py
+++ b/api/tests/routes/adage_iframe/get_authenticate_test.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest.mock import patch
 
 from flask import url_for
 import pytest
@@ -24,7 +23,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 
 DEFAULT_UAI = "EAU123"
-DEFAULT_RURAL_LEVEL = models.InstitutionRuralLevel.URBAIN_DENSE.value
+DEFAULT_RURAL_LEVEL = models.InstitutionRuralLevel.URBAIN_DENSE
 
 
 @pytest.fixture(name="valid_user", scope="module")
@@ -66,20 +65,17 @@ class AuthenticateTest:
         institution = EducationalInstitutionFactory(
             institutionId=DEFAULT_UAI,
             programs=[program],
+            ruralLevel=DEFAULT_RURAL_LEVEL,
         )
 
         valid_encoded_token = self._create_adage_valid_token(valid_user, uai_code=DEFAULT_UAI)
 
-        mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
-        with patch(mock_path) as mock_run_query:
-            mock_run_query.return_value = [{"institution_rural_level": DEFAULT_RURAL_LEVEL}]
-
-            response = client.with_explicit_token(valid_encoded_token).get("/adage-iframe/authenticate")
+        response = client.with_explicit_token(valid_encoded_token).get("/adage-iframe/authenticate")
 
         assert response.status_code == 200
         assert response.json == {
             **expected_serialized_auth_base(redactor, institution),
-            "institutionRuralLevel": DEFAULT_RURAL_LEVEL,
+            "institutionRuralLevel": DEFAULT_RURAL_LEVEL.value,
             "programs": [{"name": program.name, "label": program.label, "description": program.description}],
         }
 


### PR DESCRIPTION
In order to cut costs, we do store the institution rurality level within the database instead of using BigQuery for that.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques