### PR TITLE
(PC-26929)[API] feat: allow empty dates for collective offer templates

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -361,14 +361,15 @@ def update_collective_offer_template(offer_id: int, new_values: dict) -> None:
     nationalProgramId = new_values.pop("nationalProgramId", None)
     national_program_api.link_or_unlink_offer_to_program(nationalProgramId, offer_to_update)
 
-    if dates := new_values.pop("dates", None):
-        start = dates["start"]
-        end = dates["end"]
-
-        if start.date() < offer_to_update.dateCreated.date():
-            raise educational_exceptions.StartsBeforeOfferCreation()
-
-        offer_to_update.dateRange = DateTimeRange(start, end)
+    if "dates" in new_values:
+        dates = new_values.pop("dates", None)
+        if dates:
+            start, end = dates["start"], dates["end"]
+            if start.date() < offer_to_update.dateCreated.date():
+                raise educational_exceptions.StartsBeforeOfferCreation()
+            offer_to_update.dateRange = DateTimeRange(start, end)
+        else:
+            offer_to_update.dateRange = None
 
     _update_collective_offer(offer=offer_to_update, new_values=new_values)
 

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -639,10 +639,6 @@ class PatchCollectiveOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
 class PatchCollectiveOfferTemplateBodyModel(PatchCollectiveOfferBodyModel):
     priceDetail: PriceDetail | None
     domains: list[int] | None
-
-    # TODO(jeremieb) | None is temporary
-    # when the frontend clients are up to date, dateRange should
-    # become mandatory
     dates: DateRangeModel | None
 
     @validator("domains")

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -122,6 +122,27 @@ class Returns200Test:
 
         assert response.status_code == 200
 
+    def test_without_dates_does_not_update_offer(self, pro_client, offer, template_end):
+        assert offer.dateRange.lower
+        assert offer.dateRange.upper
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer.id)
+            response = pro_client.patch(endpoint, json={})
+        assert response.status_code == 200
+        updated_offer = CollectiveOfferTemplate.query.filter(CollectiveOfferTemplate.id == offer.id).one()
+        assert updated_offer.dateRange.lower
+        assert updated_offer.dateRange.upper
+
+    def test_with_empty_dates_updates_offer(self, pro_client, offer, template_end):
+        assert offer.dateRange.lower
+        assert offer.dateRange.upper
+        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+            endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer.id)
+            response = pro_client.patch(endpoint, json={"dates": None})
+        assert response.status_code == 200
+        updated_offer = CollectiveOfferTemplate.query.filter(CollectiveOfferTemplate.id == offer.id).one()
+        assert updated_offer.dateRange is None
+
 
 class Returns400Test:
     def test_non_approved_offer_fails(self, pro_client, user):


### PR DESCRIPTION
This will enable permanent collective offers templates.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26929

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques