### PR TITLE
Pc 27170 adage responsive small screen

### DIFF
--- a/pro/src/components/Breadcrumb/Breadcrumb.module.scss
+++ b/pro/src/components/Breadcrumb/Breadcrumb.module.scss
@@ -24,8 +24,8 @@
 
         display: inline-flex;
         align-items: center;
-        white-space: nowrap;
         text-decoration: underline;
+        white-space: break-spaces;
 
         &[aria-current="page"] {
           color: inherit;

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.module.scss
@@ -5,54 +5,53 @@
 
 .adage-header-menu {
   display: flex;
-  height: rem.torem(61px);
-  align-items: center;
+  flex-direction: column;
   justify-content: center;
   flex: 1;
 
   &-item {
     height: 100%;
+  }
+}
 
-    .adage-header-link {
-      @include fonts.button;
+.adage-header-link {
+  @include fonts.button;
 
-      height: 100%;
-      display: flex;
-      align-items: center;
-      padding: 0 rem.torem(16px);
-      gap: rem.torem(8px);
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: rem.torem(16px) rem.torem(8px);
+  gap: rem.torem(8px);
 
-      &-active {
-        position: relative;
-        color: colors.$primary;
+  &-active {
+    position: relative;
+    color: colors.$primary;
 
-        &::after {
-          content: "";
-          position: absolute;
-          bottom: 0;
-          left: 0;
-          width: 100%;
-          height: rem.torem(4px);
-          background-color: colors.$primary;
-          border-radius: rem.torem(2px) rem.torem(2px) 0 0;
-        }
-
-        .adage-header-item-icon {
-          fill: colors.$primary;
-        }
-      }
-
-      &-icon {
-        width: rem.torem(20px);
-        min-width: rem.torem(20px);
-        height: rem.torem(20px);
-        fill: colors.$black;
-      }
-
-      &:hover {
-        background-color: colors.$grey-light;
-      }
+    &::after {
+      content: "";
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: rem.torem(4px);
+      background-color: colors.$primary;
+      border-radius: rem.torem(2px) rem.torem(2px) 0 0;
     }
+
+    .adage-header-item-icon {
+      fill: colors.$primary;
+    }
+  }
+
+  &-icon {
+    width: rem.torem(20px);
+    min-width: rem.torem(20px);
+    height: rem.torem(20px);
+    fill: colors.$black;
+  }
+
+  &:hover {
+    background-color: colors.$grey-light;
   }
 }
 
@@ -69,5 +68,17 @@
 @media (min-width: size.$desktop) {
   .adage-header-menu {
     gap: rem.torem(48px);
+  }
+}
+
+@media (min-width: size.$tablet) {
+  .adage-header-menu {
+    flex-direction: row;
+    text-align: center;
+    height: rem.torem(61px);
+  }
+
+  .adage-header-link {
+    padding: 0 rem.torem(16px);
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.module.scss
@@ -84,6 +84,7 @@ $offer-image-width: rem.torem(176px);
       display: flex;
       gap: rem.torem(24px);
       justify-content: flex-end;
+      align-items: center;
     }
   }
 
@@ -91,11 +92,16 @@ $offer-image-width: rem.torem(176px);
     margin-bottom: rem.torem(24px);
 
     &-row {
+      margin-bottom: rem.torem(6px);
       display: flex;
+      gap: rem.torem(16px);
       flex-wrap: wrap;
-      justify-content: space-between;
-      gap: rem.torem(12px);
-      align-items: flex-start;
+
+      &-title {
+        flex: 1;
+
+        @include fonts.title3;
+      }
     }
 
     &-label {
@@ -105,12 +111,6 @@ $offer-image-width: rem.torem(176px);
     &-venue-link {
       display: flex;
       align-items: center;
-    }
-
-    &-title {
-      margin-bottom: rem.torem(6px);
-
-      @include fonts.title3;
     }
 
     &-subtitles,
@@ -138,6 +138,10 @@ $offer-image-width: rem.torem(176px);
 
       &-item {
         list-style: none;
+
+        &-tag {
+          white-space: break-spaces;
+        }
       }
     }
 
@@ -179,12 +183,6 @@ $offer-image-width: rem.torem(176px);
 
 @media (min-width: size.$tablet) {
   .offer-container {
-    flex-wrap: unset;
-  }
-}
-
-@media (min-width: size.$mobile) {
-  .offer-header-row {
     flex-wrap: unset;
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -148,53 +148,7 @@ const Offer = ({
         <div className={style['offer-details-container']}>
           <div className={style['offer-header']}>
             <div className={style['offer-header-row']}>
-              <div>
-                <h2 className={style['offer-header-title']}>{offer.name}</h2>
-                <div className={style['offer-header-subtitles']}>
-                  <span className={style['offer-header-label']}>
-                    Proposée par
-                  </span>
-
-                  {offer.venue.adageId ? (
-                    <ButtonLink
-                      link={{
-                        isExternal: true,
-                        to: `${document.referrer}adage/ressource/partenaires/id/${offer.venue.adageId}`,
-                        target: '_blank',
-                        rel: 'noopener noreferrer',
-                      }}
-                      variant={ButtonVariant.TERNARY}
-                      className={style['offer-header-venue-link']}
-                      onClick={offerVenueLinkClicked}
-                      icon={fullLinkIcon}
-                    >
-                      {venueAndOffererName}
-                    </ButtonLink>
-                  ) : (
-                    <span>{venueAndOffererName}</span>
-                  )}
-                </div>
-                {isCollectiveOffer(offer) && offer.teacher && (
-                  <div className={style['offer-header-teacher']}>
-                    <span className={style['offer-header-label']}>
-                      Destinée à{' '}
-                    </span>
-                    <span>
-                      {offer.teacher.firstName} {offer.teacher.lastName}
-                    </span>
-                  </div>
-                )}
-                <ul className={style['offer-domains-list']}>
-                  {offer?.domains?.map((domain) => (
-                    <li
-                      className={style['offer-domains-list-item']}
-                      key={domain.id}
-                    >
-                      <Tag variant={TagVariant.LIGHT_GREY}>{domain.name}</Tag>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+              <h2 className={style['offer-header-row-title']}>{offer.name}</h2>
               <div className={style['offer-details-actions']}>
                 {canAddOfferToFavorites && (
                   <OfferFavoriteButton
@@ -232,6 +186,52 @@ const Offer = ({
                 )}
               </div>
             </div>
+
+            <div className={style['offer-header-subtitles']}>
+              <span className={style['offer-header-label']}>Proposée par</span>
+
+              {offer.venue.adageId ? (
+                <ButtonLink
+                  link={{
+                    isExternal: true,
+                    to: `${document.referrer}adage/ressource/partenaires/id/${offer.venue.adageId}`,
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                  }}
+                  variant={ButtonVariant.TERNARY}
+                  className={style['offer-header-venue-link']}
+                  onClick={offerVenueLinkClicked}
+                  icon={fullLinkIcon}
+                >
+                  {venueAndOffererName}
+                </ButtonLink>
+              ) : (
+                <span>{venueAndOffererName}</span>
+              )}
+            </div>
+            {isCollectiveOffer(offer) && offer.teacher && (
+              <div className={style['offer-header-teacher']}>
+                <span className={style['offer-header-label']}>Destinée à </span>
+                <span>
+                  {offer.teacher.firstName} {offer.teacher.lastName}
+                </span>
+              </div>
+            )}
+            <ul className={style['offer-domains-list']}>
+              {offer?.domains?.map((domain) => (
+                <li
+                  className={style['offer-domains-list-item']}
+                  key={domain.id}
+                >
+                  <Tag
+                    variant={TagVariant.LIGHT_GREY}
+                    className={style['offer-domains-list-item-tag']}
+                  >
+                    {domain.name}
+                  </Tag>
+                </li>
+              ))}
+            </ul>
           </div>
           <OfferSummary offer={offer} />
           <p className={style['offer-description']}>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27170

**Objectif**
S'assurer que les boutons des offres ne sortent pas de l'écran jusqu'à 320px. Et s'assurer que tous les liens de la navbar sont visibles jusqu'à 320px.


<img width="299" alt="Capture d’écran 2024-01-18 à 17 32 45" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/dd3b9940-0123-4e20-817f-4789a93ba740">
<img width="346" alt="Capture d’écran 2024-01-18 à 17 33 20" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/4697af2f-a191-434a-aabd-93898f8f2e07">

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques