### PR TITLE
(PC-26826)[PRO] feat: Delete WIP_ENABLE_DATES_OFFER_TEMPLATE FF

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 025c622f64f8 (pre) (head)
-65a8910cf1db (post) (head)
+f0fbdcf9961d (post) (head)

--- a/api/src/pcapi/alembic/versions/20240110T153011_f0fbdcf9961d_delete_wip_enable_dates_offers_template_ff.py
+++ b/api/src/pcapi/alembic/versions/20240110T153011_f0fbdcf9961d_delete_wip_enable_dates_offers_template_ff.py
@@ -1,0 +1,35 @@
+"""
+Remove FF WIP_ENABLE_DATES_OFFER_TEMPLATE
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "f0fbdcf9961d"
+down_revision = "65a8910cf1db"
+branch_labels = None
+depends_on = None
+
+
+def get_flag():  # type:ignore[no-untyped-def]
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="WIP_ENABLE_DATES_OFFER_TEMPLATE",
+        isActive=True,
+        description="Active la possibilité d'ajouter des dates pour les offres vitrines",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -113,7 +113,6 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_COMPLIANCE_CALL = "Activer les appels à l'API Compliance pour donner un score aux offres"
     WIP_ENABLE_MOCK_UBBLE = "Utiliser le mock Ubble à la place du vrai Ubble"
     WIP_ENABLE_BOOST_SHOWTIMES_FILTER = "Activer le filtre pour les requêtes showtimes Boost"
-    WIP_ENABLE_DATES_OFFER_TEMPLATE = "Active la possibilité d'ajouter des dates pour les offres vitrines"
     WIP_HOME_STATS = "Active la possibilité de voir les stats de consultation sur la page d'accueil"
     WIP_HOME_STATS_V2 = "Active la V2 des stats de publication d'offres sur la page d'accueil"
     WIP_ENABLE_FORMAT = "Activer le remplacement des catégories/sous-catégories par les formats"
@@ -181,7 +180,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ENABLE_SUSPICIOUS_EMAIL_SEND,
     FeatureToggle.WIP_ENABLE_TRUSTED_DEVICE,
     FeatureToggle.WIP_ENABLE_BOOST_SHOWTIMES_FILTER,
-    FeatureToggle.WIP_ENABLE_DATES_OFFER_TEMPLATE,
     FeatureToggle.WIP_HOME_STATS,
     FeatureToggle.WIP_HOME_STATS_V2,
     FeatureToggle.WIP_BEHIND_L7_LOAD_BALANCER,

--- a/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
+++ b/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
@@ -8,7 +8,6 @@ import {
   EducationalCategories,
   isCollectiveOffer,
 } from 'core/OfferEducational'
-import useActiveFeature from 'hooks/useActiveFeature'
 
 import styles from './CollectiveOfferSummary.module.scss'
 import CollectiveOfferAccessibilitySection from './components/CollectiveOfferAccessibilitySection'
@@ -41,10 +40,6 @@ const CollectiveOfferSummary = ({
 }: CollectiveOfferSummaryProps) => {
   const offerManuallyCreated = isCollectiveOffer(offer) && !offer.isPublicApi
 
-  const isTemplateOfferDatesActive = useActiveFeature(
-    'WIP_ENABLE_DATES_OFFER_TEMPLATE'
-  )
-
   return (
     <>
       <SummaryLayout>
@@ -64,9 +59,7 @@ const CollectiveOfferSummary = ({
             <CollectiveOfferVenueSection venue={offer.venue} />
             <CollectiveOfferTypeSection offer={offer} categories={categories} />
             <CollectiveOfferImagePreview offer={offer} />
-            {offer.isTemplate && isTemplateOfferDatesActive && (
-              <CollectiveOfferDateSection offer={offer} />
-            )}
+            {offer.isTemplate && <CollectiveOfferDateSection offer={offer} />}
             <CollectiveOfferLocationSection offer={offer} />
             {offer.isTemplate && <CollectiveOfferPriceSection offer={offer} />}
             <CollectiveOfferParticipantSection students={offer.students} />

--- a/pro/src/components/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
@@ -119,14 +119,11 @@ describe('CollectiveOfferSummary', () => {
     expect(screen.getAllByText(DEFAULT_RECAP_VALUE)[0]).toBeInTheDocument()
   })
 
-  it('should display the date and time if the FF is enabled', async () => {
+  it('should display the date and time of the offer', async () => {
     const offer = collectiveOfferTemplateFactory({
       dates: { start: '2023-10-24T09:14:00', end: '2023-10-24T09:16:00' },
     })
-    renderCollectiveOfferSummary(
-      { ...props, offer },
-      { features: ['WIP_ENABLE_DATES_OFFER_TEMPLATE'] }
-    )
+    renderCollectiveOfferSummary({ ...props, offer })
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
@@ -70,12 +70,7 @@ const OfferSummary = ({ offer }: OfferSummaryProps): JSX.Element => {
 
   let offerVenueLabel = `${venue.postalCode}, ${venue.city}`
 
-  const isTemplateOfferDatesAcrive = useActiveFeature(
-    'WIP_ENABLE_DATES_OFFER_TEMPLATE'
-  )
-
   const formattedDates =
-    isTemplateOfferDatesAcrive &&
     isCollectiveOfferTemplate(offer) &&
     offer.dates?.start &&
     offer.dates?.end &&

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
@@ -18,28 +18,13 @@ const renderOfferSummary = (
 }
 
 describe('offer summary', () => {
-  it('should not show the dates range on template offers if the FF is disabled', () => {
+  it('should show the dates range of a template offers', () => {
     const offer: HydratedCollectiveOfferTemplate = {
       ...defaultCollectiveTemplateOffer,
       dates: { start: '2023-10-24T00:00:00', end: '2023-10-24T23:59:00' },
       isTemplate: true,
     }
     renderOfferSummary({ offer })
-    expect(
-      screen.queryByText('Le mardi 24 octobre 2023')
-    ).not.toBeInTheDocument()
-  })
-
-  it('should show the dates range on template offers if the FF is enabled', () => {
-    const offer: HydratedCollectiveOfferTemplate = {
-      ...defaultCollectiveTemplateOffer,
-      dates: { start: '2023-10-24T00:00:00', end: '2023-10-24T23:59:00' },
-      isTemplate: true,
-    }
-    renderOfferSummary(
-      { offer },
-      { features: ['WIP_ENABLE_DATES_OFFER_TEMPLATE'] }
-    )
     expect(screen.queryByText('Le mardi 24 octobre 2023')).toBeInTheDocument()
   })
 
@@ -49,10 +34,7 @@ describe('offer summary', () => {
       dates: undefined,
       isTemplate: true,
     }
-    renderOfferSummary(
-      { offer },
-      { features: ['WIP_ENABLE_DATES_OFFER_TEMPLATE'] }
-    )
+    renderOfferSummary({ offer })
     expect(
       screen.queryByText('Le mardi 24 octobre 2023')
     ).not.toBeInTheDocument()

--- a/pro/src/screens/OfferEducational/OfferEducational.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducational.tsx
@@ -66,10 +66,6 @@ const OfferEducational = ({
   const { imageOffer, onImageDelete, onImageUpload, handleImageOnSubmit } =
     useCollectiveOfferImageUpload(offer, isTemplate)
 
-  const templateOfferDatesEnabled = useActiveFeature(
-    'WIP_ENABLE_DATES_OFFER_TEMPLATE'
-  )
-
   const isFormatActive = useActiveFeature('WIP_ENABLE_FORMAT')
   const isMarseilleEnabled = useActiveFeature('WIP_ENABLE_MARSEILLE')
 
@@ -164,10 +160,7 @@ const OfferEducational = ({
   const { resetForm, ...formik } = useFormik({
     initialValues,
     onSubmit,
-    validationSchema: getOfferEducationalValidationSchema(
-      templateOfferDatesEnabled,
-      isFormatActive
-    ),
+    validationSchema: getOfferEducationalValidationSchema(isFormatActive),
   })
 
   return (

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/__specs__/FormDates.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/__specs__/FormDates.spec.tsx
@@ -22,7 +22,7 @@ const renderFormDates = (
     <Formik
       initialValues={initialValues}
       onSubmit={vi.fn()}
-      validationSchema={getOfferEducationalValidationSchema(true, false)}
+      validationSchema={getOfferEducationalValidationSchema(false)}
     >
       {({ handleSubmit }) => (
         <form onSubmit={handleSubmit}>

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -15,9 +15,8 @@ import {
 import { computeOffersUrl } from 'core/Offers/utils'
 import { SelectOption } from 'custom_types/form'
 import { useScrollToFirstErrorAfterSubmit } from 'hooks'
-import useActiveFeature from 'hooks/useActiveFeature'
 import useNotification from 'hooks/useNotification'
-import { Banner, ButtonLink, SubmitButton } from 'ui-kit'
+import { ButtonLink, SubmitButton } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { sortByLabel } from 'utils/strings'
 
@@ -78,10 +77,6 @@ const OfferEducationalForm = ({
 
   const { values, setFieldValue, initialValues } =
     useFormikContext<OfferEducationalFormValues>()
-
-  const isDatesForTemplateOffer = useActiveFeature(
-    'WIP_ENABLE_DATES_OFFER_TEMPLATE'
-  )
 
   useScrollToFirstErrorAfterSubmit()
 
@@ -144,6 +139,7 @@ const OfferEducationalForm = ({
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     onOffererChange(values.offererId)
   }, [])
+
   return (
     <FormLayout className={styles['educational-form']} small>
       {isCollectiveOffer(offer) && offer.isPublicApi && (
@@ -152,16 +148,6 @@ const OfferEducationalForm = ({
         </BannerPublicApi>
       )}
       <FormLayout.MandatoryInfo />
-
-      {!isDatesForTemplateOffer && (
-        <Banner
-          className={styles['educational-form-banner']}
-          type="notification-info"
-        >
-          Pour proposer plusieurs dates, heures ou prix, il vous sera nécessaire
-          de <b>créer plusieurs offres</b>
-        </Banner>
-      )}
 
       <FormVenue
         isEligible={isEligible}
@@ -187,7 +173,7 @@ const OfferEducationalForm = ({
             onImageUpload={onImageUpload}
             imageOffer={imageOffer}
           />
-          {isTemplate && isDatesForTemplateOffer && (
+          {isTemplate && (
             <FormDates
               disableForm={mode === Mode.READ_ONLY}
               dateCreated={offer?.dateCreated}

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/__specs__/OfferEducationalForm.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/__specs__/OfferEducationalForm.spec.tsx
@@ -69,13 +69,25 @@ describe('OfferEducationalForm', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should render dates if offer is template and dates for template ff is active', async () => {
-    renderOfferEducationalForm(
-      { ...defaultProps, isTemplate: true },
-      { features: ['WIP_ENABLE_DATES_OFFER_TEMPLATE'] }
-    )
+  it('should show the dates section if the offer is a template', async () => {
+    renderOfferEducationalForm({ ...defaultProps, isTemplate: true })
     expect(
       await screen.findByRole('heading', { name: 'Date et heure' })
     ).toBeInTheDocument()
+  })
+
+  it('should not show the dates section if the offer is not a template', async () => {
+    renderOfferEducationalForm({ ...defaultProps, isTemplate: false })
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          /Pour proposer des offres à destination d’un groupe scolaire, vous devez renseigner un lieu pour pouvoir être remboursé./
+        )
+      ).not.toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole('heading', { name: 'Date et heure' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferEducational/validationSchema.ts
+++ b/pro/src/screens/OfferEducational/validationSchema.ts
@@ -24,10 +24,7 @@ const isPhoneValid = (phone: string | undefined): boolean => {
 const isNotEmpty = (description: string | undefined): boolean =>
   description ? Boolean(description.trim().length > 0) : false
 
-export function getOfferEducationalValidationSchema(
-  validateTemplateDates: boolean,
-  isFormatActive: boolean
-) {
+export function getOfferEducationalValidationSchema(isFormatActive: boolean) {
   return yup.object().shape({
     category: isFormatActive
       ? yup.string()
@@ -158,30 +155,26 @@ export function getOfferEducationalValidationSchema(
         then: (schema) => schema.required(),
       }),
     priceDetail: yup.string().max(MAX_DETAILS_LENGTH),
-    beginningDate: validateTemplateDates
-      ? yup.string().when('isTemplate', {
-          is: true,
-          then: (schema) =>
-            schema.required('Veuillez renseigner une date de début'),
-        })
-      : yup.string(),
-    endingDate: validateTemplateDates
-      ? yup.string().when('isTemplate', {
-          is: true,
-          then: (schema) =>
-            schema
-              .required('Veuillez renseigner une date de fin')
-              .test(
-                'endDateNoTooFar',
-                'La date de fin que vous avez choisie est trop éloignée',
-                (endDate) => {
-                  return isBefore(
-                    toDateStrippedOfTimezone(endDate),
-                    threeYearsFromNow
-                  )
-                }
-              ),
-        })
-      : yup.string(),
+    beginningDate: yup.string().when('isTemplate', {
+      is: true,
+      then: (schema) =>
+        schema.required('Veuillez renseigner une date de début'),
+    }),
+    endingDate: yup.string().when('isTemplate', {
+      is: true,
+      then: (schema) =>
+        schema
+          .required('Veuillez renseigner une date de fin')
+          .test(
+            'endDateNoTooFar',
+            'La date de fin que vous avez choisie est trop éloignée',
+            (endDate) => {
+              return isBefore(
+                toDateStrippedOfTimezone(endDate),
+                threeYearsFromNow
+              )
+            }
+          ),
+    }),
   })
 }

--- a/pro/src/screens/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
+++ b/pro/src/screens/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
@@ -12,7 +12,6 @@ import {
   COLLECTIVE_OFFER_SUBTYPE_DUPLICATE,
   DEFAULT_SEARCH_FILTERS,
 } from 'core/Offers/constants'
-import useActiveFeature from 'hooks/useActiveFeature'
 import useNotification from 'hooks/useNotification'
 import strokeBookedIcon from 'icons/stroke-booked.svg'
 import duplicateOfferIcon from 'icons/stroke-duplicate-offer.svg'
@@ -50,9 +49,6 @@ const CollectiveOfferType = ({
   const [lastDmsApplication, setLastDmsApplication] = useState<
     DMSApplicationForEAC | null | undefined
   >(null)
-  const isDatesForTemplateOffer = useActiveFeature(
-    'WIP_ENABLE_DATES_OFFER_TEMPLATE'
-  )
 
   useEffect(() => {
     const getTemplateCollectiveOffers = async () => {
@@ -154,9 +150,7 @@ const CollectiveOfferType = ({
                 COLLECTIVE_OFFER_SUBTYPE.TEMPLATE
               }
               label="Une offre vitrine"
-              description={`Cette offre n’est pas réservable. Elle ${
-                !isDatesForTemplateOffer ? 'n’a ni date, ni prix et' : ''
-              } permet aux enseignants de vous contacter pour co-construire une offre adaptée. Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.`}
+              description={`Cette offre n’est pas réservable. Elle permet aux enseignants de vous contacter pour co-construire une offre adaptée. Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.`}
               onChange={handleChange}
               value={COLLECTIVE_OFFER_SUBTYPE.TEMPLATE}
             />

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -159,7 +159,7 @@ describe('OfferType', () => {
 
     await userEvent.click(
       await screen.findByRole('radio', {
-        name: 'Une offre vitrine Cette offre n’est pas réservable. Elle n’a ni date, ni prix et permet aux enseignants de vous contacter pour co-construire une offre adaptée. Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.',
+        name: 'Une offre vitrine Cette offre n’est pas réservable. Elle permet aux enseignants de vous contacter pour co-construire une offre adaptée. Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.',
       })
     )
     await userEvent.click(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26826

**Objectif**
Supprimer le FF qui affiche quand il est actif la section dates dans le formulaire d'une offre vitrine

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques