### PR TITLE
(PC-27527)[PRO] feat: Make national programs dependant on selected do…

### DIFF
--- a/pro/src/core/OfferEducational/adapters/getCollectiveOfferFormDataAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getCollectiveOfferFormDataAdapter.ts
@@ -18,7 +18,7 @@ type Payload = {
   categories: EducationalCategories
   domains: SelectOption[]
   offerers: GetEducationalOffererResponseModel[]
-  nationalPrograms: SelectOption[]
+  nationalPrograms: SelectOption<number>[]
 }
 
 type Param = {

--- a/pro/src/core/OfferEducational/adapters/getNationalProgramAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getNationalProgramAdapter.ts
@@ -2,7 +2,11 @@ import { api } from 'apiClient/api'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
 import { SelectOption } from 'custom_types/form'
 
-type GetNationalProgramsAdapter = Adapter<void, SelectOption[], SelectOption[]>
+type GetNationalProgramsAdapter = Adapter<
+  void,
+  SelectOption<number>[],
+  SelectOption<number>[]
+>
 
 const FAILING_RESPONSE = {
   isOk: false,

--- a/pro/src/custom_types/form.ts
+++ b/pro/src/custom_types/form.ts
@@ -1,1 +1,1 @@
-export type SelectOption = { value: string | number; label: string }
+export type SelectOption<T = string | number> = { value: T; label: string }

--- a/pro/src/screens/OfferEducational/OfferEducational.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducational.tsx
@@ -41,7 +41,7 @@ export interface OfferEducationalProps {
   isOfferBooked?: boolean
   isOfferActive?: boolean
   domainsOptions: SelectOption[]
-  nationalPrograms: SelectOption[]
+  nationalPrograms: SelectOption<number>[]
   isTemplate: boolean
   isOfferCreated?: boolean
   reloadCollectiveOffer?: () => void

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -12,6 +12,7 @@ import {
 } from 'core/OfferEducational'
 import { SelectOption } from 'custom_types/form'
 import useActiveFeature from 'hooks/useActiveFeature'
+import { getNationalProgramsForDomains } from 'screens/OfferEducational/constants/getNationalProgramsForDomains'
 import {
   InfoBox,
   MultiSelectAutocomplete,
@@ -29,11 +30,11 @@ import {
   TITLE_LABEL,
 } from '../../constants/labels'
 
-interface FormTypeProps {
+export interface FormTypeProps {
   categories: EducationalCategory[]
   subCategories: EducationalSubCategory[]
   domainsOptions: SelectOption[]
-  nationalPrograms: SelectOption[]
+  nationalPrograms: SelectOption<number>[]
   disableForm: boolean
 }
 
@@ -107,6 +108,10 @@ const FormOfferType = ({
     ]
   }
 
+  const nationalProgramsForDomains = nationalPrograms.filter((program) =>
+    getNationalProgramsForDomains(values.domains).includes(program.value)
+  )
+
   return (
     <FormLayout.Section
       description="Le type de l’offre permet de la caractériser et de la valoriser au mieux pour les enseignants et chefs d’établissement."
@@ -172,7 +177,7 @@ const FormOfferType = ({
                 label: 'Sélectionnez un dispositif national',
                 value: '',
               },
-              ...nationalPrograms,
+              ...nationalProgramsForDomains,
             ]}
             label="Dispositif national"
             name="nationalProgramId"

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/__specs__/FormOfferType.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/__specs__/FormOfferType.spec.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react'
+import { Formik } from 'formik'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import FormOfferType, { FormTypeProps } from '../FormOfferType'
+
+const formTypeProps: FormTypeProps = {
+  categories: [],
+  disableForm: false,
+  domainsOptions: [],
+  nationalPrograms: [],
+  subCategories: [],
+}
+
+function renderFormOfferType(props: FormTypeProps) {
+  return renderWithProviders(
+    <Formik initialValues={{ title: '', domains: [] }} onSubmit={vi.fn()}>
+      {({ handleSubmit }) => (
+        <form onSubmit={handleSubmit}>
+          <FormOfferType {...props} />
+        </form>
+      )}
+    </Formik>
+  )
+}
+
+describe('FormOfferType', () => {
+  it('should render the form description', async () => {
+    renderFormOfferType(formTypeProps)
+    expect(
+      await screen.findByText(
+        'Le type de l’offre permet de la caractériser et de la valoriser au mieux pour les enseignants et chefs d’établissement.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should offer the national program oprtions filtered for the selected domains', async () => {
+    renderFormOfferType({
+      ...formTypeProps,
+      nationalPrograms: [
+        { value: 4, label: 'Program 1' }, //  Program with id 4 should be displayed whatever the domain selection is
+        { value: 11, label: 'Program 2' },
+      ],
+      domainsOptions: [],
+    })
+
+    expect(
+      await screen.findByRole('option', { name: 'Program 1' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('option', { name: 'Program 2' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOfferTypeStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOfferTypeStep.spec.tsx
@@ -180,8 +180,8 @@ describe('screens | OfferEducational : creation offer type step', () => {
       const overridedProps = {
         ...props,
         nationalPrograms: [
-          { value: '1', label: 'Marseille en grand' },
-          { value: '2', label: 'Collège au ciné' },
+          { value: 1, label: 'Marseille en grand' },
+          { value: 4, label: 'Olympiades' },
         ],
       }
       renderWithProviders(<OfferEducational {...overridedProps} />, {
@@ -190,10 +190,10 @@ describe('screens | OfferEducational : creation offer type step', () => {
       const nationalProgramsSelect =
         await screen.findByLabelText(/Dispositif national/)
       await userEvent.click(nationalProgramsSelect)
-      await userEvent.selectOptions(nationalProgramsSelect, '2')
+      await userEvent.selectOptions(nationalProgramsSelect, '4')
       await userEvent.tab()
 
-      expect(screen.getByText('Collège au ciné')).toBeInTheDocument()
+      expect(screen.getByText('Olympiades')).toBeInTheDocument()
     })
   })
 

--- a/pro/src/screens/OfferEducational/__specs__/getNationalProgramsForDomains.spec.ts
+++ b/pro/src/screens/OfferEducational/__specs__/getNationalProgramsForDomains.spec.ts
@@ -1,0 +1,21 @@
+import { getNationalProgramsForDomains } from '../constants/getNationalProgramsForDomains'
+
+describe('getNationalProgramsForDomains', () => {
+  it('should return the union of national programs for multiple domains', () => {
+    expect(getNationalProgramsForDomains(['6', '11'])).toHaveLength(4)
+  })
+
+  it('should return the national program Olympiade culturelle when no domains are provided', () => {
+    expect(getNationalProgramsForDomains([])).toEqual([4])
+  })
+
+  it('should return the national program Olympiade culturelle for any domains', () => {
+    expect(getNationalProgramsForDomains(['6', '11'])).toEqual(
+      expect.arrayContaining([4])
+    )
+
+    expect(getNationalProgramsForDomains(['111'])).toEqual(
+      expect.arrayContaining([4])
+    )
+  })
+})

--- a/pro/src/screens/OfferEducational/constants/getNationalProgramsForDomains.ts
+++ b/pro/src/screens/OfferEducational/constants/getNationalProgramsForDomains.ts
@@ -1,0 +1,26 @@
+export function getNationalProgramsForDomains(domains: string[]): number[] {
+  let nationalProgramsIds = new Set<number>([4])
+  for (const domain of domains) {
+    nationalProgramsIds = new Set([
+      ...nationalProgramsIds,
+      ...getNationalProgramsForDomain(domain),
+    ])
+  }
+  return Array.from(nationalProgramsIds)
+}
+
+function getNationalProgramsForDomain(domain: string): number[] {
+  switch (domain) {
+    case '11': {
+      //  Univers du livre, de la lecture et des écritures -> Jeunes en librairie, Olympiade culturelle de PARIS 2024
+      return [6, 4]
+    }
+    case '6': {
+      //  Cinéma, audiovisuel -> Collège au cinéma, Lycéens et apprentis au cinéma, Olympiade culturelle de PARIS 2024
+      return [1, 3, 4]
+    }
+    default:
+      // Olympiade culturelle de PARIS 2024
+      return [4]
+  }
+}

--- a/pro/src/screens/OfferEducational/useOfferEducationalFormData.ts
+++ b/pro/src/screens/OfferEducational/useOfferEducationalFormData.ts
@@ -14,7 +14,7 @@ type OfferEducationalFormData = {
   categories: EducationalCategories
   domains: SelectOption[]
   offerers: GetEducationalOffererResponseModel[]
-  nationalPrograms: SelectOption[]
+  nationalPrograms: SelectOption<number>[]
 }
 
 const useOfferEducationalFormData = (


### PR DESCRIPTION
…mains in collective offer form.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27527

**Objectif**
Dans le formulaire des offres collectives vitrine, afficher les options du select Dispositif National en fonction des domaines artistiques sélectionnés.
- Pas de domaine sélectionné -> Olympiade culturelle de PARIS 2024
- Univers du livre, de la lecture et des écritures -> Jeunes en librairie, Olympiade culturelle de PARIS 2024
- Cinéma, audiovisuel -> Collège au cinéma, Lycéens et apprentis au cinéma, Olympiade culturelle de PARIS 2024
- N'importe quoi d'autre -> Olympiade culturelle de PARIS 2024

**A noter**
J'ai aussi ajouté un type générique dans le type SelectOption pour spécifier le type de value. Quand on crée les options depuis un adapter (comme c'est le cas dans le NationalProgramAdapter) on devrait jamais avoir besoin de `string | number`, et l'union de ces 2 types devrait seulement être nécessaire dans les composants qui traitent à la vois des options `string` et des options `number` (par ex dans `SelectInput`)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques