### PR TITLE
(PC-26864)[API] feat: Create the new `WIP_ENABLE_PRO_SIDE_NAV` FF.

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -120,6 +120,7 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_MARSEILLE = "Activer Marseille en grand"
     WIP_GOOGLE_MAPS_VENUE_IMAGES = "Activer l'affichage des images des lieux importées depuis Google Maps"
     WIP_PARTNER_PAGE = 'Activer la nouvelle version des pages "Partenaire"'
+    WIP_ENABLE_PRO_SIDE_NAV = "Refonte de la navigation de l'app pro"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -186,6 +187,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_GOOGLE_MAPS_VENUE_IMAGES,  # FIXME Abdelmoujib: remove when feature is ready https://passculture.atlassian.net/browse/PC-26459
     FeatureToggle.WIP_PARTNER_PAGE,
     FeatureToggle.ENABLE_CRON_TO_UPDATE_OFFERER_STATS,
+    FeatureToggle.WIP_ENABLE_PRO_SIDE_NAV,
 )
 
 if settings.IS_PROD or settings.IS_STAGING:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26864

- Le ff `WIP_ENABLE_PRO_SIDE_NAV` est créé pour la nouvelle navigation latérale. 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques