### PR TITLE
(PC-26645)[BO] feat: add stats and filter by sub/category in custom reimbursement rules page

### DIFF
--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -224,12 +224,12 @@ class CustomReimbursementRuleFactory(BaseFactory):
         *args: typing.Any,
         **kwargs: typing.Any,
     ) -> models.CustomReimbursementRule:
-        if "rate" in kwargs:
+        if kwargs.get("rate") is not None:
             kwargs["amount"] = None
-        if "offerer" in kwargs:
+        if kwargs.get("offerer"):
             kwargs["offer"] = None
             kwargs["venue"] = None
-        elif "venue" in kwargs:
+        elif kwargs.get("venue"):
             kwargs["offer"] = None  # offerer is already None here
         return super()._create(model_class, *args, **kwargs)
 

--- a/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/forms.py
+++ b/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/forms.py
@@ -5,8 +5,10 @@ from flask import flash
 from flask_wtf import FlaskForm
 import wtforms
 
+from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories_v2
 from pcapi.routes.backoffice.forms import fields
+from pcapi.routes.backoffice.forms import utils
 
 
 class GetCustomReimbursementRulesListForm(FlaskForm):
@@ -35,6 +37,14 @@ class GetCustomReimbursementRulesListForm(FlaskForm):
         coerce=int,
         validators=(wtforms.validators.Optional(),),
     )
+    categories = fields.PCSelectMultipleField(
+        "Catégories",
+        choices=utils.choices_from_enum(categories.CategoryIdLabelEnum),
+        field_list_compatibility=True,
+    )
+    subcategories = fields.PCSelectMultipleField(
+        "Sous-catégories", choices=[(s.id, s.pro_label) for s in subcategories_v2.ALL_SUBCATEGORIES]
+    )
 
     def is_empty(self) -> bool:
         return not any(
@@ -42,6 +52,8 @@ class GetCustomReimbursementRulesListForm(FlaskForm):
                 self.q.data,
                 self.offerer.data,
                 self.venue.data,
+                self.categories.data,
+                self.subcategories.data,
             )
         )
 

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
@@ -1,6 +1,7 @@
 {% import "components/forms.html" as forms with context %}
 {% import "components/links.html" as links %}
 {% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
+{% from "components/turbo/spinner.html" import build_loading_spinner with context %}
 {% extends "layouts/connected.html" %}
 {% block page %}
   <div class="pt-3 px-5"
@@ -20,6 +21,13 @@
       </div>
     </div>
     <div class="filters-container">{{ forms.build_filters_form(form, dst) }}</div>
+    <div class="row">
+      <div class="col-md-11 mb-4">
+        <turbo-frame id="reimbursement_stats" src="{{ url_for("backoffice_web.reimbursement_rules.get_stats") }}">
+        {{ build_loading_spinner() }}
+        </turbo-frame>
+      </div>
+    </div>
     <div>
       {% if has_permission("CREATE_REIMBURSEMENT_RULES") %}
         <button class="btn btn-outline-primary lead fw-bold mt-2"

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list/stats.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list/stats.html
@@ -1,0 +1,28 @@
+<turbo-frame data-turbo="false" id="reimbursement_stats">
+<div class="d-flex flex-row gap-2">
+  <div class="card h-100 shadow p-2 flex-grow-1">
+    <div class="card-body">
+      <h5 class="fs-2 card-title">{{ stats.by_offerer or 0 }}</h5>
+      <p class="card-text fw-light small mb-0">
+        tarifs dérogatoires sur des <b>structures</b>
+      </p>
+    </div>
+  </div>
+  <div class="card h-100 shadow p-2 flex-grow-1">
+    <div class="card-body">
+      <h5 class="fs-2 card-title">{{ stats.by_venue or 0 }}</h5>
+      <p class="card-text fw-light small mb-0">
+        tarifs dérogatoires sur des <b>lieux</b>
+      </p>
+    </div>
+  </div>
+  <div class="card h-100 shadow p-2 flex-grow-1">
+    <div class="card-body">
+      <h5 class="fs-2 card-title">{{ stats.by_offer or 0 }}</h5>
+      <p class="card-text fw-light small mb-0">
+        tarifs dérogatoires sur des <b>offres</b>
+      </p>
+    </div>
+  </div>
+</div>
+</turbo-frame>


### PR DESCRIPTION
## But de la pull request

<img width="1210" alt="Capture d’écran 2024-01-26 à 11 30 38" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/a71202e2-c7e5-44f9-8fd5-f87198ad33b5">


 - Ajout des filtres `Catégories` et `Sous-catégories` dans la page `Tarifs dérogatoires`
 - Ajout de statistiques sur les tarifs dérogatoires par type

Ticket Jira : https://passculture.atlassian.net/browse/PC-26645

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques