### PR TITLE
(PC-27618)[PRO] fix: offer creation when several offerer does not select venue by default

### DIFF
--- a/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
@@ -1,5 +1,5 @@
 import { FormikProvider, useFormik } from 'formik'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import ConfirmDialog from 'components/Dialog/ConfirmDialog'
@@ -103,8 +103,12 @@ const InformationsScreen = ({
   )
 
   const filteredVenueList = querySubcategory
-    ? getFilteredVenueListBySubcategory(venueList, querySubcategory)
-    : getFilteredVenueListByCategoryStatus(venueList, categoryStatus)
+    ? getFilteredVenueListBySubcategory(venueList, querySubcategory).filter(
+        (venue) => venue.managingOffererId === Number(offererId)
+      )
+    : getFilteredVenueListByCategoryStatus(venueList, categoryStatus).filter(
+        (venue) => venue.managingOffererId === Number(offererId)
+      )
 
   // offer is null when we are creating a new offer
   const initialValues: IndividualOfferFormValues =


### PR DESCRIPTION


## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27618

Corriger un bug qui faisait que le lieu n'était pas vraiment sélectionné par défaut dans le formulaire de création d'offre pour les acteurs non admin avec plusieurs structures

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques