### PR TITLE
(PC-26985)[BO] feat: add informations in advanced search filters' bubbles in offer page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/list.html
@@ -6,8 +6,10 @@
   <div class="pt-3 px-5">
     <h2 class="fw-light">Offres individuelles</h2>
     {{ build_filters_form(form, dst) }}
-    <div>
-      {% for search_data_tag in search_data_tags %}<span class="border border-secondary rounded px-2">{{ search_data_tag }}</span>{% endfor %}
+    <div class="d-flex flex-row gap-2">
+      {% for search_data_tag in search_data_tags %}
+        <span class="border border-secondary rounded p-1 align-self-stretch bubble">{{ search_data_tag }}</span>
+      {% endfor %}
     </div>
     {% if advanced_query %}
       {% set advanced_url = url_for("backoffice_web.offer.get_advanced_search_form") + advanced_query %}


### PR DESCRIPTION
## But de la pull request

Amélioration des bulles de la recherche avancée dans la page des offres individuelles :

![Capture d’écran 2024-01-25 à 18 18 56](https://github.com/pass-culture/pass-culture-main/assets/155538488/8df0d434-1fe6-4eca-b9ea-9cbbe15f91ba)

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26985

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques