### PR TITLE
(PC-26788)[API] perf : improve pro list offers search

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -79,11 +79,55 @@ def get_capped_offers_for_filters(
     )
 
     offers = (
-        query.options(sa_orm.joinedload(models.Offer.venue).joinedload(offerers_models.Venue.managingOfferer))
-        .options(sa_orm.joinedload(models.Offer.stocks))
-        .options(sa_orm.joinedload(models.Offer.mediations))
-        .options(sa_orm.joinedload(models.Offer.product))
-        .options(sa_orm.joinedload(models.Offer.lastProvider))
+        query.options(
+            sa.orm.load_only(
+                models.Offer.id,
+                models.Offer.name,
+                models.Offer.isActive,
+                models.Offer.subcategoryId,
+                models.Offer.validation,
+                models.Offer.extraData,
+                models.Offer.lastProviderId,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.venue)
+            .load_only(
+                offerers_models.Venue.id,
+                offerers_models.Venue.name,
+                offerers_models.Venue.publicName,
+                offerers_models.Venue.departementCode,
+                offerers_models.Venue.isVirtual,
+            )
+            .joinedload(offerers_models.Venue.managingOfferer)
+            .load_only(offerers_models.Offerer.id, offerers_models.Offerer.name)
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.stocks).load_only(
+                models.Stock.id,
+                models.Stock.beginningDatetime,
+                models.Stock.bookingLimitDatetime,
+                models.Stock.quantity,
+                models.Stock.dnBookedQuantity,
+                models.Stock.isSoftDeleted,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.mediations).load_only(
+                models.Mediation.id,
+                models.Mediation.credit,
+                models.Mediation.dateCreated,
+                models.Mediation.isActive,
+                models.Mediation.thumbCount,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.product).load_only(
+                models.Product.id,
+                models.Product.thumbCount,
+            )
+        )
+        .options(sa_orm.joinedload(models.Offer.lastProvider).load_only(providers_models.Provider.localClass))
         .limit(offers_limit)
         .all()
     )

--- a/api/src/pcapi/infrastructure/repository/pro_offers/offers_recap_domain_converter.py
+++ b/api/src/pcapi/infrastructure/repository/pro_offers/offers_recap_domain_converter.py
@@ -28,7 +28,7 @@ def _offer_recap_to_domain(offer: Offer) -> OfferRecap:
         subcategory_id=offer.subcategoryId,
         venue_id=offer.venue.id,
         venue_is_virtual=offer.venue.isVirtual,
-        venue_managing_offerer_id=offer.venue.managingOffererId,
+        venue_managing_offerer_id=offer.venue.managingOfferer.id,
         venue_name=offer.venue.name,
         venue_offerer_name=offer.venue.managingOfferer.name,
         venue_public_name=offer.venue.publicName,


### PR DESCRIPTION
first commit : only load used columns. See next screenshot, left is before.
![Screenshot 2024-01-08 at 17 18 35](https://github.com/pass-culture/pass-culture-main/assets/95358853/51fa7e26-9ba6-4b64-ba44-26c6620ea49a)

For this user 1173909 (soculture) on staging in went from 4.5s to 0.7 . I'm afraid it will hide some n+1 queries. Before merging i want to know how i can track this on .. sentry?