### PR TITLE
(PC-26795)[BO] feat: all 'cancellation reason' filter to individual bookings page

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-232786daf672 (pre) (head)
+fc7dd42a29ac (pre) (head)
 fadf7f6f4c60 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240117T111957_fc7dd42a29ac_add_index_on_booking_cancellation_reason.py
+++ b/api/src/pcapi/alembic/versions/20240117T111957_fc7dd42a29ac_add_index_on_booking_cancellation_reason.py
@@ -1,0 +1,36 @@
+"""Add index on cancellationReason column of Booking table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi import settings
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "fc7dd42a29ac"
+down_revision = "232786daf672"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("SET SESSION statement_timeout='400s'")
+    op.create_index(
+        index_name="ix_booking_cancellation_reason",
+        table_name="booking",
+        if_not_exists=True,
+        columns=["cancellationReason"],
+        unique=False,
+        postgresql_where=sa.text('"cancellationReason" IS NOT NULL'),
+        postgresql_concurrently=True,
+    )
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    op.drop_index(
+        index_name="ix_booking_cancellation_reason",
+        table_name="booking",
+    )

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -136,6 +136,11 @@ class Booking(PcObject, Base, Model):
         ),
         nullable=True,
     )
+    Index(
+        "ix_booking_cancellation_reason",
+        cancellationReason,
+        postgresql_where=cancellationReason.is_not(None),
+    )
 
     status: BookingStatus = Column(Enum(BookingStatus), nullable=False, default=BookingStatus.CONFIRMED)
     Index("ix_booking_status", status)

--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -151,6 +151,13 @@ class GetCollectiveBookingListForm(BaseBookingListForm):
 
 
 class GetIndividualBookingListForm(BaseBookingListForm):
+    cancellation_reason = fields.PCSelectMultipleField(
+        "Raison d'annulation",
+        choices=utils.choices_from_enum(
+            bookings_models.BookingCancellationReasons, formatter=filters.format_booking_cancellation_reason
+        ),
+    )
+
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
         self.q.label.text = "Code contremarque ou liste, Nom, email ou ID (offre, bénéficiaire ou résa)"
@@ -160,14 +167,15 @@ class GetIndividualBookingListForm(BaseBookingListForm):
         self._fields.move_to_end("venue")
         self._fields.move_to_end("category")
         self._fields.move_to_end("status")
+        self._fields.move_to_end("cancellation_reason")
         self._fields.move_to_end("cashflow_batches")
 
     def is_empty(self) -> bool:
-        return super().is_empty() and not self.category.data
+        return super().is_empty() and not self.category.data and not self.cancellation_reason.data
 
     @property
     def is_single_venue_with_optional_dates(self) -> bool:
-        return super().is_single_venue_with_optional_dates and not self.category.data
+        return super().is_single_venue_with_optional_dates and not self.category.data and not self.cancellation_reason
 
     category = fields.PCSelectMultipleField(
         "Catégories", choices=utils.choices_from_enum(categories.CategoryIdLabelEnum)

--- a/api/src/pcapi/routes/backoffice/bookings/helpers.py
+++ b/api/src/pcapi/routes/backoffice/bookings/helpers.py
@@ -105,6 +105,9 @@ def get_bookings(
         )
         base_query = base_query.filter(finance_models.Cashflow.batchId.in_(form.cashflow_batches.data))
 
+    if hasattr(form, "cancellation_reason") and form.cancellation_reason.data:
+        base_query = base_query.filter(booking_class.cancellationReason.in_(form.cancellation_reason.data))  # type: ignore [union-attr]
+
     if form.q.data:
         search_query = form.q.data
 


### PR DESCRIPTION
## But de la pull request

 - Ajout d'un index sur la colonne `cancellationReason` de la table `booking`
 - Ajout d'un filtre `Raison d'annulation` dans la page `Réservations individuelles` : 

<img width="1330" alt="Capture d’écran 2024-01-16 à 17 21 00" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/e7173492-1c36-4391-b010-fc9065d4fc2c">


Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26795

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques