### PR TITLE
(PC-23042)[API] feat: Convert bankInformation into bankAccount

### DIFF
--- a/api/src/pcapi/scripts/convert_all_reimbursement_points_into_bank_accounts.py
+++ b/api/src/pcapi/scripts/convert_all_reimbursement_points_into_bank_accounts.py
@@ -1,0 +1,240 @@
+import argparse
+from datetime import datetime
+import time
+from typing import Iterable
+
+from flask_sqlalchemy import BaseQuery
+import sqlalchemy as sa
+
+from pcapi.app import app
+from pcapi.core.finance.models import BankAccount
+from pcapi.core.finance.models import BankAccountApplicationStatus
+from pcapi.core.finance.models import BankInformation
+from pcapi.core.finance.models import BankInformationStatus
+from pcapi.core.history.models import ActionHistory
+from pcapi.core.history.models import ActionType
+from pcapi.core.offerers.models import Offerer
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offerers.models import VenueBankAccountLink
+from pcapi.core.offerers.models import VenueReimbursementPointLink
+from pcapi.models import db
+
+
+app.app_context().push()
+
+comment = "(PC-23402) Migrate data from old bankInformation journey to new bankAccount journey"
+
+
+def map_bank_information_status_to_bank_account_status(
+    bank_information_status: BankInformationStatus,
+) -> BankAccountApplicationStatus:
+    match bank_information_status:
+        case BankInformationStatus.REJECTED:
+            return BankAccountApplicationStatus.REFUSED
+        case BankInformationStatus.ACCEPTED:
+            return BankAccountApplicationStatus.ACCEPTED
+        case _:
+            return BankAccountApplicationStatus.DRAFT
+
+
+def fetch_all_up_to_date_reimbursement_point_links(
+    reimbursement_point: Venue,
+) -> Iterable[VenueReimbursementPointLink]:
+    return VenueReimbursementPointLink.query.filter(
+        VenueReimbursementPointLink.reimbursementPointId == reimbursement_point.id,
+        VenueReimbursementPointLink.timespan.contains(datetime.utcnow()),
+    ).all()
+
+
+def fetch_all_bank_informations_used_by_a_reimbursement_point() -> BaseQuery:
+    return (
+        BankInformation.query.join(BankInformation.venue)
+        .join(Venue.managingOfferer)
+        .options(
+            sa.orm.contains_eager(BankInformation.venue).load_only(
+                Venue.id, Venue.name, Venue.publicName, Venue.siret, Venue.managingOffererId
+            )
+        )
+        .options(
+            sa.orm.contains_eager(BankInformation.venue)
+            .contains_eager(Venue.managingOfferer)
+            .load_only(Offerer.id, Offerer.name, Offerer.siren)
+        )
+    )
+
+
+def fetch_all_bank_information_without_reimbursement_point() -> BaseQuery:
+    return BankInformation.query.join(
+        Offerer, sa.and_(BankInformation.offererId == Offerer.id, BankInformation.venueId.is_(None))
+    ).options(sa.orm.contains_eager(BankInformation.offerer).load_only(Offerer.id, Offerer.name, Offerer.siren))
+
+
+def construct_bank_account_label(bank_information: BankInformation) -> str:
+    if bank_information.venue:
+        reimbursement_point = bank_information.venue
+        bank_accout_label = reimbursement_point.common_name
+    else:
+        offerer = bank_information.offerer
+        bank_accout_label = f"{offerer.siren} - {offerer.name}"
+
+    if len(bank_accout_label) > 100:
+        bank_accout_label = f"{bank_accout_label[:97]}..."
+
+    return bank_accout_label
+
+
+def should_skip_this_bank_information(bank_information: BankInformation) -> bool:
+    if not bank_information.iban or not bank_information.bic:
+        print(f"Skipping <BankInformation {bank_information.id}>. Missing IBAN or BIC")
+        return True
+
+    return False
+
+
+def process(dry_run: bool) -> None:
+    processed_bank_informations = 0
+    bank_accounts_created = 0
+    venue_bank_account_link_created = 0
+    skipped_bank_information_with_reimbursement_point = 0
+
+    processed_bank_informations_without_reimbursement_point = 0
+    bank_accounts_created_without_venue_bank_account_link = 0
+    skipped_bank_information_without_reimbursement_point = 0
+
+    if dry_run is True:
+        print("--------- DRY RUN ------------")
+
+    start = time.time()
+
+    query = fetch_all_bank_informations_used_by_a_reimbursement_point()
+
+    for bank_information in query.all():
+        print(
+            f"Processing <BankInformation {bank_information.id} - {bank_information.iban} - {bank_information.bic}> used by a reimbursementPoint"
+        )
+        if should_skip_this_bank_information(bank_information):
+            skipped_bank_information_with_reimbursement_point += 1
+            continue
+
+        reimbursement_point = bank_information.venue
+        print(
+            f"Found <ReimbursementPoint {reimbursement_point.id} - {reimbursement_point.name} ({reimbursement_point.publicName})>"
+        )
+
+        reimbursement_point_links = fetch_all_up_to_date_reimbursement_point_links(reimbursement_point)
+        bank_accout_label = construct_bank_account_label(bank_information)
+
+        bank_account = BankAccount(
+            id=reimbursement_point.id,
+            offererId=reimbursement_point.managingOffererId,
+            iban=bank_information.iban,
+            bic=bank_information.bic,
+            label=bank_accout_label,
+            dsApplicationId=bank_information.applicationId,
+            dateCreated=bank_information.dateModified,
+            dateLastStatusUpdate=bank_information.dateModified,
+            status=map_bank_information_status_to_bank_account_status(bank_information.status),
+        )
+        db.session.add(bank_account)
+        db.session.flush()
+        processed_bank_informations += 1
+        bank_accounts_created += 1
+
+        for link in reimbursement_point_links:
+            print(f"Linking <Venue {link.venueId}> to <BankAccount {bank_account.id}>")
+            venue_bank_account_link = VenueBankAccountLink(
+                venueId=link.venueId, bankAccountId=bank_account.id, timespan=(datetime.utcnow(),)
+            )
+            action = ActionHistory(
+                venueId=link.venueId,
+                bankAccountId=bank_account.id,
+                offererId=reimbursement_point.managingOffererId,
+                actionType=ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED,
+                comment=comment,
+            )
+            db.session.add(venue_bank_account_link)
+            db.session.add(action)
+            db.session.flush()
+            venue_bank_account_link_created += 1
+
+    ### The critical part is behind us. We are now sure that for any reimbursementPoint we have created a matching BankAccount with the same id ###
+    ### For accounting reasons, it was mandatory to ensure a perfect match betwenn any existing reimbursementPoint.id and his corresponding BankAccount.id ###
+
+    # We can now fetch remaining BankInformation (carried by any reimbursementPoint), create a matching BankAccount and let the DB handle the autoincrement
+    remaining_bank_information = fetch_all_bank_information_without_reimbursement_point()
+
+    for bank_information in remaining_bank_information.all():
+        print(
+            f"Processing <BankInformation {bank_information.id} - {bank_information.iban} - {bank_information.bic}> without a reimbursementPoint"
+        )
+        if should_skip_this_bank_information(bank_information):
+            skipped_bank_information_without_reimbursement_point += 1
+            continue
+
+        bank_accout_label = construct_bank_account_label(bank_information)
+
+        bank_account = BankAccount(
+            offererId=bank_information.offererId,
+            iban=bank_information.iban,
+            bic=bank_information.bic,
+            label=bank_accout_label,
+            dsApplicationId=bank_information.applicationId,
+            dateCreated=bank_information.dateModified,
+            dateLastStatusUpdate=bank_information.dateModified,
+            status=map_bank_information_status_to_bank_account_status(bank_information.status),
+        )
+        db.session.add(bank_account)
+        db.session.flush()
+        processed_bank_informations_without_reimbursement_point += 1
+        bank_accounts_created_without_venue_bank_account_link += 1
+
+    if dry_run:
+        db.session.rollback()
+        print(f"Skipped {skipped_bank_information_with_reimbursement_point} bankInformation with a reimbursementPoint")
+        print(f"Would have processed {processed_bank_informations} bankInformation with a reimbursementPoint")
+        print(f"Would have created {bank_accounts_created} bankAccount")
+        print(f"Would have created {venue_bank_account_link_created} VenueBankAccountLink")
+
+        print(
+            f"Skipped {skipped_bank_information_without_reimbursement_point} bankInformation without a reimbursementPoint"
+        )
+        print(
+            f"Would have processed {processed_bank_informations_without_reimbursement_point} bankInformation without a reimbursementPoint"
+        )
+        print(
+            f"Would have created {bank_accounts_created_without_venue_bank_account_link} bankAccount without any VenueBankAccountLink"
+        )
+    else:
+        print(f"Skipped {skipped_bank_information_with_reimbursement_point} bankInformation with a reimbursementPoint")
+        print(f"Processed {processed_bank_informations} bankInformation with a reimbursementPoint")
+        print(f"Created {bank_accounts_created} bankAccount")
+        print(f"Created {venue_bank_account_link_created} VenueBankAccountLink")
+
+        print(
+            f"Skipped {skipped_bank_information_without_reimbursement_point} bankInformation without a reimbursementPoint"
+        )
+        print(
+            f"Processed {processed_bank_informations_without_reimbursement_point} bankInformation without a reimbursementPoint"
+        )
+        print(
+            f"Created {bank_accounts_created_without_venue_bank_account_link} bankAccount without any VenueBankAccountLink"
+        )
+        db.session.commit()
+
+    end = time.time()
+
+    print(f"Took {end - start}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert any reimbursementPoint (venue carrying bankInformation) into a bankAccount"
+    )
+    parser.add_argument("--dry-run", action=argparse.BooleanOptionalAction, default=True)
+    args = parser.parse_args()
+
+    try:
+        process(args.dry_run)
+    except Exception as e:
+        db.session.rollback()
+        raise

--- a/api/src/pcapi/scripts/convert_all_reimbursement_points_into_bank_accounts.py
+++ b/api/src/pcapi/scripts/convert_all_reimbursement_points_into_bank_accounts.py
@@ -1,9 +1,7 @@
 import argparse
-from datetime import datetime
 import time
 from typing import Iterable
 
-from flask_sqlalchemy import BaseQuery
 import sqlalchemy as sa
 
 from pcapi.app import app
@@ -11,6 +9,8 @@ from pcapi.core.finance.models import BankAccount
 from pcapi.core.finance.models import BankAccountApplicationStatus
 from pcapi.core.finance.models import BankInformation
 from pcapi.core.finance.models import BankInformationStatus
+from pcapi.core.finance.models import Cashflow
+from pcapi.core.finance.models import Invoice
 from pcapi.core.history.models import ActionHistory
 from pcapi.core.history.models import ActionType
 from pcapi.core.offerers.models import Offerer
@@ -22,219 +22,398 @@ from pcapi.models import db
 
 app.app_context().push()
 
-comment = "(PC-23402) Migrate data from old bankInformation journey to new bankAccount journey"
+comment = "(PC-23402) data migration"
 
 
-def map_bank_information_status_to_bank_account_status(
-    bank_information_status: BankInformationStatus,
-) -> BankAccountApplicationStatus:
-    match bank_information_status:
-        case BankInformationStatus.REJECTED:
-            return BankAccountApplicationStatus.REFUSED
-        case BankInformationStatus.ACCEPTED:
-            return BankAccountApplicationStatus.ACCEPTED
-        case _:
-            return BankAccountApplicationStatus.DRAFT
+class MigrateData:
+    def __init__(self, dry_run: bool = False):
+        self.dry_run = dry_run
 
+        # metadata about the current processing
+        self.duration = 0
 
-def fetch_all_up_to_date_reimbursement_point_links(
-    reimbursement_point: Venue,
-) -> Iterable[VenueReimbursementPointLink]:
-    return VenueReimbursementPointLink.query.filter(
-        VenueReimbursementPointLink.reimbursementPointId == reimbursement_point.id,
-        VenueReimbursementPointLink.timespan.contains(datetime.utcnow()),
-    ).all()
+        self.processed_bank_informations_used_by_reimbursement_point = 0
+        self.processed_bank_informations_without_reimbursement_point = 0
+        self.processed_bank_informations_without_rp_nor_offerer = 0
+        self.processed_venue_reimbursement_point_link = 0
 
+        self.created_bank_accounts = 0
+        self.created_venue_bank_account_link = 0
+        self.created_action_history = 0
 
-def fetch_all_bank_informations_used_by_a_reimbursement_point() -> BaseQuery:
-    return (
-        BankInformation.query.join(BankInformation.venue)
-        .join(Venue.managingOfferer)
-        .options(
-            sa.orm.contains_eager(BankInformation.venue).load_only(
-                Venue.id, Venue.name, Venue.publicName, Venue.siret, Venue.managingOffererId
+        self.updated_cashflows = 0
+        self.updated_invoices = 0
+
+    @staticmethod
+    def has_reimbursement_point(bank_information: BankInformation) -> bool:
+        return bool(bank_information.venue)
+
+    @staticmethod
+    def map_bank_information_status_to_bank_account_status(
+        bank_information_status: BankInformationStatus,
+    ) -> BankAccountApplicationStatus:
+        match bank_information_status:
+            case BankInformationStatus.REJECTED:
+                return BankAccountApplicationStatus.REFUSED
+            case BankInformationStatus.ACCEPTED:
+                return BankAccountApplicationStatus.ACCEPTED
+            case _:
+                return BankAccountApplicationStatus.DRAFT
+
+    def process(self) -> None:
+        try:
+            self.start = time.time()
+            self._go()
+        except Exception:
+            db.session.rollback()
+            raise
+        else:
+            if self.dry_run:
+                db.session.rollback()
+            else:
+                db.session.commit()
+        finally:
+            self.end = time.time()
+            self.stdout()
+
+    def stdout(self) -> None:
+        print(f"Duration: {self.end - self.start}")
+        if self.dry_run:
+            print(
+                f"processed_bank_informations_used_by_reimbursement_point: {self.processed_bank_informations_used_by_reimbursement_point}"
             )
-        )
-        .options(
-            sa.orm.contains_eager(BankInformation.venue)
-            .contains_eager(Venue.managingOfferer)
-            .load_only(Offerer.id, Offerer.name, Offerer.siren)
-        )
-    )
-
-
-def fetch_all_bank_information_without_reimbursement_point() -> BaseQuery:
-    return BankInformation.query.join(
-        Offerer, sa.and_(BankInformation.offererId == Offerer.id, BankInformation.venueId.is_(None))
-    ).options(sa.orm.contains_eager(BankInformation.offerer).load_only(Offerer.id, Offerer.name, Offerer.siren))
-
-
-def construct_bank_account_label(bank_information: BankInformation) -> str:
-    if bank_information.venue:
-        reimbursement_point = bank_information.venue
-        bank_accout_label = reimbursement_point.common_name
-    else:
-        offerer = bank_information.offerer
-        bank_accout_label = f"{offerer.siren} - {offerer.name}"
-
-    if len(bank_accout_label) > 100:
-        bank_accout_label = f"{bank_accout_label[:97]}..."
-
-    return bank_accout_label
-
-
-def should_skip_this_bank_information(bank_information: BankInformation) -> bool:
-    if not bank_information.iban or not bank_information.bic:
-        print(f"Skipping <BankInformation {bank_information.id}>. Missing IBAN or BIC")
-        return True
-
-    return False
-
-
-def process(dry_run: bool) -> None:
-    processed_bank_informations = 0
-    bank_accounts_created = 0
-    venue_bank_account_link_created = 0
-    skipped_bank_information_with_reimbursement_point = 0
-
-    processed_bank_informations_without_reimbursement_point = 0
-    bank_accounts_created_without_venue_bank_account_link = 0
-    skipped_bank_information_without_reimbursement_point = 0
-
-    if dry_run is True:
-        print("--------- DRY RUN ------------")
-
-    start = time.time()
-
-    query = fetch_all_bank_informations_used_by_a_reimbursement_point()
-
-    for bank_information in query.all():
-        print(
-            f"Processing <BankInformation {bank_information.id} - {bank_information.iban} - {bank_information.bic}> used by a reimbursementPoint"
-        )
-        if should_skip_this_bank_information(bank_information):
-            skipped_bank_information_with_reimbursement_point += 1
-            continue
-
-        reimbursement_point = bank_information.venue
-        print(
-            f"Found <ReimbursementPoint {reimbursement_point.id} - {reimbursement_point.name} ({reimbursement_point.publicName})>"
-        )
-
-        reimbursement_point_links = fetch_all_up_to_date_reimbursement_point_links(reimbursement_point)
-        bank_accout_label = construct_bank_account_label(bank_information)
-
-        bank_account = BankAccount(
-            id=reimbursement_point.id,
-            offererId=reimbursement_point.managingOffererId,
-            iban=bank_information.iban,
-            bic=bank_information.bic,
-            label=bank_accout_label,
-            dsApplicationId=bank_information.applicationId,
-            dateCreated=bank_information.dateModified,
-            dateLastStatusUpdate=bank_information.dateModified,
-            status=map_bank_information_status_to_bank_account_status(bank_information.status),
-        )
-        db.session.add(bank_account)
-        db.session.flush()
-        processed_bank_informations += 1
-        bank_accounts_created += 1
-
-        for link in reimbursement_point_links:
-            print(f"Linking <Venue {link.venueId}> to <BankAccount {bank_account.id}>")
-            venue_bank_account_link = VenueBankAccountLink(
-                venueId=link.venueId, bankAccountId=bank_account.id, timespan=(datetime.utcnow(),)
+            print(
+                f"processed_bank_informations_without_reimbursement_point: {self.processed_bank_informations_without_reimbursement_point}"
             )
-            action = ActionHistory(
+            print(
+                f"processed_bank_informations_without_rp_nor_offerer: {self.processed_bank_informations_without_rp_nor_offerer}"
+            )
+            print(f"processed_venue_reimbursement_point_link: {self.processed_venue_reimbursement_point_link}")
+            print(f"Would have created {self.created_bank_accounts} bank account")
+            print(f"Would have created {self.created_venue_bank_account_link} links")
+            print(f"Would have created {self.created_action_history} ActionHistory")
+            print(f"Would have updated {self.updated_cashflows} cashflows")
+            print(f"Would have updated {self.updated_invoices} invoices")
+        else:
+            print(
+                f"processed_bank_informations_used_by_reimbursement_point: {self.processed_bank_informations_used_by_reimbursement_point}"
+            )
+            print(
+                f"processed_bank_informations_without_reimbursement_point: {self.processed_bank_informations_without_reimbursement_point}"
+            )
+            print(
+                f"processed_bank_informations_without_rp_nor_offerer: {self.processed_bank_informations_without_rp_nor_offerer}"
+            )
+            print(f"processed_venue_reimbursement_point_link: {self.processed_venue_reimbursement_point_link}")
+            print(f"Created {self.created_bank_accounts} bank account")
+            print(f"Created {self.created_venue_bank_account_link} links")
+            print(f"Created {self.created_action_history} ActionHistory")
+            print(f"Updated {self.updated_cashflows} cashflows")
+            print(f"Updated {self.updated_invoices} invoices")
+
+    def _go(self) -> None:
+        # First, convert reimbursement_point into bank_account, and all related data (links, cashflows and invoices)
+        for bank_information in self.fetch_all_bank_informations_used_by_a_reimbursement_point():
+            reimbursement_point = bank_information.venue
+            self.log_bank_information(bank_information)
+            bank_account = self.convert_reimbursement_point(bank_information)
+            self.convert_venue_reimbursement_point_link(reimbursement_point, bank_account)
+            self.update_cashflows_by_reimbursement_point(reimbursement_point, bank_information, bank_account)
+            self.update_invoices_by_reimbursement_point(reimbursement_point, bank_account)
+
+            self.sanity_checks(bank_information, bank_account)
+
+        # Then, convert every bank_information that is not used by a reimbursement_point, but that is still linked to an offerer
+        for bank_information in self.fetch_all_bank_informations_without_reimbursement_point():
+            self.log_bank_information(bank_information)
+            bank_account = self.convert_bank_information(bank_information)
+            self.update_cashflows_by_bank_information(bank_information, bank_account)
+
+            self.sanity_checks(bank_information, bank_account)
+
+        # Finally, convert orphans bank_information that still are related to cashflows
+        for bank_information in self.fetch_all_bank_information_without_rp_nor_offerer():
+            self.log_bank_information(bank_information)
+            bank_account = self.convert_bank_information(bank_information)
+            self.update_cashflows_by_bank_information(bank_information, bank_account)
+
+            self.sanity_checks(bank_information, bank_account)
+
+    def sanity_checks(self, bank_information: BankInformation, bank_account: BankAccount) -> None:
+        """Sanity checks at the end of the process of each bankInformation"""
+        if self.has_reimbursement_point(bank_information):
+            assert bank_information.venue.id == bank_account.id
+            assert bank_information.venue.managingOffererId == bank_account.offererId
+        if bank_information.offererId:
+            assert bank_information.offererId == bank_account.offererId
+        assert bank_information.iban == bank_account.iban
+        assert bank_information.bic == bank_account.bic
+
+    def log_bank_information(self, bank_information: BankInformation) -> None:
+        print(f"bank_information {bank_information.id} {bank_information.iban} {bank_information.bic}")
+        if self.has_reimbursement_point(bank_information):
+            print(
+                f"reimbursement_point {bank_information.venue.id} {bank_information.venue.name} ({bank_information.venue.publicName}) {bank_information.venue.siret}"
+            )
+        elif bank_information.offererId:
+            print("without a reimbursement_point")
+        else:
+            print("orphan")
+
+    def construct_bank_account_label(self, bank_information: BankInformation) -> str:
+        if self.has_reimbursement_point(bank_information):
+            reimbursement_point = bank_information.venue
+            bank_accout_label = reimbursement_point.common_name
+        elif bank_information.offererId:
+            offerer = bank_information.offerer
+            bank_accout_label = f"{offerer.siren} - {offerer.name}"
+        else:
+            # orphan bank_information
+            bank_accout_label = f"XXXX XXXX XXXX {bank_information.iban[-4:]}"
+
+        if len(bank_accout_label) > 100:
+            bank_accout_label = f"{bank_accout_label[:97]}..."
+
+        return bank_accout_label
+
+    def fetch_all_bank_informations_used_by_a_reimbursement_point(self) -> Iterable[BankInformation]:
+        return (
+            BankInformation.query.join(BankInformation.venue)
+            .join(Venue.managingOfferer)
+            .filter(BankInformation.iban.is_not(None), BankInformation.bic.is_not(None))
+            .options(
+                sa.orm.contains_eager(BankInformation.venue)
+                .load_only(Venue.id, Venue.name, Venue.publicName, Venue.siret, Venue.managingOffererId)
+                .contains_eager(Venue.managingOfferer)
+                .load_only(Offerer.id, Offerer.name, Offerer.siren)
+            )
+        ).all()
+
+    def fetch_all_bank_informations_without_reimbursement_point(self) -> Iterable[BankInformation]:
+        return (
+            BankInformation.query.filter(
+                BankInformation.iban.is_not(None),
+                BankInformation.bic.is_not(None),
+                BankInformation.venueId.is_(None),
+                BankInformation.offererId.is_not(None),
+            )
+            .join(BankInformation.offerer)
+            .options(sa.orm.contains_eager(BankInformation.offerer).load_only(Offerer.id, Offerer.name, Offerer.siren))
+            .all()
+        )
+
+    def fetch_all_bank_information_without_rp_nor_offerer(self) -> Iterable[BankInformation]:
+        """Return orphans bankInformation (i.e. used by any reimbursementPoint or link to any Offerer)
+        while still being link to Cashflows."""
+        return (
+            BankInformation.query.join(Cashflow, BankInformation.id == Cashflow.bankInformationId)
+            .filter(
+                BankInformation.iban.is_not(None),
+                BankInformation.bic.is_not(None),
+                BankInformation.venueId.is_(None),
+                BankInformation.offererId.is_(None),
+            )
+            .all()
+        )
+
+    def fetch_reimbursement_points_links(self, reimbursement_point: Venue) -> Iterable[VenueReimbursementPointLink]:
+        return VenueReimbursementPointLink.query.filter(
+            VenueReimbursementPointLink.reimbursementPointId == reimbursement_point.id
+        ).all()
+
+    def fetch_cashflows_by_reimbursement_point(self, reimbursement_point: Venue) -> Iterable[Cashflow]:
+        return (
+            Cashflow.query.join(Cashflow.reimbursementPoint)
+            .filter(Cashflow.reimbursementPointId == reimbursement_point.id)
+            .with_entities(Cashflow.id, Cashflow.bankInformationId)
+            .all()
+        )
+
+    def fetch_cashflows_by_bank_information(self, bank_information: BankInformation) -> Iterable[Cashflow]:
+        return (
+            Cashflow.query.join(Cashflow.reimbursementPoint)
+            .join(Venue.managingOfferer)
+            .filter(Cashflow.bankInformationId == bank_information.id)
+            .options(
+                sa.orm.contains_eager(Cashflow.reimbursementPoint)
+                .contains_eager(Venue.managingOfferer)
+                .load_only(Offerer.id)
+            )
+            .all()
+        )
+
+    def fetch_invoices(self, reimbursement_point: Venue) -> Iterable[Invoice]:
+        return (
+            Invoice.query.filter(Invoice.reimbursementPointId == reimbursement_point.id)
+            .with_entities(Invoice.id, Invoice.reimbursementPointId)
+            .all()
+        )
+
+    def convert_venue_reimbursement_point_link(self, reimbursement_point: Venue, bank_account: BankAccount) -> None:
+        """
+        Convert all existing VenueReimbursementPointLink into their new-journey-equivalent VenueBankAccountLink
+
+        An ActionHistory is also created so we can keep track of this action in the BackOffice.
+        """
+        links = self.fetch_reimbursement_points_links(reimbursement_point)
+        processed = 0
+
+        for link in links:
+            new_link = VenueBankAccountLink(
+                venueId=link.venueId, bankAccountId=bank_account.id, timespan=(link.timespan.lower, link.timespan.upper)
+            )
+            action_history = ActionHistory(
+                actionType=ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED,
                 venueId=link.venueId,
                 bankAccountId=bank_account.id,
-                offererId=reimbursement_point.managingOffererId,
-                actionType=ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED,
                 comment=comment,
             )
-            db.session.add(venue_bank_account_link)
-            db.session.add(action)
+            db.session.add(new_link)
+            db.session.add(action_history)
             db.session.flush()
-            venue_bank_account_link_created += 1
+            processed += 1
 
-    ### The critical part is behind us. We are now sure that for any reimbursementPoint we have created a matching BankAccount with the same id ###
-    ### For accounting reasons, it was mandatory to ensure a perfect match betwenn any existing reimbursementPoint.id and his corresponding BankAccount.id ###
+        self.processed_venue_reimbursement_point_link += processed
+        self.created_venue_bank_account_link += processed
+        self.created_action_history += processed
 
-    # We can now fetch remaining BankInformation (carried by any reimbursementPoint), create a matching BankAccount and let the DB handle the autoincrement
-    remaining_bank_information = fetch_all_bank_information_without_reimbursement_point()
+        print(f"Processed {processed} links for reimbursement_point {reimbursement_point.id}")
 
-    for bank_information in remaining_bank_information.all():
-        print(
-            f"Processing <BankInformation {bank_information.id} - {bank_information.iban} - {bank_information.bic}> without a reimbursementPoint"
-        )
-        if should_skip_this_bank_information(bank_information):
-            skipped_bank_information_without_reimbursement_point += 1
-            continue
+    def convert_reimbursement_point(self, bank_information: BankInformation) -> BankAccount:
+        """
+        Convert a reimbursementPoint into a BankAccount.
 
-        bank_accout_label = construct_bank_account_label(bank_information)
+        BankAccount.id == ReimbursementPoint.id
+        BankAccount.offererId == ReimbursementPoint.managingOffererId
+        BankAccount.iban == BankInformation.iban
+        BankAccount.bic == BankInformation.bic
+        BankAccount.dsApplicationId == BankInformation.applicationId
+        BankAccount.label == ReimbursementPoint.common_name
+        """
+        assert bank_information  # type hinting
+        assert bank_information.iban
+        assert bank_information.bic
+
+        bank_account_label = self.construct_bank_account_label(bank_information)
 
         bank_account = BankAccount(
-            offererId=bank_information.offererId,
+            id=bank_information.venue.id,
             iban=bank_information.iban,
             bic=bank_information.bic,
-            label=bank_accout_label,
+            label=bank_account_label,
             dsApplicationId=bank_information.applicationId,
             dateCreated=bank_information.dateModified,
             dateLastStatusUpdate=bank_information.dateModified,
-            status=map_bank_information_status_to_bank_account_status(bank_information.status),
+            status=self.map_bank_information_status_to_bank_account_status(bank_information.status),
+            offererId=bank_information.venue.managingOffererId,
         )
+
         db.session.add(bank_account)
         db.session.flush()
-        processed_bank_informations_without_reimbursement_point += 1
-        bank_accounts_created_without_venue_bank_account_link += 1
 
-    if dry_run:
-        db.session.rollback()
-        print(f"Skipped {skipped_bank_information_with_reimbursement_point} bankInformation with a reimbursementPoint")
-        print(f"Would have processed {processed_bank_informations} bankInformation with a reimbursementPoint")
-        print(f"Would have created {bank_accounts_created} bankAccount")
-        print(f"Would have created {venue_bank_account_link_created} VenueBankAccountLink")
+        self.processed_bank_informations_used_by_reimbursement_point += 1
+        self.created_bank_accounts += 1
 
-        print(
-            f"Skipped {skipped_bank_information_without_reimbursement_point} bankInformation without a reimbursementPoint"
-        )
-        print(
-            f"Would have processed {processed_bank_informations_without_reimbursement_point} bankInformation without a reimbursementPoint"
-        )
-        print(
-            f"Would have created {bank_accounts_created_without_venue_bank_account_link} bankAccount without any VenueBankAccountLink"
-        )
-    else:
-        print(f"Skipped {skipped_bank_information_with_reimbursement_point} bankInformation with a reimbursementPoint")
-        print(f"Processed {processed_bank_informations} bankInformation with a reimbursementPoint")
-        print(f"Created {bank_accounts_created} bankAccount")
-        print(f"Created {venue_bank_account_link_created} VenueBankAccountLink")
+        return bank_account
 
-        print(
-            f"Skipped {skipped_bank_information_without_reimbursement_point} bankInformation without a reimbursementPoint"
-        )
-        print(
-            f"Processed {processed_bank_informations_without_reimbursement_point} bankInformation without a reimbursementPoint"
-        )
-        print(
-            f"Created {bank_accounts_created_without_venue_bank_account_link} bankAccount without any VenueBankAccountLink"
-        )
-        db.session.commit()
+    def convert_bank_information(self, bank_information: BankInformation) -> BankAccount:
+        """
+        Convert every BankInformation into a BankAccount.
 
-    end = time.time()
+        BankAccount.iban == BankInformation.iban
+        BankAccount.bic == BankInformation.bic
+        BankAccount.dsApplicationId == BankInformation.applicationId
+        BankAccount.label == Offerer.siren + Offerer.name
 
-    print(f"Took {end - start}")
+        If the bankInformation is not link to any offerer, we try to retrieve it from the cashflows
+        to which it's link.
+        """
+        assert bank_information  # type hinting
+        assert bank_information.iban
+        assert bank_information.bic
+
+        bank_account_label = self.construct_bank_account_label(bank_information)
+
+        offerer_id = bank_information.offererId
+        if not bank_information.offererId:
+            cashflows = self.fetch_cashflows_by_bank_information(bank_information)
+            offerer_ids = set(cashflow.reimbursementPoint.managingOffererId for cashflow in cashflows)
+            assert len(offerer_ids) == 1
+            offerer_id = offerer_ids.pop()
+        assert offerer_id
+
+        bank_account = BankAccount(
+            iban=bank_information.iban,
+            bic=bank_information.bic,
+            label=bank_account_label,
+            dsApplicationId=bank_information.applicationId,
+            dateCreated=bank_information.dateModified,
+            dateLastStatusUpdate=bank_information.dateModified,
+            status=self.map_bank_information_status_to_bank_account_status(bank_information.status),
+            offererId=offerer_id,
+        )
+
+        db.session.add(bank_account)
+        db.session.flush()
+
+        if bank_information.offererId:
+            self.processed_bank_informations_without_reimbursement_point += 1
+        else:
+            self.processed_bank_informations_without_rp_nor_offerer += 1
+        self.created_bank_accounts += 1
+
+        return bank_account
+
+    def update_cashflows_by_reimbursement_point(
+        self, reimbursement_point: Venue, bank_information: BankInformation, bank_account: BankAccount
+    ) -> Iterable[Cashflow]:
+        cashflows = self.fetch_cashflows_by_reimbursement_point(reimbursement_point)
+        mapping = []
+        for cashflow in cashflows:
+            if bank_information.id != cashflow.bankInformationId:
+                # The denormalize bankInformation doesn't match the bankInformation used
+                # by the reimbursementPoint. This isn't the bankAccountId we want to set here
+                # This cashflow will be process later while fetching bankInformation without reimbursementPoint
+                continue
+            mapping.append({"id": cashflow.id, "bankAccountId": bank_account.id})
+
+        db.session.bulk_update_mappings(Cashflow, mapping)
+        db.session.flush()
+
+        self.updated_cashflows += len(mapping)
+        print(f"Updated {len(mapping)} cashflows for reimbursement_point {reimbursement_point.id}")
+
+        return cashflows
+
+    def update_cashflows_by_bank_information(
+        self, bank_information: BankInformation, bank_account: BankAccount
+    ) -> None:
+        cashflows = self.fetch_cashflows_by_bank_information(bank_information)
+        mapping = [{"id": cashflow.id, "bankAccountId": bank_account.id} for cashflow in cashflows]
+
+        db.session.bulk_update_mappings(Cashflow, mapping)
+        db.session.flush()
+
+        self.updated_cashflows += len(mapping)
+        print(f"Updated {len(mapping)} cashflows for bank_information {bank_information.id}")
+
+    def update_invoices_by_reimbursement_point(self, reimbursement_point: Venue, bank_account: BankAccount) -> None:
+        invoices = self.fetch_invoices(reimbursement_point)
+        mapping = [{"id": invoice.id, "bankAccountId": bank_account.id} for invoice in invoices]
+
+        db.session.bulk_update_mappings(Invoice, mapping)
+        db.session.flush()
+
+        self.updated_invoices += len(mapping)
+        print(f"Updated {len(mapping)} invoices for reimbursement_point {reimbursement_point.id}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Convert any reimbursementPoint (venue carrying bankInformation) into a bankAccount"
+        description="Migrate data from the old bankInformation journey to the new bankAccount one"
     )
     parser.add_argument("--dry-run", action=argparse.BooleanOptionalAction, default=True)
     args = parser.parse_args()
 
-    try:
-        process(args.dry_run)
-    except Exception as e:
-        db.session.rollback()
-        raise
+    migrate_data = MigrateData(args.dry_run)
+    migrate_data.process()


### PR DESCRIPTION
And convert all up-to-date VenueReimbursementPointLink into up-to-date VenueBankAccountLink

- This is a one-time script that won't be merged. 
- The stdout/stderr will be kept and archived with the task
- It run successfully in a staging environment with those numbers:

```
Skipped 2632 with a reimbursementPoint
Would have processed 20949 bankInformation with a reimbursementPoint
Would have created 20949 bankAccount
Would have created 32088 VenueBankAccountLink
Skipped 184 without a reimbursementPoint
Would have processed 3373 bankInformation without a reimbursementPoint
Would have created 3373 bankAccount without any VenueBankAccountLink
Took 190.93674850463867
```

With 31257 bankInformation in database, and:

- 4119 ignored because having any `venueId` nor `offererId`
- 2632+184 bankInformation skipped because of a missing IBAN or BIC (or both)
- 20949+3373 bankInformation migrate in the new journey

(which successfully give us 31257 bankInformation processed)

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23402

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques