### PR TITLE
(BSR)[API] ci: Bump version of "kceb/pull-request-url-action" GitHub action

### DIFF
--- a/.github/workflows/dev_on_workflow_ping_data_team.yml
+++ b/.github/workflows/dev_on_workflow_ping_data_team.yml
@@ -29,7 +29,7 @@ jobs:
             SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
       - name: "Retrieve pull request URL"
         id: "pr-url"
-        uses: kceb/pull-request-url-action@v1
+        uses: kceb/pull-request-url-action@v2
       - name: "Slack Notification"
         uses: slackapi/slack-github-action@v1.24.0
         with:
@@ -44,8 +44,8 @@ jobs:
                 "author_name": "${{ github.actor }}",
                 "author_link": "https://github.com/${{ github.actor }}",
                 "author_icon": "https://github.com/${{ github.actor }}.png",
-                "title": "Pull Request basee de donnée",
-                "title_link": "${{ steps.pr-url.outputs.url }}",
+                "title": "Pull Request base de données",
+                "title_link": "${{ steps.trimmed-pr-url.outputs.url }}",
                 "text": "Nouvelle PR avec une migration db ou une colonne en cours de suppression"
               }
             ],


### PR DESCRIPTION
Version 2 has a fix that trims the URL of the pull request. Otherwise
it contains a trailing trailing newline character. When the "Slack
notification" step includes it, it generates an invalid JSON payload.

---

Ça corrige le workflow GitHub "ping_data_team". Exemple de run où l'on voit l'erreur : https://github.com/pass-culture/pass-culture-main/actions/runs/7474653749/job/20341281390

Je ne sais pas tester la correction, mais ça ne devrait pas être pire que l'état actuel. :) 