### PR TITLE
(PC-27744)[BO] feat: flag expired offers as 'inactive' in offerer page's stats

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -588,6 +588,14 @@ class CollectiveOffer(
         result = query.one_or_none()
         return result[0] if result else None
 
+    @hybrid_property
+    def is_expired(self) -> bool:
+        return self.hasBeginningDatetimePassed
+
+    @is_expired.expression  # type: ignore [no-redef]
+    def is_expired(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls.hasBeginningDatetimePassed
+
 
 class CollectiveOfferTemplate(
     PcObject, offer_mixin.ValidationMixin, AccessibilityMixin, StatusMixin, HasImageMixin, Base, Model
@@ -871,6 +879,14 @@ class CollectiveOfferTemplate(
             offerId=collective_offer.offerId,
             priceDetail=price_detail,
         )
+
+    @hybrid_property
+    def is_expired(self) -> bool:
+        return self.hasBeginningDatetimePassed
+
+    @is_expired.expression  # type: ignore [no-redef]
+    def is_expired(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls.hasBeginningDatetimePassed
 
 
 class CollectiveStock(PcObject, Base, Model):

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1498,8 +1498,8 @@ def get_offerer_offers_stats(offerer_id: int, max_offer_count: int = 0) -> dict:
         return sa.select(sa.func.jsonb_object_agg(sa.text("status"), sa.text("number"))).select_from(
             sa.select(
                 sa.case(
-                    (offer_class.isActive.is_(True), "active"),  # type: ignore [attr-defined]
-                    (offer_class.isActive.is_(False), "inactive"),  # type: ignore [attr-defined]
+                    (sa.and_(offer_class.isActive.is_(True), offer_class.is_expired.is_(False)), "active"),  # type: ignore [attr-defined]
+                    else_="inactive",
                 ).label("status"),
                 sa.func.count(offer_class.id).label("number"),
             )
@@ -1525,7 +1525,7 @@ def get_offerer_offers_stats(offerer_id: int, max_offer_count: int = 0) -> dict:
                     ),
                 ),
             )
-            .group_by(offer_class.isActive)
+            .group_by("status")
             .subquery()
         )
 

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -722,6 +722,14 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return f"{self.name} {self.description}"
 
     @hybrid_property
+    def is_expired(self) -> bool:
+        return self.hasBookingLimitDatetimesPassed
+
+    @is_expired.expression  # type: ignore [no-redef]
+    def is_expired(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls.hasBookingLimitDatetimesPassed
+
+    @hybrid_property
     def status(self) -> OfferStatus:
         if self.validation == OfferValidationStatus.REJECTED:
             return OfferStatus.REJECTED

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -1,5 +1,6 @@
 import datetime
 
+import factory
 import pytest
 
 from pcapi.core.bookings import factories as bookings_factories
@@ -439,6 +440,36 @@ def offerer_active_collective_offers_fixture(offerer, venue_with_accepted_bank_i
         validation=offers_models.OfferValidationStatus.DRAFT.value,
     )
     return approved_offers + [rejected_offer, pending_offer, draft_offer]
+
+
+@pytest.fixture
+def offerer_expired_offers(offerer, venue_with_accepted_bank_info):
+    offers = offers_factories.OfferFactory.create_batch(
+        size=4,
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.APPROVED.value,
+    )
+    offers_factories.StockFactory.create_batch(
+        size=4,
+        offer=factory.Iterator(offers),
+        isSoftDeleted=False,
+        bookingLimitDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=10),
+    )
+    return offers
+
+
+@pytest.fixture
+def offerer_expired_collective_offers(offerer, venue_with_accepted_bank_info):
+    stocks = educational_factories.CollectiveStockFactory.create_batch(
+        size=4,
+        price=1337,
+        beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=10),
+    )
+    return educational_factories.CollectiveOfferFactory.create_batch(
+        size=4,
+        venue=venue_with_accepted_bank_info,
+        collectiveStock=factory.Iterator(stocks),
+    )
 
 
 @pytest.fixture(name="offerer_inactive_collective_offers")

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -507,6 +507,8 @@ class GetOffererStatsDataTest:
         offerer_inactive_collective_offers,
         offerer_active_collective_offer_templates,
         offerer_inactive_collective_offer_templates,
+        offerer_expired_offers,
+        offerer_expired_collective_offers,
         individual_offerer_bookings,
         collective_offerer_booking,
     ):
@@ -518,8 +520,8 @@ class GetOffererStatsDataTest:
             stats = offerer_blueprint.get_stats_data(offerer_id)
         assert stats["active"]["individual"] == 2
         assert stats["active"]["collective"] == 5
-        assert stats["inactive"]["individual"] == 5
-        assert stats["inactive"]["collective"] == 11
+        assert stats["inactive"]["individual"] == 9
+        assert stats["inactive"]["collective"] == 15
 
         total_revenue = stats["total_revenue"]
 


### PR DESCRIPTION
## But de la pull request

Inclure les offres expirées dans celles qui sont "inactives" dans les statistiques de la page structure

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27744

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~