### PR TITLE
(BSR)[PRO] chore: re generate api client

### DIFF
--- a/pro/src/apiClient/adage/AppClientAdage.ts
+++ b/pro/src/apiClient/adage/AppClientAdage.ts
@@ -5,17 +5,11 @@
 import type { BaseHttpRequest } from './core/BaseHttpRequest';
 import type { OpenAPIConfig } from './core/OpenAPI';
 import { FetchHttpRequest } from './core/FetchHttpRequest';
-
 import { DefaultService } from './services/DefaultService';
-
 type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
-
 export class AppClientAdage {
-
   public readonly default: DefaultService;
-
   public readonly request: BaseHttpRequest;
-
   constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = FetchHttpRequest) {
     this.request = new HttpRequest({
       BASE: config?.BASE ?? 'http://localhost:5001',
@@ -28,7 +22,6 @@ export class AppClientAdage {
       HEADERS: config?.HEADERS,
       ENCODE_PATH: config?.ENCODE_PATH,
     });
-
     this.default = new DefaultService(this.request);
   }
 }

--- a/pro/src/apiClient/adage/core/CancelablePromise.ts
+++ b/pro/src/apiClient/adage/core/CancelablePromise.ts
@@ -51,7 +51,7 @@ export class CancelablePromise<T> implements Promise<T> {
           return;
         }
         this.#isResolved = true;
-        this.#resolve?.(value);
+        if (this.#resolve) this.#resolve(value);
       };
 
       const onReject = (reason?: any): void => {
@@ -59,7 +59,7 @@ export class CancelablePromise<T> implements Promise<T> {
           return;
         }
         this.#isRejected = true;
-        this.#reject?.(reason);
+        if (this.#reject) this.#reject(reason);
       };
 
       const onCancel = (cancelHandler: () => void): void => {
@@ -122,7 +122,7 @@ export class CancelablePromise<T> implements Promise<T> {
       }
     }
     this.#cancelHandlers.length = 0;
-    this.#reject?.(new CancelError('Request aborted'));
+    if (this.#reject) this.#reject(new CancelError('Request aborted'));
   }
 
   public get isCancelled(): boolean {

--- a/pro/src/apiClient/adage/models/AcademiesResponseModel.ts
+++ b/pro/src/apiClient/adage/models/AcademiesResponseModel.ts
@@ -2,5 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type AcademiesResponseModel = Array<string>;

--- a/pro/src/apiClient/adage/models/AdageBaseModel.ts
+++ b/pro/src/apiClient/adage/models/AdageBaseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type AdageBaseModel = {
   iframeFrom: string;
   isFromNoResult?: boolean | null;

--- a/pro/src/apiClient/adage/models/AdageFrontRoles.ts
+++ b/pro/src/apiClient/adage/models/AdageFrontRoles.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/adage/models/AdageHeaderLink.ts
+++ b/pro/src/apiClient/adage/models/AdageHeaderLink.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/adage/models/AdageHeaderLogBody.ts
+++ b/pro/src/apiClient/adage/models/AdageHeaderLogBody.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { AdageHeaderLink } from './AdageHeaderLink';
-
 export type AdageHeaderLogBody = {
   header_link_name: AdageHeaderLink;
   iframeFrom: string;

--- a/pro/src/apiClient/adage/models/AdagePlaylistType.ts
+++ b/pro/src/apiClient/adage/models/AdagePlaylistType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/adage/models/AuthenticatedResponse.ts
+++ b/pro/src/apiClient/adage/models/AuthenticatedResponse.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { AdageFrontRoles } from './AdageFrontRoles';
 import type { EducationalInstitutionProgramModel } from './EducationalInstitutionProgramModel';
 import type { InstitutionRuralLevel } from './InstitutionRuralLevel';
 import type { RedactorPreferences } from './RedactorPreferences';
-
 export type AuthenticatedResponse = {
   departmentCode?: string | null;
   email?: string | null;

--- a/pro/src/apiClient/adage/models/BookCollectiveOfferRequest.ts
+++ b/pro/src/apiClient/adage/models/BookCollectiveOfferRequest.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type BookCollectiveOfferRequest = {
   stockId: number;
 };

--- a/pro/src/apiClient/adage/models/BookCollectiveOfferResponse.ts
+++ b/pro/src/apiClient/adage/models/BookCollectiveOfferResponse.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type BookCollectiveOfferResponse = {
   bookingId: number;
 };

--- a/pro/src/apiClient/adage/models/CatalogViewBody.ts
+++ b/pro/src/apiClient/adage/models/CatalogViewBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CatalogViewBody = {
   iframeFrom: string;
   isFromNoResult?: boolean | null;

--- a/pro/src/apiClient/adage/models/CategoriesResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CategoriesResponseModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CategoryResponseModel } from './CategoryResponseModel';
 import type { SubcategoryResponseModel } from './SubcategoryResponseModel';
-
 export type CategoriesResponseModel = {
   categories: Array<CategoryResponseModel>;
   subcategories: Array<SubcategoryResponseModel>;

--- a/pro/src/apiClient/adage/models/CategoryResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CategoryResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CategoryResponseModel = {
   id: string;
   proLabel: string;

--- a/pro/src/apiClient/adage/models/CollectiveOfferOfferVenue.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferOfferVenue.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OfferAddressType } from './OfferAddressType';
-
 export type CollectiveOfferOfferVenue = {
   address?: string | null;
   addressType: OfferAddressType;

--- a/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferOfferVenue } from './CollectiveOfferOfferVenue';
 import type { EacFormat } from './EacFormat';
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
@@ -12,7 +11,6 @@ import type { OfferDomain } from './OfferDomain';
 import type { OfferStockResponse } from './OfferStockResponse';
 import type { OfferVenueResponse } from './OfferVenueResponse';
 import type { StudentLevels } from './StudentLevels';
-
 export type CollectiveOfferResponseModel = {
   audioDisabilityCompliant?: boolean | null;
   contactEmail: string;

--- a/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferOfferVenue } from './CollectiveOfferOfferVenue';
 import type { EacFormat } from './EacFormat';
 import type { NationalProgramModel } from './NationalProgramModel';
@@ -10,7 +9,6 @@ import type { OfferDomain } from './OfferDomain';
 import type { OfferVenueResponse } from './OfferVenueResponse';
 import type { StudentLevels } from './StudentLevels';
 import type { TemplateDatesModel } from './TemplateDatesModel';
-
 export type CollectiveOfferTemplateResponseModel = {
   audioDisabilityCompliant?: boolean | null;
   contactEmail: string;

--- a/pro/src/apiClient/adage/models/CollectiveRequestBody.ts
+++ b/pro/src/apiClient/adage/models/CollectiveRequestBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveRequestBody = {
   collectiveOfferTemplateId: number;
   comment: string;

--- a/pro/src/apiClient/adage/models/CollectiveRequestResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveRequestResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveRequestResponseModel = {
   comment: string;
   email: string;

--- a/pro/src/apiClient/adage/models/Coordinates.ts
+++ b/pro/src/apiClient/adage/models/Coordinates.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type Coordinates = {
   latitude?: number | null;
   longitude?: number | null;

--- a/pro/src/apiClient/adage/models/EacFormat.ts
+++ b/pro/src/apiClient/adage/models/EacFormat.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/adage/models/EacFormatsResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EacFormatsResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { EacFormat } from './EacFormat';
-
 export type EacFormatsResponseModel = {
   formats: Array<EacFormat>;
 };

--- a/pro/src/apiClient/adage/models/EducationalInstitutionProgramModel.ts
+++ b/pro/src/apiClient/adage/models/EducationalInstitutionProgramModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalInstitutionProgramModel = {
   description?: string | null;
   label?: string | null;

--- a/pro/src/apiClient/adage/models/EducationalInstitutionResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EducationalInstitutionResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalInstitutionResponseModel = {
   city: string;
   id: number;

--- a/pro/src/apiClient/adage/models/EducationalInstitutionWithBudgetResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EducationalInstitutionWithBudgetResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalInstitutionWithBudgetResponseModel = {
   budget: number;
   city: string;

--- a/pro/src/apiClient/adage/models/EducationalRedactorResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EducationalRedactorResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalRedactorResponseModel = {
   civility?: string | null;
   email?: string | null;

--- a/pro/src/apiClient/adage/models/FavoritesResponseModel.ts
+++ b/pro/src/apiClient/adage/models/FavoritesResponseModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferResponseModel } from './CollectiveOfferResponseModel';
 import type { CollectiveOfferTemplateResponseModel } from './CollectiveOfferTemplateResponseModel';
-
 export type FavoritesResponseModel = {
   favoritesOffer: Array<CollectiveOfferResponseModel>;
   favoritesTemplate: Array<CollectiveOfferTemplateResponseModel>;

--- a/pro/src/apiClient/adage/models/FeatureResponseModel.ts
+++ b/pro/src/apiClient/adage/models/FeatureResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type FeatureResponseModel = {
   description: string;
   id: string;

--- a/pro/src/apiClient/adage/models/GetRelativeVenuesQueryModel.ts
+++ b/pro/src/apiClient/adage/models/GetRelativeVenuesQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetRelativeVenuesQueryModel = {
   getRelative?: boolean;
 };

--- a/pro/src/apiClient/adage/models/InstitutionRuralLevel.ts
+++ b/pro/src/apiClient/adage/models/InstitutionRuralLevel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/adage/models/ListCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/adage/models/ListCollectiveOfferTemplateResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferTemplateResponseModel } from './CollectiveOfferTemplateResponseModel';
-
 export type ListCollectiveOfferTemplateResponseModel = {
   collectiveOffers: Array<CollectiveOfferTemplateResponseModel>;
 };

--- a/pro/src/apiClient/adage/models/ListCollectiveOffersResponseModel.ts
+++ b/pro/src/apiClient/adage/models/ListCollectiveOffersResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferResponseModel } from './CollectiveOfferResponseModel';
-
 export type ListCollectiveOffersResponseModel = {
   collectiveOffers: Array<CollectiveOfferResponseModel>;
 };

--- a/pro/src/apiClient/adage/models/ListFeatureResponseModel.ts
+++ b/pro/src/apiClient/adage/models/ListFeatureResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { FeatureResponseModel } from './FeatureResponseModel';
-
 export type ListFeatureResponseModel = Array<FeatureResponseModel>;

--- a/pro/src/apiClient/adage/models/LocalOfferersPlaylist.ts
+++ b/pro/src/apiClient/adage/models/LocalOfferersPlaylist.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { LocalOfferersPlaylistOffer } from './LocalOfferersPlaylistOffer';
-
 export type LocalOfferersPlaylist = {
   venues: Array<LocalOfferersPlaylistOffer>;
 };

--- a/pro/src/apiClient/adage/models/LocalOfferersPlaylistOffer.ts
+++ b/pro/src/apiClient/adage/models/LocalOfferersPlaylistOffer.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type LocalOfferersPlaylistOffer = {
   city?: string | null;
   distance?: number | null;

--- a/pro/src/apiClient/adage/models/NationalProgramModel.ts
+++ b/pro/src/apiClient/adage/models/NationalProgramModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type NationalProgramModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/adage/models/OfferAddressType.ts
+++ b/pro/src/apiClient/adage/models/OfferAddressType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/adage/models/OfferDomain.ts
+++ b/pro/src/apiClient/adage/models/OfferDomain.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OfferDomain = {
   id: number;
   name: string;

--- a/pro/src/apiClient/adage/models/OfferFavoriteBody.ts
+++ b/pro/src/apiClient/adage/models/OfferFavoriteBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OfferFavoriteBody = {
   iframeFrom: string;
   isFavorite: boolean;

--- a/pro/src/apiClient/adage/models/OfferIdBody.ts
+++ b/pro/src/apiClient/adage/models/OfferIdBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OfferIdBody = {
   iframeFrom: string;
   isFromNoResult?: boolean | null;

--- a/pro/src/apiClient/adage/models/OfferManagingOffererResponse.ts
+++ b/pro/src/apiClient/adage/models/OfferManagingOffererResponse.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OfferManagingOffererResponse = {
   name: string;
 };

--- a/pro/src/apiClient/adage/models/OfferStockResponse.ts
+++ b/pro/src/apiClient/adage/models/OfferStockResponse.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OfferStockResponse = {
   beginningDatetime?: string | null;
   bookingLimitDatetime?: string | null;

--- a/pro/src/apiClient/adage/models/OfferVenueResponse.ts
+++ b/pro/src/apiClient/adage/models/OfferVenueResponse.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { Coordinates } from './Coordinates';
 import type { OfferManagingOffererResponse } from './OfferManagingOffererResponse';
-
 export type OfferVenueResponse = {
   adageId?: string | null;
   address?: string | null;

--- a/pro/src/apiClient/adage/models/PlaylistBody.ts
+++ b/pro/src/apiClient/adage/models/PlaylistBody.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { AdagePlaylistType } from './AdagePlaylistType';
-
 export type PlaylistBody = {
   elementId?: number | null;
   iframeFrom: string;

--- a/pro/src/apiClient/adage/models/PostCollectiveRequestBodyModel.ts
+++ b/pro/src/apiClient/adage/models/PostCollectiveRequestBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PostCollectiveRequestBodyModel = {
   comment: string;
   phoneNumber?: string | null;

--- a/pro/src/apiClient/adage/models/RedactorPreferences.ts
+++ b/pro/src/apiClient/adage/models/RedactorPreferences.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type RedactorPreferences = {
   broadcast_help_closed?: boolean | null;
   feedback_form_closed?: boolean | null;

--- a/pro/src/apiClient/adage/models/SearchBody.ts
+++ b/pro/src/apiClient/adage/models/SearchBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type SearchBody = {
   filters: Array<string>;
   iframeFrom: string;

--- a/pro/src/apiClient/adage/models/StockIdBody.ts
+++ b/pro/src/apiClient/adage/models/StockIdBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type StockIdBody = {
   iframeFrom: string;
   isFromNoResult?: boolean | null;

--- a/pro/src/apiClient/adage/models/StudentLevels.ts
+++ b/pro/src/apiClient/adage/models/StudentLevels.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/adage/models/SubcategoryResponseModel.ts
+++ b/pro/src/apiClient/adage/models/SubcategoryResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type SubcategoryResponseModel = {
   categoryId: string;
   id: string;

--- a/pro/src/apiClient/adage/models/SuggestionType.ts
+++ b/pro/src/apiClient/adage/models/SuggestionType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/adage/models/TemplateDatesModel.ts
+++ b/pro/src/apiClient/adage/models/TemplateDatesModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type TemplateDatesModel = {
   end: string;
   start: string;

--- a/pro/src/apiClient/adage/models/TrackingAutocompleteSuggestionBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingAutocompleteSuggestionBody.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { SuggestionType } from './SuggestionType';
-
 export type TrackingAutocompleteSuggestionBody = {
   iframeFrom: string;
   isFromNoResult?: boolean | null;

--- a/pro/src/apiClient/adage/models/TrackingFilterBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingFilterBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type TrackingFilterBody = {
   filterValues: Record<string, any>;
   iframeFrom: string;

--- a/pro/src/apiClient/adage/models/TrackingShowMoreBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingShowMoreBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type TrackingShowMoreBody = {
   iframeFrom: string;
   isFromNoResult?: boolean | null;

--- a/pro/src/apiClient/adage/models/ValidationError.ts
+++ b/pro/src/apiClient/adage/models/ValidationError.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ValidationErrorElement } from './ValidationErrorElement';
-
 /**
  * Model of a validation error response.
  */

--- a/pro/src/apiClient/adage/models/ValidationErrorElement.ts
+++ b/pro/src/apiClient/adage/models/ValidationErrorElement.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * Model of a validation error response element.
  */

--- a/pro/src/apiClient/adage/models/VenueResponse.ts
+++ b/pro/src/apiClient/adage/models/VenueResponse.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueResponse = {
   departementCode: string;
   id: number;

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -32,14 +32,10 @@ import type { TrackingAutocompleteSuggestionBody } from '../models/TrackingAutoc
 import type { TrackingFilterBody } from '../models/TrackingFilterBody';
 import type { TrackingShowMoreBody } from '../models/TrackingShowMoreBody';
 import type { VenueResponse } from '../models/VenueResponse';
-
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
-
 export class DefaultService {
-
   constructor(public readonly httpRequest: BaseHttpRequest) {}
-
   /**
    * authenticate <GET>
    * @returns AuthenticatedResponse OK
@@ -55,7 +51,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_academies <GET>
    * @returns AcademiesResponseModel OK
@@ -71,7 +66,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_educational_eligible_offers_by_uai <GET>
    * @returns ListCollectiveOffersResponseModel OK
@@ -87,7 +81,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * book_collective_offer <POST>
    * @param requestBody
@@ -109,7 +102,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_favorites <GET>
    * @returns FavoritesResponseModel OK
@@ -125,7 +117,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_educational_institution_with_budget <GET>
    * @returns EducationalInstitutionWithBudgetResponseModel OK
@@ -141,7 +132,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_favorite_for_collective_offer <DELETE>
    * @param offerId
@@ -163,7 +153,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_offer_template <GET>
    * @param offerId
@@ -186,7 +175,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * create_collective_request <POST>
    * @param offerId
@@ -213,7 +201,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_offer <GET>
    * @param offerId
@@ -236,7 +223,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_collective_offer_favorites <POST>
    * @param offerId
@@ -258,7 +244,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_favorite_for_collective_offer_template <DELETE>
    * @param offerTemplateId
@@ -280,7 +265,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_collective_template_favorites <POST>
    * @param offerId
@@ -302,7 +286,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * list_features <GET>
    * @returns ListFeatureResponseModel OK
@@ -319,7 +302,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_booking_modal_button_click <POST>
    * @param requestBody
@@ -341,7 +323,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_catalog_view <POST>
    * @param requestBody
@@ -363,7 +344,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_consult_playlist_element <POST>
    * @param requestBody
@@ -385,7 +365,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_contact_modal_button_click <POST>
    * @param requestBody
@@ -407,7 +386,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_fav_offer_button_click <POST>
    * @param requestBody
@@ -429,7 +407,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_has_seen_whole_playlist <POST>
    * @param requestBody
@@ -451,7 +428,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_header_link_click <POST>
    * @param requestBody
@@ -473,7 +449,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_offer_details_button_click <POST>
    * @param requestBody
@@ -495,7 +470,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_offer_template_details_button_click <POST>
    * @param requestBody
@@ -517,7 +491,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_has_seen_all_playlist <POST>
    * @param requestBody
@@ -539,7 +512,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_request_form_popin_dismiss <POST>
    * @param requestBody
@@ -561,7 +533,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_open_satisfaction_survey <POST>
    * @param requestBody
@@ -583,7 +554,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_search_button_click <POST>
    * @param requestBody
@@ -605,7 +575,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_search_show_more <POST>
    * @param requestBody
@@ -627,7 +596,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_tracking_autocomplete_suggestion_click <POST>
    * @param requestBody
@@ -649,7 +617,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_tracking_filter <POST>
    * @param requestBody
@@ -671,7 +638,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * log_tracking_map <POST>
    * @param requestBody
@@ -693,7 +659,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_educational_offers_categories <GET>
    * @returns CategoriesResponseModel OK
@@ -709,7 +674,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_educational_offers_formats <GET>
    * @returns EacFormatsResponseModel OK
@@ -725,7 +689,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_classroom_playlist <GET>
    * @returns ListCollectiveOfferTemplateResponseModel OK
@@ -741,7 +704,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_local_offerers_playlist <GET>
    * @returns LocalOfferersPlaylist OK
@@ -757,7 +719,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * new_template_offers_playlist <GET>
    * @returns ListCollectiveOfferTemplateResponseModel OK
@@ -774,7 +735,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * save_redactor_preferences <POST>
    * @param requestBody
@@ -795,7 +755,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venue_by_siret <GET>
    * @param siret
@@ -822,7 +781,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venue_by_id <GET>
    * @param venueId
@@ -849,5 +807,4 @@ export class DefaultService {
       },
     });
   }
-
 }

--- a/pro/src/apiClient/v1/AppClient.ts
+++ b/pro/src/apiClient/v1/AppClient.ts
@@ -5,17 +5,11 @@
 import type { BaseHttpRequest } from './core/BaseHttpRequest';
 import type { OpenAPIConfig } from './core/OpenAPI';
 import { FetchHttpRequest } from './core/FetchHttpRequest';
-
 import { DefaultService } from './services/DefaultService';
-
 type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
-
 export class AppClient {
-
   public readonly default: DefaultService;
-
   public readonly request: BaseHttpRequest;
-
   constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = FetchHttpRequest) {
     this.request = new HttpRequest({
       BASE: config?.BASE ?? 'http://localhost:5001',
@@ -28,7 +22,6 @@ export class AppClient {
       HEADERS: config?.HEADERS,
       ENCODE_PATH: config?.ENCODE_PATH,
     });
-
     this.default = new DefaultService(this.request);
   }
 }

--- a/pro/src/apiClient/v1/core/CancelablePromise.ts
+++ b/pro/src/apiClient/v1/core/CancelablePromise.ts
@@ -51,7 +51,7 @@ export class CancelablePromise<T> implements Promise<T> {
           return;
         }
         this.#isResolved = true;
-        this.#resolve?.(value);
+        if (this.#resolve) this.#resolve(value);
       };
 
       const onReject = (reason?: any): void => {
@@ -59,7 +59,7 @@ export class CancelablePromise<T> implements Promise<T> {
           return;
         }
         this.#isRejected = true;
-        this.#reject?.(reason);
+        if (this.#reject) this.#reject(reason);
       };
 
       const onCancel = (cancelHandler: () => void): void => {
@@ -122,7 +122,7 @@ export class CancelablePromise<T> implements Promise<T> {
       }
     }
     this.#cancelHandlers.length = 0;
-    this.#reject?.(new CancelError('Request aborted'));
+    if (this.#reject) this.#reject(new CancelError('Request aborted'));
   }
 
   public get isCancelled(): boolean {

--- a/pro/src/apiClient/v1/models/AdageCulturalPartnerResponseModel.ts
+++ b/pro/src/apiClient/v1/models/AdageCulturalPartnerResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type AdageCulturalPartnerResponseModel = {
   domaineIds: Array<number>;
   id: number;

--- a/pro/src/apiClient/v1/models/AdageCulturalPartnersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/AdageCulturalPartnersResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CulturalPartner } from './CulturalPartner';
-
 export type AdageCulturalPartnersResponseModel = {
   partners: Array<CulturalPartner>;
 };

--- a/pro/src/apiClient/v1/models/Address.ts
+++ b/pro/src/apiClient/v1/models/Address.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type Address = {
   city: string;
   postalCode: string;

--- a/pro/src/apiClient/v1/models/AttachImageFormModel.ts
+++ b/pro/src/apiClient/v1/models/AttachImageFormModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type AttachImageFormModel = {
   credit: string;
   croppingRectHeight: number;

--- a/pro/src/apiClient/v1/models/AttachImageResponseModel.ts
+++ b/pro/src/apiClient/v1/models/AttachImageResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type AttachImageResponseModel = {
   imageUrl: string;
 };

--- a/pro/src/apiClient/v1/models/BankAccountApplicationStatus.ts
+++ b/pro/src/apiClient/v1/models/BankAccountApplicationStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/BankAccountResponseModel.ts
+++ b/pro/src/apiClient/v1/models/BankAccountResponseModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BankAccountApplicationStatus } from './BankAccountApplicationStatus';
 import type { LinkedVenues } from './LinkedVenues';
-
 export type BankAccountResponseModel = {
   bic: string;
   dateCreated: string;

--- a/pro/src/apiClient/v1/models/BannerMetaModel.ts
+++ b/pro/src/apiClient/v1/models/BannerMetaModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CropParams } from './CropParams';
-
 export type BannerMetaModel = {
   crop_params?: CropParams;
   image_credit?: string | null;

--- a/pro/src/apiClient/v1/models/BookingExportType.ts
+++ b/pro/src/apiClient/v1/models/BookingExportType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/BookingRecapResponseBeneficiaryModel.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapResponseBeneficiaryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type BookingRecapResponseBeneficiaryModel = {
   email?: string | null;
   firstname?: string | null;

--- a/pro/src/apiClient/v1/models/BookingRecapResponseBookingStatusHistoryModel.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapResponseBookingStatusHistoryModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BookingRecapStatus } from './BookingRecapStatus';
-
 export type BookingRecapResponseBookingStatusHistoryModel = {
   date?: string | null;
   status: BookingRecapStatus;

--- a/pro/src/apiClient/v1/models/BookingRecapResponseModel.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapResponseModel.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BookingRecapResponseBeneficiaryModel } from './BookingRecapResponseBeneficiaryModel';
 import type { BookingRecapResponseBookingStatusHistoryModel } from './BookingRecapResponseBookingStatusHistoryModel';
 import type { BookingRecapResponseStockModel } from './BookingRecapResponseStockModel';
 import type { BookingRecapStatus } from './BookingRecapStatus';
-
 export type BookingRecapResponseModel = {
   beneficiary: BookingRecapResponseBeneficiaryModel;
   bookingAmount: number;

--- a/pro/src/apiClient/v1/models/BookingRecapResponseStockModel.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapResponseStockModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type BookingRecapResponseStockModel = {
   eventBeginningDatetime?: string | null;
   offerId: number;

--- a/pro/src/apiClient/v1/models/BookingRecapStatus.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/BookingStatusFilter.ts
+++ b/pro/src/apiClient/v1/models/BookingStatusFilter.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/BookingStatusHistoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/BookingStatusHistoryResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type BookingStatusHistoryResponseModel = {
   date: string;
   status: string;

--- a/pro/src/apiClient/v1/models/CategoriesResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CategoriesResponseModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CategoryResponseModel } from './CategoryResponseModel';
 import type { SubcategoryResponseModel } from './SubcategoryResponseModel';
-
 export type CategoriesResponseModel = {
   categories: Array<CategoryResponseModel>;
   subcategories: Array<SubcategoryResponseModel>;

--- a/pro/src/apiClient/v1/models/CategoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CategoryResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CategoryResponseModel = {
   id: string;
   isSelectable: boolean;

--- a/pro/src/apiClient/v1/models/ChangePasswordBodyModel.ts
+++ b/pro/src/apiClient/v1/models/ChangePasswordBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ChangePasswordBodyModel = {
   newConfirmationPassword: string;
   newPassword: string;

--- a/pro/src/apiClient/v1/models/ChangeProEmailBody.ts
+++ b/pro/src/apiClient/v1/models/ChangeProEmailBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ChangeProEmailBody = {
   token: string;
 };

--- a/pro/src/apiClient/v1/models/CollectiveBookingBankAccountStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingBankAccountStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/CollectiveBookingBankInformationStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingBankInformationStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/CollectiveBookingByIdResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingByIdResponseModel.ts
@@ -2,14 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveBookingBankAccountStatus } from './CollectiveBookingBankAccountStatus';
 import type { CollectiveBookingBankInformationStatus } from './CollectiveBookingBankInformationStatus';
 import type { CollectiveBookingEducationalRedactorResponseModel } from './CollectiveBookingEducationalRedactorResponseModel';
 import type { CollectiveOfferOfferVenueResponseModel } from './CollectiveOfferOfferVenueResponseModel';
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
 import type { StudentLevels } from './StudentLevels';
-
 export type CollectiveBookingByIdResponseModel = {
   bankAccountStatus?: CollectiveBookingBankAccountStatus | null;
   bankInformationStatus?: CollectiveBookingBankInformationStatus | null;

--- a/pro/src/apiClient/v1/models/CollectiveBookingCancellationReasons.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingCancellationReasons.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/CollectiveBookingCollectiveStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingCollectiveStockResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveBookingCollectiveStockResponseModel = {
   bookingLimitDatetime?: string | null;
   eventBeginningDatetime: string;

--- a/pro/src/apiClient/v1/models/CollectiveBookingEducationalRedactorResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingEducationalRedactorResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveBookingEducationalRedactorResponseModel = {
   civility?: string | null;
   email: string;

--- a/pro/src/apiClient/v1/models/CollectiveBookingResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingResponseModel.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BookingStatusHistoryResponseModel } from './BookingStatusHistoryResponseModel';
 import type { CollectiveBookingCancellationReasons } from './CollectiveBookingCancellationReasons';
 import type { CollectiveBookingCollectiveStockResponseModel } from './CollectiveBookingCollectiveStockResponseModel';
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
-
 export type CollectiveBookingResponseModel = {
   bookingAmount: number;
   bookingCancellationLimitDate: string;

--- a/pro/src/apiClient/v1/models/CollectiveBookingStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/CollectiveBookingStatusFilter.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingStatusFilter.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/CollectiveOfferDisplayedStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferDisplayedStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/CollectiveOfferInstitutionModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferInstitutionModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOfferInstitutionModel = {
   city: string;
   institutionId: string;

--- a/pro/src/apiClient/v1/models/CollectiveOfferOfferVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferOfferVenueResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OfferAddressType } from './OfferAddressType';
-
 export type CollectiveOfferOfferVenueResponseModel = {
   addressType: OfferAddressType;
   otherAddress: string;

--- a/pro/src/apiClient/v1/models/CollectiveOfferRedactorModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferRedactorModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOfferRedactorModel = {
   email: string;
   firstName?: string | null;

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseIdModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseIdModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOfferResponseIdModel = {
   id: number;
 };

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOffersBookingResponseModel } from './CollectiveOffersBookingResponseModel';
 import type { CollectiveOffersStockResponseModel } from './CollectiveOffersStockResponseModel';
 import type { EacFormat } from './EacFormat';
@@ -10,7 +9,6 @@ import type { EducationalInstitutionResponseModel } from './EducationalInstituti
 import type { ListOffersVenueResponseModel } from './ListOffersVenueResponseModel';
 import type { NationalProgramModel } from './NationalProgramModel';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
-
 export type CollectiveOfferResponseModel = {
   booking?: CollectiveOffersBookingResponseModel | null;
   educationalInstitution?: EducationalInstitutionResponseModel | null;

--- a/pro/src/apiClient/v1/models/CollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferTemplateBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOfferTemplateBodyModel = {
   educationalPriceDetail?: string | null;
 };

--- a/pro/src/apiClient/v1/models/CollectiveOfferTemplateResponseIdModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferTemplateResponseIdModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOfferTemplateResponseIdModel = {
   id: number;
 };

--- a/pro/src/apiClient/v1/models/CollectiveOfferType.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/CollectiveOfferVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferVenueBodyModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OfferAddressType } from './OfferAddressType';
-
 export type CollectiveOfferVenueBodyModel = {
   addressType: OfferAddressType;
   otherAddress: string;

--- a/pro/src/apiClient/v1/models/CollectiveOffersBookingResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOffersBookingResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOffersBookingResponseModel = {
   booking_status: string;
   id: number;

--- a/pro/src/apiClient/v1/models/CollectiveOffersStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOffersStockResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOffersStockResponseModel = {
   beginningDatetime?: string | null;
   bookingLimitDatetime?: string | null;

--- a/pro/src/apiClient/v1/models/CollectiveStockCreationBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveStockCreationBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveStockCreationBodyModel = {
   beginningDatetime: string;
   bookingLimitDatetime?: string | null;

--- a/pro/src/apiClient/v1/models/CollectiveStockEditionBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveStockEditionBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveStockEditionBodyModel = {
   beginningDatetime?: string | null;
   bookingLimitDatetime?: string | null;

--- a/pro/src/apiClient/v1/models/CollectiveStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveStockResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveStockResponseModel = {
   beginningDatetime?: string | null;
   bookingLimitDatetime?: string | null;

--- a/pro/src/apiClient/v1/models/Consent.ts
+++ b/pro/src/apiClient/v1/models/Consent.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type Consent = {
   accepted: Array<string>;
   mandatory: Array<string>;

--- a/pro/src/apiClient/v1/models/CookieConsentRequest.ts
+++ b/pro/src/apiClient/v1/models/CookieConsentRequest.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { Consent } from './Consent';
-
 export type CookieConsentRequest = {
   choiceDatetime: string;
   consent: Consent;

--- a/pro/src/apiClient/v1/models/CreateOffererQueryModel.ts
+++ b/pro/src/apiClient/v1/models/CreateOffererQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CreateOffererQueryModel = {
   address?: string | null;
   city: string;

--- a/pro/src/apiClient/v1/models/CreatePriceCategoryModel.ts
+++ b/pro/src/apiClient/v1/models/CreatePriceCategoryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CreatePriceCategoryModel = {
   label: string;
   price: number;

--- a/pro/src/apiClient/v1/models/CreateThumbnailBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CreateThumbnailBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CreateThumbnailBodyModel = {
   credit?: string | null;
   croppingRectHeight?: number | null;

--- a/pro/src/apiClient/v1/models/CreateThumbnailResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CreateThumbnailResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CreateThumbnailResponseModel = {
   credit?: string | null;
   id: number;

--- a/pro/src/apiClient/v1/models/CropParams.ts
+++ b/pro/src/apiClient/v1/models/CropParams.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CropParams = {
   height_crop_percent?: number;
   width_crop_percent?: number;

--- a/pro/src/apiClient/v1/models/CulturalPartner.ts
+++ b/pro/src/apiClient/v1/models/CulturalPartner.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CulturalPartner = {
   communeLibelle?: string | null;
   id: number;

--- a/pro/src/apiClient/v1/models/DMSApplicationForEAC.ts
+++ b/pro/src/apiClient/v1/models/DMSApplicationForEAC.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { DMSApplicationstatus } from './DMSApplicationstatus';
-
 export type DMSApplicationForEAC = {
   application: number;
   buildDate?: string | null;

--- a/pro/src/apiClient/v1/models/DMSApplicationstatus.ts
+++ b/pro/src/apiClient/v1/models/DMSApplicationstatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/DateRangeModel.ts
+++ b/pro/src/apiClient/v1/models/DateRangeModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type DateRangeModel = {
   end: string;
   start: string;

--- a/pro/src/apiClient/v1/models/DateRangeOnCreateModel.ts
+++ b/pro/src/apiClient/v1/models/DateRangeOnCreateModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type DateRangeOnCreateModel = {
   end: string;
   start: string;

--- a/pro/src/apiClient/v1/models/DeleteFilteredStockListBody.ts
+++ b/pro/src/apiClient/v1/models/DeleteFilteredStockListBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type DeleteFilteredStockListBody = {
   date?: string | null;
   price_category_id?: number | null;

--- a/pro/src/apiClient/v1/models/DeleteOfferRequestBody.ts
+++ b/pro/src/apiClient/v1/models/DeleteOfferRequestBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type DeleteOfferRequestBody = {
   ids: Array<number>;
 };

--- a/pro/src/apiClient/v1/models/DeleteStockListBody.ts
+++ b/pro/src/apiClient/v1/models/DeleteStockListBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type DeleteStockListBody = {
   ids_to_delete: Array<number>;
 };

--- a/pro/src/apiClient/v1/models/EacFormat.ts
+++ b/pro/src/apiClient/v1/models/EacFormat.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/EditPriceCategoryModel.ts
+++ b/pro/src/apiClient/v1/models/EditPriceCategoryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EditPriceCategoryModel = {
   id: number;
   label?: string | null;

--- a/pro/src/apiClient/v1/models/EditVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/EditVenueBodyModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueContactModel } from './VenueContactModel';
 import type { VenueTypeCode } from './VenueTypeCode';
-
 export type EditVenueBodyModel = {
   address?: string | null;
   audioDisabilityCompliant?: boolean | null;

--- a/pro/src/apiClient/v1/models/EditVenueCollectiveDataBodyModel.ts
+++ b/pro/src/apiClient/v1/models/EditVenueCollectiveDataBodyModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { StudentLevels } from './StudentLevels';
-
 export type EditVenueCollectiveDataBodyModel = {
   collectiveAccessInformation?: string | null;
   collectiveDescription?: string | null;

--- a/pro/src/apiClient/v1/models/EducationalDomainResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalDomainResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalDomainResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/EducationalDomainsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalDomainsResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { EducationalDomainResponseModel } from './EducationalDomainResponseModel';
-
 export type EducationalDomainsResponseModel = Array<EducationalDomainResponseModel>;

--- a/pro/src/apiClient/v1/models/EducationalInstitutionResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalInstitutionResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalInstitutionResponseModel = {
   city: string;
   id: number;

--- a/pro/src/apiClient/v1/models/EducationalInstitutionsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalInstitutionsQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalInstitutionsQueryModel = {
   page?: number;
   perPageLimit?: number;

--- a/pro/src/apiClient/v1/models/EducationalInstitutionsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalInstitutionsResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
-
 export type EducationalInstitutionsResponseModel = {
   educationalInstitutions: Array<EducationalInstitutionResponseModel>;
   page: number;

--- a/pro/src/apiClient/v1/models/EducationalRedactor.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactor.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalRedactor = {
   email: string;
   gender: string;

--- a/pro/src/apiClient/v1/models/EducationalRedactorQueryModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactorQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalRedactorQueryModel = {
   candidate: string;
   uai: string;

--- a/pro/src/apiClient/v1/models/EducationalRedactorResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactorResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type EducationalRedactorResponseModel = {
   civility?: string | null;
   email?: string | null;

--- a/pro/src/apiClient/v1/models/EducationalRedactors.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactors.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { EducationalRedactor } from './EducationalRedactor';
-
 export type EducationalRedactors = Array<EducationalRedactor>;

--- a/pro/src/apiClient/v1/models/FeatureResponseModel.ts
+++ b/pro/src/apiClient/v1/models/FeatureResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type FeatureResponseModel = {
   description: string;
   id: string;

--- a/pro/src/apiClient/v1/models/FinanceReimbursementPointListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/FinanceReimbursementPointListResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { FinanceReimbursementPointResponseModel } from './FinanceReimbursementPointResponseModel';
-
 export type FinanceReimbursementPointListResponseModel = Array<FinanceReimbursementPointResponseModel>;

--- a/pro/src/apiClient/v1/models/FinanceReimbursementPointResponseModel.ts
+++ b/pro/src/apiClient/v1/models/FinanceReimbursementPointResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type FinanceReimbursementPointResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/GenderEnum.ts
+++ b/pro/src/apiClient/v1/models/GenderEnum.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/GenerateOffererApiKeyResponse.ts
+++ b/pro/src/apiClient/v1/models/GenerateOffererApiKeyResponse.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GenerateOffererApiKeyResponse = {
   apiKey: string;
 };

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferCollectiveStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferCollectiveStockResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetCollectiveOfferCollectiveStockResponseModel = {
   beginningDatetime?: string | null;
   bookingLimitDatetime?: string | null;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferManagingOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferManagingOffererResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetCollectiveOfferManagingOffererResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferRequestResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferRequestResponseModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferInstitutionModel } from './CollectiveOfferInstitutionModel';
 import type { CollectiveOfferRedactorModel } from './CollectiveOfferRedactorModel';
-
 export type GetCollectiveOfferRequestResponseModel = {
   comment: string;
   dateCreated?: string | null;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveBookingStatus } from './CollectiveBookingStatus';
 import type { CollectiveOfferOfferVenueResponseModel } from './CollectiveOfferOfferVenueResponseModel';
 import type { EacFormat } from './EacFormat';
@@ -15,7 +14,6 @@ import type { OfferDomain } from './OfferDomain';
 import type { OfferStatus } from './OfferStatus';
 import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
-
 export type GetCollectiveOfferResponseModel = {
   audioDisabilityCompliant?: boolean | null;
   bookingEmails: Array<string>;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferOfferVenueResponseModel } from './CollectiveOfferOfferVenueResponseModel';
 import type { EacFormat } from './EacFormat';
 import type { GetCollectiveOfferVenueResponseModel } from './GetCollectiveOfferVenueResponseModel';
@@ -12,7 +11,6 @@ import type { OfferStatus } from './OfferStatus';
 import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 import type { TemplateDatesModel } from './TemplateDatesModel';
-
 export type GetCollectiveOfferTemplateResponseModel = {
   audioDisabilityCompliant?: boolean | null;
   bookingEmails: Array<string>;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferVenueResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetCollectiveOfferManagingOffererResponseModel } from './GetCollectiveOfferManagingOffererResponseModel';
-
 export type GetCollectiveOfferVenueResponseModel = {
   departementCode?: string | null;
   id: number;

--- a/pro/src/apiClient/v1/models/GetCollectiveVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveVenueResponseModel.ts
@@ -2,11 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetVenueDomainResponseModel } from './GetVenueDomainResponseModel';
 import type { LegalStatusResponseModel } from './LegalStatusResponseModel';
 import type { StudentLevels } from './StudentLevels';
-
 export type GetCollectiveVenueResponseModel = {
   collectiveAccessInformation?: string | null;
   collectiveDescription?: string | null;

--- a/pro/src/apiClient/v1/models/GetEducationalOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetEducationalOffererResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetEducationalOffererVenueResponseModel } from './GetEducationalOffererVenueResponseModel';
-
 export type GetEducationalOffererResponseModel = {
   id: number;
   managedVenues: Array<GetEducationalOffererVenueResponseModel>;

--- a/pro/src/apiClient/v1/models/GetEducationalOffererVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetEducationalOffererVenueResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetEducationalOffererVenueResponseModel = {
   address?: string | null;
   audioDisabilityCompliant?: boolean | null;

--- a/pro/src/apiClient/v1/models/GetEducationalOfferersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/GetEducationalOfferersQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetEducationalOfferersQueryModel = {
   offerer_id?: number | null;
 };

--- a/pro/src/apiClient/v1/models/GetEducationalOfferersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetEducationalOfferersResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetEducationalOffererResponseModel } from './GetEducationalOffererResponseModel';
-
 export type GetEducationalOfferersResponseModel = {
   educationalOfferers: Array<GetEducationalOffererResponseModel>;
 };

--- a/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetOfferLastProviderResponseModel } from './GetOfferLastProviderResponseModel';
 import type { GetOfferMediationResponseModel } from './GetOfferMediationResponseModel';
 import type { GetOfferVenueResponseModel } from './GetOfferVenueResponseModel';
@@ -10,7 +9,6 @@ import type { OfferStatus } from './OfferStatus';
 import type { PriceCategoryResponseModel } from './PriceCategoryResponseModel';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 import type { WithdrawalTypeEnum } from './WithdrawalTypeEnum';
-
 export type GetIndividualOfferResponseModel = {
   activeMediation?: GetOfferMediationResponseModel | null;
   audioDisabilityCompliant?: boolean | null;

--- a/pro/src/apiClient/v1/models/GetOfferLastProviderResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferLastProviderResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetOfferLastProviderResponseModel = {
   name: string;
 };

--- a/pro/src/apiClient/v1/models/GetOfferManagingOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferManagingOffererResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetOfferManagingOffererResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/GetOfferMediationResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferMediationResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetOfferMediationResponseModel = {
   authorId?: string | null;
   credit?: string | null;

--- a/pro/src/apiClient/v1/models/GetOfferStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferStockResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetOfferStockResponseModel = {
   activationCodesExpirationDatetime?: string | null;
   beginningDatetime?: string | null;

--- a/pro/src/apiClient/v1/models/GetOfferVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferVenueResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetOfferManagingOffererResponseModel } from './GetOfferManagingOffererResponseModel';
-
 export type GetOfferVenueResponseModel = {
   address?: string | null;
   audioDisabilityCompliant?: boolean | null;

--- a/pro/src/apiClient/v1/models/GetOffererBankAccountsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererBankAccountsResponseModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BankAccountResponseModel } from './BankAccountResponseModel';
 import type { ManagedVenues } from './ManagedVenues';
-
 export type GetOffererBankAccountsResponseModel = {
   bankAccounts: Array<BankAccountResponseModel>;
   id: number;

--- a/pro/src/apiClient/v1/models/GetOffererMemberResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererMemberResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OffererMemberStatus } from './OffererMemberStatus';
-
 export type GetOffererMemberResponseModel = {
   email: string;
   status: OffererMemberStatus;

--- a/pro/src/apiClient/v1/models/GetOffererMembersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererMembersResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetOffererMemberResponseModel } from './GetOffererMemberResponseModel';
-
 export type GetOffererMembersResponseModel = {
   members: Array<GetOffererMemberResponseModel>;
 };

--- a/pro/src/apiClient/v1/models/GetOffererNameResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererNameResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetOffererNameResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/GetOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererResponseModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetOffererVenueResponseModel } from './GetOffererVenueResponseModel';
 import type { OffererApiKey } from './OffererApiKey';
-
 export type GetOffererResponseModel = {
   address?: string | null;
   apiKey: OffererApiKey;

--- a/pro/src/apiClient/v1/models/GetOffererStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererStatsResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OffererStatsDataModel } from './OffererStatsDataModel';
-
 export type GetOffererStatsResponseModel = {
   jsonData: OffererStatsDataModel;
   offererId: number;

--- a/pro/src/apiClient/v1/models/GetOffererV2StatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererV2StatsResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetOffererV2StatsResponseModel = {
   pendingEducationalOffers: number;
   pendingPublicOffers: number;

--- a/pro/src/apiClient/v1/models/GetOffererVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererVenueResponseModel.ts
@@ -2,11 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BannerMetaModel } from './BannerMetaModel';
 import type { DMSApplicationForEAC } from './DMSApplicationForEAC';
 import type { VenueTypeCode } from './VenueTypeCode';
-
 export type GetOffererVenueResponseModel = {
   adageInscriptionDate?: string | null;
   address?: string | null;

--- a/pro/src/apiClient/v1/models/GetOfferersNamesQueryModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferersNamesQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetOfferersNamesQueryModel = {
   offerer_id?: number | null;
   validated?: boolean | null;

--- a/pro/src/apiClient/v1/models/GetOfferersNamesResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferersNamesResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetOffererNameResponseModel } from './GetOffererNameResponseModel';
-
 export type GetOfferersNamesResponseModel = {
   offerersNames: Array<GetOffererNameResponseModel>;
 };

--- a/pro/src/apiClient/v1/models/GetStocksResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetStocksResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetOfferStockResponseModel } from './GetOfferStockResponseModel';
-
 export type GetStocksResponseModel = {
   hasStocks: boolean;
   stockCount: number;

--- a/pro/src/apiClient/v1/models/GetVenueDomainResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueDomainResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetVenueDomainResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/GetVenueListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueListResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueListItemResponseModel } from './VenueListItemResponseModel';
-
 export type GetVenueListResponseModel = {
   venues: Array<VenueListItemResponseModel>;
 };

--- a/pro/src/apiClient/v1/models/GetVenueManagingOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueManagingOffererResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetVenueManagingOffererResponseModel = {
   address?: string | null;
   city: string;

--- a/pro/src/apiClient/v1/models/GetVenuePricingPointResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenuePricingPointResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetVenuePricingPointResponseModel = {
   id: number;
   siret: string;

--- a/pro/src/apiClient/v1/models/GetVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BannerMetaModel } from './BannerMetaModel';
 import type { DMSApplicationForEAC } from './DMSApplicationForEAC';
 import type { GetVenueDomainResponseModel } from './GetVenueDomainResponseModel';
@@ -12,7 +11,6 @@ import type { LegalStatusResponseModel } from './LegalStatusResponseModel';
 import type { StudentLevels } from './StudentLevels';
 import type { VenueContactModel } from './VenueContactModel';
 import type { VenueTypeCode } from './VenueTypeCode';
-
 export type GetVenueResponseModel = {
   adageInscriptionDate?: string | null;
   address?: string | null;

--- a/pro/src/apiClient/v1/models/GetVenuesOfOffererFromSiretResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenuesOfOffererFromSiretResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueOfOffererFromSiretResponseModel } from './VenueOfOffererFromSiretResponseModel';
-
 export type GetVenuesOfOffererFromSiretResponseModel = {
   offererName?: string | null;
   offererSiren?: string | null;

--- a/pro/src/apiClient/v1/models/InviteMemberQueryModel.ts
+++ b/pro/src/apiClient/v1/models/InviteMemberQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type InviteMemberQueryModel = {
   email: string;
 };

--- a/pro/src/apiClient/v1/models/InvoiceListQueryModel.ts
+++ b/pro/src/apiClient/v1/models/InvoiceListQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type InvoiceListQueryModel = {
   periodBeginningDate?: string | null;
   periodEndingDate?: string | null;

--- a/pro/src/apiClient/v1/models/InvoiceListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/InvoiceListResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { InvoiceResponseModel } from './InvoiceResponseModel';
-
 export type InvoiceListResponseModel = Array<InvoiceResponseModel>;

--- a/pro/src/apiClient/v1/models/InvoiceResponseModel.ts
+++ b/pro/src/apiClient/v1/models/InvoiceResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type InvoiceResponseModel = {
   amount: number;
   cashflowLabels: Array<string>;

--- a/pro/src/apiClient/v1/models/LegalStatusResponseModel.ts
+++ b/pro/src/apiClient/v1/models/LegalStatusResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type LegalStatusResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/LinkVenueToBankAccountBodyModel.ts
+++ b/pro/src/apiClient/v1/models/LinkVenueToBankAccountBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type LinkVenueToBankAccountBodyModel = {
   venues_ids: Array<number>;
 };

--- a/pro/src/apiClient/v1/models/LinkVenueToPricingPointBodyModel.ts
+++ b/pro/src/apiClient/v1/models/LinkVenueToPricingPointBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type LinkVenueToPricingPointBodyModel = {
   pricingPointId: number;
 };

--- a/pro/src/apiClient/v1/models/LinkedVenues.ts
+++ b/pro/src/apiClient/v1/models/LinkedVenues.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * A venue that is already linked to a bank account.
  */

--- a/pro/src/apiClient/v1/models/ListBookingsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListBookingsQueryModel.ts
@@ -2,11 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BookingExportType } from './BookingExportType';
 import type { BookingStatusFilter } from './BookingStatusFilter';
 import type { OfferType } from './OfferType';
-
 export type ListBookingsQueryModel = {
   bookingPeriodBeginningDate?: string | null;
   bookingPeriodEndingDate?: string | null;

--- a/pro/src/apiClient/v1/models/ListBookingsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListBookingsResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BookingRecapResponseModel } from './BookingRecapResponseModel';
-
 export type ListBookingsResponseModel = {
   bookingsRecap: Array<BookingRecapResponseModel>;
   page: number;

--- a/pro/src/apiClient/v1/models/ListCollectiveBookingsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveBookingsQueryModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveBookingStatusFilter } from './CollectiveBookingStatusFilter';
-
 export type ListCollectiveBookingsQueryModel = {
   bookingPeriodBeginningDate?: string | null;
   bookingPeriodEndingDate?: string | null;

--- a/pro/src/apiClient/v1/models/ListCollectiveBookingsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveBookingsResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveBookingResponseModel } from './CollectiveBookingResponseModel';
-
 export type ListCollectiveBookingsResponseModel = {
   bookingsRecap: Array<CollectiveBookingResponseModel>;
   page: number;

--- a/pro/src/apiClient/v1/models/ListCollectiveOffersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveOffersQueryModel.ts
@@ -2,11 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferDisplayedStatus } from './CollectiveOfferDisplayedStatus';
 import type { CollectiveOfferType } from './CollectiveOfferType';
 import type { EacFormat } from './EacFormat';
-
 export type ListCollectiveOffersQueryModel = {
   categoryId?: string | null;
   collectiveOfferType?: CollectiveOfferType | null;

--- a/pro/src/apiClient/v1/models/ListCollectiveOffersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveOffersResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferResponseModel } from './CollectiveOfferResponseModel';
-
 export type ListCollectiveOffersResponseModel = Array<CollectiveOfferResponseModel>;

--- a/pro/src/apiClient/v1/models/ListFeatureResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListFeatureResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { FeatureResponseModel } from './FeatureResponseModel';
-
 export type ListFeatureResponseModel = Array<FeatureResponseModel>;

--- a/pro/src/apiClient/v1/models/ListNationalProgramsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListNationalProgramsResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { NationalProgramModel } from './NationalProgramModel';
-
 export type ListNationalProgramsResponseModel = Array<NationalProgramModel>;

--- a/pro/src/apiClient/v1/models/ListOffersOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersOfferResponseModel.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ListOffersStockResponseModel } from './ListOffersStockResponseModel';
 import type { ListOffersVenueResponseModel } from './ListOffersVenueResponseModel';
 import type { OfferStatus } from './OfferStatus';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
-
 export type ListOffersOfferResponseModel = {
   hasBookingLimitDatetimesPassed: boolean;
   id: number;

--- a/pro/src/apiClient/v1/models/ListOffersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersQueryModel.ts
@@ -2,11 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferDisplayedStatus } from './CollectiveOfferDisplayedStatus';
 import type { CollectiveOfferType } from './CollectiveOfferType';
 import type { OfferStatus } from './OfferStatus';
-
 export type ListOffersQueryModel = {
   categoryId?: string | null;
   collectiveOfferType?: CollectiveOfferType | null;

--- a/pro/src/apiClient/v1/models/ListOffersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ListOffersOfferResponseModel } from './ListOffersOfferResponseModel';
-
 export type ListOffersResponseModel = Array<ListOffersOfferResponseModel>;

--- a/pro/src/apiClient/v1/models/ListOffersStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersStockResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ListOffersStockResponseModel = {
   beginningDatetime?: string | null;
   bookingQuantity?: number | null;

--- a/pro/src/apiClient/v1/models/ListOffersVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersVenueResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ListOffersVenueResponseModel = {
   departementCode?: string | null;
   id: number;

--- a/pro/src/apiClient/v1/models/ListProviderResponse.ts
+++ b/pro/src/apiClient/v1/models/ListProviderResponse.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProviderResponse } from './ProviderResponse';
-
 export type ListProviderResponse = Array<ProviderResponse>;

--- a/pro/src/apiClient/v1/models/ListVenueProviderQuery.ts
+++ b/pro/src/apiClient/v1/models/ListVenueProviderQuery.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ListVenueProviderQuery = {
   venueId: number;
 };

--- a/pro/src/apiClient/v1/models/ListVenueProviderResponse.ts
+++ b/pro/src/apiClient/v1/models/ListVenueProviderResponse.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueProviderResponse } from './VenueProviderResponse';
-
 export type ListVenueProviderResponse = {
   venue_providers: Array<VenueProviderResponse>;
 };

--- a/pro/src/apiClient/v1/models/LoginUserBodyModel.ts
+++ b/pro/src/apiClient/v1/models/LoginUserBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type LoginUserBodyModel = {
   captchaToken?: string | null;
   identifier: string;

--- a/pro/src/apiClient/v1/models/ManagedVenues.ts
+++ b/pro/src/apiClient/v1/models/ManagedVenues.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ManagedVenues = {
   bankAccountId?: number | null;
   commonName: string;

--- a/pro/src/apiClient/v1/models/NationalProgramModel.ts
+++ b/pro/src/apiClient/v1/models/NationalProgramModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type NationalProgramModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/NewPasswordBodyModel.ts
+++ b/pro/src/apiClient/v1/models/NewPasswordBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type NewPasswordBodyModel = {
   newPassword: string;
   token: string;

--- a/pro/src/apiClient/v1/models/OfferAddressType.ts
+++ b/pro/src/apiClient/v1/models/OfferAddressType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/OfferDomain.ts
+++ b/pro/src/apiClient/v1/models/OfferDomain.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OfferDomain = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/OfferImage.ts
+++ b/pro/src/apiClient/v1/models/OfferImage.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OfferImage = {
   credit?: string;
   url: string;

--- a/pro/src/apiClient/v1/models/OfferStatus.ts
+++ b/pro/src/apiClient/v1/models/OfferStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/OfferType.ts
+++ b/pro/src/apiClient/v1/models/OfferType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/OffererApiKey.ts
+++ b/pro/src/apiClient/v1/models/OffererApiKey.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OffererApiKey = {
   maxAllowed: number;
   prefixes: Array<string>;

--- a/pro/src/apiClient/v1/models/OffererMemberStatus.ts
+++ b/pro/src/apiClient/v1/models/OffererMemberStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/OffererReimbursementPointListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/OffererReimbursementPointListResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OffererReimbursementPointResponseModel } from './OffererReimbursementPointResponseModel';
-
 export type OffererReimbursementPointListResponseModel = Array<OffererReimbursementPointResponseModel>;

--- a/pro/src/apiClient/v1/models/OffererReimbursementPointResponseModel.ts
+++ b/pro/src/apiClient/v1/models/OffererReimbursementPointResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OffererReimbursementPointResponseModel = {
   iban: string;
   venueId: number;

--- a/pro/src/apiClient/v1/models/OffererStatsDataModel.ts
+++ b/pro/src/apiClient/v1/models/OffererStatsDataModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OffererViewsModel } from './OffererViewsModel';
 import type { TopOffersResponseData } from './TopOffersResponseData';
-
 export type OffererStatsDataModel = {
   dailyViews: Array<OffererViewsModel>;
   topOffers: Array<TopOffersResponseData>;

--- a/pro/src/apiClient/v1/models/OffererStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/OffererStatsResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OffererStatsResponseModel = {
   dashboardUrl: string;
 };

--- a/pro/src/apiClient/v1/models/OffererViewsModel.ts
+++ b/pro/src/apiClient/v1/models/OffererViewsModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OffererViewsModel = {
   eventDate: string;
   numberOfViews: number;

--- a/pro/src/apiClient/v1/models/PatchAllCollectiveOffersActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchAllCollectiveOffersActiveStatusBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PatchAllCollectiveOffersActiveStatusBodyModel = {
   categoryId?: string | null;
   creationMode?: string | null;

--- a/pro/src/apiClient/v1/models/PatchAllOffersActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchAllOffersActiveStatusBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PatchAllOffersActiveStatusBodyModel = {
   categoryId?: string | null;
   creationMode?: string | null;

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferActiveStatusBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PatchCollectiveOfferActiveStatusBodyModel = {
   ids: Array<number>;
   isActive: boolean;

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferBodyModel.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
 import type { EacFormat } from './EacFormat';
 import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
-
 export type PatchCollectiveOfferBodyModel = {
   audioDisabilityCompliant?: boolean | null;
   bookingEmails?: Array<string> | null;

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferEducationalInstitution.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferEducationalInstitution.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PatchCollectiveOfferEducationalInstitution = {
   educationalInstitutionId?: number | null;
   teacherEmail?: string | null;

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
@@ -2,13 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
 import type { DateRangeModel } from './DateRangeModel';
 import type { EacFormat } from './EacFormat';
 import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
-
 export type PatchCollectiveOfferTemplateBodyModel = {
   audioDisabilityCompliant?: boolean | null;
   bookingEmails?: Array<string> | null;

--- a/pro/src/apiClient/v1/models/PatchOfferActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferActiveStatusBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PatchOfferActiveStatusBodyModel = {
   ids: Array<number>;
   isActive: boolean;

--- a/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { WithdrawalTypeEnum } from './WithdrawalTypeEnum';
-
 export type PatchOfferBodyModel = {
   audioDisabilityCompliant?: boolean | null;
   bookingContact?: string | null;

--- a/pro/src/apiClient/v1/models/PatchOfferPublishBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferPublishBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PatchOfferPublishBodyModel = {
   id: number;
 };

--- a/pro/src/apiClient/v1/models/PhoneValidationStatusType.ts
+++ b/pro/src/apiClient/v1/models/PhoneValidationStatusType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
@@ -2,11 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
 import type { EacFormat } from './EacFormat';
 import type { StudentLevels } from './StudentLevels';
-
 export type PostCollectiveOfferBodyModel = {
   audioDisabilityCompliant?: boolean;
   bookingEmails: Array<string>;

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
 import type { DateRangeOnCreateModel } from './DateRangeOnCreateModel';
 import type { EacFormat } from './EacFormat';
 import type { StudentLevels } from './StudentLevels';
-
 export type PostCollectiveOfferTemplateBodyModel = {
   audioDisabilityCompliant?: boolean;
   bookingEmails: Array<string>;

--- a/pro/src/apiClient/v1/models/PostOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostOfferBodyModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { WithdrawalTypeEnum } from './WithdrawalTypeEnum';
-
 export type PostOfferBodyModel = {
   audioDisabilityCompliant: boolean;
   bookingContact?: string | null;

--- a/pro/src/apiClient/v1/models/PostOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/PostOffererResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PostOffererResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueContactModel } from './VenueContactModel';
-
 export type PostVenueBodyModel = {
   address: string;
   audioDisabilityCompliant?: boolean | null;

--- a/pro/src/apiClient/v1/models/PostVenueProviderBody.ts
+++ b/pro/src/apiClient/v1/models/PostVenueProviderBody.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PostVenueProviderBody = {
   isActive?: boolean;
   isDuo?: boolean;

--- a/pro/src/apiClient/v1/models/PriceCategoryBody.ts
+++ b/pro/src/apiClient/v1/models/PriceCategoryBody.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CreatePriceCategoryModel } from './CreatePriceCategoryModel';
 import type { EditPriceCategoryModel } from './EditPriceCategoryModel';
-
 export type PriceCategoryBody = {
   priceCategories: Array<(CreatePriceCategoryModel | EditPriceCategoryModel)>;
 };

--- a/pro/src/apiClient/v1/models/PriceCategoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/PriceCategoryResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type PriceCategoryResponseModel = {
   id: number;
   label: string;

--- a/pro/src/apiClient/v1/models/ProFlagsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ProFlagsQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ProFlagsQueryModel = {
   firebase: Record<string, any>;
 };

--- a/pro/src/apiClient/v1/models/ProUserCreationBodyV2Model.ts
+++ b/pro/src/apiClient/v1/models/ProUserCreationBodyV2Model.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ProUserCreationBodyV2Model = {
   contactOk: boolean;
   email: string;

--- a/pro/src/apiClient/v1/models/ProviderResponse.ts
+++ b/pro/src/apiClient/v1/models/ProviderResponse.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ProviderResponse = {
   hasOffererProvider: boolean;
   id: number;

--- a/pro/src/apiClient/v1/models/ReimbursementCsvQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ReimbursementCsvQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ReimbursementCsvQueryModel = {
   reimbursementPeriodBeginningDate?: string;
   reimbursementPeriodEndingDate?: string;

--- a/pro/src/apiClient/v1/models/ResetPasswordBodyModel.ts
+++ b/pro/src/apiClient/v1/models/ResetPasswordBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ResetPasswordBodyModel = {
   email: string;
   token: string;

--- a/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
+++ b/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { Target } from './Target';
-
 export type SaveNewOnboardingDataQueryModel = {
   address?: string | null;
   banId?: string | null;

--- a/pro/src/apiClient/v1/models/SharedCurrentUserResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SharedCurrentUserResponseModel.ts
@@ -2,11 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GenderEnum } from './GenderEnum';
 import type { PhoneValidationStatusType } from './PhoneValidationStatusType';
 import type { UserRole } from './UserRole';
-
 export type SharedCurrentUserResponseModel = {
   activity?: string | null;
   address?: string | null;

--- a/pro/src/apiClient/v1/models/SharedLoginUserResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SharedLoginUserResponseModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GenderEnum } from './GenderEnum';
 import type { UserRole } from './UserRole';
-
 export type SharedLoginUserResponseModel = {
   activity?: string | null;
   address?: string | null;

--- a/pro/src/apiClient/v1/models/SirenInfo.ts
+++ b/pro/src/apiClient/v1/models/SirenInfo.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { Address } from './Address';
-
 export type SirenInfo = {
   address: Address;
   ape_code: string;

--- a/pro/src/apiClient/v1/models/SiretInfo.ts
+++ b/pro/src/apiClient/v1/models/SiretInfo.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { Address } from './Address';
-
 export type SiretInfo = {
   active: boolean;
   address: Address;

--- a/pro/src/apiClient/v1/models/StockCreationBodyModel.ts
+++ b/pro/src/apiClient/v1/models/StockCreationBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type StockCreationBodyModel = {
   activationCodes?: Array<string> | null;
   activationCodesExpirationDatetime?: string | null;

--- a/pro/src/apiClient/v1/models/StockEditionBodyModel.ts
+++ b/pro/src/apiClient/v1/models/StockEditionBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type StockEditionBodyModel = {
   beginningDatetime?: string | null;
   bookingLimitDatetime?: string | null;

--- a/pro/src/apiClient/v1/models/StockIdResponseModel.ts
+++ b/pro/src/apiClient/v1/models/StockIdResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type StockIdResponseModel = {
   id: number;
 };

--- a/pro/src/apiClient/v1/models/StockStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/StockStatsResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type StockStatsResponseModel = {
   newestStock?: string | null;
   oldestStock?: string | null;

--- a/pro/src/apiClient/v1/models/StocksOrderedBy.ts
+++ b/pro/src/apiClient/v1/models/StocksOrderedBy.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/StocksQueryModel.ts
+++ b/pro/src/apiClient/v1/models/StocksQueryModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { StocksOrderedBy } from './StocksOrderedBy';
-
 export type StocksQueryModel = {
   date?: string | null;
   order_by?: StocksOrderedBy;

--- a/pro/src/apiClient/v1/models/StocksResponseModel.ts
+++ b/pro/src/apiClient/v1/models/StocksResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type StocksResponseModel = {
   stocks_count: number;
 };

--- a/pro/src/apiClient/v1/models/StocksUpsertBodyModel.ts
+++ b/pro/src/apiClient/v1/models/StocksUpsertBodyModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { StockCreationBodyModel } from './StockCreationBodyModel';
 import type { StockEditionBodyModel } from './StockEditionBodyModel';
-
 export type StocksUpsertBodyModel = {
   offerId: number;
   stocks: Array<(StockCreationBodyModel | StockEditionBodyModel)>;

--- a/pro/src/apiClient/v1/models/StudentLevels.ts
+++ b/pro/src/apiClient/v1/models/StudentLevels.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/SubcategoryIdEnum.ts
+++ b/pro/src/apiClient/v1/models/SubcategoryIdEnum.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/SubcategoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SubcategoryResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type SubcategoryResponseModel = {
   appLabel: string;
   canBeDuo: boolean;

--- a/pro/src/apiClient/v1/models/Target.ts
+++ b/pro/src/apiClient/v1/models/Target.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/TemplateDatesModel.ts
+++ b/pro/src/apiClient/v1/models/TemplateDatesModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type TemplateDatesModel = {
   end: string;
   start: string;

--- a/pro/src/apiClient/v1/models/TopOffersResponseData.ts
+++ b/pro/src/apiClient/v1/models/TopOffersResponseData.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OfferImage } from './OfferImage';
-
 export type TopOffersResponseData = {
   image?: OfferImage;
   numberOfViews: number;

--- a/pro/src/apiClient/v1/models/UserEmailValidationResponseModel.ts
+++ b/pro/src/apiClient/v1/models/UserEmailValidationResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type UserEmailValidationResponseModel = {
   newEmail?: string | null;
 };

--- a/pro/src/apiClient/v1/models/UserHasBookingResponse.ts
+++ b/pro/src/apiClient/v1/models/UserHasBookingResponse.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type UserHasBookingResponse = {
   hasBookings: boolean;
 };

--- a/pro/src/apiClient/v1/models/UserIdentityBodyModel.ts
+++ b/pro/src/apiClient/v1/models/UserIdentityBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type UserIdentityBodyModel = {
   firstName: string;
   lastName: string;

--- a/pro/src/apiClient/v1/models/UserIdentityResponseModel.ts
+++ b/pro/src/apiClient/v1/models/UserIdentityResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type UserIdentityResponseModel = {
   firstName: string;
   lastName: string;

--- a/pro/src/apiClient/v1/models/UserPhoneBodyModel.ts
+++ b/pro/src/apiClient/v1/models/UserPhoneBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type UserPhoneBodyModel = {
   phoneNumber: string;
 };

--- a/pro/src/apiClient/v1/models/UserPhoneResponseModel.ts
+++ b/pro/src/apiClient/v1/models/UserPhoneResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type UserPhoneResponseModel = {
   phoneNumber: string;
 };

--- a/pro/src/apiClient/v1/models/UserResetEmailBodyModel.ts
+++ b/pro/src/apiClient/v1/models/UserResetEmailBodyModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type UserResetEmailBodyModel = {
   email: string;
   password: string;

--- a/pro/src/apiClient/v1/models/UserRole.ts
+++ b/pro/src/apiClient/v1/models/UserRole.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/ValidationError.ts
+++ b/pro/src/apiClient/v1/models/ValidationError.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ValidationErrorElement } from './ValidationErrorElement';
-
 /**
  * Model of a validation error response.
  */

--- a/pro/src/apiClient/v1/models/ValidationErrorElement.ts
+++ b/pro/src/apiClient/v1/models/ValidationErrorElement.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * Model of a validation error response element.
  */

--- a/pro/src/apiClient/v1/models/VenueContactModel.ts
+++ b/pro/src/apiClient/v1/models/VenueContactModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueContactModel = {
   email?: string | null;
   phoneNumber?: string | null;

--- a/pro/src/apiClient/v1/models/VenueLabelListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueLabelListResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueLabelResponseModel } from './VenueLabelResponseModel';
-
 export type VenueLabelListResponseModel = Array<VenueLabelResponseModel>;

--- a/pro/src/apiClient/v1/models/VenueLabelResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueLabelResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueLabelResponseModel = {
   id: number;
   label: string;

--- a/pro/src/apiClient/v1/models/VenueListItemResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueListItemResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueTypeCode } from './VenueTypeCode';
-
 export type VenueListItemResponseModel = {
   audioDisabilityCompliant?: boolean | null;
   bookingEmail?: string | null;

--- a/pro/src/apiClient/v1/models/VenueListQueryModel.ts
+++ b/pro/src/apiClient/v1/models/VenueListQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueListQueryModel = {
   activeOfferersOnly?: boolean | null;
   offererId?: number | null;

--- a/pro/src/apiClient/v1/models/VenueOfOffererFromSiretResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueOfOffererFromSiretResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueOfOffererFromSiretResponseModel = {
   id: number;
   isPermanent: boolean;

--- a/pro/src/apiClient/v1/models/VenueProviderResponse.ts
+++ b/pro/src/apiClient/v1/models/VenueProviderResponse.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProviderResponse } from './ProviderResponse';
-
 export type VenueProviderResponse = {
   id: number;
   isActive: boolean;

--- a/pro/src/apiClient/v1/models/VenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueResponseModel = {
   id: number;
 };

--- a/pro/src/apiClient/v1/models/VenueStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueStatsResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueStatsResponseModel = {
   activeBookingsQuantity: number;
   activeOffersCount: number;

--- a/pro/src/apiClient/v1/models/VenueTypeCode.ts
+++ b/pro/src/apiClient/v1/models/VenueTypeCode.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/models/VenueTypeListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueTypeListResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueTypeResponseModel } from './VenueTypeResponseModel';
-
 export type VenueTypeListResponseModel = Array<VenueTypeResponseModel>;

--- a/pro/src/apiClient/v1/models/VenueTypeResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueTypeResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueTypeResponseModel = {
   id: string;
   label: string;

--- a/pro/src/apiClient/v1/models/VenuesEducationalStatusResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenuesEducationalStatusResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenuesEducationalStatusResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v1/models/VenuesEducationalStatusesResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenuesEducationalStatusesResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenuesEducationalStatusResponseModel } from './VenuesEducationalStatusResponseModel';
-
 export type VenuesEducationalStatusesResponseModel = {
   statuses: Array<VenuesEducationalStatusResponseModel>;
 };

--- a/pro/src/apiClient/v1/models/WithdrawalTypeEnum.ts
+++ b/pro/src/apiClient/v1/models/WithdrawalTypeEnum.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -111,14 +111,10 @@ import type { VenueResponseModel } from '../models/VenueResponseModel';
 import type { VenuesEducationalStatusesResponseModel } from '../models/VenuesEducationalStatusesResponseModel';
 import type { VenueStatsResponseModel } from '../models/VenueStatsResponseModel';
 import type { VenueTypeListResponseModel } from '../models/VenueTypeListResponseModel';
-
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
-
 export class DefaultService {
-
   constructor(public readonly httpRequest: BaseHttpRequest) {}
-
   /**
    * get_bookings_pro <GET>
    * @param page
@@ -167,7 +163,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_user_has_bookings <GET>
    * @returns UserHasBookingResponse OK
@@ -183,7 +178,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_bookings_pro <GET>
    * @param page
@@ -223,7 +217,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_user_has_collective_bookings <GET>
    * @returns UserHasBookingResponse OK
@@ -239,7 +232,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_booking_by_id <GET>
    * @param bookingId
@@ -261,7 +253,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * list_educational_domains <GET>
    * @returns EducationalDomainsResponseModel OK
@@ -277,7 +268,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_offers <GET>
    * @param nameOrIsbn
@@ -326,7 +316,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * create_collective_offer <POST>
    * @param requestBody
@@ -347,7 +336,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * create_collective_offer_template <POST>
    * @param requestBody
@@ -368,7 +356,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_collective_offers_template_active_status <PATCH>
    * @param requestBody
@@ -389,7 +376,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_offer_request <GET>
    * @param requestId
@@ -411,7 +397,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_offer_template <GET>
    * @param offerId
@@ -433,7 +418,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * edit_collective_offer_template <PATCH>
    * @param offerId
@@ -459,7 +443,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * create_collective_offer_template_from_collective_offer <POST>
    * @param offerId
@@ -487,7 +470,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_offer_template_image <DELETE>
    * @param offerId
@@ -509,7 +491,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * attach_offer_template_image <POST>
    * @param offerId
@@ -535,7 +516,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_collective_offer_template_publication <PATCH>
    * @param offerId
@@ -558,7 +538,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_collective_offers_active_status <PATCH>
    * @param requestBody
@@ -579,7 +558,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_all_collective_offers_active_status <PATCH>
    * @param requestBody
@@ -600,7 +578,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_autocomplete_educational_redactors_for_uai <GET>
    * @param uai
@@ -625,7 +602,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_collective_offer <GET>
    * @param offerId
@@ -647,7 +623,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * edit_collective_offer <PATCH>
    * @param offerId
@@ -673,7 +648,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * cancel_collective_offer_booking <PATCH>
    * @param offerId
@@ -697,7 +671,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * duplicate_collective_offer <POST>
    * @param offerId
@@ -719,7 +692,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_collective_offers_educational_institution <PATCH>
    * @param offerId
@@ -746,7 +718,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_offer_image <DELETE>
    * @param offerId
@@ -768,7 +739,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * attach_offer_image <POST>
    * @param offerId
@@ -794,7 +764,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_collective_offer_publication <PATCH>
    * @param offerId
@@ -817,7 +786,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * create_collective_stock <POST>
    * @param requestBody
@@ -838,7 +806,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * edit_collective_stock <PATCH>
    * @param collectiveStockId
@@ -867,7 +834,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_educational_partner <GET>
    * @param siret
@@ -891,7 +857,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_educational_partners <GET>
    * @returns AdageCulturalPartnersResponseModel OK
@@ -908,7 +873,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_educational_institutions <GET>
    * @param perPageLimit
@@ -934,7 +898,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * list_features <GET>
    * @returns ListFeatureResponseModel OK
@@ -950,7 +913,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_invoices <GET>
    * @param periodBeginningDate
@@ -978,7 +940,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_reimbursement_points <GET>
    * @returns FinanceReimbursementPointListResponseModel OK
@@ -994,7 +955,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_national_programs <GET>
    * @returns ListNationalProgramsResponseModel OK
@@ -1010,7 +970,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * create_offerer <POST>
    * @param requestBody
@@ -1031,7 +990,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_api_key <DELETE>
    * @param apiKeyPrefix
@@ -1053,7 +1011,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * list_educational_offerers <GET>
    * @param offererId
@@ -1075,7 +1032,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * list_offerers_names <GET>
    * @param validated
@@ -1103,7 +1059,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * save_new_onboarding_data <POST>
    * @param requestBody
@@ -1124,7 +1079,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_offerer <GET>
    * @param offererId
@@ -1146,7 +1100,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * generate_api_key_route <POST>
    * @param offererId
@@ -1168,7 +1121,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_offerer_bank_accounts_and_attached_venues <GET>
    * @param offererId
@@ -1190,7 +1142,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * link_venue_to_bank_account <PATCH>
    * @param offererId
@@ -1219,7 +1170,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_offerer_stats_dashboard_url <GET>
    * @param offererId
@@ -1241,7 +1191,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * can_offerer_create_educational_offer <GET>
    * @param offererId
@@ -1263,7 +1212,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * invite_member <POST>
    * @param offererId
@@ -1289,7 +1237,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_offerer_members <GET>
    * @param offererId
@@ -1311,7 +1258,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_available_reimbursement_points <GET>
    * @param offererId
@@ -1333,7 +1279,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_offerer_stats <GET>
    * @param offererId
@@ -1355,7 +1300,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_offerer_v2_stats <GET>
    * @param offererId
@@ -1377,7 +1321,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * list_offers <GET>
    * @param nameOrIsbn
@@ -1423,7 +1366,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_offer <POST>
    * @param requestBody
@@ -1444,7 +1386,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_offers_active_status <PATCH>
    * @param requestBody
@@ -1465,7 +1406,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_all_offers_active_status <PATCH>
    * @param requestBody
@@ -1486,7 +1426,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_categories <GET>
    * @returns CategoriesResponseModel OK
@@ -1502,7 +1441,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_draft_offers <POST>
    * @param requestBody
@@ -1523,7 +1461,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_publish_offer <PATCH>
    * @param requestBody
@@ -1545,7 +1482,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * create_thumbnail <POST>
    * @param formData
@@ -1566,7 +1502,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_thumbnail <DELETE>
    * @param offerId
@@ -1588,7 +1523,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_offer <GET>
    * @param offerId
@@ -1610,7 +1544,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_offer <PATCH>
    * @param offerId
@@ -1636,7 +1569,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_price_categories <POST>
    * @param offerId
@@ -1662,7 +1594,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_price_category <DELETE>
    * @param offerId
@@ -1687,7 +1618,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_stocks_stats <GET>
    * @param offerId
@@ -1709,7 +1639,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_stocks <GET>
    * @param offerId
@@ -1754,7 +1683,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_all_filtered_stocks <POST>
    * @param offerId
@@ -1780,7 +1708,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_stocks <POST>
    * @param offerId
@@ -1806,7 +1733,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_reimbursements_csv <GET>
    * @param venueId
@@ -1834,7 +1760,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_siren_info <GET>
    * @param siren
@@ -1856,7 +1781,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_siret_info <GET>
    * @param siret
@@ -1878,7 +1802,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * upsert_stocks <POST>
    * @param requestBody
@@ -1899,7 +1822,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_stock <DELETE>
    * @param stockId
@@ -1921,7 +1843,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * cookies_consent <POST>
    * @param requestBody
@@ -1943,7 +1864,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_profile <GET>
    * @returns SharedCurrentUserResponseModel OK
@@ -1959,7 +1879,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_user_email <POST>
    * @param requestBody
@@ -1980,7 +1899,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_user_email_pending_validation <GET>
    * @returns UserEmailValidationResponseModel OK
@@ -1996,7 +1914,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_user_identity <PATCH>
    * @param requestBody
@@ -2017,7 +1934,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_new_password <POST>
    * @param requestBody
@@ -2039,7 +1955,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_change_password <POST>
    * @param requestBody
@@ -2061,7 +1976,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_user_phone <PATCH>
    * @param requestBody
@@ -2082,7 +1996,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_pro_flags <POST>
    * @param requestBody
@@ -2104,7 +2017,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * reset_password <POST>
    * @param requestBody
@@ -2125,7 +2037,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_pro_user_rgs_seen <PATCH>
    * @returns void
@@ -2141,7 +2052,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * signin <POST>
    * @param requestBody
@@ -2162,7 +2072,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * signout <GET>
    * @returns void
@@ -2178,7 +2087,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * check_activation_token_exists <GET>
    * @param token
@@ -2201,7 +2109,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_user_tuto_seen <PATCH>
    * @returns void
@@ -2217,7 +2124,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * patch_validate_email <PATCH>
    * @param requestBody
@@ -2238,7 +2144,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * signup_pro_V2 <POST>
    * @param requestBody
@@ -2259,7 +2164,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * validate_user <PATCH>
    * @param token
@@ -2281,7 +2185,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * fetch_venue_labels <GET>
    * @returns VenueLabelListResponseModel OK
@@ -2297,7 +2200,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venue_types <GET>
    * @returns VenueTypeListResponseModel OK
@@ -2313,7 +2215,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * list_venue_providers <GET>
    * @param venueId
@@ -2335,7 +2236,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * create_venue_provider <POST>
    * @param requestBody
@@ -2356,7 +2256,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * update_venue_provider <PUT>
    * @param requestBody
@@ -2377,7 +2276,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_venue_provider <DELETE>
    * @param venueProviderId
@@ -2399,7 +2297,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venues <GET>
    * @param validated
@@ -2427,7 +2324,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * post_create_venue <POST>
    * @param requestBody
@@ -2448,7 +2344,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venues_educational_statuses <GET>
    * @returns VenuesEducationalStatusesResponseModel OK
@@ -2464,7 +2359,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venues_of_offerer_from_siret <GET>
    * @param siret
@@ -2486,7 +2380,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venue <GET>
    * @param venueId
@@ -2508,7 +2401,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * edit_venue <PATCH>
    * @param venueId
@@ -2534,7 +2426,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * delete_venue_banner <DELETE>
    * @param venueId
@@ -2556,7 +2447,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venue_collective_data <GET>
    * @param venueId
@@ -2578,7 +2468,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * edit_venue_collective_data <PATCH>
    * @param venueId
@@ -2604,7 +2493,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venue_stats_dashboard_url <GET>
    * @param venueId
@@ -2626,7 +2514,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * link_venue_to_pricing_point <POST>
    * @param venueId
@@ -2652,7 +2539,6 @@ export class DefaultService {
       },
     });
   }
-
   /**
    * get_venue_stats <GET>
    * @param venueId
@@ -2674,5 +2560,4 @@ export class DefaultService {
       },
     });
   }
-
 }

--- a/pro/src/apiClient/v2/AppClientV2.ts
+++ b/pro/src/apiClient/v2/AppClientV2.ts
@@ -5,19 +5,13 @@
 import type { BaseHttpRequest } from './core/BaseHttpRequest';
 import type { OpenAPIConfig } from './core/OpenAPI';
 import { FetchHttpRequest } from './core/FetchHttpRequest';
-
 import { ApiOffresCollectivesService } from './services/ApiOffresCollectivesService';
 import { DPrCiEApiContremarqueService } from './services/DPrCiEApiContremarqueService';
-
 type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
-
 export class AppClientV2 {
-
   public readonly apiOffresCollectives: ApiOffresCollectivesService;
   public readonly dPrCiEApiContremarque: DPrCiEApiContremarqueService;
-
   public readonly request: BaseHttpRequest;
-
   constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = FetchHttpRequest) {
     this.request = new HttpRequest({
       BASE: config?.BASE ?? 'http://localhost:5001',
@@ -30,7 +24,6 @@ export class AppClientV2 {
       HEADERS: config?.HEADERS,
       ENCODE_PATH: config?.ENCODE_PATH,
     });
-
     this.apiOffresCollectives = new ApiOffresCollectivesService(this.request);
     this.dPrCiEApiContremarque = new DPrCiEApiContremarqueService(this.request);
   }

--- a/pro/src/apiClient/v2/core/CancelablePromise.ts
+++ b/pro/src/apiClient/v2/core/CancelablePromise.ts
@@ -51,7 +51,7 @@ export class CancelablePromise<T> implements Promise<T> {
           return;
         }
         this.#isResolved = true;
-        this.#resolve?.(value);
+        if (this.#resolve) this.#resolve(value);
       };
 
       const onReject = (reason?: any): void => {
@@ -59,7 +59,7 @@ export class CancelablePromise<T> implements Promise<T> {
           return;
         }
         this.#isRejected = true;
-        this.#reject?.(reason);
+        if (this.#reject) this.#reject(reason);
       };
 
       const onCancel = (cancelHandler: () => void): void => {
@@ -122,7 +122,7 @@ export class CancelablePromise<T> implements Promise<T> {
       }
     }
     this.#cancelHandlers.length = 0;
-    this.#reject?.(new CancelError('Request aborted'));
+    if (this.#reject) this.#reject(new CancelError('Request aborted'));
   }
 
   public get isCancelled(): boolean {

--- a/pro/src/apiClient/v2/models/AuthErrorResponseModel.ts
+++ b/pro/src/apiClient/v2/models/AuthErrorResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type AuthErrorResponseModel = {
   errors: Record<string, string>;
 };

--- a/pro/src/apiClient/v2/models/BookingFormula.ts
+++ b/pro/src/apiClient/v2/models/BookingFormula.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v2/models/BookingOfferType.ts
+++ b/pro/src/apiClient/v2/models/BookingOfferType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v2/models/CollectiveBookingResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveBookingResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveBookingStatus } from './CollectiveBookingStatus';
-
 export type CollectiveBookingResponseModel = {
   cancellationLimitDate?: string | null;
   confirmationDate?: string | null;

--- a/pro/src/apiClient/v2/models/CollectiveBookingStatus.ts
+++ b/pro/src/apiClient/v2/models/CollectiveBookingStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v2/models/CollectiveOffersCategoryResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersCategoryResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOffersCategoryResponseModel = {
   id: string;
   name: string;

--- a/pro/src/apiClient/v2/models/CollectiveOffersDomainResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersDomainResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOffersDomainResponseModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v2/models/CollectiveOffersEducationalInstitutionResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersEducationalInstitutionResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOffersEducationalInstitutionResponseModel = {
   city: string;
   id: number;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListCategoriesResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListCategoriesResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOffersCategoryResponseModel } from './CollectiveOffersCategoryResponseModel';
-
 export type CollectiveOffersListCategoriesResponseModel = Array<CollectiveOffersCategoryResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListDomainsResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListDomainsResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOffersDomainResponseModel } from './CollectiveOffersDomainResponseModel';
-
 export type CollectiveOffersListDomainsResponseModel = Array<CollectiveOffersDomainResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListEducationalInstitutionResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListEducationalInstitutionResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOffersEducationalInstitutionResponseModel } from './CollectiveOffersEducationalInstitutionResponseModel';
-
 export type CollectiveOffersListEducationalInstitutionResponseModel = Array<CollectiveOffersEducationalInstitutionResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOffersResponseModel } from './CollectiveOffersResponseModel';
-
 export type CollectiveOffersListResponseModel = Array<CollectiveOffersResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListStudentLevelsResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListStudentLevelsResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOffersStudentLevelResponseModel } from './CollectiveOffersStudentLevelResponseModel';
-
 export type CollectiveOffersListStudentLevelsResponseModel = Array<CollectiveOffersStudentLevelResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListSubCategoriesResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListSubCategoriesResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveOffersSubCategoryResponseModel } from './CollectiveOffersSubCategoryResponseModel';
-
 export type CollectiveOffersListSubCategoriesResponseModel = Array<CollectiveOffersSubCategoryResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListVenuesResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListVenuesResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { VenueResponse } from './VenueResponse';
-
 export type CollectiveOffersListVenuesResponseModel = Array<VenueResponse>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersResponseModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveBookingResponseModel } from './CollectiveBookingResponseModel';
-
 export type CollectiveOffersResponseModel = {
   beginningDatetime: string;
   bookings: Array<CollectiveBookingResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersStudentLevelResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersStudentLevelResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOffersStudentLevelResponseModel = {
   id: string;
   name: string;

--- a/pro/src/apiClient/v2/models/CollectiveOffersSubCategoryResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersSubCategoryResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type CollectiveOffersSubCategoryResponseModel = {
   category: string;
   categoryId: string;

--- a/pro/src/apiClient/v2/models/EacFormat.ts
+++ b/pro/src/apiClient/v2/models/EacFormat.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v2/models/ErrorResponseModel.ts
+++ b/pro/src/apiClient/v2/models/ErrorResponseModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ErrorResponseModel = {
   errors: Record<string, Array<string>>;
 };

--- a/pro/src/apiClient/v2/models/GetBookingResponse.ts
+++ b/pro/src/apiClient/v2/models/GetBookingResponse.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { BookingFormula } from './BookingFormula';
 import type { BookingOfferType } from './BookingOfferType';
-
 export type GetBookingResponse = {
   bookingId: string;
   dateOfBirth?: string | null;

--- a/pro/src/apiClient/v2/models/GetListEducationalInstitutionsQueryModel.ts
+++ b/pro/src/apiClient/v2/models/GetListEducationalInstitutionsQueryModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetListEducationalInstitutionsQueryModel = {
   city?: string | null;
   id?: number | null;

--- a/pro/src/apiClient/v2/models/GetOffererVenuesResponse.ts
+++ b/pro/src/apiClient/v2/models/GetOffererVenuesResponse.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OffererResponse } from './OffererResponse';
 import type { VenueResponse } from './VenueResponse';
-
 export type GetOffererVenuesResponse = {
   /**
    * Offerer to which the venues belong. Entity linked to the api key used.

--- a/pro/src/apiClient/v2/models/GetOfferersVenuesQuery.ts
+++ b/pro/src/apiClient/v2/models/GetOfferersVenuesQuery.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type GetOfferersVenuesQuery = {
   siren?: string | null;
 };

--- a/pro/src/apiClient/v2/models/GetOfferersVenuesResponse.ts
+++ b/pro/src/apiClient/v2/models/GetOfferersVenuesResponse.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { GetOffererVenuesResponse } from './GetOffererVenuesResponse';
-
 export type GetOfferersVenuesResponse = Array<GetOffererVenuesResponse>;

--- a/pro/src/apiClient/v2/models/GetPublicCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v2/models/GetPublicCollectiveOfferResponseModel.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { CollectiveBookingResponseModel } from './CollectiveBookingResponseModel';
 import type { EacFormat } from './EacFormat';
 import type { NationalProgramModel } from './NationalProgramModel';
 import type { OfferVenueModel } from './OfferVenueModel';
-
 export type GetPublicCollectiveOfferResponseModel = {
   audioDisabilityCompliant?: boolean | null;
   beginningDatetime: string;

--- a/pro/src/apiClient/v2/models/ListCollectiveOffersQueryModel.ts
+++ b/pro/src/apiClient/v2/models/ListCollectiveOffersQueryModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OfferStatus } from './OfferStatus';
-
 export type ListCollectiveOffersQueryModel = {
   periodBeginningDate?: string | null;
   periodEndingDate?: string | null;

--- a/pro/src/apiClient/v2/models/ListNationalProgramsResponseModel.ts
+++ b/pro/src/apiClient/v2/models/ListNationalProgramsResponseModel.ts
@@ -2,7 +2,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { NationalProgramModel } from './NationalProgramModel';
-
 export type ListNationalProgramsResponseModel = Array<NationalProgramModel>;

--- a/pro/src/apiClient/v2/models/NationalProgramModel.ts
+++ b/pro/src/apiClient/v2/models/NationalProgramModel.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type NationalProgramModel = {
   id: number;
   name: string;

--- a/pro/src/apiClient/v2/models/OfferAddressType.ts
+++ b/pro/src/apiClient/v2/models/OfferAddressType.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v2/models/OfferStatus.ts
+++ b/pro/src/apiClient/v2/models/OfferStatus.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v2/models/OfferVenueModel.ts
+++ b/pro/src/apiClient/v2/models/OfferVenueModel.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { OfferAddressType } from './OfferAddressType';
-
 export type OfferVenueModel = {
   addressType: OfferAddressType;
   otherAddress?: string | null;

--- a/pro/src/apiClient/v2/models/OffererResponse.ts
+++ b/pro/src/apiClient/v2/models/OffererResponse.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type OffererResponse = {
   createdDatetime: string;
   id: number;

--- a/pro/src/apiClient/v2/models/PartialAccessibility.ts
+++ b/pro/src/apiClient/v2/models/PartialAccessibility.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * Accessibility for people with disabilities. Fields are null for digital venues.
  */

--- a/pro/src/apiClient/v2/models/PatchCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v2/models/PatchCollectiveOfferBodyModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { EacFormat } from './EacFormat';
 import type { OfferVenueModel } from './OfferVenueModel';
-
 export type PatchCollectiveOfferBodyModel = {
   audioDisabilityCompliant?: boolean | null;
   beginningDatetime?: string | null;

--- a/pro/src/apiClient/v2/models/PostCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v2/models/PostCollectiveOfferBodyModel.ts
@@ -2,10 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { EacFormat } from './EacFormat';
 import type { OfferVenueModel } from './OfferVenueModel';
-
 export type PostCollectiveOfferBodyModel = {
   audioDisabilityCompliant?: boolean;
   beginningDatetime: string;

--- a/pro/src/apiClient/v2/models/ValidationError.ts
+++ b/pro/src/apiClient/v2/models/ValidationError.ts
@@ -2,9 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ValidationErrorElement } from './ValidationErrorElement';
-
 /**
  * Model of a validation error response.
  */

--- a/pro/src/apiClient/v2/models/ValidationErrorElement.ts
+++ b/pro/src/apiClient/v2/models/ValidationErrorElement.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * Model of a validation error response element.
  */

--- a/pro/src/apiClient/v2/models/VenueDigitalLocation.ts
+++ b/pro/src/apiClient/v2/models/VenueDigitalLocation.ts
@@ -2,17 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenueDigitalLocation = {
   type?: VenueDigitalLocation.type;
 };
-
 export namespace VenueDigitalLocation {
-
   export enum type {
     DIGITAL = 'digital',
   }
-
-
 }
 

--- a/pro/src/apiClient/v2/models/VenuePhysicalLocation.ts
+++ b/pro/src/apiClient/v2/models/VenuePhysicalLocation.ts
@@ -2,20 +2,15 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type VenuePhysicalLocation = {
   address?: string | null;
   city?: string | null;
   postalCode?: string | null;
   type?: VenuePhysicalLocation.type;
 };
-
 export namespace VenuePhysicalLocation {
-
   export enum type {
     PHYSICAL = 'physical',
   }
-
-
 }
 

--- a/pro/src/apiClient/v2/models/VenueResponse.ts
+++ b/pro/src/apiClient/v2/models/VenueResponse.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { PartialAccessibility } from './PartialAccessibility';
 import type { VenueDigitalLocation } from './VenueDigitalLocation';
 import type { VenuePhysicalLocation } from './VenuePhysicalLocation';
 import type { VenueTypeEnum } from './VenueTypeEnum';
-
 export type VenueResponse = {
   accessibility: PartialAccessibility;
   activityDomain: VenueTypeEnum;

--- a/pro/src/apiClient/v2/models/VenueTypeEnum.ts
+++ b/pro/src/apiClient/v2/models/VenueTypeEnum.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 /**
  * An enumeration.
  */

--- a/pro/src/apiClient/v2/services/ApiOffresCollectivesService.ts
+++ b/pro/src/apiClient/v2/services/ApiOffresCollectivesService.ts
@@ -15,14 +15,10 @@ import type { ListNationalProgramsResponseModel } from '../models/ListNationalPr
 import type { OfferStatus } from '../models/OfferStatus';
 import type { PatchCollectiveOfferBodyModel } from '../models/PatchCollectiveOfferBodyModel';
 import type { PostCollectiveOfferBodyModel } from '../models/PostCollectiveOfferBodyModel';
-
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
-
 export class ApiOffresCollectivesService {
-
   constructor(public readonly httpRequest: BaseHttpRequest) {}
-
   /**
    * Annuler une réservation collective
    * @param bookingId
@@ -44,7 +40,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récupération de la liste des catégories d'offres proposées.
    * @returns CollectiveOffersListCategoriesResponseModel La liste des catégories éligibles existantes.
@@ -60,7 +55,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récupération de la liste des domaines d'éducation pouvant être associés aux offres collectives.
    * @returns CollectiveOffersListDomainsResponseModel La liste des domaines d'éducation.
@@ -76,7 +70,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récupération de la liste établissements scolaires.
    * @param id
@@ -117,7 +110,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Liste de tous les dispositifs nationaux connus
    * @returns ListNationalProgramsResponseModel Il n'y a pas de dispositifs nationaux
@@ -134,7 +126,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récupération des lieux associés au fournisseur authentifié par le jeton d'API; groupés par structures.
    * Tous les lieux enregistrés, sont listés ici avec leurs coordonnées.
@@ -157,7 +148,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récuperation des offres collectives Cette api ignore les offre vitrines et les offres commencées sur l'interface web et non finalisées.
    * @param status
@@ -190,7 +180,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Création d'une offre collective.
    * @param requestBody
@@ -214,7 +203,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Liste des formats d'offres collectives
    * @returns void
@@ -232,7 +220,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récuperation de l'offre collective avec l'identifiant offer_id.
    * @param offerId
@@ -256,7 +243,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Édition d'une offre collective.
    * @param offerId
@@ -285,7 +271,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récupération de la liste des publics cibles pour lesquelles des offres collectives peuvent être proposées.
    * @returns CollectiveOffersListStudentLevelsResponseModel La liste des domaines d'éducation.
@@ -301,7 +286,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récupération de la liste des sous-catégories d'offres proposées a un public collectif.
    * @returns CollectiveOffersListSubCategoriesResponseModel La liste des sous-catégories éligibles existantes.
@@ -317,7 +301,6 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
   /**
    * Récupération de la liste des lieux associés au fournisseur authentifiée par le jeton d'API.
    * Tous les lieux enregistrés, sont listés ici avec leurs coordonnées.
@@ -334,5 +317,4 @@ export class ApiOffresCollectivesService {
       },
     });
   }
-
 }

--- a/pro/src/apiClient/v2/services/DPrCiEApiContremarqueService.ts
+++ b/pro/src/apiClient/v2/services/DPrCiEApiContremarqueService.ts
@@ -3,14 +3,10 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { GetBookingResponse } from '../models/GetBookingResponse';
-
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
-
 export class DPrCiEApiContremarqueService {
-
   constructor(public readonly httpRequest: BaseHttpRequest) {}
-
   /**
    * [Dépréciée] Contactez partenaires.techniques@passculture.app pour plus d'informations.
    * @param token
@@ -35,7 +31,6 @@ export class DPrCiEApiContremarqueService {
       },
     });
   }
-
   /**
    * [Dépréciée] Contactez partenaires.techniques@passculture.app pour plus d'informations.
    * @param token
@@ -60,7 +55,6 @@ export class DPrCiEApiContremarqueService {
       },
     });
   }
-
   /**
    * [Dépréciée] Contactez partenaires.techniques@passculture.app pour plus d'informations.
    * @param token
@@ -86,7 +80,6 @@ export class DPrCiEApiContremarqueService {
       },
     });
   }
-
   /**
    * [Dépréciée] Contactez partenaires.techniques@passculture.app pour plus d'informations.
    * @param token
@@ -112,5 +105,4 @@ export class DPrCiEApiContremarqueService {
       },
     });
   }
-
 }


### PR DESCRIPTION
## But de la pull request

BSR réparer le cleint api pro

-> des lignes vides en moins
-> qq `machin.?toto` qui deviennent `if(machin.toto)`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques