### PR TITLE
(PC-27691)[BO] fix: timeout when loading account details page

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -209,17 +209,18 @@ def render_public_account_details(
 ) -> str:
     # Pre-load as many things as possible in the same request to avoid too many SQL queries
     # Note that extra queries are made in methods called by get_eligibility_history()
+    # Do not joinedload bookings: combinations would cause too many rows returned by postgresql - fetched in a 2nd query
     user = (
         users_models.User.query.filter_by(id=user_id)
         .options(
             sa.orm.joinedload(users_models.User.deposits),
-            sa.orm.joinedload(users_models.User.userBookings)
+            sa.orm.subqueryload(users_models.User.userBookings)
             .joinedload(bookings_models.Booking.stock)
             .joinedload(offers_models.Stock.offer),
-            sa.orm.joinedload(users_models.User.userBookings)
+            sa.orm.subqueryload(users_models.User.userBookings)
             .joinedload(bookings_models.Booking.offerer)
             .load_only(offerers_models.Offerer.name),
-            sa.orm.joinedload(users_models.User.userBookings)
+            sa.orm.subqueryload(users_models.User.userBookings)
             .joinedload(bookings_models.Booking.venue)
             .load_only(offerers_models.Venue.bookingEmail),
             sa.orm.joinedload(users_models.User.beneficiaryFraudChecks),


### PR DESCRIPTION
502 Bad Gateway on user id=2956859
All data joinedload: SQL query returned 48216 rows Query with all data except bookings: 1176 rows (depends on data) Query for bookings and joined data: 41 rows (number of bookings)

Remaining joined query could be optimized, but this is a first quick win for this page to be fetched in less than one second.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-27691

## Vérifications

Testé dans la console python sur staging avec succès