### PR TITLE
(PC-27587)[PRO] fix: Skiplink is always visible on home page.

### DIFF
--- a/pro/src/components/SkipLinks/SkipLinks.module.scss
+++ b/pro/src/components/SkipLinks/SkipLinks.module.scss
@@ -7,10 +7,10 @@
   height: 0;
   position: absolute;
   background-color: colors.$secondary;
-  top: 0;
+  top: rem.torem(-32px);
 
   &:focus-within {
-    min-height: rem.torem(32px);
+    height: rem.torem(32px);
     position: relative;
     z-index: 2;
     top: 0;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27587

**Objectif**
Après mes dernières modifs de clean de style sur les liens d'évitement, le lien apparait toujours visible sur la page d'accueil. Ce commit corrige la position du menu d'évitement.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques