### PR TITLE
(PC-26674)[PRO] fix: sort studentLevel when MeG activated

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -417,7 +417,7 @@ export const OfferFilters = ({
                     isOpen={modalOpenStatus['students']}
                     sortOptions={(options, selectedOptions) => {
                       //  Implement custom sort to not sort results alphabetically
-                      return options.sort((option1, option2) => {
+                      return [...options].sort((option1, option2) => {
                         const isSelected1 = selectedOptions.includes(
                           option1.value
                         )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26674

Lorsque l'établissement fait partie de Marseille en grand, il y a deux nouvelles valeurs dans le filtre Niveau scolaire, que l'on trie pour afficher sa de la petite classe à la plus grande (primaire -> cap 2eme année), lorsqu'on sélectionne une classe elle se retrouve tout en haut de la liste mais lorsqu'on la décoche et qu'on ferme la modal de filtre, elle doit reprendre sa place initial, ce n'était plus le cas car on modifiait directement l'objet des niveaux scolaire