### PR TITLE
(PC-27811)[API] chore: Explicitly install `poetry-plugin-export`

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -25,6 +25,10 @@ RUN pip install poetry poetry-plugin-export
 
 WORKDIR /home/pcapi
 
+# FIXME (dramelet, 2024-02-05) this is to avoid a warning about "poetry-plugin-export" not being installed,
+# even if it is installed. That line can be removed once Poetry does not warn us anymore.
+RUN poetry config warnings.export false
+
 RUN poetry check --lock
 
 RUN poetry export -o requirements.txt --without dev

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,7 +21,7 @@ COPY ./pyproject.toml ./poetry.lock ./
 
 ENV PATH=$PATH:/home/pcapi/.local/bin
 
-RUN pip install poetry
+RUN pip install poetry poetry-plugin-export
 
 WORKDIR /home/pcapi
 


### PR DESCRIPTION
As poetry warn us, in future versions, the plugin that is used to export the requirements.txt won't be automatically installed. This could break our builds

```
#22 [builder 8/9] RUN poetry export -o requirements.txt --without dev
#22 0.846 Warning: poetry-plugin-export will not be installed by default in a future version of Poetry.
#22 0.846 In order to avoid a breaking change and make your automation forward-compatible, please install poetry-plugin-export explicitly. See https://python-poetry.org/docs/plugins/#using-plugins for details on how to install a plugin.
```

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27811

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques