### PR TITLE
(PC-25229)[PRO] fix: change offer title to h2 in offer creation pages

### DIFF
--- a/pro/src/screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.tsx
+++ b/pro/src/screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.tsx
@@ -40,7 +40,7 @@ const IndivualOfferLayout = ({
       >
         <div>
           <h1>{title}</h1>
-          {offer && <h4 className={styles['offer-title']}>{offer.name}</h4>}
+          {offer && <h2 className={styles['offer-title']}>{offer.name}</h2>}
         </div>
         {shouldDisplayActionOnStatus && (
           <div className={styles['right']}>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25229

Changer le titre des offres en h2 dans le parcours d'édition/création d'offre indiv


![Capture d’écran 2024-01-12 à 08 48 55](https://github.com/pass-culture/pass-culture-main/assets/71768799/5304813a-ef27-4ec0-9851-ed996e78d376)
