### PR TITLE
(BSR)[API] test: Fix flaky test_get_venue_with_provider

### DIFF
--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -498,7 +498,8 @@ class GetVenueTest(GetEndpointHelper):
 
     def test_get_venue_with_provider(self, authenticated_client, random_venue):
         venue_provider = providers_factories.AllocineVenueProviderFactory(
-            venue=random_venue, lastSyncDate=datetime.utcnow() - timedelta(hours=5)
+            venue=random_venue,
+            lastSyncDate=datetime(2024, 1, 5, 12, 0),
         )
         venue_id = random_venue.id
 
@@ -508,7 +509,7 @@ class GetVenueTest(GetEndpointHelper):
 
         content = html_parser.content_as_text(response.data)
         assert "Provider : Allociné" in content
-        assert f"Dernière synchronisation : {venue_provider.lastSyncDate.strftime('%d/%m/%Y à ')}" in content
+        assert "Dernière synchronisation : 05/01/2024 à 13h00" in content
         assert f"/pro/venue/{venue_id}/delete/{venue_provider.provider.id}".encode() not in response.data
 
     def test_get_venue_with_provider_not_allocine(self, authenticated_client, random_venue):


### PR DESCRIPTION
The test failed when run between 4:00 and 5:00 UTC, because the
calculated last sync date was then between 23:00 and 0:00 UTC and the
date of the day was thus different in UTC and in CET.

We usually don't run tests during the night... but the CI runned pull
requests created by Dependabot around 3:00 UTC and this test always
failed.