### PR TITLE
(PC-26975)[PRO] fix: eac case for partner bloc in home

### DIFF
--- a/pro/src/pages/Home/Offerers/PartnerPageCollectiveSection.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPageCollectiveSection.tsx
@@ -10,15 +10,17 @@ import { getLastCollectiveDmsApplication } from 'utils/getLastCollectiveDmsAppli
 
 import styles from './PartnerPage.module.scss'
 
+export type PartnerPageCollectiveSectionProps = {
+  collectiveDmsApplications: DMSApplicationForEAC[]
+  venueId: number
+  hasAdageId: boolean
+}
+
 export function PartnerPageCollectiveSection({
   collectiveDmsApplications,
   venueId,
   hasAdageId,
-}: {
-  collectiveDmsApplications: DMSApplicationForEAC[]
-  venueId: number
-  hasAdageId: boolean
-}) {
+}: PartnerPageCollectiveSectionProps) {
   const { logEvent } = useAnalytics()
 
   const lastDmsApplication = getLastCollectiveDmsApplication(
@@ -37,10 +39,7 @@ export function PartnerPageCollectiveSection({
     })
   }
 
-  if (
-    lastDmsApplication?.state === DMSApplicationstatus.ACCEPTE ||
-    hasAdageId
-  ) {
+  if (hasAdageId) {
     return (
       <section className={styles['details']}>
         <div>
@@ -122,6 +121,7 @@ export function PartnerPageCollectiveSection({
     )
   }
   // Last case :
+  // (lastDmsApplication?.state === DMSApplicationstatus.ACCEPTE && !hasAdageId) ||
   // lastDmsApplication?.state === DMSApplicationstatus.EN_CONSTRUCTION ||
   // lastDmsApplication?.state === DMSApplicationstatus.EN_INSTRUCTION)
   return (

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPage.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPage.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import * as router from 'react-router-dom'
 
-import { DMSApplicationstatus, VenueTypeCode } from 'apiClient/v1'
+import { VenueTypeCode } from 'apiClient/v1'
 import { UploaderModeEnum } from 'components/ImageUploader/types'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
@@ -10,7 +10,6 @@ import {
   defaultGetOffererResponseModel,
   defaultGetOffererVenueResponseModel,
 } from 'utils/apiFactories'
-import { defaultCollectiveDmsApplication } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { PartnerPage, PartnerPageProps } from '../PartnerPage'
@@ -86,7 +85,7 @@ describe('PartnerPages', () => {
     )
   })
 
-  it('should display the EAC section when no adage', () => {
+  it('should display the EAC section', () => {
     renderPartnerPages({
       venue: {
         ...defaultGetOffererVenueResponseModel,
@@ -98,87 +97,5 @@ describe('PartnerPages', () => {
     expect(
       screen.getByText('Faire une demande de référencement ADAGE')
     ).toBeInTheDocument()
-  })
-
-  it('should display the EAC section when adage refused', () => {
-    renderPartnerPages({
-      venue: {
-        ...defaultGetOffererVenueResponseModel,
-        collectiveDmsApplications: [
-          {
-            ...defaultCollectiveDmsApplication,
-            state: DMSApplicationstatus.REFUSE,
-          },
-        ],
-      },
-    })
-
-    expect(screen.getByText('Non référencé sur ADAGE')).toBeInTheDocument()
-    expect(
-      screen.queryByText('Faire une demande de référencement ADAGE')
-    ).not.toBeInTheDocument()
-  })
-
-  it('should display the EAC section when adage is without following', () => {
-    renderPartnerPages({
-      venue: {
-        ...defaultGetOffererVenueResponseModel,
-        collectiveDmsApplications: [
-          {
-            ...defaultCollectiveDmsApplication,
-            state: DMSApplicationstatus.SANS_SUITE,
-          },
-        ],
-      },
-    })
-
-    expect(screen.getByText('Non référencé sur ADAGE')).toBeInTheDocument()
-    expect(
-      screen.queryByText('Faire une demande de référencement ADAGE')
-    ).not.toBeInTheDocument()
-  })
-
-  it('should display the EAC section when adage application in progress', () => {
-    renderPartnerPages({
-      venue: {
-        ...defaultGetOffererVenueResponseModel,
-        collectiveDmsApplications: [
-          {
-            ...defaultCollectiveDmsApplication,
-            state: DMSApplicationstatus.EN_INSTRUCTION,
-          },
-        ],
-      },
-    })
-
-    expect(screen.getByText('Référencement en cours')).toBeInTheDocument()
-  })
-
-  it('should display the EAC section when adage application accepted', () => {
-    renderPartnerPages({
-      venue: {
-        ...defaultGetOffererVenueResponseModel,
-        collectiveDmsApplications: [
-          {
-            ...defaultCollectiveDmsApplication,
-            state: DMSApplicationstatus.ACCEPTE,
-          },
-        ],
-      },
-    })
-
-    expect(screen.getByText('Référencé sur ADAGE')).toBeInTheDocument()
-  })
-
-  it('should display the EAC section when it has an adageId', () => {
-    renderPartnerPages({
-      venue: {
-        ...defaultGetOffererVenueResponseModel,
-        collectiveDmsApplications: [],
-        hasAdageId: true,
-      },
-    })
-
-    expect(screen.getByText('Référencé sur ADAGE')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPageCollectiveSection.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPageCollectiveSection.spec.tsx
@@ -1,0 +1,115 @@
+import { screen } from '@testing-library/react'
+import * as router from 'react-router-dom'
+
+import { DMSApplicationstatus, VenueTypeCode } from 'apiClient/v1'
+import { defaultCollectiveDmsApplication } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import {
+  PartnerPageCollectiveSection,
+  PartnerPageCollectiveSectionProps,
+} from '../PartnerPageCollectiveSection'
+
+const renderPartnerPageCollectiveSection = (
+  props: Partial<PartnerPageCollectiveSectionProps>
+) => {
+  renderWithProviders(
+    <PartnerPageCollectiveSection
+      collectiveDmsApplications={[defaultCollectiveDmsApplication]}
+      venueId={7}
+      hasAdageId={false}
+      {...props}
+    />
+  )
+}
+
+vi.mock('react-router-dom', async () => ({
+  ...((await vi.importActual('react-router-dom')) ?? {}),
+  useLoaderData: vi.fn(),
+}))
+
+describe('PartnerPages', () => {
+  beforeEach(() => {
+    vi.spyOn(router, 'useLoaderData').mockReturnValue({
+      venueTypes: [{ id: VenueTypeCode.FESTIVAL, label: 'Festival' }],
+    })
+  })
+
+  it('should display the EAC section when no adage', () => {
+    renderPartnerPageCollectiveSection({
+      collectiveDmsApplications: [],
+    })
+
+    expect(screen.getByText('Non référencé sur ADAGE')).toBeInTheDocument()
+    expect(
+      screen.getByText('Faire une demande de référencement ADAGE')
+    ).toBeInTheDocument()
+  })
+
+  it('should display the EAC section when adage refused', () => {
+    renderPartnerPageCollectiveSection({
+      collectiveDmsApplications: [
+        {
+          ...defaultCollectiveDmsApplication,
+          state: DMSApplicationstatus.REFUSE,
+        },
+      ],
+    })
+
+    expect(screen.getByText('Non référencé sur ADAGE')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Faire une demande de référencement ADAGE')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should display the EAC section when adage is without following', () => {
+    renderPartnerPageCollectiveSection({
+      collectiveDmsApplications: [
+        {
+          ...defaultCollectiveDmsApplication,
+          state: DMSApplicationstatus.SANS_SUITE,
+        },
+      ],
+    })
+
+    expect(screen.getByText('Non référencé sur ADAGE')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Faire une demande de référencement ADAGE')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should display the EAC section when adage application in progress', () => {
+    renderPartnerPageCollectiveSection({
+      collectiveDmsApplications: [
+        {
+          ...defaultCollectiveDmsApplication,
+          state: DMSApplicationstatus.EN_INSTRUCTION,
+        },
+      ],
+    })
+
+    expect(screen.getByText('Référencement en cours')).toBeInTheDocument()
+  })
+
+  it('should display the EAC section when adage application accepted but has not yet adageId', () => {
+    renderPartnerPageCollectiveSection({
+      collectiveDmsApplications: [
+        {
+          ...defaultCollectiveDmsApplication,
+          state: DMSApplicationstatus.ACCEPTE,
+        },
+      ],
+    })
+
+    expect(screen.getByText('Référencement en cours')).toBeInTheDocument()
+  })
+
+  it('should display the EAC section when it has an adageId', () => {
+    renderPartnerPageCollectiveSection({
+      collectiveDmsApplications: [],
+      hasAdageId: true,
+    })
+
+    expect(screen.getByText('Référencé sur ADAGE')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26975

un cas n'était pas bon : le dossier dms peut être accepté MAIS l'acteur n'a pas encore d'adage id et ne peut donc pas encore créer d'offres collective : dans ce cas on veut afficher le bloc "en cours de référencement"

+ séparation des tests pour que ça soit plus clair

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques