### PR TITLE
(PC-26814)[BO] feat: add 'region' to advanced filters in offer page

### DIFF
--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -39,6 +39,7 @@ from pcapi.routes.backoffice import search_utils
 from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.utils import date as date_utils
+from pcapi.utils import regions as regions_utils
 from pcapi.utils import string as string_utils
 from pcapi.workers import push_notification_job
 
@@ -73,6 +74,12 @@ SEARCH_FIELD_TO_PYTHON = {
         "field": "department",
         "column": offerers_models.Venue.departementCode,
         "inner_join": "venue",
+    },
+    "REGION": {
+        "field": "region",
+        "column": offerers_models.Venue.departementCode,
+        "inner_join": "venue",
+        "special": regions_utils.get_department_codes_for_regions,
     },
     "EAN": {
         "field": "string",

--- a/api/src/pcapi/routes/backoffice/offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offers/forms.py
@@ -20,6 +20,7 @@ from pcapi.routes.backoffice.forms import constants
 from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.routes.backoffice.forms import fields
 from pcapi.routes.backoffice.forms import utils
+from pcapi.routes.backoffice.utils import get_regions_choices
 
 
 class SearchOperators(enum.Enum):
@@ -47,6 +48,7 @@ class SearchAttributes(enum.Enum):
     EVENT_DATE = "Date de l'évènement"
     BOOKING_LIMIT_DATE = "Date limite de réservation"
     DEPARTMENT = "Département"
+    REGION = "Région"
     EAN = "EAN-13"
     VALIDATION = "État"
     ID = "ID de l'offre"
@@ -70,6 +72,7 @@ form_field_configuration = {
         ],
     },
     "DEPARTMENT": {"field": "department", "operator": ["IN", "NOT_IN"]},
+    "REGION": {"field": "region", "operator": ["IN", "NOT_IN"]},
     "EAN": {"field": "string", "operator": ["CONTAINS", "NO_CONTAINS", "STR_EQUALS", "STR_NOT_EQUALS"]},
     "EVENT_DATE": {
         "field": "date",
@@ -135,6 +138,7 @@ class OfferAdvancedSearchSubForm(utils.PCForm):
                 "criteria",
                 "date",
                 "department",
+                "region",
                 "integer",
                 "offerer",
                 "string",
@@ -193,6 +197,12 @@ class OfferAdvancedSearchSubForm(utils.PCForm):
     department = fields.PCSelectMultipleField(
         "Départements",
         choices=constants.area_choices,
+        search_inline=True,
+        field_list_compatibility=True,
+    )
+    region = fields.PCSelectMultipleField(
+        "Régions",
+        choices=get_regions_choices(),
         search_inline=True,
         field_list_compatibility=True,
     )

--- a/api/src/pcapi/utils/regions.py
+++ b/api/src/pcapi/utils/regions.py
@@ -3,7 +3,7 @@ import typing
 from pcapi.utils.clean_accents import clean_accents
 
 
-REGION_DEPARTMENT_CODES = {
+REGION_DEPARTMENT_CODES: dict[str, tuple[str, ...]] = {
     "Auvergne-Rhône-Alpes": ("01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74"),
     "Bourgogne-Franche-Comté": ("21", "25", "39", "58", "70", "71", "89", "90"),
     "Bretagne": ("22", "29", "35", "56"),
@@ -66,5 +66,9 @@ def get_all_regions() -> list[str]:
     return sorted(REGION_DEPARTMENT_CODES.keys(), key=clean_accents)
 
 
-def get_department_codes_for_region(region: str) -> typing.Iterable[str]:
+def get_department_codes_for_region(region: str) -> tuple[str, ...]:
     return REGION_DEPARTMENT_CODES.get(region, ())
+
+
+def get_department_codes_for_regions(regions: typing.Iterable[str]) -> tuple[str, ...]:
+    return sum((get_department_codes_for_region(region) for region in regions), ())

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -462,6 +462,19 @@ class ListOffersTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data)
         assert set(int(row["ID"]) for row in rows) == {offers[0].id, offers[2].id}
 
+    def test_list_offers_advanced_search_by_region(self, authenticated_client, offers):
+        query_args = {
+            "search-0-search_field": "REGION",
+            "search-0-operator": "IN",
+            "search-0-region": ["La Réunion", "Auvergne-Rhône-Alpes"],
+        }
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, **query_args))
+            assert response.status_code == 200
+
+        rows = html_parser.extract_table_rows(response.data)
+        assert {int(row["ID"]) for row in rows} == {offers[1].id, offers[2].id}
+
     def test_list_offers_advanced_search_by_venue(self, authenticated_client, offers):
         venue_id = offers[1].venueId
         query_args = {


### PR DESCRIPTION
## But de la pull request

Ajout du champ "Région" dans la liste des filtres de la recherche avancée dans la page "Offres individuelles"

Ticket Jira : https://passculture.atlassian.net/browse/PC-26814

<img width="805" alt="Capture d’écran 2024-01-10 à 15 51 13" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/4f1f7f2f-3b69-49ef-8500-ea1a272f04b9">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques