### PR TITLE
(PC-26400)[API] feat: Make `generate_bank_accounts_file` for the new Bank Account journey

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -65,6 +65,7 @@ import pcapi.core.users.constants as users_constants
 import pcapi.core.users.models as users_models
 from pcapi.domain import reimbursement
 from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
 from pcapi.repository import transaction
 from pcapi.tasks import finance_tasks
 from pcapi.utils import human_ids
@@ -1040,6 +1041,7 @@ def generate_payment_files(batch: models.CashflowBatch) -> None:
     """Generate all payment files that are related to the requested
     CashflowBatch and mark all related Cashflow as ``UNDER_REVIEW``.
     """
+    is_new_bank_account_journey_active = FeatureToggle.WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY.is_active()
     logger.info("Generating payment files")
     not_pending_cashflows = models.Cashflow.query.filter(
         models.Cashflow.batchId == batch.id,
@@ -1052,8 +1054,13 @@ def generate_payment_files(batch: models.CashflowBatch) -> None:
         )
 
     file_paths = {}
-    logger.info("Generating reimbursement points file")
-    file_paths["reimbursement_points"] = _generate_reimbursement_points_file(batch.cutoff)
+    if is_new_bank_account_journey_active:
+        logger.info("Generating bank accounts file")
+        file_paths["bank_accounts"] = _generate_bank_accounts_file(batch.cutoff)
+    else:
+        logger.info("Generating reimbursement points file")
+        file_paths["reimbursement_points"] = _generate_reimbursement_points_file(batch.cutoff)
+
     logger.info("Generating payments file")
     file_paths["payments"] = _generate_payments_file(batch.id)
     logger.info(
@@ -1196,6 +1203,44 @@ def _generate_reimbursement_points_file(cutoff: datetime.datetime) -> pathlib.Pa
         _clean_for_accounting(row.bic),
     )
     return _write_csv("reimbursement_points", header, rows=query, row_formatter=row_formatter)
+
+
+def _generate_bank_accounts_file(cutoff: datetime.datetime) -> pathlib.Path:
+    header = (
+        "Identifiant des coordonnées bancaires",
+        "SIRET",
+        "Nom de la structure - Libellé des coordonnées bancaires",
+        "IBAN",
+        "BIC",
+    )
+    query = (
+        offerers_models.Venue.query.join(
+            offerers_models.VenueBankAccountLink,
+            sqla.and_(
+                offerers_models.Venue.id == offerers_models.VenueBankAccountLink.venueId,
+                offerers_models.VenueBankAccountLink.timespan.contains(cutoff),
+            ),
+        )
+        .join(models.BankAccount, offerers_models.VenueBankAccountLink.bankAccountId == models.BankAccount.id)
+        .join(offerers_models.Venue.managingOfferer)
+        .order_by(offerers_models.Venue.id)
+        .with_entities(
+            models.BankAccount.id,
+            offerers_models.Venue.siret,
+            offerers_models.Offerer.name,
+            models.BankAccount.label.label("label"),
+            models.BankAccount.iban.label("iban"),
+            models.BankAccount.bic.label("bic"),
+        )
+    )
+    row_formatter = lambda row: (
+        human_ids.humanize(row.id),
+        _clean_for_accounting(row.siret),
+        _clean_for_accounting(f"{row.name} - {row.label}"),
+        _clean_for_accounting(row.iban),
+        _clean_for_accounting(row.bic),
+    )
+    return _write_csv("bank_accounts", header, rows=query, row_formatter=row_formatter)
 
 
 def _clean_for_accounting(value: str) -> str:

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1211,6 +1211,57 @@ def test_generate_reimbursement_points_file():
 
 
 @clean_temporary_files
+def test_generate_bank_accounts_file():
+    now = datetime.datetime.utcnow()
+    offerer = offerers_factories.OffererFactory(name="Nom de la structure")
+    venue_1 = offerers_factories.VenueFactory(managingOfferer=offerer)
+    venue_2 = offerers_factories.VenueFactory(
+        name='Name1\n "with double quotes"   ', siret='siret 1 "t"', managingOfferer=offerer
+    )
+    venue_3 = offerers_factories.VenueFactory(managingOfferer=offerer)
+    bank_account_1 = factories.BankAccountFactory(
+        label="old-label", iban="older-iban", bic="older-bic", offerer=offerer
+    )
+    bank_account_2 = factories.BankAccountFactory(label="some-label", iban="some-iban", bic="some-bic", offerer=offerer)
+    bank_account_3 = factories.BankAccountFactory(
+        label="newer-label", iban="newer-iban", bic="newer-bic", offerer=offerer
+    )
+    offerers_factories.VenueBankAccountLinkFactory(
+        venue=venue_1,
+        bankAccount=bank_account_1,
+        timespan=[now - datetime.timedelta(days=30), now - datetime.timedelta(days=3)],
+    )
+    offerers_factories.VenueBankAccountLinkFactory(
+        venue=venue_2,
+        bankAccount=bank_account_2,
+        timespan=[now - datetime.timedelta(days=3), now - datetime.timedelta(days=1)],
+    )
+    offerers_factories.VenueBankAccountLinkFactory(
+        venue=venue_3,
+        bankAccount=bank_account_3,
+        timespan=[
+            now - datetime.timedelta(days=1),
+        ],
+    )
+
+    n_queries = 1  # select reimbursement point data
+    with assert_num_queries(n_queries):
+        path = api._generate_bank_accounts_file(datetime.datetime.utcnow() - datetime.timedelta(days=2))
+
+    with path.open(encoding="utf-8") as fp:
+        reader = csv.DictReader(fp, quoting=csv.QUOTE_NONNUMERIC)
+        rows = list(reader)
+    assert len(rows) == 1
+    assert rows[0] == {
+        "Identifiant des coordonnées bancaires": human_ids.humanize(bank_account_2.id),
+        "SIRET": "siret 1 t",
+        "Nom de la structure - Libellé des coordonnées bancaires": "Nom de la structure - some-label",
+        "IBAN": "some-iban",
+        "BIC": "some-bic",
+    }
+
+
+@clean_temporary_files
 def test_generate_payments_file():
     used_date = datetime.datetime(2020, 1, 2)
     # This pricing belongs to a reimbursement point that is the venue


### PR DESCRIPTION
Miroring `generate_reimbursement_points_file` of the old journey, considering slight changes
asked by the accounting department

Other tests cover that part of the code (ones about `generate_payment_files`)
however they're about larger feature and includes calls to `generate_cashflows`
which is not yet handle in the new journey. Thoses tests will ported to the new
journey at the same time than `generate_cashflows`

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26400

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques