### PR TITLE
(PC-26839)[PRO] style: modification de margin-bottom de SIRET, inscription

### DIFF
--- a/pro/src/components/FormLayout/FormLayout.module.scss
+++ b/pro/src/components/FormLayout/FormLayout.module.scss
@@ -26,7 +26,7 @@ $info-box-margin-left: rem.torem(24px);
   }
 
   &-section {
-    margin-bottom: rem.torem(24px);
+    margin-bottom: rem.torem(16px);
 
     &-header {
       margin-bottom: rem.torem(24px);


### PR DESCRIPTION

## But de la pull request - modification de margin-bottom de SIRET: /parcours-inscription/structure, de 24 à 16px.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26839

Branche: PC-26839-siret-profil-style

<img width="487" alt="Capture d’écran 2024-01-30 à 14 42 17" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/d6a5b13e-5496-4819-8dae-a8e76533e5dd">
