### PR TITLE
(PC-27762)[PRO] fix: use url offererId in bank informations page

### DIFF
--- a/pro/src/context/ReimbursementContext/ReimbursementContext.tsx
+++ b/pro/src/context/ReimbursementContext/ReimbursementContext.tsx
@@ -1,21 +1,14 @@
 import React, { createContext, useContext, useState } from 'react'
 
-import {
-  GetOffererNameResponseModel,
-  GetOffererResponseModel,
-} from 'apiClient/v1'
+import { GetOffererResponseModel } from 'apiClient/v1'
 
 export interface ReimbursementContextValues {
-  offerers: GetOffererNameResponseModel[] | null
   selectedOfferer: GetOffererResponseModel | null
-  setOfferers: (offerersValues: GetOffererNameResponseModel[]) => void
   setSelectedOfferer: (offererValue: GetOffererResponseModel | null) => void
 }
 
 export const ReimbursementContext = createContext<ReimbursementContextValues>({
-  offerers: null,
   selectedOfferer: null,
-  setOfferers: () => {},
   setSelectedOfferer: () => {},
 })
 
@@ -30,17 +23,13 @@ interface ReimbursementContextProviderProps {
 export function ReimbursementContextProvider({
   children,
 }: ReimbursementContextProviderProps) {
-  const [offerers, setOfferers] = useState<GetOffererNameResponseModel[]>([])
-
   const [selectedOfferer, setSelectedOfferer] =
     useState<GetOffererResponseModel | null>(null)
 
   return (
     <ReimbursementContext.Provider
       value={{
-        offerers,
         selectedOfferer,
-        setOfferers,
         setSelectedOfferer,
       }}
     >

--- a/pro/src/core/shared/constants.ts
+++ b/pro/src/core/shared/constants.ts
@@ -20,3 +20,5 @@ export const FORM_ERROR_MESSAGE =
   'Une ou plusieurs erreurs sont présentes dans le formulaire'
 
 export const NBSP = '\u00a0'
+
+export const SAVED_OFFERER_ID_KEY = 'homepageSelectedOffererId'

--- a/pro/src/hooks/useCurrentUser.ts
+++ b/pro/src/hooks/useCurrentUser.ts
@@ -1,20 +1,23 @@
 import { useSelector } from 'react-redux'
 
 import { SharedCurrentUserResponseModel } from 'apiClient/v1'
-import { selectCurrentUser } from 'store/user/selectors'
+import { selectCurrentOffererId, selectCurrentUser } from 'store/user/selectors'
 
 export interface UseCurrentUserReturn {
   currentUser: SharedCurrentUserResponseModel
+  selectedOffererId: number | null
 }
 
 const useCurrentUser = (): UseCurrentUserReturn => {
   const currentUser = useSelector(selectCurrentUser)
+  const selectedOffererId = useSelector(selectCurrentOffererId)
 
   return {
     // TODO : handle the null case by redirecting to login
     // (currently handled by the <RouteWrapper> component)
     // eslint-disable-next-line
-    currentUser: currentUser!!
+    currentUser: currentUser!!,
+    selectedOffererId,
   }
 }
 

--- a/pro/src/pages/Home/Homepage.tsx
+++ b/pro/src/pages/Home/Homepage.tsx
@@ -14,6 +14,7 @@ import PendingBankAccountCallout from 'components/Callout/PendingBankAccountCall
 import { Newsletter } from 'components/Newsletter'
 import TutorialDialog from 'components/TutorialDialog'
 import { hasStatusCode } from 'core/OfferEducational'
+import { SAVED_OFFERER_ID_KEY } from 'core/shared'
 import { SelectOption } from 'custom_types/form'
 import useRemoteConfig from 'hooks/useRemoteConfig'
 import { HTTP_STATUS } from 'repository/pcapi/pcapiClient'
@@ -31,7 +32,6 @@ import {
   getVirtualVenueFromOfferer,
 } from './venueUtils'
 
-export const SAVED_OFFERER_ID_KEY = 'homepageSelectedOffererId'
 const getSavedOffererId = (offererOptions: SelectOption[]): string | null => {
   const isLocalStorageAvailable = localStorageAvailable()
   if (!isLocalStorageAvailable) {

--- a/pro/src/pages/Home/Offerers/OffererDetails.tsx
+++ b/pro/src/pages/Home/Offerers/OffererDetails.tsx
@@ -1,20 +1,22 @@
 import cn from 'classnames'
 import React from 'react'
+import { useDispatch } from 'react-redux'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { GetOffererResponseModel } from 'apiClient/v1'
 import { Events, OffererLinkEvents } from 'core/FirebaseEvents/constants'
+import { SAVED_OFFERER_ID_KEY } from 'core/shared'
 import { SelectOption } from 'custom_types/form'
 import useAnalytics from 'hooks/useAnalytics'
 import fullAddUserIcon from 'icons/full-add-user.svg'
 import fullEditIcon from 'icons/full-edit.svg'
+import { updateSelectedOffererId } from 'store/user/reducer'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import SelectInput from 'ui-kit/form/Select/SelectInput'
 import { localStorageAvailable } from 'utils/localStorageAvailable'
 
 import { Card } from '../Card'
-import { SAVED_OFFERER_ID_KEY } from '../Homepage'
 
 import styles from './OffererDetails.module.scss'
 
@@ -34,6 +36,7 @@ export const OffererDetails = ({
   const { logEvent } = useAnalytics()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
+  const dispatch = useDispatch()
 
   const addOffererOption: SelectOption = {
     label: '+ Ajouter une structure',
@@ -47,7 +50,7 @@ export const OffererDetails = ({
     } else if (newOffererId !== selectedOfferer?.id.toString()) {
       searchParams.set('structure', newOffererId)
       setSearchParams(searchParams)
-
+      dispatch(updateSelectedOffererId(Number(newOffererId)))
       if (localStorageAvailable()) {
         localStorage.setItem(SAVED_OFFERER_ID_KEY, newOffererId)
       }

--- a/pro/src/pages/Home/__specs__/Homepage.spec.tsx
+++ b/pro/src/pages/Home/__specs__/Homepage.spec.tsx
@@ -10,6 +10,7 @@ import * as router from 'react-router-dom'
 import { api } from 'apiClient/api'
 import { GetOffererResponseModel } from 'apiClient/v1'
 import { RemoteContextProvider } from 'context/remoteConfigContext'
+import { SAVED_OFFERER_ID_KEY } from 'core/shared'
 import * as useAnalytics from 'hooks/useAnalytics'
 import {
   defaultGetOffererVenueResponseModel,
@@ -17,7 +18,7 @@ import {
 } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
-import { Homepage, SAVED_OFFERER_ID_KEY } from '../Homepage'
+import { Homepage } from '../Homepage'
 
 vi.mock('@firebase/remote-config', () => ({
   getValue: () => ({ asString: () => 'GE' }),

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useLocation, useSearchParams } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import {
@@ -10,7 +10,6 @@ import {
 import ReimbursementBankAccount from 'components/ReimbursementBankAccount/ReimbursementBankAccount'
 import { useReimbursementContext } from 'context/ReimbursementContext/ReimbursementContext'
 import { BankAccountEvents } from 'core/FirebaseEvents/constants'
-import { SelectOption } from 'custom_types/form'
 import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
 import fullLinkIcon from 'icons/full-link.svg'
@@ -18,9 +17,7 @@ import fullMoreIcon from 'icons/full-more.svg'
 import LinkVenuesDialog from 'pages/Reimbursements/BankInformations/LinkVenuesDialog'
 import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import SelectInput from 'ui-kit/form/Select/SelectInput'
 import Spinner from 'ui-kit/Spinner/Spinner'
-import { sortByLabel } from 'utils/strings'
 
 import AddBankInformationsDialog from './AddBankInformationsDialog'
 import styles from './BankInformations.module.scss'
@@ -32,55 +29,17 @@ const BankInformations = (): JSX.Element => {
 
   const [showAddBankInformationsDialog, setShowAddBankInformationsDialog] =
     useState(false)
-  const { offerers, selectedOfferer, setSelectedOfferer } =
-    useReimbursementContext()
+  const { selectedOfferer } = useReimbursementContext()
 
   const [isOffererBankAccountsLoading, setIsOffererBankAccountsLoading] =
     useState<boolean>(false)
   const [selectedOffererBankAccounts, setSelectedOffererBankAccounts] =
     useState<GetOffererBankAccountsResponseModel | null>(null)
-  const [searchParams, setSearchParams] = useSearchParams()
-  const [isOffererLoading, setIsOffererLoading] = useState<boolean>(false)
   const [selectedBankAccount, setSelectedBankAccount] =
     useState<BankAccountResponseModel | null>(null)
-  const { structure: offererId } = Object.fromEntries(searchParams)
   const [bankAccountVenues, setBankAccountVenues] = useState<
     Array<ManagedVenues>
   >([])
-
-  const offererOptions: SelectOption[] =
-    offerers && offerers.length > 1
-      ? sortByLabel(
-          offerers.map((item) => ({
-            value: item['id'].toString(),
-            label: item['name'],
-          }))
-        )
-      : []
-
-  const updateOfferer = async (newOffererId: string) => {
-    if (newOffererId !== '') {
-      setIsOffererLoading(true)
-      const offerer = await api.getOfferer(Number(newOffererId))
-      setSelectedOfferer(offerer)
-      setIsOffererLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (!offerers || offerers.length === 0) {
-      return
-    }
-
-    if (offererId) {
-      void updateOfferer(offererId)
-    }
-    if (searchParams.has('structure')) {
-      searchParams.delete('structure')
-      setSearchParams(searchParams)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   useEffect(() => {
     const getSelectedOffererBankAccounts = async (
@@ -106,15 +65,12 @@ const BankInformations = (): JSX.Element => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedOfferer])
 
-  if (isOffererBankAccountsLoading || isOffererLoading) {
+  if (isOffererBankAccountsLoading) {
     return <Spinner />
   }
 
-  async function closeDialog(update?: boolean) {
+  function closeDialog() {
     if (selectedOfferer !== null) {
-      if (update) {
-        await updateOfferer(selectedOfferer.id.toString())
-      }
       setSelectedBankAccount(null)
     }
   }
@@ -157,22 +113,6 @@ const BankInformations = (): JSX.Element => {
           En savoir plus
         </ButtonLink>
       </div>
-      {offerers && offerers.length > 1 && (
-        <div className={styles['select-offerer-section']}>
-          <div className={styles['select-offerer-input']}>
-            <div className={styles['select-offerer-input-label']}>
-              <label htmlFor="selected-offerer">Structure</label>
-            </div>
-            <SelectInput
-              onChange={(e) => updateOfferer(e.target.value)}
-              data-testid="select-input-offerer"
-              name="offererId"
-              options={offererOptions}
-              value={selectedOfferer?.id.toString() ?? ''}
-            />
-          </div>
-        </div>
-      )}
       {selectedOffererBankAccounts &&
         selectedOffererBankAccounts?.bankAccounts.length > 0 && (
           <div className={styles['bank-accounts']}>

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -21,9 +21,7 @@ const renderBankInformations = (
   initialRouterEntriesOverrides = '/remboursements/informations-bancaires'
 ) => {
   const contextValues: ReimbursementContextValues = {
-    offerers: [],
     selectedOfferer: null,
-    setOfferers: () => {},
     setSelectedOfferer: () => {},
     ...customContext,
   }
@@ -66,17 +64,6 @@ describe('BankInformations page', () => {
 
     customContext = {
       selectedOfferer: offerer,
-      offerers: [
-        {
-          ...defaultGetOffererResponseModel,
-          name: 'first offerer',
-        },
-        {
-          ...defaultGetOffererResponseModel,
-          id: 2,
-          name: 'second offerer',
-        },
-      ],
     }
 
     vi.spyOn(api, 'getOffererBankAccountsAndAttachedVenues').mockResolvedValue({

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -173,39 +173,20 @@ describe('BankInformations page', () => {
     ).toBeInTheDocument()
   })
 
-  it('should render with default offerer select and update render on select element', async () => {
+  it('should render with default offerer select ', async () => {
     renderBankInformations(customContext, store)
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-    const selectInput = screen.getByTestId('select-input-offerer')
-    expect(screen.getByDisplayValue('first offerer')).toBeInTheDocument()
     expect(screen.queryByText('Ajouter un compte bancaire')).toBeInTheDocument()
-
-    await userEvent.selectOptions(selectInput, 'second offerer')
-
-    expect(screen.getByText('second offerer')).toBeInTheDocument()
 
     expect(
       screen.queryByText(
         'Sélectionnez une structure pour faire apparaitre tous les comptes bancaires associés'
       )
     ).not.toBeInTheDocument()
-    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
   })
 
-  it('should render select input with correct offerer if url has offerer parameter', async () => {
-    renderBankInformations(
-      customContext,
-      store,
-      '/remboursements/informations-bancaires?structure=2'
-    )
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-    expect(api.getOffererBankAccountsAndAttachedVenues).toHaveBeenCalledTimes(1)
-    expect(screen.getByText('second offerer')).toBeInTheDocument()
-  })
-
-  it('should render with default offerer select and update render on select element', async () => {
+  it('should render with default offerer select', async () => {
     vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
       offerersNames: [
         {
@@ -221,13 +202,7 @@ describe('BankInformations page', () => {
     renderBankInformations(customContext, store)
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-    const selectInput = screen.getByTestId('select-input-offerer')
-    expect(screen.getByDisplayValue('first offerer')).toBeInTheDocument()
     expect(screen.queryByText('Ajouter un compte bancaire')).toBeInTheDocument()
-
-    await userEvent.selectOptions(selectInput, 'second offerer')
-
-    expect(screen.getByText('second offerer')).toBeInTheDocument()
 
     expect(
       screen.queryByText(
@@ -235,28 +210,6 @@ describe('BankInformations page', () => {
       )
     ).not.toBeInTheDocument()
     expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
-  })
-
-  it('should render select input with correct offerer if url has offerer parameter', async () => {
-    vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
-      offerersNames: [
-        {
-          id: 1,
-          name: 'first offerer',
-        },
-        {
-          id: 2,
-          name: 'second offerer',
-        },
-      ],
-    })
-    renderBankInformations(
-      customContext,
-      store,
-      '/remboursements/informations-bancaires?structure=2'
-    )
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-    expect(screen.getByText('second offerer')).toBeInTheDocument()
   })
 
   it('should show AddBankInformationsDialog on click add bank account button', async () => {

--- a/pro/src/pages/Reimbursements/ReimbursementsBanners.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsBanners.tsx
@@ -7,6 +7,7 @@ import LinkVenueCallout from 'components/Callout/LinkVenueCallout'
 import PendingBankAccountCallout from 'components/Callout/PendingBankAccountCallout'
 import { useReimbursementContext } from 'context/ReimbursementContext/ReimbursementContext'
 import useActiveFeature from 'hooks/useActiveFeature'
+import useCurrentUser from 'hooks/useCurrentUser'
 import Spinner from 'ui-kit/Spinner/Spinner'
 
 import styles from './ReimbursementBanners.module.scss'
@@ -15,6 +16,7 @@ const ReimbursementsBanners = (): JSX.Element => {
   const isNewBankDetailsJourneyEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
+  const { selectedOffererId } = useCurrentUser()
 
   const [isOfferersLoading, setIsOfferersLoading] = useState<boolean>(false)
 
@@ -27,8 +29,11 @@ const ReimbursementsBanners = (): JSX.Element => {
       try {
         const { offerersNames } = await api.listOfferersNames()
         setOfferers(offerersNames)
+
         if (offerersNames.length >= 1) {
-          const offerer = await api.getOfferer(offerersNames[0].id)
+          const offerer = await api.getOfferer(
+            selectedOffererId || offerersNames[0].id
+          )
           setSelectedOfferer(offerer)
         }
         setIsOfferersLoading(false)

--- a/pro/src/pages/Reimbursements/ReimbursementsBanners.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsBanners.tsx
@@ -20,15 +20,13 @@ const ReimbursementsBanners = (): JSX.Element => {
 
   const [isOfferersLoading, setIsOfferersLoading] = useState<boolean>(false)
 
-  const { setOfferers, setSelectedOfferer, selectedOfferer } =
-    useReimbursementContext()
+  const { setSelectedOfferer, selectedOfferer } = useReimbursementContext()
 
   useEffect(() => {
     const fetchData = async () => {
       setIsOfferersLoading(true)
       try {
         const { offerersNames } = await api.listOfferersNames()
-        setOfferers(offerersNames)
 
         if (offerersNames.length >= 1) {
           const offerer = await api.getOfferer(

--- a/pro/src/pages/Reimbursements/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/BankInformations.spec.tsx
@@ -53,13 +53,11 @@ function renderBankInformations() {
   renderWithProviders(
     <ReimbursementContext.Provider
       value={{
-        offerers: [{ name: 'toto', id: 1 }],
         selectedOfferer: {
           ...defaultGetOffererResponseModel,
           name: 'toto',
           id: 1,
         },
-        setOfferers: () => undefined,
         setSelectedOfferer: () => undefined,
       }}
     >

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -171,6 +171,7 @@ describe('screens:StocksThing', () => {
           roles: [],
           isEmailValidated: true,
         },
+        selectedOffererId: null,
       },
     }
 

--- a/pro/src/store/StoreProvider/StoreProvider.tsx
+++ b/pro/src/store/StoreProvider/StoreProvider.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 
 import { api } from 'apiClient/api'
+import { SAVED_OFFERER_ID_KEY } from 'core/shared'
 import { updateFeatures } from 'store/features/reducer'
-import { updateUser } from 'store/user/reducer'
+import { updateSelectedOffererId, updateUser } from 'store/user/reducer'
 import Spinner from 'ui-kit/Spinner/Spinner'
+import { localStorageAvailable } from 'utils/localStorageAvailable'
 
 interface StoreProviderProps {
   children: JSX.Element | JSX.Element[]
@@ -42,6 +44,12 @@ const StoreProvider = ({
 
     const getStoreInitialState = async () => {
       await Promise.all([initializeUser(), initializeFeatures()])
+      const isLocalStorageAvailable = localStorageAvailable()
+
+      if (isLocalStorageAvailable) {
+        const savedOffererId = localStorage.getItem(SAVED_OFFERER_ID_KEY)
+        dispatch(updateSelectedOffererId(Number(savedOffererId)))
+      }
       setIsStoreInitialized(true)
     }
 

--- a/pro/src/store/StoreProvider/StoreProvider.tsx
+++ b/pro/src/store/StoreProvider/StoreProvider.tsx
@@ -44,9 +44,8 @@ const StoreProvider = ({
 
     const getStoreInitialState = async () => {
       await Promise.all([initializeUser(), initializeFeatures()])
-      const isLocalStorageAvailable = localStorageAvailable()
 
-      if (isLocalStorageAvailable) {
+      if (localStorageAvailable()) {
         const savedOffererId = localStorage.getItem(SAVED_OFFERER_ID_KEY)
         dispatch(updateSelectedOffererId(Number(savedOffererId)))
       }

--- a/pro/src/store/user/reducer.ts
+++ b/pro/src/store/user/reducer.ts
@@ -4,10 +4,12 @@ import { SharedCurrentUserResponseModel } from 'apiClient/v1'
 
 type UserState = {
   currentUser: null | SharedCurrentUserResponseModel
+  selectedOffererId: number | null
 }
 
 export const initialState: UserState = {
   currentUser: null,
+  selectedOffererId: null,
 }
 
 const userSlice = createSlice({
@@ -20,9 +22,15 @@ const userSlice = createSlice({
     ) => {
       state.currentUser = action.payload
     },
+    updateSelectedOffererId: (
+      state: UserState,
+      action: PayloadAction<number>
+    ) => {
+      state.selectedOffererId = action.payload
+    },
   },
 })
 
 export const userReducer = userSlice.reducer
 
-export const { updateUser } = userSlice.actions
+export const { updateUser, updateSelectedOffererId } = userSlice.actions

--- a/pro/src/store/user/selectors.ts
+++ b/pro/src/store/user/selectors.ts
@@ -1,3 +1,6 @@
 import { RootState } from 'store/rootReducer'
 
 export const selectCurrentUser = (state: RootState) => state.user.currentUser
+
+export const selectCurrentOffererId = (state: RootState) =>
+  state.user.selectedOffererId


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27762 

- Ajouter la structure sélectionnée sur la home dans le contexte utilisateur pour qu'elle soit acessible partout sur PC pro
- Suppression du select de structure dans la page informations bancaires (on utilise la structure sélectionnée sur la home)

![Capture d’écran 2024-02-12 à 09 59 22](https://github.com/pass-culture/pass-culture-main/assets/71768799/32dec77b-0ded-452c-a3d0-f1624860b49f)

