### PR TITLE
(PC-27482)[BO] feat: add button to force sync offers' stocks in venue page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -20,6 +20,48 @@
             <h2 class="card-title text-primary">{{ links.build_venue_name_to_pc_pro_link(venue, public_name=false) }}</h2>
             <span class="fs-5 ps-4">{{ build_venue_badges(venue) }}</span>
             <div class="d-flex row-reverse justify-content-end flex-grow-1">
+              {% if has_permission("MANAGE_PRO_ENTITY") and has_active_provider %}
+                {% set fully_sync_venue_modal_label_id = random_hash() %}
+                <button class="btn btn-outline-primary lead fw-bold mt-2"
+                        data-bs-toggle="modal"
+                        data-bs-target=".pc-trigger-sync-modal"
+                        type="button">Resynchroniser les offres</button>
+                <div class="modal modal-lg fade pc-trigger-sync-modal"
+                     tabindex="-1"
+                     aria-describedby="{{ fully_sync_venue_modal_label_id }}"
+                     aria-hidden="true">
+                  <div class="modal-dialog modal-dialog-centered">
+                    <div class="modal-content">
+                      <form action="{{ url_for("backoffice_web.venue.fully_sync_venue", venue_id=venue.id) }}"
+                            name="{{ url_for("backoffice_web.venue.fully_sync_venue", venue_id=venue.id) | action_to_name }}"
+                            method="post"
+                            data-turbo="false">
+                        <div class="modal-header"
+                             id="fully-sync-venue-modal-label">
+                          <h5 class="modal-title">Resynchroniser toutes les offres du lieu {{ venue.common_name }}</h5>
+                        </div>
+                        <div class="modal-body row">
+                          <p>
+                            Tous les stocks des offres du lieu <strong>{{ venue.common_name }} ({{ venue.id }})</strong>
+                            seront synchronisés depuis le provider. Les stocks existants seront remplacés.
+                          </p>
+                          <p>
+                            La mise à jour des données n'est pas immédiate. Les changements seront visibles dans les minutes qui suivent le lancement de la tâche.
+                          </p>
+                          {{ build_form_fields_group(fully_sync_venue_form) }}
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button"
+                                  class="btn btn-outline-primary"
+                                  data-bs-dismiss="modal">Annuler</button>
+                          <button type="submit"
+                                  class="btn btn-primary">Confirmer</button>
+                        </div>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+              {% endif %}
               {% if has_permission("MANAGE_PRO_ENTITY") %}
                 <button class="btn btn-outline-primary lead fw-bold mt-2 mx-3"
                         data-bs-toggle="modal"

--- a/api/src/pcapi/workers/fully_sync_venue_job.py
+++ b/api/src/pcapi/workers/fully_sync_venue_job.py
@@ -1,0 +1,10 @@
+from pcapi.core.offerers import models as offerers_models
+from pcapi.scripts.stock.fully_sync_venue import fully_sync_venue
+from pcapi.workers import worker
+from pcapi.workers.decorators import job
+
+
+@job(worker.low_queue)
+def fully_sync_venue_job(venue_id: int) -> None:
+    venue = offerers_models.Venue.query.get(venue_id)
+    fully_sync_venue(venue)


### PR DESCRIPTION
## But de la pull request

Ajout d'un bouton "Resynchroniser les offres" dans la page "Lieu" pour pouvoir lancer un worker de synchronisation des stocks depuis le provider


<img width="802" alt="Capture d’écran 2024-01-31 à 15 50 30" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/fb43a746-931e-4641-adb7-b0cc6249cb16">

![Capture d’écran 2024-01-31 à 15 51 19](https://github.com/pass-culture/pass-culture-main/assets/155538488/9ed6caeb-a346-43d8-803e-fd3a7ae5f545)


Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27482

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques