### PR TITLE
(BSR)[API] chore: resolve some sqlalchemy2 warnings

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -244,7 +244,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
 
     @remainingQuantity.expression  # type: ignore [no-redef]
     def remainingQuantity(cls) -> Case:  # pylint: disable=no-self-argument
-        return sa.case([(cls.quantity.is_(None), None)], else_=(cls.quantity - cls.dnBookedQuantity))
+        return sa.case((cls.quantity.is_(None), None), else_=(cls.quantity - cls.dnBookedQuantity))
 
     AUTOMATICALLY_USED_SUBCATEGORIES = [
         subcategories_v2.CARTE_MUSEE.id,
@@ -760,14 +760,12 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     @status.expression  # type: ignore [no-redef]
     def status(cls) -> Case:  # pylint: disable=no-self-argument
         return sa.case(
-            [
-                (cls.validation == OfferValidationStatus.REJECTED.name, OfferStatus.REJECTED.name),
-                (cls.validation == OfferValidationStatus.PENDING.name, OfferStatus.PENDING.name),
-                (cls.validation == OfferValidationStatus.DRAFT.name, OfferStatus.DRAFT.name),
-                (cls.isActive.is_(False), OfferStatus.INACTIVE.name),
-                (cls.hasBookingLimitDatetimesPassed.is_(True), OfferStatus.EXPIRED.name),
-                (cls.isSoldOut.is_(True), OfferStatus.SOLD_OUT.name),
-            ],
+            (cls.validation == OfferValidationStatus.REJECTED.name, OfferStatus.REJECTED.name),
+            (cls.validation == OfferValidationStatus.PENDING.name, OfferStatus.PENDING.name),
+            (cls.validation == OfferValidationStatus.DRAFT.name, OfferStatus.DRAFT.name),
+            (cls.isActive.is_(False), OfferStatus.INACTIVE.name),
+            (cls.hasBookingLimitDatetimesPassed.is_(True), OfferStatus.EXPIRED.name),
+            (cls.isSoldOut.is_(True), OfferStatus.SOLD_OUT.name),
             else_=OfferStatus.ACTIVE.name,
         )
 


### PR DESCRIPTION
## But de la pull request

BSR: résolution de deux cas dans les models de offers ou on utilisait case avec une liste de cas au lieu de les passer en arguments positionnels.

Je n'ai fait que ces deux la (alors qu'il y en a plein d'autres) car c'était le deux seuls pour lesquels j'avais des warnings et je ne sais pas a quel point ces choses la sont testés.

le warning concerné:
```
pc-backoffice    | WARNING:py.warnings:/usr/src/app/src/pcapi/core/offers/models.py:247: RemovedIn20Warning: The "whens" argument to case(), when referring to a sequence of items, is now passed as a series of positional elements, rather than as a list.  (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
pc-backoffice    |   return sa.case([(cls.quantity.is_(None), None)], else_=(cls.quantity - cls.dnBookedQuantity))

```