### PR TITLE
(BSR)[API] feat: Run `poetry check` when building Docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -25,13 +25,17 @@ RUN pip install poetry
 
 WORKDIR /home/pcapi
 
-RUN poetry export -o requirements.txt --without dev 
+RUN poetry check --lock
+
+RUN poetry export -o requirements.txt --without dev
 
 RUN pip install -r requirements.txt
 
 ########## DEV BUILDER ##########
 
 FROM builder AS builder-dev
+
+RUN poetry check --lock
 
 RUN poetry export -o requirements-dev.txt --only dev
 


### PR DESCRIPTION
This should detect inconsistencies between `pyproject.toml` and
`poetry.lock`, and will thus refuse to build the Docker image if an
unwanted changed has been added to `pyproject.toml` (without
corresponding changes to `poetry.lock`).

This is mostly useful for local builds, since this check is already
done by a GitHub workflow when building the image for testing and
other environments.

---

Exemple en local : 

```
$ ../pc start-backend
[...]
 => [backoffice builder 5/9] RUN pip install poetry                                                                                                                                     [...]
 => ERROR [backoffice builder 7/9] RUN poetry check --lock                                                                                                                               ------                                                                                                                                                                                        
 > [backoffice builder 7/9] RUN poetry check --lock:                                                                                                                                          
Error: poetry.lock is not consistent with pyproject.toml. Run `poetry lock [--no-update]` to fix it.                                                                                    
------                                                                                                                                                                                        
failed to solve: process "/bin/sh -c poetry check --lock" did not complete successfully: exit code: 1
```

