### PR TITLE
(PC-21623)[PRO] style: wording et modif des blocks, profil

### DIFF
--- a/pro/src/components/UserPasswordForm/validationSchema.ts
+++ b/pro/src/components/UserPasswordForm/validationSchema.ts
@@ -2,12 +2,7 @@ import * as yup from 'yup'
 
 import { isPasswordValid } from 'core/shared/utils/validation'
 
-const passwordErrorMessage = `Votre mot de passe doit contenir au moins :
-      - 12 caractères
-      - Un chiffre
-      - Une majuscule et une minuscule
-      - Un caractère spécial
-`
+const passwordErrorMessage = 'Veuillez renseigner votre nouveau mot de passe'
 
 const validationSchema = yup.object().shape({
   oldPassword: yup

--- a/pro/src/ui-kit/BoxRounded/BoxRounded.module.scss
+++ b/pro/src/ui-kit/BoxRounded/BoxRounded.module.scss
@@ -4,9 +4,9 @@
 
 .expandable-box {
   position: relative;
-  border-radius: rem.torem(10px);
+  border-radius: rem.torem(6px);
   border: rem.torem(1px) solid colors.$grey-medium;
-  padding: rem.torem(16px);
+  padding: rem.torem(8px);
 }
 
 .modify-button-container {


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-21623

Branche: PC-21623-profil-mdp-wording

## But de la pull request - styling de la page profil

- Changer le spacing vertical entre les blocs : 16 px.
- Changer le border radius des blocs : 6 px.
- Ajouter un message générique: “Veuillez renseigner votre nouveau mot de passe”.


<img width="993" alt="Capture d’écran 2024-01-29 à 10 49 53" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/a94ec99e-58e2-4c12-8753-993373a210ba">

<img width="641" alt="Capture d’écran 2024-01-29 à 10 45 43" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/08364759-f068-4ba9-859e-863e3373e3c9">

<img width="570" alt="Capture d’écran 2024-01-29 à 10 45 19" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/7c35010c-8907-4a0d-a821-0351bea1f2dd">
