### PR TITLE
(PC-26932)[API] fix: link product to provider from backoffice

### DIFF
--- a/api/src/pcapi/connectors/titelive.py
+++ b/api/src/pcapi/connectors/titelive.py
@@ -11,6 +11,8 @@ from pcapi.core import logging as core_logging
 from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.offers import exceptions as offers_exceptions
 import pcapi.core.offers.models as offers_models
+import pcapi.core.providers.constants as providers_constants
+import pcapi.core.providers.repository as providers_repository
 from pcapi.domain.titelive import parse_things_date_to_string
 from pcapi.utils import date as date_utils
 from pcapi.utils import requests
@@ -158,8 +160,10 @@ def get_new_product_from_ean13(ean: str) -> offers_models.Product:
 
     csr = get_closest_csr(gtl_id)
 
+    provider = providers_repository.get_provider_by_name(providers_constants.TITELIVE_EPAGINE_PROVIDER_NAME)
     return offers_models.Product(
         idAtProviders=ean,
+        lastProvider=provider,
         description=html.unescape(article["resume"]) if "resume" in article else None,
         name=html.unescape(oeuvre["titre"]),
         subcategoryId=subcategories.LIVRE_PAPIER.id,

--- a/api/tests/connectors/titelive/titelive_test.py
+++ b/api/tests/connectors/titelive/titelive_test.py
@@ -7,6 +7,7 @@ import pytest
 from pcapi.connectors import titelive
 from pcapi.connectors.titelive import GtlIdError
 from pcapi.core.categories import subcategories_v2 as subcategories
+import pcapi.core.providers.constants as providers_constants
 from pcapi.core.testing import override_settings
 from pcapi.domain.titelive import parse_things_date_to_string
 
@@ -54,7 +55,7 @@ class TiteliveTest:
         assert product.thumbCount == article["image"]
         assert product.name == oeuvre["titre"]
         assert product.subcategoryId == subcategories.LIVRE_PAPIER.id
-        assert product.extraData["author"] == oeuvre["auteurs"]
+        assert product.lastProvider.name == providers_constants.TITELIVE_EPAGINE_PROVIDER_NAME
         assert product.extraData["author"] == oeuvre["auteurs"]
         assert product.extraData["ean"] == ean
         assert product.extraData["prix_livre"] == article["prix"]


### PR DESCRIPTION
## But de la pull request
Products created by a provider should have a lastProviderId set
Since the product table is messy our apis filters products with a lastProvider not null to create offers. Theses whitelisted products could not be used.
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26932

To fix data after deployment of this fix we could run (id=9 is generic titelive provider) : 
```
staging> select count(*) from product_whitelist
+-------+
| count |
|-------|
| 52    |
+-------+
SELECT 1
Time: 0.008s

select count(*) from product where "idAtProviders" is not null and "lastProviderId" is null and "jsonData"->>'ean' in (select ean from product_whitelist);
+-------+
| count |
|-------|
| 52    |
+-------+
SELECT 1
Time: 0.013s

staging> update product set "lastProviderId"=9 where "idAtProviders" is not null and "lastProviderId" is null and "jsonData"->>'ean' in (select ean from product_whitelist);
You're about to run a destructive command.
Do you want to proceed? [y/N]: y
Your call!
UPDATE 52
Time: 0.064s
```