### PR TITLE
(BSR)[API] fix: Fix log level of offer indexation errors for error queue

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -266,7 +266,7 @@ def index_offers_in_queue(stop_only_when_empty: bool = False, from_error_queue: 
                 extra={"count": len(offer_ids)},
             )
             try:
-                reindex_offer_ids(offer_ids)
+                reindex_offer_ids(offer_ids, from_error_queue=from_error_queue)
             except Exception as exc:  # pylint: disable=broad-except
                 if settings.IS_RUNNING_TESTS:
                     raise
@@ -510,7 +510,7 @@ def index_offers_of_venues_in_queue() -> None:
                     )
                     if not offer_ids:
                         break
-                    reindex_offer_ids(offer_ids)
+                    reindex_offer_ids(offer_ids, from_error_queue=False)
                     page += 1
                 logger.info("Finished indexing offers of venue", extra={"venue": venue_id})
     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
We did not pass `from_error_queue` to `reindex_offer_ids()`, which
caused `_log_indexation_error()` to always log at the INFO level.
However, we want to log at the ERROR (exception) level when processing
the error queue.