### PR TITLE
(PC-25094)[API] test: recredit educational institution after collective incident

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 1fb084a51b0d (pre) (head)
-10b54017d02a (post) (head)
+65a8910cf1db (post) (head)

--- a/api/src/pcapi/alembic/versions/20240109T104132_65a8910cf1db_no_partial_collective_incident.py
+++ b/api/src/pcapi/alembic/versions/20240109T104132_65a8910cf1db_no_partial_collective_incident.py
@@ -1,0 +1,32 @@
+"""Update constraint: no partial incident on collective bookings
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "65a8910cf1db"
+down_revision = "10b54017d02a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Table is still empty in production
+    op.drop_constraint("booking_finance_incident_check", "booking_finance_incident")
+    op.create_check_constraint(
+        "booking_finance_incident_check",
+        "booking_finance_incident",
+        '("bookingId" IS NOT NULL AND "beneficiaryId" IS NOT NULL AND "collectiveBookingId" IS NULL) '
+        'OR ("collectiveBookingId" IS NOT NULL AND "bookingId" IS NULL AND "beneficiaryId" IS NULL AND "newTotalAmount" = 0)',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("booking_finance_incident_check", "booking_finance_incident")
+    op.create_check_constraint(
+        "booking_finance_incident_check",
+        "booking_finance_incident",
+        '("bookingId" IS NOT NULL AND "beneficiaryId" IS NOT NULL AND "collectiveBookingId" IS NULL) '
+        'OR ("collectiveBookingId" IS NOT NULL AND "bookingId" IS NULL AND "beneficiaryId" IS NULL)',
+    )

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -331,4 +331,4 @@ class CollectiveBookingFinanceIncidentFactory(BaseFactory):
 
     collectiveBooking = factory.SubFactory(educational_factories.ReimbursedCollectiveBookingFactory)
     incident = factory.SubFactory(FinanceIncidentFactory)
-    newTotalAmount = factory.LazyAttribute(lambda x: x.collectiveBooking.collectiveStock.price - 100)
+    newTotalAmount = 0

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -1012,9 +1012,11 @@ class BookingFinanceIncident(Base, Model):
     newTotalAmount: int = sqla.Column(sqla.Integer, nullable=False)
 
     __table_args__ = (
+        # - incident is either individual or collective
+        # - partial collective incident is forbidden
         sqla.CheckConstraint(
-            "(bookingId IS NOT NULL AND beneficiaryId IS NOT NULL AND collectiveBookingId IS NULL) "
-            "OR (collectiveBookingId IS NOT NULL AND bookingId IS NULL AND beneficiaryId IS NULL)",
+            '("bookingId" IS NOT NULL AND "beneficiaryId" IS NOT NULL AND "collectiveBookingId" IS NULL) '
+            'OR ("collectiveBookingId" IS NOT NULL AND "bookingId" IS NULL AND "beneficiaryId" IS NULL AND "newTotalAmount" = 0)',
             name="booking_finance_incident_check",
         ),
     )

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -16,12 +16,14 @@ import pcapi.core.bookings.api as bookings_api
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.bookings.models as bookings_models
 from pcapi.core.categories import subcategories_v2 as subcategories
+from pcapi.core.educational import exceptions as educational_exceptions
 import pcapi.core.educational.factories as educational_factories
 from pcapi.core.educational.factories import EducationalDepositFactory
 from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalYearFactory
 import pcapi.core.educational.models as educational_models
 from pcapi.core.educational.models import Ministry
+from pcapi.core.educational.validation import check_institution_fund
 from pcapi.core.finance import api
 from pcapi.core.finance import exceptions
 from pcapi.core.finance import factories
@@ -2921,3 +2923,30 @@ class UserRecreditTest:
             api.recredit_underage_users()
             assert user.deposit.amount == 30
             assert user.recreditAmountToShow is None
+
+
+class ValidateFinanceIncidentTest:
+    def test_educational_institution_is_recredited(self):
+        deposit = educational_factories.EducationalDepositFactory(amount=Decimal(1000.00), isFinal=True)
+        booking = educational_factories.ReimbursedCollectiveBookingFactory(
+            collectiveStock__price=Decimal(500.00),
+            educationalInstitution=deposit.educationalInstitution,
+            educationalYearId=deposit.educationalYearId,
+        )
+
+        collective_booking_finance_incident = factories.CollectiveBookingFinanceIncidentFactory(
+            collectiveBooking=booking
+        )
+
+        # before recredit
+        with pytest.raises(educational_exceptions.InsufficientFund):
+            check_institution_fund(
+                booking.educationalInstitution.id, booking.educationalYearId, Decimal(7800.00), deposit
+            )
+
+        api.validate_finance_incident(collective_booking_finance_incident.incident, force_debit_note=False)
+
+        assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
+
+        # after recredit, it does not raise InsufficientFund
+        check_institution_fund(booking.educationalInstitution.id, booking.educationalYearId, Decimal(700.00), deposit)

--- a/api/tests/core/finance/test_models.py
+++ b/api/tests/core/finance/test_models.py
@@ -190,3 +190,11 @@ class BankAccountRulesTest:
                 status=models.BankAccountApplicationStatus.ON_GOING,
                 timespan=(datetime.datetime.utcnow(),),
             )
+
+
+@pytest.mark.usefixtures("db_session")
+class BookingFinanceIncidentTest:
+    def test_no_partial_incident_on_collective_booking(self):
+        with pytest.raises(IntegrityError) as err:
+            factories.CollectiveBookingFinanceIncidentFactory(newTotalAmount=100)
+        assert 'booking_finance_incident" violates check constraint "booking_finance_incident_check"' in str(err.value)


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-25094

- recrédit d'un établissement scolaire après validation d'un incident (total) sur une offre collective
- renforcement de la contrainte : le métier n'autorise pas d'incident partiel sur une offre collective

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques