### PR TITLE
(PC-26990)[BO] fix: API Sirene returns [ND] in postal code for non-diffusible, use INSEE code

### DIFF
--- a/api/src/pcapi/connectors/api_adresse.py
+++ b/api/src/pcapi/connectors/api_adresse.py
@@ -39,6 +39,7 @@ class InvalidFormatException(AdresseException):
 class AddressInfo(pydantic_v1.BaseModel):
     id: str
     label: str
+    postcode: str
     latitude: float
     longitude: float
     score: float
@@ -49,9 +50,9 @@ def _get_backend() -> "BaseBackend":
     return backend_class()
 
 
-def get_municipality_centroid(city: str, postcode: str) -> AddressInfo:
+def get_municipality_centroid(city: str, postcode: str | None = None, citycode: str | None = None) -> AddressInfo:
     """Return information about the requested city."""
-    return _get_backend().get_municipality_centroid(postcode=postcode, city=city)
+    return _get_backend().get_municipality_centroid(postcode=postcode, citycode=citycode, city=city)
 
 
 def get_address(address: str, postcode: str | None = None, city: str | None = None) -> AddressInfo:
@@ -60,7 +61,9 @@ def get_address(address: str, postcode: str | None = None, city: str | None = No
 
 
 class BaseBackend:
-    def get_municipality_centroid(self, city: str, postcode: str) -> AddressInfo:
+    def get_municipality_centroid(
+        self, city: str, postcode: str | None = None, citycode: str | None = None
+    ) -> AddressInfo:
         raise NotImplementedError()
 
     def get_single_address_result(self, address: str, postcode: str | None, city: str | None = None) -> AddressInfo:
@@ -68,11 +71,14 @@ class BaseBackend:
 
 
 class TestingBackend(BaseBackend):
-    def get_municipality_centroid(self, city: str, postcode: str) -> AddressInfo:
+    def get_municipality_centroid(
+        self, city: str, postcode: str | None = None, citycode: str | None = None
+    ) -> AddressInfo:
         # Used to check non-diffusible SIREN/SIRET
         return AddressInfo(
             id="06029",
             label="Cannes",
+            postcode="06400",
             score=0.9549627272727272,
             latitude=43.555468,
             longitude=7.004585,
@@ -82,6 +88,7 @@ class TestingBackend(BaseBackend):
         return AddressInfo(
             id="75101_9575_00003",
             label="3 Rue de Valois 75001 Paris",
+            postcode="75001",
             score=0.9651727272727272,
             latitude=48.87171,
             longitude=2.308289,
@@ -116,11 +123,14 @@ class ApiAdresseBackend(BaseBackend):
             raise AdresseApiException("Unexpected non-JSON response from Adresse API")
         return data
 
-    def get_municipality_centroid(self, city: str, postcode: str) -> AddressInfo:
+    def get_municipality_centroid(
+        self, city: str, postcode: str | None = None, citycode: str | None = None
+    ) -> AddressInfo:
         """Fallback to querying the city, because the q parameter must contain part of the address label"""
         parameters = {
             "q": city,
             "postcode": postcode,
+            "citycode": citycode,
             "type": "municipality",
             "autocomplete": 0,
             "limit": 1,
@@ -190,4 +200,5 @@ class ApiAdresseBackend(BaseBackend):
             longitude=coordinates[0],
             score=properties["score"],
             label=properties["label"],
+            postcode=properties["postcode"],
         )

--- a/api/src/pcapi/connectors/sirene.py
+++ b/api/src/pcapi/connectors/sirene.py
@@ -145,7 +145,7 @@ class TestingBackend(BaseBackend):
 
     nd_address = _Address(
         street="[ND]",
-        postal_code="06400",
+        postal_code="[ND]",
         city="CANNES",
         insee_code="06029",
     )

--- a/api/tests/connectors/api_adresse/api_adresse_test.py
+++ b/api/tests/connectors/api_adresse/api_adresse_test.py
@@ -19,6 +19,7 @@ def test_nominal_case(requests_mock):
     assert address_info == api_adresse.AddressInfo(
         id="75118_2974_00018",
         label="18 Rue Duhesme 75018 Paris",
+        postcode="75018",
         latitude=48.890787,
         longitude=2.338562,
         score=0.9806027272727271,
@@ -42,6 +43,7 @@ def test_fallback_to_municipality(requests_mock):
     assert address_info == api_adresse.AddressInfo(
         id="75118",
         label="Paris 18e Arrondissement",
+        postcode="75018",
         latitude=48.892045,
         longitude=2.348679,
         score=0.2084164031620553,

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -767,7 +767,7 @@ class CreateOffererTest(PostEndpointHelper):
             "ds_dossier_id": int(form_data["ds_id"]),
             "sirene_info": {
                 "active": True,
-                "address": {"city": "CANNES", "insee_code": "06029", "postal_code": "06400", "street": "[ND]"},
+                "address": {"city": "CANNES", "insee_code": "06029", "postal_code": "[ND]", "street": "[ND]"},
                 "ape_code": "90.01Z",
                 "diffusible": False,
                 "head_office_siret": "90000000100001",


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-26990
Correction après test non concluant sur testing : oups, le code postal n'est pas diffusible, seulement la ville et le code INSEE !

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques