### PR TITLE
(PC-27819)[API] chore: remplace backref with back_populates

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -77,7 +77,7 @@ class BookingExportType(enum.Enum):
 class ExternalBooking(PcObject, Base, Model):
     bookingId: int = Column(BigInteger, ForeignKey("booking.id"), index=True, nullable=False)
 
-    booking: Mapped["Booking"] = relationship("Booking", foreign_keys=[bookingId], backref="externalBookings")
+    booking: Mapped["Booking"] = relationship("Booking", foreign_keys=[bookingId], back_populates="externalBookings")
 
     barcode: str = Column(String, nullable=False)
 
@@ -96,15 +96,17 @@ class Booking(PcObject, Base, Model):
 
     stockId: int = Column(BigInteger, ForeignKey("stock.id"), index=True, nullable=False)
 
-    stock: Mapped["offers_models.Stock"] = relationship("Stock", foreign_keys=[stockId], backref="bookings")
+    stock: Mapped["offers_models.Stock"] = relationship("Stock", foreign_keys=[stockId], back_populates="bookings")
 
     venueId: int = Column(BigInteger, ForeignKey("venue.id"), index=True, nullable=False)
 
-    venue: Mapped["offerers_models.Venue"] = relationship("Venue", foreign_keys=[venueId], backref="bookings")
+    venue: Mapped["offerers_models.Venue"] = relationship("Venue", foreign_keys=[venueId], back_populates="bookings")
 
     offererId: int = Column(BigInteger, ForeignKey("offerer.id"), index=True, nullable=False)
 
-    offerer: Mapped["offerers_models.Offerer"] = relationship("Offerer", foreign_keys=[offererId], backref="bookings")
+    offerer: Mapped["offerers_models.Offerer"] = relationship(
+        "Offerer", foreign_keys=[offererId], back_populates="bookings"
+    )
 
     quantity: int = Column(Integer, nullable=False, default=1)
 
@@ -116,7 +118,7 @@ class Booking(PcObject, Base, Model):
         "ActivationCode", uselist=False, back_populates="booking"
     )
 
-    user: Mapped["users_models.User"] = relationship("User", foreign_keys=[userId], backref="userBookings")
+    user: Mapped["users_models.User"] = relationship("User", foreign_keys=[userId], back_populates="userBookings")
 
     amount: Decimal = Column(Numeric(10, 2), nullable=False)
 
@@ -218,7 +220,9 @@ class Booking(PcObject, Base, Model):
 
         token = self.activationCode.code if self.activationCode else self.token
 
-        return url.replace("{token}", token).replace("{offerId}", humanize(offer.id)).replace("{email}", self.email)
+        return (
+            url.replace("{token}", token).replace("{offerId}", humanize(offer.id) or "").replace("{email}", self.email)
+        )
 
     @staticmethod
     def restize_internal_error(ie: sa_exc.InternalError) -> tuple[str, str]:

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -155,6 +155,18 @@ class Booking(PcObject, Base, Model):
         "Deposit", foreign_keys=[depositId], back_populates="bookings"
     )
 
+    finance_events: Mapped["finance_models.FinanceEvent | None"] = relationship(
+        finance_models.FinanceEvent, back_populates="booking"
+    )
+
+    pricings: Mapped[list["finance_models.Pricing"]] = relationship("Pricing", back_populates="booking")
+
+    externalBookings: Mapped[list["ExternalBooking"]] = relationship("ExternalBooking", back_populates="booking")
+
+    incidents: Mapped[list["finance_models.BookingFinanceIncident"]] = relationship(
+        "BookingFinanceIncident", back_populates="booking"
+    )
+
     def mark_as_used(self) -> None:
         if self.is_used_or_reimbursed:
             raise exceptions.BookingHasAlreadyBeenUsed()

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1049,7 +1049,7 @@ class EducationalDeposit(PcObject, Base, Model):
     )
 
     educationalInstitution: EducationalInstitution = relationship(
-        EducationalInstitution, foreign_keys=[educationalInstitutionId], backref="deposits"
+        EducationalInstitution, foreign_keys=[educationalInstitutionId], back_populates="deposits"
     )
 
     educationalYearId: str = sa.Column(
@@ -1057,7 +1057,7 @@ class EducationalDeposit(PcObject, Base, Model):
     )
 
     educationalYear: sa_orm.Mapped["EducationalYear"] = relationship(
-        EducationalYear, foreign_keys=[educationalYearId], backref="deposits"
+        EducationalYear, foreign_keys=[educationalYearId], back_populates="deposits"
     )
 
     amount: Decimal = sa.Column(Numeric(10, 2), nullable=False)
@@ -1152,11 +1152,13 @@ class CollectiveBooking(PcObject, Base, Model):
 
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=True, nullable=False)
 
-    venue: sa_orm.Mapped["Venue"] = relationship("Venue", foreign_keys=[venueId], backref="collectiveBookings")
+    venue: sa_orm.Mapped["Venue"] = relationship("Venue", foreign_keys=[venueId], back_populates="collectiveBookings")
 
     offererId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offerer.id"), index=True, nullable=False)
 
-    offerer: sa_orm.Mapped["Offerer"] = relationship("Offerer", foreign_keys=[offererId], backref="collectiveBookings")
+    offerer: sa_orm.Mapped["Offerer"] = relationship(
+        "Offerer", foreign_keys=[offererId], back_populates="collectiveBookings"
+    )
 
     cancellationDate = sa.Column(sa.DateTime, nullable=True)
 
@@ -1183,7 +1185,7 @@ class CollectiveBooking(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("educational_institution.id"), nullable=False
     )
     educationalInstitution: sa_orm.Mapped["EducationalInstitution"] = relationship(
-        EducationalInstitution, foreign_keys=[educationalInstitutionId], backref="collectiveBookings"
+        EducationalInstitution, foreign_keys=[educationalInstitutionId], back_populates="collectiveBookings"
     )
 
     educationalYearId: str = sa.Column(sa.String(30), sa.ForeignKey("educational_year.adageId"), nullable=False)

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1022,6 +1022,8 @@ class EducationalInstitution(PcObject, Base, Model):
         "CollectivePlaylist", back_populates="institution"
     )
 
+    deposits: list["EducationalDeposit"] = relationship("EducationalDeposit", back_populates="educationalInstitution")
+
     __table_args__ = (sa.Index("ix_educational_institution_type_name_city", institutionType + " " + name + " " + city),)
 
     @property
@@ -1037,6 +1039,8 @@ class EducationalYear(PcObject, Base, Model):
     beginningDate: datetime = sa.Column(sa.DateTime, nullable=False)
 
     expirationDate: datetime = sa.Column(sa.DateTime, nullable=False)
+
+    deposits: list["EducationalDeposit"] = relationship("EducationalDeposit", back_populates="educationalYear")
 
 
 class EducationalDeposit(PcObject, Base, Model):
@@ -1152,12 +1156,14 @@ class CollectiveBooking(PcObject, Base, Model):
 
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=True, nullable=False)
 
-    venue: sa_orm.Mapped["Venue"] = relationship("Venue", foreign_keys=[venueId], back_populates="collectiveBookings")
+    venue: sa_orm.Mapped["Venue"] = relationship(
+        "Venue", foreign_keys=[venueId]
+    )  # , back_populates="collectiveBookings")
 
     offererId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offerer.id"), index=True, nullable=False)
 
     offerer: sa_orm.Mapped["Offerer"] = relationship(
-        "Offerer", foreign_keys=[offererId], back_populates="collectiveBookings"
+        "Offerer", foreign_keys=[offererId]  # , back_populates="collectiveBookings"
     )
 
     cancellationDate = sa.Column(sa.DateTime, nullable=True)
@@ -1185,7 +1191,7 @@ class CollectiveBooking(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("educational_institution.id"), nullable=False
     )
     educationalInstitution: sa_orm.Mapped["EducationalInstitution"] = relationship(
-        EducationalInstitution, foreign_keys=[educationalInstitutionId], back_populates="collectiveBookings"
+        EducationalInstitution, foreign_keys=[educationalInstitutionId]  # , back_populates="collectiveBookings"
     )
 
     educationalYearId: str = sa.Column(sa.String(30), sa.ForeignKey("educational_year.adageId"), nullable=False)
@@ -1206,6 +1212,14 @@ class CollectiveBooking(PcObject, Base, Model):
         EducationalRedactor,
         back_populates="collectiveBookings",
         uselist=False,
+    )
+
+    pricings: sa_orm.Mapped[list["finance_models.Pricing"]] = relationship(
+        "Pricing"  # , back_populates="collective_booking"
+    )
+
+    incidents: sa_orm.Mapped["finance_models.BookingFinanceIncident"] = relationship(
+        "BookingFinanceIncident", back_populates="collectiveBooking"
     )
 
     def cancel_booking(
@@ -1441,6 +1455,11 @@ class CollectiveDmsApplication(PcObject, Base, Model):
     instructionDate = sa.Column(sa.DateTime, nullable=True)
     processingDate = sa.Column(sa.DateTime, nullable=True)
     userDeletionDate = sa.Column(sa.DateTime, nullable=True)
+    venue: sa_orm.Mapped["Venue"] = sa.orm.relationship(
+        "Venue",
+        back_populates="collectiveDmsApplications",
+        primaryjoin="foreign(CollectiveDmsApplication.siret) == Venue.siret",
+    )
 
 
 CollectiveBooking.trig_update_cancellationDate_on_isCancelled_ddl = f"""

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -46,7 +46,7 @@ class Deposit(PcObject, Base, Model):
 
     userId: int = sqla.Column(sqla.BigInteger, sqla.ForeignKey("user.id"), index=True, nullable=False)
 
-    user: "users_models.User" = sqla_orm.relationship("User", foreign_keys=[userId], backref="deposits")
+    user: "users_models.User" = sqla_orm.relationship("User", foreign_keys=[userId], back_populates="deposits")
 
     bookings: list["bookings_models.Booking"] = sqla_orm.relationship("Booking", back_populates="deposit")
 
@@ -217,7 +217,7 @@ class BankAccountApplicationStatus(enum.Enum):
 class BankInformation(PcObject, Base, Model):
     offererId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("offerer.id"), index=True, nullable=True)
     offerer: sqla_orm.Mapped["offerers_models.Offerer | None"] = sqla_orm.relationship(
-        "Offerer", foreign_keys=[offererId], backref=sqla_orm.backref("bankInformation", uselist=False)
+        "Offerer", foreign_keys=[offererId], back_populates="bankInformation", uselist=False
     )
     venueId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), index=True, nullable=True, unique=True)
     venue: sqla_orm.Mapped["offerers_models.Venue | None"] = sqla_orm.relationship(
@@ -298,7 +298,7 @@ class FinanceEvent(Base, Model):
 
     bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
     booking: sqla_orm.Mapped["bookings_models.Booking | None"] = sqla_orm.relationship(
-        "Booking", foreign_keys=[bookingId], backref="finance_events"
+        "Booking", foreign_keys=[bookingId], back_populates="finance_events"
     )
     collectiveBookingId = sqla.Column(
         sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
@@ -310,7 +310,7 @@ class FinanceEvent(Base, Model):
         sqla.BigInteger, sqla.ForeignKey("booking_finance_incident.id"), index=True, nullable=True
     )
     bookingFinanceIncident: sqla_orm.Mapped["BookingFinanceIncident | None"] = sqla_orm.relationship(
-        "BookingFinanceIncident", foreign_keys=[bookingFinanceIncidentId], backref="finance_events"
+        "BookingFinanceIncident", foreign_keys=[bookingFinanceIncidentId], back_populates="finance_events"
     )
 
     # `venueId` is denormalized and comes from `booking.venueId`
@@ -374,17 +374,17 @@ class Pricing(Base, Model):
 
     bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
     booking: sqla_orm.Mapped["bookings_models.Booking | None"] = sqla_orm.relationship(
-        "Booking", foreign_keys=[bookingId], backref="pricings"
+        "Booking", foreign_keys=[bookingId], back_populates="pricings"
     )
     collectiveBookingId = sqla.Column(
         sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
     )
     collectiveBooking: sqla_orm.Mapped["educational_models.CollectiveBooking | None"] = sqla_orm.relationship(
-        "CollectiveBooking", foreign_keys=[collectiveBookingId], backref="pricings"
+        "CollectiveBooking", foreign_keys=[collectiveBookingId], back_populates="pricings"
     )
     eventId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("finance_event.id"), index=True, nullable=False)
     event: sqla_orm.Mapped[FinanceEvent] = sqla_orm.relationship(
-        "FinanceEvent", foreign_keys=[eventId], backref="pricings"
+        "FinanceEvent", foreign_keys=[eventId], back_populates="pricings"
     )
 
     venueId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), index=True, nullable=False)
@@ -563,19 +563,19 @@ class CustomReimbursementRule(ReimbursementRule, Base, Model):
     offerId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("offer.id"), nullable=True)
 
     offer: sqla_orm.Mapped["offers_models.Offer | None"] = sqla_orm.relationship(
-        "Offer", foreign_keys=[offerId], backref="custom_reimbursement_rules"
+        "Offer", foreign_keys=[offerId], back_populates="custom_reimbursement_rules"
     )
 
     venueId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), nullable=True)
 
     venue: sqla_orm.Mapped["offerers_models.Venue | None"] = sqla_orm.relationship(
-        "Venue", foreign_keys=[venueId], backref="custom_reimbursement_rules"
+        "Venue", foreign_keys=[venueId], back_populates="custom_reimbursement_rules"
     )
 
     offererId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("offerer.id"), nullable=True)
 
     offerer: sqla_orm.Mapped["offerers_models.Offerer | None"] = sqla_orm.relationship(
-        "Offerer", foreign_keys=[offererId], backref="custom_reimbursement_rules"
+        "Offerer", foreign_keys=[offererId], back_populates="custom_reimbursement_rules"
     )
 
     # A list of identifiers of subcategories on which the rule applies.
@@ -711,7 +711,7 @@ class Cashflow(Base, Model):
     )
 
     batchId: int = sqla.Column(sqla.BigInteger, sqla.ForeignKey("cashflow_batch.id"), index=True, nullable=False)
-    batch: "CashflowBatch" = sqla_orm.relationship("CashflowBatch", foreign_keys=[batchId], backref="cashflows")
+    batch: "CashflowBatch" = sqla_orm.relationship("CashflowBatch", foreign_keys=[batchId], back_populates="cashflows")
 
     # See the note about `amount` at the beginning of this module.
     # The amount cannot be zero.
@@ -869,14 +869,16 @@ class InvoiceCashflow(Base, Model):
 class Payment(Base, Model):
     id: int = sqla.Column(sqla.BigInteger, primary_key=True, autoincrement=True)
     bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
-    booking: "bookings_models.Booking" = sqla_orm.relationship("Booking", foreign_keys=[bookingId], backref="payments")
+    booking: "bookings_models.Booking" = sqla_orm.relationship(
+        "Booking", foreign_keys=[bookingId], back_populates="payments"
+    )
     collectiveBookingId = sqla.Column(
         sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
     )
     collectiveBooking: "educational_models.CollectiveBooking" = sqla_orm.relationship(
         "CollectiveBooking",
         foreign_keys=[collectiveBookingId],
-        backref="payments",
+        back_populates="payments",
     )
     # Contrary to other models, this amount is in euros, not eurocents.
     amount: decimal.Decimal = sqla.Column(sqla.Numeric(10, 2), nullable=False)
@@ -887,7 +889,7 @@ class Payment(Base, Model):
         sqla.ForeignKey("custom_reimbursement_rule.id"),
     )
     customReimbursementRule: CustomReimbursementRule | None = sqla_orm.relationship(
-        "CustomReimbursementRule", foreign_keys=[customReimbursementRuleId], backref="payments"
+        "CustomReimbursementRule", foreign_keys=[customReimbursementRuleId], back_populates="payments"
     )
     recipientName: str = sqla.Column(sqla.String(140), nullable=False)
     recipientSiren: str = sqla.Column(sqla.String(9), nullable=False)
@@ -906,7 +908,7 @@ class Payment(Base, Model):
     transactionLabel = sqla.Column(sqla.String(140), nullable=True)
     paymentMessageId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("payment_message.id"), nullable=True)
     paymentMessage: "PaymentMessage" = sqla_orm.relationship(
-        "PaymentMessage", foreign_keys=[paymentMessageId], backref=sqla_orm.backref("payments")
+        "PaymentMessage", foreign_keys=[paymentMessageId], back_populates="payments"
     )
     batchDate = sqla.Column(sqla.DateTime, nullable=True, index=True)
 
@@ -944,7 +946,7 @@ class TransactionStatus(enum.Enum):
 class PaymentStatus(Base, Model):
     id: int = sqla.Column(sqla.BigInteger, primary_key=True, autoincrement=True)
     paymentId: int = sqla.Column(sqla.BigInteger, sqla.ForeignKey("payment.id"), index=True, nullable=False)
-    payment: Payment = sqla_orm.relationship("Payment", foreign_keys=[paymentId], backref="statuses")
+    payment: Payment = sqla_orm.relationship("Payment", foreign_keys=[paymentId], back_populates="statuses")
     date: datetime.datetime = sqla.Column(
         sqla.DateTime, nullable=False, default=datetime.datetime.utcnow, server_default=sqla.func.now()
     )
@@ -991,7 +993,7 @@ class FinanceIncident(Base, Model):
 
     venueId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), nullable=False)
     venue: sqla_orm.Mapped["offerers_models.Venue | None"] = sqla_orm.relationship(
-        "Venue", foreign_keys=[venueId], backref="finance_incidents"
+        "Venue", foreign_keys=[venueId], back_populates="finance_incidents"
     )
 
     details: dict | None = sqla.Column(
@@ -1052,24 +1054,24 @@ class BookingFinanceIncident(Base, Model):
 
     bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
     booking: sqla_orm.Mapped["bookings_models.Booking | None"] = sqla_orm.relationship(
-        "Booking", foreign_keys=[bookingId], backref="incidents"
+        "Booking", foreign_keys=[bookingId], back_populates="incidents"
     )
 
     collectiveBookingId = sqla.Column(
         sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
     )
     collectiveBooking: sqla_orm.Mapped["educational_models.CollectiveBooking | None"] = sqla_orm.relationship(
-        "CollectiveBooking", foreign_keys=[collectiveBookingId], backref="incidents"
+        "CollectiveBooking", foreign_keys=[collectiveBookingId], back_populates="incidents"
     )
 
     incidentId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("finance_incident.id"), index=True, nullable=False)
     incident: sqla_orm.Mapped["FinanceIncident"] = sqla_orm.relationship(
-        "FinanceIncident", foreign_keys=[incidentId], backref="booking_finance_incidents"
+        "FinanceIncident", foreign_keys=[incidentId], back_populates="booking_finance_incidents"
     )
 
     beneficiaryId: int = sqla.Column(sqla.BigInteger, sqla.ForeignKey("user.id"), index=True, nullable=True)
     beneficiary: sqla_orm.Mapped["users_models.User | None"] = sqla_orm.relationship(
-        "User", foreign_keys=[beneficiaryId], backref="incidents"
+        "User", foreign_keys=[beneficiaryId], back_populates="incidents"
     )
 
     newTotalAmount: int = sqla.Column(sqla.Integer, nullable=False)  # in cents

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -549,7 +549,7 @@ class BeneficiaryFraudCheck(PcObject, Base, Model):
     )
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
     user: users_models.User = sa.orm.relationship(
-        "User", foreign_keys=[userId], backref="beneficiaryFraudChecks", order_by=dateCreated
+        "User", foreign_keys=[userId], back_populates="beneficiaryFraudChecks", order_by=dateCreated
     )
 
     def get_detailed_source(self) -> str:
@@ -612,7 +612,7 @@ class OrphanDmsApplication(PcObject, Base, Model):
 class BeneficiaryFraudReview(PcObject, Base, Model):
     __tablename__ = "beneficiary_fraud_review"
     authorId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
-    author: users_models.User = sa.orm.relationship("User", foreign_keys=[authorId], backref="adminFraudReviews")
+    author: users_models.User = sa.orm.relationship("User", foreign_keys=[authorId], back_populates="adminFraudReviews")
     dateReviewed: datetime.datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
     eligibilityType: users_models.EligibilityType | None = sa.Column(
         sa.Enum(users_models.EligibilityType, create_constraint=False), nullable=True
@@ -621,7 +621,7 @@ class BeneficiaryFraudReview(PcObject, Base, Model):
     review = sa.Column(sa.Enum(FraudReviewStatus, create_constraint=False))
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
     user: users_models.User = sa.orm.relationship(
-        "User", foreign_keys=[userId], backref=sa.orm.backref("beneficiaryFraudReviews")
+        "User", foreign_keys=[userId], back_populates="beneficiaryFraudReviews"
     )
 
 

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -117,7 +117,9 @@ class ActionHistory(PcObject, Base, Model):
     user: users_models.User | None = sa.orm.relationship(
         "User",
         foreign_keys=[userId],
-        backref=sa.orm.backref("action_history", order_by=ACTION_HISTORY_ORDER_BY, passive_deletes=True),
+        back_populates="action_history",
+        order_by=ACTION_HISTORY_ORDER_BY,
+        passive_deletes=True,
     )
 
     offererId: int | None = sa.Column(
@@ -126,7 +128,9 @@ class ActionHistory(PcObject, Base, Model):
     offerer: sa.orm.Mapped["offerers_models.Offerer | None"] = sa.orm.relationship(
         "Offerer",
         foreign_keys=[offererId],
-        backref=sa.orm.backref("action_history", order_by=ACTION_HISTORY_ORDER_BY, passive_deletes=True),
+        back_populates="action_history",
+        order_by=ACTION_HISTORY_ORDER_BY,
+        passive_deletes=True,
     )
 
     venueId: int | None = sa.Column(
@@ -135,7 +139,9 @@ class ActionHistory(PcObject, Base, Model):
     venue: sa.orm.Mapped["offerers_models.Venue | None"] = sa.orm.relationship(
         "Venue",
         foreign_keys=[venueId],
-        backref=sa.orm.backref("action_history", order_by=ACTION_HISTORY_ORDER_BY, passive_deletes=True),
+        back_populates="action_history",
+        order_by=ACTION_HISTORY_ORDER_BY,
+        passive_deletes=True,
     )
 
     financeIncidentId: int | None = sa.Column(
@@ -144,7 +150,9 @@ class ActionHistory(PcObject, Base, Model):
     financeIncident: sa.orm.Mapped["finance_models.FinanceIncident | None"] = sa.orm.relationship(
         "FinanceIncident",
         foreign_keys=[financeIncidentId],
-        backref=sa.orm.backref("action_history", order_by="ActionHistory.actionDate.asc()", passive_deletes=True),
+        back_populates="action_history",
+        order_by="ActionHistory.actionDate.asc()",
+        passive_deletes=True,
     )
 
     bankAccountId: int | None = sa.Column(
@@ -154,7 +162,9 @@ class ActionHistory(PcObject, Base, Model):
     bankAccount: sa.orm.Mapped["finance_models.BankAccount | None"] = sa.orm.relationship(
         "BankAccount",
         foreign_keys=[bankAccountId],
-        backref=sa.orm.backref("action_history", order_by=ACTION_HISTORY_ORDER_BY, passive_deletes=True),
+        back_populates="action_history",
+        order_by=ACTION_HISTORY_ORDER_BY,
+        passive_deletes=True,
     )
 
     ruleId: int | None = sa.Column(
@@ -164,7 +174,9 @@ class ActionHistory(PcObject, Base, Model):
     rule: sa.orm.Mapped["offers_models.OfferValidationRule | None"] = sa.orm.relationship(
         "OfferValidationRule",
         foreign_keys=[ruleId],
-        backref=sa.orm.backref("action_history", order_by=ACTION_HISTORY_ORDER_BY, passive_deletes=True),
+        back_populates="action_history",
+        order_by=ACTION_HISTORY_ORDER_BY,
+        passive_deletes=True,
     )
 
     comment = sa.Column(sa.Text(), nullable=True)

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -33,7 +33,6 @@ from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.ext.mutable import MutableList
 import sqlalchemy.orm as sa_orm
 from sqlalchemy.orm import Mapped
-from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import Case
@@ -276,7 +275,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     managingOffererId: int = Column(BigInteger, ForeignKey("offerer.id"), nullable=False, index=True)
 
     managingOfferer: sa_orm.Mapped["Offerer"] = relationship(
-        "Offerer", foreign_keys=[managingOffererId], backref="managedVenues"
+        "Offerer", foreign_keys=[managingOffererId], back_populates="managedVenues"
     )
 
     bookingEmail = Column(String(120), nullable=True)
@@ -356,7 +355,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     thumb_path_component = "venues"
 
     criteria: list["criteria_models.Criterion"] = sa.orm.relationship(
-        "Criterion", backref=db.backref("venue_criteria", lazy="dynamic"), secondary="venue_criterion"
+        "Criterion", back_populates="venue_criteria", lazy="dynamic", secondary="venue_criterion"
     )
 
     dmsToken: str = Column(Text, nullable=False, unique=True)
@@ -394,7 +393,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     )
     collectiveDmsApplications: Mapped[list[educational_models.CollectiveDmsApplication]] = relationship(
         educational_models.CollectiveDmsApplication,
-        backref=backref("venue"),
+        back_populates="venue",
         primaryjoin="foreign(CollectiveDmsApplication.siret) == Venue.siret",
         uselist=True,
     )
@@ -1097,7 +1096,7 @@ class UserOfferer(PcObject, Base, Model, ValidationStatusMixin):
 
 class ApiKey(PcObject, Base, Model):
     offererId: int = Column(BigInteger, ForeignKey("offerer.id"), index=True, nullable=False)
-    offerer: sa_orm.Mapped[Offerer] = relationship("Offerer", foreign_keys=[offererId], backref=backref("apiKeys"))
+    offerer: sa_orm.Mapped[Offerer] = relationship("Offerer", foreign_keys=[offererId], back_populates="apiKeys")
     providerId: int = Column(BigInteger, ForeignKey("provider.id", ondelete="CASCADE"), index=True)
     provider: sa_orm.Mapped["providers_models.Provider"] = relationship(
         "Provider", foreign_keys=[providerId], back_populates="apiKeys"
@@ -1185,7 +1184,9 @@ class OffererInvitation(PcObject, Base, Model):
     email: str = Column(Text, nullable=False)
     dateCreated: datetime = Column(DateTime, nullable=False, default=datetime.utcnow)
     userId: int = Column(BigInteger, ForeignKey("user.id"), nullable=False, index=True)
-    user: sa_orm.Mapped["users_models.User"] = relationship("User", foreign_keys=[userId], backref="OffererInvitations")
+    user: sa_orm.Mapped["users_models.User"] = relationship(
+        "User", foreign_keys=[userId], back_populates="OffererInvitations"
+    )
     status: InvitationStatus = Column(db_utils.MagicEnum(InvitationStatus), nullable=False)
 
     __table_args__ = (UniqueConstraint("offererId", "email", name="unique_offerer_invitation"),)

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -151,11 +151,11 @@ class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
 class Mediation(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, DeactivableMixin):
     __tablename__ = "mediation"
 
-    author: sa_orm.Mapped["User"] | None = sa.orm.relationship("User", backref="mediations")
+    author: sa_orm.Mapped["User"] | None = sa.orm.relationship("User", back_populates="mediations")
     authorId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
     credit = sa.Column(sa.String(255), nullable=True)
     dateCreated: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    offer: sa_orm.Mapped["Offer"] = sa.orm.relationship("Offer", backref="mediations")
+    offer: sa_orm.Mapped["Offer"] = sa.orm.relationship("Offer", back_populates="mediations")
     offerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id"), index=True, nullable=False)
     thumb_path_component = "mediations"
 
@@ -173,7 +173,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     )
     dateModified: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
     dnBookedQuantity: int = sa.Column(sa.BigInteger, nullable=False, server_default=sa.text("0"))
-    offer: sa_orm.Mapped["Offer"] = sa.orm.relationship("Offer", backref="stocks")
+    offer: sa_orm.Mapped["Offer"] = sa.orm.relationship("Offer", back_populates="stocks")
     offerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id"), index=True, nullable=False)
     price: decimal.Decimal = sa.Column(
         sa.Numeric(10, 2), sa.CheckConstraint("price >= 0", name="check_price_is_not_negative"), nullable=False
@@ -408,12 +408,12 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
 
     authorId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), nullable=True)
     author: sa_orm.Mapped["User"] | None = relationship(
-        "User", backref="offers", foreign_keys=[authorId], uselist=False
+        "User", back_populates="offers", foreign_keys=[authorId], uselist=False
     )
     bookingContact = sa.Column(sa.String(120), nullable=True)
     bookingEmail = sa.Column(sa.String(120), nullable=True)
     criteria: sa_orm.Mapped["Criterion"] = sa.orm.relationship(
-        "Criterion", backref=db.backref("criteria", lazy="dynamic"), secondary="offer_criterion"
+        "Criterion", back_populates="criteria", lazy="dynamic", secondary="offer_criterion"
     )
     dateCreated: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
     dateModifiedAtLastProvider = sa.Column(sa.DateTime, nullable=True, default=datetime.datetime.utcnow)
@@ -443,13 +443,13 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     isNational: bool = sa.Column(sa.Boolean, default=False, nullable=False)
     name: str = sa.Column(sa.String(140), nullable=False)
     priceCategories: sa_orm.Mapped[list["PriceCategory"]] = sa.orm.relationship("PriceCategory", back_populates="offer")
-    product: Product = sa.orm.relationship(Product, backref="offers")
+    product: Product = sa.orm.relationship(Product, back_populates="offers")
     productId: int = sa.Column(sa.BigInteger, sa.ForeignKey("product.id"), index=True, nullable=True)
     rankingWeight = sa.Column(sa.Integer, nullable=True)
     subcategoryId: str = sa.Column(sa.Text, nullable=False, index=True)
     url = sa.Column(sa.String(255), nullable=True)
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), nullable=False, index=True)
-    venue: sa_orm.Mapped["Venue"] = sa.orm.relationship("Venue", foreign_keys=[venueId], backref="offers")
+    venue: sa_orm.Mapped["Venue"] = sa.orm.relationship("Venue", foreign_keys=[venueId], back_populates="offers")
     withdrawalDelay = sa.Column(sa.BigInteger, nullable=True)
     withdrawalDetails = sa.Column(sa.Text, nullable=True)
     withdrawalType = sa.Column(sa.Enum(WithdrawalTypeEnum), nullable=True)
@@ -929,7 +929,7 @@ class OfferValidationSubRuleField(enum.Enum):
 class OfferValidationSubRule(PcObject, Base, Model):
     __tablename__ = "offer_validation_sub_rule"
     validationRule: sa.orm.Mapped["OfferValidationRule"] = sa.orm.relationship(
-        "OfferValidationRule", backref="subRules", order_by="OfferValidationSubRule.id.asc()"
+        "OfferValidationRule", back_populates="subRules", order_by="OfferValidationSubRule.id.asc()"
     )
     validationRuleId = sa.Column(sa.BigInteger, sa.ForeignKey("offer_validation_rule.id"), index=True, nullable=False)
     model: OfferValidationModel = sa.Column(sa.Enum(OfferValidationModel), nullable=True)
@@ -1034,9 +1034,9 @@ class OfferReport(PcObject, Base, Model):
         ),
     )
 
-    user: sa.orm.Mapped["User"] = sa.orm.relationship("User", backref="reported_offers")
+    user: sa.orm.Mapped["User"] = sa.orm.relationship("User", back_populates="reported_offers")
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
-    offer: sa.orm.Mapped["Offer"] = sa.orm.relationship("Offer", backref="reports")
+    offer: sa.orm.Mapped["Offer"] = sa.orm.relationship("Offer", back_populates="reports")
     offerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id"), index=True, nullable=False)
     reason: Reason = sa.Column(sa.Enum(Reason, create_constraint=False), nullable=False, index=True)
     reportedAt: datetime.datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -68,6 +68,10 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
     # presence of this field signifies the provider implements pass Culture's individual offers API
     apiKeys: sa_orm.Mapped["offerers_models.ApiKey"] = sa_orm.relationship("ApiKey", back_populates="provider")
 
+    cinemaProviderPivots: sa_orm.Mapped[list["CinemaProviderPivot"]] = sa_orm.relationship(
+        "CinemaProviderPivot", back_populates="provider"
+    )
+
     @property
     def isAllocine(self) -> bool:
         from pcapi import local_providers  # avoid import loop
@@ -118,24 +122,8 @@ class VenueProvider(PcObject, Base, Model, DeactivableMixin):
 
     providerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("provider.id"), index=True, nullable=False)
 
-<<<<<<< HEAD
     provider: sa_orm.Mapped["Provider"] = sa_orm.relationship(
         "Provider", foreign_keys=[providerId], backref="venueProviders"
-=======
-    provider: sa_orm.Mapped["Provider"] = relationship(
-        "Provider", foreign_keys=[providerId], back_populates="venueProviders"
-    )
-
-    venueIdAtOfferProvider: str = Column(String(70), nullable=True)
-
-    lastSyncDate = Column(DateTime, nullable=True)
-
-    # describe if synchronised offers are available for duo booking or not
-    isDuoOffers = Column(Boolean, nullable=True)
-
-    isFromAllocineProvider = column_property(  # type: ignore [misc]
-        exists(select(Provider.id).where(and_(Provider.id == providerId, Provider.localClass == "AllocineStocks")))
->>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     venueIdAtOfferProvider: str = sa.Column(sa.String(70), nullable=True)
@@ -206,24 +194,14 @@ class CinemaProviderPivot(PcObject, Base, Model):
 
     venueId = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=False, nullable=True, unique=True)
 
-<<<<<<< HEAD
     venue: sa_orm.Mapped["Venue | None"] = sa_orm.relationship(
-        Venue, foreign_keys=[venueId], backref="cinemaProviderPivot", uselist=False
-=======
-    venue: sa_orm.Mapped["Venue | None"] = relationship(
         Venue, foreign_keys=[venueId], back_populates="cinemaProviderPivot", uselist=False
->>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     providerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("provider.id"), nullable=False)
 
-<<<<<<< HEAD
     provider: sa_orm.Mapped["Provider"] = sa_orm.relationship(
-        "Provider", foreign_keys=[providerId], backref="cinemaProviderPivots"
-=======
-    provider: sa_orm.Mapped["Provider"] = relationship(
         "Provider", foreign_keys=[providerId], back_populates="cinemaProviderPivots"
->>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     idAtProvider: str = sa.Column(sa.Text, nullable=False)
@@ -249,13 +227,8 @@ class CDSCinemaDetails(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
 
-<<<<<<< HEAD
     cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = sa_orm.relationship(
-        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], backref="CDSCinemaDetails", uselist=False
-=======
-    cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = relationship(
-        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], back_populates="CDSCinemaDetails", uselist=False
->>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
+        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], uselist=False
     )
 
     cinemaApiToken: str = sa.Column(sa.Text, nullable=False)
@@ -274,6 +247,10 @@ class AllocineVenueProvider(VenueProvider):
 
     internalId: str = sa.Column(sa.Text, nullable=False, unique=True)
 
+    priceRules: sa_orm.Mapped[list["AllocineVenueProviderPriceRule"]] = sa_orm.relationship(
+        "AllocineVenueProviderPriceRule", back_populates="allocineVenueProvider"
+    )
+
     __mapper_args__ = {
         "polymorphic_identity": "allocine_venue_provider",
     }
@@ -286,13 +263,8 @@ class AllocineVenueProviderPriceRule(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("allocine_venue_provider.id"), index=True, nullable=False
     )
 
-<<<<<<< HEAD
     allocineVenueProvider: sa_orm.Mapped["AllocineVenueProvider"] = sa_orm.relationship(
-        "AllocineVenueProvider", foreign_keys=[allocineVenueProviderId], backref="priceRules"
-=======
-    allocineVenueProvider: sa_orm.Mapped["AllocineVenueProvider"] = relationship(
         "AllocineVenueProvider", foreign_keys=[allocineVenueProviderId], back_populates="priceRules"
->>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     price: decimal.Decimal = sa.Column(
@@ -341,11 +313,7 @@ class StockDetail:
 class AllocinePivot(PcObject, Base, Model):
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=False, nullable=False, unique=True)
 
-<<<<<<< HEAD
-    venue: sa_orm.Mapped["Venue"] = sa_orm.relationship(Venue, foreign_keys=[venueId], backref="allocinePivot")
-=======
-    venue: sa_orm.Mapped["Venue"] = relationship(Venue, foreign_keys=[venueId], back_populates="allocinePivot")
->>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
+    venue: sa_orm.Mapped["Venue"] = sa_orm.relationship(Venue, foreign_keys=[venueId], back_populates="allocinePivot")
 
     theaterId: str = sa.Column(sa.String(20), nullable=False, unique=True)
 
@@ -385,7 +353,7 @@ class BoostCinemaDetails(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
     cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = sa_orm.relationship(
-        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], back_populates="BoostCinemaDetails", uselist=False
+        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], uselist=False
     )
     cinemaUrl: str = sa.Column(sa.Text, nullable=False)  # including http:// or https:// and trailing /
     username: str = sa.Column(sa.Text, nullable=False)
@@ -401,7 +369,7 @@ class CGRCinemaDetails(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
     cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = sa_orm.relationship(
-        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], back_populates="CGRCinemaDetails", uselist=False
+        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], uselist=False
     )
     cinemaUrl: str = sa.Column(sa.Text, nullable=False)
     numCinema: int = sa.Column(sa.Integer, nullable=True)
@@ -415,7 +383,7 @@ class EMSCinemaDetails(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
     cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = sa_orm.relationship(
-        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], back_populates="EMSCinemaDetails", uselist=False
+        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], uselist=False
     )
     lastVersion: int = sa.Column(sa.BigInteger, default=0, nullable=False)
 

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -118,8 +118,24 @@ class VenueProvider(PcObject, Base, Model, DeactivableMixin):
 
     providerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("provider.id"), index=True, nullable=False)
 
+<<<<<<< HEAD
     provider: sa_orm.Mapped["Provider"] = sa_orm.relationship(
         "Provider", foreign_keys=[providerId], backref="venueProviders"
+=======
+    provider: sa_orm.Mapped["Provider"] = relationship(
+        "Provider", foreign_keys=[providerId], back_populates="venueProviders"
+    )
+
+    venueIdAtOfferProvider: str = Column(String(70), nullable=True)
+
+    lastSyncDate = Column(DateTime, nullable=True)
+
+    # describe if synchronised offers are available for duo booking or not
+    isDuoOffers = Column(Boolean, nullable=True)
+
+    isFromAllocineProvider = column_property(  # type: ignore [misc]
+        exists(select(Provider.id).where(and_(Provider.id == providerId, Provider.localClass == "AllocineStocks")))
+>>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     venueIdAtOfferProvider: str = sa.Column(sa.String(70), nullable=True)
@@ -190,14 +206,24 @@ class CinemaProviderPivot(PcObject, Base, Model):
 
     venueId = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=False, nullable=True, unique=True)
 
+<<<<<<< HEAD
     venue: sa_orm.Mapped["Venue | None"] = sa_orm.relationship(
         Venue, foreign_keys=[venueId], backref="cinemaProviderPivot", uselist=False
+=======
+    venue: sa_orm.Mapped["Venue | None"] = relationship(
+        Venue, foreign_keys=[venueId], back_populates="cinemaProviderPivot", uselist=False
+>>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     providerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("provider.id"), nullable=False)
 
+<<<<<<< HEAD
     provider: sa_orm.Mapped["Provider"] = sa_orm.relationship(
         "Provider", foreign_keys=[providerId], backref="cinemaProviderPivots"
+=======
+    provider: sa_orm.Mapped["Provider"] = relationship(
+        "Provider", foreign_keys=[providerId], back_populates="cinemaProviderPivots"
+>>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     idAtProvider: str = sa.Column(sa.Text, nullable=False)
@@ -223,8 +249,13 @@ class CDSCinemaDetails(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
 
+<<<<<<< HEAD
     cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = sa_orm.relationship(
         CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], backref="CDSCinemaDetails", uselist=False
+=======
+    cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = relationship(
+        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], back_populates="CDSCinemaDetails", uselist=False
+>>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     cinemaApiToken: str = sa.Column(sa.Text, nullable=False)
@@ -255,8 +286,13 @@ class AllocineVenueProviderPriceRule(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("allocine_venue_provider.id"), index=True, nullable=False
     )
 
+<<<<<<< HEAD
     allocineVenueProvider: sa_orm.Mapped["AllocineVenueProvider"] = sa_orm.relationship(
         "AllocineVenueProvider", foreign_keys=[allocineVenueProviderId], backref="priceRules"
+=======
+    allocineVenueProvider: sa_orm.Mapped["AllocineVenueProvider"] = relationship(
+        "AllocineVenueProvider", foreign_keys=[allocineVenueProviderId], back_populates="priceRules"
+>>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
     )
 
     price: decimal.Decimal = sa.Column(
@@ -305,7 +341,11 @@ class StockDetail:
 class AllocinePivot(PcObject, Base, Model):
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=False, nullable=False, unique=True)
 
+<<<<<<< HEAD
     venue: sa_orm.Mapped["Venue"] = sa_orm.relationship(Venue, foreign_keys=[venueId], backref="allocinePivot")
+=======
+    venue: sa_orm.Mapped["Venue"] = relationship(Venue, foreign_keys=[venueId], back_populates="allocinePivot")
+>>>>>>> 40e1342593 ((PC-27819)[API] chore: remplace backref with back_populates)
 
     theaterId: str = sa.Column(sa.String(20), nullable=False, unique=True)
 
@@ -345,7 +385,7 @@ class BoostCinemaDetails(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
     cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = sa_orm.relationship(
-        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], backref="BoostCinemaDetails", uselist=False
+        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], back_populates="BoostCinemaDetails", uselist=False
     )
     cinemaUrl: str = sa.Column(sa.Text, nullable=False)  # including http:// or https:// and trailing /
     username: str = sa.Column(sa.Text, nullable=False)
@@ -361,7 +401,7 @@ class CGRCinemaDetails(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
     cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = sa_orm.relationship(
-        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], backref="CGRCinemaDetails", uselist=False
+        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], back_populates="CGRCinemaDetails", uselist=False
     )
     cinemaUrl: str = sa.Column(sa.Text, nullable=False)
     numCinema: int = sa.Column(sa.Integer, nullable=True)
@@ -375,7 +415,7 @@ class EMSCinemaDetails(PcObject, Base, Model):
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
     cinemaProviderPivot: sa_orm.Mapped["CinemaProviderPivot | None"] = sa_orm.relationship(
-        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], backref="EMSCinemaDetails", uselist=False
+        CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId], back_populates="EMSCinemaDetails", uselist=False
     )
     lastVersion: int = sa.Column(sa.BigInteger, default=0, nullable=False)
 

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -671,11 +671,11 @@ class Favorite(PcObject, Base, Model):
 
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=False)
 
-    user: orm.Mapped["User"] = orm.relationship("User", foreign_keys=[userId], backref="favorites")
+    user: orm.Mapped["User"] = orm.relationship("User", foreign_keys=[userId], back_populates="favorites")
 
     offerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id"), index=True, nullable=False)
 
-    offer: orm.Mapped["Offer"] = orm.relationship("Offer", foreign_keys=[offerId], backref="favorites")
+    offer: orm.Mapped["Offer"] = orm.relationship("Offer", foreign_keys=[offerId], back_populates="favorites")
 
     dateCreated = sa.Column(sa.DateTime, nullable=True, default=datetime.utcnow)
 
@@ -708,7 +708,7 @@ class UserEmailHistory(PcObject, Base, Model):
 
     userId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), index=True, nullable=True)
     user: sa.orm.Mapped["User"] = orm.relationship(
-        "User", foreign_keys=[userId], backref=orm.backref("email_history", passive_deletes=True)
+        "User", foreign_keys=[userId], back_populates="email_history", passive_deletes=True
     )
 
     oldUserEmail: str = sa.Column(sa.String(120), nullable=False, unique=False, index=True)

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -50,7 +50,7 @@ class BeneficiaryImport(PcObject, Base, Model):
         server_default=sa.text(EligibilityType.AGE18.name),  # TODO (viconnex) remove default values
     )
     beneficiary: sa_orm.Mapped["User"] = relationship(
-        "User", foreign_keys=[beneficiaryId], backref="beneficiaryImports"
+        "User", foreign_keys=[beneficiaryId], back_populates="beneficiaryImports"
     )
 
     @hybrid_property

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -52,6 +52,9 @@ class BeneficiaryImport(PcObject, Base, Model):
     beneficiary: sa_orm.Mapped["User"] = relationship(
         "User", foreign_keys=[beneficiaryId], back_populates="beneficiaryImports"
     )
+    statuses: sa_orm.Mapped[list["BeneficiaryImportStatus"]] = relationship(
+        "BeneficiaryImportStatus", back_populates="beneficiaryImport"
+    )
 
     @hybrid_property
     def currentStatus(self):

--- a/api/src/pcapi/models/beneficiary_import_status.py
+++ b/api/src/pcapi/models/beneficiary_import_status.py
@@ -55,7 +55,7 @@ class BeneficiaryImportStatus(PcObject, Base, Model):
     beneficiaryImportId: int = Column(BigInteger, ForeignKey("beneficiary_import.id"), index=True, nullable=False)
 
     beneficiaryImport: sa_orm.Mapped["BeneficiaryImport"] = relationship(
-        "BeneficiaryImport", foreign_keys=[beneficiaryImportId], backref="statuses"
+        "BeneficiaryImport", foreign_keys=[beneficiaryImportId], back_populates="statuses"
     )
 
     authorId = Column(BigInteger, ForeignKey("user.id"), nullable=True)


### PR DESCRIPTION
According to SQLAlchemy documentation, backref should be avoided in favor of back_populates, even with 1.4.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27819

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques