### PR TITLE
(PC-27728)[PRO] fix: add alternative text to indicate Callout type

### DIFF
--- a/pro/src/components/Banner/BannerCreateOfferAdmin.tsx
+++ b/pro/src/components/Banner/BannerCreateOfferAdmin.tsx
@@ -9,8 +9,8 @@ const BannerCreateOfferAdmin = (): JSX.Element => (
     links={[
       {
         href: '/accueil',
-        linkTitle: 'Aller à l’accueil',
-        icon: strokeShowIcon,
+        label: 'Aller à l’accueil',
+        icon: { src: strokeShowIcon, alt: '' },
         isExternal: false,
       },
     ]}

--- a/pro/src/components/Banner/BannerInvisibleSiren.tsx
+++ b/pro/src/components/Banner/BannerInvisibleSiren.tsx
@@ -13,7 +13,7 @@ const BannerInvisibleSiren = ({
     links={[
       {
         href: 'https://statut-diffusion-sirene.insee.fr/',
-        linkTitle: `Modifier la visibilité de mon ${
+        label: `Modifier la visibilité de mon ${
           isNewOnboarding ? 'SIRET' : 'SIREN'
         }`,
       },

--- a/pro/src/components/Banner/BannerPendingEmailValidation.tsx
+++ b/pro/src/components/Banner/BannerPendingEmailValidation.tsx
@@ -13,7 +13,7 @@ const BannerPendingEmailValidation = ({ email }: Props): JSX.Element => (
     links={[
       {
         href: 'https://aide.passculture.app/hc/fr/articles/5723750427676',
-        linkTitle: 'Je n’ai pas reçu le lien de confirmation',
+        label: 'Je n’ai pas reçu le lien de confirmation',
       },
     ]}
     type="attention"

--- a/pro/src/components/Banner/BannerRGS.tsx
+++ b/pro/src/components/Banner/BannerRGS.tsx
@@ -18,9 +18,8 @@ const BannerRGS: React.FC<Props> = ({ closable, onClose }: Props) => (
         isExternal: true,
       },
     ]}
+    title="Soyez vigilant !"
   >
-    <strong>Soyez vigilant !</strong>
-    <br />
     Vos identifiants de connexion sont personnels et ne doivent pas être
     partagés. Pour assurer la protection de votre compte, découvrez nos
     recommandations.

--- a/pro/src/components/Banner/BannerRGS.tsx
+++ b/pro/src/components/Banner/BannerRGS.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import Callout from 'components/Callout/Callout'
-import fullLinkIcon from 'icons/full-link.svg'
 
 interface Props {
   closable?: boolean
@@ -15,9 +14,8 @@ const BannerRGS: React.FC<Props> = ({ closable, onClose }: Props) => (
     links={[
       {
         href: 'https://aide.passculture.app/hc/fr/articles/4458607720732--Acteurs-Culturels-Comment-assurer-la-s%C3%A9curit%C3%A9-de-votre-compte-',
-        linkTitle: 'Consulter nos recommandations de sécurité',
-        icon: fullLinkIcon,
-        svgAlt: 'Nouvelle fenêtre',
+        label: 'Consulter nos recommandations de sécurité',
+        isExternal: true,
       },
     ]}
   >

--- a/pro/src/components/Banner/BannerReimbursementsInfo.tsx
+++ b/pro/src/components/Banner/BannerReimbursementsInfo.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import Callout from 'components/Callout/Callout'
-import fullLinkIcon from 'icons/full-link.svg'
 
 const BannerReimbursementsInfo = (): JSX.Element => {
   return (
@@ -10,15 +9,13 @@ const BannerReimbursementsInfo = (): JSX.Element => {
       links={[
         {
           href: 'https://passculture.zendesk.com/hc/fr/articles/4411992051601',
-          linkTitle: 'Quand votre prochain remboursement sera-t-il effectué ?',
-          icon: fullLinkIcon,
-          svgAlt: 'Nouvelle fenêtre',
+          label: 'Quand votre prochain remboursement sera-t-il effectué ?',
+          isExternal: true,
         },
         {
           href: 'https://passculture.zendesk.com/hc/fr/articles/4412007300369',
-          linkTitle: 'Connaître les modalités de remboursement',
-          icon: fullLinkIcon,
-          svgAlt: 'Nouvelle fenêtre',
+          label: 'Connaître les modalités de remboursement',
+          isExternal: true,
         },
       ]}
     >

--- a/pro/src/components/Banner/OfferRefundWarning.tsx
+++ b/pro/src/components/Banner/OfferRefundWarning.tsx
@@ -8,8 +8,8 @@ const OfferRefundWarning = () => {
       links={[
         {
           href: 'https://aide.passculture.app/hc/fr/articles/6043184068252',
-          svgAlt: 'Nouvelle fenêtre',
-          linkTitle:
+          isExternal: true,
+          label:
             'Quelles sont les offres numériques éligibles au remboursement ?',
         },
       ]}

--- a/pro/src/components/Banner/WithdrawalReminder.tsx
+++ b/pro/src/components/Banner/WithdrawalReminder.tsx
@@ -9,8 +9,8 @@ const WithdrawalReminder = () => {
       links={[
         {
           href: CGU_URL,
-          linkTitle: "Consulter les Conditions Générales d'Utilisation",
-          svgAlt: 'Nouvelle fenêtre',
+          label: "Consulter les Conditions Générales d'Utilisation",
+          isExternal: true,
         },
       ]}
       type="notification-info"

--- a/pro/src/components/Callout/AddBankAccountCallout.tsx
+++ b/pro/src/components/Callout/AddBankAccountCallout.tsx
@@ -35,22 +35,23 @@ const AddBankAccountCallout = ({
   return (
     <Callout
       title="Ajoutez un compte bancaire pour percevoir vos remboursements"
-      links={[
-        {
-          href: '/remboursements/informations-bancaires',
-          linkTitle: 'Ajouter un compte bancaire',
-          targetLink: '',
-          isExternal: false,
-          onClick: () => {
-            logEvent?.(BankAccountEvents.CLICKED_ADD_BANK_ACCOUNT, {
-              from: location.pathname,
-              offererId: offerer.id,
-            })
-          },
-        },
-      ]}
-      type={CalloutVariant.ERROR}
-      titleOnly={titleOnly}
+      links={
+        titleOnly
+          ? undefined
+          : [
+              {
+                href: '/remboursements/informations-bancaires',
+                label: 'Ajouter un compte bancaire',
+                onClick: () => {
+                  logEvent?.(BankAccountEvents.CLICKED_ADD_BANK_ACCOUNT, {
+                    from: location.pathname,
+                    offererId: offerer.id,
+                  })
+                },
+              },
+            ]
+      }
+      variant={CalloutVariant.ERROR}
     >
       <div>
         Rendez-vous dans l’onglet Informations bancaires de votre page Gestion

--- a/pro/src/components/Callout/Callout.stories.tsx
+++ b/pro/src/components/Callout/Callout.stories.tsx
@@ -32,11 +32,12 @@ export const WithLink: StoryObj<typeof Callout> = {
     links: [
       {
         href: 'https://pro.testing.passculture.team',
-        linkTitle: 'Lien vers le pass culture',
+        label: 'Lien interne au pass culture pro',
       },
       {
         href: 'https://pro.testing.passculture.team',
-        linkTitle: 'Lien vers autre chose',
+        label: 'Lien externe',
+        isExternal: true,
       },
     ],
   },

--- a/pro/src/components/Callout/Callout.tsx
+++ b/pro/src/components/Callout/Callout.tsx
@@ -2,7 +2,6 @@ import cn from 'classnames'
 import React from 'react'
 
 import { CalloutVariant } from 'components/Callout/types'
-import fullNextIcon from 'icons/full-next.svg'
 import strokeCloseIcon from 'icons/stroke-close.svg'
 import strokeErrorIcon from 'icons/stroke-error.svg'
 import strokeInfoIcon from 'icons/stroke-info.svg'
@@ -21,8 +20,7 @@ export interface CalloutProps {
   links?: Link[]
   closable?: boolean
   onClose?: undefined | (() => void)
-  type?: CalloutVariant
-  titleOnly?: boolean
+  variant?: CalloutVariant
 }
 
 interface CalloutVariantProps {
@@ -37,12 +35,11 @@ const Callout = ({
   links,
   closable = false,
   onClose,
-  type = CalloutVariant.DEFAULT,
-  titleOnly = false,
+  variant = CalloutVariant.DEFAULT,
 }: CalloutProps): JSX.Element => {
   let calloutIcon: CalloutVariantProps
   /* istanbul ignore next: graphic variations */
-  switch (type) {
+  switch (variant) {
     case CalloutVariant.WARNING:
       calloutIcon = { src: strokeWarningIcon, alt: 'Attention' }
       break
@@ -57,12 +54,12 @@ const Callout = ({
       break
   }
 
-  const hasNoBottomSpace = (titleOnly || !title) && !links
+  const hasNoBottomSpace = (!children || !title) && !links
   return (
     <div
       className={cn(
         styles['callout'],
-        styles[`callout-${type}`],
+        styles[`callout-${variant}`],
         hasNoBottomSpace ? styles['small-callout'] : '',
         className
       )}
@@ -75,14 +72,8 @@ const Callout = ({
       />
       <div className={styles['content']}>
         {title && <div className={styles['title']}>{title}</div>}
-        {!titleOnly && (
-          <>
-            {children && (
-              <div className={styles['callout-text']}>{children}</div>
-            )}
-            <LinkNodes links={links} defaultLinkIcon={fullNextIcon} />
-          </>
-        )}
+        {children && <div className={styles['callout-text']}>{children}</div>}
+        {links && <LinkNodes links={links} />}
       </div>
       {closable && (
         <button

--- a/pro/src/components/Callout/Callout.tsx
+++ b/pro/src/components/Callout/Callout.tsx
@@ -25,6 +25,11 @@ export interface CalloutProps {
   titleOnly?: boolean
 }
 
+interface CalloutVariantProps {
+  src: string
+  alt: string
+}
+
 const Callout = ({
   children,
   className,
@@ -35,20 +40,20 @@ const Callout = ({
   type = CalloutVariant.DEFAULT,
   titleOnly = false,
 }: CalloutProps): JSX.Element => {
-  let calloutIconSrc
+  let calloutIcon: CalloutVariantProps
   /* istanbul ignore next: graphic variations */
   switch (type) {
     case CalloutVariant.WARNING:
-      calloutIconSrc = strokeWarningIcon
+      calloutIcon = { src: strokeWarningIcon, alt: 'Attention' }
       break
     case CalloutVariant.SUCCESS:
-      calloutIconSrc = strokeValidIcon
+      calloutIcon = { src: strokeValidIcon, alt: 'Confirmation' }
       break
     case CalloutVariant.ERROR:
-      calloutIconSrc = strokeErrorIcon
+      calloutIcon = { src: strokeErrorIcon, alt: 'Erreur' }
       break
     default:
-      calloutIconSrc = strokeInfoIcon
+      calloutIcon = { src: strokeInfoIcon, alt: 'Information' }
       break
   }
 
@@ -63,8 +68,8 @@ const Callout = ({
       )}
     >
       <SvgIcon
-        src={calloutIconSrc}
-        alt=""
+        src={calloutIcon.src}
+        alt={calloutIcon.alt}
         className={styles['icon']}
         width="20"
       />

--- a/pro/src/components/Callout/LinkVenueCallout.tsx
+++ b/pro/src/components/Callout/LinkVenueCallout.tsx
@@ -41,7 +41,7 @@ const LinkVenueCallout = ({
       } à un compte bancaire`}
       links={
         titleOnly
-          ? []
+          ? undefined
           : [
               {
                 href:

--- a/pro/src/components/Callout/LinkVenueCallout.tsx
+++ b/pro/src/components/Callout/LinkVenueCallout.tsx
@@ -39,23 +39,28 @@ const LinkVenueCallout = ({
           ? 'vos lieux'
           : 'votre lieu'
       } à un compte bancaire`}
-      links={[
-        {
-          href:
-            '/remboursements/informations-bancaires?structure=' + offerer.id,
-          linkTitle: 'Gérer le rattachement de mes lieux',
-          targetLink: '',
-          isExternal: false,
-          onClick: () => {
-            logEvent?.(BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT, {
-              from: location.pathname,
-              offererId: offerer.id,
-            })
-          },
-        },
-      ]}
-      type={CalloutVariant.ERROR}
-      titleOnly={titleOnly}
+      links={
+        titleOnly
+          ? []
+          : [
+              {
+                href:
+                  '/remboursements/informations-bancaires?structure=' +
+                  offerer.id,
+                label: 'Gérer le rattachement de mes lieux',
+                onClick: () => {
+                  logEvent?.(
+                    BankAccountEvents.CLICKED_ADD_VENUE_TO_BANK_ACCOUNT,
+                    {
+                      from: location.pathname,
+                      offererId: offerer.id,
+                    }
+                  )
+                },
+              },
+            ]
+      }
+      variant={CalloutVariant.ERROR}
     >
       <p>
         Rendez-vous dans l’onglet Informations bancaires de votre page Gestion

--- a/pro/src/components/Callout/PendingBankAccountCallout.tsx
+++ b/pro/src/components/Callout/PendingBankAccountCallout.tsx
@@ -27,25 +27,26 @@ const PendingBankAccountCallout = ({
   return (
     <Callout
       title="Compte bancaire en cours de validation par nos services"
-      links={[
-        {
-          href: '/remboursements/informations-bancaires',
-          linkTitle: 'Suivre mon dossier de compte bancaire',
-          targetLink: '',
-          isExternal: false,
-          onClick: () => {
-            logEvent?.(
-              BankAccountEvents.CLICKED_BANK_DETAILS_RECORD_FOLLOW_UP,
+      links={
+        titleOnly
+          ? undefined
+          : [
               {
-                from: location.pathname,
-                offererId: offerer.id,
-              }
-            )
-          },
-        },
-      ]}
-      type={CalloutVariant.INFO}
-      titleOnly={titleOnly}
+                href: '/remboursements/informations-bancaires',
+                label: 'Suivre mon dossier de compte bancaire',
+                onClick: () => {
+                  logEvent?.(
+                    BankAccountEvents.CLICKED_BANK_DETAILS_RECORD_FOLLOW_UP,
+                    {
+                      from: location.pathname,
+                      offererId: offerer.id,
+                    }
+                  )
+                },
+              },
+            ]
+      }
+      variant={CalloutVariant.INFO}
     />
   )
 }

--- a/pro/src/components/Callout/__specs__/Callout.spec.tsx
+++ b/pro/src/components/Callout/__specs__/Callout.spec.tsx
@@ -1,46 +1,83 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
+
+import { CalloutVariant } from 'components/Callout/types'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Callout, { CalloutProps } from '../Callout'
 
 describe('Callout', () => {
   const props: CalloutProps = {
     title: 'This is a banner warning',
-    links: [{ href: '/some/site', linkTitle: 'linkTitle' }],
+    links: [
+      {
+        href: '/some/site',
+        label: 'link label',
+        icon: null,
+        isExternal: true,
+      },
+    ],
   }
 
-  it('should render Callout', () => {
-    render(<Callout {...props}>This is the content</Callout>)
+  it('should display title, content and links', () => {
+    renderWithProviders(<Callout {...props}>This is the content</Callout>)
 
     expect(screen.getByText('This is a banner warning')).toBeInTheDocument()
     expect(screen.getByText('This is the content')).toBeInTheDocument()
-    const link = screen.getByRole('link', {
-      name: props.links?.[0]?.linkTitle,
-    })
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', props.links?.[0]?.href)
-    expect(link).toHaveAttribute('target', '_blank')
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+
+    expect(
+      screen.getByRole('link', {
+        name: /link label/,
+      })
+    ).toBeInTheDocument()
     expect(screen.queryByAltText('Fermer le message')).not.toBeInTheDocument()
   })
 
-  it('should render a closable Callout', () => {
-    props.closable = true
-    render(<Callout {...props}>Closable content</Callout>)
+  it('should close the Callout', async () => {
+    const spyClose = jest.fn()
+    renderWithProviders(
+      <Callout {...{ ...props, closable: true, onClose: spyClose }} />
+    )
 
-    expect(screen.getByLabelText('Fermer le message')).toBeInTheDocument()
+    await userEvent.click(screen.getByLabelText('Fermer le message'))
+
+    expect(spyClose).toHaveBeenCalledTimes(1)
   })
 
-  it('should render a title only Callout', () => {
-    props.titleOnly = true
-    render(<Callout {...props}>Closable content</Callout>)
+  it('should display an Information callout', () => {
+    renderWithProviders(<Callout {...props} />)
 
-    expect(screen.queryByText('This is a banner warning')).toBeInTheDocument()
-    expect(screen.queryByText('This is the content')).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole('link', {
-        name: props.links?.[0]?.linkTitle,
-      })
-    ).not.toBeInTheDocument()
+    expect(screen.getAllByRole('img')[0]).toHaveAttribute(
+      'aria-label',
+      'Information'
+    )
+  })
+
+  it('should display an Error callout', () => {
+    renderWithProviders(<Callout {...props} variant={CalloutVariant.ERROR} />)
+
+    expect(screen.getAllByRole('img')[0]).toHaveAttribute(
+      'aria-label',
+      'Erreur'
+    )
+  })
+
+  it('should display a Success callout', () => {
+    renderWithProviders(<Callout {...props} variant={CalloutVariant.SUCCESS} />)
+
+    expect(screen.getAllByRole('img')[0]).toHaveAttribute(
+      'aria-label',
+      'Confirmation'
+    )
+  })
+
+  it('should display a Warning callout', () => {
+    renderWithProviders(<Callout {...props} variant={CalloutVariant.WARNING} />)
+
+    expect(screen.getAllByRole('img')[0]).toHaveAttribute(
+      'aria-label',
+      'Attention'
+    )
   })
 })

--- a/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
+++ b/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
@@ -179,7 +179,6 @@ const Categories = ({
               to: 'https://aide.passculture.app/hc/fr/articles/4411999013265--Acteurs-Culturels-Quelle-cat%C3%A9gorie-et-sous-cat%C3%A9gorie-choisir-lors-de-la-cr%C3%A9ation-d-offres-',
               text: 'Quelles catégories choisir ?',
               target: '_blank',
-              rel: 'noopener noreferrer',
             }}
             svgAlt="Nouvelle fenêtre"
           >
@@ -240,7 +239,7 @@ const Categories = ({
             links={[
               {
                 href: `/structures/${offererId}/lieux/creation`,
-                linkTitle: '+ Ajouter un lieu',
+                label: '+ Ajouter un lieu',
                 isExternal: false,
               },
             ]}

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
@@ -80,8 +80,6 @@ const UsefulInformations = ({
               isExternal: true,
               to: 'https://aide.passculture.app/hc/fr/articles/4413389597329--Acteurs-Culturels-Quelles-modalit%C3%A9s-de-retrait-indiquer-pour-ma-structure-',
               text: 'Quelles modalités de retrait choisir ?',
-              target: '_blank',
-              rel: 'noopener noreferrer',
             }}
             svgAlt="Nouvelle fenêtre"
           >

--- a/pro/src/components/LegalInfos/LegalInfos.tsx
+++ b/pro/src/components/LegalInfos/LegalInfos.tsx
@@ -30,7 +30,6 @@ const LegalInfos = ({ title, className }: LegalInfoProps): JSX.Element => {
         link={{
           to: 'https://pass.culture.fr/cgu-professionnels/',
           isExternal: true,
-          rel: 'noopener noreferrer',
           target: '_blank',
         }}
         variant={ButtonVariant.QUATERNARY}
@@ -52,7 +51,6 @@ const LegalInfos = ({ title, className }: LegalInfoProps): JSX.Element => {
         link={{
           to: 'https://pass.culture.fr/donnees-personnelles/',
           isExternal: true,
-          rel: 'noopener noreferrer',
           target: '_blank',
         }}
         variant={ButtonVariant.QUATERNARY}
@@ -81,7 +79,6 @@ const LegalInfos = ({ title, className }: LegalInfoProps): JSX.Element => {
         link={{
           to: 'mailto:support-pro@passculture.app',
           isExternal: true,
-          rel: 'noopener noreferrer',
           target: '_blank',
         }}
       >

--- a/pro/src/components/VenueForm/Accessibility/Accessibility.tsx
+++ b/pro/src/components/VenueForm/Accessibility/Accessibility.tsx
@@ -29,8 +29,6 @@ const Accessibility = ({ isCreatingVenue }: AccessiblityProps) => {
               text: 'En savoir plus',
               to: 'https://aide.passculture.app/hc/fr/articles/4412007286289--Acteurs-Culturels-Comment-indiquer-les-conditions-d-accessibilit%C3%A9-d-une-offre-sur-le-pass-Culture-',
               isExternal: true,
-              target: '_blank',
-              rel: 'noopener noreferrer',
               'aria-label': 'en savoir plus sur les modalités d’accessibilité',
             }}
           >

--- a/pro/src/components/VenueForm/BankAccountInfos/BankAccountInfos.tsx
+++ b/pro/src/components/VenueForm/BankAccountInfos/BankAccountInfos.tsx
@@ -4,7 +4,6 @@ import { BankAccountResponseModel } from 'apiClient/v1'
 import Callout from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
 import FormLayout from 'components/FormLayout'
-import fullNextIcon from 'icons/full-next.svg'
 import { TextInput } from 'ui-kit'
 
 interface BankAccountInfosProps {
@@ -24,13 +23,11 @@ const BankAccountInfos = ({ venueBankAccount }: BankAccountInfosProps) => {
         />
       )}
       <Callout
-        type={CalloutVariant.INFO}
+        variant={CalloutVariant.INFO}
         links={[
           {
-            linkTitle: 'Gérer les remboursements',
-            isExternal: false,
+            label: 'Gérer les remboursements',
             href: '/remboursements/informations-bancaires',
-            icon: fullNextIcon,
           },
         ]}
       >

--- a/pro/src/components/VenueForm/WithdrawalDetails/WithdrawalDetails.tsx
+++ b/pro/src/components/VenueForm/WithdrawalDetails/WithdrawalDetails.tsx
@@ -14,8 +14,6 @@ const WithdrawalDetails = () => {
               text: 'En savoir plus',
               to: 'https://aide.passculture.app/hc/fr/articles/4413389597329--Acteurs-Culturels-Quelles-modalit%C3%A9s-de-retrait-indiquer-pour-ma-structure-',
               isExternal: true,
-              target: '_blank',
-              rel: 'noopener noreferrer',
               'aria-label': 'en savoir plus sur les modalités de retrait',
             }}
           >

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -91,8 +91,6 @@ export const AdageHeader = () => {
               to: `${document.referrer}adage/index/docGet/format/pptx/doc/PRESENTATION_J_UTILISE_PASS_CULTURE`,
               isExternal: true,
               download: true,
-              rel: 'noreferrer',
-              target: '_blank',
             }}
             icon={fullDownloadIcon}
           >

--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 
 import { apiAdage } from 'apiClient/api'
 import Callout from 'components/Callout/Callout'
-import fullLinkIcon from 'icons/full-link.svg'
 import strokeMyInstitution from 'icons/stroke-my-institution.svg'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -62,9 +61,7 @@ const OffersForMyInstitution = (): JSX.Element => {
           {
             href: `${document.referrer}adage/passculture/index`,
             isExternal: true,
-            icon: fullLinkIcon,
-            linkTitle: 'Voir la page “Suivi pass Culture”',
-            svgAlt: 'Nouvelle fenêtre',
+            label: 'Voir la page “Suivi pass Culture”',
           },
         ]}
       >

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/NoResultsPage.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/NoResultsPage.tsx
@@ -43,7 +43,6 @@ export const NoResultsPage = ({
             isExternal: true,
             to: `${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`,
             target: '_blank',
-            rel: 'noopener noreferrer',
           }}
           variant={ButtonVariant.TERNARY}
           icon={fullLinkIcon}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -196,7 +196,6 @@ const Offer = ({
                     isExternal: true,
                     to: `${document.referrer}adage/ressource/partenaires/id/${offer.venue.adageId}`,
                     target: '_blank',
-                    rel: 'noopener noreferrer',
                   }}
                   variant={ButtonVariant.TERNARY}
                   className={style['offer-header-venue-link']}

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
@@ -83,7 +83,6 @@ export const SurveySatisfaction = ({
             link={{
               to: 'https://passculture.qualtrics.com/jfe/form/SV_8w5mdHmrxly9bcW',
               isExternal: true,
-              rel: 'noopener noreferrer',
               target: '_blank',
             }}
             className={styles['survey-button']}

--- a/pro/src/pages/CookiesFooter/CookiesFooter.tsx
+++ b/pro/src/pages/CookiesFooter/CookiesFooter.tsx
@@ -19,9 +19,7 @@ const CookiesFooter = ({ className }: { className?: string }): JSX.Element => (
             link={{
               to: 'https://pass.culture.fr/cgu-professionnels/',
               isExternal: true,
-              rel: 'noopener noreferrer',
               target: '_blank',
-              'aria-label': 'Nouvelle fenêtre',
             }}
           >
             CGU professionnels
@@ -34,9 +32,7 @@ const CookiesFooter = ({ className }: { className?: string }): JSX.Element => (
             link={{
               to: 'https://pass.culture.fr/donnees-personnelles/',
               isExternal: true,
-              rel: 'noopener noreferrer',
               target: '_blank',
-              'aria-label': 'Nouvelle fenêtre',
             }}
           >
             Charte des Données Personnelles

--- a/pro/src/pages/Desk/Desk.tsx
+++ b/pro/src/pages/Desk/Desk.tsx
@@ -177,14 +177,12 @@ export const Desk = (): JSX.Element => {
               },
             ]}
             className={`${styles['desk-callout']}`}
+            title=" N’oubliez pas de vérifier l’identité du bénéficiaire avant de
+            valider la contremarque."
           >
-            <strong>
-              N’oubliez pas de vérifier l’identité du bénéficiaire avant de
-              valider la contremarque.
-            </strong>
-            {
-              ' Les pièces d’identité doivent impérativement être présentées physiquement. Merci de ne pas accepter les pièces d’identité au format numérique.'
-            }
+            Les pièces d’identité doivent impérativement être présentées
+            physiquement. Merci de ne pas accepter les pièces d’identité au
+            format numérique.
           </Callout>
         </form>
       </FormikProvider>

--- a/pro/src/pages/Desk/Desk.tsx
+++ b/pro/src/pages/Desk/Desk.tsx
@@ -5,7 +5,6 @@ import React, { useState } from 'react'
 import { GetBookingResponse } from 'apiClient/v2'
 import { AppLayout } from 'app/AppLayout'
 import Callout from 'components/Callout/Callout'
-import fullLinkIcon from 'icons/full-link.svg'
 import { SubmitButton, TextInput } from 'ui-kit'
 import Titles from 'ui-kit/Titles/Titles'
 
@@ -173,8 +172,8 @@ export const Desk = (): JSX.Element => {
             links={[
               {
                 href: 'https://aide.passculture.app/hc/fr/articles/4416062183569--Acteurs-Culturels-Modalités-de-retrait-et-CGU',
-                linkTitle: 'Modalités de retrait et CGU',
-                icon: fullLinkIcon,
+                label: 'Modalités de retrait et CGU',
+                isExternal: true,
               },
             ]}
             className={`${styles['desk-callout']}`}

--- a/pro/src/pages/Home/Offerers/OffererBanners.tsx
+++ b/pro/src/pages/Home/Offerers/OffererBanners.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { GetOffererResponseModel } from 'apiClient/v1'
-import fullLinkIcon from 'icons/full-link.svg'
 import { Banner } from 'ui-kit'
 
 import { hasOffererAtLeastOnePhysicalVenue } from '../venueUtils'
@@ -27,8 +26,8 @@ export const OffererBanners = ({
         links={[
           {
             href: `https://aide.passculture.app/hc/fr/articles/4514252662172--Acteurs-Culturels-S-inscrire-et-comprendre-le-fonctionnement-du-pass-Culture-cr%C3%A9ation-d-offres-gestion-des-r%C3%A9servations-remboursements-etc-`,
-            linkTitle: 'En savoir plus',
-            icon: fullLinkIcon,
+            label: 'En savoir plus',
+            isExternal: true,
             'aria-label':
               'Acteurs Culturels: s’inscrire et comprendre le fonctionnement (Nouvelle fenêtre, site https://aide.passculture.app)',
           },
@@ -54,10 +53,8 @@ export const OffererBanners = ({
         links={[
           {
             href: `https://aide.passculture.app/hc/fr/articles/4514252662172--Acteurs-Culturels-S-inscrire-et-comprendre-le-fonctionnement-du-pass-Culture-cr%C3%A9ation-d-offres-gestion-des-r%C3%A9servations-remboursements-etc-`,
-            linkTitle: 'En savoir plus sur le fonctionnement du pass Culture',
-            icon: fullLinkIcon,
-            'aria-label':
-              'Acteurs Culturels: s’inscrire et comprendre le fonctionnement (Nouvelle fenêtre, site https://aide.passculture.app)',
+            label: 'En savoir plus sur le fonctionnement du pass Culture',
+            isExternal: true,
           },
         ]}
       >
@@ -93,10 +90,10 @@ export const OffererBanners = ({
         links={[
           {
             href: `https://aide.passculture.app/hc/fr/articles/4411992075281--Acteurs-Culturels-Comment-cr%C3%A9er-un-lieu-`,
-            linkTitle: 'En savoir plus sur la création d’un lieu',
+            label: 'En savoir plus sur la création d’un lieu',
             'aria-label':
               'Acteurs Culturels: Comment ajouter de nouveaux lieux sur votre espace et les paramétrer ? (Nouvelle fenêtre, site https://aide.passculture.app)',
-            icon: fullLinkIcon,
+            isExternal: true,
           },
         ]}
       >

--- a/pro/src/pages/Home/Offerers/PartnerPage.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPage.tsx
@@ -160,8 +160,7 @@ export const PartnerPage = ({
             className={styles['venue-button']}
             link={{
               to: `/structures/${offerer.id}/lieux/${venue.id}?modification`,
-              isExternal: false,
-              'aria-label': `Gérer la page de ${venue.name}`,
+              'aria-label': `Gérer la page ${venue.name}`,
             }}
           >
             Gérer ma page
@@ -195,7 +194,6 @@ export const PartnerPage = ({
             to: venuePreviewLink,
             isExternal: true,
             target: '_blank',
-            rel: 'noopener noreferrer',
           }}
           svgAlt="Nouvelle fenêtre"
           className={styles['details-link']}

--- a/pro/src/pages/Home/Offerers/PartnerPageCollectiveSection.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPageCollectiveSection.tsx
@@ -75,7 +75,6 @@ export function PartnerPageCollectiveSection({
             to: 'https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage',
             isExternal: true,
             target: '_blank',
-            rel: 'noopener noreferrer',
           }}
           svgAlt="Nouvelle fenêtre"
           className={styles['details-link']}
@@ -91,7 +90,6 @@ export function PartnerPageCollectiveSection({
             to: 'https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires',
             isExternal: true,
             target: '_blank',
-            rel: 'noopener noreferrer',
           }}
           svgAlt="Nouvelle fenêtre"
           className={styles['details-link']}
@@ -142,7 +140,6 @@ export function PartnerPageCollectiveSection({
           to: 'https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires',
           isExternal: true,
           target: '_blank',
-          rel: 'noopener noreferrer',
         }}
         svgAlt="Nouvelle fenêtre"
         className={styles['details-link']}

--- a/pro/src/pages/Home/ProfileAndSupport/Support.tsx
+++ b/pro/src/pages/Home/ProfileAndSupport/Support.tsx
@@ -30,7 +30,6 @@ export const Support: () => JSX.Element | null = () => {
                 to: 'https://aide.passculture.app',
                 isExternal: true,
                 target: '_blank',
-                rel: 'noopener noreferrer',
               }}
               icon={fullLinkIcon}
               onClick={() =>
@@ -50,7 +49,6 @@ export const Support: () => JSX.Element | null = () => {
                 to: 'https://passcultureapp.notion.site/pass-Culture-Documentation-323b1a0ec309406192d772e7d803fbd0',
                 isExternal: true,
                 target: '_blank',
-                rel: 'noopener noreferrer',
               }}
               icon={fullLinkIcon}
               onClick={() =>
@@ -70,7 +68,6 @@ export const Support: () => JSX.Element | null = () => {
                 to: 'mailto:support-pro@passculture.app',
                 isExternal: true,
                 target: '_blank',
-                rel: 'noopener noreferrer',
               }}
               icon={fullMailIcon}
               onClick={() =>
@@ -90,7 +87,6 @@ export const Support: () => JSX.Element | null = () => {
                 to: 'https://pass.culture.fr/cgu-professionnels/',
                 isExternal: true,
                 target: '_blank',
-                rel: 'noopener noreferrer',
               }}
               icon={fullLinkIcon}
               onClick={() =>

--- a/pro/src/pages/Home/StatisticsDashboard/CumulatedViews.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/CumulatedViews.tsx
@@ -82,7 +82,6 @@ export const CumulatedViews = ({ dailyViews }: CumulatedViewsProps) => {
               link={{
                 to: 'https://passcultureapp.notion.site/Les-bonnes-pratiques-et-tudes-du-pass-Culture-323b1a0ec309406192d772e7d803fbd0',
                 isExternal: true,
-                rel: 'noopener noreferrer',
                 target: '_blank',
               }}
               svgAlt="Nouvelle fenêtre"

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -109,7 +109,6 @@ export const VenueOfferSteps = ({
                   icon={fullNextIcon}
                   link={{
                     to: venueCreationUrl,
-                    isExternal: false,
                   }}
                   onClick={() => {
                     logEvent?.(Events.CLICKED_CREATE_VENUE, {
@@ -130,7 +129,6 @@ export const VenueOfferSteps = ({
                   link={{
                     to: 'https://aide.passculture.app/hc/fr/articles/4411992075281--Acteurs-Culturels-Comment-cr%C3%A9er-un-lieu-',
                     isExternal: true,
-                    rel: 'noopener noreferrer',
                     target: '_blank',
                   }}
                   icon={fullInfoIcon}
@@ -155,7 +153,6 @@ export const VenueOfferSteps = ({
                 icon={fullNextIcon}
                 link={{
                   to: `/offre/creation?lieu=${venue.id}&structure=${offerer.id}`,
-                  isExternal: false,
                 }}
               >
                 Créer une offre
@@ -171,7 +168,6 @@ export const VenueOfferSteps = ({
                   icon={fullNextIcon}
                   link={{
                     to: `/structures/${offerer.id}/lieux/${venue.id}#reimbursement`,
-                    isExternal: false,
                   }}
                   onClick={() => {
                     logEvent?.(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
@@ -193,7 +189,6 @@ export const VenueOfferSteps = ({
                   icon={fullNextIcon}
                   link={{
                     to: `remboursements/informations-bancaires?structure=${offerer.id}`,
-                    isExternal: false,
                   }}
                   onClick={() => {
                     logEvent?.(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
@@ -213,7 +208,6 @@ export const VenueOfferSteps = ({
                 icon={fullNextIcon}
                 link={{
                   to: `/structures/${offerer.id}/lieux/${venue.id}/eac`,
-                  isExternal: false,
                 }}
               >
                 Renseigner mes informations à destination des enseignants
@@ -237,7 +231,6 @@ export const VenueOfferSteps = ({
                   icon={fullNextIcon}
                   link={{
                     to: `/structures/${offerer.id}/lieux/${venue.id}#venue-collective-data`,
-                    isExternal: false,
                   }}
                   onClick={() => {
                     logEvent?.(Events.CLICKED_EAC_DMS_TIMELINE, {

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/ApiKey/ApiKey.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/ApiKey/ApiKey.tsx
@@ -84,7 +84,7 @@ const ApiKey = ({
         links={[
           {
             href: 'https://www.notion.so/passcultureapp/pass-Culture-Int-grations-techniques-231e16685c9a438b97bdcd7737cdd4d1',
-            linkTitle: 'En savoir plus sur les clés API',
+            label: 'En savoir plus sur les clés API',
           },
         ]}
         type="notification-info"

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ApplicationBanner/ApplicationBanner.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ApplicationBanner/ApplicationBanner.tsx
@@ -11,7 +11,8 @@ const ApplicationBanner = ({ applicationId }: ApplicationBannerProps) => (
     links={[
       {
         href: `https://www.demarches-simplifiees.fr/dossiers/${applicationId}/messagerie`,
-        linkTitle: 'Voir le dossier en cours',
+        label: 'Voir le dossier en cours',
+        isExternal: true,
       },
     ]}
     type="notification-info"

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ApplicationBanner/__specs__/ApplicationBanner.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ApplicationBanner/__specs__/ApplicationBanner.spec.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ApplicationBanner from '../ApplicationBanner'
 
@@ -11,7 +13,7 @@ describe('when offerer has no bank informations', () => {
     }
 
     // when
-    render(<ApplicationBanner {...props} />)
+    renderWithProviders(<ApplicationBanner {...props} />)
     expect(
       await screen.findByText(
         'Les coordonnées bancaires de votre lieu sont en cours de validation par notre service financier. Vos remboursements seront rétroactifs une fois vos coordonnées bancaires validées.'

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
@@ -87,8 +87,9 @@ const PricingPoint = ({
           links={[
             {
               href: `https://aide.passculture.app/hc/fr/articles/4413973462929--Acteurs-Culturels-Comment-rattacher-mes-points-de-remboursement-et-mes-coordonn%C3%A9es-bancaires-%C3%A0-un-SIRET-de-r%C3%A9f%C3%A9rence-`,
-              linkTitle: 'En savoir plus sur les barèmes de remboursement',
-              icon: fullLinkIcon,
+              label:
+                'Comment ajouter vos coordonnées bancaires sur un lieu sans SIRET ?',
+              isExternal: true,
             },
           ]}
           className={`${styles['desk-callout']}`}

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
@@ -52,8 +52,7 @@ const ReimbursementFields = ({
               links={[
                 {
                   href: `/structures/${offerer.id}/lieux/creation`,
-                  linkTitle: 'Créer un lieu avec SIRET',
-                  isExternal: false,
+                  label: 'Créer un lieu avec SIRET',
                 },
               ]}
             >

--- a/pro/src/pages/Reimbursements/BankInformations/AddBankInformationsDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/AddBankInformationsDialog.tsx
@@ -32,7 +32,6 @@ const AddBankInformationsDialog = ({
         link={{
           to: DS_BANK_ACCOUNT_PROCEDURE_ID,
           isExternal: true,
-          rel: 'noopener noreferrer',
           target: '_blank',
         }}
         icon={fullLinkIcon}

--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
@@ -134,7 +134,7 @@ const LinkVenuesDialog = ({
         {hasVenuesWithoutPricingPoint && (
           <Callout
             title="Certains de vos lieux n’ont pas de SIRET"
-            type={CalloutVariant.ERROR}
+            variant={CalloutVariant.ERROR}
             className={styles['dialog-callout']}
           >
             Sélectionnez un SIRET pour chacun de ces lieux avant de pouvoir les

--- a/pro/src/pages/Reimbursements/BankInformations/PricingPointDialog/PricingPointDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/PricingPointDialog/PricingPointDialog.tsx
@@ -5,7 +5,6 @@ import { ManagedVenues } from 'apiClient/v1'
 import Callout from 'components/Callout/Callout'
 import DialogBox from 'components/DialogBox'
 import useNotification from 'hooks/useNotification'
-import fullLinkIcon from 'icons/full-link.svg'
 import { Button, Select, SubmitButton } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -74,8 +73,8 @@ const PricingPointDialog = ({
           {
             href: 'https://aide.passculture.app/hc/fr/articles/4413973462929--Acteurs-Culturels-Comment-rattacher-mes-points-de-remboursement-et-mes-coordonn%C3%A9es-bancaires-%C3%A0-un-SIRET-de-r%C3%A9f%C3%A9rence-',
             isExternal: true,
-            icon: fullLinkIcon,
-            linkTitle: 'En savoir plus sur les barèmes de remboursement',
+            label:
+              'Comment ajouter vos coordonnées bancaires sur un lieu sans SIRET ?',
           },
         ]}
       >

--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
@@ -341,12 +341,13 @@ const InvoiceTable = ({ invoices }: InvoiceTableProps) => {
                   link={{
                     isExternal: true,
                     to: invoice.url,
-                    rel: 'noopener noreferrer',
                     target: '_blank',
                     download: true,
                   }}
                   icon={fullDownloadIcon}
-                  svgAlt={`Justificatif de ${invoice.amount >= 0 ? 'remboursement' : 'trop perçu'} ${invoice.reference}, nouvelle fenêtre, format`}
+                  svgAlt={`Justificatif de ${
+                    invoice.amount >= 0 ? 'remboursement' : 'trop perçu'
+                  } ${invoice.reference}, nouvelle fenêtre, format`}
                   variant={ButtonVariant.TERNARY}
                 >
                   PDF

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.module.scss
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.module.scss
@@ -22,10 +22,6 @@
   margin-bottom: rem.torem(24px);
 }
 
-.contact-link {
-  margin-top: rem.torem(8px);
-}
-
 .banner-text-gap {
   margin-top: rem.torem(24px);
 }

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.tsx
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import Callout from 'components/Callout/Callout'
 import fullMailIcon from 'icons/full-mail.svg'
-import { ButtonLink } from 'ui-kit'
 
 import styles from './SignupConfirmation.module.scss'
 
@@ -17,7 +16,16 @@ const SignupConfirmation = () => (
         Vous allez recevoir un lien de confirmation par email. Cliquez sur ce
         lien pour confirmer la création de votre compte.
       </div>
-      <Callout>
+      <Callout
+        links={[
+          {
+            href: 'mailto:support-pro@passculture.app',
+            isExternal: true,
+            icon: { src: fullMailIcon, alt: 'Nouvelle fenêtre, par email' },
+            label: 'Contacter le support',
+          },
+        ]}
+      >
         <p>
           Si vous ne recevez pas d’email de notre part d’ici 5 minutes, vérifiez
           que le message n’est pas dans le dossier “indésirables” ou “spam” de
@@ -26,18 +34,6 @@ const SignupConfirmation = () => (
         <p className={styles['banner-text-gap']}>
           Si vous n’avez rien reçu d’ici demain, merci de contacter le support.
         </p>
-        <ButtonLink
-          link={{
-            to: 'mailto:support-pro@passculture.app',
-            isExternal: true,
-            target: '_blank',
-            rel: 'noopener noreferrer',
-          }}
-          icon={fullMailIcon}
-          className={styles['contact-link']}
-        >
-          Contacter le support
-        </ButtonLink>
       </Callout>
     </div>
   </section>

--- a/pro/src/pages/Signup/SignupContainer/OperationProcedures/OperationProcedures.tsx
+++ b/pro/src/pages/Signup/SignupContainer/OperationProcedures/OperationProcedures.tsx
@@ -4,7 +4,6 @@ import { useLocation } from 'react-router-dom'
 import Callout from 'components/Callout/Callout'
 import { Events } from 'core/FirebaseEvents/constants'
 import useAnalytics from 'hooks/useAnalytics'
-import fullLinkIcon from 'icons/full-link.svg'
 
 import styles from './OperationProcedures.module.scss'
 
@@ -17,12 +16,10 @@ const OperatingProcedures = (): JSX.Element => {
       links={[
         {
           href: 'https://passculture.zendesk.com/hc/fr/articles/4411999179665',
-          linkTitle: 'Consulter notre centre d’aide',
+          label: 'Consulter notre centre d’aide',
           isExternal: true,
           onClick: () =>
             logEvent?.(Events.CLICKED_HELP_CENTER, { from: location.pathname }),
-          icon: fullLinkIcon,
-          svgAlt: 'Nouvelle fenêtre',
         },
       ]}
       className={styles['desk-callout']}

--- a/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
+++ b/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
@@ -159,7 +159,7 @@ const CollectiveOfferConfirmation = ({
         links={[
           {
             href: `https://aide.passculture.app/hc/fr/articles/4416082284945--Acteurs-Culturels-Quel-est-le-cycle-de-vie-de-mon-offre-collective-de-sa-cr%C3%A9ation-%C3%A0-son-remboursement`,
-            linkTitle:
+            label:
               'Quel est le cycle de vie d’une offre collective, de sa création à son remboursement',
           },
         ]}

--- a/pro/src/screens/IndividualOffer/IndivualOfferLayout/OfferStatusBanner/OfferStatusBanner.tsx
+++ b/pro/src/screens/IndividualOffer/IndivualOfferLayout/OfferStatusBanner/OfferStatusBanner.tsx
@@ -15,7 +15,8 @@ const OfferStatusBanner = ({ status }: OfferStatusBannerProps): JSX.Element => {
         links={[
           {
             href: CGU_URL,
-            linkTitle: 'Consulter les Conditions Générales d’Utilisation',
+            label: 'Consulter les Conditions Générales d’Utilisation',
+            isExternal: true,
           },
         ]}
       >

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/EventCancellationBanner.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/EventCancellationBanner.tsx
@@ -18,7 +18,7 @@ export const EventCancellationBanner = ({
       links={[
         {
           href: 'https://aide.passculture.app/hc/fr/articles/4411992053649--Acteurs-Culturels-Comment-annuler-ou-reporter-un-%C3%A9v%C3%A9nement-',
-          linkTitle: 'Comment reporter ou annuler un évènement ?',
+          label: 'Comment reporter ou annuler un évènement ?',
         },
       ]}
       isBanner

--- a/pro/src/screens/IndividualOffer/StocksThing/ActivationCodeFormDialog/AddActivationCodeForm.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/ActivationCodeFormDialog/AddActivationCodeForm.tsx
@@ -49,9 +49,8 @@ const AddActivationCodeForm = ({
           link={{
             isExternal: true,
             to: '/csvtemplates/CodesActivations-Gabarit.csv',
-            target: '_blank',
-            rel: 'noopener noreferrer',
             type: 'text/csv',
+            target: '_blank',
           }}
           icon={fullDownloadIcon}
         >

--- a/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
@@ -254,7 +254,7 @@ const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
     links = [
       {
         href: 'https://aide.passculture.app/hc/fr/articles/4411991970705--Acteurs-culturels-Comment-cr%C3%A9er-une-offre-num%C3%A9rique-avec-des-codes-d-activation-',
-        linkTitle: 'Comment gérer les codes d’activation ?',
+        label: 'Comment gérer les codes d’activation ?',
       },
     ]
   }

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/FormDates.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/FormDates.tsx
@@ -53,7 +53,7 @@ const FormDates = ({
       />
       {values.datesType === 'specific_dates' && (
         <>
-          <Callout type={CalloutVariant.INFO} className={styles.banner}>
+          <Callout variant={CalloutVariant.INFO} className={styles.banner}>
             Votre offre sera désactivée automatiquement à l’issue des dates
             précisées ci-dessous.
           </Callout>

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
@@ -89,11 +89,11 @@ const FormVenue = ({
           links={[
             {
               href: 'https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage',
-              linkTitle: 'Faire une demande de référencement',
+              label: 'Faire une demande de référencement',
             },
             {
               href: 'https://aide.passculture.app/hc/fr/articles/5700215550364',
-              linkTitle:
+              label:
                 'Ma demande de référencement a été acceptée mais je ne peux toujours pas créer d’offres collectives',
             },
           ]}
@@ -141,7 +141,7 @@ const FormVenue = ({
             links={[
               {
                 href: `/structures/${values.offererId}/lieux/creation`,
-                linkTitle: 'Renseigner un lieu',
+                label: 'Renseigner un lieu',
               },
             ]}
           >

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -138,7 +138,7 @@ const OfferEducationalStock = <
                     links={[
                       {
                         href: 'https://passculture.zendesk.com/hc/fr/articles/4412973958673--Acteurs-culturels-Comment-modifier-une-offre-collective-pr%C3%A9-r%C3%A9serv%C3%A9e-',
-                        linkTitle:
+                        label:
                           'Consultez l’article “Comment modifier ou annuler une offre collective préréservée/réservée”',
                       },
                     ]}

--- a/pro/src/screens/OfferEducationalStock/ShowcaseBannerInfo/ShowcaseBannerInfo.tsx
+++ b/pro/src/screens/OfferEducationalStock/ShowcaseBannerInfo/ShowcaseBannerInfo.tsx
@@ -9,7 +9,7 @@ const ShowcaseBannerInfo = (): JSX.Element => (
       {
         isExternal: true,
         href: 'https://aide.passculture.app/hc/fr/articles/4416082284945',
-        linkTitle:
+        label:
           'Consultez l’article “Quel est le cycle de vie de mon offre collective, de sa création à son remboursement ?”',
       },
     ]}

--- a/pro/src/screens/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
+++ b/pro/src/screens/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
@@ -207,7 +207,7 @@ const CollectiveOfferType = ({
             links={[
               {
                 href: `/structures/${queryOffererId}/lieux/${lastDmsApplication?.venueId}#venue-collective-data`,
-                linkTitle: 'Voir ma demande de référencement',
+                label: 'Voir ma demande de référencement',
               },
             ]}
           >
@@ -218,11 +218,11 @@ const CollectiveOfferType = ({
             links={[
               {
                 href: 'https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage',
-                linkTitle: 'Faire une demande de référencement',
+                label: 'Faire une demande de référencement',
               },
               {
                 href: 'https://aide.passculture.app/hc/fr/articles/5700215550364',
-                linkTitle:
+                label:
                   'Ma demande de référencement a été acceptée mais je ne peux toujours pas créer d’offres collectives',
               },
             ]}

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -14,7 +14,6 @@ import getSiretData from 'core/Venue/adapters/getSiretDataAdapter'
 import { getVenuesOfOffererFromSiretAdapter } from 'core/Venue/adapters/getVenuesOfOffererFromSiretAdapter'
 import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
-import fullLinkIcon from 'icons/full-link.svg'
 import { MAYBE_APP_USER_APE_CODE } from 'pages/Signup/SignupContainer/constants'
 import MaybeAppUserDialog from 'pages/Signup/SignupContainer/MaybeAppUserDialog'
 
@@ -137,8 +136,8 @@ const Offerer = (): JSX.Element => {
               links={[
                 {
                   href: 'https://aide.passculture.app/hc/fr/articles/4633420022300--Acteurs-Culturels-Collectivit%C3%A9-Lieu-rattach%C3%A9-%C3%A0-une-collectivit%C3%A9-S-inscrire-et-param%C3%A9trer-son-compte-pass-Culture-',
-                  linkTitle: 'En savoir plus',
-                  icon: fullLinkIcon,
+                  label: 'En savoir plus',
+                  isExternal: true,
                 },
               ]}
             >

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -140,11 +140,9 @@ const Offerer = (): JSX.Element => {
                   isExternal: true,
                 },
               ]}
+              title="Vous êtes un équipement d’une collectivité ou d’un établissement
+              public ?"
             >
-              <strong>
-                Vous êtes un équipement d’une collectivité ou d’un établissement
-                public ?
-              </strong>
               <p className={styles['callout-content-info']}>
                 Renseignez le SIRET de la structure à laquelle vous êtes
                 rattaché.

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -135,7 +135,7 @@ describe('Offerer', () => {
     ).toBeInTheDocument()
 
     expect(
-      screen.getByRole('link', { name: 'En savoir plus' })
+      screen.getByRole('link', { name: /En savoir plus/ })
     ).toBeInTheDocument()
   })
 

--- a/pro/src/ui-kit/Banners/Banner/Banner.stories.tsx
+++ b/pro/src/ui-kit/Banners/Banner/Banner.stories.tsx
@@ -61,11 +61,11 @@ export const WithLink: StoryObj<typeof Banner> = {
     links: [
       {
         href: 'https://pro.testing.passculture.team',
-        linkTitle: 'Lien vers le pass culture',
+        label: 'Lien vers le pass culture',
       },
       {
         href: '#',
-        linkTitle: 'Un autre lien',
+        label: 'Un autre lien',
       },
     ],
     minimalStyle: false,

--- a/pro/src/ui-kit/Banners/Banner/__specs__/Banner.spec.tsx
+++ b/pro/src/ui-kit/Banners/Banner/__specs__/Banner.spec.tsx
@@ -1,23 +1,30 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
 
-import fullNextIcon from 'icons/full-next.svg'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Banner, { BannerProps } from '../Banner'
 
 describe('Banner', () => {
   const props: BannerProps = {
     closable: true,
-    links: [{ href: '/some/site', linkTitle: 'linkTitle', icon: fullNextIcon }],
+    links: [
+      {
+        href: '/some/site',
+        label: 'link label',
+        isExternal: true,
+        icon: null,
+      },
+    ],
   }
 
   it('should render the Banner', () => {
-    render(<Banner {...props}>This is the banner content</Banner>)
+    renderWithProviders(<Banner {...props}>This is the banner content</Banner>)
 
     // then
     expect(screen.getByText('This is the banner content')).toBeInTheDocument()
     const link = screen.getByRole('link', {
-      name: props.links?.[0]?.linkTitle,
+      name: props.links?.[0]?.label,
     })
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', props.links?.[0]?.href)
@@ -28,15 +35,13 @@ describe('Banner', () => {
       'aria-label',
       'Masquer le bandeau'
     )
-    expect(screen.getByRole('img')).toHaveAttribute(
-      'class',
-      'close-icon-banner'
-    )
   })
 
   it('should display close icon with light type', () => {
     props.type = 'light'
-    render(<Banner {...props}>This is the banner light content</Banner>)
+    renderWithProviders(
+      <Banner {...props}>This is the banner light content</Banner>
+    )
     expect(screen.getByRole('img')).toHaveAttribute(
       'aria-label',
       'Masquer le bandeau'

--- a/pro/src/ui-kit/Banners/LinkNodes/LinkNodes.tsx
+++ b/pro/src/ui-kit/Banners/LinkNodes/LinkNodes.tsx
@@ -1,65 +1,73 @@
 import React from 'react'
 
 import fullLinkIcon from 'icons/full-link.svg'
-import { ButtonLink } from 'ui-kit/Button'
+import fullNextIcon from 'icons/full-next.svg'
+import ButtonLink, { LinkProps } from 'ui-kit/Button/ButtonLink'
 
 import styles from './LinkNodes.module.scss'
 
 export type Link = {
-  icon?: string
+  icon?: {
+    src: string
+    alt: string
+  } | null
   href: string
-  linkTitle: string
-  targetLink?: string
-  hideLinkIcon?: boolean
+  label: string
+  target?: string
   isExternal?: boolean
   onClick?: () => void
-  svgAlt?: string
   'aria-label'?: string
-}
-
-interface LinkNodeProps {
-  link: Link
-  defaultLinkIcon?: string
 }
 
 interface LinkNodesProps {
   links?: Link[]
-  defaultLinkIcon?: string
 }
 
-const LinkNode = ({
-  link: {
-    icon,
-    href,
-    linkTitle,
-    targetLink = '_blank',
-    hideLinkIcon,
-    isExternal = true,
-    onClick,
-    svgAlt,
-    'aria-label': ariaLabel,
-  },
-  defaultLinkIcon = fullLinkIcon,
-}: LinkNodeProps): React.ReactNode => (
-  <ButtonLink
-    link={{
-      isExternal: isExternal,
-      to: href,
-      target: targetLink,
-      rel: 'noopener noreferrer',
-      'aria-label': ariaLabel,
-    }}
-    icon={hideLinkIcon ? undefined : icon ?? defaultLinkIcon}
-    className={styles['bi-link']}
-    onClick={onClick}
-    svgAlt={svgAlt}
-  >
-    {linkTitle}
-  </ButtonLink>
-)
+export const LinkNode = ({
+  icon,
+  href,
+  label,
+  isExternal,
+  onClick,
+  'aria-label': ariaLabel,
+}: Link): React.ReactNode => {
+  const forwardLink: LinkProps = { to: href, isExternal }
+  if (isExternal) {
+    forwardLink.target = '_blank'
+  }
+  if (ariaLabel) {
+    forwardLink['aria-label'] = ariaLabel
+  }
+  return (
+    <ButtonLink
+      link={forwardLink}
+      icon={
+        icon === null
+          ? undefined
+          : icon
+            ? icon.src
+            : isExternal
+              ? fullLinkIcon
+              : fullNextIcon
+      }
+      className={styles['bi-link']}
+      onClick={onClick}
+      svgAlt={
+        icon === null
+          ? undefined
+          : icon?.alt
+            ? icon.alt
+            : isExternal
+              ? 'Nouvelle fenêtre'
+              : ''
+      }
+    >
+      {label}
+    </ButtonLink>
+  )
+}
 
 const LinkNodes = ({
-  defaultLinkIcon,
   links = [],
 }: LinkNodesProps): React.ReactNode | React.ReactNode[] => {
   if (links.length > 1) {
@@ -68,17 +76,14 @@ const LinkNodes = ({
         {links.map((link) => {
           return (
             <li key={link.href} className={styles['bi-link-item']}>
-              <LinkNode link={link} defaultLinkIcon={defaultLinkIcon} />
+              <LinkNode {...link} />
             </li>
           )
         })}
       </ul>
     )
   }
-
-  return (
-    links[0] && <LinkNode link={links[0]} defaultLinkIcon={defaultLinkIcon} />
-  )
+  return links[0] && <LinkNode {...links[0]} />
 }
 
 export default LinkNodes

--- a/pro/src/ui-kit/Banners/LinkNodes/__specs__/LinkNodes.spec.tsx
+++ b/pro/src/ui-kit/Banners/LinkNodes/__specs__/LinkNodes.spec.tsx
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import fullMailIcon from 'icons/full-mail.svg'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { LinkNode } from '../LinkNodes'
+
+describe('LinkNodes', () => {
+  it('should display an external link with icon', () => {
+    renderWithProviders(
+      <LinkNode href="/some/site" label="link label" isExternal />
+    )
+
+    const link = screen.getByRole('link', {
+      name: /link label/,
+    })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/some/site')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'aria-label',
+      'Nouvelle fenêtre'
+    )
+  })
+
+  it('should display an internal link with icon', () => {
+    renderWithProviders(<LinkNode href="/some/site" label="link label" />)
+
+    const link = screen.getByRole('link', {
+      name: /link label/,
+    })
+    expect(link).toHaveAttribute('href', '/some/site')
+  })
+
+  it('should display a custom external link with icon', () => {
+    renderWithProviders(
+      <LinkNode
+        href="mailto:support-pro@passculture.app"
+        isExternal
+        icon={{ src: fullMailIcon, alt: 'Nouvelle fenêtre, par email' }}
+        label="Contacter le support"
+      />
+    )
+
+    const link = screen.getByRole('link', {
+      name: /Contacter le support/,
+    })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'aria-label',
+      'Nouvelle fenêtre, par email'
+    )
+  })
+})

--- a/pro/src/ui-kit/Button/ButtonLink.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.tsx
@@ -8,10 +8,10 @@ import styles from './Button.module.scss'
 import { ButtonVariant, IconPositionEnum, SharedButtonProps } from './types'
 
 export type LinkProps = {
-  isExternal: boolean
+  isExternal?: boolean
   to: string
-  rel?: string
   target?: string
+  rel?: string
   'aria-label'?: string
   'aria-current'?: 'page'
   type?: string
@@ -103,6 +103,7 @@ const ButtonLink = ({
       href={absoluteUrl}
       onClick={callback}
       onBlur={(e) => onBlur?.(e)}
+      rel="noopener noreferrer"
       {...disabled}
       {...linkProps}
     >


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27728

Au départ, ajouter les textes alternatifs en fonction du type de bannière.

Au passage
- refacto des liens dans les Callout et Banner pour avoir une interface cohérente au niveau des liens externes et internes
- fix graphique des titres dans les CallOut

## Recette
### textes alternatifs:
- dans le code: le `svg` doit avoir un `aria-label` qui indique le type de bannière: "Attention", "Confirmation", "Erreur" ou "Information"
- à la synthèse vocale: la lecture doit indiquer le type de bannière: "Attention", "Confirmation", "Erreur" ou "Information"

### titres
#### avant
<img width="563" alt="Capture d’écran 2024-02-02 à 09 42 29 (2)" src="https://github.com/pass-culture/pass-culture-main/assets/101103940/788a8b74-6957-41e5-8a7c-c052af74e225">
<img width="789" alt="Capture d’écran 2024-02-02 à 09 45 24 (2)" src="https://github.com/pass-culture/pass-culture-main/assets/101103940/d44d99a5-a3bf-4911-9418-4daa7cfdfefb">

#### après
<img width="560" alt="Capture d’écran 2024-02-02 à 09 49 03 (2)" src="https://github.com/pass-culture/pass-culture-main/assets/101103940/3dd4b36a-c5a0-467f-ad3f-674431578899">
<img width="785" alt="Capture d’écran 2024-02-02 à 09 50 08 (2)" src="https://github.com/pass-culture/pass-culture-main/assets/101103940/b09b59c6-9b49-4d17-ae8e-7099514819d2">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques