### PR TITLE
(PC-27152)[PRO] feat: When admin, adage offer page breadcrumb sends b…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from 'react'
 import { useLocation, useParams, useSearchParams } from 'react-router-dom'
 
+import { AdageFrontRoles } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
-import Breadcrumb from 'components/Breadcrumb/Breadcrumb'
+import Breadcrumb, { Crumb } from 'components/Breadcrumb/Breadcrumb'
 import strokePassIcon from 'icons/stroke-pass.svg'
+import strokeSearchIcon from 'icons/stroke-search.svg'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import Spinner from 'ui-kit/Spinner/Spinner'
 
+import useAdageUser from '../../hooks/useAdageUser'
 import Offer from '../OffersInstantSearch/OffersSearch/Offers/Offer'
 
 import offerInfosFallback from './assets/offer-infos-fallback.svg'
@@ -19,6 +22,8 @@ export const OfferInfos = () => {
 
   const [offer, setOffer] = useState(state?.offer)
   const [loading, setLoading] = useState(false)
+
+  const { adageUser } = useAdageUser()
 
   useEffect(() => {
     async function getOffer() {
@@ -46,6 +51,22 @@ export const OfferInfos = () => {
     return <Spinner />
   }
 
+  const originCrumb: Crumb = {
+    title:
+      adageUser.role === AdageFrontRoles.READONLY ? 'Recherche' : 'Découvrir',
+    link: {
+      isExternal: false,
+      to:
+        adageUser.role === AdageFrontRoles.READONLY
+          ? `/adage-iframe/recherche?token=${adageAuthToken}`
+          : `/adage-iframe/decouverte?token=${adageAuthToken}`,
+    },
+    icon:
+      adageUser.role === AdageFrontRoles.READONLY
+        ? strokeSearchIcon
+        : strokePassIcon,
+  }
+
   return (
     <div className={styles['offers-info']}>
       {offer ? (
@@ -53,14 +74,7 @@ export const OfferInfos = () => {
           <div className={styles['offers-info-breadcrumb']}>
             <Breadcrumb
               crumbs={[
-                {
-                  title: 'Découvrir',
-                  link: {
-                    isExternal: false,
-                    to: `/adage-iframe/decouverte?token=${adageAuthToken}`,
-                  },
-                  icon: strokePassIcon,
-                },
+                originCrumb,
                 {
                   title: offer.name,
                   link: {

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/__specs__/OfferInfos.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/__specs__/OfferInfos.spec.tsx
@@ -1,6 +1,7 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import * as router from 'react-router-dom'
 
+import { AdageFrontRoles, AuthenticatedResponse } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
 import {
@@ -25,9 +26,9 @@ vi.mock('react-router-dom', async () => ({
   }),
 }))
 
-const renderOfferInfos = () => {
+const renderOfferInfos = (user: AuthenticatedResponse = defaultAdageUser) => {
   renderWithProviders(
-    <AdageUserContextProvider adageUser={defaultAdageUser}>
+    <AdageUserContextProvider adageUser={user}>
       <OfferInfos />
     </AdageUserContextProvider>
   )
@@ -58,6 +59,12 @@ describe('OfferInfos', () => {
     renderOfferInfos()
 
     expect(screen.getByRole('link', { name: 'Découvrir' })).toBeInTheDocument()
+  })
+
+  it('should display the breadcrumb with a link back to the search page if the user is admin', () => {
+    renderOfferInfos({ ...defaultAdageUser, role: AdageFrontRoles.READONLY })
+
+    expect(screen.getByRole('link', { name: 'Recherche' })).toBeInTheDocument()
   })
 
   it('should display the offer that is passed through the router when the user navigates within the app', () => {


### PR DESCRIPTION
…ack to search page instead of discovery.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27152

**Objectif**
Ne pas afficher un lien de redirection vers la découverte dans le fil d'ariane d'une page offre lorsqu'on est admin sur adage (ils n'ont pas accès à la page de découverte).

**Pour reproduire**
- Créer un token adage avec l'option pour être admin : `flask generate_fake_adage_token --readonly`
- Aller sur l'url `http://localhost:3001/adage-iframe/decouverte/offre/[ID_DUNE_OFFRE_DE_LA_RECHERCHE]?token=[TOKEN_ADMIN]`

<img width="681" alt="Capture d’écran 2024-01-18 à 14 48 44" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/631f4d11-f358-4e5a-9b5d-075c2a3cb126">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques