### PR TITLE
(PC-27559)[PRO] feat: Add dynamic back link in adage offers pages bre…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -69,6 +69,8 @@ export const AppLayout = (): JSX.Element => {
           />
           <Route path="mes-favoris" element={<OffersFavorites />} />
           <Route path="decouverte/offre/:offerId" element={<OfferInfos />} />
+          <Route path="recherche/offre/:offerId" element={<OfferInfos />} />
+          <Route path="mes-favoris/offre/:offerId" element={<OfferInfos />} />
         </Routes>
       </main>
     </div>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -6,6 +6,7 @@ import { apiAdage } from 'apiClient/api'
 import Breadcrumb, { Crumb } from 'components/Breadcrumb/Breadcrumb'
 import strokePassIcon from 'icons/stroke-pass.svg'
 import strokeSearchIcon from 'icons/stroke-search.svg'
+import strokeStarIcon from 'icons/stroke-star.svg'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import Spinner from 'ui-kit/Spinner/Spinner'
@@ -17,13 +18,51 @@ import offerInfosFallback from './assets/offer-infos-fallback.svg'
 import styles from './OfferInfos.module.scss'
 
 export const OfferInfos = () => {
-  const { state } = useLocation()
+  const { state, pathname } = useLocation()
   const { offerId } = useParams()
+  const [searchParams] = useSearchParams()
+  const adageAuthToken = searchParams.get('token')
+
+  const parentRouteInUrl = pathname.split('/')[2] ?? 'recherche'
 
   const [offer, setOffer] = useState(state?.offer)
   const [loading, setLoading] = useState(false)
 
   const { adageUser } = useAdageUser()
+
+  const crumbForCurrentRoute: { [key: string]: Crumb } = {
+    recherche: {
+      title: 'Recherche',
+      link: {
+        isExternal: false,
+        to: `/adage-iframe/recherche?token=${adageAuthToken}`,
+      },
+      icon: strokeSearchIcon,
+    },
+    decouverte: {
+      title: 'Découvrir',
+      link: {
+        isExternal: false,
+        to: `/adage-iframe/decouverte?token=${adageAuthToken}`,
+      },
+      icon: strokePassIcon,
+    },
+    ['mes-favoris']: {
+      title: 'Mes favoris',
+      link: {
+        isExternal: false,
+        to: `/adage-iframe/mes-favoris?token=${adageAuthToken}`,
+      },
+      icon: strokeStarIcon,
+    },
+  }
+
+  const originCrumb: Crumb =
+    crumbForCurrentRoute[
+      adageUser.role === AdageFrontRoles.READONLY
+        ? 'recherche'
+        : parentRouteInUrl
+    ]
 
   useEffect(() => {
     async function getOffer() {
@@ -44,27 +83,8 @@ export const OfferInfos = () => {
     }
   }, [offerId, state?.offer])
 
-  const [searchParams] = useSearchParams()
-  const adageAuthToken = searchParams.get('token')
-
   if (loading) {
     return <Spinner />
-  }
-
-  const originCrumb: Crumb = {
-    title:
-      adageUser.role === AdageFrontRoles.READONLY ? 'Recherche' : 'Découvrir',
-    link: {
-      isExternal: false,
-      to:
-        adageUser.role === AdageFrontRoles.READONLY
-          ? `/adage-iframe/recherche?token=${adageAuthToken}`
-          : `/adage-iframe/decouverte?token=${adageAuthToken}`,
-    },
-    icon:
-      adageUser.role === AdageFrontRoles.READONLY
-        ? strokeSearchIcon
-        : strokePassIcon,
   }
 
   return (

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/__specs__/OfferInfos.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/__specs__/OfferInfos.spec.tsx
@@ -38,7 +38,7 @@ const defaultUseLocationValue = {
   state: { offer: defaultCollectiveTemplateOffer },
   hash: '',
   key: '',
-  pathname: '',
+  pathname: '/adage-iframe/decouverte/offre/10',
   search: '',
 }
 
@@ -58,13 +58,61 @@ describe('OfferInfos', () => {
   it('should display the breadcrumb with a link back to the discovery home', () => {
     renderOfferInfos()
 
-    expect(screen.getByRole('link', { name: 'Découvrir' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Découvrir' })).toHaveAttribute(
+      'href',
+      '/adage-iframe/decouverte?token=null'
+    )
+  })
+
+  it("should display the breadcrumb with a link to the search page if the url doesn't contain a known parent page name", () => {
+    vi.spyOn(router, 'useLocation').mockReturnValueOnce({
+      ...defaultUseLocationValue,
+      pathname: '',
+    })
+
+    renderOfferInfos()
+
+    expect(screen.getByRole('link', { name: 'Recherche' })).toHaveAttribute(
+      'href',
+      '/adage-iframe/recherche?token=null'
+    )
+  })
+
+  it("should display the breadcrumb with a link back to the search page if the url contains 'recherche'", () => {
+    vi.spyOn(router, 'useLocation').mockReturnValueOnce({
+      ...defaultUseLocationValue,
+      pathname: '/adage-iframe/recherche/offre/10',
+    })
+
+    renderOfferInfos()
+
+    expect(screen.getByRole('link', { name: 'Recherche' })).toHaveAttribute(
+      'href',
+      '/adage-iframe/recherche?token=null'
+    )
+  })
+
+  it("should display the breadcrumb with a link back to the favorite page if the url contains 'mes-favoris'", () => {
+    vi.spyOn(router, 'useLocation').mockReturnValueOnce({
+      ...defaultUseLocationValue,
+      pathname: '/adage-iframe/mes-favoris/offre/10',
+    })
+
+    renderOfferInfos()
+
+    expect(screen.getByRole('link', { name: 'Mes favoris' })).toHaveAttribute(
+      'href',
+      '/adage-iframe/mes-favoris?token=null'
+    )
   })
 
   it('should display the breadcrumb with a link back to the search page if the user is admin', () => {
     renderOfferInfos({ ...defaultAdageUser, role: AdageFrontRoles.READONLY })
 
-    expect(screen.getByRole('link', { name: 'Recherche' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Recherche' })).toHaveAttribute(
+      'href',
+      '/adage-iframe/recherche?token=null'
+    )
   })
 
   it('should display the offer that is passed through the router when the user navigates within the app', () => {


### PR DESCRIPTION
…adcrumb.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27559

**FF à activer**
WIP_ENABLE_DISCOVERY

**Objectif**
Dans les pages offre d'adage (accessible en cliquant sur une offre depuis la page découverte), avoir le premier lien du fil d'ariane dépendant de la page parente dans le router

Pour tester l'affichage du fil d'ariane, il faut pour l'instant changer à la main l'url en remplaçant "decouverte" par "mes favoris" et "recherche"

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques