### PR TITLE
(PC-26962)fix: prevent user to submit offerer creation multiple times

### DIFF
--- a/pro/src/pages/Offerers/OffererCreation/OffererCreation.tsx
+++ b/pro/src/pages/Offerers/OffererCreation/OffererCreation.tsx
@@ -118,7 +118,10 @@ export const OffererCreation = (): JSX.Element => {
                   </ButtonLink>
                 </div>
                 <div>
-                  <SubmitButton variant={ButtonVariant.PRIMARY}>
+                  <SubmitButton
+                    variant={ButtonVariant.PRIMARY}
+                    disabled={formik.isSubmitting}
+                  >
                     Créer
                   </SubmitButton>
                 </div>

--- a/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.tsx
+++ b/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.tsx
@@ -193,4 +193,39 @@ describe('src | components | OffererCreation', () => {
       screen.getByText('Le code SIREN saisi n’est pas valide.')
     ).toBeInTheDocument()
   })
+
+  it('should disable creation button while submitting', async () => {
+    vi.spyOn(api, 'getSirenInfo').mockResolvedValue({
+      name: 'Ma Petite structure',
+      siren: '881457238',
+      address: {
+        street: '4 rue du test',
+        city: 'Plessix-Balisson',
+        postalCode: '22350',
+      },
+      ape_code: '',
+    })
+
+    vi.spyOn(api, 'createOfferer').mockRejectedValueOnce({
+      id: 1,
+    } as PostOffererResponseModel)
+
+    renderOffererCreation({})
+
+    await userEvent.type(screen.getByLabelText('SIREN'), '881457238')
+    await userEvent.tab()
+
+    const creationButton = screen.getByRole('button', { name: 'Créer' })
+    expect(creationButton).toBeEnabled()
+
+    // Here we dont wait userEvent.click because we want to test the state of the button before the call end
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    userEvent.click(screen.getByRole('button', { name: 'Créer' }))
+    await waitFor(() => {
+      expect(creationButton).toBeDisabled()
+    })
+    await waitFor(() => {
+      expect(creationButton).toBeEnabled()
+    })
+  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26962


Empêcher l'utilisateur de soumettre plusieurs fois le formulaire de création de structure. 
Solution tech : disable le bouton pendant l'appel API à la route de création


Screen 


![Capture d’écran 2024-01-16 à 17 25 13](https://github.com/pass-culture/pass-culture-main/assets/71768799/5e3105f7-c842-4eb4-8cb3-d37ad3b7c66c)


