### PR TITLE
(BSR)[API] fix: Handle garbage in `human_ids.dehumanize()`

### DIFF
--- a/api/src/pcapi/utils/human_ids.py
+++ b/api/src/pcapi/utils/human_ids.py
@@ -1,6 +1,5 @@
 from base64 import b32decode
 from base64 import b32encode
-import binascii
 
 import click
 
@@ -29,7 +28,7 @@ def dehumanize(public_id: str | None) -> int | None:
         public_id += "=" * (8 - missing_padding)
     try:
         xbytes = b32decode(public_id.replace("8", "O").replace("9", "I"))
-    except binascii.Error:
+    except Exception:
         raise NonDehumanizableId("id non dehumanizable")
     return int_from_bytes(xbytes)
 

--- a/api/tests/utils/human_ids_test.py
+++ b/api/tests/utils/human_ids_test.py
@@ -1,0 +1,19 @@
+import pytest
+
+from pcapi.utils import human_ids
+
+
+def test_humanize():
+    assert human_ids.humanize(None) is None
+    assert human_ids.humanize(1234) == "ATJA"
+
+
+def test_dehumanize():
+    assert human_ids.dehumanize(None) is None
+    assert human_ids.dehumanize("ATJA") == 1234
+
+
+@pytest.mark.parametrize("value", ("garbage", "é", "---", "   "))
+def test_dehumanize_garbage(value):
+    with pytest.raises(human_ids.NonDehumanizableId):
+        human_ids.dehumanize(value)


### PR DESCRIPTION
Passing garbage to `dehumanize()` could raise unhandled exceptions. I
managed to generate a UnicodeDecodeError, but I am sure we can
generate other exceptions. Catching a generic exception is the best
defense.

---

Erreur vue dans le back-office : https://sentry.passculture.team/organizations/sentry/issues/1257360/