### PR TITLE
(PC-27536)[EAC] feat: add isTemplate to offers response models

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -186,6 +186,7 @@ class CollectiveOfferResponseModel(BaseModel, common_models.AccessibilityComplia
     nationalProgram: NationalProgramModel | None
     isFavorite: bool | None
     formats: typing.Sequence[EacFormat] | None
+    isTemplate: bool = False
 
     @classmethod
     def build(
@@ -276,6 +277,7 @@ class CollectiveOfferTemplateResponseModel(BaseModel, common_models.Accessibilit
     isFavorite: bool | None
     dates: TemplateDatesModel | None
     formats: typing.Sequence[EacFormat] | None
+    isTemplate: bool = True
 
     @classmethod
     def build(

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -320,6 +320,7 @@ class TemplateDatesModel(BaseModel):
 class GetCollectiveOfferTemplateResponseModel(GetCollectiveOfferBaseResponseModel):
     priceDetail: PriceDetail | None = Field(alias="educationalPriceDetail")
     dates: TemplateDatesModel | None
+    isTemplate: bool = True
 
     class Config:
         orm_mode = True
@@ -365,6 +366,7 @@ class GetCollectiveOfferResponseModel(GetCollectiveOfferBaseResponseModel):
     teacher: EducationalRedactorResponseModel | None
     isPublicApi: bool
     formats: typing.Sequence[subcategories.EacFormat] | None
+    isTemplate: bool = False
 
     @classmethod
     def from_orm(cls, offer: CollectiveOffer) -> "GetCollectiveOfferResponseModel":

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -116,6 +116,7 @@ class CollectiveOfferTemplateTest:
                 "end": format_into_utc_date(offer.end),
             },
             "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
+            "isTemplate": True,
         }
 
     def test_get_collective_offer_template_if_inactif(self, eac_client, redactor):

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -135,6 +135,7 @@ class CollectiveOfferTest:
             "nationalProgram": {"id": offer.nationalProgramId, "name": offer.nationalProgram.name},
             "isFavorite": False,
             "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
+            "isTemplate": False,
         }
 
     def test_is_a_redactors_favorite(self, eac_client):

--- a/api/tests/routes/adage_iframe/get_favorites_test.py
+++ b/api/tests/routes/adage_iframe/get_favorites_test.py
@@ -124,6 +124,7 @@ class GetFavoriteOfferTest:
                         "name": stock.collectiveOffer.nationalProgram.name,
                     },
                     "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
+                    "isTemplate": False,
                 }
             ],
             "favoritesTemplate": [
@@ -183,6 +184,7 @@ class GetFavoriteOfferTest:
                         "end": collective_offer_template.end.isoformat(),
                     },
                     "formats": [fmt.value for fmt in subcategories.EVENEMENT_CINE.formats],
+                    "isTemplate": True,
                 }
             ],
         }

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -73,6 +73,7 @@ class Returns200Test:
         assert response_json["templateId"] == template.id
         assert response_json["nationalProgram"] == {"id": national_program.id, "name": national_program.name}
         assert response_json["formats"] == [fmt.value for fmt in subcategories.SEANCE_CINE.formats]
+        assert not response_json["isTemplate"]
 
     def test_sold_out(self, client):
         # Given

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -88,6 +88,7 @@ class Returns200Test:
         assert response.json["interventionArea"] == ["01", "2A"]
         assert response.json["description"] == "Ma super description"
         assert response.json["nationalProgram"] == {"id": national_program.id, "name": national_program.name}
+        assert not response.json["isTemplate"]
 
         updated_offer = CollectiveOffer.query.get(offer.id)
         assert updated_offer.name == "New name"

--- a/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
+++ b/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
@@ -153,6 +153,7 @@ class Returns200Test:
             "teacher": None,
             "nationalProgram": {"id": national_program.id, "name": national_program.name},
             "formats": [fmt.value for fmt in subcategories.SEANCE_CINE.formats],
+            "isTemplate": False,
         }
 
     def test_duplicate_collective_offer_without_subcategoryId(self, client):

--- a/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
@@ -28,6 +28,7 @@ export type CollectiveOfferResponseModel = {
   isExpired: boolean;
   isFavorite?: boolean | null;
   isSoldOut: boolean;
+  isTemplate?: boolean;
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name: string;

--- a/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
@@ -26,6 +26,7 @@ export type CollectiveOfferTemplateResponseModel = {
   isExpired: boolean;
   isFavorite?: boolean | null;
   isSoldOut: boolean;
+  isTemplate?: boolean;
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name: string;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -37,6 +37,7 @@ export type GetCollectiveOfferResponseModel = {
   isEditable: boolean;
   isNonFreeOffer?: boolean | null;
   isPublicApi: boolean;
+  isTemplate?: boolean;
   isVisibilityEditable: boolean;
   lastBookingId?: number | null;
   lastBookingStatus?: CollectiveBookingStatus | null;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
@@ -32,6 +32,7 @@ export type GetCollectiveOfferTemplateResponseModel = {
   isCancellable: boolean;
   isEditable: boolean;
   isNonFreeOffer?: boolean | null;
+  isTemplate?: boolean;
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name: string;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27536

Ajout d'un champ `isTemplate` aux réponses (_iframe_ adage et portail pro) qui concernent les offres collectives (vitrines ou non).