### PR TITLE
Pc 26956 rpa connect as bo

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -43,6 +43,7 @@ class ActionType(enum.Enum):
     USER_UNSUSPENDED = "Compte réactivé"
     USER_PHONE_VALIDATED = "Validation manuelle du numéro de téléphone"
     USER_EMAIL_VALIDATED = "Validation manuelle de l'email"
+    CONNECT_AS_USER = "Connexion d'un admin"
     # Fraud and compliance actions:
     BLACKLIST_DOMAIN_NAME = "Blacklist d'un nom de domaine"
     REMOVE_BLACKLISTED_DOMAIN_NAME = "Suppression d'un nom de domaine banni"

--- a/api/src/pcapi/core/token/serialization.py
+++ b/api/src/pcapi/core/token/serialization.py
@@ -1,0 +1,8 @@
+from pcapi.routes.serialization import BaseModel
+
+
+class ConnectAsInternalModel(BaseModel):
+    redirect_link: str
+    user_id: int
+    internal_admin_email: str
+    internal_admin_id: int

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -598,6 +598,14 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
     def has_test_role(cls) -> bool:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.TEST])
 
+    @hybrid_property
+    def has_anonymized_role(self) -> bool:
+        return UserRole.ANONYMIZED in self.roles
+
+    @has_anonymized_role.expression  # type: ignore [no-redef]
+    def has_anonymized_role(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls.roles.contains([UserRole.ANONYMIZED])
+
 
 User.trig_ensure_password_or_sso_exists_ddl = sa.DDL(
     """

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -116,7 +116,7 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_MARSEILLE = "Activer Marseille en grand"
     WIP_GOOGLE_MAPS_VENUE_IMAGES = "Activer l'affichage des images des lieux importées depuis Google Maps"
     WIP_ENABLE_PRO_SIDE_NAV = "Refonte de la navigation de l'app pro"
-    WIP_CONNECT_AS = "Permettre a un admin de se connecter en tant qu'un pro"
+    WIP_CONNECT_AS = "Permettre à un admin de se connecter en tant qu'un compte pro sur PC Pro"
     WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN = "Activer le nouveau design des offres sur adage"
     WIP_ENABLE_NATIONAL_PROGRAM_NEW_RULES_PUBLIC_API = (
         "Activer les nouvelles règles de création et d'édition d'offres collecrives pour l'API publique (collective)"

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -116,6 +116,7 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_MARSEILLE = "Activer Marseille en grand"
     WIP_GOOGLE_MAPS_VENUE_IMAGES = "Activer l'affichage des images des lieux importées depuis Google Maps"
     WIP_ENABLE_PRO_SIDE_NAV = "Refonte de la navigation de l'app pro"
+    WIP_CONNECT_AS = "Permettre a un admin de se connecter en tant qu'un pro"
     WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN = "Activer le nouveau design des offres sur adage"
     WIP_ENABLE_NATIONAL_PROGRAM_NEW_RULES_PUBLIC_API = (
         "Activer les nouvelles règles de création et d'édition d'offres collecrives pour l'API publique (collective)"
@@ -185,6 +186,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_GOOGLE_MAPS_VENUE_IMAGES,  # FIXME Abdelmoujib: remove when feature is ready https://passculture.atlassian.net/browse/PC-26459
     FeatureToggle.ENABLE_CRON_TO_UPDATE_OFFERER_STATS,
     FeatureToggle.WIP_ENABLE_PRO_SIDE_NAV,
+    FeatureToggle.WIP_CONNECT_AS,
     FeatureToggle.WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN,
     FeatureToggle.WIP_ENABLE_COLLECTIVE_CUSTOM_CONTACT,
 )

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -442,6 +442,8 @@ def get_pro_users(offerer_id: int) -> utils.BackofficeResponse:
         users_models.User.firstName,
         users_models.User.lastName,
         users_models.User.email,
+        users_models.User.isActive,
+        users_models.User.roles,
     )
 
     rows = (
@@ -451,6 +453,8 @@ def get_pro_users(offerer_id: int) -> utils.BackofficeResponse:
             users_models.User.lastName,
             users_models.User.full_name,
             users_models.User.email,
+            users_models.User.isActive,
+            users_models.User.roles,
             offerers_models.UserOfferer,
             offerers_models.OffererInvitation,
         )
@@ -519,12 +523,16 @@ def get_pro_users(offerer_id: int) -> utils.BackofficeResponse:
             "email": user_invited.email,
             "UserOfferer": None,
             "OffererInvitation": user_invited,
+            "isActive": False,
+            "roles": [],
         }
         for user_invited in users_invited
     ]
     return render_template(
         "offerer/get/details/users.html",
         rows=users_pro + users_invited_formatted,
+        admin_role=users_models.UserRole.ADMIN,
+        anonymized_role=users_models.UserRole.ANONYMIZED,
         **kwargs,
     )
 

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/users.html
@@ -58,6 +58,7 @@
       <th scope="col">Prénom / Nom</th>
       <th scope="col">Email</th>
       <th scope="col">Invitation</th>
+      {% if is_feature_active('WIP_CONNECT_AS') %}<th scope="col">Connect as</th>{% endif %}
     </tr>
   </thead>
   <tbody>
@@ -126,20 +127,28 @@
             Invité le {{ offerer_invitation.dateCreated | format_date_time }} par {{ links.build_pro_user_name_to_details_link(offerer_invitation.user.id, offerer_invitation.user.full_name) }}
           {% endif %}
         </td>
+        {% if is_feature_active('WIP_CONNECT_AS') %}
+          <td class="fw-bolder">
+            {% if row.isActive and (admin_role not in row.roles) and (anonymized_role not in row.roles) %}
+              <a href="{{ url_for('backoffice_web.pro_user.connect_as', user_id=row.id, csrf_token=csrf_token._value() ) }}"
+                 target="_blank"
+                 rel="noopener">
+                <i class="bi bi-arrow-up-right-square-fill"></i>
+              </a>
+            {% endif %}
+          </td>
+        {% endif %}
       </tr>
     {% endfor %}
   </tbody>
 </table>
 {% for user_offerer in rows | map(attribute="UserOfferer") %}
   {% if user_offerer %}
-    {{ build_lazy_modal(
-    url_for("backoffice_web.validation.get_reject_user_offerer_form", user_offerer_id=user_offerer.id),
+    {{ build_lazy_modal(url_for("backoffice_web.validation.get_reject_user_offerer_form", user_offerer_id=user_offerer.id) ,
     "reject-modal-" + user_offerer.id|string) }}
-    {{ build_lazy_modal(
-    url_for("backoffice_web.validation.get_user_offerer_pending_form", user_offerer_id=user_offerer.id),
+    {{ build_lazy_modal(url_for("backoffice_web.validation.get_user_offerer_pending_form", user_offerer_id=user_offerer.id) ,
     "pending-modal-" + user_offerer.id|string) }}
-    {{ build_lazy_modal(
-    url_for("backoffice_web.offerer.get_delete_user_offerer_form", offerer_id=user_offerer.offerer.id, user_offerer_id=user_offerer.id),
+    {{ build_lazy_modal(url_for("backoffice_web.offerer.get_delete_user_offerer_form", offerer_id=user_offerer.offerer.id, user_offerer_id=user_offerer.id) ,
     "delete-modal-" + user_offerer.id|string) }}
   {% endif %}
 {% endfor %}

--- a/api/src/pcapi/serialization/decorator.py
+++ b/api/src/pcapi/serialization/decorator.py
@@ -73,6 +73,7 @@ def spectree_serialize(
     on_error_statuses: list[int] | None = None,
     api: spectree.SpecTree = default_api,
     json_format: bool = True,
+    raw_response: bool = False,
     response_headers: dict[str, str] | None = None,
     resp: SpectreeResponse | None = None,
 ) -> Callable[[Any], Any]:
@@ -90,6 +91,7 @@ def spectree_serialize(
         on_error_statuses: list of possible error statuses. Defaults to [].
         api: [description]. Defaults to default_api.
         json_format: JSON format response if true, else text format response. Defaults to True.
+        raw_response: transmit the route response without touching it. Defaults to False.
         response_headers: a dict of headers to be added to the response. defaults to {}.
         resp: a Spectree.Response explicitely listing the possible responses.
 
@@ -166,6 +168,8 @@ def spectree_serialize(
                 kwargs["form"] = form_in_kwargs(**form)
 
             result = route(*args, **kwargs)
+            if raw_response:
+                return result
             if json_format:
                 return _make_json_response(
                     content=result,

--- a/api/src/pcapi/utils/urls.py
+++ b/api/src/pcapi/utils/urls.py
@@ -71,6 +71,10 @@ def build_pc_pro_bank_account_link(bank_account: finance_models.BankAccount) -> 
     return f"{settings.PRO_URL}/remboursements/informations-bancaires?structure={bank_account.offererId}"
 
 
+def build_pc_pro_connect_as_link(token: str) -> str:
+    return f"{settings.API_URL}/users/connect-as/{token}"
+
+
 def build_backoffice_public_account_link(user_id: int) -> str:
     return f"{settings.BACKOFFICE_URL}/public-accounts/{user_id}"
 

--- a/api/tests/routes/pro/get_connect_as_test.py
+++ b/api/tests/routes/pro/get_connect_as_test.py
@@ -1,0 +1,339 @@
+from pcapi.core.testing import override_features
+from pcapi.core.token import SecureToken
+from pcapi.core.token.serialization import ConnectAsInternalModel
+from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
+
+
+class Returns200Test:
+    @override_features(WIP_CONNECT_AS=True)
+    def test_current_user_has_rights_to_impersonate_a_pro(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        target = users_factories.ProFactory()
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 302
+        assert response.location == expected_redirect_link
+        # check user is impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == target.id
+            assert session["_user_id"] == str(target.id)
+            assert session["internal_admin_email"] == admin.email
+            assert session["internal_admin_id"] == admin.id
+
+    @override_features(WIP_CONNECT_AS=True)
+    def test_current_user_has_rights_to_impersonate_a_non_attached_pro(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        target = users_factories.ProFactory(roles=[users_models.UserRole.NON_ATTACHED_PRO])
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 302
+        assert response.location == expected_redirect_link
+        # check user is impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == target.id
+            assert session["_user_id"] == str(target.id)
+            assert session["internal_admin_email"] == admin.email
+            assert session["internal_admin_id"] == admin.id
+
+
+class Returns401Test:
+    @override_features(WIP_CONNECT_AS=True)
+    def test_user_not_connected(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        target = users_factories.ProFactory()
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 401
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert "user_id" not in session
+            assert "_user_id" not in session
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+
+class Returns403Test:
+    @override_features(WIP_CONNECT_AS=True)
+    def test_user_is_not_admin(self, client, db_session):
+        # given
+        admin = users_factories.UserFactory(email="admin@example.com")
+        target = users_factories.ProFactory()
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 403
+        assert response.json == {
+            "global": "L'utilisateur doit être connecté avec un compte admin pour pouvoir utiliser cet endpoint",
+        }
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+    @override_features(WIP_CONNECT_AS=True)
+    def test_token_is_invalid(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        token = "xROk-l708o7G5gWf3BBVlHOviiVPODGDHxCBbCHcycLFI8n3yaCgQcUGH0WYSq3ROXU2DD7P-pyLKNdQjcKNFg"  # ggignore
+
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{token}")
+
+        # then
+        assert response.status_code == 403
+        assert response.json == {"global": "Le token est invalide"}
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+    @override_features(WIP_CONNECT_AS=True)
+    def test_token_is_for_other_admin(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory()
+        target = users_factories.ProFactory()
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=0,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 403
+        assert response.json == {"global": "Le token a été généré pour un autre admin"}
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+    @override_features(WIP_CONNECT_AS=True)
+    def test_user_is_not_active(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        target = users_factories.ProFactory(isActive=False)
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 403
+        assert response.json == {"user": "L'utilisateur est inactif"}
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+    @override_features(WIP_CONNECT_AS=True)
+    def test_user_is_admin(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        target = users_factories.AdminFactory()
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 403
+        assert response.json == {"user": "L'utilisateur est un admin"}
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+    @override_features(WIP_CONNECT_AS=True)
+    def test_user_is_anonymous(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        target = users_factories.ProFactory(roles=[users_models.UserRole.PRO, users_models.UserRole.ANONYMIZED])
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 403
+        assert response.json == {"user": "L'utilisateur est anonyme"}
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+    @override_features(WIP_CONNECT_AS=True)
+    def test_user_is_not_pro(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        target = users_factories.BeneficiaryGrant18Factory()
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 403
+        assert response.json == {"user": "L'utilisateur n'est pas un pro"}
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+
+class Returns404Test:
+    @override_features(WIP_CONNECT_AS=True)
+    def test_user_not_found(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=0,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 404
+        assert response.json == {"user": "L'utilisateur demandé n'existe pas"}
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session
+
+    @override_features(WIP_CONNECT_AS=False)
+    def test_current_user_has_rights_to_impersonate_a_pro(self, client, db_session):
+        # given
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        target = users_factories.ProFactory()
+
+        expected_redirect_link = "https://example.com"
+        secure_token = SecureToken(
+            data=ConnectAsInternalModel(
+                redirect_link=expected_redirect_link,
+                user_id=target.id,
+                internal_admin_email=admin.email,
+                internal_admin_id=admin.id,
+            ).dict(),
+        )
+        # when
+        response = client.with_session_auth(admin.email).get(f"/users/connect-as/{secure_token.token}")
+
+        # then
+        assert response.status_code == 404
+        assert response.json == {"global": "La route n'est pas active"}
+        # check user is not impersonated
+        with client.client.session_transaction() as session:
+            assert session["user_id"] == admin.id
+            assert session["_user_id"] == str(admin.id)
+            assert "internal_admin_email" not in session
+            assert "internal_admin_id" not in session

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1887,6 +1887,27 @@ export class DefaultService {
     });
   }
   /**
+   * connect_as <GET>
+   * @param token
+   * @returns any OK
+   * @throws ApiError
+   */
+  public connectAs(
+    token: string,
+  ): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/users/connect-as/{token}',
+      path: {
+        'token': token,
+      },
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
    * cookies_consent <POST>
    * @param requestBody
    * @returns void


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26956
![image](https://github.com/pass-culture/pass-culture-main/assets/6198015/5390fb9f-eb98-45ef-891d-e136cf19b4ff)

## Solution technique

Cette pr se borne a prendre le compte d'un admin dans le BO et a le connecter à pro sur le compte d'un utilisateur pro arbitraire. La gestion du cycle de vie de cet admin connecté comme un pro est hors du scope de cette pr.

Cette pr met plus l’accès sur la sécurité que l'utilisabilité et poe donc des contraintes forte sur l'utilisateur utilisant la feature.

PRO et le BO étant sur des applications flask différentes les sessions ne sont pas partagés enter les deux, il est donc indispensable d'utiliser un endpoint du coté backend pro pour connecter l'utilisateur venant du BO. Pour le faire de manière sécurisé les données de connections (id de l'utilisateur vers lequel se connecter notamment) ne sont pas transmises dans le lien afin d'éviter un bug permettant de contourner les sécurité. A la place est transmis un token complètement aléatoire pointant vers un enregistrement redis avec les données. En l'absence (ou invalidation) de ce token il est impossible de récupérer les informations de connection et donc de se connecter. Une deuxième sécurité a été d'imposer a ce que l'utilisateur soit déjà connecté en tant qu'admin a PRO pour limiter les risques au cas ou les autres sécurités aient faillies. La dernière mesure de sécurité de ce coté est de rendre les token personnels, ils ne peuvent être utilisés que par les competes qui les ont générés, pour éviter le cas d'un utilisateur du BO malveillant qui essayerait de se faire passer pour un autre.

Les token pre-existant dans la code base ne permettent pas un niveau de sécurité suffisant car il sont facile a deviner pour une attaque ciblée. Cette pr créé donc un nouveau type de token de 512bits aléatoire (impossibles a deviner dans un temps réaliste).

Il aurait été coûteux et inutile de générer les tokens a l'affichage de la page dans le BO, la stratégie choisie a donc été de faire un lien vers une page du BO qui va ensuite rediriger vers la connexion a PRO qui va lui même rediriger vers la page demandée par le BO (pour l'instant la landing page a la connexion d'un pro). 

Nous avons déjà parlé de la sécurité de la partie backend, pour la partie BO, c'est beaucoup plus simple. On passe par un endpoint en get (pour que ce soit un minimum user-friendly), le fait de passer en GET facilite les attaques de type CSRF , donc un token aléatoire a été ajouté a cet endpoint pour valider l'origine de la requête. Une fois la requete validée et l'utilisateur visé par la requête accepté comme eligible (c'est bien un compte pro, actif, non anonymisé n'ayant pas les droits d'admin) un token est généré et les instruction de connection sont inscrites dans le redis. et l'utilisateur redirigé vers PRO avec le token.


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques