### PR TITLE
(BSR)[BO] fix: authlib version bump breaking change

### DIFF
--- a/api/src/pcapi/routes/backoffice/auth.py
+++ b/api/src/pcapi/routes/backoffice/auth.py
@@ -60,7 +60,7 @@ def authorize() -> utils.BackofficeResponse:
     from pcapi.utils import login_manager
 
     token = backoffice_oauth.google.authorize_access_token()
-    google_user = backoffice_oauth.google.parse_id_token(token)
+    google_user = backoffice_oauth.google.parse_id_token(token, nonce=None)
     google_email = google_user["email"]
     user = users_repository.find_user_by_email(google_email)
 


### PR DESCRIPTION
J'ai reconstruit l'image docker du backend principal mais j'ai oublié de reconstruire l'image du backoffice.

Cette PR répare bien la connexion du backoffice pour authlib 1.3