### PR TITLE
(PC-27640)[PRO] fix: prefer public name in pagePartner select in Home

### DIFF
--- a/pro/src/pages/Home/Offerers/PartnerPages.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPages.tsx
@@ -43,7 +43,7 @@ export const PartnerPages = ({ venues, offerer }: PartnerPagesProps) => {
     const map = new Map()
     for (const venue of venues) {
       options.push({
-        label: venue.name,
+        label: venue.publicName || venue.name,
         value: venue.id.toString(),
       })
       map.set(venue.id.toString(), venue)

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPages.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPages.spec.tsx
@@ -62,7 +62,12 @@ describe('PartnerPages', () => {
     renderPartnerPages({
       venues: [
         defaultGetOffererVenueResponseModel,
-        { ...defaultGetOffererVenueResponseModel, id: 1 },
+        {
+          ...defaultGetOffererVenueResponseModel,
+          id: 1,
+          name: 'an other venue',
+          publicName: 'a really cool name !',
+        },
       ],
     })
 
@@ -70,8 +75,10 @@ describe('PartnerPages', () => {
       screen.getByRole('heading', { name: 'Vos pages partenaire' })
     ).toBeInTheDocument()
     expect(
-      screen.queryByLabelText(/Sélectionnez votre page partenaire/)
+      screen.getByLabelText(/Sélectionnez votre page partenaire/)
     ).toBeInTheDocument()
+    // it should use public name if available
+    expect(screen.getByText('a really cool name !')).toBeInTheDocument()
   })
 
   it('should load saved venue in localStorage if no get parameter', () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27640

- utiliser le public name (nom d'usage) de la venue dans le select des page partenaires sur la Home

pour tester:

    activer WIP_PARTNER_PAGE
    mettre ses lieu en isPermanent = true


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques