### PR TITLE
(PC-26468)[EAC] fix: adage: gender ("civilite") can be null

### DIFF
--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -774,7 +774,10 @@ def get_autocomplete_educational_redactors_for_uai(
     return educational_redactors.EducationalRedactors(
         __root__=[
             educational_redactors.EducationalRedactor(
-                name=redactor["nom"], surname=redactor["prenom"], gender=redactor["civilite"], email=redactor["mail"]
+                name=redactor["nom"],
+                surname=redactor["prenom"],
+                gender=redactor.get("civilite"),
+                email=redactor["mail"],
             )
             for redactor in redactors
         ]

--- a/api/src/pcapi/routes/serialization/educational_redactors.py
+++ b/api/src/pcapi/routes/serialization/educational_redactors.py
@@ -22,7 +22,7 @@ class EducationalRedactorQueryModel(BaseModel):
 class EducationalRedactor(BaseModel):
     name: str
     surname: str
-    gender: str
+    gender: str | None
     email: str
 
 

--- a/pro/src/apiClient/v1/models/EducationalRedactor.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactor.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 export type EducationalRedactor = {
   email: string;
-  gender: string;
+  gender?: string | null;
   name: string;
   surname: string;
 };


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26468

Fix : le champ `gender` (`civilite`) n'est optionnel. Il s'agissait d'une erreur de documentation : dans la pratique, cette information peut être nulle.