### PR TITLE
(PC-24505)[PRO] feat: Dont show focus outline on inputs with border o…

### DIFF
--- a/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.module.scss
@@ -4,7 +4,6 @@
 @use "styles/variables/_colors.scss" as colors;
 @use "styles/variables/_size.scss" as size;
 
-
 .base-checkbox {
   display: flex;
 
@@ -33,7 +32,6 @@
       color: forms.$input-text-color-disabled;
       cursor: default;
     }
-
   }
 
   &-icon {
@@ -56,8 +54,9 @@
     background-color: forms.$input-bg-color;
     border: rem.torem(2px) solid forms.$input-border-color;
     border-radius: rem.torem(3px);
-    transition: border 150ms ease,
-    background 150ms ease;
+    transition:
+      border 150ms ease,
+      background 150ms ease;
     flex: 0 0 auto;
     font-size: inherit;
     margin-right: rem.torem(8px);
@@ -105,7 +104,8 @@
       }
     }
 
-    &:disabled, &:disabled:checked {
+    &:disabled,
+    &:disabled:checked {
       background-color: colors.$grey-medium;
       border-color: colors.$grey-medium;
       cursor: not-allowed;
@@ -153,7 +153,7 @@
     outline: none;
   }
 
-  &:focus-within {
+  &:has(input:focus-visible) {
     outline: rem.torem(1px) solid colors.$input-text-color;
     outline-offset: rem.torem(4px);
     border-radius: rem.torem(4px);

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
@@ -19,7 +19,7 @@
     }
   }
 
-  &:focus-within {
+  &:has(input:focus-visible) {
     outline: rem.torem(1px) solid colors.$input-text-color;
     outline-offset: rem.torem(4px);
     border-radius: rem.torem(4px);
@@ -165,7 +165,7 @@
     white-space: nowrap;
   }
 
-  &:focus-within {
+  &:has(input:focus-visible) {
     outline: rem.torem(1px) solid colors.$black;
     outline-offset: rem.torem(4px);
   }


### PR DESCRIPTION
…n click.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24505

**Objectif**
N'afficher l'outline de la box contenant l'input que lorsqu'on TAB jusqu'à l'élément et pas au click.
Même chose pour les radio buttons.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques