### PR TITLE
(BSR) ci: improve GHA concurrency syntax

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -12,9 +12,9 @@ on:
 permissions: write-all
 
 concurrency:
-  # cancel previous workflow of the same branch except on master
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref == 'refs/heads/master' && false || true }}
+  # cancel previous workflow of the same branch, except on master
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   check-api:
@@ -174,6 +174,10 @@ jobs:
 
   deploy-to-testing:
     name: "Deploy to testing"
+    # helm can only run one upgrade at a time,
+    concurrency:
+      group: deploy-to-testing
+      cancel-in-progress: false
     needs: [test-api, test-pro]
     if: |
       always() &&


### PR DESCRIPTION
## But de la pull request

Amélioration du workflow `dev_on_push_workflow_main`

- modification de la syntaxe de `concurrency` globale cf [cette syntaxe de SO](https://stackoverflow.com/a/75403978)
- ajout d'une `concurrency` au niveau du job `deploy-to-testing`

Ainsi, chaque push sur une branche de PR annulera le workflow en cours, mais sur `master` et `maint/*` , un job `deploy-to-testing` pourra finir de s'exécuter et le plus récent en date sera préservé.

Doc GHA sur `concurrency`: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Impacts:
- Lors des merges, les tests d'un workflow en cours ne seront plus annulés
- Les déploiements sur testing ne seront pas annulés si un 2e workflow est démarré, et le déploiement sera mis en attente.
 Si un 3e est démarré, le premier sera mené à bien, le 2e (pas encore commencé) sera annulé, et le 3e est mis en attente.