### PR TITLE
(PC-27040)[PRO] fix: image do not change with venue in PartnerPage in Home

### DIFF
--- a/pro/src/pages/Home/Offerers/PartnerPages.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPages.tsx
@@ -87,7 +87,16 @@ export const PartnerPages = ({ venues, offerer }: PartnerPagesProps) => {
         </>
       )}
 
-      {selectedVenue && <PartnerPage offerer={offerer} venue={selectedVenue} />}
+      {selectedVenue && (
+        <PartnerPage
+          offerer={offerer}
+          venue={selectedVenue}
+          // In order to have the image state changing in PartnerPage,
+          // we wanna the state reset when the venue change, see :
+          // https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key
+          key={selectedVenue.id}
+        />
+      )}
     </section>
   )
 }

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPages.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPages.spec.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import React from 'react'
+import { userEvent } from '@testing-library/user-event'
 import * as router from 'react-router-dom'
 
 import { VenueTypeCode } from 'apiClient/v1'
@@ -97,5 +97,53 @@ describe('PartnerPages', () => {
     expect(
       screen.getByText(defaultGetOffererVenueResponseModel.name)
     ).toBeInTheDocument()
+  })
+
+  it('should should change image when changing venue', async () => {
+    const venues = [
+      {
+        ...defaultGetOffererVenueResponseModel,
+        id: 42,
+        bannerUrl: 'MyFirstImage',
+        name: 'first venue',
+        bannerMeta: {
+          original_image_url: 'MyFirstImage',
+          crop_params: {
+            height_crop_percent: 12,
+            width_crop_percent: 12,
+            x_crop_percent: 12,
+            y_crop_percent: 12,
+          },
+        },
+      },
+      {
+        ...defaultGetOffererVenueResponseModel,
+        id: 666,
+        bannerUrl: 'MyOtherImage',
+        name: 'other venue',
+        bannerMeta: {
+          original_image_url: 'MyOtherImage',
+          crop_params: {
+            height_crop_percent: 12,
+            width_crop_percent: 12,
+            x_crop_percent: 12,
+            y_crop_percent: 12,
+          },
+        },
+      },
+    ]
+
+    renderPartnerPages({ venues })
+
+    let image = screen.getByAltText('Prévisualisation de l’image')
+    expect(image).toHaveAttribute('src', 'MyFirstImage')
+
+    await userEvent.selectOptions(
+      screen.getByLabelText('Sélectionnez votre page partenaire'),
+      '666'
+    )
+
+    image = screen.getByAltText('Prévisualisation de l’image')
+    expect(image).toHaveAttribute('src', 'MyOtherImage')
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27040

Quand on changeait de lieu sur la home pour le bloc page partenaire, l'image n'était pas mise à jour

pour tester: 
- activer WIP_PARTNER_PAGE
- mettre ses lieu en isPermanent = true

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques