### PR TITLE
(PC-27638)[PRO] refactor: move all skiplinks to app layout

### DIFF
--- a/pro/src/app/AppLayout.tsx
+++ b/pro/src/app/AppLayout.tsx
@@ -8,37 +8,32 @@ import SkipLinks from 'components/SkipLinks'
 export interface AppLayoutProps {
   children?: React.ReactNode
   pageName?: string
-  fullscreen?: boolean
   className?: string
+  layout?: 'basic' | 'funnel' | 'without-nav'
 }
 
 export const AppLayout = ({
   children,
   className,
   pageName = 'Accueil',
-  fullscreen = false,
+  layout = 'basic',
 }: AppLayoutProps) => (
   <>
-    {!fullscreen && (
-      <>
-        <SkipLinks />
-        <Header />
-      </>
-    )}
-
+    <SkipLinks />
+    {layout == 'basic' && <Header />}
     <main
       id="content"
       className={classnames(
         {
           page: true,
           [`${pageName}-page`]: true,
-          container: !fullscreen,
-          fullscreen,
+          container: layout === 'basic',
+          'without-nav': layout === 'without-nav',
         },
         className
       )}
     >
-      {fullscreen ? (
+      {layout === 'funnel' || layout === 'without-nav' ? (
         children
       ) : (
         <div className="page-content">

--- a/pro/src/pages/EmailChangeValidation/EmailChangeValidation.tsx
+++ b/pro/src/pages/EmailChangeValidation/EmailChangeValidation.tsx
@@ -36,7 +36,7 @@ const EmailChangeValidation = (): JSX.Element => {
   }
 
   return (
-    <AppLayout fullscreen pageName="sign-in">
+    <AppLayout pageName="sign-in" layout="without-nav">
       <EmailChangeValidationScreen isSuccess={isSuccess} />
     </AppLayout>
   )

--- a/pro/src/pages/LostPassword/LostPassword.module.scss
+++ b/pro/src/pages/LostPassword/LostPassword.module.scss
@@ -4,17 +4,8 @@
 @use "styles/mixins/_layout.scss" as layout;
 @use "styles/variables/_size.scss" as size;
 
-.lost-password {
-  display: flex;
-  flex-direction: column;
-
-  .logo-side {
-    @include layout.logo-side;
-  }
-
-  @media (min-width: size.$tablet) {
-    flex-direction: row;
-  }
+.logo-side {
+  @include layout.logo-side;
 }
 
 .content {

--- a/pro/src/pages/LostPassword/LostPassword.tsx
+++ b/pro/src/pages/LostPassword/LostPassword.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react'
 
 import { api } from 'apiClient/api'
 import { AppLayout } from 'app/AppLayout'
-import SkipLinks from 'components/SkipLinks'
 import useInitReCaptcha from 'hooks/useInitReCaptcha'
 import useNotification from 'hooks/useNotification'
 import useRedirectLoggedUser from 'hooks/useRedirectLoggedUser'
@@ -38,42 +37,35 @@ export const LostPassword = (): JSX.Element => {
   }
 
   return (
-    <>
-      <SkipLinks displayMenu={false} />
-
-      <div className={styles['lost-password']}>
-        <header className={styles['logo-side']}>
-          <SvgIcon
-            className="logo-unlogged"
-            viewBox="0 0 282 120"
-            alt="Pass Culture pro, l’espace des acteurs culturels"
-            src={logoPassCultureProFullIcon}
-            width="135"
+    <AppLayout pageName="lost-password" layout="without-nav">
+      <header className={styles['logo-side']}>
+        <SvgIcon
+          className="logo-unlogged"
+          viewBox="0 0 282 120"
+          alt="Pass Culture pro, l’espace des acteurs culturels"
+          src={logoPassCultureProFullIcon}
+          width="135"
+        />
+      </header>
+      <div className={styles['content']}>
+        {mailSent ? (
+          <Hero
+            linkLabel="Revenir à l’accueil"
+            linkTo="/"
+            text="Vous allez recevoir par email les instructions pour définir un nouveau mot de passe."
+            title="Merci !"
           />
-        </header>
-
-        <AppLayout fullscreen pageName="lost-password">
-          <div className={styles['content']}>
-            {mailSent ? (
-              <Hero
-                linkLabel="Revenir à l’accueil"
-                linkTo="/"
-                text="Vous allez recevoir par email les instructions pour définir un nouveau mot de passe."
-                title="Merci !"
-              />
-            ) : (
-              <Formik
-                initialValues={{ email: '' }}
-                onSubmit={submitChangePasswordRequest}
-                validationSchema={validationSchema}
-              >
-                <ChangePasswordRequestForm />
-              </Formik>
-            )}
-          </div>
-        </AppLayout>
+        ) : (
+          <Formik
+            initialValues={{ email: '' }}
+            onSubmit={submitChangePasswordRequest}
+            validationSchema={validationSchema}
+          >
+            <ChangePasswordRequestForm />
+          </Formik>
+        )}
       </div>
-    </>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/ResetPassword/ResetPassword.module.scss
+++ b/pro/src/pages/ResetPassword/ResetPassword.module.scss
@@ -2,22 +2,8 @@
 @use "styles/variables/_size.scss" as size;
 @use "styles/mixins/_rem.scss" as rem;
 
-.reset-password {
-  display: flex;
-  flex-direction: column;
-
-  .logo-side {
-    @include layout.logo-side;
-  }
-
-  @media (min-width: size.$tablet) {
-    flex-direction: row;
-
-    & > main {
-      display: flex;
-      align-items: center;
-    }
-  }
+.logo-side {
+  @include layout.logo-side;
 }
 
 .content {

--- a/pro/src/pages/ResetPassword/ResetPassword.tsx
+++ b/pro/src/pages/ResetPassword/ResetPassword.tsx
@@ -40,7 +40,7 @@ export const ResetPassword = (): JSX.Element => {
   })
 
   return (
-    <div className={styles['reset-password']}>
+    <AppLayout pageName="reset-password" layout="without-nav">
       <header className={styles['logo-side']}>
         <SvgIcon
           className="logo-unlogged"
@@ -50,38 +50,35 @@ export const ResetPassword = (): JSX.Element => {
           width="135"
         />
       </header>
-
-      <AppLayout fullscreen pageName="reset-password">
-        <div className={styles['content']}>
-          {passwordChanged && !isBadToken && (
-            <Hero
-              linkLabel="Se connecter"
-              linkTo="/connexion"
-              text="Vous pouvez dès à présent vous connecter avec votre nouveau mot de passe"
-              title="Mot de passe changé !"
-            />
-          )}
-          {(!token || isBadToken) && (
-            <Hero
-              linkLabel="Recevoir un nouveau lien"
-              linkTo="/demande-mot-de-passe"
-              text="Le lien pour réinitialiser votre mot de passe a expiré. Veuillez recommencer la procédure pour recevoir un nouveau lien par email."
-              title="Ce lien a expiré !"
-            />
-          )}
-          {token && !passwordChanged && !isBadToken && (
-            <section>
-              <h1 className={styles['change-password-title']}>
-                Définir un nouveau mot de passe
-              </h1>
-              <FormikProvider value={formik}>
-                <ChangePasswordForm />
-              </FormikProvider>
-            </section>
-          )}
-        </div>
-      </AppLayout>
-    </div>
+      <div className={styles['content']}>
+        {passwordChanged && !isBadToken && (
+          <Hero
+            linkLabel="Se connecter"
+            linkTo="/connexion"
+            text="Vous pouvez dès à présent vous connecter avec votre nouveau mot de passe"
+            title="Mot de passe changé !"
+          />
+        )}
+        {(!token || isBadToken) && (
+          <Hero
+            linkLabel="Recevoir un nouveau lien"
+            linkTo="/demande-mot-de-passe"
+            text="Le lien pour réinitialiser votre mot de passe a expiré. Veuillez recommencer la procédure pour recevoir un nouveau lien par email."
+            title="Ce lien a expiré !"
+          />
+        )}
+        {token && !passwordChanged && !isBadToken && (
+          <section>
+            <h1 className={styles['change-password-title']}>
+              Définir un nouveau mot de passe
+            </h1>
+            <FormikProvider value={formik}>
+              <ChangePasswordForm />
+            </FormikProvider>
+          </section>
+        )}
+      </div>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/SignIn/SignIn.tsx
+++ b/pro/src/pages/SignIn/SignIn.tsx
@@ -6,7 +6,6 @@ import { useSearchParams } from 'react-router-dom'
 import { api } from 'apiClient/api'
 import { HTTP_STATUS, isErrorAPIError } from 'apiClient/helpers'
 import { AppLayout } from 'app/AppLayout'
-import SkipLinks from 'components/SkipLinks'
 import useInitReCaptcha from 'hooks/useInitReCaptcha'
 import useNotification from 'hooks/useNotification'
 import useRedirectLoggedUser from 'hooks/useRedirectLoggedUser'
@@ -95,37 +94,30 @@ export const SignIn = (): JSX.Element => {
   }
 
   return (
-    <>
-      <SkipLinks displayMenu={false} />
+    <AppLayout pageName="sign-in" layout="without-nav">
+      <header className={styles['logo-side']}>
+        <SvgIcon
+          className="logo-unlogged"
+          viewBox="0 0 282 120"
+          alt="Pass Culture pro, l’espace des acteurs culturels"
+          src={logoPassCultureProFullIcon}
+          width="135"
+        />
+      </header>
+      <section className={styles['content']}>
+        <h1 className={styles['title']}>
+          Bienvenue sur l’espace dédié aux acteurs culturels
+        </h1>
 
-      <div className={styles['sign-in']}>
-        <header className={styles['logo-side']}>
-          <SvgIcon
-            className="logo-unlogged"
-            viewBox="0 0 282 120"
-            alt="Pass Culture pro, l’espace des acteurs culturels"
-            src={logoPassCultureProFullIcon}
-            width="135"
-          />
-        </header>
-
-        <AppLayout fullscreen pageName="sign-in">
-          <section className={styles['content']}>
-            <h1 className={styles['title']}>
-              Bienvenue sur l’espace dédié aux acteurs culturels
-            </h1>
-
-            <div className={styles['mandatory']}>
-              Tous les champs sont obligatoires
-            </div>
-            <FormikProvider value={formik}>
-              <SigninForm />
-            </FormikProvider>
-            <CookiesFooter className={styles['cookies-footer']} />
-          </section>
-        </AppLayout>
-      </div>
-    </>
+        <div className={styles['mandatory']}>
+          Tous les champs sont obligatoires
+        </div>
+        <FormikProvider value={formik}>
+          <SigninForm />
+        </FormikProvider>
+        <CookiesFooter className={styles['cookies-footer']} />
+      </section>
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/SignIn/Signin.module.scss
+++ b/pro/src/pages/SignIn/Signin.module.scss
@@ -5,23 +5,8 @@
 @use "styles/variables/_forms.scss" as forms;
 @use "styles/variables/_size.scss" as size;
 
-.sign-in {
-  display: flex;
-  flex-direction: column;
-
-  @media (min-width: size.$tablet) {
-    flex-direction: row;
-    width: 100%;
-
-    & > main {
-      display: flex;
-      align-items: center;
-    }
-  }
-
-  .logo-side {
-    @include layout.logo-side;
-  }
+.logo-side {
+  @include layout.logo-side;
 }
 
 .content {

--- a/pro/src/pages/Signup/Signup.module.scss
+++ b/pro/src/pages/Signup/Signup.module.scss
@@ -1,15 +1,6 @@
 @use "styles/mixins/_layout.scss" as layout;
 @use "styles/variables/_size.scss" as size;
 
-.sign-up {
-  display: flex;
-  flex-direction: column;
-
-  .logo-side {
-    @include layout.logo-side;
-  }
-
-  @media (min-width: size.$tablet) {
-    flex-direction: row;
-  }
+.logo-side {
+  @include layout.logo-side;
 }

--- a/pro/src/pages/Signup/Signup.tsx
+++ b/pro/src/pages/Signup/Signup.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { AppLayout } from 'app/AppLayout'
-import SkipLinks from 'components/SkipLinks'
 import useActiveFeature from 'hooks/useActiveFeature'
 import logoPassCultureProFullIcon from 'icons/logo-pass-culture-pro-full.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -15,25 +14,18 @@ export const Signup = () => {
     'ENABLE_PRO_ACCOUNT_CREATION'
   )
   return (
-    <>
-      <SkipLinks displayMenu={false} />
-
-      <div className={styles['sign-up']}>
-        <header className={styles['logo-side']}>
-          <SvgIcon
-            className="logo-unlogged"
-            viewBox="0 0 282 120"
-            alt="Pass Culture pro, l’espace des acteurs culturels"
-            src={logoPassCultureProFullIcon}
-            width="135"
-          />
-        </header>
-
-        <AppLayout fullscreen pageName="sign-up">
-          {isProAccountCreationEnabled ? <Outlet /> : <SignupUnavailable />}
-        </AppLayout>
-      </div>
-    </>
+    <AppLayout pageName="sign-up" layout="without-nav">
+      <header className={styles['logo-side']}>
+        <SvgIcon
+          className="logo-unlogged"
+          viewBox="0 0 282 120"
+          alt="Pass Culture pro, l’espace des acteurs culturels"
+          src={logoPassCultureProFullIcon}
+          width="135"
+        />
+      </header>
+      {isProAccountCreationEnabled ? <Outlet /> : <SignupUnavailable />}
+    </AppLayout>
   )
 }
 

--- a/pro/src/pages/SignupJourneyRoutes/SignupJourneyRoutes.tsx
+++ b/pro/src/pages/SignupJourneyRoutes/SignupJourneyRoutes.tsx
@@ -3,7 +3,6 @@ import { NavLink, Outlet, useLocation } from 'react-router-dom'
 
 import { AppLayout } from 'app/AppLayout'
 import { SignupJourneyFormLayout } from 'components/SignupJourneyFormLayout'
-import SkipLinks from 'components/SkipLinks'
 import { SignupJourneyContextProvider } from 'context/SignupJourneyContext'
 import { Events } from 'core/FirebaseEvents/constants'
 import useAnalytics from 'hooks/useAnalytics'
@@ -31,39 +30,36 @@ export const SignupJourneyRoutes = () => {
 
   return (
     <>
-      <SkipLinks displayMenu={false} />
-
-      <header className={styles['header']}>
-        <div className={styles['header-content']}>
-          <SvgIcon
-            className={styles['header-logo']}
-            alt="Pass Culture pro, l’espace des acteurs culturels"
-            src={logoPassCultureProIcon}
-            viewBox="0 0 119 40"
-          />
-          <NavLink
-            onClick={() =>
-              logEvent?.(Events.CLICKED_LOGOUT, { from: location.pathname })
-            }
-            to={`${location.pathname}?logout}`}
-            className={styles['logout-link']}
-          >
-            <SvgIcon
-              className="nav-item-icon"
-              src={fullLogoutIcon}
-              alt=""
-              width="20"
-            />
-            Se déconnecter
-          </NavLink>
-        </div>
-      </header>
-
       <AppLayout
-        fullscreen
         pageName="sign-up-journey"
         className={styles['sign-up-journey']}
+        layout="funnel"
       >
+        <header className={styles['header']}>
+          <div className={styles['header-content']}>
+            <SvgIcon
+              className={styles['header-logo']}
+              alt="Pass Culture pro, l’espace des acteurs culturels"
+              src={logoPassCultureProIcon}
+              viewBox="0 0 119 40"
+            />
+            <NavLink
+              onClick={() =>
+                logEvent?.(Events.CLICKED_LOGOUT, { from: location.pathname })
+              }
+              to={`${location.pathname}?logout}`}
+              className={styles['logout-link']}
+            >
+              <SvgIcon
+                className="nav-item-icon"
+                src={fullLogoutIcon}
+                alt=""
+                width="20"
+              />
+              Se déconnecter
+            </NavLink>
+          </div>
+        </header>
         <SignupJourneyContextProvider>
           <SignupJourneyFormLayout>
             <Outlet />

--- a/pro/src/screens/EmailChangeValidation/EmailChangeValidation.module.scss
+++ b/pro/src/screens/EmailChangeValidation/EmailChangeValidation.module.scss
@@ -5,19 +5,8 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_size.scss" as size;
 
-.email-validation {
-  display: flex;
-  flex-direction: column;
-
-  @media (min-width: size.$tablet) {
-    flex-direction: row;
-    width: 100%;
-    align-items: center;
-  }
-
-  .logo-side {
-    @include layout.logo-side;
-  }
+.logo-side {
+  @include layout.logo-side;
 }
 
 .content {

--- a/pro/src/screens/EmailChangeValidation/EmailChangeValidation.tsx
+++ b/pro/src/screens/EmailChangeValidation/EmailChangeValidation.tsx
@@ -1,8 +1,6 @@
 // react hooks and usages doc : https://reactjs.org/docs/hooks-intro.html
 import React from 'react'
 
-import { AppLayout } from 'app/AppLayout'
-import SkipLinks from 'components/SkipLinks'
 import logoPassCultureProFullIcon from 'icons/logo-pass-culture-pro-full.svg'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -19,54 +17,47 @@ const EmailChangeValidation = ({
 }: EmailChangeValidationProps): JSX.Element => {
   return (
     <>
-      <SkipLinks displayMenu={false} />
-
-      <div className={styles['email-validation']}>
-        <header className={styles['logo-side']}>
-          <SvgIcon
-            className="logo-unlogged"
-            viewBox="0 0 282 120"
-            alt="Pass Culture pro, l’espace des acteurs culturels"
-            src={logoPassCultureProFullIcon}
-            width="135"
-          />
-        </header>
-
-        <AppLayout fullscreen pageName="sign-up">
-          {isSuccess && (
-            <section className={styles['content']}>
-              <h1>Et voilà !</h1>
-              <p className={styles['subtitle']}>
-                Merci d’avoir confirmé votre changement d’adresse email.
-              </p>
-              <ButtonLink
-                variant={ButtonVariant.PRIMARY}
-                link={{ to: '/', isExternal: false }}
-              >
-                Se connecter
-              </ButtonLink>
-            </section>
-          )}
-          {!isSuccess && (
-            <section className={styles['content']}>
-              <h1>Votre lien a expiré !</h1>
-              <p className={styles['subtitle']}>
-                Votre adresse email n’a pas été modifiée car le lien reçu par
-                mail expire 24 heures après sa réception.
-              </p>
-              <p className={styles['subtitle']}>
-                Connectez-vous avec votre ancienne adresse email.
-              </p>
-              <ButtonLink
-                variant={ButtonVariant.PRIMARY}
-                link={{ to: '/', isExternal: false }}
-              >
-                Se connecter
-              </ButtonLink>
-            </section>
-          )}
-        </AppLayout>
-      </div>
+      <header className={styles['logo-side']}>
+        <SvgIcon
+          className="logo-unlogged"
+          viewBox="0 0 282 120"
+          alt="Pass Culture pro, l’espace des acteurs culturels"
+          src={logoPassCultureProFullIcon}
+          width="135"
+        />
+      </header>
+      {isSuccess && (
+        <section className={styles['content']}>
+          <h1>Et voilà !</h1>
+          <p className={styles['subtitle']}>
+            Merci d’avoir confirmé votre changement d’adresse email.
+          </p>
+          <ButtonLink
+            variant={ButtonVariant.PRIMARY}
+            link={{ to: '/', isExternal: false }}
+          >
+            Se connecter
+          </ButtonLink>
+        </section>
+      )}
+      {!isSuccess && (
+        <section className={styles['content']}>
+          <h1>Votre lien a expiré !</h1>
+          <p className={styles['subtitle']}>
+            Votre adresse email n’a pas été modifiée car le lien reçu par mail
+            expire 24 heures après sa réception.
+          </p>
+          <p className={styles['subtitle']}>
+            Connectez-vous avec votre ancienne adresse email.
+          </p>
+          <ButtonLink
+            variant={ButtonVariant.PRIMARY}
+            link={{ to: '/', isExternal: false }}
+          >
+            Se connecter
+          </ButtonLink>
+        </section>
+      )}
     </>
   )
 }

--- a/pro/src/styles/global/_page.scss
+++ b/pro/src/styles/global/_page.scss
@@ -48,8 +48,15 @@ main {
     }
   }
 
-  &.fullscreen {
-    margin: 0 auto;
+  &.without-nav {
+    display: flex;
+    flex-direction: column;
+
+    @media (min-width: size.$tablet) {
+      flex-direction: row;
+      width: 100%;
+      margin: 0 auto;
+    }
   }
 
   &.container {

--- a/pro/src/styles/mixins/_layout.scss
+++ b/pro/src/styles/mixins/_layout.scss
@@ -26,6 +26,7 @@
 
 @mixin full-content-side() {
   padding: rem.torem(24px);
+  margin: auto;
 
   @media (min-width: size.$tablet) {
     min-width: size.$full-content-min-width;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27368

Déplacer SkipLinks pour qu'il ne soit plus que dans AppLayout et pas dans les sous-pages (ex: Signin). L'objectif est de simplifier le composant AppLayout en vu de la refonte. 


**Pour tester :** 

Vérifier le bonne affichage des pages suivantes (responsive ou non), ainsi que l'affichage du menu d'évitement sur ces pages : 

- Connexion
- Inscription
- Mot de passe oublié
- Changement de mot de passe
- Parcours d’inscription 
- Accueil

