### PR TITLE
(PC-26712)[EAC] feat: adage iframe logs: add index field

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -146,6 +146,7 @@ def log_consult_playlist_element(
             "offerId": body.elementId if body.playlistType == serialization.AdagePlaylistType.OFFER else None,
             "venueId": body.elementId if body.playlistType == serialization.AdagePlaylistType.VENUE else None,
             "domainId": body.elementId if body.playlistType == serialization.AdagePlaylistType.DOMAIN else None,
+            "index": body.index,
             "playlistId": body.playlistId,
             "from": body.iframeFrom,
             "queryId": body.queryId,
@@ -154,7 +155,6 @@ def log_consult_playlist_element(
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
     )
-    return
 
 
 @blueprint.adage_iframe.route("/logs/fav-offer/", methods=["POST"])

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -36,6 +36,7 @@ class PlaylistBody(AdageBaseModel):
     playlistType: AdagePlaylistType
     playlistId: int
     elementId: int | None
+    index: int | None
 
 
 class SearchBody(AdageBaseModel):

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -34,15 +34,15 @@ class LogsTest:
         }
 
     @pytest.mark.parametrize(
-        "playlist_type,element_id,offer_id,venue_id,domain_id",
+        "playlist_type,element_id,index,offer_id,venue_id,domain_id",
         [
-            ("offer", 34, 34, None, None),
-            ("venue", 45, None, 45, None),
-            ("domain", 56, None, None, 56),
+            ("offer", 34, 1, 34, None, None),
+            ("venue", 45, 2, None, 45, None),
+            ("domain", 56, None, None, None, 56),
         ],
     )
     def test_log_consult_playlist_element(
-        self, client, caplog, playlist_type, element_id, offer_id, venue_id, domain_id
+        self, client, caplog, playlist_type, element_id, index, offer_id, venue_id, domain_id
     ):
         # given
         adage_jwt_fake_valid_token = create_adage_valid_token_with_email(email="test@mail.com")
@@ -57,6 +57,7 @@ class LogsTest:
                     "iframeFrom": "for_my_institution",
                     "queryId": "1234a",
                     "elementId": element_id,
+                    "index": index,
                     "playlistId": 99,
                     "playlistType": playlist_type,
                 },
@@ -76,6 +77,7 @@ class LogsTest:
             "offerId": offer_id,
             "venueId": venue_id,
             "domainId": domain_id,
+            "index": index,
         }
 
     def test_log_has_seen_whole_playlist(self, client, caplog):

--- a/pro/src/apiClient/adage/models/PlaylistBody.ts
+++ b/pro/src/apiClient/adage/models/PlaylistBody.ts
@@ -6,6 +6,7 @@ import type { AdagePlaylistType } from './AdagePlaylistType';
 export type PlaylistBody = {
   elementId?: number | null;
   iframeFrom: string;
+  index?: number | null;
   isFromNoResult?: boolean | null;
   playlistId: number;
   playlistType: AdagePlaylistType;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26712

Ajout d'un champ `index` (optionnel par soucis de rétrocompatibilité).