### PR TITLE
(BSR)[API] fix: Detect deleted files in `check_folder_changes` workflow

### DIFF
--- a/.github/workflows/dev_on_workflow_check_folder_changes.yml
+++ b/.github/workflows/dev_on_workflow_check_folder_changes.yml
@@ -22,7 +22,7 @@ jobs:
     name: "Check folder changes"
     runs-on: ubuntu-latest
     outputs:
-      folder_changed: ${{ steps.folder-check-changed-files.outputs.any_changed }}
+      folder_changed: ${{ steps.folder-check-changed-files.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
Deleted files were ignored. For example, when a file in "api/" was
deleted, tests were not executed. We would like to execute tests when
files are deleted.

As per the docs (https://github.com/tj-actions/changed-files#outputs-):

    any_changed: includes a combination of all added, copied, modified
    and renamed files (ACMR)

    any_modified: includes a combination of all added, copied,
    modified, renamed, and deleted files (ACMRD).