### PR TITLE
(PC-27560)[PRO] feat: active header for subroutes adage

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderMenu/AdageHeaderMenu.tsx
@@ -37,7 +37,6 @@ export const AdageHeaderMenu = ({
             <li className={styles['adage-header-menu-item']}>
               <NavLink
                 to={`/adage-iframe/decouverte?token=${adageAuthToken}`}
-                end
                 className={({ isActive }) => {
                   return cn(styles['adage-header-link'], {
                     [styles['adage-header-link-active']]: isActive,
@@ -53,7 +52,6 @@ export const AdageHeaderMenu = ({
           <li className={styles['adage-header-menu-item']}>
             <NavLink
               to={`/adage-iframe/recherche?token=${adageAuthToken}`}
-              end
               className={({ isActive }) => {
                 return cn(styles['adage-header-link'], {
                   [styles['adage-header-link-active']]: isActive,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27560

Activer la couleur dans le header : 

exemple:

je suis sur la découverte, je clique sur une offre qui me redirige sur une page dédiée contenant /découverte/offerid/2 on veut que le header s'active pour Découverte
pour le lien de partage, si l'on est pas admin, nous aurons /recherche/offerid/2 dans ce cas, le header est activé pour Rechercher