### PR TITLE
(PC-26827)[PRO] fix: checkbox filter adage width

### DIFF
--- a/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
+++ b/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
@@ -8,7 +8,6 @@
   flex-direction: column;
   gap: rem.torem(24px);
   height: rem.torem(250px);
-  width: max-content;
 }
 
 .search-list {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26827

La barre de scroll s'affichait directement à la fin de l'élément le plus long de la liste, on change pour qu'il soit au fond de la div quelque soit l'élément 

Avant : 
<img width="464" alt="Capture d’écran 2024-01-11 à 17 43 39" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/b2deaf38-9ced-4196-81a0-1ba8fb5d978b">

Après : 
<img width="566" alt="Capture d’écran 2024-01-11 à 17 44 09" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/99c271cf-deab-4980-af72-5a1d3a773014">

## Vérifications

- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques