### PR TITLE
(PC-27837)[ADAGE] fix: playlist too long to load

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -953,9 +953,9 @@ def get_collective_offer_template_by_ids(offer_ids: list[int]) -> list[education
     return query
 
 
-def get_collective_offer_templates_for_playlist(
+def get_collective_offer_templates_for_playlist_query(
     institution_id: int, playlist_type: educational_models.PlaylistType, max_distance: int | None = 60
-) -> list[educational_models.CollectiveOfferTemplate]:
+) -> BaseQuery:
     query = educational_models.CollectivePlaylist.query.filter(
         educational_models.CollectivePlaylist.type == playlist_type,
         educational_models.CollectivePlaylist.institutionId == institution_id,
@@ -980,12 +980,7 @@ def get_collective_offer_templates_for_playlist(
             educational_models.CollectiveOfferTemplate.domains
         ),
     )
-    query = query.options(
-        sa.orm.joinedload(educational_models.CollectivePlaylist.collective_offer_template).joinedload(
-            educational_models.CollectiveOfferTemplate.collective_playlists
-        ),
-    )
-    return query.all()
+    return query
 
 
 def user_has_bookings(user: User) -> bool:

--- a/api/src/pcapi/routes/adage_iframe/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/playlists.py
@@ -54,8 +54,12 @@ def get_classroom_playlist(
     if not redactor:
         raise ApiErrors(errors={"auth": "unknown redactor"}, status_code=403)
 
-    playlist_items = repository.get_collective_offer_templates_for_playlist(
-        institution_id=institution.id, playlist_type=educational_models.PlaylistType.CLASSROOM
+    playlist_items = (
+        repository.get_collective_offer_templates_for_playlist_query(
+            institution_id=institution.id, playlist_type=educational_models.PlaylistType.CLASSROOM
+        )
+        .limit(10)
+        .all()
     )
     favorite_ids = favorites_api.get_redactors_favorite_templates_subset(
         redactor, [item.collective_offer_template.id for item in playlist_items]
@@ -130,8 +134,12 @@ def new_template_offers_playlist(
     if not redactor:
         raise ApiErrors(errors={"auth": "unknown redactor"}, status_code=403)
 
-    playlist_items = repository.get_collective_offer_templates_for_playlist(
-        institution_id=institution.id, playlist_type=educational_models.PlaylistType.NEW_OFFER
+    playlist_items = (
+        repository.get_collective_offer_templates_for_playlist_query(
+            institution_id=institution.id, playlist_type=educational_models.PlaylistType.NEW_OFFER
+        )
+        .limit(10)
+        .all()
     )
     favorite_ids = favorites_api.get_redactors_favorite_templates_subset(
         redactor, [item.collective_offer_template.id for item in playlist_items]
@@ -172,8 +180,12 @@ def get_local_offerers_playlist(
     if not institution:
         raise ApiErrors({"message": "institutionId is mandatory"}, status_code=403)
 
-    playlist_items = repository.get_collective_offer_templates_for_playlist(
-        institution_id=institution.id, playlist_type=educational_models.PlaylistType.LOCAL_OFFERER
+    playlist_items = (
+        repository.get_collective_offer_templates_for_playlist_query(
+            institution_id=institution.id, playlist_type=educational_models.PlaylistType.LOCAL_OFFERER
+        )
+        .limit(10)
+        .all()
     )
 
     distances = {item.venueId: item.distanceInKm for item in playlist_items}


### PR DESCRIPTION
There was two issues identified so far:
1. a join from the playlist onto itself which created a combination on the playlist content and therefore way too many duplicated SQL rows to load (around 14_000 rows while 10 were expected).
2. there was a missing limit to 10 elements per playlist.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27837

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques