### PR TITLE
(PC-27611)[PRO] feat: Fix margins in adage my institution and favorit…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavorites.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavorites.module.scss
@@ -1,9 +1,8 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .favorite-list {
-  padding-bottom: rem.torem(32px);
-
-  li:not(:last-child) {
-    margin-bottom: rem.torem(16px);
-  }
+  padding: rem.torem(32px) 0;
+  display: flex;
+  flex-direction: column;
+  gap: rem.torem(16px);
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.module.scss
@@ -26,4 +26,7 @@
 
 .offers-list {
   padding-bottom: rem.torem(32px);
+  display: flex;
+  flex-direction: column;
+  gap: rem.torem(16px);
 }


### PR DESCRIPTION
…es pages.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27611

**Objectif**
Corriger l'absence de marge entre les offres de la page mon établissement d'adage, et corriger l'absence d'espace entre le titre de la page mes favoris d'adage et le contenu.

<img width="637" alt="Capture d’écran 2024-01-25 à 16 08 34" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/75d115c5-bd35-4145-90ed-bb8623de315c">
<img width="636" alt="Capture d’écran 2024-01-25 à 16 08 42" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/bb60d787-cc2f-4ec2-938e-98398868d1a7">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques