### PR TITLE
(BSR)[API] feat: exit with a non-zero code if alembic upgrade fails

### DIFF
--- a/api/src/pcapi/alembic/run_migrations.py
+++ b/api/src/pcapi/alembic/run_migrations.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import time
 
 from alembic import context
@@ -96,8 +97,7 @@ def run_migrations() -> None:
 
             attempt += 1
             if attempt > settings.DB_MIGRATION_MAX_ATTEMPTS:
-                logger.error("FAILURE: Migrations failed to be run.")
-                break
+                sys.exit("FAILURE: Migrations failed to be run.")
 
             logger.warning("Retrying in %d seconds...", settings.DB_MIGRATION_RETRY_DELAY)
             time.sleep(settings.DB_MIGRATION_RETRY_DELAY)


### PR DESCRIPTION
Toujours renvoyer un exit code différent de 0 en cas d'échec des migrations.

Testé avec une migration incluant
```python
def upgrade() -> None:
    raise OperationalError("", None, None)
```

```shell
➜ alembic upgrade post@head
WARNI [pcapi.alembic.run_migrations] Alembic will use a DB connection with these settings: lock_timeout = 5000 ms, statement_timeout = 60000 ms
WARNI [pcapi.alembic.run_migrations] Running migrations: attempt 1/1
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade fadf7f6f4c60 -> f21a18bd0d27, test
WARNI [pcapi.alembic.run_migrations] OperationalError: None
WARNI [pcapi.alembic.run_migrations] [SQL: ]
FAILURE: Migrations failed to be run.

➜ echo $?
1
```
