### PR TITLE
(PC-27668)[API] fix: allow deletion of unbooked stocks with tickets

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -219,16 +219,17 @@ def check_event_expiration(stock: educational_models.CollectiveStock | models.St
 
 def check_stock_is_deletable(stock: models.Stock) -> None:
     check_validation_status(stock.offer)
-    check_stock_is_not_from_charlie_api(stock.offer)
+    check_stock_is_not_from_charlie_api(stock)
     if not stock.isEventDeletable:
         raise exceptions.TooLateToDeleteStock()
 
 
-def check_stock_is_not_from_charlie_api(offer: models.Offer) -> None:
+def check_stock_is_not_from_charlie_api(stock: models.Stock) -> None:
     if (
-        offer.lastProvider
-        and offer.lastProvider.hasProviderEnableCharlie
-        and offer.withdrawalType == models.WithdrawalTypeEnum.IN_APP
+        stock.dnBookedQuantity
+        and stock.offer.lastProvider
+        and stock.offer.lastProvider.hasProviderEnableCharlie
+        and stock.offer.withdrawalType == models.WithdrawalTypeEnum.IN_APP
     ):
         raise exceptions.StockFromCharlieApiCannotBeDeleted()
 

--- a/api/tests/routes/public/individual_offers/v1/delete_date_test.py
+++ b/api/tests/routes/public/individual_offers/v1/delete_date_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers.models import WithdrawalTypeEnum
@@ -15,27 +16,45 @@ class DeleteDateTest:
             venue=venue,
             lastProvider=api_key.provider,
         )
-        to_delete_stock = offers_factories.EventStockFactory(offer=event_offer)
+        stock_to_delete = offers_factories.EventStockFactory(offer=event_offer)
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).delete(
-            f"/public/offers/v1/events/{event_offer.id}/dates/{to_delete_stock.id}",
+            f"/public/offers/v1/events/{event_offer.id}/dates/{stock_to_delete.id}",
         )
 
         assert response.status_code == 204
         assert response.json is None
-        assert to_delete_stock.isSoftDeleted is True
+        assert stock_to_delete.isSoftDeleted is True
 
-    def test_400_if_delete_date_with_stock_from_charlie_api(self, client):
+    def test_delete_unbooked_date_with_ticket(self, client):
         venue, api_key = utils.create_offerer_provider_linked_to_venue(with_charlie=True)
         event_offer = offers_factories.EventOfferFactory(
             venue=venue,
             lastProvider=api_key.provider,
             withdrawalType=WithdrawalTypeEnum.IN_APP,
         )
-        to_delete_stock = offers_factories.EventStockFactory(offer=event_offer)
+        stock_to_delete = offers_factories.EventStockFactory(offer=event_offer)
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).delete(
-            f"/public/offers/v1/events/{event_offer.id}/dates/{to_delete_stock.id}",
+            f"/public/offers/v1/events/{event_offer.id}/dates/{stock_to_delete.id}",
+        )
+
+        assert response.status_code == 204
+        assert response.json is None
+        assert stock_to_delete.isSoftDeleted is True
+
+    def test_400_if_delete_date_with_booked_stock_from_charlie_api(self, client):
+        venue, api_key = utils.create_offerer_provider_linked_to_venue(with_charlie=True)
+        event_offer = offers_factories.EventOfferFactory(
+            venue=venue,
+            lastProvider=api_key.provider,
+            withdrawalType=WithdrawalTypeEnum.IN_APP,
+        )
+        stock_to_delete = offers_factories.EventStockFactory(offer=event_offer)
+        bookings_factories.BookingFactory(quantity=1, stock=stock_to_delete)
+
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).delete(
+            f"/public/offers/v1/events/{event_offer.id}/dates/{stock_to_delete.id}",
         )
 
         assert response.status_code == 400
@@ -43,7 +62,7 @@ class DeleteDateTest:
             "code": "STOCK_FROM_CHARLIE_API_CANNOT_BE_DELETED",
             "global": ["You can't delete a stock where bookings have tickets"],
         }
-        assert to_delete_stock.isSoftDeleted is False
+        assert stock_to_delete.isSoftDeleted is False
 
     def test_404_if_already_soft_deleted(self, client):
         venue, api_key = utils.create_offerer_provider_linked_to_venue()
@@ -77,10 +96,10 @@ class DeleteDateTest:
             venue=venue,
             lastProvider=api_key.provider,
         )
-        to_delete_stock = offers_factories.EventStockFactory(offer=event_offer)
+        stock_to_delete = offers_factories.EventStockFactory(offer=event_offer)
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).delete(
-            f"/public/offers/v1/events/{event_offer.id}/dates/{to_delete_stock.id}",
+            f"/public/offers/v1/events/{event_offer.id}/dates/{stock_to_delete.id}",
         )
 
         assert response.status_code == 404


### PR DESCRIPTION
We should be able to delete unbooked stocks from offer with tickets (withdrawalType=IN_APP)

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27668

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques