### PR TITLE
(PC-25161)[PRO] feat: add link for venue page when searching with ven…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/NoResultsPage.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/NoResultsPage.tsx
@@ -1,12 +1,21 @@
 import React from 'react'
 
+import { VenueResponse } from 'apiClient/adage'
+import fullLinkIcon from 'icons/full-link.svg'
+import { ButtonLink } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
+
 import styles from './NoResultsPage.module.scss'
 
 interface NoResultsPageProps {
   query?: string
+  venue?: VenueResponse | null
 }
 
-export const NoResultsPage = ({ query }: NoResultsPageProps): JSX.Element => {
+export const NoResultsPage = ({
+  query,
+  venue,
+}: NoResultsPageProps): JSX.Element => {
   const noResultText = !query ? (
     'Nous n’avons trouvé aucune offre publiée'
   ) : (
@@ -26,8 +35,23 @@ export const NoResultsPage = ({ query }: NoResultsPageProps): JSX.Element => {
     <div className={styles['no-results']}>
       <p className={styles['no-results-text']}>{noResultText}</p>
       <p className={styles['no-results-suggestion']}>
-        {noResultSuggestionText}
+        {!venue && noResultSuggestionText}
       </p>
+      {venue?.adageId && (
+        <ButtonLink
+          link={{
+            isExternal: true,
+            to: `${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          }}
+          variant={ButtonVariant.TERNARY}
+          icon={fullLinkIcon}
+          svgAlt="Nouvelle fenêtre"
+        >
+          Voir la fiche du partenaire
+        </ButtonLink>
+      )}
     </div>
   )
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/__specs__/NoResultsPage.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/__specs__/NoResultsPage.spec.tsx
@@ -5,18 +5,34 @@ import { NoResultsPage } from '../NoResultsPage'
 
 describe('NoResultPage', () => {
   it('should display the searched query when something was searched ', () => {
-    render(<NoResultsPage query="Musée du Louvre" />)
+    render(<NoResultsPage query="Musée du Louvre" venue={null} />)
 
     expect(screen.getByText('Musée du Louvre')).toBeInTheDocument()
   })
 
   it('should display the default message when nothing was searched ', () => {
-    render(<NoResultsPage query="" />)
+    render(<NoResultsPage query="" venue={null} />)
 
     expect(
       screen.getByText(
         'Votre recherche semble trop ciblée... Réessayez en supprimant un ou plusieurs filtres.'
       )
+    ).toBeInTheDocument()
+  })
+
+  it('should display venue link when no result and venue filter active ', () => {
+    const venue = {
+      id: 1,
+      name: 'test',
+      relative: [],
+      departementCode: '75',
+      adageId: '123456',
+    }
+
+    render(<NoResultsPage query="noting nothing" venue={venue} />)
+
+    expect(
+      screen.getByRole('link', { name: /Voir la fiche du partenaire/ })
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-instantsearch'
 import { useParams } from 'react-router-dom'
 
-import { AdageFrontRoles } from 'apiClient/adage'
+import { AdageFrontRoles, VenueResponse } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
 import useActiveFeature from 'hooks/useActiveFeature'
 import fullGoTop from 'icons/full-go-top.svg'
@@ -37,6 +37,7 @@ export interface OffersProps {
   submitCount?: number
   isBackToTopVisibile?: boolean
   indexId?: string //  IndexId is necessary if the component is within the scope of a react-instantsearch <Index />
+  venue?: VenueResponse | null
 }
 
 type HydratedOffer = HydratedCollectiveOffer | HydratedCollectiveOfferTemplate
@@ -50,6 +51,7 @@ export const Offers = ({
   submitCount,
   isBackToTopVisibile = false,
   indexId,
+  venue,
 }: OffersProps): JSX.Element | null => {
   const { hits, isLastPage, showMore } = useInfiniteHits()
   const { nbHits } = useStats()
@@ -176,7 +178,9 @@ export const Offers = ({
   }
 
   if (hits?.length === 0 || offers.length === 0 || !results) {
-    return displayNoResult ? <NoResultsPage query={results?.query} /> : null
+    return displayNoResult ? (
+      <NoResultsPage query={results?.query} venue={venue} />
+    ) : null
   }
 
   return (

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -216,6 +216,7 @@ export const OffersSearch = ({
           submitCount={formik.submitCount}
           isBackToTopVisibile={!isOfferFiltersVisible}
           indexId="main_offers_index"
+          venue={formik.values.venue}
         />
         {nbHits === 0 && !isUserAdmin && (
           <OffersSuggestions formValues={formik.values} />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25161

Lorsqu'il y a  le filtre des lieux lors d'une recherche et que nous ne trouvons pas d'offre, on ajoute un lien qui redirige vers la page du partenaire

Pour tester la feature : 

1. prendre le lien généré par la pr et l'ajouter dans le lien d'adage en testing (en changeant le lien de l'iframe depuis la console)
2. ajouter à la fin de l'url de l'iframe &venue=834 qui correspond à un lieu existant en testing et qui a un adageId
3. faire une recherche qui emmène à aucun résultat
4. cliquer sur le lien pour voir si il redirige au bon endroit

<img width="1512" alt="Capture d’écran 2024-01-11 à 15 20 16" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/6ebcc23e-7632-411a-8da6-4e6977cae098">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques