### PR TITLE
(PC-27515)[API] feat: add unicity to AccessibilityProvider ID and VenueId

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 ca50ad3c3fd6 (pre) (head)
-4cc9e281e291 (post) (head)
+5da6795c25fa (post) (head)

--- a/api/src/pcapi/alembic/versions/20240122T164604_5da6795c25fa_make_accessibilityprovider_venueid_and_externalaccessibilityproviderid_unique.py
+++ b/api/src/pcapi/alembic/versions/20240122T164604_5da6795c25fa_make_accessibilityprovider_venueid_and_externalaccessibilityproviderid_unique.py
@@ -1,0 +1,26 @@
+"""
+Add unicity constraint to AccessibilityProvider.venueId and externalAccessibilityProviderId
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "5da6795c25fa"
+down_revision = "4cc9e281e291"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_accessibility_provider_venueId", table_name="accessibility_provider")
+    op.create_index(op.f("ix_accessibility_provider_venueId"), "accessibility_provider", ["venueId"], unique=True)
+    op.create_unique_constraint(
+        "make_accessibility_provider_unique", "accessibility_provider", ["externalAccessibilityId"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("make_accessibility_provider_unique", "accessibility_provider", type_="unique")
+    op.drop_index(op.f("ix_accessibility_provider_venueId"), table_name="accessibility_provider")
+    op.create_index("ix_accessibility_provider_venueId", "accessibility_provider", ["venueId"], unique=False)

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -712,11 +712,14 @@ class GooglePlacesInfo(PcObject, Base, Model):
 
 
 class AccessibilityProvider(PcObject, Base, Model):
-    venueId: int = Column(BigInteger, ForeignKey("venue.id", ondelete="CASCADE"), index=True, nullable=False)
+    venueId: int = Column(
+        BigInteger, ForeignKey("venue.id", ondelete="CASCADE"), index=True, nullable=False, unique=True
+    )
     venue: sa_orm.Mapped[Venue] = relationship("Venue", foreign_keys=[venueId], back_populates="accessibilityProvider")
     externalAccessibilityId: str | None = Column(
         Text,
         nullable=True,
+        unique=True,
     )
     externalAccessibilityData: dict | None = sa.Column(MutableDict.as_mutable(JSONB), nullable=True)
     lastUpdateAtProvider: datetime = Column(DateTime, nullable=False, default=datetime.utcnow)


### PR DESCRIPTION
## But de la pull request

Comme cette table (AccessibilityProvider) est nouvelle, inutilisée et vide je me suis permis de me passer de l'ajout d'un index CONCURRENTLY

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27515

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques