### PR TITLE
(PC-26068)[PRO] fix: dont display leaving guard pop-in when redirecti…

### DIFF
--- a/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/utils/index.ts
+++ b/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/utils/index.ts
@@ -78,9 +78,7 @@ export const shouldBlockNavigation: BlockerFunction = ({
 
   if (
     from === STEP_RECAP &&
-    nextLocation.pathname.startsWith(
-      '/remboursements/informations-bancaires?structure='
-    )
+    nextLocation.pathname.startsWith('/remboursements/informations-bancaires')
   ) {
     return false
   }


### PR DESCRIPTION
…ng to bank info page

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26068 

Ne pas afficher la pop-in 'Etes vous sur de vouloir quitter la création d'offre' lors du clic sur `Ajouter un compte bancaire` en fin de parcours de création d'offre collective. 

**Info sur la correction** 

La propriété pathname ne contient pas les query-params, c'est pourquoi on doit comparer seulement sur `/remboursements/informations-bancaires`

**Pour reproduire :** 

- Activer le FF WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY
- Sélectionner la structure 'eac_with_no_offer' (relancer la sandbox pour générer cette structure)
- Créer une offre collective payante (prix > 0) -> la pop-in s'affiche au clic sur `Publier`
- Vérifier que la pop-in `Etes vous sur de vouloir quitter la création d'offre` ne s'affiche pas (voir vidéo dans le ticket pour voir le cas ou elle s'affiche)