### PR TITLE
(BSR)[API] Ajout d'un fichier de configuration pour pgcli

### DIFF
--- a/api/bin/pgcli-wrapper.sh
+++ b/api/bin/pgcli-wrapper.sh
@@ -31,6 +31,8 @@ else color=""; fi
 color_reset="\x1b[0m"
 prompt="${color}${environment}>${color_reset} "
 
+config_path="$(dirname $0)/../etc/pgcli.ini"
+
 # `--prompt` is manually added here, I don't know how to properly
 # quote it to include the trailing space.
-pgcli ${args} --prompt "${prompt}"
+pgcli ${args} --prompt "${prompt}" --pgclirc "${config_path}"

--- a/api/bin/pgcli-wrapper.sh
+++ b/api/bin/pgcli-wrapper.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 #
 # A wrapper around pgcli that:
+# - loads our "etc/pgcli.ini" configuration file;
 # - defaults to $DATABASE_URL if no argument is given;
-# - disables automatic LIMIT;
-# - disables startup and exit messages;
 # - sets a colored prompt that clearly distinguishes when you're on
 #   your development machine or on production.
 #
@@ -11,16 +10,6 @@
 # Default to $DATABASE_URL if no argument is given.
 args="$*"
 if [ $# -eq 0 ]; then args="${DATABASE_URL} "; fi
-
-# Disable automatic LIMIT.
-# This may be an nice feature when you're used to pgcli. Otherwise,
-# you may very well miss the warning (especially if the SQL query is
-# fast) and not notice that the output was cropped to 1000 rows (which
-# is the default).
-args+=" --row-limit 0"
-
-# Disable startup and exit messages.
-args+=" --less-chatty"
 
 # Determine color of the prompt, depending on the environment.
 environment=$(hostname | cut -d"-" -f1)

--- a/api/etc/pgcli.ini
+++ b/api/etc/pgcli.ini
@@ -1,0 +1,4 @@
+[main]
+# keyring is installed (as a dependency of Poetry). Because it's not
+# configured, a warning is displayed if the option is not disabled.
+keyring = false

--- a/api/etc/pgcli.ini
+++ b/api/etc/pgcli.ini
@@ -12,3 +12,12 @@ less_chatty = true
 # fast) and not notice that the output was cropped to 1000 rows (which
 # is the default).
 row_limit = 0
+
+# Destructive warning mode will alert you before executing a sql statement
+# that may cause harm to the database such as "drop table", "drop database"
+# or "shutdown".
+destructive_warning = true
+
+# When this option is on (and if `destructive_warning` is set),
+# destructive statements are not executed when outside of a transaction.
+destructive_statements_require_transaction = true

--- a/api/etc/pgcli.ini
+++ b/api/etc/pgcli.ini
@@ -2,3 +2,13 @@
 # keyring is installed (as a dependency of Poetry). Because it's not
 # configured, a warning is displayed if the option is not disabled.
 keyring = false
+
+# Disable startup and exit messages.
+less_chatty = true
+
+# Disable automatic LIMIT.
+# This may be an nice feature when you're used to pgcli. Otherwise,
+# you may very well miss the warning (especially if the SQL query is
+# fast) and not notice that the output was cropped to 1000 rows (which
+# is the default).
+row_limit = 0


### PR DESCRIPTION
3 commits, à relire séparément :

- ajout d'un fichier de configuration minimal (pour éviter
  l'avertissement relatif à "keyring" qui apparaît au démarrage de
  pgcli depuis qu'on est passé à Poetry).

- déplacement des options définies dans "pgcli-wrapper.sh"

- configuration de pgcli pour rejeter les requêtes "destructives"
  (`insert`, `delete`, `update`, `alter table`, etc.) si une
  transaction n'est pas en cours.

Cf. messages de commit pour plus de détails.