### PR TITLE
(PC-26492)[PRO] style: wording de récap de no réservation

### DIFF
--- a/pro/src/pages/Bookings/NoBookingsForPreFiltersMessage/NoBookingsForPreFiltersMessage.tsx
+++ b/pro/src/pages/Bookings/NoBookingsForPreFiltersMessage/NoBookingsForPreFiltersMessage.tsx
@@ -33,7 +33,7 @@ const NoBookingsForPreFiltersMessage = ({
       icon={fullRefresh}
       onClick={resetPreFilters}
     >
-      Réinitialiser les filtres
+      Afficher toutes les réservations
     </Button>
   </div>
 )

--- a/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -211,7 +211,7 @@ describe('components | BookingsRecap | Pro user', () => {
     await submitFilters()
 
     // When
-    const resetButton = screen.getByText('Réinitialiser les filtres', {
+    const resetButton = screen.getByText('Afficher toutes les réservations', {
       selector: '.button-ternary-pink',
     })
     await userEvent.click(resetButton)


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26492

## But de la pull request - wording de récap de no réservation

Changer le wording du CTA “Réinitialiser les filtres” pour “Afficher toutes les réservations”

Branche: PC-26492-wording-reservation-cta2

<img width="815" alt="Capture d’écran 2024-01-10 à 12 00 45" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/8a7658af-b7f2-48ad-99d0-b68f7274ee8a">
