### PR TITLE
(PC-25819)[BO] fix: timeout when searching for offers

### DIFF
--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -279,7 +279,9 @@ def _get_offer_ids_query(form: forms.InternalSearchForm) -> BaseQuery:
                     query = main_query
 
     # +1 to check if there are more results than requested
-    return query.with_entities(offers_models.Offer.id).distinct().limit(form.limit.data + 1)
+    # union() above may cause duplicates, but distinct() affects performance and causes timeout;
+    # actually duplicate ids can be accepted since the current function is called inside .in_()
+    return query.with_entities(offers_models.Offer.id).limit(form.limit.data + 1)
 
 
 def _get_offers(form: forms.InternalSearchForm) -> list[offers_models.Offer]:


### PR DESCRIPTION
With distinct, query nevers returns when called in staging console:

 SELECT DISTINCT offer.id AS id
 FROM offer
 WHERE (offer."jsonData" ->> 'showSubType') IN ('105')
 LIMIT 100;

Without distinct, results are returned in 55 ms:

 SELECT offer.id AS id
 FROM offer
 WHERE (offer."jsonData" ->> 'showSubType') IN ('105')
 LIMIT 100;

## But de la pull request

Suite au test du Ticket Jira sur staging : https://passculture.atlassian.net/browse/PC-25819

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques