### PR TITLE
(BSR)[API] refactor: remove fixme that has been abandonned

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -403,14 +403,6 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
         "VenueBankAccountLink", back_populates="venue", passive_deletes=True
     )
 
-    # FIXME: ogeber 27.11 uncomment once all permanent venues have a ban_id (cf ticket 25999)
-    # __table_args__ = (
-    #     CheckConstraint(
-    #         "(isPermanent = FALSE OR (isPermanent = TRUE AND banId IS NOT NULL))",
-    #         name="check_ban_id_is_non_nullable_when_venue_is_permanent"
-    #     ),
-    # )
-
     def _get_type_banner_url(self) -> str | None:
         elligible_banners: tuple[str, ...] = VENUE_TYPE_DEFAULT_BANNERS.get(self.venueTypeCode, tuple())
         try:


### PR DESCRIPTION
## But de la pull request

BSR: on ne va finalement pas rendre la colonne banId non nullable (car il existe des lieux permanents non virtuels qui n'ont pas de banId , par exemple ceux situés à st-pierre et miquelon ) 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques