### PR TITLE
(PC-27531)[PRO] feat: Add tracker log to adage offer share button click.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferShareLink/OfferShareLink.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferShareLink/OfferShareLink.tsx
@@ -1,9 +1,11 @@
+import { apiAdage } from 'apiClient/api'
 import strokeShareIcon from 'icons/stroke-share.svg'
 import {
   HydratedCollectiveOffer,
   HydratedCollectiveOfferTemplate,
 } from 'pages/AdageIframe/app/types/offers'
 import ListIconButton from 'ui-kit/ListIconButton'
+import { LOGS_DATA } from 'utils/config'
 
 import styles from './OfferShareLink.module.scss'
 
@@ -21,12 +23,23 @@ Bonjour,
 %0D%0A%0D%0ACordialement
   `
 
+  function handleShareButtonClicked() {
+    if (LOGS_DATA) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      apiAdage.logTrackingCtaShare({
+        iframeFrom: location.pathname,
+        offerId: offer.id,
+        source: '',
+      })
+    }
+  }
+
   return (
     <ListIconButton
       className={styles['share-link']}
       url={`mailto:?subject=Partage d’offre sur ADAGE - ${offer.name}&body=${mailBody}`}
-      isExternal={true}
       icon={strokeShareIcon}
+      onClick={handleShareButtonClicked}
     >
       Partager l’offre par email
     </ListIconButton>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27531

**Objectif**
Ajouter un log au moment ou un utilisateur clique sur le bouton de partage d'une offre dans la liste des offres adage

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques