### PR TITLE
(PC-27532)[EAC] feat: iframe: logs: new route: share cta

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -363,3 +363,22 @@ def log_search_show_more(
         user_email=authenticated_information.email,
     )
     return
+
+
+@blueprint.adage_iframe.route("/logs/tracking-cta-share", methods=["POST"])
+@spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
+@adage_jwt_required
+def log_tracking_cta_share(
+    authenticated_information: AuthenticatedInformation,
+    body: serialization.TrackingCTAShareBody,
+) -> None:
+    institution = find_educational_institution_by_uai_code(authenticated_information.uai)
+    extra_data = body.dict()
+    extra_data["from"] = extra_data.pop("iframeFrom")
+    educational_utils.log_information_for_data_purpose(
+        event_name="TrackingCTAShare",
+        extra_data=extra_data,
+        user_email=authenticated_information.email,
+        uai=authenticated_information.uai,
+        user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
+    )

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -83,3 +83,8 @@ class TrackingAutocompleteSuggestionBody(AdageBaseModel):
 
 class TrackingShowMoreBody(AdageBaseModel):
     source: str
+
+
+class TrackingCTAShareBody(AdageBaseModel):
+    source: str
+    offerId: int

--- a/pro/src/apiClient/adage/index.ts
+++ b/pro/src/apiClient/adage/index.ts
@@ -61,6 +61,7 @@ export type { SubcategoryResponseModel } from './models/SubcategoryResponseModel
 export { SuggestionType } from './models/SuggestionType';
 export type { TemplateDatesModel } from './models/TemplateDatesModel';
 export type { TrackingAutocompleteSuggestionBody } from './models/TrackingAutocompleteSuggestionBody';
+export type { TrackingCTAShareBody } from './models/TrackingCTAShareBody';
 export type { TrackingFilterBody } from './models/TrackingFilterBody';
 export type { TrackingShowMoreBody } from './models/TrackingShowMoreBody';
 export type { ValidationError } from './models/ValidationError';

--- a/pro/src/apiClient/adage/models/TrackingCTAShareBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingCTAShareBody.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type TrackingCTAShareBody = {
+  iframeFrom: string;
+  isFromNoResult?: boolean | null;
+  offerId: number;
+  queryId?: string | null;
+  source: string;
+};
+

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -29,6 +29,7 @@ import type { RedactorPreferences } from '../models/RedactorPreferences';
 import type { SearchBody } from '../models/SearchBody';
 import type { StockIdBody } from '../models/StockIdBody';
 import type { TrackingAutocompleteSuggestionBody } from '../models/TrackingAutocompleteSuggestionBody';
+import type { TrackingCTAShareBody } from '../models/TrackingCTAShareBody';
 import type { TrackingFilterBody } from '../models/TrackingFilterBody';
 import type { TrackingShowMoreBody } from '../models/TrackingShowMoreBody';
 import type { VenueResponse } from '../models/VenueResponse';
@@ -623,6 +624,27 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'POST',
       url: '/adage-iframe/logs/tracking-autocompletion',
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        403: `Forbidden`,
+        404: `Not Found`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
+   * log_tracking_cta_share <POST>
+   * @param requestBody
+   * @returns void
+   * @throws ApiError
+   */
+  public logTrackingCtaShare(
+    requestBody?: TrackingCTAShareBody,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/adage-iframe/logs/tracking-cta-share',
       body: requestBody,
       mediaType: 'application/json',
       errors: {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27532

Ajoute d'une route (iframe adage) afin d'ajouter un log de suivi pour le CTA de partage d'offre.