### PR TITLE
(PC-26920)[ADAGE] feat: add API to get collective offers for institution

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/authentication.py
+++ b/api/src/pcapi/routes/adage_iframe/authentication.py
@@ -2,6 +2,7 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.educational.api import favorites as educational_api_favorite
 from pcapi.core.educational.api.institution import get_educational_institution_department_code
+from pcapi.core.educational.api.institution import get_offers_count_for_my_institution
 from pcapi.core.educational.exceptions import MissingRequiredRedactorInformation
 from pcapi.core.educational.repository import find_educational_institution_by_uai_code
 from pcapi.routes.adage_iframe import blueprint
@@ -13,7 +14,6 @@ from pcapi.routes.adage_iframe.serialization.adage_authentication import AdageFr
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AuthenticatedInformation
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AuthenticatedResponse
 from pcapi.routes.adage_iframe.serialization.adage_authentication import EducationalInstitutionProgramModel
-from pcapi.routes.adage_iframe.serialization.adage_authentication import get_offers_count
 from pcapi.routes.adage_iframe.serialization.redactor import RedactorPreferences
 from pcapi.serialization.decorator import spectree_serialize
 
@@ -34,7 +34,7 @@ def authenticate(authenticated_information: AuthenticatedInformation) -> Authent
         redactor = _get_redactor(authenticated_information)
         preferences = _get_preferences(redactor)
         favorites_count = _get_favorites_count(redactor)
-        offer_count = get_offers_count(authenticated_information)
+        offer_count = get_offers_count_for_my_institution(authenticated_information.uai)
         programs = _get_programs(institution)
 
         return AuthenticatedResponse(

--- a/api/src/pcapi/routes/adage_iframe/serialization/adage_authentication.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/adage_authentication.py
@@ -3,7 +3,6 @@ import logging
 
 from pydantic.v1 import Field
 from pydantic.v1 import ValidationError
-import sqlalchemy as sa
 
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.exceptions import MissingRequiredRedactorInformation
@@ -79,19 +78,3 @@ def get_redactor_information_from_adage_authentication(
     except ValidationError:
         raise MissingRequiredRedactorInformation()
     return redactor_information
-
-
-def get_offers_count(authenticated_information: AuthenticatedInformation) -> int:
-    offer_query = (
-        educational_models.CollectiveOffer.query.join(
-            educational_models.EducationalInstitution, educational_models.CollectiveOffer.institution
-        )
-        .options(
-            sa.orm.joinedload(educational_models.CollectiveOffer.collectiveStock).joinedload(
-                educational_models.CollectiveStock.collectiveBookings
-            ),
-        )
-        .filter(educational_models.EducationalInstitution.institutionId == authenticated_information.uai)
-    )
-    offer_count = len([query for query in offer_query if query.isBookable])
-    return offer_count

--- a/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution.py
+++ b/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+from datetime import timedelta
+
+from flask import url_for
+import pytest
+
+import pcapi.core.educational.factories as educational_factories
+import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.testing import assert_num_queries
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+stock_date = datetime(2021, 5, 15)
+educational_year_dates = {"start": datetime(2020, 9, 1), "end": datetime(2021, 8, 31)}
+
+
+UAI = "1234UAI"
+EMAIL = "toto@mail.com"
+
+
+@pytest.fixture(name="eac_client")
+def eac_client_fixture(client):
+    return client.with_adage_token(email=EMAIL, uai=UAI)
+
+
+@pytest.fixture(name="redactor")
+def redactor_fixture():
+    return educational_factories.EducationalRedactorFactory(email=EMAIL)
+
+
+class CollectiveOfferTest:
+    def test_get_collective_offer_for_my_institution(self, eac_client, redactor):
+        # Given
+        START_DATE = datetime.today() + timedelta(days=3)
+        venue = offerers_factories.VenueFactory()
+        institution = educational_factories.EducationalInstitutionFactory(institutionId=UAI)
+        stocks = educational_factories.CollectiveStockFactory.create_batch(
+            2,
+            beginningDatetime=START_DATE,
+            collectiveOffer__institution=institution,
+            collectiveOffer__offerVenue={
+                "venueId": venue.id,
+                "addressType": "offererVenue",
+                "otherAddress": "",
+            },
+        )
+
+        dst = url_for("adage_iframe.get_collective_offers_for_my_institution")
+
+        # When
+        # 1. fetch redactor
+        # 2. fetch collective offer and related data
+        # 3. fetch the offerVenue's details (Venue)
+        # 4. find out if its a redactor's favorite
+        with assert_num_queries(4):
+            response = eac_client.get(dst)
+
+            # Then
+            assert response.status_code == 200
+            response_data = sorted(response.json["collectiveOffers"], key=lambda offer: offer["id"])
+            assert len(response_data) == 2, response_data
+            assert response_data[0]["id"] == stocks[0].collectiveOffer.id
+            assert response_data[0]["educationalInstitution"]["id"] == institution.id
+            assert response_data[0]["stock"]["id"] == stocks[0].id
+            assert response_data[1]["id"] == stocks[1].collectiveOffer.id
+            assert response_data[1]["educationalInstitution"]["id"] == institution.id
+            assert response_data[1]["stock"]["id"] == stocks[1].id

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -202,6 +202,21 @@ export class DefaultService {
     });
   }
   /**
+   * get_collective_offers_for_my_institution <GET>
+   * @returns ListCollectiveOffersResponseModel OK
+   * @throws ApiError
+   */
+  public getCollectiveOffersForMyInstitution(): CancelablePromise<ListCollectiveOffersResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/adage-iframe/collective/offers/my_institution',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
    * get_collective_offer <GET>
    * @param offerId
    * @returns CollectiveOfferResponseModel OK


### PR DESCRIPTION
This API will make it possible to get rid of the use of Algolia to list the offers made for a given institution.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26920

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques