### PR TITLE
(PC-26335)[BO] feat: Add finance incident to reimbursement details csv

### DIFF
--- a/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
+++ b/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
@@ -28,7 +28,7 @@ def _build_full_address(street: str | None, postal_code: str | None, city: str |
     return " ".join((street or "", postal_code or "", city or ""))
 
 
-def _get_validation_period(cutoff: datetime.datetime) -> str:
+def _get_validation_period(cutoff: datetime.datetime, is_incident: bool = False) -> str:
     """Indicate the 2-week period during which most(*) bookings have
     been validated that correspond with the requested cutoff.
 
@@ -48,7 +48,7 @@ def _get_validation_period(cutoff: datetime.datetime) -> str:
         fortnight = "1ère quinzaine"
     else:
         fortnight = "2nde quinzaine"
-    return f"Validées et remboursables sur {month} : {fortnight}"
+    return f"{'Incident' if is_incident else 'Validées et remboursables'} sur {month} : {fortnight}"
 
 
 def _legacy_get_validation_period(transaction_label: str) -> str:
@@ -114,7 +114,8 @@ class ReimbursementDetails:
         if using_legacy_models:
             self.validation_period = _legacy_get_validation_period(payment_info.transaction_label)
         else:
-            self.validation_period = _get_validation_period(payment_info.cashflow_batch_cutoff)
+            is_incident = getattr(payment_info, "is_incident", False)
+            self.validation_period = _get_validation_period(payment_info.cashflow_batch_cutoff, is_incident=is_incident)
 
         # Invoice info
         if using_legacy_models:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26335

Adaptation du fichier "details des remboursements" téléchargeable sur la page d'un lieu.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques