### PR TITLE
(PC-26976)[PRO] fix: title hierarchy - move offer name into h1

### DIFF
--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
@@ -26,6 +26,7 @@
 
   &-sub-heading {
     max-width: rem.torem(588px);
+    display: block;
     font-weight: 500;
   }
 

--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -67,11 +67,12 @@ const CollectiveOfferLayout = ({
           </Tag>
         )}
         {}
-        <h1 className={styles['eac-layout-heading']}>{title}</h1>
-
-        {subTitle && (
-          <h2 className={styles['eac-layout-sub-heading']}>{subTitle}</h2>
-        )}
+        <h1 className={styles['eac-layout-heading']}>
+          {title}{' '}
+          {subTitle && (
+            <span className={styles['eac-layout-sub-heading']}>{subTitle}</span>
+          )}
+        </h1>
       </div>
 
       {

--- a/pro/src/components/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
+++ b/pro/src/components/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
@@ -50,7 +50,7 @@ describe('CollectiveOfferLayout', () => {
   it('should render summary page layout in edition', () => {
     renderCollectiveOfferLayout('/offre/A1/collectif/recapitulatif', {})
 
-    const title = screen.getByRole('heading', { name: 'Récapitulatif' })
+    const title = screen.getByRole('heading', { name: /Récapitulatif/ })
 
     expect(title).toBeInTheDocument()
   })
@@ -59,7 +59,7 @@ describe('CollectiveOfferLayout', () => {
     renderCollectiveOfferLayout('/offre/A1/collectif/', { isCreation: true })
 
     const title = screen.getByRole('heading', {
-      name: 'Créer une nouvelle offre collective',
+      name: /Créer une nouvelle offre collective/,
     })
 
     expect(title).toBeInTheDocument()
@@ -72,7 +72,7 @@ describe('CollectiveOfferLayout', () => {
     })
 
     const title = screen.getByRole('heading', {
-      name: 'Créer une offre pour un établissement scolaire',
+      name: /Créer une offre pour un établissement scolaire/,
     })
 
     expect(title).toBeInTheDocument()

--- a/pro/src/pages/CollectiveOfferCreation/__specs__/CollectiveOfferCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferCreation/__specs__/CollectiveOfferCreation.spec.tsx
@@ -40,7 +40,7 @@ describe('CollectiveOfferCreation', () => {
 
     expect(
       await screen.findByRole('heading', {
-        name: 'Créer une nouvelle offre collective',
+        name: /Créer une nouvelle offre collective/,
       })
     ).toBeInTheDocument()
     expect(
@@ -58,7 +58,7 @@ describe('CollectiveOfferCreation', () => {
 
     expect(
       await screen.findByRole('heading', {
-        name: 'Créer une nouvelle offre collective',
+        name: /Créer une nouvelle offre collective/,
       })
     ).toBeInTheDocument()
     expect(screen.getByText('Offre vitrine')).toBeInTheDocument()

--- a/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
@@ -45,7 +45,7 @@ describe('CollectiveOfferStockCreation', () => {
 
     expect(
       await screen.findByRole('heading', {
-        name: 'Créer une nouvelle offre collective',
+        name: /Créer une nouvelle offre collective/,
       })
     ).toBeInTheDocument()
     expect(
@@ -93,7 +93,7 @@ describe('CollectiveOfferStockCreation', () => {
     renderCollectiveStockCreation('/offre/A1/collectif/stocks', props)
     expect(
       await screen.findByRole('heading', {
-        name: 'Créer une offre pour un établissement scolaire',
+        name: /Créer une offre pour un établissement scolaire/,
       })
     ).toBeInTheDocument()
 

--- a/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
@@ -68,7 +68,7 @@ describe('CollectiveOfferSummaryCreation', () => {
     )
     expect(
       screen.getByRole('heading', {
-        name: 'Créer une nouvelle offre collective',
+        name: /Créer une nouvelle offre collective/,
       })
     ).toBeInTheDocument()
     expect(

--- a/pro/src/pages/CollectiveOfferVisibility/__specs__/CollectiveOfferCreationVisibility.spec.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/__specs__/CollectiveOfferCreationVisibility.spec.tsx
@@ -43,7 +43,7 @@ describe('CollectiveOfferVisibility', () => {
 
     expect(
       await screen.findByRole('heading', {
-        name: 'Créer une nouvelle offre collective',
+        name: /Créer une nouvelle offre collective/,
       })
     ).toBeInTheDocument()
 

--- a/pro/src/screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.module.scss
+++ b/pro/src/screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.module.scss
@@ -13,6 +13,7 @@
 .offer-title {
   @include fonts.title4;
 
+  display: block;
   font-weight: 500;
 }
 

--- a/pro/src/screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.tsx
+++ b/pro/src/screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.tsx
@@ -39,8 +39,12 @@ const IndivualOfferLayout = ({
         })}
       >
         <div>
-          <h1>{title}</h1>
-          {offer && <h2 className={styles['offer-title']}>{offer.name}</h2>}
+          <h1>
+            {title}{' '}
+            {offer && (
+              <span className={styles['offer-title']}>{offer.name}</span>
+            )}
+          </h1>
         </div>
         {shouldDisplayActionOnStatus && (
           <div className={styles['right']}>

--- a/pro/src/screens/IndividualOffer/IndivualOfferLayout/__specs__/IndivualOfferLayout.spec.tsx
+++ b/pro/src/screens/IndividualOffer/IndivualOfferLayout/__specs__/IndivualOfferLayout.spec.tsx
@@ -54,10 +54,10 @@ describe('IndivualOfferLayout', () => {
     expect(screen.getByText('Stock & Prix')).toBeInTheDocument()
 
     expect(
-      screen.getByRole('heading', { name: 'offer name' })
+      screen.getByRole('heading', { name: /offer name/ })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('heading', { name: 'layout title' })
+      screen.getByRole('heading', { name: /layout title/ })
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26976

## Recette

Avec le plugin HeadingsMap, vérifier que le nom de l’offre est bien inclus dans le titre de niveau 1, sur les parcours de création et de modification d’offre collective et individuelle

Au niveau graphique l'affichage devrait être iso

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques