### PR TITLE
(PC-27001)[BO] feat: quicklink PC pro - status page offre filtrées

### DIFF
--- a/api/src/pcapi/utils/urls.py
+++ b/api/src/pcapi/utils/urls.py
@@ -46,7 +46,7 @@ def build_pc_pro_offerer_link(offerer: offerers_models.Offerer) -> str:
 
 
 def build_pc_pro_offerer_offers_link(offerer: offerers_models.Offerer) -> str:
-    return f"{settings.PRO_URL}/offres?structure={offerer.id}&statut=active"
+    return f"{settings.PRO_URL}/offres?structure={offerer.id}"
 
 
 def build_pc_pro_venue_link(venue: offerers_models.Venue) -> str:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27001

## Vérifications

lorsqu’on est sur la page structure, ça nous envoie vers le lien exterieur suivant : https://passculture.pro/offres?structure=10381&statut=active 

On aimerait que ce soit https://passculture.pro/offres?structure=10381 