### PR TITLE
(PC-26492)[PRO] style: wording de noreservations

### DIFF
--- a/pro/src/pages/Bookings/NoBookingsForPreFiltersMessage/NoBookingsForPreFiltersMessage.tsx
+++ b/pro/src/pages/Bookings/NoBookingsForPreFiltersMessage/NoBookingsForPreFiltersMessage.tsx
@@ -33,7 +33,7 @@ const NoBookingsForPreFiltersMessage = ({
       icon={fullRefresh}
       onClick={resetPreFilters}
     >
-      Afficher toutes les réservations
+      Réinitialiser les filtres
     </Button>
   </div>
 )

--- a/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -211,7 +211,7 @@ describe('components | BookingsRecap | Pro user', () => {
     await submitFilters()
 
     // When
-    const resetButton = screen.getByText('Afficher toutes les réservations', {
+    const resetButton = screen.getByText('Réinitialiser les filtres', {
       selector: '.button-ternary-pink',
     })
     await userEvent.click(resetButton)


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26492

## But de la pull request 

Revue UI : Le wording du CTA sur l’onglet réservation des pages offres est toujours “Réinitialiser les filtres” et non “Afficher toutes les réservations”

Branche: PC-26492-wording-reservation-cta3

<img width="867" alt="Capture d’écran 2024-01-16 à 13 09 42" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/b60f3964-295f-4e73-b8da-46e1b2422ea5">
