### PR TITLE
PC 27568 eac collective api add national programs rules

### DIFF
--- a/api/.squawk.toml
+++ b/api/.squawk.toml
@@ -9,5 +9,6 @@ excluded_rules = [
   "renaming-column",
   "prefer-identity",
   # every timestamp is stored as UTC, which is i18n best practice
-  "prefer-timestamptz"
+  "prefer-timestamptz",
+  "prefer-identity"
 ]

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-d118574a7888 (pre) (head)
+ba414c8b1ee4 (pre) (head)
 ce97cf13d894 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240205T120726_ba414c8b1ee4_add_domain_to_national_program_intermediate_table.py
+++ b/api/src/pcapi/alembic/versions/20240205T120726_ba414c8b1ee4_add_domain_to_national_program_intermediate_table.py
@@ -1,0 +1,38 @@
+"""add domain to national program intermediate table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "ba414c8b1ee4"
+down_revision = "d118574a7888"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "domain_to_national_program",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("domainId", sa.BigInteger(), nullable=False),
+        sa.Column("nationalProgramId", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["domainId"], ["educational_domain.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["nationalProgramId"], ["national_program.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("domainId", "nationalProgramId", name="unique_domain_to_national_program"),
+    )
+    op.create_index(
+        op.f("ix_domain_to_national_program_domainId"), "domain_to_national_program", ["domainId"], unique=False
+    )
+    op.create_index(
+        op.f("ix_domain_to_national_program_nationalProgramId"),
+        "domain_to_national_program",
+        ["nationalProgramId"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("domain_to_national_program")

--- a/api/src/pcapi/core/educational/api/national_program.py
+++ b/api/src/pcapi/core/educational/api/national_program.py
@@ -55,3 +55,25 @@ def get_national_program(program_id: int | None) -> models.NationalProgram | Non
         return None
 
     return models.NationalProgram.query.get(program_id)
+
+
+def link_domain_to_national_program_by_ids(domain_id: int, program_id: int, commit: bool = True) -> None:
+    domain = models.EducationalDomain.query.get(domain_id)
+    if not domain:
+        raise exceptions.EducationalDomainNotFound()
+
+    program = get_national_program(program_id)
+    if not program:
+        raise exceptions.NationalProgramNotFound()
+
+    link_domain_to_national_program(domain=domain, program=program, commit=commit)
+
+
+def link_domain_to_national_program(
+    domain: models.EducationalDomain, program: models.NationalProgram, commit: bool = True
+) -> None:
+    link = models.DomainToNationalProgram(domainId=domain.id, nationalProgramId=program.id)
+
+    db.session.add(link)
+    if commit:
+        db.session.commit()

--- a/api/src/pcapi/core/educational/api/national_program.py
+++ b/api/src/pcapi/core/educational/api/national_program.py
@@ -1,3 +1,7 @@
+import typing
+
+import sqlalchemy as sa
+
 from pcapi.core.educational import exceptions
 from pcapi.core.educational import models
 from pcapi.models import db
@@ -77,3 +81,10 @@ def link_domain_to_national_program(
     db.session.add(link)
     if commit:
         db.session.commit()
+
+
+def get_national_programs_from_domains(domain_ids: typing.Sequence[int]) -> typing.Sequence[models.NationalProgram]:
+    query = models.EducationalDomain.query.filter(models.EducationalDomain.id.in_(domain_ids)).options(
+        sa.orm.load_only(models.EducationalDomain.id).joinedload(models.EducationalDomain.nationalPrograms)
+    )
+    return [program for domain in query for program in domain.nationalPrograms]

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -31,6 +31,7 @@ from pcapi.core.offers import validation as offer_validation
 from pcapi.core.providers import models as providers_models
 from pcapi.core.users.models import User
 from pcapi.models import db
+from pcapi.models import feature
 from pcapi.models import offer_mixin
 from pcapi.models import validation_status_mixin
 from pcapi.routes.adage.v1.serialization import prebooking
@@ -482,6 +483,9 @@ def create_collective_offer_public(
     if not len(educational_domains) == len(body.domains):
         raise exceptions.EducationalDomainsNotFound()
 
+    if feature.FeatureToggle.WIP_ENABLE_NATIONAL_PROGRAM_NEW_RULES_PUBLIC_API.is_active():
+        offer_validation.validate_national_program(body.nationalProgramId, body.domains)
+
     institution = educational_repository.get_educational_institution_public(
         institution_id=body.educational_institution_id,
         uai=body.educational_institution,
@@ -595,6 +599,9 @@ def edit_collective_offer_public(
             domains = educational_repository.get_educational_domains_from_ids(value)
             if len(domains) != len(value):
                 raise exceptions.EducationalDomainsNotFound()
+
+            if feature.FeatureToggle.WIP_ENABLE_NATIONAL_PROGRAM_NEW_RULES_PUBLIC_API.is_active():
+                offer_validation.validate_national_program(new_values.get("nationalProgramId"), value)
             offer.domains = domains
         elif key in ("educationalInstitutionId", "educationalInstitution"):
             if value is not None:

--- a/api/src/pcapi/core/educational/exceptions.py
+++ b/api/src/pcapi/core/educational/exceptions.py
@@ -103,6 +103,10 @@ class EducationalDomainsNotFound(Exception):
     pass
 
 
+class EducationalDomainNotFound(Exception):
+    pass
+
+
 class EducationalInstitutionNotFound(Exception):
     pass
 

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1074,7 +1074,11 @@ def get_query_for_collective_offers_template_by_ids_for_user(user: User, ids: It
 
 
 def get_educational_domains_from_ids(ids: Iterable[int]) -> list[educational_models.EducationalDomain]:
-    return educational_models.EducationalDomain.query.filter(educational_models.EducationalDomain.id.in_(ids)).all()
+    return (
+        educational_models.EducationalDomain.query.filter(educational_models.EducationalDomain.id.in_(ids))
+        .options(sa.orm.joinedload(educational_models.EducationalDomain.nationalPrograms))
+        .all()
+    )
 
 
 def get_all_educational_domains_ordered_by_name() -> list[educational_models.EducationalDomain]:

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -118,6 +118,9 @@ class FeatureToggle(enum.Enum):
     WIP_PARTNER_PAGE = 'Activer la nouvelle version des pages "Partenaire"'
     WIP_ENABLE_PRO_SIDE_NAV = "Refonte de la navigation de l'app pro"
     WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN = "Activer le nouveau design des offres sur adage"
+    WIP_ENABLE_NATIONAL_PROGRAM_NEW_RULES_PUBLIC_API = (
+        "Activer les nouvelles règles de création et d'édition d'offres collecrives pour l'API publique (collective)"
+    )
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -190,6 +193,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
 if settings.IS_PROD or settings.IS_STAGING:
     FEATURES_DISABLED_BY_DEFAULT += (FeatureToggle.WIP_ENABLE_OFFER_CREATION_API_V1,)
     FEATURES_DISABLED_BY_DEFAULT += (FeatureToggle.WIP_ENABLE_FINANCE_INCIDENT,)
+    FEATURES_DISABLED_BY_DEFAULT += (FeatureToggle.WIP_ENABLE_NATIONAL_PROGRAM_NEW_RULES_PUBLIC_API,)
 
 if settings.IS_TESTING:
     testing_features_disabled_by_default = set(FEATURES_DISABLED_BY_DEFAULT)

--- a/api/src/pcapi/routes/public/collective/endpoints/domains.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/domains.py
@@ -32,7 +32,7 @@ def list_educational_domains() -> domains_serialization.CollectiveOffersListDoma
 
     return domains_serialization.CollectiveOffersListDomainsResponseModel(
         __root__=[
-            domains_serialization.CollectiveOffersDomainResponseModel.from_orm(educational_domain)
+            domains_serialization.CollectiveOffersDomainResponseModel.build(educational_domain)
             for educational_domain in educational_domains
         ]
     )

--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -148,6 +148,7 @@ def post_collective_offer_public(
     # in French, to be used by Swagger for the API documentation
     """Création d'une offre collective."""
     image_as_bytes = None
+
     if body.image_file:
         try:
             image_as_bytes = utils.get_bytes_from_base64_string(body.image_file)
@@ -251,6 +252,8 @@ def post_collective_offer_public(
             errors={"subcategoryId": ["La sous-catégorie n'est pas éligible pour les offres collectives."]},
             status_code=404,
         )
+    except offers_validation.OfferValidationError as err:
+        raise ApiErrors(errors={err.field: err.msg}, status_code=400)
 
     if image_as_bytes and body.image_credit is not None:
         educational_api_offer.attach_image(
@@ -555,6 +558,8 @@ def patch_collective_offer_public(
             },
             status_code=403,
         )
+    except offers_validation.OfferValidationError as err:
+        raise ApiErrors(errors={err.field: err.msg}, status_code=400)
 
     if image_as_bytes and offer.imageCredit is not None:
         educational_api_offer.attach_image(

--- a/api/src/pcapi/routes/public/collective/serialization/domains.py
+++ b/api/src/pcapi/routes/public/collective/serialization/domains.py
@@ -1,12 +1,22 @@
+import typing
+
+from pcapi.core.educational import models
 from pcapi.routes.serialization import BaseModel
+from pcapi.routes.serialization.national_programs import NationalProgramModel
 
 
 class CollectiveOffersDomainResponseModel(BaseModel):
     id: int
     name: str
+    nationalPrograms: typing.Sequence[NationalProgramModel]
 
     class Config:
         orm_mode = True
+
+    @classmethod
+    def build(cls, domain: models.EducationalDomain) -> "CollectiveOffersDomainResponseModel":
+        programs = [NationalProgramModel(id=program.id, name=program.name) for program in domain.nationalPrograms]
+        return cls(id=domain.id, name=domain.name, nationalPrograms=programs)
 
 
 class CollectiveOffersListDomainsResponseModel(BaseModel):

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from datetime import timedelta
 from itertools import count
 from itertools import cycle
+import typing
 
 from pcapi.core.categories.subcategories_v2 import EacFormat
 from pcapi.core.educational import factories as educational_factories
@@ -23,9 +24,9 @@ def create_offers(
     offerers: list[offerers_models.Offerer], institutions: list[educational_models.EducationalInstitution]
 ) -> None:
     reset_offer_id_seq()
-    domains = create_domains()
-    offerers_iterator = iter(offerers)
     national_programs = create_national_programs()
+    domains = create_domains(national_programs)
+    offerers_iterator = iter(offerers)
 
     # eac_1
     offerer = next(offerers_iterator)
@@ -472,25 +473,59 @@ def create_booking_base_list(
             )
 
 
-def create_domains() -> list[educational_models.EducationalDomain]:
+def create_domains(
+    national_programs: typing.Sequence[educational_models.NationalProgram],
+) -> list[educational_models.EducationalDomain]:
+    college_au_cinema = [np for np in national_programs if np.id == 1]
+    lyceens_apprentis_au_cinema = [np for np in national_programs if np.id == 3]
+    olympiade_culturelle = [np for np in national_programs if np.id == 4]
+    jeunes_en_librairie = [np for np in national_programs if np.id == 6]
     return [
-        educational_factories.EducationalDomainFactory(name="Architecture", id=1),
-        educational_factories.EducationalDomainFactory(name="Arts du cirque et arts de la rue", id=2),
-        educational_factories.EducationalDomainFactory(name="Arts numériques", id=4),
-        educational_factories.EducationalDomainFactory(name="Arts visuels, arts plastiques, arts appliqués", id=5),
-        educational_factories.EducationalDomainFactory(name="Cinéma, audiovisuel", id=6),
-        educational_factories.EducationalDomainFactory(name="Culture scientifique, technique et industrielle", id=7),
-        educational_factories.EducationalDomainFactory(name="Danse", id=8),
-        educational_factories.EducationalDomainFactory(name="Design", id=9),
-        educational_factories.EducationalDomainFactory(name="Développement durable", id=10),
-        educational_factories.EducationalDomainFactory(name="Univers du livre, de la lecture et des écritures", id=11),
-        educational_factories.EducationalDomainFactory(name="Musique", id=12),
-        educational_factories.EducationalDomainFactory(name="Patrimoine", id=13),
-        educational_factories.EducationalDomainFactory(name="Photographie", id=14),
-        educational_factories.EducationalDomainFactory(name="Théâtre, expression dramatique, marionnettes", id=15),
-        educational_factories.EducationalDomainFactory(name="Bande dessinée", id=16),
-        educational_factories.EducationalDomainFactory(name="Média et information", id=17),
-        educational_factories.EducationalDomainFactory(name="Mémoire", id=18),
+        educational_factories.EducationalDomainFactory(
+            name="Architecture", id=1, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Arts du cirque et arts de la rue", id=2, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Arts numériques", id=4, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Arts visuels, arts plastiques, arts appliqués", id=5, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Cinéma, audiovisuel",
+            id=6,
+            nationalPrograms=college_au_cinema + lyceens_apprentis_au_cinema,
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Culture scientifique, technique et industrielle", id=7, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(name="Danse", id=8, nationalPrograms=olympiade_culturelle),
+        educational_factories.EducationalDomainFactory(name="Design", id=9, nationalPrograms=olympiade_culturelle),
+        educational_factories.EducationalDomainFactory(
+            name="Développement durable", id=10, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Univers du livre, de la lecture et des écritures",
+            id=11,
+            nationalPrograms=jeunes_en_librairie,
+        ),
+        educational_factories.EducationalDomainFactory(name="Musique", id=12, nationalPrograms=olympiade_culturelle),
+        educational_factories.EducationalDomainFactory(name="Patrimoine", id=13, nationalPrograms=olympiade_culturelle),
+        educational_factories.EducationalDomainFactory(
+            name="Photographie", id=14, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Théâtre, expression dramatique, marionnettes", id=15, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Bande dessinée", id=16, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(
+            name="Média et information", id=17, nationalPrograms=olympiade_culturelle
+        ),
+        educational_factories.EducationalDomainFactory(name="Mémoire", id=18, nationalPrograms=olympiade_culturelle),
     ]
 
 
@@ -500,6 +535,7 @@ def create_national_programs() -> list[educational_models.NationalProgram]:
         educational_factories.NationalProgramFactory(name="Lycéens et apprentis au cinéma", id=3),
         educational_factories.NationalProgramFactory(name="L’Olympiade culturelle", id=4),
         educational_factories.NationalProgramFactory(name="Théâtre au collège", id=5),
+        educational_factories.NationalProgramFactory(name="Jeunes en librairie", id=6),
     ]
 
 

--- a/api/tests/core/educational/api/test_national_program.py
+++ b/api/tests/core/educational/api/test_national_program.py
@@ -1,0 +1,37 @@
+import pytest
+
+from pcapi.core.educational import factories
+import pcapi.core.educational.api.national_program as api
+from pcapi.core.testing import assert_num_queries
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class GetNationalProgramFromDomainsTest:
+    def test_get_programs(self):
+        program = factories.NationalProgramFactory()
+        domain_id = factories.EducationalDomainFactory(nationalPrograms=[program]).id
+
+        with assert_num_queries(1):
+            programs = api.get_national_programs_from_domains([domain_id])
+
+            assert len(programs) == 1
+            assert programs[0].id == program.id
+
+    def test_no_programs(self):
+        domain_id = factories.EducationalDomainFactory(nationalPrograms=[]).id
+
+        with assert_num_queries(1):
+            programs = api.get_national_programs_from_domains([domain_id])
+            assert not programs
+
+    def test_no_domains(self):
+        with assert_num_queries(1):
+            programs = api.get_national_programs_from_domains([])
+            assert not programs
+
+    def test_unknown_domain(self):
+        with assert_num_queries(1):
+            programs = api.get_national_programs_from_domains([-1])
+            assert not programs

--- a/api/tests/routes/public/blueprint_v2_openapi_test.py
+++ b/api/tests/routes/public/blueprint_v2_openapi_test.py
@@ -75,8 +75,13 @@ def test_public_api(client, app):
                     "properties": {
                         "id": {"title": "Id", "type": "integer"},
                         "name": {"title": "Name", "type": "string"},
+                        "nationalPrograms": {
+                            "items": {"$ref": "#/components/schemas/NationalProgramModel"},
+                            "title": "Nationalprograms",
+                            "type": "array",
+                        },
                     },
-                    "required": ["id", "name"],
+                    "required": ["id", "name", "nationalPrograms"],
                     "title": "CollectiveOffersDomainResponseModel",
                     "type": "object",
                 },
@@ -1353,41 +1358,31 @@ def test_public_api(client, app):
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/AuthErrorResponseModel"}}
                             },
-                            "description": "Authentification " "nécessaire",
+                            "description": "Authentification nécessaire",
                         },
                         "403": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "Vous "
-                            "n'avez "
-                            "pas "
-                            "les "
-                            "droits "
-                            "nécessaires "
-                            "pour "
-                            "voir "
-                            "cette "
-                            "offre "
-                            "collective",
+                            "description": "Vous n'avez pas les droits nécessaires pour voir cette offre collective",
                         },
                         "404": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponseModel"}}
                             },
-                            "description": "L'offre " "collective " "n'existe " "pas",
+                            "description": "L'offre collective n'existe pas",
                         },
                         "422": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
                             },
-                            "description": "Unprocessable " "Entity",
+                            "description": "Unprocessable Entity",
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "Liste des " "formats " "d'offres " "collectives",
+                    "summary": "Liste des formats d'offres collectives",
                     "tags": ["API offres collectives"],
-                },
+                }
             },
             "/v2/collective/offers/{offer_id}": {
                 "get": {

--- a/api/tests/routes/public/collective/endpoints/get_collective_offers_educational_domains_test.py
+++ b/api/tests/routes/public/collective/endpoints/get_collective_offers_educational_domains_test.py
@@ -14,7 +14,9 @@ class CollectiveOffersGetEducationalDomainsTest:
         offerer = offerers_factories.OffererFactory()
         offerers_factories.ApiKeyFactory(offerer=offerer)
 
-        domain1 = educational_factories.EducationalDomainFactory(name="Arts numériques")
+        programs = educational_factories.NationalProgramFactory.create_batch(2)
+
+        domain1 = educational_factories.EducationalDomainFactory(name="Arts numériques", nationalPrograms=programs)
         domain2 = educational_factories.EducationalDomainFactory(name="Cinéma, audiovisuel")
 
         # When
@@ -26,9 +28,10 @@ class CollectiveOffersGetEducationalDomainsTest:
         assert response.status_code == 200
 
         response_list = sorted(response.json, key=itemgetter("id"))
+        domain1_programs = [{"id": p.id, "name": p.name} for p in programs]
         assert response_list == [
-            {"id": domain1.id, "name": "Arts numériques"},
-            {"id": domain2.id, "name": "Cinéma, audiovisuel"},
+            {"id": domain1.id, "name": "Arts numériques", "nationalPrograms": domain1_programs},
+            {"id": domain2.id, "name": "Cinéma, audiovisuel", "nationalPrograms": []},
         ]
 
     def test_list_educational_domains_empty(self, client):

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
@@ -42,7 +42,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         national_program = educational_factories.NationalProgramFactory()
 
-        domain = educational_factories.EducationalDomainFactory()
+        domain = educational_factories.EducationalDomainFactory(nationalPrograms=[national_program])
         educational_institution = educational_factories.EducationalInstitutionFactory()
         offer = educational_factories.CollectiveOfferFactory(
             imageCredit="pouet",

--- a/pro/src/apiClient/v2/models/CollectiveOffersDomainResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersDomainResponseModel.ts
@@ -2,8 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { NationalProgramModel } from './NationalProgramModel';
 export type CollectiveOffersDomainResponseModel = {
   id: number;
   name: string;
+  nationalPrograms: Array<NationalProgramModel>;
 };
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27568

Retranscrire côté api publique des règles qui ont été implémentées sur le portail pro, côté front, au sujet de la création et de l'édition d'offres collectives. A présent, les dispositifs nationaux sont rattachés à des domaines éducatifs et une offre ne peut donc plus être créée ou éditée s'il y a une incohérence entre les domaines et le dispositif national.

## Implémentation

1. Ajout d'une table permettant de faire le lien entre des domaines et des dispositifs nationaux.
2. Mise à jour de la route des domaines éducatifs de l'api publique collective : un champ `nationalPrograms` fait son apparition dans chaque objet renvoyé.
3. Vérification lors de la création et de l'édition d'une offre collective que les données envoyées par le client sont bien cohérentes (pas de dispositif national non rattaché aux domaines indiqués).

## Raisons

Il aurait été possible et plus simple au premier abord d'ajouter un dict qui se chargerait d'établir un lien entre domaines et dispositifs. Il faudrait alors se baser sur des données en (majeure) partie en base de données et en partie dans le code. Les liens ont peu de chances de changer et d'évoluer, et sans urgence dans tous les cas... toutefois :

1. il serait plus compliqué de déterminer les liens entre domaines et dispositifs en SQL ;
2. on détectera moins bien une faute de frappe, ou un oubli.

Et s'il n'y a rien d'indispensables là-dedans, il me semblait que le léger surcoût lié à cette approche permet au moins d'éviter de se disperser : toutes les données sont en base et on peut toujours dire à tel instant quels sont les liens existant.

## Remplir la nouvelle table

Un script est disponible dans le ticket JIRA.