### PR TITLE
PC-27464 add genres by label in offer

### DIFF
--- a/api/src/pcapi/domain/movie_types.py
+++ b/api/src/pcapi/domain/movie_types.py
@@ -8,6 +8,18 @@ class MovieType:
     children: list | None = None
 
 
+def get_movie_label(code: str) -> str | None:
+    for movie_type in movie_types:
+        if movie_type.name == code:
+            return movie_type.label
+        # TODO: (lixxday, 26/01/2024) This is a workaround
+        # When this function is used in a pydantic validator, it will be called twice
+        # To avoid always retunrning empty responses, we check if the code is the label
+        if movie_type.label == code:
+            return movie_type.label
+    return None
+
+
 movie_types = [
     MovieType(name="ACTION", label="Action"),
     MovieType(name="ADVENTURE", label="Aventure"),

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -18,6 +18,7 @@ from pcapi.core.offers.models import ReasonMeta
 from pcapi.core.offers.models import Stock
 from pcapi.core.providers.titelive_gtl import GTLS
 from pcapi.core.users.models import ExpenseDomain
+from pcapi.domain.movie_types import get_movie_label
 from pcapi.domain.music_types import MUSIC_SUB_TYPES_LABEL_BY_CODE
 from pcapi.domain.music_types import MUSIC_TYPES_LABEL_BY_CODE
 from pcapi.domain.show_types import SHOW_SUB_TYPES_LABEL_BY_CODE
@@ -159,6 +160,17 @@ class OfferExtraData(BaseModel):
     editeur: str | None
     gtlLabels: GtlLabels | None
     genres: list[str] | None
+
+    @validator("genres", pre=True, allow_reuse=True)
+    def convert_movie_types(cls, genres: list[str] | None) -> list[str] | None:
+        if not genres:
+            return None
+        movie_types = []
+        for genre in genres:
+            movie_type = get_movie_label(genre)
+            if movie_type:
+                movie_types.append(movie_type)
+        return movie_types
 
     _convert_music_sub_type = validator("musicSubType", pre=True, allow_reuse=True)(
         get_id_converter(MUSIC_SUB_TYPES_LABEL_BY_CODE, "musicSubType")

--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -431,7 +431,7 @@ def creat_cine_offer_with_cast(venue: offerers_models.Venue) -> None:
         extra_data={
             "cast": [Fake.name() for _ in range(random.randint(1, 10))],
             "releaseDate": Fake.date(),
-            "genres": [random.choice(movie_types).label for _ in range(random.randint(1, 4))],
+            "genres": [random.choice(movie_types).name for _ in range(random.randint(1, 4))],
             "stageDirector": Fake.name(),
         },
         subcategory=subcategories_v2.SEANCE_CINE,

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -45,7 +45,7 @@ class OffersTest:
             "stageDirector": "metteur en scène",
             "speaker": "intervenant",
             "visa": "vasi",
-            "genres": ["genre1", "genre2"],
+            "genres": ["ACTION", "DRAMA"],
             "cast": ["cast1", "cast2"],
             "editeur": "editeur",
             "gtl_id": "01030000",
@@ -200,7 +200,7 @@ class OffersTest:
             "speaker": "intervenant",
             "stageDirector": "metteur en scène",
             "visa": "vasi",
-            "genres": ["genre1", "genre2"],
+            "genres": ["Action", "Drame"],
             "cast": ["cast1", "cast2"],
             "editeur": "editeur",
             "gtlLabels": {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27464

ça ressemble à un breaking change, mais ce champs est relativement nouveau et pas encore utilisé par l'app. On le modifie justement à la demande des devs fronts, pour être cohérent avec les autres champs (e.g. `musicType`)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques