### PR TITLE
(PC-26985)[BO] fix: correctly align advanced search filters in offers page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/components/forms/field_list_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/field_list_field.html
@@ -7,9 +7,9 @@
       data-field-name="{{ field.name }}"
       class="field-list list-unstyled flex-grow">
     {% for subfield in field %}
-      <li class="d-flex align-items-start justify-content-between gap-2">
+      <li class="d-flex align-items-start justify-content-between gap-2 pt-2">
         {{ subfield }}
-        <button class="btn btn-primary field-list-rm-btn"
+        <button class="btn btn-primary field-list-rm-btn align-self-center"
                 type="button">
           <i class="bi bi-trash3 pe-none"></i>
         </button>

--- a/api/src/pcapi/routes/backoffice/templates/components/forms/form_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/form_field.html
@@ -1,5 +1,5 @@
 {% set configuration_name = random_hash() %}
-<div class="pc-form-field-field gap-2 mb-2 input-group"
+<div class="pc-form-field-field gap-2 input-group"
      data-original-name="{{ field.name }}"
      data-clone-function-name="_formFieldCloneFunction"
      data-configuration-class="pc-{{ configuration_name }}"
@@ -8,7 +8,7 @@
   <span class="d-none pc-form-field-json-data">{{ field.json_data }}</span>
 </div>
 <!-- (Almost) duplicated form field html for field list field widget -->
-<div class="d-none pc-form-field-empty-container gap-2 mb-2 input-group"
+<div class="d-none pc-form-field-empty-container gap-2 input-group"
      data-original-name="{{ field.name }}"
      data-clone-function-name="_formFieldCloneFunction"
      data-configuration-class="pc-{{ configuration_name }}"

--- a/api/src/pcapi/routes/backoffice/templates/components/forms/string_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/string_field.html
@@ -1,21 +1,19 @@
 {% import "components/clipboard.html" as clipboard %}
-<div class="{% if field.flags.hidden %} d-none {% else %} d-flex {% endif %} align-items-center gap-1">
-  <div class="form-floating flex-grow-1 {% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField" %} d-inline-block {% elif field.type == "PCOptHiddenField" or field.type == "PCPostalCodeHiddenField" or field.type == "PCOptPostalCodeHiddenField" or field.type == "PCOptHiddenIntegerField" or field.type == "PCHiddenField" %} d-none {% endif %} pc-field-{{ field.name }}">
-    {% set string_field_id = random_hash() %}
-    <input {% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField" or field.type == "PCOptHiddenIntegerField" %} type="number" {% elif field.type == "PCPasswordField" or field.type == "PCOptPasswordField" %} type="password" {% else %} type="text" {% endif %}
-           id="{{ string_field_id }}"
-           name="{{ field.name }}"
-           data-original-name="{{ field.name }}"
-           class="form-control value-element-form {% if field.flags.required %}pc-required{% endif %}"
-           value="{{ field.data | empty_string_if_null }}"
-           {% if field.flags.required %}required {% endif +%}
-           {% if field.flags.pattern %}pattern="{{ field.flags.pattern }}"{% endif %}
-           {% if field.flags.minlength %}minlength="{{ field.flags.minlength }}"{% endif %}
-           {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %}
-           {% if field.flags.disabled %}disabled{% endif %} />
-    <label class="label-element-form"
-           data-original-name="{{ field.name }}"
-           for="{{ string_field_id }}">{{ field.label.text }}</label>
-  </div>
+<div class="form-floating flex-grow-1 {% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField" %} d-inline-block {% elif field.type == "PCOptHiddenField" or field.type == "PCPostalCodeHiddenField" or field.type == "PCOptPostalCodeHiddenField" or field.type == "PCOptHiddenIntegerField" or field.type == "PCHiddenField" %} d-none {% endif %} pc-field-{{ field.name }}">
+  {% set string_field_id = random_hash() %}
+  <input {% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField" or field.type == "PCOptHiddenIntegerField" %} type="number" {% elif field.type == "PCPasswordField" or field.type == "PCOptPasswordField" %} type="password" {% else %} type="text" {% endif %}
+         id="{{ string_field_id }}"
+         name="{{ field.name }}"
+         data-original-name="{{ field.name }}"
+         class="form-control value-element-form {% if field.flags.required %}pc-required{% endif %}"
+         value="{{ field.data | empty_string_if_null }}"
+         {% if field.flags.required %}required {% endif +%}
+         {% if field.flags.pattern %}pattern="{{ field.flags.pattern }}"{% endif %}
+         {% if field.flags.minlength %}minlength="{{ field.flags.minlength }}"{% endif %}
+         {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %}
+         {% if field.flags.disabled %}disabled{% endif %} />
+  <label class="label-element-form"
+         data-original-name="{{ field.name }}"
+         for="{{ string_field_id }}">{{ field.label.text }}</label>
   {% if field.flags.copy_button %}<span class="ms-1">{{ clipboard.copy_to_clipboard(field.data, "Copier") }}</span>{% endif %}
 </div>

--- a/api/src/pcapi/routes/backoffice/templates/components/forms/tom_select_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/tom_select_field.html
@@ -19,7 +19,7 @@
 </div>
 {% if field.field_list_compatibility %}
   <!-- (Almost) duplicated html for field list field widget -->
-  <div class="form-floating {{ field.name }}-container pc-field-{{ field.name }} d-none empty-tom-select-form-container"
+  <div class="form-floating {{ field.name }}-container pc-field-{{ field.name }} d-none empty-tom-select-form-container {% if field.search_inline %}pc-search-inline{% endif %}"
        data-original-name="{{ field.name }}"
        data-clone-function-name="_tomSelectCloneFunction">
     {% set tom_select_field_id = random_hash() %}

--- a/api/src/pcapi/static/backoffice/js/addons/pc-field-list.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-field-list.js
@@ -128,7 +128,7 @@ class PcFieldList extends PcAddOn {
     const $emptyForm = $ul.querySelector(`.${PcFieldList.PC_FORM_FIELD_EMPTY_CONTAINER_CLASS}`)
     const $removeButton = $ul.querySelector(PcFieldList.REMOVE_BUTTON_SELECTOR).cloneNode(true)
     const $li = document.createElement('li')
-    $li.classList.add("d-flex", "align-items-start", "justify-content-between", "gap-2")
+    $li.classList.add("d-flex", "align-items-start", "justify-content-between", "gap-2", "pt-2")
     const $newEmptyForm = $emptyForm.cloneNode(true)
     $li.append($newEmptyForm, $emptyForm.cloneNode(true), $removeButton) // we keep a clone within the newly added and edited $newEmptyForm form
     // tomSelect code
@@ -232,6 +232,8 @@ class PcFieldList extends PcAddOn {
     const { fieldListContainerId } = event.target.dataset
     const $fieldListContainer = this.#getFieldListContainerFromId(fieldListContainerId)
     const $ul = $fieldListContainer.querySelector(PcFieldList.PC_FIELD_LIST_UL_SELECTOR)
+    const { entriesCount: previousCount } = $ul.dataset
+    $ul.dataset.entriesCount = Number(previousCount) - 1
     const $li = event.target.parentElement // remove button is within li
     $li.remove()
     this.#filterMinEntries($ul)


### PR DESCRIPTION

## But de la pull request

Alignement des champs des filtres de la recherche avancée dans la page des offres.

Avant:

![before](https://github.com/pass-culture/pass-culture-main/assets/155538488/afab7a21-1f3d-4c34-99af-38825ee4e6dd)

Après:

![after](https://github.com/pass-culture/pass-culture-main/assets/155538488/834e68b1-69f1-4f20-8934-c8d17893c3cc)


Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26985

## Vérifications

- [ ] ~J'ai écrit les tests nécessaires~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques