### PR TITLE
(PC-27004)[EAC] feat: e2e route: get adage (fake) token

### DIFF
--- a/api/.env.integration
+++ b/api/.env.integration
@@ -78,3 +78,4 @@ WEBAPP_V2_URL=https://integration.passculture.app
 WEBAPP_V2_REDIRECT_URL=https://redirect.integration.passculture.app
 ZENDESK_SELL_API_URL=https://api.getbase.com
 ZENDESK_SELL_BACKEND=pcapi.core.external.zendesk_sell_backends.logger.LoggerBackend
+ENABLE_TEST_ROUTES=0

--- a/api/.env.production
+++ b/api/.env.production
@@ -104,3 +104,4 @@ WEBAPP_V2_REDIRECT_URL=https://redirect.passculture.app
 ZENDESK_API_URL=https://passculture.zendesk.com/api/v2
 ZENDESK_SELL_API_URL=https://api.getbase.com
 ZENDESK_SELL_BACKEND=pcapi.core.external.zendesk_sell_backends.zendesk_sell.ZendeskSellBackend
+ENABLE_TEST_ROUTES=0

--- a/api/tests/routes/internal/testing_test.py
+++ b/api/tests/routes/internal/testing_test.py
@@ -1,6 +1,8 @@
+from flask import url_for
 import pytest
 
 from pcapi.core.testing import override_features
+from pcapi.core.testing import override_settings
 from pcapi.models.feature import Feature
 
 
@@ -25,3 +27,18 @@ class FeaturesToggleTest:
         assert response.status_code == 204
         feature = Feature.query.filter_by(name="ENABLE_NATIVE_APP_RECAPTCHA").one()
         assert feature.isActive
+
+
+def test_create_adage_jwt_fake_token(client):
+    dst = url_for("adage_iframe.create_adage_jwt_fake_token")
+    response = client.get(dst)
+
+    assert response.status_code == 200
+    assert response.json["token"]
+
+
+@override_settings(ENABLE_TEST_ROUTES=False)
+def test_route_unreachable(client):
+    dst = url_for("adage_iframe.create_adage_jwt_fake_token")
+    response = client.get(dst)
+    assert response.status_code == 404

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -771,6 +771,22 @@ export class DefaultService {
     });
   }
   /**
+   * create_adage_jwt_fake_token <GET>
+   * @returns any OK
+   * @throws ApiError
+   */
+  public createAdageJwtFakeToken(): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/adage-iframe/testing/token',
+      errors: {
+        403: `Forbidden`,
+        404: `Not Found`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
    * get_venue_by_siret <GET>
    * @param siret
    * @param getRelative


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27004

Pour permettre les test e2e pour l'_iframe_ adage, le client front aura besoin d'un token adage valide. Cette PR ajoute une route qui en renvoie un et qui n'est accessible que si le FF `ENABLE_TEST_ROUTES` est activé.