### PR TITLE
(PC-26925)[PRO] feat: Use api to get adage offers for my institution.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.module.scss
@@ -15,11 +15,15 @@
 }
 
 .my-institution-callout {
-    white-space: pre-wrap;
-    margin-top: rem.torem(16px);
-    margin-bottom: rem.torem(32px);
+  white-space: pre-wrap;
+  margin-top: rem.torem(16px);
+  margin-bottom: rem.torem(32px);
 }
 
 .callout-text {
   margin-bottom: rem.torem(16px);
+}
+
+.offers-list {
+  padding-bottom: rem.torem(32px);
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26925

**Objectif**
Replacer l'appel à algolia dans la page Mon établissement d'adage par un appel à la nouvelle api backend qui renvoit directement la liste des offres concernées.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques