### PR TITLE
(PC-26938)[PRO] feat: Prefill template offer creation dates.

### DIFF
--- a/pro/src/core/OfferEducational/utils/__specs__/computeInitialValuesFromOffer.spec.ts
+++ b/pro/src/core/OfferEducational/utils/__specs__/computeInitialValuesFromOffer.spec.ts
@@ -1,5 +1,9 @@
 import { DEFAULT_EAC_FORM_VALUES } from 'core/OfferEducational/constants'
-import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import {
+  collectiveOfferFactory,
+  collectiveOfferTemplateFactory,
+} from 'utils/collectiveApiFactories'
+import { formatShortDateForInput } from 'utils/date'
 
 import { computeInitialValuesFromOffer } from '../computeInitialValuesFromOffer'
 
@@ -26,5 +30,32 @@ describe('computeInitialValuesFromOffer', () => {
         })
       ).notificationEmails
     ).toEqual(['someemail@example.com'])
+  })
+
+  it('should pre-set todays dates for a template offer creation initial values', () => {
+    expect(
+      computeInitialValuesFromOffer(
+        { educationalCategories: [], educationalSubCategories: [] },
+        [],
+        true,
+        undefined
+      ).beginningDate
+    ).toEqual(formatShortDateForInput(new Date()))
+  })
+
+  it('should fill the time values to the start date time', () => {
+    expect(
+      computeInitialValuesFromOffer(
+        { educationalCategories: [], educationalSubCategories: [] },
+        [],
+        true,
+        collectiveOfferTemplateFactory({
+          dates: {
+            end: '2024-01-29T23:00:28.040559Z',
+            start: '2024-01-23T23:00:28.040547Z',
+          },
+        })
+      ).hour
+    ).toEqual('23:00')
   })
 })

--- a/pro/src/core/OfferEducational/utils/computeInitialValuesFromOffer.ts
+++ b/pro/src/core/OfferEducational/utils/computeInitialValuesFromOffer.ts
@@ -1,13 +1,12 @@
-import { format } from 'date-fns'
-
 import {
   SubcategoryIdEnum,
   StudentLevels,
   GetEducationalOffererResponseModel,
 } from 'apiClient/v1'
 import {
-  FORMAT_HH_mm,
-  FORMAT_ISO_DATE_ONLY,
+  formatShortDateForInput,
+  formatTimeForInput,
+  getToday,
   toDateStrippedOfTimezone,
 } from 'utils/date'
 
@@ -130,11 +129,16 @@ export const computeInitialValuesFromOffer = (
   )
 
   if (offer === undefined) {
+    const today = formatShortDateForInput(getToday())
     return {
       ...DEFAULT_EAC_FORM_VALUES,
       offererId: initialOffererId,
       venueId: initialVenueId,
       isTemplate,
+      beginningDate: isTemplate
+        ? today
+        : DEFAULT_EAC_FORM_VALUES['beginningDate'],
+      endingDate: isTemplate ? today : DEFAULT_EAC_FORM_VALUES['endingDate'],
     }
   }
 
@@ -205,21 +209,15 @@ export const computeInitialValuesFromOffer = (
       : undefined,
     beginningDate:
       isCollectiveOfferTemplate(offer) && offer.dates
-        ? format(
-            toDateStrippedOfTimezone(offer.dates.start),
-            FORMAT_ISO_DATE_ONLY
-          )
+        ? formatShortDateForInput(toDateStrippedOfTimezone(offer.dates.start))
         : DEFAULT_EAC_FORM_VALUES.beginningDate,
     endingDate:
       isCollectiveOfferTemplate(offer) && offer.dates
-        ? format(
-            toDateStrippedOfTimezone(offer.dates.end),
-            FORMAT_ISO_DATE_ONLY
-          )
+        ? formatShortDateForInput(toDateStrippedOfTimezone(offer.dates.end))
         : DEFAULT_EAC_FORM_VALUES.endingDate,
     hour:
       isCollectiveOfferTemplate(offer) && offer.dates
-        ? format(toDateStrippedOfTimezone(offer.dates.start), FORMAT_HH_mm)
+        ? formatTimeForInput(toDateStrippedOfTimezone(offer.dates.start))
         : DEFAULT_EAC_FORM_VALUES.hour,
     formats: offer.formats ?? DEFAULT_EAC_FORM_VALUES.formats,
   }

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/FormDates.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/FormDates.tsx
@@ -1,5 +1,5 @@
 import { useFormikContext } from 'formik'
-import React from 'react'
+import { ChangeEvent } from 'react'
 
 import Callout from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
@@ -19,11 +19,20 @@ const FormDates = ({
   disableForm,
   dateCreated,
 }: FormDatesProps): JSX.Element => {
-  const { values } = useFormikContext<OfferEducationalFormValues>()
+  const { values, setFieldValue } =
+    useFormikContext<OfferEducationalFormValues>()
   const minBeginningDate = dateCreated ? new Date(dateCreated) : new Date()
   const minDateForEndingDate = isDateValid(values.beginningDate)
     ? new Date(values.beginningDate)
     : new Date()
+
+  async function handleBeginningDateChange(e: ChangeEvent<HTMLInputElement>) {
+    const newBeginningDate = e.target.value
+    if (newBeginningDate) {
+      await setFieldValue('endingDate', newBeginningDate)
+    }
+  }
+
   return (
     <FormLayout.Section title="Date et heure">
       <RadioGroup
@@ -55,6 +64,7 @@ const FormDates = ({
               disabled={disableForm}
               minDate={minBeginningDate}
               hideFooter
+              onChange={handleBeginningDateChange}
             />
             <DatePicker
               name="endingDate"

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/__specs__/FormDates.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/__specs__/FormDates.spec.tsx
@@ -168,4 +168,24 @@ describe('FormDates', () => {
       startDate
     )
   })
+
+  it('should set endingDate when the beginningDate changes', async () => {
+    renderFormDates(
+      { ...defaultProps, dateCreated: '2021-01-01' },
+      {
+        ...DEFAULT_EAC_FORM_VALUES,
+        isTemplate: true,
+        datesType: 'specific_dates',
+        beginningDate: '',
+      }
+    )
+
+    const beginningInput = screen.getByLabelText('Date de début')
+
+    await userEvent.type(beginningInput, '2025-02-02')
+    expect(screen.getByLabelText('Date de fin')).toHaveAttribute(
+      'value',
+      '2025-02-02'
+    )
+  })
 })

--- a/pro/src/utils/__specs__/date.spec.ts
+++ b/pro/src/utils/__specs__/date.spec.ts
@@ -1,6 +1,8 @@
 import {
   FORMAT_DD_MM_YYYY_HH_mm,
   formatBrowserTimezonedDateAsUTC,
+  formatShortDateForInput,
+  formatTimeForInput,
   getRangeToFrenchText,
   toDateStrippedOfTimezone,
   toISOStringWithoutMilliseconds,
@@ -103,5 +105,17 @@ describe('getRangeToFrenchText', () => {
     const formattedRange = getRangeToFrenchText(from, to)
 
     expect(formattedRange).toBe('Du 17 novembre 2020 au 10 janvier 2021 à 08h')
+  })
+
+  it('should format a date with the right format for a HTML input', () => {
+    const date = new Date('2020-11-17T08:00:00Z')
+
+    expect(formatShortDateForInput(date)).toBe('2020-11-17')
+  })
+
+  it('should format a time with the right format for a HTML input', () => {
+    const date = new Date('2020-11-17T23:10:00Z')
+
+    expect(formatTimeForInput(date)).toBe('23:10')
   })
 })

--- a/pro/src/utils/date.ts
+++ b/pro/src/utils/date.ts
@@ -99,3 +99,18 @@ export const getYearMonthDay = (date: string) => {
   const [year, month, day] = date.split('-')
   return [parseInt(year), parseInt(month) - 1, parseInt(day)]
 }
+
+export function formatShortDateForInput(date: Date) {
+  //  sv-se is similar to ISO 8601 for the short date format, which is used in HTML Input dates
+  //  The output format is yyyy-MM-dd
+  return new Intl.DateTimeFormat('sv-se').format(date)
+}
+
+export function formatTimeForInput(date: Date) {
+  //  sv-se is similar to ISO 8601 for the time format, which is used in HTML Input dates
+  //  The output format is HH:mm
+  return new Intl.DateTimeFormat('sv-se', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26938

**Objectif**
- A la création d'une offre vitrine collective, lorsqu'on choisit des dates spécifiques, voir les dates de début et de fin pré-remplies à aujourd'hui
- Quand on modifie la date de début, mettre à jour la date de fin à la même valeur que la date de début

**A noter**
Au passage ajout de 2 fonctions qui permettent de préciser le formattage le + approprié pour un input HTML sans se baser sur une constante d'affichage. Voir le commentaire des retours de Marie.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques