### PR TITLE
(PC-26897)[API] fix: error when updating a beneficiary_fraud_check which was never touched

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1565,7 +1565,6 @@ def anonymize_user(user: users_models.User, *, force: bool = False) -> None:
         beneficiary_fraud_check.resultContent = None
         beneficiary_fraud_check.reason = "Anonymized"
         beneficiary_fraud_check.dateCreated = beneficiary_fraud_check.dateCreated.replace(day=1, month=1)
-        beneficiary_fraud_check.updatedAt = beneficiary_fraud_check.updatedAt.replace(day=1, month=1)
 
     for beneficiary_fraud_review in user.beneficiaryFraudReviews:
         beneficiary_fraud_review.reason = "Anonymized"

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -2071,8 +2071,6 @@ class AnonymizeBeneficiaryUsersTest:
                 assert beneficiary_fraud_check.reason == "Anonymized"
                 assert beneficiary_fraud_check.dateCreated.day == 1
                 assert beneficiary_fraud_check.dateCreated.month == 1
-                assert beneficiary_fraud_check.updatedAt.day == 1
-                assert beneficiary_fraud_check.updatedAt.month == 1
 
             for beneficiary_fraud_review in user_to_anonymize.beneficiaryFraudReviews:
                 assert beneficiary_fraud_review.reason == "Anonymized"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26897

## Explications

1) Un code absent ne peut pas causer de bugs
2) le cas n'est plus possible a créer avec le schéma de db actuel (le champ updatedAt est toujours remplis en pratique)
3) l'anonymisation de ce champ est inutile puisqu'il portera TOUJOURS la date de l'anonymisation qui ne permet pas de ré identifier le jeune.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques