### PR TITLE
(PC-26930)[PRO] fix: Remove CSP REPORT ONLY from meta tag in index.html

### DIFF
--- a/pro/src/.env.integration
+++ b/pro/src/.env.integration
@@ -5,7 +5,6 @@ VITE_ENV_WORDING="d'intégration"
 VITE_URL_FOR_MAINTENANCE=https://maintenance.passculture.app?source=https://integration.passculture.pro/
 VITE_SENTRY_SAMPLE_RATE=0.01
 VITE_SENTRY_SERVER_URL=https://50f5694849704813b4154c5868b73365@sentry.passculture.team/2
-VITE_CSP_REPORT_URI=https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365
 VITE_DEMARCHES_SIMPLIFIEES_RIB_VENUE_PROCEDURE_ID_V4=https://www.demarches-simplifiees.fr/commencer/staging-cb-depot-de-coordonnees-bancaires-de-rembo
 VITE_RECAPTCHA_SITE_KEY=6Lc2AK0ZAAAAAMjhRGJQxiCak9VLYHTr3HrPczfX
 VITE_FIREBASE_PUBLIC_API_KEY=AIzaSyAhXSv-Wk5I3hHAga5KhCe_SUhdmY-2eyQ

--- a/pro/src/.env.production
+++ b/pro/src/.env.production
@@ -5,7 +5,6 @@ VITE_ENV_WORDING='de production'
 VITE_URL_FOR_MAINTENANCE=https://maintenance.passculture.app?source=https://passculture.pro/
 VITE_SENTRY_SAMPLE_RATE=0.01
 VITE_SENTRY_SERVER_URL=https://50f5694849704813b4154c5868b73365@sentry.passculture.team/2
-VITE_CSP_REPORT_URI=https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365
 VITE_DEMARCHES_SIMPLIFIEES_RIB_VENUE_PROCEDURE_ID_V4=https://www.demarches-simplifiees.fr/commencer/prod-cb-depot-de-coordonnees-bancaires-de-rembours
 # FIXME: Update DS V5 url when DS v5 is deployed
 VITE_DEMARCHES_SIMPLIFIEES_BANK_ACCOUNT_PROCEDURE_ID=https://www.demarches-simplifiees.fr/commencer/354ba5a9-e215-4051-84fd-cf35d5390543

--- a/pro/src/.env.staging
+++ b/pro/src/.env.staging
@@ -5,7 +5,6 @@ VITE_ENV_WORDING='de staging'
 VITE_URL_FOR_MAINTENANCE=https://maintenance.passculture.app?source=https://pro.staging.passculture.team/
 VITE_SENTRY_SAMPLE_RATE=0.01
 VITE_SENTRY_SERVER_URL=https://50f5694849704813b4154c5868b73365@sentry.passculture.team/2
-VITE_CSP_REPORT_URI=https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365
 VITE_DEMARCHES_SIMPLIFIEES_RIB_VENUE_PROCEDURE_ID_V4=https://www.demarches-simplifiees.fr/commencer/staging-cb-depot-de-coordonnees-bancaires-de-rembo
 VITE_DEMARCHES_SIMPLIFIEES_BANK_ACCOUNT_PROCEDURE_ID=https://www.demarches-simplifiees.fr/commencer/792c02de-53b1-4a22-9e3a-6149cd2041ee
 VITE_RECAPTCHA_SITE_KEY=6LdCAK0ZAAAAACLJjzV7Q_n91SPITi6xKOPHk8HY

--- a/pro/src/.env.testing
+++ b/pro/src/.env.testing
@@ -5,7 +5,6 @@ VITE_ENV_WORDING='de testing'
 VITE_URL_FOR_MAINTENANCE=https://maintenance.passculture.app?source=https://pro.testing.passculture.team/
 VITE_SENTRY_SAMPLE_RATE=0.01
 VITE_SENTRY_SERVER_URL=https://50f5694849704813b4154c5868b73365@sentry.passculture.team/2
-VITE_CSP_REPORT_URI=https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365
 VITE_DEMARCHES_SIMPLIFIEES_RIB_VENUE_PROCEDURE_ID_V4=https://www.demarches-simplifiees.fr/commencer/test/c52a2b8f-92d3-4e7a-9418-0c23c22d4853
 VITE_RECAPTCHA_SITE_KEY=6Lc2AK0ZAAAAAMjhRGJQxiCak9VLYHTr3HrPczfX
 VITE_FIREBASE_PUBLIC_API_KEY=AIzaSyDv-igPDFDCvZDofcjiZ-TUBLwB3sIcjZ0

--- a/pro/src/index.html
+++ b/pro/src/index.html
@@ -25,13 +25,6 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://*.getbeamer.com/; style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css https://fonts.googleapis.com/css 'unsafe-inline'"
     />
-    <!--
-        CSP report only to detect csp errors and help us clean the policy
-      -->
-    <meta
-      http-equiv="Content-Security-Policy-Report-Only"
-      content="default-src 'self'; report-uri %CSP_REPORT_URI%; report-to %CSP_REPORT_URI%"
-    />
     <% } %>
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" href="/favicon.ico" />

--- a/pro/src/utils/config.ts
+++ b/pro/src/utils/config.ts
@@ -16,8 +16,6 @@ export const ENVIRONMENT_NAME = import.meta.env.MODE
 export const ENV_WORDING = import.meta.env.VITE_ENV_WORDING
 export const SENTRY_SAMPLE_RATE = import.meta.env.VITE_SENTRY_SAMPLE_RATE ?? '0'
 export const SENTRY_SERVER_URL = import.meta.env.VITE_SENTRY_SERVER_URL
-// ts-unused-exports:disable-next-line
-export const CSP_REPORT_URI = import.meta.env.VITE_CSP_REPORT_URI
 export const DEMARCHES_SIMPLIFIEES_RIB_VENUE_PROCEDURE_ID_V4 = import.meta.env
   .VITE_DEMARCHES_SIMPLIFIEES_RIB_VENUE_PROCEDURE_ID_V4
 export const RECAPTCHA_SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY ?? ''


### PR DESCRIPTION
…in index.html.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26930

**Objectif**
Le `Content-Security-Policy-Report-Only` n'est pas supporté dans une balise `<meta>`, il faut que ce Header soit ajouté dans les réponses HTTP côté back. Cette PR supprime donc l'ajout de la balise.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques