### PR TITLE
(PC-27785)[ADAGE] fix: imgUrl on the local playlist is always None

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/playlists.py
@@ -182,8 +182,8 @@ def get_local_offerers_playlist(
     return playlists_serializers.LocalOfferersPlaylist(
         venues=[
             playlists_serializers.LocalOfferersPlaylistOffer(
-                img_url=venue.bannerUrl,
-                public_name=venue.publicName,
+                imgUrl=venue.bannerUrl,
+                publicName=venue.publicName,
                 name=venue.name,
                 distance=format_distance(distances[venue.id]),
                 city=venue.city,

--- a/api/src/pcapi/routes/adage_iframe/serialization/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/playlists.py
@@ -9,12 +9,13 @@ class LocalOfferersPlaylistOffer(BaseModel):
     id: int
     name: str
     distance: Decimal | None
-    img_url: str | None
-    public_name: str | None
+    imgUrl: str | None
+    publicName: str | None
     city: str | None
 
     class Config:
         alias_generator = to_camel
+        allow_population_by_field_name = True
 
 
 class LocalOfferersPlaylist(BaseModel):

--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -163,7 +163,8 @@ class GetLocalOfferersPlaylistTest(SharedPlaylistsErrorTests):
     endpoint = "adage_iframe.get_local_offerers_playlist"
 
     def test_get_local_offerers_playlist(self, client):
-        playlist_venues = offerers_factories.VenueFactory.create_batch(2)
+        IMAGE_URL = "http://localhost/image.png"
+        playlist_venues = offerers_factories.VenueFactory.create_batch(2, _bannerUrl=IMAGE_URL)
         offerers_factories.VenueFactory()
 
         institution = educational_factories.EducationalInstitutionFactory()
@@ -197,6 +198,7 @@ class GetLocalOfferersPlaylistTest(SharedPlaylistsErrorTests):
         for idx, response_venue in enumerate(response_venues):
             assert response_venue["id"] == venues[idx].id
             assert response_venue["distance"] == expected_distance
+            assert response_venue["imgUrl"] == IMAGE_URL
 
     def test_no_rows(self, client):
         institution = educational_factories.EducationalInstitutionFactory()


### PR DESCRIPTION
Pydandic does not make it easy to distinguish between serialization and deserialization meaning we can't know which is which between the camelCase and snake_case to use.
This fixes LocalOfferersPlaylistOffer by updating the fields to camelCase fields.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27785

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques