### PR TITLE
(BSR)[API] feat: Lighter Algolia offer serialization with max stock creation date only

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -515,7 +515,8 @@ class AlgoliaBackend(base.SearchBackend):
                 "searchGroupName": offer.subcategory.search_group_name,
                 "searchGroupNamev2": offer.subcategory.search_group_name,
                 "showType": show_type_label,
-                "stocksDateCreated": sorted(stocks_date_created),
+                # For backward compatibility, this must be a list.
+                "stocksDateCreated": [max(stocks_date_created)] if stocks_date_created else [],
                 "students": extra_data.get("students") or [],
                 "subcategoryId": offer.subcategory.id,
                 "thumbUrl": url_path(offer.thumbUrl) if offer.thumbUrl else None,


### PR DESCRIPTION
On va probablement **NE PAS MERGER** cette pull request, et plutôt merger #11154.

---

Before this commit, we sent the creation date of each stock, which was
heavy for offers that have many stocks.

But, in fact, we use this attribute in Algolia only to look for
recently added offers (e.g. offers created since 15 days). Thus, the
latest creation date is enough.