### PR TITLE
(PC-26689)[EAC] feat: adage iframe: add adageId to /venues route

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/serialization/venues.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/venues.py
@@ -12,6 +12,7 @@ class VenueResponse(BaseModel):
     name: str
     departementCode: str
     relative: list[int]
+    adageId: str | None
 
     class Config:
         orm_mode = True

--- a/api/tests/routes/adage_iframe/get_venue_by_id_test.py
+++ b/api/tests/routes/adage_iframe/get_venue_by_id_test.py
@@ -20,7 +20,9 @@ class VenueByIdTest:
 
     def test_return_venue_with_publicName_of_given_id(self, client):
         # Given
-        requested_venue = offerers_factories.VenueFactory(publicName="Un petit surnom", isPermanent=True)
+        requested_venue = offerers_factories.VenueFactory(
+            publicName="Un petit surnom", isPermanent=True, adageId="123456"
+        )
         offerers_factories.VenueFactory(managingOfferer=requested_venue.managingOfferer, isPermanent=True)
         offerers_factories.VenueFactory(isPermanent=True)
         valid_encoded_token = self._create_adage_valid_token()
@@ -38,6 +40,7 @@ class VenueByIdTest:
             "publicName": requested_venue.publicName,
             "relative": [],
             "departementCode": "75",
+            "adageId": requested_venue.adageId,
         }
 
     def test_return_venue_without_publicName_of_given_id(self, client):
@@ -60,6 +63,7 @@ class VenueByIdTest:
             "publicName": None,
             "relative": [],
             "departementCode": "75",
+            "adageId": requested_venue.adageId,
         }
 
     def test_relative_venue(self, client):
@@ -86,6 +90,7 @@ class VenueByIdTest:
             "publicName": None,
             "relative": [venue2.id, venue3.id],
             "departementCode": "75",
+            "adageId": requested_venue.adageId,
         }
 
     def test_return_error_if_venue_does_not_exist(self, client):

--- a/api/tests/routes/adage_iframe/get_venue_by_siret_test.py
+++ b/api/tests/routes/adage_iframe/get_venue_by_siret_test.py
@@ -40,6 +40,7 @@ class VenueBySiretTest:
             "publicName": requested_venue.publicName,
             "relative": [],
             "departementCode": "75",
+            "adageId": requested_venue.adageId,
         }
 
     def test_return_venue_without_publicName_of_given_siret(self, client):
@@ -62,6 +63,7 @@ class VenueBySiretTest:
             "publicName": None,
             "relative": [],
             "departementCode": "75",
+            "adageId": requested_venue.adageId,
         }
 
     def test_return_relative_venue(self, client):
@@ -84,6 +86,7 @@ class VenueBySiretTest:
             "publicName": requested_venue.publicName,
             "relative": [venue2.id],
             "departementCode": "75",
+            "adageId": requested_venue.adageId,
         }
 
     def test_return_error_if_venue_does_not_exist(self, client):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26689

Ajout d'un champ adageId à la route `/adage-iframe/venues/{venue_id}`.