### PR TITLE
(PC-26241)[PRO] fix: uxui creation edition eac offer

### DIFF
--- a/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
@@ -43,12 +43,12 @@ const CollectiveOfferNavigation = ({
   const requestIdUrl = requestId ? `?requete=${requestId}` : ''
 
   if (isEditingExistingOffer) {
-    stepList[CollectiveOfferStep.DETAILS] = {
-      id: CollectiveOfferStep.DETAILS,
-      label: 'Détails de l’offre',
-      url: `/offre/${offerId}/collectif/edition`,
-    }
     if (!isTemplate) {
+      stepList[CollectiveOfferStep.DETAILS] = {
+        id: CollectiveOfferStep.DETAILS,
+        label: 'Détails de l’offre',
+        url: `/offre/${offerId}/collectif/edition`,
+      }
       stepList[CollectiveOfferStep.STOCKS] = {
         id: CollectiveOfferStep.STOCKS,
         label: 'Date et prix',

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferTypeSection/CollectiveOfferTypeSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferTypeSection/CollectiveOfferTypeSection.tsx
@@ -39,42 +39,46 @@ export default function CollectiveOfferTypeSection({
   }, [offer.subcategoryId])
   const isFormatActive = useActiveFeature('WIP_ENABLE_FORMAT')
   return (
-    <SummaryLayout.SubSection title="Type d’offre">
-      {isFormatActive ? (
-        <SummaryLayout.Row
-          title="Format"
-          description={offer.formats?.join(', ') || DEFAULT_RECAP_VALUE}
-        />
-      ) : (
-        <>
+    <>
+      <SummaryLayout.SubSection title="Type d’offre">
+        {isFormatActive ? (
           <SummaryLayout.Row
-            title="Catégorie"
-            description={category?.label || DEFAULT_RECAP_VALUE}
+            title="Format"
+            description={offer.formats?.join(', ') || DEFAULT_RECAP_VALUE}
           />
-          <SummaryLayout.Row
-            title="Sous-catégorie"
-            description={subCategory?.label || DEFAULT_RECAP_VALUE}
-          />
-        </>
-      )}
+        ) : (
+          <>
+            <SummaryLayout.Row
+              title="Catégorie"
+              description={category?.label || DEFAULT_RECAP_VALUE}
+            />
+            <SummaryLayout.Row
+              title="Sous-catégorie"
+              description={subCategory?.label || DEFAULT_RECAP_VALUE}
+            />
+          </>
+        )}
 
-      <SummaryLayout.Row
-        title="Domaine artistique et culturel"
-        description={offer.domains.map((domain) => domain.name).join(', ')}
-      />
-      <SummaryLayout.Row
-        title="Dispositif national"
-        description={offer.nationalProgram?.name || DEFAULT_RECAP_VALUE}
-      />
-      <SummaryLayout.Row title="Titre de l’offre" description={offer.name} />
-      <SummaryLayout.Row
-        title="Description"
-        description={offer.description || DEFAULT_RECAP_VALUE}
-      />
-      <SummaryLayout.Row
-        title="Durée"
-        description={formatDuration(offer.durationMinutes)}
-      />
-    </SummaryLayout.SubSection>
+        <SummaryLayout.Row
+          title="Domaine artistique et culturel"
+          description={offer.domains.map((domain) => domain.name).join(', ')}
+        />
+        <SummaryLayout.Row
+          title="Dispositif national"
+          description={offer.nationalProgram?.name || DEFAULT_RECAP_VALUE}
+        />
+      </SummaryLayout.SubSection>
+      <SummaryLayout.SubSection title="Informations artistiques">
+        <SummaryLayout.Row title="Titre de l’offre" description={offer.name} />
+        <SummaryLayout.Row
+          title="Description"
+          description={offer.description || DEFAULT_RECAP_VALUE}
+        />
+        <SummaryLayout.Row
+          title="Durée"
+          description={formatDuration(offer.durationMinutes)}
+        />
+      </SummaryLayout.SubSection>
+    </>
   )
 }

--- a/pro/src/components/OfferEducationalActions/OfferEducationalActions.module.scss
+++ b/pro/src/components/OfferEducationalActions/OfferEducationalActions.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   justify-content: center;
   gap: rem.torem(16px);
+  margin: rem.torem(6px) 0;
 }
 
 .separator {

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -182,34 +182,36 @@ const FormOfferType = ({
           />
         </FormLayout.Row>
       )}
-      <FormLayout.Row>
-        <TextInput
-          countCharacters
-          label={TITLE_LABEL}
-          maxLength={110}
-          name="title"
-          disabled={disableForm}
-        />
-      </FormLayout.Row>
-      <FormLayout.Row>
-        <TextArea
-          countCharacters
-          label={DESCRIPTION_LABEL}
-          maxLength={MAX_DETAILS_LENGTH}
-          name="description"
-          placeholder="Détaillez ici votre projet et son interêt pédagogique."
-          disabled={disableForm}
-        />
-      </FormLayout.Row>
-      <FormLayout.Row>
-        <TextInput
-          isOptional
-          label={DURATION_LABEL}
-          name="duration"
-          placeholder="HH:MM"
-          disabled={disableForm}
-        />
-      </FormLayout.Row>
+      <FormLayout.Section title="Informations artistiques">
+        <FormLayout.Row>
+          <TextInput
+            countCharacters
+            label={TITLE_LABEL}
+            maxLength={110}
+            name="title"
+            disabled={disableForm}
+          />
+        </FormLayout.Row>
+        <FormLayout.Row>
+          <TextArea
+            countCharacters
+            label={DESCRIPTION_LABEL}
+            maxLength={MAX_DETAILS_LENGTH}
+            name="description"
+            placeholder="Détaillez ici votre projet et son interêt pédagogique."
+            disabled={disableForm}
+          />
+        </FormLayout.Row>
+        <FormLayout.Row>
+          <TextInput
+            isOptional
+            label={DURATION_LABEL}
+            name="duration"
+            placeholder="HH:MM"
+            disabled={disableForm}
+          />
+        </FormLayout.Row>
+      </FormLayout.Section>
     </FormLayout.Section>
   )
 }

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
@@ -73,15 +73,17 @@ const FormVenue = ({
       description="Le lieu de rattachement permet d'associer vos coordonnées bancaires à votre offre pour permettre le remboursement par le pass Culture."
       title="Lieu de rattachement de votre offre"
     >
-      <FormLayout.Row>
-        <Select
-          onChange={(e) => onChangeOfferer(e.target.value)}
-          disabled={offerersOptions.length === 1 || disableOfferSelection}
-          label={OFFERER_LABEL}
-          name="offererId"
-          options={offerersOptions}
-        />
-      </FormLayout.Row>
+      {offerersOptions.length > 1 && (
+        <FormLayout.Row>
+          <Select
+            onChange={(e) => onChangeOfferer(e.target.value)}
+            disabled={offerersOptions.length === 1 || disableOfferSelection}
+            label={OFFERER_LABEL}
+            name="offererId"
+            options={offerersOptions}
+          />
+        </FormLayout.Row>
+      )}
       {isEligible === false && offerersOptions.length !== 0 && (
         <Banner
           links={[

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -204,15 +204,15 @@ const OfferEducationalForm = ({
           >
             Annuler et quitter
           </ButtonLink>
-        </ActionsBarSticky.Left>
-        <ActionsBarSticky.Right>
           <SubmitButton
             disabled={!isEligible || mode === Mode.READ_ONLY}
             isLoading={isLoading}
           >
-            {mode === Mode.CREATION ? 'Étape suivante' : 'Enregistrer'}
+            {mode === Mode.CREATION
+              ? 'Étape suivante'
+              : 'Enregistrer les modifications'}
           </SubmitButton>
-        </ActionsBarSticky.Right>
+        </ActionsBarSticky.Left>
       </ActionsBarSticky>
     </FormLayout>
   )

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
@@ -36,15 +36,6 @@ describe('screens | OfferEducational : creation offerer step', () => {
         .mockResolvedValue(eligibilityResponse(true))
     })
 
-    it('should display offerer select with pre-selected options', async () => {
-      renderWithProviders(<OfferEducational {...props} />)
-      const offererSelect = await screen.findByLabelText('Structure')
-
-      expect(offererSelect).toHaveValue(props.userOfferers[0].id.toString())
-      expect(offererSelect).toBeDisabled()
-      expect(offererSelect.children).toHaveLength(1)
-    })
-
     it('should test eligibility and display venue input if offerer is eligible', async () => {
       renderWithProviders(
         <OfferEducational
@@ -133,21 +124,14 @@ describe('screens | OfferEducational : creation offerer step', () => {
         .mockResolvedValue(eligibilityResponse(true))
     })
 
-    it('should pre-select both selects and display the next step', async () => {
+    it('should select venue and display the next step', async () => {
       renderWithProviders(<OfferEducational {...props} />)
 
       const offerTypeTitle = await screen.findByRole('heading', {
         name: 'Type d’offre',
       })
-      const offererSelect = await screen.findByLabelText('Structure')
+
       const venueSelect = await screen.findByLabelText('Lieu')
-
-      expect(offererSelect).toBeInTheDocument()
-      expect(offererSelect).toHaveValue(props.userOfferers[0].id.toString())
-      expect(offererSelect.children).toHaveLength(1)
-      expect(offererSelect).toBeDisabled()
-
-      expect(screen.queryByTestId('error-offererId')).not.toBeInTheDocument()
 
       expect(venueSelect).toBeInTheDocument()
       expect(venueSelect).toHaveValue(

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
@@ -74,7 +74,7 @@ describe('screens | OfferEducational', () => {
       screen.getByLabelText(INTERVENTION_AREA_LABEL),
     ]
     const submitButton = screen.getByRole('button', {
-      name: 'Enregistrer',
+      name: 'Enregistrer les modifications',
     })
     await waitFor(() => {
       inputs.forEach((input) => expect(input).toBeDisabled())

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalEventAddressStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalEventAddressStep.spec.tsx
@@ -33,8 +33,6 @@ describe('screens | OfferEducational : event address step', () => {
 
     it('should display venue radio buttons with pre-selected offerer venue and a disabled select', async () => {
       renderWithProviders(<OfferEducational {...props} />)
-      // wait for page to be rendered
-      expect(screen.getByLabelText('Structure')).toBeInTheDocument()
 
       expect(await screen.findByLabelText('Dans votre lieu')).toBeChecked()
       expect(
@@ -171,6 +169,7 @@ describe('screens | OfferEducational : event address step', () => {
     it('should prefill intervention field with venue intervention field when selecting venue', async () => {
       const offererId = '55'
       const venueId = '42'
+
       renderWithProviders(
         <OfferEducational
           {...props}

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -191,8 +191,6 @@ const OfferEducationalStock = <
                 >
                   Étape précédente
                 </ButtonLink>
-              </ActionsBarSticky.Left>
-              <ActionsBarSticky.Right>
                 <SubmitButton
                   className=""
                   disabled={
@@ -201,9 +199,11 @@ const OfferEducationalStock = <
                   }
                   isLoading={isLoading}
                 >
-                  {mode === Mode.EDITION ? 'Enregistrer' : 'Étape suivante'}
+                  {mode === Mode.EDITION
+                    ? 'Enregistrer les modifications'
+                    : 'Étape suivante'}
                 </SubmitButton>
-              </ActionsBarSticky.Right>
+              </ActionsBarSticky.Left>
             </ActionsBarSticky>
           </FormLayout>
         </form>

--- a/pro/src/ui-kit/Tabs/Tabs.tsx
+++ b/pro/src/ui-kit/Tabs/Tabs.tsx
@@ -25,50 +25,53 @@ const NAV_ITEM_ICON_SIZE = '24'
 
 const Tabs = ({ nav, selectedKey, tabs }: FilterTabsProps): JSX.Element => {
   const location = useLocation()
-  const content = (
-    <ul className={styles['tabs']}>
-      {tabs.map(({ key, label, url, icon, onClick }) => {
-        return (
-          <li
-            className={cn(styles['tabs-tab'], {
-              [styles['is-selected']]: selectedKey === key,
-            })}
-            key={`tab_${key}`}
-          >
-            {url ? (
-              <Link
-                className={styles['tabs-tab-link']}
-                key={`tab${url}`}
-                to={url}
-                aria-current={
-                  nav && location.pathname === url ? 'page' : undefined
-                }
-              >
-                {icon && (
-                  <SvgIcon
-                    src={icon}
-                    alt=""
-                    className={styles['tabs-tab-icon']}
-                    width={NAV_ITEM_ICON_SIZE}
-                  />
-                )}
-                <span className={styles['tabs-tab-label']}>{label}</span>
-              </Link>
-            ) : (
-              <Button
-                variant={ButtonVariant.TERNARY}
-                icon={icon}
-                onClick={onClick}
-                className={styles['tabs-tab-button']}
-              >
-                {label}
-              </Button>
-            )}
-          </li>
-        )
-      })}
-    </ul>
-  )
+  const content =
+    tabs.length > 0 ? (
+      <ul className={styles['tabs']}>
+        {tabs.map(({ key, label, url, icon, onClick }) => {
+          return (
+            <li
+              className={cn(styles['tabs-tab'], {
+                [styles['is-selected']]: selectedKey === key,
+              })}
+              key={`tab_${key}`}
+            >
+              {url ? (
+                <Link
+                  className={styles['tabs-tab-link']}
+                  key={`tab${url}`}
+                  to={url}
+                  aria-current={
+                    nav && location.pathname === url ? 'page' : undefined
+                  }
+                >
+                  {icon && (
+                    <SvgIcon
+                      src={icon}
+                      alt=""
+                      className={styles['tabs-tab-icon']}
+                      width={NAV_ITEM_ICON_SIZE}
+                    />
+                  )}
+                  <span className={styles['tabs-tab-label']}>{label}</span>
+                </Link>
+              ) : (
+                <Button
+                  variant={ButtonVariant.TERNARY}
+                  icon={icon}
+                  onClick={onClick}
+                  className={styles['tabs-tab-button']}
+                >
+                  {label}
+                </Button>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    ) : (
+      <></>
+    )
 
   return nav ? <nav aria-label={nav}>{content}</nav> : content
 }

--- a/pro/src/ui-kit/form/CheckboxGroup/CheckboxGroup.module.scss
+++ b/pro/src/ui-kit/form/CheckboxGroup/CheckboxGroup.module.scss
@@ -4,6 +4,7 @@
   &-item {
     // RomainC: I don't understand why it doesn't exactly match the sketch
     margin-bottom: rem.torem(12px);
+    width: max-content;
 
     &:last-of-type {
       margin-bottom: 0;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26241

Changement ux ui sur les pages de création et d'édition d'une offre vitrine ou réservable

- Retirer le Tabs "Détails de l'offre" pour une offre vitrine
- Ajouter une partie Informations artistiques
- Changement du wording de la barre d'action "Enregistrer" > "Enregistrer les modifications"
- Réduire la zone de clic des checkbox

## Vérifications

- [x] J'ai écrit les tests nécessaires