### PR TITLE
(PC-26958)[EAC] feat: synchronize two playlists data

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/__init__.py
+++ b/api/src/pcapi/connectors/big_query/queries/__init__.py
@@ -1,7 +1,7 @@
 from .adage_playlists import ClassroomPlaylistQuery  # noqa: F401
 from .adage_playlists import InstitutionRuralLevelQuery  # noqa: F401
 from .adage_playlists import LocalOfferersQuery  # noqa: F401
-from .adage_playlists import NewTemplateOffersPlaylist  # noqa: F401
+from .adage_playlists import NewTemplateOffersPlaylistQuery  # noqa: F401
 from .favorites_not_booked import FavoritesNotBooked  # noqa: F401
 from .favorites_not_booked import FavoritesNotBookedModel  # noqa: F401
 from .last_30_days_booking import Last30DaysBookings  # noqa: F401

--- a/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
+++ b/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
@@ -30,7 +30,7 @@ class NewTemplateOffersPlaylistModel(pydantic_v1.BaseModel):
     distance_in_km: float
 
 
-class NewTemplateOffersPlaylist(BaseQuery):
+class NewTemplateOffersPlaylistQuery(BaseQuery):
     raw_query = f"""
         SELECT
             distinct collective_offer_id,

--- a/api/src/pcapi/core/educational/api/playlists.py
+++ b/api/src/pcapi/core/educational/api/playlists.py
@@ -1,6 +1,8 @@
+from dataclasses import dataclass
 import logging
 
 import pcapi.connectors.big_query.queries as big_query
+from pcapi.connectors.big_query.queries.base import BaseQuery
 import pcapi.core.educational.models as educational_models
 from pcapi.models import db
 
@@ -8,44 +10,72 @@ from pcapi.models import db
 logger = logging.getLogger(__name__)
 
 
-def synchronize_classroom_playlist(
-    playlist_type: educational_models.PlaylistType, institution: educational_models.EducationalInstitution
+@dataclass
+class QueryCtx:
+    query: type[BaseQuery]
+    bq_attr_name: str
+    local_attr_name: str
+
+
+QUERY_DESC = {
+    educational_models.PlaylistType.CLASSROOM: QueryCtx(
+        query=big_query.ClassroomPlaylistQuery,
+        bq_attr_name="collective_offer_id",
+        local_attr_name="collectiveOfferTemplateId",
+    ),
+    educational_models.PlaylistType.NEW_OFFER: QueryCtx(
+        query=big_query.NewTemplateOffersPlaylistQuery,
+        bq_attr_name="collective_offer_id",
+        local_attr_name="collectiveOfferTemplateId",
+    ),
+    educational_models.PlaylistType.LOCAL_OFFERER: QueryCtx(
+        query=big_query.LocalOfferersQuery, bq_attr_name="venue_id", local_attr_name="venueId"
+    ),
+}
+
+
+def synchronize_institution_playlist(
+    playlist_type: educational_models.PlaylistType,
+    institution: educational_models.EducationalInstitution,
+    bq_extra_filters: dict,
 ) -> None:
-    new_rows = {
-        int(row.collective_offer_id): row.distance_in_km
-        for row in big_query.ClassroomPlaylistQuery().execute(institution_id=str(institution.id))
-    }
+    bq_extra_filters = {k: v for k, v in bq_extra_filters.items() if v}
+    bq_filters = {"institution_id": str(institution.id), **bq_extra_filters}
+
+    ctx = QUERY_DESC[playlist_type]
+    new_rows = {int(getattr(row, ctx.bq_attr_name)): row.distance_in_km for row in ctx.query().execute(**bq_filters)}
+
     actual_rows = {
-        row.collectiveOfferTemplateId: row
+        getattr(row, ctx.local_attr_name): row
         for row in educational_models.CollectivePlaylist.query.filter(
             educational_models.CollectivePlaylist.type == playlist_type,
             educational_models.CollectivePlaylist.institution == institution,
         )
     }
 
-    offer_ids_to_remove = actual_rows.keys() - new_rows.keys()
-    offer_ids_to_add = new_rows.keys() - actual_rows.keys()
-    offer_ids_to_update = new_rows.keys() & actual_rows.keys()
+    item_ids_to_remove = actual_rows.keys() - new_rows.keys()
+    item_ids_to_add = new_rows.keys() - actual_rows.keys()
+    item_ids_to_update = new_rows.keys() & actual_rows.keys()
 
-    playlist_ids_to_remove = [actual_rows[offer_id].id for offer_id in offer_ids_to_remove]
+    playlist_ids_to_remove = [actual_rows[item_id].id for item_id in item_ids_to_remove]
 
     playlist_items_to_add = [
         {
             "type": playlist_type,
             "institutionId": institution.id,
-            "distanceInKm": new_rows[offer_id],
-            "collectiveOfferTemplateId": offer_id,
+            "distanceInKm": new_rows[item_id],
+            ctx.local_attr_name: item_id,
         }
-        for offer_id in offer_ids_to_add
+        for item_id in item_ids_to_add
     ]
 
     playlist_items_to_update = [
         {
-            "id": actual_rows[offer_id].id,
-            "distanceInKm": new_rows[offer_id],
+            "id": actual_rows[item_id].id,
+            "distanceInKm": new_rows[item_id],
         }
-        for offer_id in offer_ids_to_update
-        if new_rows[offer_id] != actual_rows[offer_id].distanceInKm
+        for item_id in item_ids_to_update
+        if new_rows[item_id] != actual_rows[item_id].distanceInKm
     ]
 
     if playlist_ids_to_remove:
@@ -58,15 +88,30 @@ def synchronize_classroom_playlist(
         db.session.bulk_update_mappings(educational_models.CollectivePlaylist, playlist_items_to_update)
 
 
-def synchronize_classroom_playlists() -> None:
-    playlist_type = educational_models.PlaylistType.CLASSROOM
+def synchronize_collective_playlist(playlist_type: educational_models.PlaylistType, with_range: bool = False) -> None:
     institutions = educational_models.EducationalInstitution.query.all()
     for institution in institutions:
         try:
-            synchronize_classroom_playlist(playlist_type, institution)
+            extra_args = _compute_extra_args(institution.ruralLevel, with_range)
+            synchronize_institution_playlist(playlist_type, institution, extra_args)
             # Might be a shame that this will clear the initial institution query and will refetch
             # the institution every time. Small price to pay I guess.
             db.session.commit()
         except Exception:  # pylint: disable=broad-except
             logger.exception("Failed to synchronize playlist %s for institution %s", playlist_type, institution)
             db.session.rollback()
+
+
+def _compute_extra_args(rural_level: educational_models.InstitutionRuralLevel, with_range: bool = False) -> dict:
+    if with_range:
+        max_range = {
+            educational_models.InstitutionRuralLevel.URBAIN_DENSE: 3,
+            educational_models.InstitutionRuralLevel.URBAIN_DENSITE_INTERMEDIAIRE: 10,
+            educational_models.InstitutionRuralLevel.RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE: 15,
+            educational_models.InstitutionRuralLevel.RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE: 60,
+            educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE: 60,
+            educational_models.InstitutionRuralLevel.RURAL_AUTONOME_TRES_PEU_DENSE: 60,
+            None: 60,
+        }.get(rural_level, 60)
+        return {"range": max_range}
+    return {}

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -200,7 +200,19 @@ def synchronise_rurality_level() -> None:
     institution_api.synchronise_rurality_level()
 
 
-@blueprint.cli.command("synchronise_collective_playlists")
+@blueprint.cli.command("synchronise_collective_classroom_playlist")
 @log_cron_with_transaction
-def synchronise_collective_playlists() -> None:
-    playlists_api.synchronize_classroom_playlists()
+def synchronise_collective_playlist() -> None:
+    playlists_api.synchronize_collective_playlist(educational_models.PlaylistType.CLASSROOM)
+
+
+@blueprint.cli.command("synchronise_collective_new_offer_playlist")
+@log_cron_with_transaction
+def synchronise_collective_new_offer_playlist() -> None:
+    playlists_api.synchronize_collective_playlist(educational_models.PlaylistType.NEW_OFFER)
+
+
+@blueprint.cli.command("synchronise_collective_local_offerers_playlist")
+@log_cron_with_transaction
+def synchronise_collective_local_offerer_playlist() -> None:
+    playlists_api.synchronize_collective_playlist(educational_models.PlaylistType.LOCAL_OFFERER, with_range=True)

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -342,3 +342,4 @@ class PlaylistFactory(BaseFactory):
     type = models.PlaylistType.CLASSROOM
     institution = factory.SubFactory(EducationalInstitutionFactory)
     collective_offer_template = factory.SubFactory(CollectiveOfferTemplateFactory)
+    venue = factory.SubFactory(offerers_factories.VenueFactory)

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -954,13 +954,16 @@ def get_collective_offer_template_by_ids(offer_ids: list[int]) -> list[education
 
 
 def get_collective_offer_templates_for_playlist(
-    institution_id: int,
+    institution_id: int, playlist_type: educational_models.PlaylistType, max_distance: int | None = 60
 ) -> list[educational_models.CollectiveOfferTemplate]:
     query = educational_models.CollectivePlaylist.query.filter(
-        educational_models.CollectivePlaylist.type == educational_models.PlaylistType.CLASSROOM,
+        educational_models.CollectivePlaylist.type == playlist_type,
         educational_models.CollectivePlaylist.institutionId == institution_id,
-        educational_models.CollectivePlaylist.distanceInKm <= 60,
     )
+
+    if max_distance:
+        query = query.filter(educational_models.CollectivePlaylist.distanceInKm <= max_distance)
+
     query = query.options(
         sa.orm.joinedload(educational_models.CollectivePlaylist.collective_offer_template)
         .joinedload(

--- a/api/tests/core/educational/api/test_playlists.py
+++ b/api/tests/core/educational/api/test_playlists.py
@@ -5,13 +5,21 @@ import pytest
 import pcapi.core.educational.api.playlists as playlist_api
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.educational.models as educational_models
+import pcapi.core.offerers.factories as offerers_factories
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
 class SynchronizePlaylistsTest:
-    def test_synchronize_classroom_playlists(self):
+    @pytest.mark.parametrize(
+        "playlist_type",
+        (
+            educational_models.PlaylistType.CLASSROOM,
+            educational_models.PlaylistType.NEW_OFFER,
+        ),
+    )
+    def test_synchronize_collective_playlist(self, playlist_type):
         initial_distance = 5.001234
         updated_distance = 10.001234
         institution = educational_factories.EducationalInstitutionFactory()
@@ -24,7 +32,7 @@ class SynchronizePlaylistsTest:
 
         for offer in offers[:3]:
             educational_factories.PlaylistFactory(
-                type=educational_models.PlaylistType.CLASSROOM,
+                type=playlist_type,
                 distanceInKm=initial_distance,
                 institution=institution,
                 collective_offer_template=offer,
@@ -37,7 +45,7 @@ class SynchronizePlaylistsTest:
                 {"collective_offer_id": str(offers[1].id), "distance_in_km": updated_distance},
                 {"collective_offer_id": str(offers[3].id), "distance_in_km": updated_distance},
             ]
-            playlist_api.synchronize_classroom_playlists()
+            playlist_api.synchronize_collective_playlist(playlist_type)
 
         playlist_items = educational_models.CollectivePlaylist.query.order_by(
             educational_models.CollectivePlaylist.id
@@ -54,21 +62,86 @@ class SynchronizePlaylistsTest:
 
         assert playlist_data == [
             {
-                "type": educational_models.PlaylistType.CLASSROOM,
+                "type": playlist_type,
                 "distance_in_km": initial_distance,
                 "offer_id": offers[0].id,
                 "institution_id": institution.id,
             },
             {
-                "type": educational_models.PlaylistType.CLASSROOM,
+                "type": playlist_type,
                 "distance_in_km": updated_distance,
                 "offer_id": offers[1].id,
                 "institution_id": institution.id,
             },
             {
-                "type": educational_models.PlaylistType.CLASSROOM,
+                "type": playlist_type,
                 "distance_in_km": updated_distance,
                 "offer_id": offers[3].id,
+                "institution_id": institution.id,
+            },
+        ]
+
+    def test_synchronize_local_offerer_playlist(self):
+        initial_distance = 5.001234
+        updated_distance = 10.001234
+        institution = educational_factories.EducationalInstitutionFactory()
+        # Create 4 venues:
+        #  #1 will be on playlist and should not be updated
+        #  #2 will be on playlist and should be updated
+        #  #3 will be on playlist and should be removed
+        #  #4 will not be on playlist and should be created
+        venues = offerers_factories.VenueFactory.create_batch(4)
+
+        playlist_type = educational_models.PlaylistType.LOCAL_OFFERER
+
+        for venue in venues[:3]:
+            educational_factories.PlaylistFactory(
+                type=playlist_type,
+                distanceInKm=initial_distance,
+                institution=institution,
+                collective_offer_template=None,
+                venue=venue,
+            )
+
+        mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
+        with patch(mock_path) as mock_run_query:
+            mock_run_query.return_value = [
+                {"venue_id": str(venues[0].id), "distance_in_km": initial_distance},
+                {"venue_id": str(venues[1].id), "distance_in_km": updated_distance},
+                {"venue_id": str(venues[3].id), "distance_in_km": updated_distance},
+            ]
+            playlist_api.synchronize_collective_playlist(playlist_type)
+
+        playlist_items = educational_models.CollectivePlaylist.query.order_by(
+            educational_models.CollectivePlaylist.id
+        ).all()
+        playlist_data = [
+            {
+                "type": item.type,
+                "distance_in_km": item.distanceInKm,
+                "venue_id": item.venueId,
+                "institution_id": item.institutionId,
+            }
+            for item in playlist_items
+        ]
+
+        assert playlist_data == [
+            {
+                "type": playlist_type,
+                "distance_in_km": initial_distance,
+                "venue_id": venues[0].id,
+                "institution_id": institution.id,
+            },
+            {
+                "type": playlist_type,
+                "distance_in_km": updated_distance,
+                "venue_id": venues[1].id,
+                "institution_id": institution.id,
+            },
+            {
+                "type": playlist_type,
+                "distance_in_km": updated_distance,
+                "venue_id": venues[3].id,
                 "institution_id": institution.id,
             },
         ]

--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -7,7 +7,8 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
-from pcapi.models import db
+
+# from pcapi.models import db
 from pcapi.routes.serialization import collective_offers_serialize
 
 
@@ -89,62 +90,56 @@ class GetClassroomPlaylistTest(SharedPlaylistsErrorTests):
         assert "auth" in response.json
 
 
-class GetNewTemplateOffersPlaylistTest(SharedPlaylistsErrorTests):
+class GetNewTemplateOffersPlaylistQueryTest(SharedPlaylistsErrorTests):
     endpoint = "adage_iframe.new_template_offers_playlist"
 
     def test_new_template_offers_playlist(self, client):
-        offers = educational_factories.CollectiveOfferTemplateFactory.create_batch(3)
-        for offer in offers:
+        institution = educational_factories.EducationalInstitutionFactory()
+        expected_distance = 10.0
+
+        playlist_offers = educational_factories.CollectiveOfferTemplateFactory.create_batch(2)
+        for offer in playlist_offers:
             offer.offerVenue = {
                 "addressType": collective_offers_serialize.OfferAddressType.OFFERER_VENUE.value,
                 "otherAddress": "",
                 "venueId": offer.venueId,
             }
-        redactor = educational_factories.EducationalRedactorFactory()
 
-        expected_distance = 10.0
+            educational_models.CollectivePlaylist(
+                type=educational_models.PlaylistType.NEW_OFFER,
+                distanceInKm=expected_distance,
+                institution=institution,
+                collective_offer_template=offer,
+            )
 
-        iframe_client = _get_iframe_client(client, email=redactor.email)
+        redactor = educational_factories.EducationalRedactorFactory(
+            favoriteCollectiveOfferTemplates=[playlist_offers[0]]
+        )
 
-        favs = [
-            educational_models.CollectiveOfferTemplateEducationalRedactor(
-                educationalRedactorId=redactor.id,
-                collectiveOfferTemplateId=offers[1].id,
-            ),
-            educational_models.CollectiveOfferTemplateEducationalRedactor(
-                educationalRedactorId=redactor.id,
-                collectiveOfferTemplateId=offers[2].id,
-            ),
-        ]
-        db.session.add(favs[0])
-        db.session.add(favs[1])
-        db.session.flush()
+        educational_factories.CollectiveOfferTemplateFactory()
 
-        mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
-        with patch(mock_path) as mock_run_query:
-            mock_run_query.return_value = [
-                {"collective_offer_id": str(offers[0].id), "distance_in_km": expected_distance},
-                {"collective_offer_id": str(offers[1].id), "distance_in_km": expected_distance},
-                {"collective_offer_id": str(offers[2].id), "distance_in_km": expected_distance},
-            ]
+        iframe_client = _get_iframe_client(client, email=redactor.email, uai=institution.institutionId)
 
-            # fetch institution (1 query)
-            # fetch redactor (1 query)
-            # fetch redactor's favorites (1 query)
-            # fetch playlist data (1 query)
-            with assert_num_queries(4):
-                response = iframe_client.get(url_for(self.endpoint))
+        # fetch institution (1 query)
+        # fetch redactor (1 query)
+        # fetch redactor's favorites (1 query)
+        # fetch playlist data (1 query)
+        with assert_num_queries(4):
+            response = iframe_client.get(url_for(self.endpoint))
 
-                assert response.status_code == 200
+            assert response.status_code == 200
+            assert len(response.json["collectiveOffers"]) == len(playlist_offers)
 
-                assert len(response.json["collectiveOffers"]) == len(offers)
-                response_offers = sorted(response.json["collectiveOffers"], key=lambda o: o["id"])
+        response_offers = sorted(response.json["collectiveOffers"], key=lambda resp: resp["id"])
+        playlist_offers = sorted(playlist_offers, key=lambda resp: resp.id)
 
-                for idx, response_offer in enumerate(response_offers):
-                    assert response_offer["id"] == offers[idx].id
-                    assert response_offer["venue"]["distance"] == expected_distance
-                    assert response_offer["offerVenue"]["distance"] == expected_distance
-                    assert response_offer["isFavorite"] == bool(idx)
+        for idx, response_offer in enumerate(response_offers):
+            assert response_offer["id"] == playlist_offers[idx].id
+            assert response_offer["venue"]["distance"] == expected_distance
+            assert response_offer["offerVenue"]["distance"] == expected_distance
+            assert response_offer["isFavorite"] == (
+                redactor.favoriteCollectiveOfferTemplates[0].id == response_offer["id"]
+            )
 
     def test_no_rows(self, client):
         iframe_client = _get_iframe_client(client)
@@ -168,44 +163,50 @@ class GetLocalOfferersPlaylistTest(SharedPlaylistsErrorTests):
     endpoint = "adage_iframe.get_local_offerers_playlist"
 
     def test_get_local_offerers_playlist(self, client):
-        venues = sorted(offerers_factories.VenueFactory.create_batch(2), key=lambda v: v.id)
-        expected_distance = 10
+        playlist_venues = offerers_factories.VenueFactory.create_batch(2)
+        offerers_factories.VenueFactory()
 
-        iframe_client = _get_iframe_client(client)
+        institution = educational_factories.EducationalInstitutionFactory()
 
-        mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
-        with (
-            patch(mock_path) as mock_run_query,
-            patch("pcapi.routes.adage_iframe.playlists._get_max_range_for_local_venues") as mock_max_range,
-        ):
-            mock_run_query.return_value = [
-                {"venue_id": venues[0].id, "distance_in_km": expected_distance},
-                {"venue_id": venues[1].id, "distance_in_km": expected_distance},
-            ]
-            mock_max_range.return_value = 60
+        expected_distance = 10.0
 
-            # fetch the institution (1 query)
-            # fetch venues data (1 query)
-            with assert_num_queries(2):
-                response = iframe_client.get(url_for(self.endpoint))
+        for venue in playlist_venues:
+            educational_models.CollectivePlaylist(
+                type=educational_models.PlaylistType.LOCAL_OFFERER,
+                distanceInKm=expected_distance,
+                institution=institution,
+                venue=venue,
+            )
 
-            assert response.status_code == 200
-            assert len(response.json["venues"]) == 2
+        redactor = educational_factories.EducationalRedactorFactory()
 
-            for idx, response_venue in enumerate(sorted(response.json["venues"], key=lambda v: v["id"])):
-                assert response_venue["id"] == venues[idx].id
-                assert response_venue["distance"] == expected_distance
+        iframe_client = _get_iframe_client(client, email=redactor.email, uai=institution.institutionId)
 
-    def test_no_rows(self, client):
-        iframe_client = _get_iframe_client(client)
-
-        mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
-        with patch(mock_path) as mock_run_query:
-            mock_run_query.return_value = []
+        # fetch the institution (1 query)
+        # fetch playlist items (1 query)
+        # fetch venues (1 query)
+        with assert_num_queries(3):
             response = iframe_client.get(url_for(self.endpoint))
 
-            assert response.status_code == 200
-            assert response.json == {"venues": []}
+        assert response.status_code == 200
+        assert len(response.json["venues"]) == len(playlist_venues)
+
+        response_venues = sorted(response.json["venues"], key=lambda resp: resp["id"])
+        venues = sorted(playlist_venues, key=lambda venue: venue.id)
+
+        for idx, response_venue in enumerate(response_venues):
+            assert response_venue["id"] == venues[idx].id
+            assert response_venue["distance"] == expected_distance
+
+    def test_no_rows(self, client):
+        institution = educational_factories.EducationalInstitutionFactory()
+        redactor = educational_factories.EducationalRedactorFactory()
+        iframe_client = _get_iframe_client(client, email=redactor.email, uai=institution.institutionId)
+
+        response = iframe_client.get(url_for(self.endpoint))
+
+        assert response.status_code == 200
+        assert response.json == {"venues": []}
 
 
 def _get_iframe_client(client, email=None, uai=None):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26958

Ne plus faire appel à BQ à chaque requête d'une des _playlist_ Adage (page de découverte).
Une précédente PR avait mis en place tout le nécessaire et celle-ci la complète en ajoutant la synchronisation des données pour les _playlists_ des nouvelles offres et des lieux à proximité. Les deux routes qui faisaient appel à BQ vont maintenant chercher les données dans notre base.