### PR TITLE
(PC-25654)[PRO] fix: error for offerer banner in homepage

### DIFF
--- a/pro/src/pages/Home/Homepage.tsx
+++ b/pro/src/pages/Home/Homepage.tsx
@@ -147,17 +147,17 @@ export const Homepage = (): JSX.Element => {
         <PendingBankAccountCallout offerer={selectedOfferer} />
       </div>
 
-      {selectedOfferer?.isValidated && selectedOfferer?.isActive && (
-        <>
-          <OffererBanners
-            isUserOffererValidated={isUserOffererValidated}
-            offerer={selectedOfferer}
-          />
+      {selectedOfferer !== null && (
+        <OffererBanners
+          isUserOffererValidated={isUserOffererValidated}
+          offerer={selectedOfferer}
+        />
+      )}
 
-          <section className={styles['section']}>
-            <StatisticsDashboard offerer={selectedOfferer} />
-          </section>
-        </>
+      {selectedOfferer?.isValidated && selectedOfferer?.isActive && (
+        <section className={styles['section']}>
+          <StatisticsDashboard offerer={selectedOfferer} />
+        </section>
       )}
 
       <section className={styles['section']} ref={offerersRef}>

--- a/pro/src/pages/Home/__specs__/Homepage.spec.tsx
+++ b/pro/src/pages/Home/__specs__/Homepage.spec.tsx
@@ -196,6 +196,7 @@ describe('Homepage', () => {
         screen.queryByText('Présence sur le pass Culture')
       ).not.toBeInTheDocument()
     })
+
     it('should not display statistics dashboard when selected offerer is validated but not active', async () => {
       vi.spyOn(api, 'getOfferer').mockResolvedValue({
         ...defaultGetOffererResponseModel,
@@ -263,5 +264,19 @@ describe('Homepage', () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
     expect(api.getOfferer).toHaveBeenCalledWith(baseOfferers[0].id)
+  })
+
+  it('should display pending offerer banner when rattachement is pending', async () => {
+    vi.spyOn(api, 'getOfferer').mockRejectedValueOnce({ status: 403 })
+
+    renderHomePage(store)
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+    expect(
+      screen.getByText(
+        'Le rattachement à votre structure est en cours de traitement par les équipes du pass Culture'
+      )
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25654

Fix: les bannières offerer ne s'affichent plus quand la structure est en cours de rattachement

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques