### PR TITLE
(PC-26488)[API] feat: Add rq-exporter

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -4245,7 +4245,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4643,6 +4642,22 @@ files = [
 [package.dependencies]
 click = ">=5.0.0"
 redis = ">=4.0.0"
+
+[[package]]
+name = "rq-exporter"
+version = "2.1.2"
+description = "Prometheus exporter for Python RQ (Redis Queue)"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "rq-exporter-2.1.2.tar.gz", hash = "sha256:41ed9e833e2d7f6e1f35c4ffec6a7921cc7ab4d0ff26925d4d2fadb8843321fe"},
+    {file = "rq_exporter-2.1.2-py3-none-any.whl", hash = "sha256:79fd7c3fb6d047b884a3b2c27c8ec863c48d1cbca6025d76a78d2014bef7a174"},
+]
+
+[package.dependencies]
+prometheus-client = ">=0.8.0"
+redis = ">=3.5.3"
+rq = ">=1.8.0"
 
 [[package]]
 name = "rsa"
@@ -5803,4 +5818,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b2d7f7ce2bd2ff43781bc000cc8d58271e3727c4bd332d71d06cb715f42191ae"
+content-hash = "3f9c1ce53d15fb4c4e616a914766375dc90f08183f98a15d208016af3dc06549"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -74,6 +74,7 @@ fiona = "^1.9.5"
 py7zr = "^0.20.8"
 pyproj = "^3.6.1"
 googlemaps = "^4.10.0"
+rq-exporter = "^2.1.2"
 
 [tool.poetry.group.dev]
 optional = true

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -16,8 +16,10 @@ from flask_login import LoginManager
 from flask_login import current_user
 import prometheus_flask_exporter.multiprocess
 import redis
+import rq_exporter
 import sentry_sdk
 from sqlalchemy import orm
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.middleware.profiler import ProfilerMiddleware
 import werkzeug.middleware.proxy_fix
 
@@ -138,6 +140,11 @@ if settings.PROFILE_REQUESTS:
     app.wsgi_app = ProfilerMiddleware(  # type: ignore [method-assign]
         app.wsgi_app,
         restrictions=profiling_restrictions,
+    )
+
+if int(os.environ.get("ENABLE_RQ_PROMETHEUS_EXPORTER", "0")):
+    app.wsgi_app = DispatcherMiddleware(  # type: ignore [method-assign]
+        app.wsgi_app, {"/rq_metrics": rq_exporter.create_app()}
     )
 
 


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26488

New exporter to monitor rq jobs.
Inspired by flask documentation about [application dispatching.](https://flask.palletsprojects.com/en/3.0.x/patterns/appdispatch/)
 
GET http://localhost:5001/rq_metrics returns : 
```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 58064.0
python_gc_objects_collected_total{generation="1"} 7686.0
python_gc_objects_collected_total{generation="2"} 146.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 1529.0
python_gc_collections_total{generation="1"} 138.0
python_gc_collections_total{generation="2"} 9.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="11",patchlevel="6",version="3.11.6"} 1.0
# HELP rq_request_processing_seconds Time spent collecting RQ data
# TYPE rq_request_processing_seconds summary
rq_request_processing_seconds_count 1.0
rq_request_processing_seconds_sum 0.0024400840047746897
# HELP rq_request_processing_seconds_created Time spent collecting RQ data
# TYPE rq_request_processing_seconds_created gauge
rq_request_processing_seconds_created 1.7062638400543702e+09
# HELP rq_workers RQ workers
# TYPE rq_workers gauge
# HELP rq_workers_success_total RQ workers success count
# TYPE rq_workers_success_total counter
# HELP rq_workers_failed_total RQ workers fail count
# TYPE rq_workers_failed_total counter
# HELP rq_workers_working_time_total RQ workers spent seconds
# TYPE rq_workers_working_time_total counter
# HELP rq_jobs RQ jobs by state
# TYPE rq_jobs gauge
rq_jobs{queue="default",status="queued"} 0.0
rq_jobs{queue="default",status="started"} 0.0
rq_jobs{queue="default",status="finished"} 1.0
rq_jobs{queue="default",status="failed"} 0.0
rq_jobs{queue="default",status="deferred"} 0.0
rq_jobs{queue="default",status="scheduled"} 0.0
rq_jobs{queue="low",status="queued"} 0.0
rq_jobs{queue="low",status="started"} 0.0
rq_jobs{queue="low",status="finished"} 0.0
rq_jobs{queue="low",status="failed"} 0.0
rq_jobs{queue="low",status="deferred"} 0.0
rq_jobs{queue="low",status="scheduled"} 0.0
```