### PR TITLE
(BSR)[PRO] feat: Remove "too many login attempts" error message

### DIFF
--- a/pro/src/pages/SignIn/SignIn.tsx
+++ b/pro/src/pages/SignIn/SignIn.tsx
@@ -81,16 +81,12 @@ export const SignIn = (): JSX.Element => {
 
   const onHandleFail = (payload: SigninApiErrorResponse) => {
     const { errors, status } = payload
-    if (status === HTTP_STATUS.TOO_MANY_REQUESTS) {
-      notify.error(
-        'Nombre de tentatives de connexion dépassé. Veuillez réessayer dans 1 minute.'
-      )
-    } else if (errors && Object.values(errors).length > 0) {
-      notify.error('Identifiant ou mot de passe incorrect.')
-      formik.setStatus('apiError')
-      formik.setFieldError('email', 'Identifiant ou mot de passe incorrect.')
-      formik.setFieldError('password', 'Identifiant ou mot de passe incorrect.')
-    }
+      if (errors && Object.values(errors).length > 0) {
+        notify.error('Identifiant ou mot de passe incorrect.')
+        formik.setStatus('apiError')
+        formik.setFieldError('email', 'Identifiant ou mot de passe incorrect.')
+        formik.setFieldError('password', 'Identifiant ou mot de passe incorrect.')
+      }
   }
 
   return (

--- a/pro/src/pages/SignIn/__specs__/SignIn.spec.tsx
+++ b/pro/src/pages/SignIn/__specs__/SignIn.spec.tsx
@@ -277,43 +277,6 @@ describe('SignIn', () => {
     expect(screen.getByLabelText('Adresse email *')).toHaveFocus()
   })
 
-  it('should display an error message when login rate limit exceeded', async () => {
-    renderSignIn()
-
-    const email = screen.getByLabelText('Adresse email *')
-    await userEvent.type(email, 'MonPetitEmail@exemple.com')
-    const password = screen.getByLabelText('Mot de passe *')
-    await userEvent.type(password, 'MCSolar85')
-
-    vi.spyOn(api, 'signin').mockRejectedValueOnce(
-      new ApiError(
-        {} as ApiRequestOptions,
-        {
-          url: '',
-          body: {
-            identifier: [
-              'Nombre de tentatives de connexion dépassé, veuillez réessayer dans une minute',
-            ],
-          },
-          status: HTTP_STATUS.TOO_MANY_REQUESTS,
-        } as ApiResult,
-        ''
-      )
-    )
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Se connecter',
-      })
-    )
-
-    expect(
-      await screen.findByText(
-        'Nombre de tentatives de connexion dépassé. Veuillez réessayer dans 1 minute.'
-      )
-    ).toBeInTheDocument()
-  })
-
   describe('sign in with new onboarding feature', () => {
     it('should not call listOfferersNames if user is admin', () => {
       const listOfferersNamesRequest = vi


### PR DESCRIPTION
Now that we have switched to Cloud Armor, 429 HTTP responses come from
Cloud Armor (and not the backend itself) and don't have the proper
CORS HTTP headers. The frontend thus cannot read the response and the
"Connecter" button freezes in the "disabled" state.