### PR TITLE
(PC-25410)[API] feat: add command to send reminder at least 30 minutes before an online event

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -50,6 +50,7 @@ class TransactionalEmail(Enum):
     EMAIL_CONFIRMATION = models.Template(
         id_prod=201, id_not_prod=15, tags=["jeunes_confirmation_mail"], use_priority_queue=True
     )
+    ONLINE_EVENT_REMINDER = models.Template(id_prod=1092, id_not_prod=154)
     EXPIRED_BOOKING_TO_BENEFICIARY = models.Template(id_prod=145, id_not_prod=34, tags=["jeunes_resa_expiree"])
     FRAUD_SUSPICION = models.Template(id_prod=82, id_not_prod=24, tags=["jeunes_compte_en_cours_d_analyse"])
     NEW_PASSWORD_REQUEST = models.Template(

--- a/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
+++ b/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
@@ -1,0 +1,120 @@
+import datetime
+import logging
+
+import sqlalchemy as sa
+
+from pcapi.core import mails
+from pcapi.core.bookings import models as booking_models
+from pcapi.core.mails import transactional as mails_transactional
+from pcapi.core.mails.models import TransactionalEmailData
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
+from pcapi.utils import date as date_utils
+
+
+logger = logging.getLogger(__name__)
+
+
+class OnlineEventReminderData:
+    event_hour: datetime.datetime | None
+    offer_name: str
+    offer_url: str
+    recipients: list[str]
+    booking_id: int
+    withdrawal_details: str
+
+    def __init__(self, booking: booking_models.Booking) -> None:
+        event_hour_utc = booking.stock.beginningDatetime
+        event_hour_localized = (
+            date_utils.utc_datetime_to_department_timezone(
+                event_hour_utc,
+                booking.venue.departementCode,
+            )
+            if event_hour_utc
+            else None
+        )
+
+        stock = booking.stock
+        self.event_hour = event_hour_localized
+        self.offer_name = stock.offer.name
+        self.offer_url = stock.offer.url
+        self.recipients = []
+        self.booking_id = booking.id
+        self.withdrawal_details = stock.offer.withdrawalDetails
+
+    def add_recipient(self, email: str) -> None:
+        self.recipients.append(email)
+
+
+def _get_online_reminder_data(data: OnlineEventReminderData) -> TransactionalEmailData | None:
+    if not data.event_hour:
+        logger.exception("Cannot send reminder without event hour", extra={"data": data})
+        return None
+
+    return TransactionalEmailData(
+        template=mails_transactional.sendinblue_template_ids.TransactionalEmail.ONLINE_EVENT_REMINDER.value,
+        params={
+            "OFFER_NAME": data.offer_name,
+            "DIGITAL_OFFER_URL": data.offer_url,
+            "EVENT_HOUR": data.event_hour.strftime("%Hh%M"),
+            "OFFER_WITHDRAWAL_DETAILS": data.withdrawal_details,
+        },
+    )
+
+
+def _get_online_bookings_happening_soon() -> sa.orm.query.Query:
+    """
+    'Soon' means in the next hour but not in the next 30 minutes.
+    This is to send the reminder at least 30 minutes before the event starts.
+    """
+    now = datetime.datetime.utcnow()
+    # We normalize the minute to 0 or 30 to get the next-next 30 minutes
+    normalized_minute = 0 if now.minute < 30 else 30
+    normalized_now = now.replace(minute=normalized_minute, second=0, microsecond=0)
+
+    in_30_minutes = normalized_now + datetime.timedelta(minutes=30)
+    in_1_hour = normalized_now + datetime.timedelta(hours=1)
+    bookings_query = (
+        booking_models.Booking.query.join(Stock)
+        .join(Offer)
+        .join(Venue)
+        .options(
+            sa.orm.joinedload(booking_models.Booking.user),
+            sa.orm.joinedload(booking_models.Booking.stock).joinedload(Stock.offer).joinedload(Offer.venue),
+        )
+        .filter(
+            booking_models.Booking.status == booking_models.BookingStatus.CONFIRMED,
+            Stock.beginningDatetime >= in_30_minutes,
+            Stock.beginningDatetime < in_1_hour,
+            Offer.isEvent.is_(True),  # type: ignore [attr-defined]
+            Offer.isDigital.is_(True),  # type: ignore [attr-defined]
+        )
+    )
+
+    return bookings_query
+
+
+def _get_email_data_by_stock(bookings_query: sa.orm.query.Query) -> dict[str, OnlineEventReminderData]:
+    email_data_by_stock = {}
+    for booking in bookings_query:
+        if booking.stockId not in email_data_by_stock:
+            email_data_by_stock[booking.stockId] = OnlineEventReminderData(booking=booking)
+        email_data_by_stock[booking.stockId].add_recipient(booking.user.email)
+    return email_data_by_stock
+
+
+def _send_email_by_stock(email_data_by_stock: dict[str, OnlineEventReminderData]) -> None:
+    for data in email_data_by_stock.values():
+        email_data = _get_online_reminder_data(data)
+        if not email_data:
+            continue
+        for email in data.recipients:
+            # We send emails separately because we want to be able to cancel a single email if a user cancels their booking
+            mails.send(recipients=[email], data=email_data)
+
+
+def send_online_event_event_reminder() -> None:
+    bookings_query = _get_online_bookings_happening_soon()
+    email_data_by_stock = _get_email_data_by_stock(bookings_query)
+    _send_email_by_stock(email_data_by_stock)

--- a/api/src/pcapi/core/users/commands.py
+++ b/api/src/pcapi/core/users/commands.py
@@ -3,6 +3,7 @@ import logging
 import click
 
 from pcapi import settings
+from pcapi.core.mails.transactional.users import online_event_reminder
 import pcapi.core.users.api as user_api
 import pcapi.core.users.constants as users_constants
 import pcapi.scheduled_tasks.decorators as cron_decorators
@@ -17,6 +18,12 @@ logger = logging.getLogger(__name__)
 @cron_decorators.log_cron_with_transaction
 def notify_users_before_deletion_of_suspended_account() -> None:
     user_api.notify_users_before_deletion_of_suspended_account()
+
+
+@blueprint.cli.command("notify_users_before_online_event")
+@cron_decorators.log_cron_with_transaction
+def notify_users_before_online_event() -> None:
+    online_event_reminder.send_online_event_event_reminder()
 
 
 @blueprint.cli.command("delete_suspended_accounts_after_withdrawal_period")

--- a/api/tests/core/mails/transactional/users/online_event_reminder_test.py
+++ b/api/tests/core/mails/transactional/users/online_event_reminder_test.py
@@ -1,0 +1,126 @@
+import datetime
+
+import pytest
+
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.bookings import models as bookings_models
+from pcapi.core.categories import subcategories_v2 as subcategories
+import pcapi.core.mails.testing as mails_testing
+from pcapi.core.mails.transactional.users import online_event_reminder
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.utils.date import utc_datetime_to_department_timezone
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class OnlineEventReminderTest:
+    def setup_method(self):
+        now = datetime.datetime.utcnow()
+        normalized_minute = 0 if now.minute < 30 else 30
+
+        self.now = now.replace(minute=normalized_minute, second=0, microsecond=0)
+        self.in_20_minutes = self.now + datetime.timedelta(minutes=20)
+        self.in_35_minutes = self.now + datetime.timedelta(minutes=35)
+        self.in_50_minutes = self.now + datetime.timedelta(minutes=50)
+        self.in_2_hours = self.now + datetime.timedelta(hours=2)
+
+    def test_get_online_bookings_happening_soon(self) -> None:
+        online_conference = offers_factories.EventOfferFactory(
+            url="http://example.com/offer/1", subcategoryId=subcategories.CONFERENCE.id
+        )
+        # Event happening in less than 1 hour
+        offers_factories.EventStockFactory(beginningDatetime=self.in_50_minutes, offer=online_conference)
+        # Event happening in less than 30 minutes
+        offers_factories.EventStockFactory(beginningDatetime=self.in_20_minutes, offer=online_conference)
+        # Event happening in more than 1 hour
+        offers_factories.EventStockFactory(beginningDatetime=self.in_2_hours, offer=online_conference)
+
+        # All events are booked
+        bookings_factories.BookingFactory(stock=online_conference.stocks[0])
+        bookings_factories.BookingFactory(stock=online_conference.stocks[1])
+        bookings_factories.BookingFactory(stock=online_conference.stocks[2])
+
+        query = online_event_reminder._get_online_bookings_happening_soon()
+
+        assert query.count() == 1
+        assert query.one().stock.beginningDatetime == self.in_50_minutes
+
+    def test_get_email_data_by_stock(self):
+        online_conference = offers_factories.EventOfferFactory(
+            url="http://example.com/offer/1", subcategoryId=subcategories.CONFERENCE.id
+        )
+        online_meetup = offers_factories.EventOfferFactory(
+            url="http://example.com/offer/2", subcategoryId=subcategories.RENCONTRE.id
+        )
+        # The online conference and the online meetup are happening soon at different times
+        online_conference_stock = offers_factories.EventStockFactory(
+            beginningDatetime=self.in_50_minutes, offer=online_conference
+        )
+        online_meetup_stock = offers_factories.EventStockFactory(
+            beginningDatetime=self.in_35_minutes, offer=online_meetup
+        )
+
+        # All events are booked multiple times
+        bookings_factories.BookingFactory(stock=online_conference.stocks[0])
+        bookings_factories.BookingFactory(stock=online_conference.stocks[0])
+
+        bookings_factories.BookingFactory(stock=online_meetup.stocks[0])
+        bookings_factories.BookingFactory(stock=online_meetup.stocks[0])
+        bookings_factories.BookingFactory(stock=online_meetup.stocks[0])
+
+        with assert_no_duplicated_queries():
+            query = online_event_reminder._get_online_bookings_happening_soon()  # tested above
+            email_data_by_stocks = online_event_reminder._get_email_data_by_stock(query)
+
+        assert len(email_data_by_stocks) == 2
+
+        online_conference_data = email_data_by_stocks[online_conference_stock.id]
+        expected_event_hour = utc_datetime_to_department_timezone(
+            self.in_50_minutes, online_conference.venue.departementCode
+        )
+        assert online_conference_data.offer_name == online_conference.name
+        assert online_conference_data.offer_url == online_conference.url
+        assert online_conference_data.event_hour == expected_event_hour
+        assert online_conference_data.withdrawal_details == online_conference.withdrawalDetails
+        assert len(online_conference_data.recipients) == 2
+
+        online_meetup_data = email_data_by_stocks[online_meetup_stock.id]
+        expected_event_hour = utc_datetime_to_department_timezone(
+            self.in_35_minutes, online_meetup.venue.departementCode
+        )
+        assert online_meetup_data.offer_name == online_meetup.name
+        assert online_meetup_data.offer_url == online_meetup.url
+        assert online_meetup_data.event_hour == expected_event_hour
+        assert online_meetup_data.withdrawal_details == online_meetup.withdrawalDetails
+        assert len(online_meetup_data.recipients) == 3
+
+    def test_send_reminder_email(self):
+        online_conference = offers_factories.EventOfferFactory(
+            url="http://example.com/offer/1", subcategoryId=subcategories.CONFERENCE.id
+        )
+        stock = offers_factories.EventStockFactory(beginningDatetime=self.in_50_minutes, offer=online_conference)
+        bookings_factories.BookingFactory(stock=stock)
+        online_event_reminder.send_online_event_event_reminder()
+        assert len(mails_testing.outbox) == 1
+
+        expected_event_hour = utc_datetime_to_department_timezone(
+            self.in_50_minutes, online_conference.venue.departementCode
+        )
+
+        assert mails_testing.outbox[0]["params"] == {
+            "DIGITAL_OFFER_URL": online_conference.url,
+            "EVENT_HOUR": expected_event_hour.strftime("%Hh%M"),
+            "OFFER_NAME": online_conference.name,
+            "OFFER_WITHDRAWAL_DETAILS": online_conference.withdrawalDetails,
+        }
+
+    def test_do_not_send_reminder_email_if_booking_cancelled(self):
+        online_conference = offers_factories.EventOfferFactory(
+            url="http://example.com/offer/1", subcategoryId=subcategories.CONFERENCE.id
+        )
+        stock = offers_factories.EventStockFactory(beginningDatetime=self.in_50_minutes, offer=online_conference)
+        bookings_factories.BookingFactory(stock=stock, status=bookings_models.BookingStatus.CANCELLED)
+        online_event_reminder.send_online_event_event_reminder()
+        assert len(mails_testing.outbox) == 0


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25410
Cette PR prend en compte un commentaire de [cette PR](https://github.com/pass-culture/pass-culture-main/pull/9783) (sur slack) proposant une implémentation plus simple. 

Au lieu de schedule des emails et de les annuler le cas échéant, on fait tourner un cron plus régulièrement (toute les 30 minutes) pour notifier. 
Au lieu d'un email _exactement_ 30 min avant, nos utilisateurs auront un email _au moins_ 30 min avant

## Vérifications

- [x] J'ai écrit les tests nécessaires
