### PR TITLE
(BSR)[API] test: Remove test of PDF metadata

### DIFF
--- a/api/tests/utils/pdf_creation_test.py
+++ b/api/tests/utils/pdf_creation_test.py
@@ -59,16 +59,3 @@ class GeneratePdfFromHtmlTest:
         # the first run, but it often failed on CI, even though
         # debugging statements showed that the cache was used (and
         # thus that the second run should be faster).
-
-    def test_metadata(self, example_html, css_font_http_request_mock):
-        date_string = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S") + "Z"
-        metadata = pdf.PdfMetadata(
-            author="Pass Culture Dev Team",
-            title="Le dispositif pass Culture",
-            description="Des explications issues du site",
-        )
-        pdf_file = pdf.generate_pdf_from_html(html_content=example_html, metadata=metadata)
-        assert "/Author (Pass Culture Dev Team)".encode() in pdf_file
-        assert "/Title (Le dispositif pass Culture)".encode() in pdf_file
-        assert f"/CreationDate ({date_string})".encode() in pdf_file
-        assert f"/ModDate ({date_string})".encode() in pdf_file


### PR DESCRIPTION
We will soon upgrade to a recent version of Weasyprint. Starting from
Weasyprint 59.0, metadata does not appear in clear in the generated
PDF file anymore. It could be because of optimizations that were
shipped in that version, or some other reason. Anyway, our tests
cannot easily check that the metadata is included in a generated PDF
file. We would have to parse the PDF, and we don't want to. We don't
do anything complicated with our PDF metadata, so we can rely on
Weasyprint to correctly handle metadata (which it does) and not have
any specific test.

Also, the test was flaky: we look for the startup time (with second
precision) of the test in the generated PDF. If it took too much
time (or if we were just unlucky enough that the generation spanned
over 2 seconds), the creation and/or the modification date in the
metadata could be different from what we expect.