### PR TITLE
(BSR)[API] feat: add named query to find long-running SQL transactions

### DIFF
--- a/api/etc/pgcli.ini
+++ b/api/etc/pgcli.ini
@@ -21,3 +21,22 @@ destructive_warning = true
 # When this option is on (and if `destructive_warning` is set),
 # destructive statements are not executed when outside of a transaction.
 destructive_statements_require_transaction = true
+
+# Named queries are queries you can execute by name.
+[named queries]
+# See the documentation on named queries for more examples.
+long_transactions = """
+    SELECT
+        age(clock_timestamp(), xact_start) as transaction_time,
+        age(clock_timestamp(), query_start) as spent_time,
+        pid,
+        state,
+        client_addr,
+        query
+    FROM
+        pg_stat_activity
+    WHERE
+        NOT state = 'idle'
+    ORDER BY
+        transaction_time DESC;
+    """


### PR DESCRIPTION
## But de la pull request

Enregistrer une named query dans la config pgcli afin de trouver les transactions longues.
On l'invoque ainsi: `\n long_transactions`

(@xordoquy a la paternité de la syntaxe de la requête)