### PR TITLE
(PC-25233)[PRO] fix: Création d'offre, récap & confirmation - revoir hiérarchie des titres

### DIFF
--- a/pro/src/components/AccessibilitySummarySection/AccessibilitySummarySection.tsx
+++ b/pro/src/components/AccessibilitySummarySection/AccessibilitySummarySection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import { AccessiblityEnum } from 'core/shared'
 import { AccessibilityLabel } from 'ui-kit/AccessibilityLabel'
 
@@ -21,10 +22,8 @@ const AccessibilitySummarySection = ({
   motorDisabilityCompliant,
   audioDisabilityCompliant,
 }: AccessibilitySummarySectionProps) => (
-  <SummaryLayout.SubSection title="Accessibilité">
-    {noDisabilityCompliance && (
-      <SummaryLayout.Row description="Non accessible" />
-    )}
+  <SummarySubSection title="Accessibilité">
+    {noDisabilityCompliance && <SummaryRow description="Non accessible" />}
     {visualDisabilityCompliant && (
       <AccessibilityLabel
         className={styles['accessibility-row']}
@@ -49,7 +48,7 @@ const AccessibilitySummarySection = ({
         name={AccessiblityEnum.AUDIO}
       />
     )}
-  </SummaryLayout.SubSection>
+  </SummarySubSection>
 )
 
 export default AccessibilitySummarySection

--- a/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
+++ b/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 
 import BannerPublicApi from 'components/Banner/BannerPublicApi'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryContent } from 'components/SummaryLayout/SummaryContent'
+import { SummaryLayout } from 'components/SummaryLayout/SummaryLayout'
+import { SummarySection } from 'components/SummaryLayout/SummarySection'
 import {
   CollectiveOffer,
   CollectiveOfferTemplate,
@@ -43,14 +45,14 @@ const CollectiveOfferSummary = ({
   return (
     <>
       <SummaryLayout>
-        <SummaryLayout.Content fullWidth>
+        <SummaryContent fullWidth>
           {isCollectiveOffer(offer) && offer.isPublicApi && (
             <BannerPublicApi className={styles['banner-space']}>
               Offre créée par votre outil de billetterie via l’API offres
               collectives
             </BannerPublicApi>
           )}
-          <SummaryLayout.Section
+          <SummarySection
             title="Détails de l’offre"
             editLink={
               offerManuallyCreated || offer.isTemplate ? offerEditLink : ''
@@ -73,10 +75,10 @@ const CollectiveOfferSummary = ({
                 bookingEmails={offer.bookingEmails}
               />
             )}
-          </SummaryLayout.Section>
+          </SummarySection>
 
           {!offer.isTemplate && (
-            <SummaryLayout.Section
+            <SummarySection
               title="Date & Prix"
               editLink={
                 offerManuallyCreated || offer.isTemplate ? stockEditLink : ''
@@ -86,11 +88,11 @@ const CollectiveOfferSummary = ({
                 stock={offer.collectiveStock}
                 venueDepartmentCode={offer.venue.departementCode}
               />
-            </SummaryLayout.Section>
+            </SummarySection>
           )}
 
           {!offer.isTemplate && (
-            <SummaryLayout.Section
+            <SummarySection
               title={'Établissement et enseignant'}
               editLink={
                 offerManuallyCreated || offer.isTemplate
@@ -102,9 +104,9 @@ const CollectiveOfferSummary = ({
                 institution={offer.institution}
                 teacher={offer.teacher}
               />
-            </SummaryLayout.Section>
+            </SummarySection>
           )}
-        </SummaryLayout.Content>
+        </SummaryContent>
       </SummaryLayout>
     </>
   )

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferContactSection/CollectiveOfferContactSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferContactSection/CollectiveOfferContactSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 
 interface CollectiveOfferContactSectionProps {
   phone?: string | null
@@ -12,10 +13,10 @@ const CollectiveOfferContactSection = ({
   email,
 }: CollectiveOfferContactSectionProps) => {
   return (
-    <SummaryLayout.SubSection title="Contact">
-      <SummaryLayout.Row title="Téléphone" description={phone} />
-      <SummaryLayout.Row title="Email" description={email} />
-    </SummaryLayout.SubSection>
+    <SummarySubSection title="Contact">
+      <SummaryRow title="Téléphone" description={phone} />
+      <SummaryRow title="Email" description={email} />
+    </SummarySubSection>
   )
 }
 

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/CollectiveOfferDateSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection/CollectiveOfferDateSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import { CollectiveOfferTemplate } from 'core/OfferEducational'
 import { getRangeToFrenchText, toDateStrippedOfTimezone } from 'utils/date'
 
@@ -21,8 +22,8 @@ export default function CollectiveOfferDateSection({
   }
 
   return (
-    <SummaryLayout.SubSection title="Date et heure">
-      <SummaryLayout.Row description={description} />
-    </SummaryLayout.SubSection>
+    <SummarySubSection title="Date et heure">
+      <SummaryRow description={description} />
+    </SummarySubSection>
   )
 }

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferImagePreview/CollectiveOfferImagePreview.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferImagePreview/CollectiveOfferImagePreview.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames'
 import React from 'react'
 
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import { CollectiveOfferTemplate, CollectiveOffer } from 'core/OfferEducational'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -16,7 +16,7 @@ const CollectiveOfferImagePreview = ({
   offer,
 }: CollectiveOfferImagePreviewProps): JSX.Element => {
   return (
-    <SummaryLayout.SubSection title="Image de l’offre">
+    <SummarySubSection title="Image de l’offre">
       {offer?.imageUrl ? (
         <img
           alt={offer.name}
@@ -28,7 +28,7 @@ const CollectiveOfferImagePreview = ({
           <SvgIcon alt={offer.name} src={strokeOfferIcon} />
         </div>
       )}
-    </SummaryLayout.SubSection>
+    </SummarySubSection>
   )
 }
 

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferLocationSection/CollectiveOfferLocationSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferLocationSection/CollectiveOfferLocationSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import { CollectiveOffer, CollectiveOfferTemplate } from 'core/OfferEducational'
 import { useGetVenue } from 'core/Venue/adapters/getVenueAdapter'
 import useNotification from 'hooks/useNotification'
@@ -30,16 +31,16 @@ export default function CollectiveOfferLocationSection({
   }
 
   return (
-    <SummaryLayout.SubSection title="Lieu de l’évènement">
-      <SummaryLayout.Row
+    <SummarySubSection title="Lieu de l’évènement">
+      <SummaryRow
         description={formatOfferEventAddress(offer.offerVenue, venue)}
       />
       {interventionAreas && (
-        <SummaryLayout.Row
+        <SummaryRow
           title="Zone de mobilité pour l’évènement"
           description={interventionAreas}
         />
       )}
-    </SummaryLayout.SubSection>
+    </SummarySubSection>
   )
 }

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferNotificationSection/CollectiveOfferNotificationSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferNotificationSection/CollectiveOfferNotificationSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 
 interface CollectiveOfferNotificationSectionProps {
   bookingEmails: string[]
@@ -10,11 +11,11 @@ const CollectiveOfferNotificationSection = ({
   bookingEmails,
 }: CollectiveOfferNotificationSectionProps) => {
   return (
-    <SummaryLayout.SubSection title="Notifications des réservations">
+    <SummarySubSection title="Notifications des réservations">
       {bookingEmails.map((email) => (
-        <SummaryLayout.Row description={email} key={email} />
+        <SummaryRow description={email} key={email} />
       ))}
-    </SummaryLayout.SubSection>
+    </SummarySubSection>
   )
 }
 

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferParticipantSection/CollectiveOfferParticipantSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferParticipantSection/CollectiveOfferParticipantSection.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
 import { StudentLevels } from 'apiClient/v1'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 
 interface CollectiveOfferParticipantSectionProps {
   students: StudentLevels[]
@@ -11,11 +12,11 @@ const CollectiveOfferParticipantSection = ({
   students,
 }: CollectiveOfferParticipantSectionProps) => {
   return (
-    <SummaryLayout.SubSection title="Participants">
+    <SummarySubSection title="Participants">
       {students.map((student) => (
-        <SummaryLayout.Row description={student} key={student} />
+        <SummaryRow description={student} key={student} />
       ))}
-    </SummaryLayout.SubSection>
+    </SummarySubSection>
   )
 }
 

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPriceSection/CollectiveOfferPriceSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPriceSection/CollectiveOfferPriceSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import { CollectiveOfferTemplate } from 'core/OfferEducational'
 
 import { DEFAULT_RECAP_VALUE } from '../constants'
@@ -13,10 +14,10 @@ export default function CollectiveOfferPriceSection({
   offer,
 }: CollectiveOfferPriceSectionProps) {
   return (
-    <SummaryLayout.SubSection title="Prix">
-      <SummaryLayout.Row
+    <SummarySubSection title="Prix">
+      <SummaryRow
         description={offer.educationalPriceDetail || DEFAULT_RECAP_VALUE}
       />
-    </SummaryLayout.SubSection>
+    </SummarySubSection>
   )
 }

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferStockSection/CollectiveOfferStockSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferStockSection/CollectiveOfferStockSection.tsx
@@ -2,7 +2,7 @@ import format from 'date-fns/format'
 import React from 'react'
 
 import { GetCollectiveOfferCollectiveStockResponseModel } from 'apiClient/v1'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
 import { TOTAL_PRICE_LABEL } from 'screens/OfferEducationalStock/constants/labels'
 import { FORMAT_DD_MM_YYYY, FORMAT_HH_mm } from 'utils/date'
 import { getLocalDepartementDateTimeFromUtc } from 'utils/timezone'
@@ -31,7 +31,7 @@ const CollectiveOfferStockSection = ({
   /* istanbul ignore next: DEBT, TO FIX */
   return (
     <>
-      <SummaryLayout.Row
+      <SummaryRow
         title="Date"
         description={
           (stock?.beginningDatetime &&
@@ -39,7 +39,7 @@ const CollectiveOfferStockSection = ({
           DEFAULT_RECAP_VALUE
         }
       />
-      <SummaryLayout.Row
+      <SummaryRow
         title="Horaire"
         description={
           (stock?.beginningDatetime &&
@@ -47,15 +47,12 @@ const CollectiveOfferStockSection = ({
           DEFAULT_RECAP_VALUE
         }
       />
-      <SummaryLayout.Row
+      <SummaryRow
         title="Nombre de participants"
         description={stock?.numberOfTickets || DEFAULT_RECAP_VALUE}
       />
-      <SummaryLayout.Row
-        title={TOTAL_PRICE_LABEL}
-        description={`${stock?.price}€`}
-      />
-      <SummaryLayout.Row
+      <SummaryRow title={TOTAL_PRICE_LABEL} description={`${stock?.price}€`} />
+      <SummaryRow
         title="Date limite de réservation"
         description={
           (stock?.bookingLimitDatetime &&
@@ -63,7 +60,7 @@ const CollectiveOfferStockSection = ({
           DEFAULT_RECAP_VALUE
         }
       />
-      <SummaryLayout.Row
+      <SummaryRow
         title="Détails"
         description={stock?.educationalPriceDetail || DEFAULT_RECAP_VALUE}
       />

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferTypeSection/CollectiveOfferTypeSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferTypeSection/CollectiveOfferTypeSection.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import {
   CollectiveOffer,
   CollectiveOfferTemplate,
@@ -40,45 +41,45 @@ export default function CollectiveOfferTypeSection({
   const isFormatActive = useActiveFeature('WIP_ENABLE_FORMAT')
   return (
     <>
-      <SummaryLayout.SubSection title="Type d’offre">
+      <SummarySubSection title="Type d’offre">
         {isFormatActive ? (
-          <SummaryLayout.Row
+          <SummaryRow
             title="Format"
             description={offer.formats?.join(', ') || DEFAULT_RECAP_VALUE}
           />
         ) : (
           <>
-            <SummaryLayout.Row
+            <SummaryRow
               title="Catégorie"
               description={category?.label || DEFAULT_RECAP_VALUE}
             />
-            <SummaryLayout.Row
+            <SummaryRow
               title="Sous-catégorie"
               description={subCategory?.label || DEFAULT_RECAP_VALUE}
             />
           </>
         )}
 
-        <SummaryLayout.Row
+        <SummaryRow
           title="Domaine artistique et culturel"
           description={offer.domains.map((domain) => domain.name).join(', ')}
         />
-        <SummaryLayout.Row
+        <SummaryRow
           title="Dispositif national"
           description={offer.nationalProgram?.name || DEFAULT_RECAP_VALUE}
         />
-      </SummaryLayout.SubSection>
-      <SummaryLayout.SubSection title="Informations artistiques">
-        <SummaryLayout.Row title="Titre de l’offre" description={offer.name} />
-        <SummaryLayout.Row
+      </SummarySubSection>
+      <SummarySubSection title="Informations artistiques">
+        <SummaryRow title="Titre de l’offre" description={offer.name} />
+        <SummaryRow
           title="Description"
           description={offer.description || DEFAULT_RECAP_VALUE}
         />
-        <SummaryLayout.Row
+        <SummaryRow
           title="Durée"
           description={formatDuration(offer.durationMinutes)}
         />
-      </SummaryLayout.SubSection>
+      </SummarySubSection>
     </>
   )
 }

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferVenueSection/CollectiveOfferVenueSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferVenueSection/CollectiveOfferVenueSection.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
 import { GetCollectiveOfferVenueResponseModel } from 'apiClient/v1'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 
 interface CollectiveOfferSummaryProps {
   venue: GetCollectiveOfferVenueResponseModel
@@ -11,16 +12,10 @@ const CollectiveOfferVenueSection = ({
   venue,
 }: CollectiveOfferSummaryProps) => {
   return (
-    <SummaryLayout.SubSection title="Lieu de rattachement de votre offre">
-      <SummaryLayout.Row
-        title="Structure"
-        description={venue.managingOfferer.name}
-      />
-      <SummaryLayout.Row
-        title="Lieu"
-        description={venue.publicName || venue.name}
-      />
-    </SummaryLayout.SubSection>
+    <SummarySubSection title="Lieu de rattachement de votre offre">
+      <SummaryRow title="Structure" description={venue.managingOfferer.name} />
+      <SummaryRow title="Lieu" description={venue.publicName || venue.name} />
+    </SummarySubSection>
   )
 }
 

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferVisibilitySection/CollectiveOfferVisibilitySection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferVisibilitySection/CollectiveOfferVisibilitySection.tsx
@@ -4,7 +4,7 @@ import {
   EducationalInstitutionResponseModel,
   EducationalRedactorResponseModel,
 } from 'apiClient/v1'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
 
 interface CollectiveOfferStockSectionProps {
   institution?: EducationalInstitutionResponseModel | null
@@ -35,12 +35,12 @@ const CollectiveOfferStockSection = ({
 
   return (
     <>
-      <SummaryLayout.Row
+      <SummaryRow
         title="Établissement scolaire auquel vous adressez votre offre"
         description={getVisibilityDescription(institution)}
       />
       {teacher && (
-        <SummaryLayout.Row
+        <SummaryRow
           title="Enseignant avec qui vous avez construit cette offre"
           description={
             <div>

--- a/pro/src/components/SummaryLayout/SummaryAside.tsx
+++ b/pro/src/components/SummaryLayout/SummaryAside.tsx
@@ -8,8 +8,9 @@ interface SummaryLayoutSideProps {
   children?: React.ReactNode | React.ReactNode[]
 }
 
-const Side = ({ className, children }: SummaryLayoutSideProps): JSX.Element => (
+export const SummaryAside = ({
+  className,
+  children,
+}: SummaryLayoutSideProps): JSX.Element => (
   <div className={cn(style['summary-layout-side'], className)}>{children}</div>
 )
-
-export default Side

--- a/pro/src/components/SummaryLayout/SummaryContent.tsx
+++ b/pro/src/components/SummaryLayout/SummaryContent.tsx
@@ -9,7 +9,7 @@ interface SummaryLayoutContentProps {
   fullWidth?: boolean
 }
 
-const Content = ({
+export const SummaryContent = ({
   className,
   children,
   fullWidth = false,
@@ -22,5 +22,3 @@ const Content = ({
     {children}
   </div>
 )
-
-export default Content

--- a/pro/src/components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/components/SummaryLayout/SummaryLayout.module.scss
@@ -1,6 +1,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/variables/_colors.scss" as colors;
 @use "styles/variables/_size.scss" as size;
+@use "styles/mixins/_fonts.scss" as fonts;
 
 .summary-layout {
   display: flex;
@@ -51,6 +52,8 @@
     margin-bottom: rem.torem(24px);
 
     &-title {
+      @include fonts.title4;
+
       margin-bottom: rem.torem(8px);
     }
 
@@ -92,4 +95,8 @@
       margin-bottom: 0;
     }
   }
+}
+
+.section-title {
+  @include fonts.title3;
 }

--- a/pro/src/components/SummaryLayout/SummaryLayout.stories.tsx
+++ b/pro/src/components/SummaryLayout/SummaryLayout.stories.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { withRouter } from 'storybook-addon-react-router-v6'
 
-import { SummaryLayout } from '.'
+import { SummaryContent } from './SummaryContent'
+import { SummaryLayout } from './SummaryLayout'
+import { SummaryRow } from './SummaryRow'
+import { SummarySection } from './SummarySection'
+import { SummarySubSection } from './SummarySubSection'
 
 export default {
   title: 'components/SummaryLayout',
@@ -12,41 +16,41 @@ export default {
 const Template = () => (
   <div style={{ width: 780 }}>
     <SummaryLayout>
-      <SummaryLayout.Content>
-        <SummaryLayout.Section title="Lorem ipsum dolor sit amet" editLink="/">
-          <SummaryLayout.SubSection title="Sub section title">
-            <SummaryLayout.Row
+      <SummaryContent>
+        <SummarySection title="Lorem ipsum dolor sit amet" editLink="/">
+          <SummarySubSection title="Sub section title">
+            <SummaryRow
               description="Lorem ipsum dolor sit amet. Et libero officia 33 perferendis quam ut tempore quos hic dolorum? Hic repellat nemo facilis magnam aut eaque fuga ex magnam cupiditate eos consequatur repellat. Cum enim repellendus qui omnis impedit et autem quod rem libero officiis est rerum possimus."
               title="Lorem"
             />
-          </SummaryLayout.SubSection>
-        </SummaryLayout.Section>
-        <SummaryLayout.Section title="Lorem ipsum dolor sit amet" editLink="/">
-          <SummaryLayout.SubSection title="Sub section title">
-            <SummaryLayout.Row
+          </SummarySubSection>
+        </SummarySection>
+        <SummarySection title="Lorem ipsum dolor sit amet" editLink="/">
+          <SummarySubSection title="Sub section title">
+            <SummaryRow
               description="Description  : Lorem ipsum dolor sit amet. Et libero officia 33 perferendis quam ut tempore quos hic dolorum? Hic repellat nemo facilis magnam aut eaque fuga ex magnam cupiditate eos consequatur repellat. Cum enim repellendus qui omnis impedit et autem quod rem libero officiis est rerum possimus."
               title="Lorem"
             />
-            <SummaryLayout.Row
+            <SummaryRow
               description="Lorem ipsum dolor sit amet"
               title="Lorem"
             />
-          </SummaryLayout.SubSection>
-          <SummaryLayout.SubSection title="Sub section title">
-            <SummaryLayout.Row description="Pas de titre" />
-          </SummaryLayout.SubSection>
-          <SummaryLayout.SubSection title="Sub section title">
-            <SummaryLayout.Row
+          </SummarySubSection>
+          <SummarySubSection title="Sub section title">
+            <SummaryRow description="Pas de titre" />
+          </SummarySubSection>
+          <SummarySubSection title="Sub section title">
+            <SummaryRow
               description="Description  : Lorem ipsum dolor sit amet. Et libero officia 33 perferendis quam ut tempore quos hic dolorum? Hic repellat nemo facilis magnam aut eaque fuga ex magnam cupiditate eos consequatur repellat. Cum enim repellendus qui omnis impedit et autem quod rem libero officiis est rerum possimus."
               title="Lorem"
             />
-            <SummaryLayout.Row
+            <SummaryRow
               description="Lorem ipsum dolor sit amet"
               title="Lorem"
             />
-          </SummaryLayout.SubSection>
-        </SummaryLayout.Section>
-      </SummaryLayout.Content>
+          </SummarySubSection>
+        </SummarySection>
+      </SummaryContent>
     </SummaryLayout>
   </div>
 )

--- a/pro/src/components/SummaryLayout/SummaryLayout.tsx
+++ b/pro/src/components/SummaryLayout/SummaryLayout.tsx
@@ -2,28 +2,15 @@ import cn from 'classnames'
 import React from 'react'
 
 import style from './SummaryLayout.module.scss'
-import Content from './SummaryLayoutContent'
-import Row from './SummaryLayoutRow'
-import Section from './SummaryLayoutSection'
-import Side from './SummaryLayoutSide'
-import SubSection from './SummaryLayoutSubSection'
 
 interface SummaryLayoutProps {
   children?: React.ReactNode | React.ReactNode[]
   className?: string
 }
 
-const SummaryLayout = ({
+export const SummaryLayout = ({
   children,
   className,
 }: SummaryLayoutProps): JSX.Element => (
   <div className={cn(style['summary-layout'], className)}>{children}</div>
 )
-
-SummaryLayout.Content = Content
-SummaryLayout.Side = Side
-SummaryLayout.Row = Row
-SummaryLayout.SubSection = SubSection
-SummaryLayout.Section = Section
-
-export default SummaryLayout

--- a/pro/src/components/SummaryLayout/SummaryRow.tsx
+++ b/pro/src/components/SummaryLayout/SummaryRow.tsx
@@ -9,7 +9,7 @@ interface SummaryLayoutRowProps {
   title?: string
 }
 
-const Row = ({
+export const SummaryRow = ({
   className,
   description,
   title,
@@ -24,5 +24,3 @@ const Row = ({
     </span>
   </div>
 )
-
-export default Row

--- a/pro/src/components/SummaryLayout/SummarySection.tsx
+++ b/pro/src/components/SummaryLayout/SummarySection.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames'
 import React from 'react'
 
 import fullEditIcon from 'icons/full-edit.svg'
-import { ButtonLink, Title } from 'ui-kit'
+import { ButtonLink } from 'ui-kit'
 
 import style from './SummaryLayout.module.scss'
 
@@ -24,9 +24,8 @@ export const SummarySection = ({
   <div className={cn(style['summary-layout-section'], className)}>
     <div className={style['summary-layout-section-header']}>
       <div className={style['summary-layout-section-header-content']}>
-        <Title as="h3" level={3}>
-          {title}
-        </Title>
+        <h2 className={style['section-title']}>{title}</h2>
+
         {editLink && (
           <ButtonLink
             link={{

--- a/pro/src/components/SummaryLayout/SummarySection.tsx
+++ b/pro/src/components/SummaryLayout/SummarySection.tsx
@@ -14,7 +14,7 @@ interface SummaryLayoutSectionProps {
   'aria-label'?: string
 }
 
-const Section = ({
+export const SummarySection = ({
   title,
   children,
   className,
@@ -46,5 +46,3 @@ const Section = ({
     {children}
   </div>
 )
-
-export default Section

--- a/pro/src/components/SummaryLayout/SummarySubSection.tsx
+++ b/pro/src/components/SummaryLayout/SummarySubSection.tsx
@@ -11,7 +11,7 @@ interface SummaryLayoutSubSectionProps {
   className?: string
 }
 
-const SubSection = ({
+export const SummarySubSection = ({
   title,
   children,
   className,
@@ -28,5 +28,3 @@ const SubSection = ({
     <div className={style['summary-layout-sub-section-separator']}></div>
   </div>
 )
-
-export default SubSection

--- a/pro/src/components/SummaryLayout/SummarySubSection.tsx
+++ b/pro/src/components/SummaryLayout/SummarySubSection.tsx
@@ -1,8 +1,6 @@
 import cn from 'classnames'
 import React from 'react'
 
-import { Title } from 'ui-kit'
-
 import style from './SummaryLayout.module.scss'
 
 interface SummaryLayoutSubSectionProps {
@@ -17,14 +15,10 @@ export const SummarySubSection = ({
   className,
 }: SummaryLayoutSubSectionProps): JSX.Element => (
   <div className={cn(style['summary-layout-sub-section'], className)}>
-    <Title
-      as="h4"
-      className={style['summary-layout-sub-section-title']}
-      level={4}
-    >
-      {title}
-    </Title>
+    <h3 className={style['summary-layout-sub-section-title']}>{title}</h3>
+
     {children}
+
     <div className={style['summary-layout-sub-section-separator']}></div>
   </div>
 )

--- a/pro/src/components/SummaryLayout/index.tsx
+++ b/pro/src/components/SummaryLayout/index.tsx
@@ -1,1 +1,0 @@
-export { default as SummaryLayout } from './SummaryLayout'

--- a/pro/src/pages/CollectiveOfferFromRequest/CollectiveOfferFromRequest.tsx
+++ b/pro/src/pages/CollectiveOfferFromRequest/CollectiveOfferFromRequest.tsx
@@ -4,7 +4,8 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { GetCollectiveOfferRequestResponseModel } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import ActionsBarSticky from 'components/ActionsBarSticky'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySection } from 'components/SummaryLayout/SummarySection'
 import { Events } from 'core/FirebaseEvents/constants'
 import {
   CollectiveOfferTemplate,
@@ -109,9 +110,9 @@ export const CollectiveOfferFromRequest = (): JSX.Element => {
             modifiables.
             <br /> L’offre sera visible par l’enseignant sur Adage.
           </div>
-          <SummaryLayout.Section title="Détails de la demande">
+          <SummarySection title="Détails de la demande">
             <div className={styles['eac-section']}>
-              <SummaryLayout.Row
+              <SummaryRow
                 title="Demande reçue le"
                 description={
                   informations?.dateCreated
@@ -119,13 +120,13 @@ export const CollectiveOfferFromRequest = (): JSX.Element => {
                     : '-'
                 }
               />
-              <SummaryLayout.Row
+              <SummaryRow
                 title="Offre concernée"
                 description={offerTemplate?.name}
               />
             </div>
             <div className={styles['eac-section']}>
-              <SummaryLayout.Row
+              <SummaryRow
                 title="Etablissement scolaire"
                 description={
                   <div>
@@ -135,29 +136,29 @@ export const CollectiveOfferFromRequest = (): JSX.Element => {
                   </div>
                 }
               />
-              <SummaryLayout.Row
+              <SummaryRow
                 title="Prénom et nom de l’enseignant"
                 description={`${informations?.redactor.firstName} ${informations?.redactor.lastName} `}
               />
-              <SummaryLayout.Row
+              <SummaryRow
                 title="Téléphone"
                 description={informations?.phoneNumber ?? '-'}
               />
-              <SummaryLayout.Row
+              <SummaryRow
                 title="Email"
                 description={informations?.redactor.email}
               />
             </div>
 
-            <SummaryLayout.Row
+            <SummaryRow
               title="Nombre d'élèves"
               description={informations?.totalStudents ?? '-'}
             />
-            <SummaryLayout.Row
+            <SummaryRow
               title="Nombre d'accompagnateurs"
               description={informations?.totalTeachers ?? '-'}
             />
-            <SummaryLayout.Row
+            <SummaryRow
               title="Date souhaitée"
               description={
                 informations?.requestedDate
@@ -165,11 +166,11 @@ export const CollectiveOfferFromRequest = (): JSX.Element => {
                   : '-'
               }
             />
-            <SummaryLayout.Row
+            <SummaryRow
               title="Descriptif de la demande"
               description={informations?.comment}
             />
-          </SummaryLayout.Section>
+          </SummarySection>
           <ActionsBarSticky>
             <ActionsBarSticky.Right>
               <Button onClick={handleButtonClick}>

--- a/pro/src/screens/IndividualOffer/BookingsSummary/BookingsSummary.tsx
+++ b/pro/src/screens/IndividualOffer/BookingsSummary/BookingsSummary.tsx
@@ -2,7 +2,7 @@ import format from 'date-fns/format'
 import React, { useEffect, useState } from 'react'
 
 import { BookingRecapResponseModel } from 'apiClient/v1'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummarySection } from 'components/SummaryLayout/SummarySection'
 import {
   DEFAULT_PRE_FILTERS,
   EMPTY_FILTER_VALUE,
@@ -83,7 +83,7 @@ export const BookingsSummaryScreen = ({
   })
 
   return (
-    <SummaryLayout.Section title="Réservations">
+    <SummarySection title="Réservations">
       {bookings !== null ? (
         <>
           <IndividualBookingsTable
@@ -98,6 +98,6 @@ export const BookingsSummaryScreen = ({
       ) : (
         <Spinner />
       )}
-    </SummaryLayout.Section>
+    </SummarySection>
   )
 }

--- a/pro/src/screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen.tsx
@@ -4,7 +4,8 @@ import { api } from 'apiClient/api'
 import { GetOfferStockResponseModel } from 'apiClient/v1'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { StocksEvent } from 'components/StocksEventList/StocksEventList'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySection } from 'components/SummaryLayout/SummarySection'
 import { useIndividualOfferContext } from 'context/IndividualOfferContext'
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { getIndividualOfferUrl } from 'core/Offers/utils/getIndividualOfferUrl'
@@ -66,13 +67,13 @@ export const StocksSummaryScreen = () => {
   )?.canBeDuo
 
   return (
-    <SummaryLayout.Section
+    <SummarySection
       title={offer.isEvent ? 'Dates et capacité' : 'Stocks et prix'}
       editLink={editLink}
       aria-label="Modifier les stocks et prix"
     >
       {stockWarningText && (
-        <SummaryLayout.Row
+        <SummaryRow
           className={styles['stock-section-warning']}
           description={stockWarningText}
         />
@@ -87,6 +88,6 @@ export const StocksSummaryScreen = () => {
           isDuo={offer.isDuo}
         />
       )}
-    </SummaryLayout.Section>
+    </SummarySection>
   )
 }

--- a/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 
 import AccessibilitySummarySection from 'components/AccessibilitySummarySection'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySection } from 'components/SummaryLayout/SummarySection'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import { useIndividualOfferContext } from 'context/IndividualOfferContext'
 import {
   OFFER_WITHDRAWAL_TYPE_LABELS,
@@ -41,23 +43,20 @@ const OfferSummary = ({
   })
 
   return (
-    <SummaryLayout.Section
+    <SummarySection
       title="Détails de l’offre"
       editLink={editLink}
       aria-label="Modifier les détails de l’offre"
     >
-      <SummaryLayout.SubSection title="Type d’offre">
-        <SummaryLayout.Row
-          title="Catégorie"
-          description={offerData.categoryName}
-        />
-        <SummaryLayout.Row
+      <SummarySubSection title="Type d’offre">
+        <SummaryRow title="Catégorie" description={offerData.categoryName} />
+        <SummaryRow
           title="Sous-catégorie"
           description={offerData.subCategoryName}
         />
 
         {conditionalFields.includes('musicType') && (
-          <SummaryLayout.Row
+          <SummaryRow
             title="Genre musical"
             description={
               /* istanbul ignore next: DEBT, TO FIX */
@@ -66,7 +65,7 @@ const OfferSummary = ({
           />
         )}
         {offerData.musicSubTypeName && (
-          <SummaryLayout.Row
+          <SummaryRow
             title="Sous-genre"
             description={offerData.musicSubTypeName}
           />
@@ -74,7 +73,7 @@ const OfferSummary = ({
         {
           /* istanbul ignore next: DEBT, TO FIX */
           conditionalFields.includes('showType') && (
-            <SummaryLayout.Row
+            <SummaryRow
               title="Type de spectacle"
               description={
                 /* istanbul ignore next: DEBT, TO FIX */
@@ -86,20 +85,17 @@ const OfferSummary = ({
         {
           /* istanbul ignore next: DEBT, TO FIX */
           offerData.showSubTypeName && (
-            <SummaryLayout.Row
+            <SummaryRow
               title="Sous-type"
               description={offerData.showSubTypeName}
             />
           )
         }
-      </SummaryLayout.SubSection>
+      </SummarySubSection>
 
-      <SummaryLayout.SubSection title="Informations artistiques">
-        <SummaryLayout.Row
-          title="Titre de l’offre"
-          description={offerData.name}
-        />
-        <SummaryLayout.Row
+      <SummarySubSection title="Informations artistiques">
+        <SummaryRow title="Titre de l’offre" description={offerData.name} />
+        <SummaryRow
           title="Description"
           description={
             /* istanbul ignore next: DEBT, TO FIX */
@@ -110,22 +106,19 @@ const OfferSummary = ({
         {
           /* istanbul ignore next: DEBT, TO FIX */
           conditionalFields.includes('speaker') && (
-            <SummaryLayout.Row
-              title="Intervenant"
-              description={offerData.speaker}
-            />
+            <SummaryRow title="Intervenant" description={offerData.speaker} />
           )
         }
         {
           /* istanbul ignore next: DEBT, TO FIX */
           conditionalFields.includes('author') && (
-            <SummaryLayout.Row title="Auteur" description={offerData.author} />
+            <SummaryRow title="Auteur" description={offerData.author} />
           )
         }
         {
           /* istanbul ignore next: DEBT, TO FIX */
           conditionalFields.includes('visa') && (
-            <SummaryLayout.Row
+            <SummaryRow
               title="Visa d’exploitation"
               description={offerData.visa}
             />
@@ -134,13 +127,13 @@ const OfferSummary = ({
         {
           /* istanbul ignore next: DEBT, TO FIX */
           conditionalFields.includes('ean') && (
-            <SummaryLayout.Row title="EAN-13" description={offerData.ean} />
+            <SummaryRow title="EAN-13" description={offerData.ean} />
           )
         }
         {
           /* istanbul ignore next: DEBT, TO FIX */
           conditionalFields.includes('stageDirector') && (
-            <SummaryLayout.Row
+            <SummaryRow
               title="Metteur en scène"
               description={offerData.stageDirector}
             />
@@ -149,16 +142,13 @@ const OfferSummary = ({
         {
           /* istanbul ignore next: DEBT, TO FIX */
           conditionalFields.includes('performer') && (
-            <SummaryLayout.Row
-              title="Interprète"
-              description={offerData.performer}
-            />
+            <SummaryRow title="Interprète" description={offerData.performer} />
           )
         }
         {
           /* istanbul ignore next: DEBT, TO FIX */
           conditionalFields.includes('durationMinutes') && (
-            <SummaryLayout.Row
+            <SummaryRow
               title="Durée"
               description={
                 offerData.durationMinutes
@@ -168,14 +158,11 @@ const OfferSummary = ({
             />
           )
         }
-      </SummaryLayout.SubSection>
+      </SummarySubSection>
 
-      <SummaryLayout.SubSection title="Informations pratiques">
-        <SummaryLayout.Row
-          title="Structure"
-          description={offerData.offererName}
-        />
-        <SummaryLayout.Row
+      <SummarySubSection title="Informations pratiques">
+        <SummaryRow title="Structure" description={offerData.offererName} />
+        <SummaryRow
           title="Lieu"
           description={
             /* istanbul ignore next: DEBT, TO FIX */ offerData.venuePublicName ||
@@ -183,7 +170,7 @@ const OfferSummary = ({
           }
         />
 
-        <SummaryLayout.Row
+        <SummaryRow
           title="Informations de retrait"
           description={
             /* istanbul ignore next: DEBT, TO FIX */
@@ -194,7 +181,7 @@ const OfferSummary = ({
         {
           /* istanbul ignore next: DEBT, TO FIX */
           offerData.withdrawalType && (
-            <SummaryLayout.Row
+            <SummaryRow
               title="Précisez la façon dont vous distribuerez les billets"
               description={
                 OFFER_WITHDRAWAL_TYPE_LABELS[offerData.withdrawalType]
@@ -206,7 +193,7 @@ const OfferSummary = ({
         {
           /* istanbul ignore next: DEBT, TO FIX */
           offerData.withdrawalDelay && (
-            <SummaryLayout.Row
+            <SummaryRow
               title="Heure de retrait"
               description={`${humanizeDelay(
                 offerData.withdrawalDelay
@@ -216,7 +203,7 @@ const OfferSummary = ({
         }
 
         {isBookingContactEnabled && offerData.bookingContact && (
-          <SummaryLayout.Row
+          <SummaryRow
             title="Email de contact"
             description={
               /* istanbul ignore next: DEBT, TO FIX */
@@ -226,7 +213,7 @@ const OfferSummary = ({
         )}
 
         {conditionalFields.includes('url') && (
-          <SummaryLayout.Row
+          <SummaryRow
             title="URL d’accès à l’offre"
             description={
               /* istanbul ignore next: DEBT, TO FIX */
@@ -234,7 +221,7 @@ const OfferSummary = ({
             }
           />
         )}
-      </SummaryLayout.SubSection>
+      </SummarySubSection>
 
       <AccessibilitySummarySection
         noDisabilityCompliance={offerData.accessibility[AccessiblityEnum.NONE]}
@@ -252,26 +239,26 @@ const OfferSummary = ({
         }
       />
 
-      <SummaryLayout.SubSection title="Lien pour le grand public">
-        <SummaryLayout.Row
+      <SummarySubSection title="Lien pour le grand public">
+        <SummaryRow
           title="URL de votre site ou billetterie"
           description={
             /* istanbul ignore next: DEBT, TO FIX */
             offerData.externalTicketOfficeUrl || ' - '
           }
         />
-      </SummaryLayout.SubSection>
+      </SummarySubSection>
 
-      <SummaryLayout.SubSection title="Notifications des réservations">
-        <SummaryLayout.Row
+      <SummarySubSection title="Notifications des réservations">
+        <SummaryRow
           title="Email auquel envoyer les notifications"
           description={
             /* istanbul ignore next: DEBT, TO FIX */
             offerData.bookingEmail || ' - '
           }
         />
-      </SummaryLayout.SubSection>
-    </SummaryLayout.Section>
+      </SummarySubSection>
+    </SummarySection>
   )
 }
 

--- a/pro/src/screens/IndividualOffer/SummaryScreen/PriceCategoriesSection/PriceCategoriesSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/PriceCategoriesSection/PriceCategoriesSection.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySection } from 'components/SummaryLayout/SummarySection'
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { IndividualOffer } from 'core/Offers/types'
 import { getIndividualOfferUrl } from 'core/Offers/utils/getIndividualOfferUrl'
@@ -26,7 +27,7 @@ export const PriceCategoriesSection = ({ offer, canBeDuo }: Props) => {
   })
 
   return (
-    <SummaryLayout.Section
+    <SummarySection
       title="Tarifs"
       editLink={editLink}
       aria-label="Modifier les tarifs de l’offre"
@@ -37,11 +38,11 @@ export const PriceCategoriesSection = ({ offer, canBeDuo }: Props) => {
         </div>
       ))}
       {canBeDuo && (
-        <SummaryLayout.Row
+        <SummaryRow
           title='Accepter les réservations "Duo"'
           description={offer.isDuo ? 'Oui' : 'Non'}
         />
       )}
-    </SummaryLayout.Section>
+    </SummarySection>
   )
 }

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/RecurrenceSection/RecurrenceSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/RecurrenceSection/RecurrenceSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { StockStatsResponseModel } from 'apiClient/v1'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
 import { FORMAT_DD_MM_YYYY } from 'utils/date'
 import { pluralizeString } from 'utils/pluralize'
 import { formatLocalTimeDateString } from 'utils/timezone'
@@ -52,12 +52,9 @@ const RecurrenceSection = ({
 
   return (
     <>
-      <SummaryLayout.Row
-        title="Nombre de dates"
-        description={formattedStockCount}
-      />
-      <SummaryLayout.Row title="Période concernée" description={periodText} />
-      <SummaryLayout.Row title="Capacité totale" description={totalCapacity} />
+      <SummaryRow title="Nombre de dates" description={formattedStockCount} />
+      <SummaryRow title="Période concernée" description={periodText} />
+      <SummaryRow title="Capacité totale" description={totalCapacity} />
     </>
   )
 }

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockSection.tsx
@@ -7,7 +7,8 @@ import {
   StockStatsResponseModel,
 } from 'apiClient/v1'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
+import { SummarySection } from 'components/SummaryLayout/SummarySection'
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { IndividualOffer } from 'core/Offers/types'
 import { getIndividualOfferUrl } from 'core/Offers/utils/getIndividualOfferUrl'
@@ -99,13 +100,13 @@ const StockSection = ({ offer, canBeDuo }: StockSectionProps): JSX.Element => {
 
   return (
     <>
-      <SummaryLayout.Section
+      <SummarySection
         title={offer.isEvent ? 'Dates et capacité' : 'Stocks et prix'}
         editLink={editLink}
         aria-label="Modifier les stocks et prix"
       >
         {stockWarningText && (
-          <SummaryLayout.Row
+          <SummaryRow
             className={styles['stock-section-warning']}
             description={stockWarningText}
           />
@@ -123,7 +124,7 @@ const StockSection = ({ offer, canBeDuo }: StockSectionProps): JSX.Element => {
             isDuo={offer.isDuo}
           />
         )}
-      </SummaryLayout.Section>
+      </SummarySection>
     </>
   )
 }

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/StockThingSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/StockThingSection.tsx
@@ -2,7 +2,7 @@ import { format } from 'date-fns-tz'
 import React from 'react'
 
 import { GetOfferStockResponseModel } from 'apiClient/v1'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryRow } from 'components/SummaryLayout/SummaryRow'
 import { FORMAT_DD_MM_YYYY, toDateStrippedOfTimezone } from 'utils/date'
 import { formatPrice } from 'utils/formatPrice'
 
@@ -23,10 +23,10 @@ const StockThingSection = ({
 
   return (
     <>
-      <SummaryLayout.Row title="Prix" description={formatPrice(stock.price)} />
+      <SummaryRow title="Prix" description={formatPrice(stock.price)} />
 
       {stock.bookingLimitDatetime && (
-        <SummaryLayout.Row
+        <SummaryRow
           title="Date limite de réservation"
           description={format(
             toDateStrippedOfTimezone(stock.bookingLimitDatetime),
@@ -35,7 +35,7 @@ const StockThingSection = ({
         />
       )}
 
-      <SummaryLayout.Row
+      <SummaryRow
         title="Quantité"
         description={
           stock.quantity !== null && stock.quantity !== undefined
@@ -46,7 +46,7 @@ const StockThingSection = ({
 
       {/* Some things offer can be duo like ESCAPE_GAME or CARTE_MUSEE */}
       {canBeDuo && (
-        <SummaryLayout.Row
+        <SummaryRow
           title='Accepter les réservations "Duo"'
           description={isDuo ? 'Oui' : 'Non'}
         />

--- a/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -5,7 +5,9 @@ import { api } from 'apiClient/api'
 import Callout from 'components/Callout/Callout'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { OfferAppPreview } from 'components/OfferAppPreview'
-import { SummaryLayout } from 'components/SummaryLayout'
+import { SummaryAside } from 'components/SummaryLayout/SummaryAside'
+import { SummaryContent } from 'components/SummaryLayout/SummaryContent'
+import { SummaryLayout } from 'components/SummaryLayout/SummaryLayout'
 import { useIndividualOfferContext } from 'context/IndividualOfferContext'
 import {
   Events,
@@ -140,7 +142,7 @@ const SummaryScreen = () => {
       )}
 
       <SummaryLayout>
-        <SummaryLayout.Content>
+        <SummaryContent>
           <OfferSection conditionalFields={conditionalFields} offer={offer} />
 
           {mode === OFFER_WIZARD_MODE.CREATION && offer.isEvent && (
@@ -150,9 +152,9 @@ const SummaryScreen = () => {
           {mode === OFFER_WIZARD_MODE.CREATION && (
             <StockSection offer={offer} canBeDuo={canBeDuo} />
           )}
-        </SummaryLayout.Content>
+        </SummaryContent>
 
-        <SummaryLayout.Side>
+        <SummaryAside>
           <div className={styles['offer-creation-preview-title']}>
             <SvgIcon
               src={phoneStrokeIcon}
@@ -184,7 +186,7 @@ const SummaryScreen = () => {
               </DisplayOfferInAppLink>
             </div>
           )}
-        </SummaryLayout.Side>
+        </SummaryAside>
       </SummaryLayout>
       <ActionBar
         onClickNext={publishOffer}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25233

## Vérifications

Vérifier créa d'offre indiv + collective, summary + recap, + détails d'une offre qui utilise les mêmes composants

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/9b6ee26a-a47b-4e6b-8050-611b9bcdedda)
