### PR TITLE
(BSR)[API] ci: edit concurrency group namings

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -13,7 +13,7 @@ permissions: write-all
 
 concurrency:
   # cancel previous workflow of the same branch except on master
-  group: ${{ github.ref }}
+  group: main-${{ github.ref }}
   cancel-in-progress: ${{ github.ref == 'refs/heads/master' && false || true }}
 
 jobs:
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
     if: github.base_ref == 'master'
     concurrency:
-      group: tests-main-${{ github.ref }}
+      group: update-api-client-template-${{ github.ref }}
       cancel-in-progress: true
     with:
       TRIGGER_ONLY_ON_API_CHANGE: true
@@ -220,7 +220,7 @@ jobs:
   update-jira-issue:
     name: "Update Jira issue"
     if: ${{ always() && github.ref == 'refs/heads/master' }}
-    concurrency: ${{ github.workflow }}-${{ github.ref }}
+    concurrency: update-jira-issue-${{ github.workflow }}-${{ github.ref }}
     uses: ./.github/workflows/dev_on_workflow_update_jira_issues.yml
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
## But de la pull request

S'assurer que les concurrency groups sont bien distincts, car GHA ne prévient pas en cas de conflit.

Seul une interrogation via API permet de le remarquer

```
➜ gh run view 7476235346

  * dbaty/fix_ping_data_gh_action 1 [on_push] Initiate workflow #10127 · 7476235346
  Triggered via pull_request about 20 hours ago

  JOBS
  X Check api folder changes / Check folder changes in 0s (ID 20346159045)
  X Check db migration folder changes / Check folder changes in 0s (ID 20346159457)
  X Check maintenance-site folder changes / Check folder changes in 0s (ID 20346159954)
  X Check pro folder changes / Check folder changes in 0s (ID 20346160358)
  X Reset cache on master on dependency update / Update API Client template in 0s (ID 20346160652)
  * Update Jira issue / issue-number (ID 20346161028)
  X Update api client template / Update API Client template in 0s (ID 20346161354)
  X MyPy cop in 0s (ID 20346162152)
  X Deploy maintenance site in 0s (ID 20346162497)
  X Ping data team on slack in 0s (ID 20346162837)
  X Build API (backend) Docker image in 0s (ID 20346163231)
  X Tests pro in 0s (ID 20346163558)
  X [PRO] Deploy PR version for validation in 0s (ID 20346163897)
  X Deploy Storybook in 0s (ID 20346164237)
  X Tests pro E2E in 0s (ID 20346164508)
  X Test api in 0s (ID 20346164877)
  X Dependabot in 0s (ID 20346165228)
  X Deploy to testing in 0s (ID 20346165614)
  X Slack notification in 0s (ID 20346165959)

  ANNOTATIONS
  X Canceling since a deadlock for concurrency group '1 [on_push] Initiate workflow-refs/heads/master' was detected between 'top level workflow' and 'update-jira-issue'
  Check api folder changes / Check folder changes: .github#1

  X Canceling since a deadlock for concurrency group '1 [on_push] Initiate workflow-refs/heads/master' was detected between 'top level workflow' and 'update-jira-issue'
  Check db migration folder changes / Check folder changes: .github#1

  X Canceling since a deadlock for concurrency group '1 [on_push] Initiate workflow-refs/heads/master' was detected between 'top level workflow' and 'update-jira-issue'
  Check maintenance-site folder changes / Check folder changes: .github#1

  X Canceling since a deadlock for concurrency group '1 [on_push] Initiate workflow-refs/heads/master' was detected between 'top level workflow' and 'update-jira-issue'
  Check pro folder changes / Check folder changes: .github#1

  X Canceling since a deadlock for concurrency group '1 [on_push] Initiate workflow-refs/heads/master' was detected between 'top level workflow' and 'update-jira-issue'
  Reset cache on master on dependency update / Update API Client template: .github#1

  X Canceling since a deadlock for concurrency group '1 [on_push] Initiate workflow-refs/heads/master' was detected between 'top level workflow' and 'update-jira-issue'
  Update api client template / Update API Client template: .github#1


  For more information about a job, try: gh run view --job=<job-id>
  View this run on GitHub: https://github.com/pass-culture/pass-culture-main/actions/runs/7476235346
```


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques