### PR TITLE
(PC-26537)[API] fix: add missing incident columns in invoice file

### DIFF
--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -290,6 +290,8 @@
             <th>Lieux</th>
             <th>Montant des réservations validées (TTC)</th>
             <th>Montant de la contribution offreur (TTC)</th>
+            <th>Incidents (TTC)</th>
+            <th>Contribution offreur incidents (TTC)</th>
             <th class="coloredSection">Montant remboursé (TTC)</th>
             <th class="minimizedCell">Dont offres individuelles (TTC)</th>
             <th class="minimizedCell">Dont offres collectives (TTC)</th>
@@ -301,9 +303,11 @@
             <td>{{ venue.venue_name }}</td>
             <td>{{ venue.validated_booking_amount|fr_currency_opposite }} €</td>
             <td>{{ (venue.validated_booking_amount - venue.reimbursed_amount)|fr_currency_opposite }} €</td>
-            <td class="coloredSection">{{ venue.reimbursed_amount|fr_currency_opposite }} €</td>
-            <td>{{ venue.individual_amount|fr_currency_opposite }} €</td>
-            <td>{{ (venue.reimbursed_amount - venue.individual_amount)|fr_currency_opposite }} €</td>
+            <td>{{ (venue.finance_incident_amount + venue.finance_incident_contribution)|fr_currency }} €</td>
+            <td>{{ venue.finance_incident_contribution|fr_currency }} €</td>
+            <td class="coloredSection">{{ (venue.reimbursed_amount + venue.finance_incident_amount)|fr_currency_opposite }} €</td>
+            <td>{{ (venue.individual_amount + venue.individual_incident_amount)|fr_currency_opposite }} €</td>
+            <td>{{ (venue.reimbursed_amount - venue.individual_amount + (venue.finance_incident_amount - venue.individual_incident_amount))|fr_currency_opposite }} €</td>
         </tr>
 {% endfor %}
     </tbody>

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -230,6 +230,15 @@
     </tr>
 
     <tr>
+        <td class="headRow">Incidents</td>
+        <td>100 %</td>
+        <td>-30,00 €</td>
+        <td>0 %</td>
+        <td>0,00 €</td>
+        <td>-30,00 €</td>
+    </tr>
+
+    <tr>
         <td class="headRow">Réservations</td>
         <td>95 %</td>
         <td>83,30 €</td>
@@ -241,10 +250,10 @@
     <tr style="color: dimgrey">
         <td class="headRow">SOUS-TOTAL</td>
         <td></td>
-        <td>25 979,30 €</td>
+        <td>25 949,30 €</td>
         <td></td>
         <td>4,16 €</td>
-        <td>25 975,14 €</td>
+        <td>25 945,14 €</td>
     </tr>
 
     <tr class="coloredSection">
@@ -343,10 +352,10 @@
     <tr class="bottomTableText">
         <td class="headRow">TOTAL</td>
         <td></td>
-        <td>26 100,30 €</td>
+        <td>26 070,30 €</td>
         <td></td>
         <td>64,36 €</td>
-        <td>26 035,94 €</td>
+        <td>26 005,94 €</td>
     </tr>
     </tbody>
 </table>
@@ -375,13 +384,13 @@
         <td>Virement FR2710010000000000000000064</td>
         <td class="cashflow_batch_label">1</td>
         <td class="cashflow_creation_date">21/12/2021</td>
-        <td>26 035,94 €</td>
+        <td>26 005,94 €</td>
         <td>Coiffeur justificaTIF</td>
     </tr>
 
     <tr class="coloredSection bottomTableText">
         <td class="headRow" colspan="3">TOTAL RÈGLEMENT PASS CULTURE</td>
-        <td>26 035,94 €</td>
+        <td>26 005,94 €</td>
     </tr>
     </tbody>
 </table>
@@ -392,6 +401,8 @@
             <th>Lieux</th>
             <th>Montant des réservations validées (TTC)</th>
             <th>Montant de la contribution offreur (TTC)</th>
+            <th>Incidents (TTC)</th>
+            <th>Contribution offreur incidents (TTC)</th>
             <th class="coloredSection">Montant remboursé (TTC)</th>
             <th class="minimizedCell">Dont offres individuelles (TTC)</th>
             <th class="minimizedCell">Dont offres collectives (TTC)</th>
@@ -403,14 +414,18 @@
             <td>Coiffeur justificaTIF</td>
             <td>25 474,30 €</td>
             <td>66,36 €</td>
-            <td class="coloredSection">25 407,94 €</td>
-            <td>20 157,94 €</td>
-            <td>5 250,00 €</td>
+            <td>70,00 €</td>
+            <td>2,00 €</td>
+            <td class="coloredSection">25 339,94 €</td>
+            <td>20 119,94 €</td>
+            <td>5 220,00 €</td>
         </tr>
 
         <tr>
             <td>Coiffeur collecTIF</td>
             <td>666,00 €</td>
+            <td>0,00 €</td>
+            <td>0,00 €</td>
             <td>0,00 €</td>
             <td class="coloredSection">666,00 €</td>
             <td>0,00 €</td>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26537

- Ajout de deux colonnes manquantes concernant les incidents de finance dans le justificatif de remboursement.
- Ajout d'un incident collectif dans les tests

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/d298a24d-0ae2-451c-ad0b-95c86ade169a)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques