### PR TITLE
(BSR)[API] test: Forbid directly passing `venue` to `BookingFactory`

### DIFF
--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -69,6 +69,12 @@ class BookingFactory(BaseFactory):
             stock: offers_models.Stock = kwargs["stock"]
             stock.dnBookedQuantity = stock.dnBookedQuantity + kwargs.get("quantity", 1)
             kwargs["stock"] = stock
+        if "venue" in kwargs:
+            # `Booking.venue` is denormalized from `Booking.stock.offer.venue`.
+            # Users of the factory who provide it directly probably
+            # expect that it will set the venue of the offer, but it
+            # does not.
+            raise ValueError("Do not pass `venue`, pass `stock__offer__venue` instead.")
         kwargs["venue"] = kwargs["stock"].offer.venue
         kwargs["offerer"] = kwargs["stock"].offer.venue.managingOfferer
         return super()._create(model_class, *args, **kwargs)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings.py
@@ -105,7 +105,6 @@ def _create_bookings_for_other_beneficiaries(
                 amount=booking_amount if booking_amount is not None else stock.price,
                 token=str(token),
                 offerer=offer.venue.managingOfferer,
-                venue=offer.venue,
             )
             if is_used:
                 finance_factories.UsedBookingFinanceEventFactory(booking=booking)

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -289,7 +289,7 @@ class PriceEventTest:
 
     def test_price_event_on_cancelled_booking(self):
         venue = offerers_factories.VenueFactory(pricing_point="self", reimbursement_point="self")
-        booking = bookings_factories.ReimbursedBookingFactory(venue=venue, stock__offer__venue=venue)
+        booking = bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
         used_event = factories.UsedBookingFinanceEventFactory(booking=booking)
         original_pricing = api.price_event(used_event)
         original_pricing.status = models.PricingStatus.INVOICED
@@ -988,7 +988,7 @@ class GenerateCashflowsLegacyTest:
         stock = offers_factories.StockFactory(
             offer=offer, price=incident_booking_amount, beginningDatetime=_beginningDatetime
         )
-        reimbursed_booking = bookings_factories.ReimbursedBookingFactory(stock=stock, venue=reimbursement_point1)
+        reimbursed_booking = bookings_factories.ReimbursedBookingFactory(stock=stock)
 
         event = api.add_event(
             motive=models.FinanceEventMotive.BOOKING_USED,
@@ -1275,7 +1275,7 @@ class GenerateCashflowsTest:
         stock = offers_factories.StockFactory(
             offer=offer, price=incident_booking_amount, beginningDatetime=_beginningDatetime
         )
-        reimbursed_booking = bookings_factories.ReimbursedBookingFactory(stock=stock, venue=venue1)
+        reimbursed_booking = bookings_factories.ReimbursedBookingFactory(stock=stock)
 
         event = api.add_event(
             motive=models.FinanceEventMotive.BOOKING_USED,
@@ -1743,7 +1743,6 @@ def test_generate_payments_file_legacy_journey():
     incident_booking = bookings_factories.ReimbursedBookingFactory(
         amount=12,
         dateUsed=used_date,
-        venue=offer_venue2,
         stock__offer__name="Une histoire plutôt bien",
         stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         stock__offer__venue=offer_venue2,
@@ -1934,7 +1933,6 @@ def test_generate_payments_file_new_journey():
     incident_booking = bookings_factories.ReimbursedBookingFactory(
         amount=12,
         dateUsed=used_date,
-        venue=venue2,
         stock__offer__name="Une histoire plutôt bien",
         stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         stock__offer__venue=venue2,

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -3272,7 +3272,6 @@ class UpdateUsedStockPriceTest:
         booking_to_edit = bookings_factories.UsedBookingFactory(
             stock=stock_to_edit,
             amount=decimal.Decimal("123.45"),
-            venue=venue,
         )
         stock_untouched = factories.StockFactory(
             offer=offer,
@@ -3281,7 +3280,6 @@ class UpdateUsedStockPriceTest:
         booking_untouched = bookings_factories.UsedBookingFactory(
             stock=stock_untouched,
             amount=decimal.Decimal("123.45"),
-            venue=venue,
         )
         cancelled_event = finance_factories.FinanceEventFactory(
             booking=booking_to_edit, venue=venue, pricingPoint=venue
@@ -3327,17 +3325,14 @@ class UpdateUsedStockPriceTest:
         assert finance_models.Pricing.query.filter_by(id=later_pricing_id).count() == 0
 
     def test_update_used_stock_price_should_update_confirmed_events(self):
-        offer = factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
-        venue = offer.venue
         stock_to_edit = factories.StockFactory(
-            offer=offer,
+            offer__subcategoryId=subcategories.CONFERENCE.id,
             price=decimal.Decimal("123.45"),
         )
         booking_to_edit = bookings_factories.BookingFactory(
             status=bookings_models.BookingStatus.CONFIRMED,
             stock=stock_to_edit,
             amount=decimal.Decimal("123.45"),
-            venue=venue,
         )
 
         api.update_used_stock_price(booking_to_edit.stock, 50.1)

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -517,9 +517,8 @@ def offerer_stocks_fixture(offerer_active_individual_offers):
 
 
 @pytest.fixture(name="individual_offerer_bookings")
-def individual_offerer_bookings_fixture(offerer_stocks, venue_with_accepted_bank_info):
-    used_simple = bookings_factories.BookingFactory(
-        status=bookings_models.BookingStatus.USED,
+def individual_offerer_bookings_fixture(offerer_stocks):
+    used_simple = bookings_factories.UsedBookingFactory(
         quantity=1,
         amount=10,
         stock=offerer_stocks[0],
@@ -530,11 +529,7 @@ def individual_offerer_bookings_fixture(offerer_stocks, venue_with_accepted_bank
         amount=10,
         stock=offerer_stocks[1],
     )
-    cancelled = bookings_factories.BookingFactory(
-        status=bookings_models.BookingStatus.CANCELLED,
-        venue=venue_with_accepted_bank_info,
-        stock=offerer_stocks[2],
-    )
+    cancelled = bookings_factories.CancelledBookingFactory(stock=offerer_stocks[2])
     return [used_simple, confirmed_duo, cancelled]
 
 

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -190,7 +190,6 @@ class ValidateIncidentTest(PostEndpointHelper):
         venue = offerers_factories.VenueFactory(reimbursement_point="self")
         booking_incident = finance_factories.IndividualBookingFinanceIncidentFactory(
             booking__amount=10.10,
-            booking__venue=venue,
             booking__stock__offer__venue=venue,
             incident__venue=venue,
             newTotalAmount=0,
@@ -1164,7 +1163,7 @@ class ForceDebitNoteTest(PostEndpointHelper):
 
     def test_force_debit_note(self, authenticated_client):
         venue = offerers_factories.VenueFactory(pricing_point="self", reimbursement_point="self")
-        booking = bookings_factories.ReimbursedBookingFactory(venue=venue, stock__offer__venue=venue)
+        booking = bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
         original_event = finance_factories.UsedBookingFinanceEventFactory(booking=booking)
         original_pricing = api.price_event(original_event)
         original_pricing.status = finance_models.PricingStatus.INVOICED
@@ -1211,7 +1210,7 @@ class ForceDebitNoteTest(PostEndpointHelper):
     def test_force_debit_note_on_finished_incident(self, authenticated_client):
         venue = offerers_factories.VenueFactory(pricing_point="self", reimbursement_point="self")
         finance_factories.BankInformationFactory(venue=venue)
-        booking = bookings_factories.ReimbursedBookingFactory(venue=venue, stock__offer__venue=venue)
+        booking = bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
         original_event = finance_factories.UsedBookingFinanceEventFactory(booking=booking)
         original_pricing = api.price_event(original_event)
         original_pricing.status = finance_models.PricingStatus.INVOICED
@@ -1226,7 +1225,7 @@ class ForceDebitNoteTest(PostEndpointHelper):
                 incident_validation_date=datetime.datetime.utcnow(),
             )
         )
-        booking = bookings_factories.UsedBookingFactory(venue=venue, stock__offer__venue=venue, amount=20)
+        booking = bookings_factories.UsedBookingFactory(stock__offer__venue=venue, amount=20)
         events_to_price.append(
             finance_factories.FinanceEventFactory(
                 venue=venue, booking=booking, status=finance_models.FinanceEventStatus.READY
@@ -1260,7 +1259,7 @@ class CancelDebitNoteTest(PostEndpointHelper):
     def test_cancel_debit_note(self, authenticated_client):
         reimbursement_point = offerers_factories.VenueFactory(bookingEmail="pro@example.com")
         venue = offerers_factories.VenueFactory(pricing_point="self", reimbursement_point=reimbursement_point)
-        booking = bookings_factories.ReimbursedBookingFactory(venue=venue, stock__offer__venue=venue)
+        booking = bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
         original_event = finance_factories.UsedBookingFinanceEventFactory(booking=booking)
         original_pricing = api.price_event(original_event)
         original_pricing.status = finance_models.PricingStatus.INVOICED
@@ -1326,7 +1325,7 @@ class CancelDebitNoteTest(PostEndpointHelper):
     def test_cancel_debit_note_on_finished_incident(self, authenticated_client):
         venue = offerers_factories.VenueFactory(pricing_point="self", reimbursement_point="self")
         finance_factories.BankInformationFactory(venue=venue)
-        booking = bookings_factories.ReimbursedBookingFactory(venue=venue, stock__offer__venue=venue)
+        booking = bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
         original_event = finance_factories.UsedBookingFinanceEventFactory(booking=booking)
         original_pricing = api.price_event(original_event)
         original_pricing.status = finance_models.PricingStatus.INVOICED
@@ -1344,7 +1343,7 @@ class CancelDebitNoteTest(PostEndpointHelper):
                 incident_validation_date=datetime.datetime.utcnow(),
             )
         )
-        booking = bookings_factories.UsedBookingFactory(venue=venue, stock__offer__venue=venue, amount=20)
+        booking = bookings_factories.UsedBookingFactory(stock__offer__venue=venue, amount=20)
         events_to_price.append(
             finance_factories.FinanceEventFactory(
                 venue=venue, booking=booking, status=finance_models.FinanceEventStatus.READY

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -1862,7 +1862,6 @@ class EditOfferStockTest(PostEndpointHelper):
         booking_to_edit = bookings_factories.UsedBookingFactory(
             stock=stock_to_edit,
             amount=decimal.Decimal("123.45"),
-            venue=venue,
         )
         stock_untouched = offers_factories.StockFactory(
             offer=offer,
@@ -1871,7 +1870,6 @@ class EditOfferStockTest(PostEndpointHelper):
         booking_untouched = bookings_factories.UsedBookingFactory(
             stock=stock_untouched,
             amount=decimal.Decimal("123.45"),
-            venue=venue,
         )
         cancelled_event = finance_factories.FinanceEventFactory(
             booking=booking_to_edit, venue=venue, pricingPoint=venue
@@ -1921,7 +1919,6 @@ class EditOfferStockTest(PostEndpointHelper):
 
     def test_offer_stock_edit_with_french_decimal(self, authenticated_client):
         offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
-        venue = offer.venue
         stock_to_edit = offers_factories.StockFactory(
             offer=offer,
             price=decimal.Decimal("123.45"),
@@ -1929,7 +1926,6 @@ class EditOfferStockTest(PostEndpointHelper):
         booking_to_edit = bookings_factories.UsedBookingFactory(
             stock=stock_to_edit,
             amount=decimal.Decimal("123.45"),
-            venue=venue,
         )
 
         response = self.post_to_endpoint(
@@ -1946,7 +1942,6 @@ class EditOfferStockTest(PostEndpointHelper):
 
     def test_offer_stock_edit_confirmed_booking(self, authenticated_client):
         offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
-        venue = offer.venue
         stock_to_edit = offers_factories.StockFactory(
             offer=offer,
             price=decimal.Decimal("123.45"),
@@ -1955,7 +1950,6 @@ class EditOfferStockTest(PostEndpointHelper):
             status=BookingStatus.CONFIRMED,
             stock=stock_to_edit,
             amount=decimal.Decimal("123.45"),
-            venue=venue,
         )
 
         response = self.post_to_endpoint(
@@ -1974,7 +1968,6 @@ class EditOfferStockTest(PostEndpointHelper):
         venue = offer.venue
         event = finance_factories.FinanceEventFactory(
             booking__amount=decimal.Decimal("123.45"),
-            booking__venue=venue,
             booking__stock__offer=offer,
             booking__stock__price=decimal.Decimal("123.45"),
             venue=venue,
@@ -2017,7 +2010,6 @@ class EditOfferStockTest(PostEndpointHelper):
         venue = offer.venue
         event = finance_factories.FinanceEventFactory(
             booking__amount=decimal.Decimal("123.45"),
-            booking__venue=venue,
             booking__stock__offer=offer,
             booking__stock__price=decimal.Decimal("123.45"),
             venue=venue,
@@ -2050,7 +2042,6 @@ class EditOfferStockTest(PostEndpointHelper):
 
     def test_offer_stock_edit_no_used_or_confirmed_bookings(self, authenticated_client, app):
         offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
-        venue = offer.venue
         stock = offers_factories.StockFactory(
             offer=offer,
             price=decimal.Decimal("123.45"),
@@ -2058,7 +2049,6 @@ class EditOfferStockTest(PostEndpointHelper):
         bookings_factories.BookingFactory(
             status=BookingStatus.CANCELLED,
             stock=stock,
-            venue=venue,
         )
 
         response = self.post_to_endpoint(
@@ -2085,7 +2075,6 @@ class EditOfferStockTest(PostEndpointHelper):
         venue = offer.venue
         event = finance_factories.FinanceEventFactory(
             booking__amount=decimal.Decimal("123.45"),
-            booking__venue=venue,
             booking__stock__offer=offer,
             booking__stock__price=decimal.Decimal("123.45"),
             venue=venue,

--- a/api/tests/routes/public/individual_offers/v1/get_booking_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_booking_test.py
@@ -27,7 +27,6 @@ class GetBookingByTokenReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -75,7 +74,6 @@ class GetBookingByTokenReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -130,9 +128,7 @@ class GetBookingByTokenReturns403Test:
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         next_week = datetime.datetime.utcnow() + datetime.timedelta(weeks=1)
 
-        offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.StockFactory(offer=offer, beginningDatetime=next_week)
         booking = bookings_factories.BookingFactory(stock=stock)
 
@@ -176,15 +172,10 @@ class GetBookingByTokenReturns404Test:
 
     def test_inactive_venue_provider(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue(is_venue_provider_active=False)
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
-        booking = bookings_factories.BookingFactory(
-            venue=venue,
-            stock=product_stock,
-        )
+        booking = bookings_factories.BookingFactory(stock=product_stock)
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
             f"/public/bookings/v1/token/{booking.token.lower()}",
@@ -203,7 +194,6 @@ class GetBookingByTokenReturns404Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -221,9 +211,7 @@ class GetBookingByTokenReturns404Test:
 class GetBookingByTokenReturns410Test:
     def test_when_booking_is_already_validated(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
         booking = bookings_factories.UsedBookingFactory(stock=product_stock)
 
@@ -236,9 +224,7 @@ class GetBookingByTokenReturns410Test:
 
     def test_when_booking_is_cancelled(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
         booking = bookings_factories.CancelledBookingFactory(stock=product_stock)
 

--- a/api/tests/routes/public/individual_offers/v1/get_bookings_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_bookings_test.py
@@ -24,7 +24,6 @@ class GetBookingsByOfferReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -49,7 +48,6 @@ class GetBookingsByOfferReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -100,7 +98,6 @@ class GetBookingsByOfferReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -108,7 +105,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         booking_2 = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
@@ -188,7 +184,6 @@ class GetBookingsByOfferReturns200Test:
             beginningDatetime=past,
         )
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -196,7 +191,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         booking_2 = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
@@ -279,7 +273,6 @@ class GetBookingsByOfferReturns200Test:
             beginningDatetime=past + datetime.timedelta(days=2),
         )
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -287,7 +280,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
@@ -346,7 +338,6 @@ class GetBookingsByOfferReturns200Test:
             beginningDatetime=past + datetime.timedelta(days=2),
         )
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -354,7 +345,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
@@ -414,7 +404,6 @@ class GetBookingsByOfferReturns200Test:
             beginningDatetime=past + datetime.timedelta(days=2),
         )
         booking = bookings_factories.ReimbursedBookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -422,7 +411,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         bookings_factories.UsedBookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
@@ -481,7 +469,6 @@ class GetBookingsByOfferReturns200Test:
             beginningDatetime=past + datetime.timedelta(days=2),
         )
         bookings_factories.ReimbursedBookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -489,7 +476,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         bookings_factories.UsedBookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
@@ -497,7 +483,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         booking = bookings_factories.UsedBookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-3@example.com",
             user__phoneNumber="0698273632",
@@ -549,7 +534,6 @@ class GetBookingsByOfferReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -557,7 +541,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         booking_2 = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
@@ -565,7 +548,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-3@example.com",
             user__phoneNumber="0698890987",
@@ -641,7 +623,6 @@ class GetBookingsByOfferReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -649,7 +630,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         booking_2 = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
@@ -657,7 +637,6 @@ class GetBookingsByOfferReturns200Test:
             stock=event_stock,
         )
         booking_3 = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-3@example.com",
             user__phoneNumber="0698890987",
@@ -754,9 +733,7 @@ class GetBookingsByOfferReturns401Test:
 class GetBookingsByOfferReturns400Test:
     def test_no_offer_id_provided(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
         bookings_factories.UsedBookingFactory(stock=product_stock)
 
@@ -786,14 +763,9 @@ class GetBookingsByOfferReturns404Test:
 
     def test_inactive_venue_provider(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue(is_venue_provider_active=False)
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
-        bookings_factories.BookingFactory(
-            venue=venue,
-            stock=product_stock,
-        )
+        bookings_factories.BookingFactory(stock=product_stock)
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
             f"/public/bookings/v1/bookings?offer_id={product_offer.id}",

--- a/api/tests/routes/public/individual_offers/v1/patch_cancel_booking_by_token_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_cancel_booking_by_token_test.py
@@ -26,7 +26,6 @@ class CancelBookingByTokenReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -50,7 +49,6 @@ class CancelBookingByTokenReturns200Test:
         in_3_days = datetime.datetime.utcnow() + datetime.timedelta(days=3)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=in_3_days)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=yesterday,
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -83,9 +81,7 @@ class PatchBookingByTokenReturns403Test:
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
 
-        offer = offers_factories.EventOfferFactory(
-            venue=venue,
-        )
+        offer = offers_factories.EventOfferFactory(venue=venue)
         stock = offers_factories.EventStockFactory(offer=offer, beginningDatetime=tomorrow)
         booking = bookings_factories.BookingFactory(stock=stock)
 
@@ -101,9 +97,7 @@ class PatchBookingByTokenReturns403Test:
         in_2_weeks = datetime.datetime.utcnow() + datetime.timedelta(weeks=1)
         two_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=2)
 
-        offer = offers_factories.EventOfferFactory(
-            venue=venue,
-        )
+        offer = offers_factories.EventOfferFactory(venue=venue)
         stock = offers_factories.EventStockFactory(offer=offer, beginningDatetime=in_2_weeks)
         booking = bookings_factories.BookingFactory(stock=stock, dateCreated=two_days_ago)
 
@@ -119,9 +113,7 @@ class PatchBookingByTokenReturns403Test:
         yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         in_36_hours = datetime.datetime.utcnow() + datetime.timedelta(hours=36)
 
-        offer = offers_factories.EventOfferFactory(
-            venue=venue,
-        )
+        offer = offers_factories.EventOfferFactory(venue=venue)
         stock = offers_factories.EventStockFactory(offer=offer, beginningDatetime=in_36_hours)
         booking = bookings_factories.BookingFactory(stock=stock, dateCreated=yesterday)
 
@@ -164,7 +156,6 @@ class PatchBookingByTokenReturns404Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -180,14 +171,9 @@ class PatchBookingByTokenReturns404Test:
 
     def test_inactive_venue_provider(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue(is_venue_provider_active=False)
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
-        booking = bookings_factories.BookingFactory(
-            venue=venue,
-            stock=product_stock,
-        )
+        booking = bookings_factories.BookingFactory(stock=product_stock)
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
             f"/public/bookings/v1/cancel/token/{booking.token.lower()}",
         )
@@ -197,9 +183,7 @@ class PatchBookingByTokenReturns404Test:
 class PatchBookingByTokenReturns410Test:
     def test_when_booking_is_already_canceled(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
         booking = bookings_factories.CancelledBookingFactory(stock=product_stock)
 

--- a/api/tests/routes/public/individual_offers/v1/patch_validate_booking_by_token_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_validate_booking_by_token_test.py
@@ -26,7 +26,6 @@ class ValidateBookingByTokenReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -49,7 +48,6 @@ class ValidateBookingByTokenReturns200Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -82,9 +80,7 @@ class PatchBookingByTokenReturns403Test:
         venue, _ = utils.create_offerer_provider_linked_to_venue()
         next_week = datetime.datetime.utcnow() + datetime.timedelta(weeks=1)
 
-        offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.StockFactory(offer=offer, beginningDatetime=next_week)
         booking = bookings_factories.BookingFactory(stock=stock)
 
@@ -137,7 +133,6 @@ class PatchBookingByTokenReturns404Test:
         past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
-            venue=venue,
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
@@ -153,14 +148,9 @@ class PatchBookingByTokenReturns404Test:
 
     def test_venue_provider_inactive(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue(is_venue_provider_active=False)
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
-        booking = bookings_factories.BookingFactory(
-            venue=venue,
-            stock=product_stock,
-        )
+        booking = bookings_factories.BookingFactory(stock=product_stock)
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
             f"/public/bookings/v1/use/token/{booking.token.lower()}",
         )
@@ -170,9 +160,7 @@ class PatchBookingByTokenReturns404Test:
 class PatchBookingByTokenReturns410Test:
     def test_when_booking_is_already_validated(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
         booking = bookings_factories.UsedBookingFactory(stock=product_stock)
 
@@ -185,9 +173,7 @@ class PatchBookingByTokenReturns410Test:
 
     def test_when_booking_is_cancelled(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
-        product_offer = offers_factories.ThingOfferFactory(
-            venue=venue,
-        )
+        product_offer = offers_factories.ThingOfferFactory(venue=venue)
         product_stock = offers_factories.StockFactory(offer=product_offer)
         booking = bookings_factories.CancelledBookingFactory(stock=product_stock)
 


### PR DESCRIPTION
`Booking.venue` is denormalized from `Booking.stock.offer.venue`.
Users of the factory who provide it directly probably expect that it
will set the venue of the offer, but it does not. Now an error is
raised which should make that clear.