### PR TITLE
(PC-26763)[API] chore: log_action refactoring

### DIFF
--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -44,13 +44,10 @@ def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
 
         with transaction():
             db.session.add(offerers_models.OffererTagMapping(offererId=offerer.id, tagId=tag.id))
-            db.session.add(
-                history_api.log_action(
-                    history_models.ActionType.INFO_MODIFIED,
-                    None,
-                    offerer=offerer,
-                    comment="La structure est détectée comme inactive via l'API Sirene (INSEE)",
-                    modified_info={"tags": {"new_info": tag.label}},
-                    save=False,
-                )
+            history_api.add_action(
+                history_models.ActionType.INFO_MODIFIED,
+                None,
+                offerer=offerer,
+                comment="La structure est détectée comme inactive via l'API Sirene (INSEE)",
+                modified_info={"tags": {"new_info": tag.label}},
             )

--- a/api/src/pcapi/core/permissions/api.py
+++ b/api/src/pcapi/core/permissions/api.py
@@ -6,7 +6,6 @@ from pcapi.core.history import api as history_api
 from pcapi.core.history import models as history_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
-from pcapi.models import db
 from pcapi.repository import transaction
 
 
@@ -48,14 +47,11 @@ def update_role(
         role.name = name
         role.permissions = permissions
 
-        db.session.add(
-            history_api.log_action(
-                action_type=history_models.ActionType.ROLE_PERMISSIONS_CHANGED,
-                author=author,
-                role_name=role.name,
-                modified_info=modified_info,
-                save=False,
-            )
+        history_api.add_action(
+            action_type=history_models.ActionType.ROLE_PERMISSIONS_CHANGED,
+            author=author,
+            role_name=role.name,
+            modified_info=modified_info,
         )
 
     return role

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -104,15 +104,12 @@ def delete_venue_provider(
     # Save data now: it won't be available after we have deleted the object.
     venue_id = venue_provider.venueId
     provider_name = venue_provider.provider.name
-    db.session.add(
-        history_api.log_action(
-            history_models.ActionType.LINK_VENUE_PROVIDER_DELETED,
-            author,
-            venue=venue_provider.venue,
-            save=False,
-            provider_id=venue_provider.providerId,
-            provider_name=venue_provider.provider.name,
-        )
+    history_api.add_action(
+        history_models.ActionType.LINK_VENUE_PROVIDER_DELETED,
+        author,
+        venue=venue_provider.venue,
+        provider_id=venue_provider.providerId,
+        provider_name=venue_provider.provider.name,
     )
     db.session.delete(venue_provider)
     db.session.commit()

--- a/api/src/pcapi/local_providers/provider_manager.py
+++ b/api/src/pcapi/local_providers/provider_manager.py
@@ -252,15 +252,12 @@ def collect_elligible_venues_and_activate_ems_sync() -> None:
                     "venue_provider_id": allocine_venue_provider.id,
                 },
             )
-            db.session.add(
-                history_api.log_action(
-                    action_type=history_models.ActionType.LINK_VENUE_PROVIDER_DELETED,
-                    author=None,
-                    venue=venue_to_activate,
-                    save=False,
-                    provider_id=allocine_venue_provider.providerId,
-                    provider_name="Allociné",
-                )
+            history_api.add_action(
+                action_type=history_models.ActionType.LINK_VENUE_PROVIDER_DELETED,
+                author=None,
+                venue=venue_to_activate,
+                provider_id=allocine_venue_provider.providerId,
+                provider_name="Allociné",
             )
 
             venue_providers_to_activate.append(

--- a/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
@@ -17,7 +17,7 @@ from pcapi.core.history import models as history_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
-from pcapi.repository import repository
+from pcapi.models import db
 from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.forms import search as search_forms
 from pcapi.routes.backoffice.forms.search import TypeOptions
@@ -136,14 +136,15 @@ def update_bank_account(bank_account_id: int) -> utils.BackofficeResponse:
         return render_bank_account_details(bank_account, edit_form=form), 400
 
     if bank_account.label != form.label.data:
-        action = history_api.log_action(
+        history_api.add_action(
             history_models.ActionType.INFO_MODIFIED,
             current_user,
             bank_account=bank_account,
             modified_info={"label": {"old_info": bank_account.label, "new_info": form.label.data}},
         )
         bank_account.label = form.label.data
-        repository.save(bank_account, action)
+        db.session.add(bank_account)
+        db.session.commit()
         flash("Les informations ont bien été mises à jour", "success")
 
     return redirect(url_for("backoffice_web.bank_account.get", bank_account_id=bank_account_id), code=303)

--- a/api/src/pcapi/routes/backoffice/finance/finance_incidents_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/finance/finance_incidents_blueprint.py
@@ -23,6 +23,7 @@ from pcapi.core.offerers import models as offerer_models
 from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
+from pcapi.models import db
 from pcapi.routes.backoffice import filters
 from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.finance import forms
@@ -421,13 +422,13 @@ def comment_incident(finance_incident_id: int) -> utils.BackofficeResponse:
     if not form.validate():
         flash("Le formulaire comporte des erreurs", "warning")
     else:
-        history_api.log_action(
+        history_api.add_action(
             history_models.ActionType.COMMENT,
             author=current_user,
             finance_incident=incident,
             comment=form.comment.data,
-            save=True,
         )
+        db.session.commit()
         flash("Commentaire enregistré", "success")
 
     return redirect(

--- a/api/src/pcapi/routes/backoffice/offer_validation_rules/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offer_validation_rules/blueprint.py
@@ -271,14 +271,11 @@ def create_rule() -> utils.BackofficeResponse:
             db.session.add(sub_rule)
             db.session.flush()
             _add_sub_rule_data_to_history(sub_rule, sub_rules_info["sub_rules_created"])
-        db.session.add(
-            history_api.log_action(
-                history_models.ActionType.RULE_CREATED,
-                current_user,
-                rule=new_rule,
-                sub_rules_info=sub_rules_info,
-                save=False,
-            )
+        history_api.add_action(
+            history_models.ActionType.RULE_CREATED,
+            current_user,
+            rule=new_rule,
+            sub_rules_info=sub_rules_info,
         )
         db.session.commit()
         flash("Règle créée avec succès", "success")
@@ -320,14 +317,11 @@ def delete_rule(rule_id: int) -> utils.BackofficeResponse:
                 _add_sub_rule_data_to_history(sub_rule, sub_rules_info["sub_rules_deleted"])
                 db.session.delete(sub_rule)
             rule_to_delete.isActive = False
-            db.session.add(
-                history_api.log_action(
-                    history_models.ActionType.RULE_DELETED,
-                    current_user,
-                    rule=rule_to_delete,
-                    sub_rules_info=sub_rules_info,
-                    save=False,
-                )
+            history_api.add_action(
+                history_models.ActionType.RULE_DELETED,
+                current_user,
+                rule=rule_to_delete,
+                sub_rules_info=sub_rules_info,
             )
             db.session.commit()
         except sa.exc.IntegrityError as exc:
@@ -473,14 +467,11 @@ def edit_rule(rule_id: int) -> utils.BackofficeResponse:
                 sub_rules_info["sub_rules_created"],
             ]
         ):
-            db.session.add(
-                history_api.log_action(
-                    history_models.ActionType.RULE_MODIFIED,
-                    current_user,
-                    rule=rule_to_update,
-                    sub_rules_info=sub_rules_info,
-                    save=False,
-                )
+            history_api.add_action(
+                history_models.ActionType.RULE_MODIFIED,
+                current_user,
+                rule=rule_to_update,
+                sub_rules_info=sub_rules_info,
             )
         db.session.commit()
 

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -15,7 +15,6 @@ from pcapi.connectors.dms.models import GraphQLApplicationStates
 from pcapi.core.educational import models as educational_models
 from pcapi.core.external.attributes import api as external_attributes_api
 from pcapi.core.finance import models as finance_models
-from pcapi.core.history import api as history_api
 from pcapi.core.history import models as history_models
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import exceptions as offerers_exceptions
@@ -378,22 +377,15 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
         flash(msg, "warning")
         return _render_offerer_details(offerer_id, edit_offerer_form=form), 400
 
-    modified_info = offerers_api.update_offerer(
+    offerers_api.update_offerer(
         offerer,
+        current_user,
         name=form.name.data,
         city=form.city.data,
         postal_code=form.postal_code.data,
         address=form.address.data,
         tags=form.tags.data,
     )
-
-    if modified_info:
-        history_api.log_action(
-            history_models.ActionType.INFO_MODIFIED,
-            current_user,
-            offerer=offerer,
-            modified_info=modified_info,
-        )
 
     flash("Informations mises à jour", "success")
     return _self_redirect(offerer.id)

--- a/api/src/pcapi/routes/backoffice/pro_users/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro_users/blueprint.py
@@ -137,6 +137,7 @@ def update_pro_user(user_id: int) -> utils.BackofficeResponse:
         last_name=form.last_name.data,
         phone_number=form.phone_number.data,
         postal_code=form.postal_code.data,
+        commit=False,
     )
 
     if form.email.data and form.email.data != email_utils.sanitize_email(user.email):
@@ -153,7 +154,8 @@ def update_pro_user(user_id: int) -> utils.BackofficeResponse:
         external_attributes_api.update_external_pro(old_email)  # to delete previous user info from SendinBlue
         external_attributes_api.update_external_user(user)
 
-    snapshot.log_update(save=True)
+    snapshot.add_action()
+    db.session.commit()
 
     flash("Informations mises à jour", "success")
     return redirect(url_for(".get", user_id=user_id), code=303)

--- a/api/src/pcapi/routes/backoffice/providers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/providers/blueprint.py
@@ -85,16 +85,15 @@ def create_provider() -> utils.BackofficeResponse:
         offerer, is_offerer_new = _get_or_create_offerer(form)
         offerer_provider = offerers_models.OffererProvider(offerer=offerer, provider=provider)
         api_key, clear_secret = offerers_api.generate_provider_api_key(provider)
+        db.session.add_all([provider, offerer, offerer_provider, api_key])
 
-        action_history = history_api.log_action(
+        history_api.add_action(
             history_models.ActionType.OFFERER_NEW,
             current_user,
             offerer=offerer,
             comment="Création automatique via création de partenaire",
-            save=False,
         )
 
-        db.session.add_all([provider, offerer, offerer_provider, api_key, action_history])
         db.session.commit()
     except sa.exc.IntegrityError:
         db.session.rollback()

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -675,7 +675,7 @@ def update_venue(venue_id: int) -> utils.BackofficeResponse:
 @venue_blueprint.route("/<int:venue_id>/comment", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PRO_ENTITY)
 def comment_venue(venue_id: int) -> utils.BackofficeResponse:
-    venue = offerers_models.Venue.query.fitler_by(id=venue_id).with_for_update(key_share=True, read=True).one_or_none()
+    venue = offerers_models.Venue.query.filter_by(id=venue_id).with_for_update(key_share=True, read=True).one_or_none()
     if not venue:
         raise NotFound()
 

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -70,7 +70,7 @@ def patch_user_identity(body: users_serializers.UserIdentityBodyModel) -> users_
         )
         raise errors
     attributes = body.dict()
-    users_api.update_user_info(user, author=current_user, **attributes).log_update(save=True)
+    users_api.update_user_info(user, author=current_user, **attributes)
     return users_serializers.UserIdentityResponseModel.from_orm(user)
 
 
@@ -87,7 +87,7 @@ def patch_user_phone(body: users_serializers.UserPhoneBodyModel) -> users_serial
         )
         raise errors
     attributes = body.dict()
-    users_api.update_user_info(user, author=current_user, **attributes).log_update(save=True)
+    users_api.update_user_info(user, author=current_user, **attributes)
     return users_serializers.UserPhoneResponseModel.from_orm(user)
 
 

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -672,7 +672,7 @@ class UpdateUserInfoTest:
         user = users_factories.UserFactory(firstName="Noël", lastName="Flantier")
 
         modified_info = users_api.update_user_info(
-            user, author=user, first_name="Hubert", last_name="Bonisseur de la Bath"
+            user, author=user, first_name="Hubert", last_name="Bonisseur de la Bath", commit=False
         )
         assert modified_info.to_dict() == {
             "firstName": {"new_info": "Hubert", "old_info": "Noël"},


### PR DESCRIPTION
## But de la pull request

Refactor de la fonction `log_action` pour en faire une fonction qui ajoute une action dans la table `ActionHistory` sans faire de commit par défaut. Ce qui pousse à faire un `db.session.commit()` en dehors de la fonction pour être sûr qu'on enregistre tous les objets dans la même transaction et éviter d'avoir des incohérences dans l'historique. 

Ticket Jira : https://passculture.atlassian.net/browse/PC-26763

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~