### PR TITLE
revert [PC-26353] do not index collective offers anymore

### DIFF
--- a/api/src/pcapi/core/educational/api/favorites.py
+++ b/api/src/pcapi/core/educational/api/favorites.py
@@ -59,6 +59,58 @@ def get_redactor_all_favorites_count(redactor_id: int) -> int:
     Note:
         Non-eligible for search offers (and templates) are ignored.
     """
+    return _offer_favorites_count(redactor_id) + _offer_template_favorites_count(redactor_id)
+
+
+def _offer_favorites_count(redactor_id: int) -> int:
+    # TODO(jeremieb): make CollectiveOffer's is_eligible_for_search
+    # a hybrid_property to allow filtering (not sure this is possible however)
+    # lots of joinedload because of is_eligible_for_search
+    favorite_offers_query = (
+        educational_models.CollectiveOfferEducationalRedactor.query.filter_by(educationalRedactorId=redactor_id)
+        .options(
+            # load the favorite's collective offer...
+            sa.orm.joinedload(educational_models.CollectiveOfferEducationalRedactor.collectiveOffer)
+            .load_only(
+                educational_models.CollectiveOffer.id,
+                educational_models.CollectiveOffer.venueId,
+                educational_models.CollectiveOffer.validation,
+                educational_models.CollectiveOffer.isActive,
+            )
+            # ... to fetch its venue...
+            .joinedload(educational_models.CollectiveOffer.venue)
+            .load_only(offerers_models.Venue.managingOffererId)
+            # ... to fetch its managing offerer...
+            .joinedload(offerers_models.Venue.managingOfferer)
+            .load_only(offerers_models.Offerer.isActive, offerers_models.Offerer.validationStatus)
+        )
+        .options(
+            # load the favorite's collective offer...
+            sa.orm.joinedload(educational_models.CollectiveOfferEducationalRedactor.collectiveOffer)
+            .load_only(
+                educational_models.CollectiveOffer.id,
+            )
+            # ... to fetch its stock...
+            .joinedload(educational_models.CollectiveOffer.collectiveStock)
+            .load_only(
+                educational_models.CollectiveStock.beginningDatetime,
+                educational_models.CollectiveStock.bookingLimitDatetime,
+                educational_models.CollectiveStock.collectiveOfferId,
+            )
+            # ... to fetch its booking...
+            .joinedload(educational_models.CollectiveStock.collectiveBookings)
+            .load_only(educational_models.CollectiveBooking.status)
+        )
+    )
+
+    favorite_offers = [
+        favorite for favorite in favorite_offers_query if favorite.collectiveOffer.is_eligible_for_search
+    ]
+
+    return len(favorite_offers)
+
+
+def _offer_template_favorites_count(redactor_id: int) -> int:
     # TODO(jeremieb): make CollectiveOfferTemplate's is_eligible_for_search
     # a hybrid_property to allow filtering (not sure this is possible however)
     # lots of joinedload because of is_eligible_for_search

--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -3,6 +3,7 @@ import logging
 
 import sqlalchemy as sa
 
+from pcapi.core import search
 from pcapi.core.educational import exceptions
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository as educational_repository
@@ -69,6 +70,11 @@ def create_collective_stock(
     logger.info(
         "Collective stock has been created",
         extra={"collective_offer": collective_offer.id, "collective_stock_id": collective_stock.id},
+    )
+
+    search.async_index_collective_offer_ids(
+        [collective_offer.id],
+        reason=search.IndexationReason.STOCK_CREATION,
     )
 
     return collective_stock
@@ -139,6 +145,10 @@ def edit_collective_stock(
         db.session.commit()
 
     logger.info("Stock has been updated", extra={"stock": stock.id})
+    search.async_index_collective_offer_ids(
+        [stock.collectiveOfferId],
+        reason=search.IndexationReason.STOCK_UPDATE,
+    )
 
     notify_educational_redactor_on_collective_offer_or_stock_edit(
         stock.collectiveOffer.id,

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -461,8 +461,7 @@ class CollectiveOffer(
             return self.collectiveStock.isBookable
         return False
 
-    # TODO(jeremieb - 2023/12/29): to be removed, is possible
-    is_eligible_for_search = False
+    is_eligible_for_search = isBookable
 
     @property
     def isReleased(self) -> bool:

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -334,6 +334,11 @@ def update_collective_offer(
 
     updated_fields = _update_collective_offer(offer=offer_to_update, new_values=new_values)
 
+    search.async_index_collective_offer_ids(
+        [offer_to_update.id],
+        reason=search.IndexationReason.OFFER_UPDATE,
+    )
+
     educational_api_offer.notify_educational_redactor_on_collective_offer_or_stock_edit(
         offer_to_update.id,
         updated_fields,
@@ -462,6 +467,12 @@ def batch_update_collective_offers(query: BaseQuery, update_fields: dict) -> Non
         )
         query_to_update.update(update_fields, synchronize_session=False)
         db.session.commit()
+
+        search.async_index_collective_offer_ids(
+            collective_offer_ids_batch,
+            reason=search.IndexationReason.OFFER_BATCH_UPDATE,
+            log_extra={"changes": set(update_fields.keys())},
+        )
 
 
 def batch_update_collective_offers_template(query: BaseQuery, update_fields: dict) -> None:

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -385,9 +385,10 @@ class AlgoliaBackend(base.SearchBackend):
         self,
         collective_offers: Iterable[educational_models.CollectiveOffer],
     ) -> None:
-        # TODO(jeremieb): to remove, once we are sure that removing this
-        # function won't break anything
-        pass
+        if not collective_offers:
+            return
+        objects = [self.serialize_collective_offer(collective_offer) for collective_offer in collective_offers]
+        self.algolia_collective_offers_client.save_objects(objects)
 
     def index_collective_offer_templates(
         self,

--- a/api/src/pcapi/core/search/commands/indexation.py
+++ b/api/src/pcapi/core/search/commands/indexation.py
@@ -39,9 +39,7 @@ def index_offers_in_algolia_by_venue() -> None:
 @log_cron_with_transaction
 def index_collective_offers() -> None:
     """Pop collective offers from indexation queue and reindex them."""
-    # TODO(jeremieb): to remove, once we are sure that removing this
-    # function won't break anything (eg. deactivate cron tasks)
-    pass  # pylint: disable=unnecessary-pass
+    search.index_collective_offers_in_queue()
 
 
 @blueprint.cli.command("index_collective_offer_templates")
@@ -93,9 +91,7 @@ def index_offers_in_error_in_algolia_by_offer() -> None:
 @log_cron_with_transaction
 def index_collective_offers_in_error() -> None:
     """Pop collective offers from the error queue and reindex them."""
-    # TODO(jeremieb): to remove, once we are sure that removing this
-    # function won't break anything (eg. deactivate cron tasks)
-    pass  # pylint: disable=unnecessary-pass
+    search.index_collective_offers_in_queue(from_error_queue=True)
 
 
 @blueprint.cli.command("index_collective_offers_templates_in_error")
@@ -182,9 +178,16 @@ def partially_index_collective_offers(
     offers that are eligible for search. You control the first and
     last pages of the batches (starting from page 1).
     """
-    # TODO(jeremieb): to remove, once we are sure that removing this
-    # function won't break anything (eg. deactivate cron tasks)
-    pass  # pylint: disable=unnecessary-pass
+    if clear:
+        search.unindex_all_collective_offers(only_non_template=True)
+    _partially_index(
+        what="collective offers",
+        getter=collective_offers_repository.get_paginated_active_collective_offer_ids,
+        indexation_callback=search._reindex_collective_offer_ids,
+        batch_size=batch_size,
+        starting_page=starting_page,
+        last_page=last_page,
+    )
 
 
 @blueprint.cli.command("partially_index_collective_offer_templates")

--- a/api/src/pcapi/routes/adage_iframe/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/offers.py
@@ -55,9 +55,6 @@ def get_educational_offers_categories(
 def get_educational_eligible_offers_by_uai(
     authenticated_information: AuthenticatedInformation,
 ) -> serializers.ListCollectiveOffersResponseModel:
-    # TODO(jeremieb): remove since it should return only indexable
-    # collective offers...and we won't index them anymore.
-    # Keep the route for now to avoid any breaking change.
     if authenticated_information.uai is None:
         raise ApiErrors({"institutionId": "institutionId is required"}, status_code=400)
 

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -8,6 +8,7 @@ from flask import url_for
 from flask_login import current_user
 import sqlalchemy as sa
 
+from pcapi.core import search
 from pcapi.core.educational import adage_backends as adage_client
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.adage_backends.serialize import serialize_collective_offer
@@ -221,6 +222,11 @@ def _batch_validate_or_reject_collective_offers(
 
         if collective_offer.institutionId is not None:
             adage_client.notify_institution_association(serialize_collective_offer(collective_offer))
+
+    search.async_index_collective_offer_ids(
+        collective_offer_update_succeed_ids,
+        reason=search.IndexationReason.OFFER_BATCH_VALIDATION,
+    )
 
     if len(collective_offer_update_succeed_ids) == 1:
         flash(

--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_search_objects.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_search_objects.py
@@ -24,6 +24,16 @@ def create_data_search_indexed_objects() -> None:
         # Collective offers and collective offer templates are in the same index.
         # Thus, the next line will unindex all of them.
         search.unindex_all_collective_offers()
+        collective_offer_ids = [
+            collective_offer_id
+            for collective_offer_id, in educational_models.CollectiveOffer.query.with_entities(
+                educational_models.CollectiveOffer.id
+            )
+        ]
+        search.async_index_collective_offer_ids(
+            collective_offer_ids,
+            reason=search.IndexationReason.OFFER_CREATION,
+        )
 
         collective_offer_template_ids = [
             collective_offer_template_id

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_search_objects.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_search_objects.py
@@ -24,6 +24,16 @@ def create_industrial_search_indexed_objects() -> None:
         # Collective offers and collective offer templates are in the same index.
         # Thus, the next line will unindex all of them.
         search.unindex_all_collective_offers()
+        collective_offer_ids = [
+            collective_offer_id
+            for collective_offer_id, in educational_models.CollectiveOffer.query.with_entities(
+                educational_models.CollectiveOffer.id
+            )
+        ]
+        search.async_index_collective_offer_ids(
+            collective_offer_ids,
+            reason=search.IndexationReason.OFFER_CREATION,
+        )
 
         collective_offer_template_ids = [
             collective_offer_template_id

--- a/api/tests/core/educational/api/test_favorites.py
+++ b/api/tests/core/educational/api/test_favorites.py
@@ -28,10 +28,10 @@ def collective_offer_template_fixture(redactor):
 
 class GetRedactorAllFavoritesCountTest:
     def test_count(self, redactor, offer, template):
-        assert get_redactor_all_favorites_count(redactor.id) == 1
+        assert get_redactor_all_favorites_count(redactor.id) == 2
 
     def test_only_collective_offers(self, redactor, offer):
-        assert get_redactor_all_favorites_count(redactor.id) == 0
+        assert get_redactor_all_favorites_count(redactor.id) == 1
 
     def test_only_collective_offer_templates(self, redactor, template):
         assert get_redactor_all_favorites_count(redactor.id) == 1
@@ -41,11 +41,14 @@ class GetRedactorAllFavoritesCountTest:
 
     def test_ignore_not_eligible_for_search_offers(self, redactor, offer, template):
         factories.CollectiveOfferFactory(teacher=redactor)
-        assert get_redactor_all_favorites_count(redactor.id) == 1
+        assert get_redactor_all_favorites_count(redactor.id) == 2
 
-    def test_igore_favorites_from_another_user(self, redactor, template):
-        factories.EducationalRedactorFactory(
-            favoriteCollectiveOfferTemplates=[factories.CollectiveOfferTemplateFactory()]
-        )
+    def test_igore_favorites_from_another_user(self, redactor, offer):
+        another_redactor = factories.EducationalRedactorFactory()
+        another_offer = factories.CollectiveStockFactory().collectiveOffer
+        another_offer_template = factories.CollectiveOfferTemplateFactory()
+
+        another_redactor.favoriteCollectiveOffers = [another_offer]
+        another_redactor.favoriteCollectiveOfferTemplates = [another_offer_template]
 
         assert get_redactor_all_favorites_count(redactor.id) == 1

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -7,6 +7,7 @@ from flask import current_app
 from freezegun.api import freeze_time
 import pytest
 
+from pcapi.core import search
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.api import adage as educational_api_adage
 from pcapi.core.educational.api import booking as educational_api_booking
@@ -16,6 +17,7 @@ from pcapi.core.educational.api.offer import unindex_expired_collective_offers_t
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.offers import exceptions as offers_exceptions
+import pcapi.core.search.testing as search_testing
 from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
 from pcapi.models.offer_mixin import OfferValidationStatus
@@ -48,6 +50,9 @@ class CreateCollectiveOfferStocksTest:
         assert stock.price == 1200
         assert stock.numberOfTickets == 35
         assert stock.stockId is None
+
+        search.index_collective_offers_in_queue()
+        assert offer.id in search_testing.search_store["collective-offers"]
 
     def should_set_booking_limit_datetime_to_beginning_datetime_when_not_provided(self) -> None:
         # Given

--- a/api/tests/core/search/test_backend_algolia.py
+++ b/api/tests/core/search/test_backend_algolia.py
@@ -28,6 +28,7 @@ class FakeOffer:
     [
         ("enqueue_offer_ids", algolia.REDIS_OFFER_IDS_NAME),
         ("enqueue_offer_ids_in_error", algolia.REDIS_OFFER_IDS_IN_ERROR_NAME),
+        ("enqueue_collective_offer_ids", algolia.REDIS_COLLECTIVE_OFFER_IDS_TO_INDEX),
         (
             "enqueue_collective_offer_ids_in_error",
             algolia.REDIS_COLLECTIVE_OFFER_IDS_IN_ERROR_TO_INDEX,
@@ -59,6 +60,7 @@ def test_enqueue_functions(enqueue_function_name, queue):
     [
         ("pop_offer_ids_from_queue", False, algolia.REDIS_OFFER_IDS_NAME),
         ("pop_offer_ids_from_queue", True, algolia.REDIS_OFFER_IDS_IN_ERROR_NAME),
+        ("pop_collective_offer_ids_from_queue", False, algolia.REDIS_COLLECTIVE_OFFER_IDS_TO_INDEX),
         (
             "pop_collective_offer_ids_from_queue",
             True,
@@ -192,6 +194,17 @@ def test_unindex_venue_ids(app):
         posted_json = posted.last_request.json()
         assert posted_json["requests"][0]["action"] == "deleteObject"
         assert posted_json["requests"][0]["body"]["objectID"] == 1
+
+
+def test_index_collective_offers():
+    backend = get_backend()
+    collective_offer = educational_factories.CollectiveStockFactory.build().collectiveOffer
+    with requests_mock.Mocker() as mock:
+        posted = mock.post("https://dummy-app-id.algolia.net/1/indexes/testing-collective-offers/batch", json={})
+        backend.index_collective_offers([collective_offer])
+        posted_json = posted.last_request.json()
+        assert posted_json["requests"][0]["action"] == "updateObject"
+        assert posted_json["requests"][0]["body"]["objectID"] == collective_offer.id
 
 
 def test_unindex_collective_offer_ids():

--- a/api/tests/core/search/test_commands_indexation.py
+++ b/api/tests/core/search/test_commands_indexation.py
@@ -108,6 +108,32 @@ def test_update_products_booking_count_and_reindex_offers_if_same_ean(mocked_asy
 
 
 @clean_database
+def test_partially_index_collective_offers(app):
+    _inactive_offer = educational_factories.CollectiveStockFactory(collectiveOffer__isActive=False).collectiveOffer
+    _unbookable_offer = educational_factories.CollectiveOfferFactory()
+    bookable_offer1 = educational_factories.CollectiveStockFactory().collectiveOffer
+    _bookable_offer2 = educational_factories.CollectiveStockFactory().collectiveOffer
+
+    # `get_paginated_active_collective_offer_ids()` returns the first
+    # 2 active offers, which are _unbookable_offer and bookable_offer1.
+    # Only the latter is indexed.
+    expected_to_be_reindexed = {
+        bookable_offer1.id,
+    }
+
+    # fmt: off
+    run_command(
+        app,
+        "partially_index_collective_offers",
+        "--batch-size", 1,
+        "--last-page", 2,
+    )
+    # fmt: on
+
+    assert set(search_testing.search_store["collective-offers"].keys()) == expected_to_be_reindexed
+
+
+@clean_database
 def test_partially_index_collective_offer_templates(app):
     _not_indexable_template = educational_factories.CollectiveOfferTemplateFactory(isActive=False)
     indexable_template1 = educational_factories.CollectiveOfferTemplateFactory()

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -297,6 +297,70 @@ def test_serialize_venue_with_one_bookable_offer():
     assert serialized["has_at_least_one_bookable_offer"]
 
 
+def test_serialize_collective_offer():
+    domain1 = educational_factories.EducationalDomainFactory(name="Danse")
+    domain2 = educational_factories.EducationalDomainFactory(name="Architecture")
+    educational_institution = educational_factories.EducationalInstitutionFactory()
+    collective_offer = educational_factories.CollectiveOfferFactory(
+        dateCreated=datetime.datetime(2022, 1, 1, 10, 0, 0),
+        name="Titre formidable",
+        description="description formidable",
+        students=[StudentLevels.CAP1, StudentLevels.CAP2],
+        subcategoryId=subcategories.CONCERT.id,
+        venue__postalCode="86140",
+        venue__name="La Moyenne Librairie SA",
+        venue__publicName="La Moyenne Librairie",
+        venue__managingOfferer__name="Les Librairies Associées",
+        venue__departementCode="86",
+        venue__latitude=algolia.DEFAULT_LATITUDE,
+        venue__longitude=algolia.DEFAULT_LONGITUDE,
+        venue__adageId="123456",
+        educational_domains=[domain1, domain2],
+        institution=educational_institution,
+        interventionArea=["1", "90", "94"],
+        offerVenue={"addressType": OfferAddressType.OTHER, "venueId": None, "otherAddress": "Quelque part"},
+    )
+    educational_factories.CollectiveStockFactory(
+        beginningDatetime=datetime.datetime(2022, 1, 1, 11, 0, 0),
+        collectiveOffer=collective_offer,
+    )
+
+    serialized = algolia.AlgoliaBackend().serialize_collective_offer(collective_offer)
+    assert serialized == {
+        "objectID": collective_offer.id,
+        "offer": {
+            "dateCreated": 1641031200.0,
+            "name": "Titre formidable",
+            "students": ["CAP - 1re année", "CAP - 2e année"],
+            "subcategoryId": subcategories.CONCERT.id,
+            "domains": [domain1.id, domain2.id],
+            "educationalInstitutionUAICode": educational_institution.institutionId,
+            "interventionArea": ["1", "90", "94"],
+            "schoolInterventionArea": None,
+            "eventAddressType": OfferAddressType.OTHER.value,
+            "beginningDatetime": 1641034800.0,
+            "description": collective_offer.description,
+        },
+        "offerer": {
+            "name": "Les Librairies Associées",
+        },
+        "venue": {
+            "academy": "Poitiers",
+            "departmentCode": "86",
+            "id": collective_offer.venue.id,
+            "name": "La Moyenne Librairie SA",
+            "publicName": "La Moyenne Librairie",
+            "adageId": collective_offer.venue.adageId,
+        },
+        "_geoloc": {
+            "lat": float(collective_offer.venue.latitude),
+            "lng": float(collective_offer.venue.longitude),
+        },
+        "isTemplate": False,
+        "formats": [fmt.value for fmt in subcategories.CONCERT.formats],
+    }
+
+
 def test_serialize_collective_offer_without_institution():
     collective_offer = educational_factories.CollectiveStockFactory().collectiveOffer
     serialized = algolia.AlgoliaBackend().serialize_collective_offer(collective_offer)

--- a/api/tests/routes/adage_iframe/get_all_offers_linked_to_uai_test.py
+++ b/api/tests/routes/adage_iframe/get_all_offers_linked_to_uai_test.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import pytest
 
+from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.testing import assert_num_queries
 
@@ -16,7 +17,18 @@ class AllOffersByUaiTest:
 
         educational_redactor = educational_factories.EducationalRedactorFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
-        educational_factories.CollectiveOfferFactory()
+        national_program = educational_factories.NationalProgramFactory()
+        collective_offer = educational_factories.CollectiveOfferFactory(
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            domains=[educational_factories.EducationalDomainFactory()],
+            institution=educational_institution,
+            teacher=educational_factories.EducationalRedactorFactory(),
+            nationalProgramId=national_program.id,
+        )
+        stock = educational_factories.CollectiveStockFactory(
+            price=10,
+            collectiveOffer=collective_offer,
+        )
 
         test_client = client.with_adage_token(
             email=educational_redactor.email, uai=educational_institution.institutionId
@@ -32,14 +44,102 @@ class AllOffersByUaiTest:
 
         # then
         assert response.status_code == 200
-        assert response.json == {"collectiveOffers": []}
+        assert response.json == {
+            "collectiveOffers": [
+                {
+                    "audioDisabilityCompliant": False,
+                    "mentalDisabilityCompliant": False,
+                    "motorDisabilityCompliant": False,
+                    "visualDisabilityCompliant": False,
+                    "id": collective_offer.id,
+                    "subcategoryLabel": collective_offer.subcategory.app_label,
+                    "description": collective_offer.description,
+                    "isExpired": False,
+                    "isSoldOut": False,
+                    "name": collective_offer.name,
+                    "stock": {
+                        "id": stock.id,
+                        "beginningDatetime": stock.beginningDatetime.isoformat(),
+                        "bookingLimitDatetime": stock.bookingLimitDatetime.isoformat(),
+                        "isBookable": stock.isBookable,
+                        "price": 1000,
+                        "numberOfTickets": stock.numberOfTickets,
+                        "educationalPriceDetail": None,
+                    },
+                    "venue": {
+                        "id": collective_offer.venue.id,
+                        "address": "1 boulevard Poissonnière",
+                        "city": "Paris",
+                        "name": collective_offer.venue.name,
+                        "postalCode": collective_offer.venue.postalCode,
+                        "publicName": collective_offer.venue.publicName,
+                        "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
+                        "distance": None,
+                        "managingOfferer": {"name": collective_offer.venue.managingOfferer.name},
+                        "adageId": None,
+                    },
+                    "students": ["Lycée - Seconde"],
+                    "offerVenue": {
+                        "addressType": "other",
+                        "distance": None,
+                        "otherAddress": "1 rue des polissons, Paris 75017",
+                        "venueId": None,
+                        "name": None,
+                        "publicName": None,
+                        "address": None,
+                        "postalCode": None,
+                        "city": None,
+                    },
+                    "contactEmail": collective_offer.contactEmail,
+                    "contactPhone": collective_offer.contactPhone,
+                    "durationMinutes": collective_offer.durationMinutes,
+                    "offerId": collective_offer.offerId,
+                    "educationalPriceDetail": None,
+                    "domains": [{"id": collective_offer.domains[0].id, "name": collective_offer.domains[0].name}],
+                    "educationalInstitution": {
+                        "id": educational_institution.id,
+                        "name": educational_institution.name,
+                        "postalCode": educational_institution.postalCode,
+                        "city": educational_institution.city,
+                        "institutionType": educational_institution.institutionType,
+                    },
+                    "interventionArea": ["93", "94", "95"],
+                    "imageCredit": None,
+                    "imageUrl": None,
+                    "teacher": {
+                        "email": stock.collectiveOffer.teacher.email,
+                        "firstName": stock.collectiveOffer.teacher.firstName,
+                        "lastName": stock.collectiveOffer.teacher.lastName,
+                        "civility": stock.collectiveOffer.teacher.civility,
+                    },
+                    "nationalProgram": {
+                        "id": stock.collectiveOffer.nationalProgram.id,
+                        "name": stock.collectiveOffer.nationalProgram.name,
+                    },
+                    "isFavorite": False,
+                    "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
+                }
+            ]
+        }
 
     def test_all_offers_by_uai_favorite(self, client):
         # given
 
         educational_redactor = educational_factories.EducationalRedactorFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
-        educational_factories.CollectiveOfferFactory()
+        national_program = educational_factories.NationalProgramFactory()
+        collective_offer = educational_factories.CollectiveOfferFactory(
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            domains=[educational_factories.EducationalDomainFactory()],
+            institution=educational_institution,
+            teacher=educational_factories.EducationalRedactorFactory(),
+            nationalProgramId=national_program.id,
+            educationalRedactorsFavorite=[educational_redactor],
+        )
+        stock = educational_factories.CollectiveStockFactory(
+            price=10,
+            collectiveOffer=collective_offer,
+        )
 
         test_client = client.with_adage_token(
             email=educational_redactor.email, uai=educational_institution.institutionId
@@ -55,7 +155,83 @@ class AllOffersByUaiTest:
 
         # then
         assert response.status_code == 200
-        assert response.json == {"collectiveOffers": []}
+        assert response.json == {
+            "collectiveOffers": [
+                {
+                    "audioDisabilityCompliant": False,
+                    "mentalDisabilityCompliant": False,
+                    "motorDisabilityCompliant": False,
+                    "visualDisabilityCompliant": False,
+                    "id": collective_offer.id,
+                    "subcategoryLabel": collective_offer.subcategory.app_label,
+                    "description": collective_offer.description,
+                    "isExpired": False,
+                    "isSoldOut": False,
+                    "name": collective_offer.name,
+                    "stock": {
+                        "id": stock.id,
+                        "beginningDatetime": stock.beginningDatetime.isoformat(),
+                        "bookingLimitDatetime": stock.bookingLimitDatetime.isoformat(),
+                        "isBookable": stock.isBookable,
+                        "price": 1000,
+                        "numberOfTickets": stock.numberOfTickets,
+                        "educationalPriceDetail": None,
+                    },
+                    "venue": {
+                        "id": collective_offer.venue.id,
+                        "address": "1 boulevard Poissonnière",
+                        "city": "Paris",
+                        "name": collective_offer.venue.name,
+                        "postalCode": collective_offer.venue.postalCode,
+                        "publicName": collective_offer.venue.publicName,
+                        "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
+                        "distance": None,
+                        "managingOfferer": {"name": collective_offer.venue.managingOfferer.name},
+                        "adageId": None,
+                    },
+                    "students": ["Lycée - Seconde"],
+                    "offerVenue": {
+                        "addressType": "other",
+                        "distance": None,
+                        "otherAddress": "1 rue des polissons, Paris 75017",
+                        "venueId": None,
+                        "name": None,
+                        "publicName": None,
+                        "address": None,
+                        "postalCode": None,
+                        "city": None,
+                    },
+                    "contactEmail": collective_offer.contactEmail,
+                    "contactPhone": collective_offer.contactPhone,
+                    "durationMinutes": collective_offer.durationMinutes,
+                    "offerId": collective_offer.offerId,
+                    "educationalPriceDetail": None,
+                    "domains": [{"id": collective_offer.domains[0].id, "name": collective_offer.domains[0].name}],
+                    "educationalInstitution": {
+                        "id": educational_institution.id,
+                        "name": educational_institution.name,
+                        "postalCode": educational_institution.postalCode,
+                        "city": educational_institution.city,
+                        "institutionType": educational_institution.institutionType,
+                    },
+                    "interventionArea": ["93", "94", "95"],
+                    "imageCredit": None,
+                    "imageUrl": None,
+                    "teacher": {
+                        "email": stock.collectiveOffer.teacher.email,
+                        "firstName": stock.collectiveOffer.teacher.firstName,
+                        "lastName": stock.collectiveOffer.teacher.lastName,
+                        "civility": stock.collectiveOffer.teacher.civility,
+                    },
+                    "nationalProgram": {
+                        "id": stock.collectiveOffer.nationalProgram.id,
+                        "name": stock.collectiveOffer.nationalProgram.name,
+                    },
+                    "isFavorite": True,
+                    "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
+                }
+            ]
+        }
 
     def test_all_offers_by_uai_not_bookable(self, client):
         # given

--- a/api/tests/routes/adage_iframe/get_authenticate_test.py
+++ b/api/tests/routes/adage_iframe/get_authenticate_test.py
@@ -106,6 +106,7 @@ class AuthenticateTest:
 
     def test_favorites_count(self, client) -> None:
         redactor = EducationalRedactorFactory(
+            favoriteCollectiveOffers=[CollectiveStockFactory().collectiveOffer],
             favoriteCollectiveOfferTemplates=[CollectiveOfferTemplateFactory()],
         )
 
@@ -113,13 +114,13 @@ class AuthenticateTest:
 
         # fetch the institution
         # fetch the redactor
-        # count the redactor's favorites (templates only)
+        # count the redactor's favorites (2 requests: offers and templates)
         # count the offers linked to institution uai
-        with assert_num_queries(4):
+        with assert_num_queries(5):
             response = client.get(url_for("adage_iframe.authenticate"))
 
         assert response.status_code == 200
-        assert response.json["favoritesCount"] == 1
+        assert response.json["favoritesCount"] == 2
 
     def test_preferences_are_correctly_serialized(self, client) -> None:
         educational_institution = EducationalInstitutionFactory()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26353

La PR initiale désactivait l'indexation des offres collectives réservables mais, ce faisant, l'onglet "dans mon établissement", qui utilise l'indexation, ne marche plus.

PR initiale: https://github.com/pass-culture/pass-culture-main/pull/9899

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques