### PR TITLE
(PC-25784)[PRO] style: Make skiplink outline visible.

### DIFF
--- a/pro/.stylelintrc.json
+++ b/pro/.stylelintrc.json
@@ -4,6 +4,7 @@
     "at-rule-no-unknown": null,
     "no-descending-specificity": null,
     "scss/at-extend-no-missing-placeholder": null,
+    "scss/operator-no-newline-after": null,
     "font-family-no-missing-generic-family-keyword": null
   },
   "ignoreFiles": [

--- a/pro/src/components/SkipLinks/SkipLinks.module.scss
+++ b/pro/src/components/SkipLinks/SkipLinks.module.scss
@@ -7,12 +7,7 @@
   height: 0;
   position: absolute;
   background-color: colors.$secondary;
-  top: rem.torem(-100px);
-  display: grid;
-
-  @media (min-width: size.$desktop) {
-    grid-template-columns: size.$header-grid-template-columns;
-  }
+  top: 0;
 
   &:focus-within {
     min-height: rem.torem(32px);
@@ -25,25 +20,10 @@
     display: flex;
     gap: rem.torem(16px);
     align-items: center;
-    height: rem.torem(32px);
-
-    @media (min-width: size.$desktop) {
-      justify-content: flex-end;
-    }
-
-    // Align skiplink to passculture logo, add logo margin and padding of a nav item creating more space
-    margin-right: calc(
-      size.$nav-brand-margin-right + size.$header-nav-item-padding +
-        rem.torem(4px)
-    );
 
     &-button {
       color: colors.$white;
       outline-color: colors.$white;
-
-      & svg {
-        fill: colors.$white;
-      }
     }
   }
 }

--- a/pro/src/components/SkipLinks/SkipLinks.module.scss
+++ b/pro/src/components/SkipLinks/SkipLinks.module.scss
@@ -32,17 +32,17 @@
     }
 
     // Align skiplink to passculture logo, add logo margin and padding of a nav item creating more space
-    margin-right: calc(size.$nav-brand-margin-right + size.$header-nav-item-padding + rem.torem(4px));
+    margin-right: calc(
+      size.$nav-brand-margin-right + size.$header-nav-item-padding +
+        rem.torem(4px)
+    );
 
     &-button {
       color: colors.$white;
+      outline-color: colors.$white;
 
       & svg {
         fill: colors.$white;
-      }
-
-      &:focus {
-        border-color: white;
       }
     }
   }

--- a/pro/src/styles/variables/_size.scss
+++ b/pro/src/styles/variables/_size.scss
@@ -30,7 +30,6 @@ $full-content-max-width: rem.torem(600px);
 // Mixin used to "center" with input
 // We are using margin-top and not flex center because when there is an error the
 // input field grows at the bottom and we don't want the aligned content to move with it
-// stylelint-disable scss/operator-no-newline-after
 @mixin input-center-with-top-margin($content-height, $no-label: false) {
   @if $no-label {
     margin-top: calc((#{$input-min-height} - #{$content-height}) / 2);


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25784

**Objectif**
Rendre la outline du focus des skiplink visible. Elle était noir sur bleu marine et je l'ai mise en blanc 👍 

**A noter**
J'ai aussi retiré la règle `scss/operator-no-newline-after` qui est en conflit avec la longueur maximale des lignes définie par prettier. Cette règle semble concerner des cas assez marginaux : https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/operator-no-newline-after/README.md


<img width="704" alt="Capture d’écran 2024-01-19 à 16 04 51" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/f764b3d5-c9e8-40f9-b70e-564b024dab98">

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques