### PR TITLE
(PC-27558)[PRO] feat: filter invoice on bank account if FF enabled

### DIFF
--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames'
 import { compareAsc, format } from 'date-fns'
 
-import { InvoiceResponseModel } from 'apiClient/v1'
+import { InvoiceResponseV2Model } from 'apiClient/v1'
 import { SortArrow } from 'components/StocksEventList/SortArrow'
 import useActiveFeature from 'hooks/useActiveFeature'
 import {
@@ -20,7 +20,7 @@ import { formatPrice } from 'utils/formatPrice'
 import styles from './InvoiceTable.module.scss'
 
 type InvoiceTableProps = {
-  invoices: InvoiceResponseModel[]
+  invoices: InvoiceResponseV2Model[]
 }
 
 enum InvoicesOrderedBy {
@@ -32,7 +32,7 @@ enum InvoicesOrderedBy {
 }
 
 function sortInvoices(
-  invoices: InvoiceResponseModel[],
+  invoices: InvoiceResponseV2Model[],
   currentSortingColumn: InvoicesOrderedBy | null,
   sortingMode: SortingMode
 ) {
@@ -51,12 +51,8 @@ function sortInvoices(
     case InvoicesOrderedBy.REIMBURSEMENT_POINT_NAME:
       return [...invoices].sort((a, b) =>
         sortingMode === SortingMode.ASC
-          ? (a.reimbursementPointName ?? '').localeCompare(
-              b.reimbursementPointName ?? ''
-            )
-          : (b.reimbursementPointName ?? '').localeCompare(
-              a.reimbursementPointName ?? ''
-            )
+          ? (a.bankAccountLabel ?? '').localeCompare(b.bankAccountLabel ?? '')
+          : (b.bankAccountLabel ?? '').localeCompare(a.bankAccountLabel ?? '')
       )
 
     case InvoicesOrderedBy.DOCUMENT_TYPE:
@@ -303,7 +299,7 @@ const InvoiceTable = ({ invoices }: InvoiceTableProps) => {
                   className={cn(styles['data'], styles['document-type-column'])}
                   data-label="Point de remboursement"
                 >
-                  {invoice.reimbursementPointName}
+                  {invoice.bankAccountLabel}
                 </td>
               )}
               <td

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
@@ -70,12 +70,24 @@ const BASE_REIMBURSEMENT_POINTS = [
   },
 ]
 
+const BASE_BANK_ACCOUNTS = [
+  {
+    id: 1,
+    label: 'My first bank account',
+  },
+  {
+    id: 2,
+    label: 'My second bank account',
+  },
+]
+
 describe('reimbursementsWithFilters', () => {
   beforeEach(() => {
     vi.spyOn(api, 'getInvoices').mockResolvedValueOnce(BASE_INVOICES)
     vi.spyOn(api, 'getReimbursementPoints').mockResolvedValueOnce(
       BASE_REIMBURSEMENT_POINTS
     )
+    vi.spyOn(api, 'getBankAccounts').mockResolvedValueOnce(BASE_BANK_ACCOUNTS)
   })
 
   it('shoud render a table with invoices', async () => {

--- a/pro/src/pages/Reimbursements/__specs__/Reimbursements.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/Reimbursements.spec.tsx
@@ -50,6 +50,7 @@ const renderReimbursements = (options?: RenderWithProvidersOptions) => {
 describe('Reimbursement page', () => {
   beforeEach(() => {
     vi.spyOn(api, 'getReimbursementPoints').mockResolvedValue([])
+    vi.spyOn(api, 'getBankAccounts').mockResolvedValue([])
   })
 
   it('should render reimbursement page with FF WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY off', async () => {
@@ -89,6 +90,7 @@ describe('Reimbursement page with FF WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY enabled
 
     vi.spyOn(api, 'getOfferer').mockResolvedValue(selectedOfferer)
     vi.spyOn(api, 'getReimbursementPoints').mockResolvedValue([])
+    vi.spyOn(api, 'getBankAccounts').mockResolvedValue([])
   })
 
   it('should render reimbursement page', async () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27558

Filtrer les justificatifs de remboursements sur le compte bancaire et non plus le point de remboursement si le FF est activé `WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY`

![Capture d’écran 2024-02-07 à 17 35 00](https://github.com/pass-culture/pass-culture-main/assets/71768799/4c328916-e86d-4c1d-830e-8a340dee5418)


