### PR TITLE
(PC-27031)[EAC] feat: new AdageVenueAddress model

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-d3bd3af52558 (pre) (head)
+381fef70eb7a (pre) (head)
 6be778edb2f4 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240130T172755_381fef70eb7a_add_adage_venue_address_model.py
+++ b/api/src/pcapi/alembic/versions/20240130T172755_381fef70eb7a_add_adage_venue_address_model.py
@@ -1,0 +1,34 @@
+"""add adage venue address model"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "381fef70eb7a"
+down_revision = "d3bd3af52558"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "adage_venue_address",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("adageId", sa.Text(), nullable=True),
+        sa.Column("adageInscriptionDate", sa.DateTime(), nullable=True),
+        sa.Column("venueId", sa.BigInteger(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["venueId"],
+            ["venue.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("adageId"),
+    )
+    op.create_index(op.f("ix_adage_venue_address_venueId"), "adage_venue_address", ["venueId"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_adage_venue_address_venueId"), table_name="adage_venue_address")
+    op.drop_table("adage_venue_address")

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1644,3 +1644,12 @@ class CollectivePlaylist(PcObject, Base, Model):
     )
 
     Index("ix_collective_playlist_type_institutionId", type, institutionId)
+
+
+class AdageVenueAddress(PcObject, Base, Model):
+    adageId: str | None = sa.Column(sa.Text, nullable=True, unique=True)
+    adageInscriptionDate: datetime | None = sa.Column(sa.DateTime, nullable=True)
+    venueId: int | None = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=True, nullable=True)
+    venue: sa_orm.Mapped["Venue"] = sa.orm.relationship(
+        "Venue", foreign_keys=[venueId], back_populates="adage_addresses"
+    )

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -421,6 +421,10 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
         "AccessibilityProvider", back_populates="venue", uselist=False
     )
 
+    adage_addresses: sa_orm.Mapped[educational_models.AdageVenueAddress | None] = sa.orm.relationship(
+        "AdageVenueAddress", back_populates="venue", uselist=False
+    )
+
     def _get_type_banner_url(self) -> str | None:
         elligible_banners: tuple[str, ...] = VENUE_TYPE_DEFAULT_BANNERS.get(self.venueTypeCode, tuple())
         try:


### PR DESCRIPTION
Intermediate model that will be used to link existing venues to addresses (that does not exist yet).

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27031

Ajout d'un modèle intermédiaire qui servira à lier les lieux (Venue - existants) aux adresses (Address - à venir). Cette table intermédiaire peut toutefois être remplie en attendant l'arrivée des adresses.