### PR TITLE
(PC-27556) perf: remove useless check 

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1073,15 +1073,6 @@ def set_offer_status_based_on_fraud_criteria(offer: AnyOffer) -> models.OfferVal
     return status
 
 
-def _load_product_by_ean(ean: str | None) -> models.Product:
-    if not ean:
-        raise exceptions.MissingEAN()
-    product = models.Product.query.filter(models.Product.extraData["ean"].astext == ean).first()
-    if product is None or not product.isGcuCompatible:
-        raise exceptions.NotEligibleEAN()
-    return product
-
-
 def unindex_expired_offers(process_all_expired: bool = False) -> None:
     """Unindex offers that have expired.
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -257,7 +257,7 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
             )
         for product in existing_products:
             try:
-                ean = product.extraData["ean"]  # type: ignore [index]
+                ean = product.extraData["ean"] if product.extraData else None
                 stock_data = serialized_products_stocks[ean]
                 created_offer = _create_offer_from_product(
                     venue,
@@ -379,10 +379,7 @@ def _create_offer_from_product(
     product: offers_models.Product,
     provider: providers_models.Provider,
 ) -> offers_models.Offer:
-    ean = None
-    if product.extraData:
-        ean = product.extraData.get("ean")
-        offers_validation.check_ean_does_not_exist(ean, venue)
+    ean = product.extraData.get("ean") if product.extraData else None
 
     offer = offers_api.build_new_offer_from_product(venue, product, ean, provider.id)
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1883,34 +1883,6 @@ class ResolveOfferValidationRuleTest:
         assert api.set_offer_status_based_on_fraud_criteria(collective_offer) == expected_status
 
 
-@pytest.mark.usefixtures("db_session")
-class LoadProductByEan:
-    def test_returns_product_if_found_and_is_gcu_compatible(self):
-        ean = "2221001648"
-        product = factories.ProductFactory(extraData={"ean": ean}, isGcuCompatible=True)
-
-        result = api._load_product_by_ean(ean)
-
-        assert result == product
-
-    def test_raise_api_error_if_no_product(self):
-        factories.ProductFactory(isGcuCompatible=True)
-
-        with pytest.raises(exceptions.NotEligibleEAN) as exception_info:
-            api._load_product_by_ean("2221001649")
-
-        assert exception_info.value.errors["ean"] == ["product not eligible to pass Culture"]
-
-    def test_raise_api_error_if_product_is_not_gcu_compatible(self):
-        ean = "2221001648"
-        factories.ProductFactory(extraData={"ean": ean}, isGcuCompatible=False)
-
-        with pytest.raises(exceptions.NotEligibleEAN) as exception_info:
-            api._load_product_by_ean(ean)
-
-        assert exception_info.value.errors["ean"] == ["product not eligible to pass Culture"]
-
-
 @freeze_time("2020-01-05 10:00:00")
 @pytest.mark.usefixtures("db_session")
 class UnindexExpiredOffersTest:


### PR DESCRIPTION
## But de la pull request
Remove a check that was executed once by offer to create and could takes up to 3/4 of execution time (see the autogrouped queries [here](https://sentry.passculture.team/organizations/sentry/performance/api:a5d1c196a8914071b4aa0a34f851d468/?environment=production&project=5&query=transaction.duration%3A%3C15m&statsPeriod=90d&transaction=pcapi.routes.public.individual_offers.v1.products._create_or_update_ean_offers&unselectedSeries=p100%28%29))
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27556

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques