### PR TITLE
(PC-26400)[API] feat: Add offerer SIREN column in bank accounts files

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1444,7 +1444,7 @@ def _generate_reimbursement_points_file(cutoff: datetime.datetime) -> pathlib.Pa
 def _generate_bank_accounts_file(cutoff: datetime.datetime) -> pathlib.Path:
     header = (
         "Identifiant des coordonnées bancaires",
-        "SIRET",
+        "SIREN de la structure",
         "Nom de la structure - Libellé des coordonnées bancaires",
         "IBAN",
         "BIC",
@@ -1462,8 +1462,8 @@ def _generate_bank_accounts_file(cutoff: datetime.datetime) -> pathlib.Path:
         .order_by(offerers_models.Venue.id)
         .with_entities(
             models.BankAccount.id,
-            offerers_models.Venue.siret,
-            offerers_models.Offerer.name,
+            offerers_models.Offerer.name.label("offerer_name"),
+            offerers_models.Offerer.siren.label("offerer_siren"),
             models.BankAccount.label.label("label"),
             models.BankAccount.iban.label("iban"),
             models.BankAccount.bic.label("bic"),
@@ -1471,8 +1471,8 @@ def _generate_bank_accounts_file(cutoff: datetime.datetime) -> pathlib.Path:
     )
     row_formatter = lambda row: (
         human_ids.humanize(row.id),
-        _clean_for_accounting(row.siret),
-        _clean_for_accounting(f"{row.name} - {row.label}"),
+        _clean_for_accounting(row.offerer_siren),
+        _clean_for_accounting(f"{row.offerer_name} - {row.label}"),
         _clean_for_accounting(row.iban),
         _clean_for_accounting(row.bic),
     )

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1616,7 +1616,7 @@ def test_generate_bank_accounts_file():
     assert len(rows) == 1
     assert rows[0] == {
         "Identifiant des coordonnées bancaires": human_ids.humanize(bank_account_2.id),
-        "SIRET": "siret 1 t",
+        "SIREN de la structure": bank_account_2.offerer.siren,
         "Nom de la structure - Libellé des coordonnées bancaires": "Nom de la structure - some-label",
         "IBAN": "some-iban",
         "BIC": "some-bic",


### PR DESCRIPTION
And removing SIRET column, because it doesn't make sense in the new bank account journey context, since a bank account can be link to multiples venues and thus sirets.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26400

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques