### PR TITLE
(PC-26704)[API] fix: correct banId for onboarding

### DIFF
--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -68,7 +68,7 @@ class DMSApplicationForEAC(BaseModel):
 
 class PostVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
     address: base.VenueAddress
-    banId: base.VenueBanId
+    banId: base.VenueBanId | None
     bookingEmail: base.VenueBookingEmail
     city: base.VenueCity
     comment: base.VenueComment | None

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -2417,6 +2417,29 @@ class CreateFromOnboardingDataTest:
         assert created_venue.longitude == decimal.Decimal("48.87171")
         assert created_venue.postalCode == "75001"
 
+    def test_missing_banId(self):
+        user = users_factories.ProFactory(email="pro@example.com")
+        onboarding_data = self.get_onboarding_data(create_venue_without_siret=False)
+        onboarding_data.banId = None
+
+        created_user_offerer = offerers_api.create_from_onboarding_data(user, onboarding_data)
+
+        # Offerer has been created
+        created_offerer = created_user_offerer.offerer
+        assert created_offerer.name == "MINISTERE DE LA CULTURE"
+        assert created_offerer.siren == "853318459"
+        assert created_offerer.city == "Paris"
+        assert created_offerer.postalCode == "75001"
+        # 1 virtual Venue + 1 Venue with siret have been created
+        assert len(created_user_offerer.offerer.managedVenues) == 2
+        created_venue, _ = sorted(created_user_offerer.offerer.managedVenues, key=lambda v: v.isVirtual)
+        assert created_venue.address == "3 RUE DE VALOIS"
+        assert created_venue.banId is None
+        assert created_venue.city == "Paris"
+        assert created_venue.latitude == decimal.Decimal("2.30829")
+        assert created_venue.longitude == decimal.Decimal("48.87171")
+        assert created_venue.postalCode == "75001"
+
 
 class InviteMembersTest:
     def test_offerer_invitation_created_when_invite_new_user(self):

--- a/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
@@ -8,7 +8,7 @@ import type { VenueContactModel } from './VenueContactModel';
 export type PostVenueBodyModel = {
   address: string;
   audioDisabilityCompliant?: boolean | null;
-  banId: string;
+  banId?: string | null;
   bookingEmail: string;
   city: string;
   comment?: string | null;


### PR DESCRIPTION
Suite à la PR précédente , l'onboarding est bloqué si le banId est nul. Ce ticket devrait permettre de corriger ça tout en gardant le fix original

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26704

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques