### PR TITLE
(PC-24894)[API] fix: remove bulk Batch event tracking

### DIFF
--- a/api/src/pcapi/core/external/batch.py
+++ b/api/src/pcapi/core/external/batch.py
@@ -107,12 +107,3 @@ def track_ubble_ko_event(user_id: int, reason_code: fraud_models.FraudReasonCode
         event_name=event_name, event_payload={"error_code": reason_code.value}, user_id=user_id
     )
     batch_tasks.track_event_task.delay(payload)
-
-
-def bulk_track_ubble_ko_events(users_per_code: dict[fraud_models.FraudReasonCode, list[int]]) -> None:
-    event_name = push_notifications.BatchEvent.HAS_UBBLE_KO_STATUS
-    for reason_code, user_ids in users_per_code.items():
-        payload = batch_tasks.TrackBatchBulkEventRequest(
-            event_name=event_name, event_payload={"error_code": reason_code.value}, user_ids=user_ids
-        )
-        batch_tasks.bulk_track_events_task.delay(payload)

--- a/api/src/pcapi/core/mails/transactional/users/ubble/reminder_emails.py
+++ b/api/src/pcapi/core/mails/transactional/users/ubble/reminder_emails.py
@@ -1,4 +1,3 @@
-import collections
 import datetime
 import logging
 
@@ -6,7 +5,6 @@ from dateutil.relativedelta import relativedelta
 import sqlalchemy as sqla
 
 from pcapi import settings
-from pcapi.core.external.batch import bulk_track_ubble_ko_events
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.fraud.ubble.constants as ubble_constants
 from pcapi.core.mails.transactional import send_subscription_document_error_email
@@ -30,8 +28,6 @@ def send_reminders() -> None:
         reason_codes_filter=list(ubble_constants.REASON_CODES_FOR_LONG_ACTION_REMINDERS),
     )
 
-    users_to_notify_per_code = collections.defaultdict(list)
-
     for user, relevant_reason_code in users_with_quick_actions + users_with_long_actions:
         if not relevant_reason_code:
             logger.error(
@@ -40,10 +36,7 @@ def send_reminders() -> None:
             )
             continue
 
-        users_to_notify_per_code[relevant_reason_code].append(user.id)
         send_subscription_document_error_email(user.email, relevant_reason_code, is_reminder=True)
-
-    bulk_track_ubble_ko_events(users_to_notify_per_code)
 
 
 def _find_users_to_remind(

--- a/api/src/pcapi/notifications/push/__init__.py
+++ b/api/src/pcapi/notifications/push/__init__.py
@@ -48,12 +48,3 @@ def track_event(
     backend().track_event(
         user_id, event.value, event_payload, can_be_asynchronously_retried=can_be_asynchronously_retried
     )
-
-
-def bulk_track_events(
-    user_ids: list[int], event: BatchEvent, event_payload: dict, can_be_asynchronously_retried: bool = False
-) -> None:
-    backend = import_string(settings.PUSH_NOTIFICATION_BACKEND)
-    backend().bulk_track_events(
-        user_ids, event.value, event_payload, can_be_asynchronously_retried=can_be_asynchronously_retried
-    )

--- a/api/src/pcapi/notifications/push/backends/batch.py
+++ b/api/src/pcapi/notifications/push/backends/batch.py
@@ -163,31 +163,3 @@ class BatchBackend:
 
         make_post_request(BatchAPI.ANDROID)
         make_post_request(BatchAPI.IOS)
-
-    def bulk_track_events(
-        self, user_ids: list[int], event_name: str, event_payload: dict, can_be_asynchronously_retried: bool = False
-    ) -> None:
-        """https://doc.batch.com/api/trigger-events-api/track-events/"""
-
-        def make_post_request(api: BatchAPI) -> None:
-            self.handle_request(
-                "POST",
-                f"{API_URL}/1.0/{api.value}/events/users",
-                api_name="bulk_track_events",
-                payload=[
-                    {
-                        "id": str(user_id),
-                        "events": [
-                            {
-                                "name": f"ue.{event_name}",
-                                "attributes": event_payload,
-                            },
-                        ],
-                    }
-                    for user_id in user_ids
-                ],
-                can_be_asynchronously_retried=can_be_asynchronously_retried,
-            )
-
-        make_post_request(BatchAPI.ANDROID)
-        make_post_request(BatchAPI.IOS)

--- a/api/src/pcapi/notifications/push/backends/logger.py
+++ b/api/src/pcapi/notifications/push/backends/logger.py
@@ -58,13 +58,3 @@ class LoggerBackend:
             user_id,
             extra={"event_payload": event_payload, "can_be_asynchronously_retried": can_be_asynchronously_retried},
         )
-
-    def bulk_track_events(
-        self, user_ids: list[int], event_name: str, event_payload: dict, can_be_asynchronously_retried: bool = False
-    ) -> None:
-        logger.info(
-            "A request to track event=ue.%s would be sent for %d users",
-            event_name,
-            len(user_ids),
-            extra={"event_payload": event_payload, "can_be_asynchronously_retried": can_be_asynchronously_retried},
-        )

--- a/api/src/pcapi/notifications/push/backends/testing.py
+++ b/api/src/pcapi/notifications/push/backends/testing.py
@@ -61,18 +61,3 @@ class TestingBackend(LoggerBackend):
                 "can_be_asynchronously_retried": can_be_asynchronously_retried,
             }
         )
-
-    def bulk_track_events(
-        self, user_ids: list[int], event_name: str, event_payload: dict, can_be_asynchronously_retried: bool = False
-    ) -> None:
-        super().bulk_track_events(
-            user_ids, event_name, event_payload, can_be_asynchronously_retried=can_be_asynchronously_retried
-        )
-        testing.requests.append(
-            {
-                "user_ids": user_ids,
-                "event_name": event_name,
-                "event_payload": event_payload,
-                "can_be_asynchronously_retried": can_be_asynchronously_retried,
-            }
-        )

--- a/api/src/pcapi/tasks/batch_tasks.py
+++ b/api/src/pcapi/tasks/batch_tasks.py
@@ -4,7 +4,6 @@ import logging
 
 from pcapi import settings
 import pcapi.notifications.push as push_notifications
-from pcapi.notifications.push import bulk_track_events
 from pcapi.notifications.push import delete_user_attributes
 from pcapi.notifications.push import send_transactional_notification
 from pcapi.notifications.push import track_event
@@ -33,12 +32,6 @@ class TrackBatchEventRequest(BaseModel):
     event_payload: dict
 
 
-class TrackBatchBulkEventRequest(BaseModel):
-    user_ids: list[int]
-    event_name: push_notifications.BatchEvent
-    event_payload: dict
-
-
 @task(settings.GCP_BATCH_CUSTOM_DATA_ANDROID_QUEUE_NAME, "/batch/android/update_user_attributes")  # type: ignore [arg-type]
 def update_user_attributes_android_task(payload: UpdateBatchAttributesRequest) -> None:
     update_user_attributes(BatchAPI.ANDROID, payload.user_id, payload.attributes, can_be_asynchronously_retried=True)
@@ -62,8 +55,3 @@ def send_transactional_notification_task(payload: TransactionalNotificationData)
 @task(settings.GCP_BATCH_CUSTOM_EVENT_QUEUE_NAME, "/batch/track_event")
 def track_event_task(payload: TrackBatchEventRequest) -> None:
     track_event(payload.user_id, payload.event_name, payload.event_payload, can_be_asynchronously_retried=True)
-
-
-@task(settings.GCP_BATCH_CUSTOM_EVENT_QUEUE_NAME, "/batch/bulk_track_events")
-def bulk_track_events_task(payload: TrackBatchBulkEventRequest) -> None:
-    bulk_track_events(payload.user_ids, payload.event_name, payload.event_payload, can_be_asynchronously_retried=True)


### PR DESCRIPTION
Il existe un délai après un KO Ubble après lequel l'utilisateur reçoit une notification Batch. Ce délai étant actuellement géré par le backend **et** par l'interface web Batch, celui du backend est inutile.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-24894
