### PR TITLE
(PC-27759)[PRO] fix: Date de début in formsDates now have an asterisk.

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/__specs__/FormDates.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormDates/__specs__/FormDates.spec.tsx
@@ -180,10 +180,10 @@ describe('FormDates', () => {
       }
     )
 
-    const beginningInput = screen.getByLabelText('Date de début')
+    const beginningInput = screen.getByLabelText('Date de début *')
 
     await userEvent.type(beginningInput, '2025-02-02')
-    expect(screen.getByLabelText('Date de fin')).toHaveAttribute(
+    expect(screen.getByLabelText('Date de fin *')).toHaveAttribute(
       'value',
       '2025-02-02'
     )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27759

**Objectif**
Corriger le test unitaire qui fail après le merge du nouveau formulaire FormDates qui a encore des labels d’inputs sans le “*” dans les tests.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques