### PR TITLE
(PC-27672)[PRO] style: Fix style of ListIconButton isExternal element

### DIFF
--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/BookingLinkCell/BookingLinkCell.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/BookingLinkCell/BookingLinkCell.tsx
@@ -9,8 +9,6 @@ import {
   formatBrowserTimezonedDateAsUTC,
 } from 'utils/date'
 
-import styles from '../../OfferItem.module.scss'
-
 interface BookingLinkCellProps {
   bookingId: number
   bookingStatus: string
@@ -33,7 +31,6 @@ const BookingLinkCell = ({
   const bookingLink = `/reservations/collectives?page=1&offerEventDate=${eventDateFormated}&bookingStatusFilter=booked&offerType=all&offerVenueId=all&bookingId=${bookingId}`
   return (
     <ListIconButton
-      className={styles['button']}
       url={bookingLink}
       isExternal={false}
       icon={arrowIcon}

--- a/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
+++ b/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
@@ -14,7 +14,9 @@
   transition: background-color 100ms ease-in-out;
   cursor: pointer;
 
-  &:hover, &:active:not(:disabled), &:hover:not(:disabled), &:focus-visible {
+  &:active:not(:disabled),
+  &:hover:not(:disabled),
+  &:focus-visible {
     .button-icon {
       height: rem.torem(20px);
       width: rem.torem(20px);
@@ -26,6 +28,7 @@
   }
 
   &:active {
+    color: colors.$tertiary;
     background-color: transparent;
   }
 
@@ -34,22 +37,14 @@
   }
 
   &-icon {
+    transition: all 100ms ease-in-out;
     height: rem.torem(24px);
     width: rem.torem(24px);
-    transition: all 100ms ease-in-out;
-    fill: colors.$black;
-
-    &:active {
-      fill: colors.$tertiary;
-    }
   }
 
   &:disabled {
     cursor: not-allowed;
-
-    .button-icon {
-      fill: colors.$grey-semi-dark;
-    }
+    color: colors.$grey-semi-dark;
   }
 }
 

--- a/pro/src/ui-kit/ListIconButton/ListIconButton.tsx
+++ b/pro/src/ui-kit/ListIconButton/ListIconButton.tsx
@@ -76,7 +76,7 @@ const ListIconButton = ({
     </a>
   ) : (
     <Link
-      className={className}
+      className={cn(styles['button'], className)}
       onClick={onClick}
       to={`${url}`}
       {...tooltipProps}

--- a/pro/src/ui-kit/Tooltip/Tooltip.module.scss
+++ b/pro/src/ui-kit/Tooltip/Tooltip.module.scss
@@ -10,10 +10,10 @@ $arrow-triangle-height: rem.torem(8px);
   display: flex;
   justify-content: center;
 
-
   .tooltip {
     @include fonts.caption;
 
+    display: block;
     align-self: start;
     color: white;
     padding: rem.torem(4px);

--- a/pro/src/ui-kit/Tooltip/Tooltip.tsx
+++ b/pro/src/ui-kit/Tooltip/Tooltip.tsx
@@ -19,17 +19,17 @@ const Tooltip = ({
   // Tooltip should implement onMouseOver onMouseOut onFocus onBlur onKeyDown
   // on parent to be accessible
   return (
-    <div className={cn(styles['tooltip-container'], className)}>
+    <span className={cn(styles['tooltip-container'], className)}>
       {children}
-      <div
+      <span
         className={cn(styles['tooltip'], {
           ['visually-hidden']: visuallyHidden,
         })}
         role="tooltip"
       >
         {content}
-      </div>
-    </div>
+      </span>
+    </span>
   )
 }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27672

**Objectif**
S'assurer que tous les boutons `ListIconButton` ont le même style.

**Réalisation**
Ajouter les classes sur le `ListIconButton` dans le cas ou il est `isExternal`. Et au passage j'ai réaligné les styles du bouton [avec la maquette](https://www.figma.com/file/AEXCkb4KbUyPmB4BRFa88s/PRO---Library?type=design&node-id=8112-100762&mode=dev), et j'ai mis des spans dans les `Tooltip` à la place des divs (https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques