### PR TITLE
(BSR)[API] refactor: Remove return value of `send_transactional_sms`

### DIFF
--- a/api/src/pcapi/notifications/sms/__init__.py
+++ b/api/src/pcapi/notifications/sms/__init__.py
@@ -2,6 +2,6 @@ from pcapi import settings
 from pcapi.utils.module_loading import import_string
 
 
-def send_transactional_sms(recipient: str, content: str) -> bool:
+def send_transactional_sms(recipient: str, content: str) -> None:
     backend = import_string(settings.SMS_NOTIFICATION_BACKEND)
-    return backend().send_transactional_sms(recipient, content)
+    backend().send_transactional_sms(recipient, content)

--- a/api/src/pcapi/notifications/sms/backends/logger.py
+++ b/api/src/pcapi/notifications/sms/backends/logger.py
@@ -5,10 +5,9 @@ logger = logging.getLogger(__name__)
 
 
 class LoggerBackend:
-    def send_transactional_sms(self, recipient: str, content: str) -> bool:
+    def send_transactional_sms(self, recipient: str, content: str) -> None:
         logger.info(
             "A transactional sms request would be sent to number='%s' with content='%s'.",
             recipient,
             content,
         )
-        return True

--- a/api/src/pcapi/notifications/sms/backends/testing.py
+++ b/api/src/pcapi/notifications/sms/backends/testing.py
@@ -3,7 +3,7 @@ from pcapi.notifications.sms.backends.logger import LoggerBackend
 
 
 class TestingBackend(LoggerBackend):
-    def send_transactional_sms(self, recipient: str, content: str) -> bool:
+    def send_transactional_sms(self, recipient: str, content: str) -> None:
         super().send_transactional_sms(recipient, content)
         testing.requests.append(
             {
@@ -11,4 +11,3 @@ class TestingBackend(LoggerBackend):
                 "content": content,
             }
         )
-        return True


### PR DESCRIPTION
It's always True and, actually, never used.

See 5b7bfb6c6f854b15c895bacb3a5 for a similar changes for mails.