### PR TITLE
(PC-26802)[PRO] fix: Dont allow for svg inlined by vite within strybo…

### DIFF
--- a/pro/.storybook/main.ts
+++ b/pro/.storybook/main.ts
@@ -14,7 +14,14 @@ const config: StorybookConfig = {
   staticDirs: ['../src/public'],
   framework: {
     name: '@storybook/react-vite',
-    options: {},
+    options: {}
+  },
+  async viteFinal(config) {
+    if (config.build) {
+      //  Make sure that the <use> content in svgs is not inlined which is forbidden by some browsers
+      config.build.assetsInlineLimit = 0;
+    }
+    return config;
   },
   docs: {
     autodocs: false,


### PR DESCRIPTION
…ok setup.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26802

**Objectif**
Les icons n'apparaissent pas sur chrome dans le storybook lorsque les balises svg `<use>` ont leur données inline ce qui est interdit sur certains navigateurs pour des raisons de sécurité. Comme déjà fait pour le build de vite depuis la version 5, ici j'ajoute le paramètre du build pour que les petits use ne soient pas inlinés.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques