### PR TITLE
(PC-27613)[API] feat: Restart bank_account_id_seq at 200_000

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-ca50ad3c3fd6 (pre) (head)
+d3bd3af52558 (pre) (head)
 4f738fc2e54a (post) (head)

--- a/api/src/pcapi/alembic/versions/20240126T144443_d3bd3af52558_restart_bank_account_id_seq.py
+++ b/api/src/pcapi/alembic/versions/20240126T144443_d3bd3af52558_restart_bank_account_id_seq.py
@@ -1,0 +1,21 @@
+"""Restart bank_account_id_seq at 200_000
+"""
+
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "d3bd3af52558"
+down_revision = "ca50ad3c3fd6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER SEQUENCE public.bank_account_id_seq RESTART WITH 200000")
+
+
+def downgrade() -> None:
+    # Nothing to downgrade
+    pass


### PR DESCRIPTION
The sequence was initially set to start at 100_000 to ensure a perfect match between a reimbursementPoint.id in the old bankInformation journey and a soon-to-be bankAccount.id in the new journey. This is all for accounting reasons and there can be any mismatch

However, there's already venues holding bankInformation (i.e. reimbursementPoint) where id goes beyong 100_000

Hence restarting at 200_000.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27613

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques