### PR TITLE
(PC-27040)[PRO] fix: image just uploaded disapears for partners in home

### DIFF
--- a/pro/src/pages/Home/Homepage.tsx
+++ b/pro/src/pages/Home/Homepage.tsx
@@ -166,6 +166,7 @@ export const Homepage = (): JSX.Element => {
           isLoading={isLoading}
           offererOptions={offererOptions}
           isUserOffererValidated={isUserOffererValidated}
+          setSelectedOfferer={setSelectedOfferer}
         />
       </section>
 

--- a/pro/src/pages/Home/Offerers/Offerers.tsx
+++ b/pro/src/pages/Home/Offerers/Offerers.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useLocation, useSearchParams } from 'react-router-dom'
 
 import { GetOffererResponseModel } from 'apiClient/v1'
@@ -26,6 +26,7 @@ export interface OfferersProps {
   isLoading: boolean
   isUserOffererValidated: boolean
   offererOptions: SelectOption[]
+  setSelectedOfferer: (offerer: GetOffererResponseModel) => void
 }
 
 const Offerers = ({
@@ -33,6 +34,7 @@ const Offerers = ({
   selectedOfferer,
   isLoading,
   isUserOffererValidated,
+  setSelectedOfferer,
 }: OfferersProps) => {
   const isPartnerPageActive = useActiveFeature('WIP_PARTNER_PAGE')
   const [openSuccessDialog, setOpenSuccessDialog] = useState(false)
@@ -114,7 +116,11 @@ const Offerers = ({
           />
 
           {isPartnerPageActive && permanentVenues.length > 0 && (
-            <PartnerPages venues={permanentVenues} offerer={selectedOfferer} />
+            <PartnerPages
+              venues={permanentVenues}
+              offerer={selectedOfferer}
+              setSelectedOfferer={setSelectedOfferer}
+            />
           )}
 
           {!isOffererSoftDeleted && (

--- a/pro/src/pages/Home/Offerers/PartnerPage.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPage.tsx
@@ -35,9 +35,14 @@ import { PartnerPageCollectiveSection } from './PartnerPageCollectiveSection'
 export interface PartnerPageProps {
   offerer: GetOffererResponseModel
   venue: GetOffererVenueResponseModel
+  setSelectedOfferer: (offerer: GetOffererResponseModel) => void
 }
 
-export const PartnerPage = ({ offerer, venue }: PartnerPageProps) => {
+export const PartnerPage = ({
+  offerer,
+  venue,
+  setSelectedOfferer,
+}: PartnerPageProps) => {
   const { logEvent } = useAnalytics()
   const notify = useNotification()
   const { venueTypes } = useLoaderData() as HomepageLoaderData
@@ -72,6 +77,19 @@ export const PartnerPage = ({ offerer, venue }: PartnerPageProps) => {
       setImageValues(
         buildInitialValues(editedVenue.bannerUrl, editedVenue.bannerMeta)
       )
+      // we update the offerer state to keep venue with its new image
+      setSelectedOfferer({
+        ...offerer,
+        managedVenues: (offerer.managedVenues ?? []).map((iteratedVenue) =>
+          iteratedVenue.id === venue.id
+            ? {
+                ...venue,
+                bannerUrl: editedVenue.bannerUrl,
+                bannerMeta: editedVenue.bannerMeta,
+              }
+            : iteratedVenue
+        ),
+      })
 
       notify.success('Vos modifications ont bien été prises en compte')
     } catch {

--- a/pro/src/pages/Home/Offerers/PartnerPages.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPages.tsx
@@ -29,9 +29,14 @@ const getSavedVenueId = (
 export interface PartnerPagesProps {
   offerer: GetOffererResponseModel
   venues: GetOffererVenueResponseModel[]
+  setSelectedOfferer: (offerer: GetOffererResponseModel) => void
 }
 
-export const PartnerPages = ({ venues, offerer }: PartnerPagesProps) => {
+export const PartnerPages = ({
+  venues,
+  offerer,
+  setSelectedOfferer,
+}: PartnerPagesProps) => {
   const [venuesOptions, setVenuesOptions] = useState<SelectOption[]>([])
   const [mapVenues, setMapVenues] = useState<
     Map<string, GetOffererVenueResponseModel>
@@ -91,6 +96,7 @@ export const PartnerPages = ({ venues, offerer }: PartnerPagesProps) => {
         <PartnerPage
           offerer={offerer}
           venue={selectedVenue}
+          setSelectedOfferer={setSelectedOfferer}
           // In order to have the image state changing in PartnerPage,
           // we wanna the state reset when the venue change, see :
           // https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key

--- a/pro/src/pages/Home/Offerers/__specs__/Offerers.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/Offerers.spec.tsx
@@ -30,6 +30,7 @@ const renderOfferers = (
       selectedOfferer={defaultGetOffererResponseModel}
       isLoading={false}
       isUserOffererValidated
+      setSelectedOfferer={vi.fn()}
       {...props}
     />,
     options

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPage.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPage.spec.tsx
@@ -21,6 +21,7 @@ const renderPartnerPages = (props: Partial<PartnerPageProps>) => {
     <PartnerPage
       offerer={{ ...defaultGetOffererResponseModel }}
       venue={{ ...defaultGetOffererVenueResponseModel }}
+      setSelectedOfferer={vi.fn()}
       {...props}
     />
   )

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPages.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPages.spec.tsx
@@ -20,6 +20,7 @@ const renderPartnerPages = (props: Partial<PartnerPagesProps> = {}) => {
     <PartnerPages
       venues={[defaultGetOffererVenueResponseModel]}
       offerer={defaultGetOffererResponseModel}
+      setSelectedOfferer={vi.fn()}
       {...props}
     />
   )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27040

Fix image page partenaire
-> quand on vient d'uploader une image, il faut ré-appeler les venue (et donc l'offerer) pour que la venue se mette à jour (et que l'image ne disparaisse pas)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques