### PR TITLE
Pc 26198 template offer no dates

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/CollectiveOfferDateSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/CollectiveOfferDateSection.tsx
@@ -11,21 +11,18 @@ export type CollectiveOfferDateSectionProps = {
 export default function CollectiveOfferDateSection({
   offer,
 }: CollectiveOfferDateSectionProps) {
-  if (!offer.dates?.start || !offer.dates?.end) {
-    return null
+  let description = 'Tout au long de l’année scolaire (l’offre est permanente)'
+
+  if (offer.dates?.start && offer.dates?.end) {
+    const startDateWithoutTz = toDateStrippedOfTimezone(offer.dates.start)
+    const endDateWithoutTz = toDateStrippedOfTimezone(offer.dates.end)
+
+    description = getRangeToFrenchText(startDateWithoutTz, endDateWithoutTz)
   }
-
-  const startDateWithoutTz = toDateStrippedOfTimezone(offer.dates.start)
-  const endDateWithoutTz = toDateStrippedOfTimezone(offer.dates.end)
-
-  const datesFormatted = getRangeToFrenchText(
-    startDateWithoutTz,
-    endDateWithoutTz
-  )
 
   return (
     <SummaryLayout.SubSection title="Date et heure">
-      <SummaryLayout.Row description={datesFormatted} />
+      <SummaryLayout.Row description={description} />
     </SummaryLayout.SubSection>
   )
 }

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/__specs__/CollectiveOfferDateSection.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/__specs__/CollectiveOfferDateSection.spec.tsx
@@ -37,6 +37,10 @@ describe('CollectiveOfferDateSection', () => {
       ...props,
       offer,
     })
-    expect(screen.queryByText('Date et heure')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Tout au long de l’année scolaire (l’offre est permanente)'
+      )
+    ).toBeInTheDocument()
   })
 })

--- a/pro/src/core/OfferEducational/constants.ts
+++ b/pro/src/core/OfferEducational/constants.ts
@@ -45,6 +45,7 @@ export const DEFAULT_EAC_FORM_VALUES: OfferEducationalFormValues = {
   imageCredit: '',
   nationalProgramId: '',
   isTemplate: false,
+  datesType: 'permanent',
   beginningDate: '',
   endingDate: '',
   hour: '',

--- a/pro/src/core/OfferEducational/types.ts
+++ b/pro/src/core/OfferEducational/types.ts
@@ -27,6 +27,8 @@ export type EducationalCategories = {
   educationalSubCategories: EducationalSubCategory[]
 }
 
+export type OfferDatesType = 'permanent' | 'specific_dates'
+
 export type OfferEducationalFormValues = {
   category: string
   subCategory?: SubcategoryIdEnum
@@ -55,6 +57,7 @@ export type OfferEducationalFormValues = {
   imageCredit?: string
   nationalProgramId?: string
   isTemplate: boolean
+  datesType?: OfferDatesType
   beginningDate?: string
   endingDate?: string
   hour?: string

--- a/pro/src/core/OfferEducational/utils/__specs__/createOfferPayload.spec.ts
+++ b/pro/src/core/OfferEducational/utils/__specs__/createOfferPayload.spec.ts
@@ -24,6 +24,7 @@ describe('createOfferPayload', () => {
           ...DEFAULT_EAC_FORM_VALUES,
           beginningDate: '2021-09-01',
           endingDate: '2021-09-10',
+          datesType: 'specific_dates',
         },
         true,
         false

--- a/pro/src/core/OfferEducational/utils/computeInitialValuesFromOffer.ts
+++ b/pro/src/core/OfferEducational/utils/computeInitialValuesFromOffer.ts
@@ -198,6 +198,11 @@ export const computeInitialValuesFromOffer = (
     'search-interventionArea': '',
     nationalProgramId: offer.nationalProgram?.id?.toString() || '',
     isTemplate: offer.isTemplate,
+    datesType: isCollectiveOfferTemplate(offer)
+      ? offer.dates
+        ? 'specific_dates'
+        : 'permanent'
+      : undefined,
     beginningDate:
       isCollectiveOfferTemplate(offer) && offer.dates
         ? format(

--- a/pro/src/core/OfferEducational/utils/createOfferPayload.ts
+++ b/pro/src/core/OfferEducational/utils/createOfferPayload.ts
@@ -80,7 +80,10 @@ export const createCollectiveOfferPayload = (
     priceDetail: isTemplate ? offer.priceDetail : undefined,
     nationalProgramId: Number(offer.nationalProgramId),
     dates:
-      isTemplate && offer.beginningDate && offer.endingDate
+      isTemplate &&
+      offer.datesType === 'specific_dates' &&
+      offer.beginningDate &&
+      offer.endingDate
         ? serializeDates(offer.beginningDate, offer.endingDate, offer.hour)
         : undefined,
     formats: isFormatActive ? offer.formats : null,

--- a/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
@@ -70,18 +70,6 @@ const venue = {
   departementCode: '75',
 }
 
-const isDiscoveryActive = {
-  features: {
-    list: [
-      {
-        nameKey: 'WIP_ENABLE_DISCOVERY',
-        isActive: true,
-      },
-    ],
-    initialized: true,
-  },
-}
-
 vi.mock('apiClient/api', () => ({
   apiAdage: {
     getEducationalOffersCategories: vi.fn(),
@@ -189,27 +177,6 @@ describe('app', () => {
 
       await screen.findByRole('button', { name: /Lieu : Lib de Par's/ })
     })
-    it('should display error messagee when venueId does not exist', async () => {
-      const mockLocation = {
-        ...window.location,
-        search: '?venue=999',
-      }
-
-      window.location = mockLocation
-
-      vi.spyOn(apiAdage, 'getVenueById').mockRejectedValueOnce(null)
-
-      renderApp({
-        initialRouterEntries: ['/recherche?venue=999'],
-        storeOverrides: isDiscoveryActive,
-      })
-
-      expect(
-        await screen.findByText(
-          'Lieu inconnu. Tous les résultats sont affichés.'
-        )
-      ).toBeInTheDocument()
-    })
 
     it('should add geo location filter when user has latitude and longitude', async () => {
       vi.spyOn(apiAdage, 'authenticate').mockResolvedValueOnce({
@@ -235,44 +202,6 @@ describe('app', () => {
         }),
         {}
       )
-    })
-
-    it('should trigger an error notification when siret is invalid', async () => {
-      const mockLocation = {
-        ...window.location,
-        search: '?siret=123456789',
-      }
-
-      window.location = mockLocation
-
-      vi.spyOn(apiAdage, 'getVenueBySiret').mockRejectedValueOnce(null)
-
-      renderApp()
-
-      expect(
-        await screen.findByText(
-          'Lieu inconnu. Tous les résultats sont affichés.'
-        )
-      ).toBeInTheDocument()
-    })
-
-    it('should trigger an error notification when venue is invalid', async () => {
-      const mockLocation = {
-        ...window.location,
-        search: '?venue=123456789',
-      }
-
-      window.location = mockLocation
-
-      vi.spyOn(apiAdage, 'getVenueById').mockRejectedValueOnce(null)
-
-      renderApp()
-
-      expect(
-        await screen.findByText(
-          'Lieu inconnu. Tous les résultats sont affichés.'
-        )
-      ).toBeInTheDocument()
     })
   })
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
@@ -72,12 +72,13 @@ const OfferSummary = ({ offer }: OfferSummaryProps): JSX.Element => {
 
   const formattedDates =
     isCollectiveOfferTemplate(offer) &&
-    offer.dates?.start &&
-    offer.dates?.end &&
-    getRangeToFrenchText(
-      toDateStrippedOfTimezone(offer.dates.start),
-      toDateStrippedOfTimezone(offer.dates.end)
-    )
+    ((offer.dates?.start &&
+      offer.dates?.end &&
+      getRangeToFrenchText(
+        toDateStrippedOfTimezone(offer.dates.start),
+        toDateStrippedOfTimezone(offer.dates.end)
+      )) ||
+      'Tout au long de l’année scolaire (l’offre est permanente)')
 
   if (offerVenue) {
     if (offerVenue.addressType === OfferAddressType.OTHER) {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
@@ -39,4 +39,18 @@ describe('offer summary', () => {
       screen.queryByText('Le mardi 24 octobre 2023')
     ).not.toBeInTheDocument()
   })
+
+  it('should show that the offer is permanent when there are no dates on a template offer', () => {
+    const offer: HydratedCollectiveOfferTemplate = {
+      ...defaultCollectiveTemplateOffer,
+      dates: undefined,
+      isTemplate: true,
+    }
+    renderOfferSummary({ offer })
+    expect(
+      screen.queryByText(
+        'Tout au long de l’année scolaire (l’offre est permanente)'
+      )
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/OffersInstantSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/OffersInstantSearch.spec.tsx
@@ -1,0 +1,113 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+
+import { apiAdage } from 'apiClient/api'
+import Notification from 'components/Notification/Notification'
+import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
+import { defaultAdageUser } from 'utils/adageFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { OffersInstantSearch } from '../OffersInstantSearch'
+import * as utils from '../utils'
+
+const venue = {
+  id: 1436,
+  name: 'Librairie de Paris',
+  publicName: "Librairie de Par's",
+  relative: [],
+  departementCode: '75',
+}
+
+vi.mock('apiClient/api', () => ({
+  apiAdage: {
+    getVenueById: vi.fn(() => {
+      return venue
+    }),
+    getVenueBySiret: vi.fn(() => {
+      return venue
+    }),
+  },
+}))
+
+vi.mock('react-instantsearch', async () => {
+  return {
+    ...((await vi.importActual('react-instantsearch')) ?? {}),
+    Configure: vi.fn(() => <div />),
+    InstantSearch: vi.fn(({ children }) => <div>{children}</div>),
+    useStats: () => ({ nbHits: 1 }),
+    useSearchBox: () => ({ refine: vi.fn() }),
+    useInfiniteHits: () => ({
+      hits: [],
+    }),
+    useInstantSearch: () => ({ scopedResults: [] }),
+    Index: vi.fn(() => <div />),
+  }
+})
+
+function renderOffersInstantSearch() {
+  renderWithProviders(
+    <AdageUserContextProvider adageUser={defaultAdageUser}>
+      <OffersInstantSearch />
+      <Notification />
+    </AdageUserContextProvider>
+  )
+}
+
+describe('OffersInstantSearch', () => {
+  beforeEach(() => {
+    window.IntersectionObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }))
+  })
+
+  it('should show an error message when the venue id is invalid', async () => {
+    const mockLocation = {
+      ...window.location,
+      search: '?venue=1436',
+    }
+    window.location = mockLocation
+
+    vi.spyOn(apiAdage, 'getVenueById').mockRejectedValueOnce(null)
+
+    renderOffersInstantSearch()
+
+    expect(
+      await screen.findByText('Lieu inconnu. Tous les résultats sont affichés.')
+    ).toBeInTheDocument()
+  })
+
+  it('should show an error message when the siret is invalid', async () => {
+    const mockLocation = {
+      ...window.location,
+      search: '?siret=1436',
+    }
+    window.location = mockLocation
+
+    vi.spyOn(apiAdage, 'getVenueBySiret').mockRejectedValueOnce(null)
+
+    renderOffersInstantSearch()
+
+    expect(
+      await screen.findByText('Lieu inconnu. Tous les résultats sont affichés.')
+    ).toBeInTheDocument()
+  })
+
+  it('should filter on the venue specified in the url', async () => {
+    const mockLocation = {
+      ...window.location,
+      search: '?venue=1436',
+    }
+    window.location = mockLocation
+
+    const setFiltersSpy = vi
+      .spyOn(utils, 'adageFiltersToFacetFilters')
+      .mockReturnValue({ queryFilters: [], filtersKeys: [] })
+
+    renderOffersInstantSearch()
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(setFiltersSpy).toHaveBeenCalledOnce()
+  })
+})

--- a/pro/src/pages/CollectiveOfferEdition/utils/__specs__/createPatchOfferPayload.spec.ts
+++ b/pro/src/pages/CollectiveOfferEdition/utils/__specs__/createPatchOfferPayload.spec.ts
@@ -46,6 +46,7 @@ describe('createPatchOfferPayload', () => {
     interventionArea: ['2A'],
     beginningDate: '2021-09-01',
     endingDate: '2021-09-30',
+    datesType: 'specific_dates',
     hour: '10:00',
     isTemplate: false,
   }
@@ -81,6 +82,7 @@ describe('createPatchOfferPayload', () => {
     nationalProgramId: '1',
     beginningDate: '2021-09-01',
     endingDate: '2021-09-30',
+    datesType: 'specific_dates',
     hour: '10:00',
     isTemplate: false,
     formats: [EacFormat.ATELIER_DE_PRATIQUE],
@@ -133,14 +135,20 @@ describe('createPatchOfferPayload', () => {
   })
   it('should return the correct patch offer payload for a template offer when dates are empty', () => {
     const payload = createPatchOfferTemplatePayload(
-      { ...offer, priceDetail: '123', isTemplate: true, beginningDate: '' },
+      {
+        ...offer,
+        priceDetail: '123',
+        isTemplate: true,
+        beginningDate: '',
+        datesType: 'permanent',
+      },
       initialValues
     )
 
     expect(payload).toMatchObject({
       venueId: venueId,
       priceDetail: '123',
-      dates: undefined,
+      dates: null,
     })
   })
 })

--- a/pro/src/pages/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
+++ b/pro/src/pages/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
@@ -136,6 +136,7 @@ export const createPatchOfferTemplatePayload = (
     'imageCredit',
     'beginningDate',
     'endingDate',
+    'datesType',
     'hour',
     'isTemplate',
   ]
@@ -156,9 +157,10 @@ export const createPatchOfferTemplatePayload = (
   changedValues.contactPhone = offer.phone || null
   changedValues.nationalProgramId = Number(offer.nationalProgramId) || null
   changedValues.dates =
-    offer.beginningDate && offer.endingDate
+    offer.datesType === 'specific_dates' &&
+    offer.beginningDate &&
+    offer.endingDate
       ? serializeDates(offer.beginningDate, offer.endingDate, offer.hour)
-      : undefined
-
+      : null
   return changedValues
 }

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/FormDates.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/FormDates.tsx
@@ -5,7 +5,8 @@ import Callout from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
 import FormLayout from 'components/FormLayout'
 import { OfferEducationalFormValues } from 'core/OfferEducational'
-import { DatePicker, TimePicker } from 'ui-kit'
+import { DatePicker, RadioGroup, TimePicker } from 'ui-kit'
+import { BaseRadioVariant } from 'ui-kit/form/shared/BaseRadio/types'
 import { isDateValid } from 'utils/date'
 
 import styles from './FormDates.module.scss'
@@ -24,37 +25,54 @@ const FormDates = ({
     ? new Date(values.beginningDate)
     : new Date()
   return (
-    <FormLayout.Section
-      title="Date et heure"
-      description="Indiquez la date et l'heure ou la période pendant laquelle votre offre peut avoir lieu."
-    >
-      <Callout type={CalloutVariant.INFO} className={styles.banner}>
-        Votre offre sera désactivée automatiquement à l’issue des dates
-        précisées ci-dessous.
-      </Callout>
-      <FormLayout.Row className={styles.container}>
-        <DatePicker
-          name="beginningDate"
-          label="Date de début"
-          disabled={disableForm}
-          minDate={minBeginningDate}
-          hideFooter
-        />
-        <DatePicker
-          name="endingDate"
-          label="Date de fin"
-          disabled={disableForm}
-          minDate={minDateForEndingDate}
-          hideFooter
-        />
-        <TimePicker
-          name="hour"
-          label="Horaire"
-          disabled={disableForm}
-          isOptional
-          hideFooter
-        />
-      </FormLayout.Row>
+    <FormLayout.Section title="Date et heure">
+      <RadioGroup
+        group={[
+          {
+            label: 'Tout au long de l’année scolaire, l’offre est permanente',
+            value: 'permanent',
+          },
+          {
+            label: 'Pendant une période précise uniquement',
+            value: 'specific_dates',
+          },
+        ]}
+        variant={BaseRadioVariant.SECONDARY}
+        withBorder
+        legend="Quand votre offre peut-elle avoir lieu ?"
+        name="datesType"
+      />
+      {values.datesType === 'specific_dates' && (
+        <>
+          <Callout type={CalloutVariant.INFO} className={styles.banner}>
+            Votre offre sera désactivée automatiquement à l’issue des dates
+            précisées ci-dessous.
+          </Callout>
+          <FormLayout.Row className={styles.container}>
+            <DatePicker
+              name="beginningDate"
+              label="Date de début"
+              disabled={disableForm}
+              minDate={minBeginningDate}
+              hideFooter
+            />
+            <DatePicker
+              name="endingDate"
+              label="Date de fin"
+              disabled={disableForm}
+              minDate={minDateForEndingDate}
+              hideFooter
+            />
+            <TimePicker
+              name="hour"
+              label="Horaire"
+              disabled={disableForm}
+              isOptional
+              hideFooter
+            />
+          </FormLayout.Row>
+        </>
+      )}
     </FormLayout.Section>
   )
 }

--- a/pro/src/screens/OfferEducational/validationSchema.ts
+++ b/pro/src/screens/OfferEducational/validationSchema.ts
@@ -3,7 +3,7 @@ import { parsePhoneNumberFromString } from 'libphonenumber-js'
 import * as yup from 'yup'
 
 import { OfferAddressType } from 'apiClient/v1'
-import { MAX_DETAILS_LENGTH } from 'core/OfferEducational'
+import { MAX_DETAILS_LENGTH, OfferDatesType } from 'core/OfferEducational'
 import { toDateStrippedOfTimezone } from 'utils/date'
 
 const threeYearsFromNow = addYears(new Date(), 3)
@@ -155,13 +155,15 @@ export function getOfferEducationalValidationSchema(isFormatActive: boolean) {
         then: (schema) => schema.required(),
       }),
     priceDetail: yup.string().max(MAX_DETAILS_LENGTH),
-    beginningDate: yup.string().when('isTemplate', {
-      is: true,
+    beginningDate: yup.string().when(['isTemplate', 'datesType'], {
+      is: (isTemplate: boolean, datesType: OfferDatesType) =>
+        isTemplate && datesType === 'specific_dates',
       then: (schema) =>
         schema.required('Veuillez renseigner une date de début'),
     }),
-    endingDate: yup.string().when('isTemplate', {
-      is: true,
+    endingDate: yup.string().when(['isTemplate', 'datesType'], {
+      is: (isTemplate: boolean, datesType: OfferDatesType) =>
+        isTemplate && datesType === 'specific_dates',
       then: (schema) =>
         schema
           .required('Veuillez renseigner une date de fin')


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26198

**Objectif**
Dans le formulaire d'une offre vitrine collective, ajouter un radio button pour choisir si l'offre est permanente (pas de dates) ou si elle a des dates précises (fonctionnement actuel). Aussi adaptation du text dans le résumé d'une offre et dans adage pour les offres permanentes.

**A vérifier**
- Créer une offre vitrine collective : voir le radio button par défaut sur "permanente" - l'offre est valide quand soit elle est permanente soit elle a des dates inscrites
- Update une offre vitrine colelctive qui a des dates : le radio button est par défaut sur les dates
- Update une offre vitrine colelctive qui est permanente : le radio button est par défaut sur "permanente"
- Après création d'une offre permanente, le texte adapté s'affiche dans le résumé sur le portail pro
- Après création d'une offre permanente, le texte adapté s'affiche dans les infos de l'offre sur adage

<img width="809" alt="Capture d’écran 2024-01-16 à 08 36 00" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/3ba102ac-3e34-479d-b6d6-9d0fd87baa14">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques