### PR TITLE
(PC-25360)[BO] feat: add links to related offers in offerer and venue pages

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -174,7 +174,18 @@
               <p class="mb-1">
                 <a href="{{ offerer | pc_pro_offerer_offers_link }}"
                    target="_blank"
-                   class="fw-bold link-primary">Offres associées</a>
+                   class="fw-bold link-primary">
+                  Offres associées
+                  <i class="bi bi-box-arrow-up-right"></i>
+                </a>
+              </p>
+              <p class="mb-1">
+                <a href="{{ url_for("backoffice_web.offer.list_offers", offerer=offerer.id) }}"
+                   class="fw-bold link-primary">Offres BO</a>
+              </p>
+              <p class="mb-1">
+                <a href="{{ url_for("backoffice_web.individual_bookings.list_individual_bookings", offerer=offerer.id) }}"
+                   class="fw-bold link-primary">Réservations BO</a>
               </p>
               <div>
                 {% if zendesk_sell_synchronisation_form %}

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -323,12 +323,26 @@
               <p class="mb-1">
                 <a href="{{ venue | pc_pro_venue_bookings_link }}"
                    target="_blank"
-                   class="fw-bold link-primary">Réservations</a>
+                   class="fw-bold link-primary">
+                  Réservations
+                  <i class="bi bi-box-arrow-up-right"></i>
+                </a>
               </p>
               <p class="mb-1">
                 <a href="{{ venue | pc_pro_venue_offers_link }}"
                    target="_blank"
-                   class="fw-bold link-primary">Offres associées</a>
+                   class="fw-bold link-primary">
+                  Offres associées
+                  <i class="bi bi-box-arrow-up-right"></i>
+                </a>
+              </p>
+              <p class="mb-1">
+                <a href="{{ url_for("backoffice_web.offer.list_offers", **{"search-0-search_field": "VENUE",  "search-0-venue": venue.id, "search-0-operator": "IN"}) }}"
+                   class="fw-bold link-primary">Offres BO</a>
+              </p>
+              <p class="mb-1">
+                <a href="{{ url_for("backoffice_web.individual_bookings.list_individual_bookings", venue=venue.id) }}"
+                   class="fw-bold link-primary">Réservations BO</a>
               </p>
               <div>
                 {% if zendesk_sell_synchronisation_form %}


### PR DESCRIPTION
## But de la pull request

Ajout de liens vers les pages "Offres" et "Offres individuelles" dans les pages "Acteurs culturels" et "Lieux".

Ticket Jira : https://passculture.atlassian.net/browse/PC-25360

 - Acteurs culturels :
 
<img width="921" alt="Capture d’écran 2024-01-09 à 16 59 35" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/c5cc2f13-4974-427e-8151-e5898a878254">

 - Lieux : 

<img width="926" alt="Capture d’écran 2024-01-09 à 17 00 08" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/2fa59a7b-c774-44a6-9c29-d955b8bf8409">


## Vérifications

 - [x] ~J'ai écrit les tests nécessaires~
 - [x] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques