### PR TITLE
(PC-27860)[API] feat: avoid too many BigQuery requests

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
+++ b/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
@@ -7,6 +7,7 @@ from .base import BaseQuery
 
 
 class ClassroomPlaylistModel(pydantic_v1.BaseModel):
+    institution_id: str
     collective_offer_id: str
     distance_in_km: float
 
@@ -16,16 +17,20 @@ class ClassroomPlaylistQuery(BaseQuery):
         SELECT
             collective_offer_id,
             distance_in_km,
+            institution_id
         FROM
             `{settings.BIG_QUERY_TABLE_BASENAME}.adage_home_playlist_moving_offerers`
         WHERE
-            institution_id = @institution_id
+            distance_in_km <= 60
+        ORDER BY
+            institution_id
     """
 
     model = ClassroomPlaylistModel
 
 
 class NewTemplateOffersPlaylistModel(pydantic_v1.BaseModel):
+    institution_id: str
     collective_offer_id: str
     distance_in_km: float
 
@@ -34,21 +39,21 @@ class NewTemplateOffersPlaylistQuery(BaseQuery):
     raw_query = f"""
         SELECT
             distinct collective_offer_id,
-            distance_in_km
+            distance_in_km,
+            institution_id
         FROM
             `{settings.BIG_QUERY_TABLE_BASENAME}.adage_home_playlist_new_template_offers`
         WHERE
-            institution_id = @institution_id
-        AND
             distance_in_km <= 60
-        ORDER BY distance_in_km ASC
-        LIMIT 10
+        ORDER BY
+            institution_id
     """
 
     model = NewTemplateOffersPlaylistModel
 
 
 class LocalOfferersModel(pydantic_v1.BaseModel):
+    institution_id: str
     venue_id: str
     distance_in_km: float
 
@@ -56,15 +61,17 @@ class LocalOfferersModel(pydantic_v1.BaseModel):
 class LocalOfferersQuery(BaseQuery):
     raw_query = f"""
         SELECT
-            distinct venue_id,
-            distance_in_km
+            institution_id,
+            venue_id,
+            MIN(distance_in_km) as distance_in_km
         FROM
             `{settings.BIG_QUERY_TABLE_BASENAME}.adage_home_playlist_local_offerers`
         WHERE
-            distance_in_km <= @range
-            and institution_id = @institution_id
-        LIMIT
-            10
+            distance_in_km <= 60
+        GROUP BY
+            institution_id, venue_id
+        ORDER BY
+            institution_id, venue_id
     """
 
     model = LocalOfferersModel

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -215,4 +215,4 @@ def synchronise_collective_new_offer_playlist() -> None:
 @blueprint.cli.command("synchronise_collective_local_offerers_playlist")
 @log_cron_with_transaction
 def synchronise_collective_local_offerer_playlist() -> None:
-    playlists_api.synchronize_collective_playlist(educational_models.PlaylistType.LOCAL_OFFERER, with_range=True)
+    playlists_api.synchronize_collective_playlist(educational_models.PlaylistType.LOCAL_OFFERER)

--- a/api/tests/core/educational/api/test_playlists.py
+++ b/api/tests/core/educational/api/test_playlists.py
@@ -41,9 +41,21 @@ class SynchronizePlaylistsTest:
         mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
         with patch(mock_path) as mock_run_query:
             mock_run_query.return_value = [
-                {"collective_offer_id": str(offers[0].id), "distance_in_km": initial_distance},
-                {"collective_offer_id": str(offers[1].id), "distance_in_km": updated_distance},
-                {"collective_offer_id": str(offers[3].id), "distance_in_km": updated_distance},
+                {
+                    "institution_id": str(institution.id),
+                    "collective_offer_id": str(offers[0].id),
+                    "distance_in_km": initial_distance,
+                },
+                {
+                    "institution_id": str(institution.id),
+                    "collective_offer_id": str(offers[1].id),
+                    "distance_in_km": updated_distance,
+                },
+                {
+                    "institution_id": str(institution.id),
+                    "collective_offer_id": str(offers[3].id),
+                    "distance_in_km": updated_distance,
+                },
             ]
             playlist_api.synchronize_collective_playlist(playlist_type)
 
@@ -106,9 +118,21 @@ class SynchronizePlaylistsTest:
         mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
         with patch(mock_path) as mock_run_query:
             mock_run_query.return_value = [
-                {"venue_id": str(venues[0].id), "distance_in_km": initial_distance},
-                {"venue_id": str(venues[1].id), "distance_in_km": updated_distance},
-                {"venue_id": str(venues[3].id), "distance_in_km": updated_distance},
+                {
+                    "institution_id": str(institution.id),
+                    "venue_id": str(venues[0].id),
+                    "distance_in_km": initial_distance,
+                },
+                {
+                    "institution_id": str(institution.id),
+                    "venue_id": str(venues[1].id),
+                    "distance_in_km": updated_distance,
+                },
+                {
+                    "institution_id": str(institution.id),
+                    "venue_id": str(venues[3].id),
+                    "distance_in_km": updated_distance,
+                },
             ]
             playlist_api.synchronize_collective_playlist(playlist_type)
 


### PR DESCRIPTION
Synchronization uses the BigQuery pagination to deal with huge data set instead of making multiple queries with offset/limit or as previously on a per institution basis.

## But de la pull request

Ticket Jira: https://passculture.atlassian.net/browse/PC-27860

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques