### PR TITLE
(PC-27658)[API] feat: Add CSP-REPORT-ONLY response header.

### DIFF
--- a/api/.env.testing
+++ b/api/.env.testing
@@ -94,6 +94,7 @@ SENDINBLUE_PRO_INACTIVE_90_DAYS_ID=35
 SENDINBLUE_PRO_NO_ACTIVE_OFFERS_40_DAYS_ID=40
 SENDINBLUE_PRO_NO_BOOKINGS_40_DAYS_ID=41
 SENTRY_SAMPLE_RATE=0.01
+SENTRY_CSP_REPORT_ONLY_URI=https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365
 SIRENE_BACKEND=pcapi.connectors.entreprise.backends.insee.InseeBackend
 SLACK_CHANGE_FEATURE_FLIP_CHANNEL=feature-flip-ehp
 SMS_NOTIFICATION_BACKEND=pcapi.notifications.sms.backends.sendinblue.ToDevSendinblueBackend

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -124,6 +124,9 @@ def add_security_headers(response: flask.wrappers.Response) -> flask.wrappers.Re
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload"
+    response.headers["Content-Security-Policy-Report-Only"] = (
+        f"default-src 'self'; report-uri {settings.SENTRY_CSP_REPORT_ONLY_URI}; report-to {settings.SENTRY_CSP_REPORT_ONLY_URI}"
+    )
 
     return response
 

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -97,6 +97,7 @@ REDIS_VENUE_IDS_CHUNK_SIZE = int(os.environ.get("REDIS_VENUE_IDS_CHUNK_SIZE", 10
 # SENTRY
 SENTRY_DSN = secrets_utils.get("SENTRY_DSN", "")
 SENTRY_SAMPLE_RATE = float(os.environ.get("SENTRY_SAMPLE_RATE", 0))
+SENTRY_CSP_REPORT_ONLY_URI = os.environ.get("SENTRY_CSP_REPORT_ONLY_URI", "")
 
 
 # USERS


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27658

**Objectif**
Pour obtenir le rapport d’erreur csp sur sentry, on doit ajouter l’uri sentry dans les response headers

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques