### PR TITLE
(PC-27542)[PRO] style: Make disclose dialog rsponsive and min-height …

### DIFF
--- a/pro/src/components/DialogBox/DialogBox.module.scss
+++ b/pro/src/components/DialogBox/DialogBox.module.scss
@@ -22,9 +22,8 @@
 }
 
 .dialog-box-close-container {
-  display: flex;
-  width: 100%;
-  justify-content: flex-end;
+  display: block;
+  float: right;
 }
 
 .dialog-box-close {
@@ -35,7 +34,6 @@
   justify-content: center;
   margin: rem.torem(-2px) rem.torem(-2px) rem.torem(-9px) 0;
   width: rem.torem(44px);
-  position: absolute;
 
   &-icon {
     width: rem.torem(24px);
@@ -52,9 +50,9 @@
 }
 
 @media (min-width: size.$tablet) {
-    .dialog-box-content {
-      min-width: rem.torem(534px);
-    }
+  .dialog-box-content {
+    min-width: rem.torem(534px);
+  }
 
   .dialog-box-full-content-width {
     width: size.$main-content-width !important;

--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
@@ -10,7 +10,7 @@ $banner-height: rem.torem(124px);
 
 .dialog {
   &-with-banner {
-    height: $modal-height + $banner-height;
+    min-height: $modal-height + $banner-height;
   }
 
   &-title {
@@ -67,20 +67,23 @@ $banner-height: rem.torem(124px);
   }
 
   @media (min-width: size.$tablet) {
-    height: $modal-height;
+    min-height: $modal-height;
     width: $modal-width;
 
     &-with-banner {
-      height: $modal-height + $banner-height;
+      min-height: $modal-height + $banner-height;
     }
   }
 }
 
 .discard-dialog {
-  width: $modal-width;
-  height: $modal-height;
+  min-height: $modal-height;
 
   &-with-banner {
-    height: $modal-height + $banner-height;
+    min-height: $modal-height + $banner-height;
+  }
+
+  @media (min-width: size.$tablet) {
+    width: $modal-width;
   }
 }


### PR DESCRIPTION
…instead of height.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27542

**Objectif**
Remplacer les `height` des dialogs des remboursements par des `min-height` et s'assurer que les dialogs s'ouvrent bien les uns par dessus les autres sans dépasser (au moins sur grands écrans).
On a aussi retouché le style du bouton pour quitter un dialog sinon il passait derrière les titres des dialogs.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques