### PR TITLE
(BSR)[PRO] ci: trigger api client job when frontend deps change

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -82,7 +82,7 @@ jobs:
       cancel-in-progress: true
     with:
       TRIGGER_ONLY_ON_API_CHANGE: true
-      TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: false
+      TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
## But de la pull request

Le job update api client doit être lancé aussi quand les dépendances front changent : si `openapi-typescript-codegen` est mis à jour, cela peut casser le schéma d'API et on doit le vérifier.

[cf discussion sur Slack](https://passcultureteam.slack.com/archives/CPZ7U1CNP/p1704874588259529)