### PR TITLE
(PC-26875)[PRO] feat: Do not display the banner if pending bank account.

### DIFF
--- a/pro/src/components/Callout/AddBankAccountCallout.tsx
+++ b/pro/src/components/Callout/AddBankAccountCallout.tsx
@@ -21,6 +21,7 @@ const AddBankAccountCallout = ({
   const location = useLocation()
   const displayBankAccountBanner =
     offerer &&
+    !offerer.hasPendingBankAccount &&
     !offerer.hasValidBankAccount &&
     offerer.venuesWithNonFreeOffersWithoutBankAccounts.length > 0
 

--- a/pro/src/components/Callout/__specs__/AddBankAccountCallout.spec.tsx
+++ b/pro/src/components/Callout/__specs__/AddBankAccountCallout.spec.tsx
@@ -16,7 +16,7 @@ describe('AddBankAccountCallout', () => {
   const props: AddBankAccountCalloutProps = {
     titleOnly: false,
   }
-  it('should not render AddBankAccountCallout without FF', () => {
+  it('should not render AddBankAccountCallout without WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY FF', () => {
     renderWithProviders(<AddBankAccountCallout {...props} />)
 
     expect(
@@ -36,31 +36,56 @@ describe('AddBankAccountCallout', () => {
     ).not.toBeInTheDocument()
   })
 
-  describe('With FF enabled', () => {
-    it.each([
-      {
+  describe('With WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY FF enabled', () => {
+    it(`should not render the add bank account banner when the user has no valid bank account`, () => {
+      props.offerer = {
         ...defaultGetOffererResponseModel,
         hasValidBankAccount: false,
         venuesWithNonFreeOffersWithoutBankAccounts: [],
-      },
+      }
+      renderWithProviders(<AddBankAccountCallout {...props} />, {
+        features: ['WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'],
+      })
+
+      expect(
+        screen.queryByText(
+          'Ajoutez un compte bancaire pour percevoir vos remboursements'
+        )
+      ).not.toBeInTheDocument()
+    })
+
+    it(`should not render the add bank account banner when the user has a valid bank account and venues with non free offers to link`, () => {
+      props.offerer = {
+        ...defaultGetOffererResponseModel,
+        hasValidBankAccount: true,
+        venuesWithNonFreeOffersWithoutBankAccounts: [1],
+      }
+      renderWithProviders(<AddBankAccountCallout {...props} />, {
+        features: ['WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'],
+      })
+
+      expect(
+        screen.queryByText(
+          'Ajoutez un compte bancaire pour percevoir vos remboursements'
+        )
+      ).not.toBeInTheDocument()
+    })
+
+    it.each([
       {
         ...defaultGetOffererResponseModel,
-        id: 2,
+        id: 3,
         venuesWithNonFreeOffersWithoutBankAccounts: [1],
-        hasValidBankAccount: true,
+        hasPendingBankAccount: true,
       },
     ])(
-      `should not render the add bank account banner when hasValidBankAccount = $hasValidBankAccount and venuesWithNonFreeOffersWithoutBankAccounts = $venuesWithNonFreeOffersWithoutBankAccounts`,
-      ({
-        hasValidBankAccount,
-        venuesWithNonFreeOffersWithoutBankAccounts,
-        ...rest
-      }) => {
+      `should not render the add bank account banner if the offerer has no valid bank account and some unlinked venues but a pending bank account`,
+      () => {
         props.offerer = {
-          hasValidBankAccount: hasValidBankAccount,
-          venuesWithNonFreeOffersWithoutBankAccounts:
-            venuesWithNonFreeOffersWithoutBankAccounts,
-          ...rest,
+          ...defaultGetOffererResponseModel,
+          hasValidBankAccount: false,
+          venuesWithNonFreeOffersWithoutBankAccounts: [1],
+          hasPendingBankAccount: true,
         }
         renderWithProviders(<AddBankAccountCallout {...props} />, {
           features: ['WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'],


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26875

- Ne pas afficher la bannière si un compte en banque est en attente de validation.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques