### PR TITLE
(PC-26711)[PRO] feat: Use index and elementId for adage playlist clic…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
@@ -28,6 +28,7 @@ export type TrackerElementArg = {
   playlistId: number
   playlistType: AdagePlaylistType
   elementId?: number
+  index?: number
 }
 
 export const AdageDiscovery = () => {
@@ -89,10 +90,12 @@ export const AdageDiscovery = () => {
     playlistId,
     playlistType,
     elementId,
+    index,
   }: {
     playlistId: number
     playlistType: AdagePlaylistType
     elementId?: number
+    index?: number
   }) => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     apiAdage.logConsultPlaylistElement({
@@ -100,6 +103,7 @@ export const AdageDiscovery = () => {
       playlistId,
       playlistType,
       elementId,
+      index,
     })
   }
 
@@ -131,9 +135,9 @@ export const AdageDiscovery = () => {
                 playlistType: AdagePlaylistType.DOMAIN,
               })
             }
-            elements={domainsOptions.map((elm, key) => {
+            elements={domainsOptions.map((elm, index) => {
               const colorAndMotif =
-                colorAndMotifOrder[key % colorAndMotifOrder.length]
+                colorAndMotifOrder[index % colorAndMotifOrder.length]
 
               return (
                 <DomainsCard
@@ -141,7 +145,7 @@ export const AdageDiscovery = () => {
                     trackPlaylistElementClicked({
                       playlistId: DOMAINS_PLAYLIST,
                       playlistType: AdagePlaylistType.DOMAIN,
-                      elementId: key,
+                      index,
                     })
                   }
                   key={`domains-${elm.value}`}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/ClassroomPlaylist/ClassroomPlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/ClassroomPlaylist/ClassroomPlaylist.tsx
@@ -20,6 +20,7 @@ type ClassroomPlaylistProps = {
     playlistId,
     playlistType,
     elementId,
+    index,
   }: TrackerElementArg) => void
 }
 
@@ -74,7 +75,8 @@ export const ClassroomPlaylist = ({
             trackPlaylistElementClicked({
               playlistId: CLASSROOM_PLAYLIST,
               playlistType: AdagePlaylistType.OFFER,
-              elementId: index,
+              index,
+              elementId: offerElement.id,
             })
           }
           key={`card-offer-class-${offerElement.id}`}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/NewOfferPlaylist/NewOfferPlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/NewOfferPlaylist/NewOfferPlaylist.tsx
@@ -20,6 +20,7 @@ type NewOfferPlaylistProps = {
     playlistId,
     playlistType,
     elementId,
+    index,
   }: TrackerElementArg) => void
 }
 
@@ -68,13 +69,14 @@ export const NewOfferPlaylist = ({
           playlistType: AdagePlaylistType.OFFER,
         })
       }
-      elements={offers.map((offer, i) => (
+      elements={offers.map((offer, index) => (
         <OfferCardComponent
           handlePlaylistElementTracking={() =>
             trackPlaylistElementClicked({
               playlistId: NEW_OFFER_PLAYLIST,
               playlistType: AdagePlaylistType.OFFER,
-              elementId: i,
+              index,
+              elementId: offer.id,
             })
           }
           key={offer.id}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/VenuePlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/VenuePlaylist.tsx
@@ -24,6 +24,7 @@ type VenuePlaylistProps = {
     playlistId,
     playlistType,
     elementId,
+    index,
   }: TrackerElementArg) => void
 }
 
@@ -96,7 +97,8 @@ export const VenuePlaylist = ({
             trackPlaylistElementClicked({
               playlistId: VENUE_PLAYLIST,
               playlistType: AdagePlaylistType.VENUE,
-              elementId: index,
+              index,
+              elementId: venue.id,
             })
           }
           venue={venue}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
@@ -136,7 +136,8 @@ describe('AdageDiscovery', () => {
 
     expect(apiAdage.logConsultPlaylistElement).toHaveBeenCalledWith(
       expect.objectContaining({
-        elementId: 0,
+        elementId: undefined,
+        index: 0,
         playlistId: DOMAINS_PLAYLIST,
         playlistType: 'domain',
       })


### PR DESCRIPTION
…k logs.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26711

**FF à activer**
WIP_ENABLE_DISCOVERY

**Objectif**
Quand on log les événements des clic sur les éléments des playlists de la découverte adage, on veut envoyer l'elementId et l'index de l'élément cliqué. Alors que pour l'instant on envoie l'index dans le champ elementId. Pour le domaine artistique index = elementId donc on envoie que l'index.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques