### PR TITLE
(BSR)[API] fix: handle case where all release dates are null

### DIFF
--- a/api/src/pcapi/core/providers/allocine_movie_list.py
+++ b/api/src/pcapi/core/providers/allocine_movie_list.py
@@ -74,8 +74,7 @@ def _build_movie_id_at_providers(provider: Provider, allocine_id: int) -> str:
 
 
 def _get_most_recent_release_date(releases: list[allocine_serializers.AllocineMovieRelease]) -> str | None:
-    if not releases:
-        return None
-    return sorted([release.releaseDate.date.isoformat() for release in releases if release.releaseDate], reverse=True)[
-        0
-    ]
+    sorted_releases = sorted(
+        [release.releaseDate.date.isoformat() for release in releases if release.releaseDate], reverse=True
+    )
+    return sorted_releases[0] if sorted_releases else None


### PR DESCRIPTION
## But de la pull request

Gestion du cas `releases=[AllocineMovieRelease(releaseDate=None, ...)]`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques