### PR TITLE
Edit dependabot options

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
         update-types: ['version-update:semver-major', 'version-update:semver-minor']
       # We are not ready to handle upper version of spectree, even for patches
       - dependency-name: 'spectree'
+    # Disable automatic rebasing for poetry pull requests
+    rebase-strategy: "disabled"
 
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     schedule:
       interval: 'daily'
       time: '03:00'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
     ignore:
       # Except for critical ones where we only allow patches update
       - dependency-name: 'flask'


### PR DESCRIPTION
## But de la pull request

- Dependabot ne doit plus rebase automatiquement chaque jour ou après chaque autre bump de depéndance: [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy)
- Dependabot peut ouvrir jusqu'à 15 PRs, pour tenir compte des PRs longues à merger
