### PR TITLE
(PC-24554)[PRO] fix: remove unecessary select in aria label

### DIFF
--- a/pro/src/pages/Home/Offerers/OffererDetails.tsx
+++ b/pro/src/pages/Home/Offerers/OffererDetails.tsx
@@ -57,7 +57,7 @@ export const OffererDetails = ({
             name="offererId"
             options={[...offererOptions, addOffererOption]}
             value={selectedOfferer.id.toString()}
-            aria-label="Sélectionner une structure"
+            aria-label="Structure"
           />
         </div>
 

--- a/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.tsx
@@ -81,7 +81,7 @@ describe('OffererDetails', () => {
     renderOffererDetails()
 
     await userEvent.selectOptions(
-      screen.getByLabelText('Sélectionner une structure'),
+      screen.getByLabelText('Structure'),
       '+ Ajouter une structure'
     )
 

--- a/pro/src/pages/Home/__specs__/Homepage.spec.tsx
+++ b/pro/src/pages/Home/__specs__/Homepage.spec.tsx
@@ -196,7 +196,7 @@ describe('Homepage', () => {
     vi.spyOn(api, 'getOfferer').mockResolvedValueOnce(newOfferer)
 
     await userEvent.selectOptions(
-      screen.getByLabelText('Sélectionner une structure'),
+      screen.getByLabelText('Structure'),
       'Structure 2'
     )
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24554

Remplacer `Sélectionner la structure` par `Structure` dans le aria-label de sélection d'une strcutrue de la page d'accueil. En effet inutile de repriser dans le aria-label la nature du champs HTML

