### PR TITLE
(PC-26869)[PRO] feat: Hide the offer creation button with the WIP_ENABLE_PRO_SIDE_NAV FF.

### DIFF
--- a/pro/cypress/e2e/createEventIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/createEventIndividualOffer.cy.ts
@@ -1,5 +1,7 @@
 describe('Create an individual offer (event)', () => {
   it('should create an individual offer', () => {
+    cy.setFeatureFlags([{ name: 'WIP_ENABLE_PRO_SIDE_NAV', isActive: false }])
+
     cy.login({
       email: 'pro_adage_eligible@example.com',
       password: 'user@AZERTY123',

--- a/pro/cypress/e2e/createThingIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/createThingIndividualOffer.cy.ts
@@ -1,5 +1,7 @@
 describe('Create an individual offer (thing)', () => {
   it('should create an individual offer', () => {
+    cy.setFeatureFlags([{ name: 'WIP_ENABLE_PRO_SIDE_NAV', isActive: false }])
+
     // Random 13-digit number because we can't use the same EAN twice
     const ean = String(
       Math.floor(1000000000000 + Math.random() * 9000000000000)

--- a/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
@@ -7,6 +7,8 @@ import {
   GetOffererResponseModel,
   GetOffererStatsResponseModel,
 } from 'apiClient/v1'
+import useActiveFeature from 'hooks/useActiveFeature'
+import useCurrentUser from 'hooks/useCurrentUser'
 import fullMoreIcon from 'icons/full-more.svg'
 import strokeNoBookingIcon from 'icons/stroke-no-booking.svg'
 import { ButtonLink } from 'ui-kit/Button'
@@ -21,13 +23,20 @@ import { MostViewedOffers } from './MostViewedOffers'
 import { OfferStats } from './OfferStats'
 import styles from './StatisticsDashboard.module.scss'
 
-export interface StatisticsDashboardProps {
+interface StatisticsDashboardProps {
   offerer: GetOffererResponseModel
 }
 
 export const StatisticsDashboard = ({ offerer }: StatisticsDashboardProps) => {
   const [stats, setStats] = useState<GetOffererStatsResponseModel | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+
+  const { currentUser } = useCurrentUser()
+
+  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+
+  const displayCreateOfferButton =
+    (isNewSideBarNavigation && currentUser.isAdmin) || !isNewSideBarNavigation
 
   useEffect(() => {
     const loadStats = async () => {
@@ -46,16 +55,18 @@ export const StatisticsDashboard = ({ offerer }: StatisticsDashboardProps) => {
       <div className={styles['header']}>
         <h2 className={styles['title']}>Présence sur le pass Culture</h2>
 
-        <ButtonLink
-          variant={ButtonVariant.PRIMARY}
-          link={{
-            isExternal: false,
-            to: `/offre/creation?structure=${offerer.id}`,
-          }}
-          icon={fullMoreIcon}
-        >
-          Créer une offre
-        </ButtonLink>
+        {displayCreateOfferButton && (
+          <ButtonLink
+            variant={ButtonVariant.PRIMARY}
+            link={{
+              isExternal: false,
+              to: `/offre/creation?structure=${offerer.id}`,
+            }}
+            icon={fullMoreIcon}
+          >
+            Créer une offre
+          </ButtonLink>
+        )}
       </div>
 
       {!isLoading && (

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -18,6 +18,7 @@ import {
 import { Audience } from 'core/shared'
 import getUserValidatedOfferersNamesAdapter from 'core/shared/adapters/getUserValidatedOfferersNamesAdapter'
 import { SelectOption } from 'custom_types/form'
+import useActiveFeature from 'hooks/useActiveFeature'
 import fullPlusIcon from 'icons/full-plus.svg'
 import strokeLibraryIcon from 'icons/stroke-library.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
@@ -76,6 +77,8 @@ const Offers = ({
   const [areAllOffersSelected, setAreAllOffersSelected] = useState(false)
   const [selectedOfferIds, setSelectedOfferIds] = useState<string[]>([])
 
+  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+
   const { isAdmin } = currentUser
   const currentPageOffersSubset = offers.slice(
     (currentPageNumber - 1) * NUMBER_OF_OFFERS_PER_PAGE,
@@ -108,6 +111,8 @@ const Offers = ({
   )
 
   const [isOffererValidated, setIsOffererValidated] = useState<boolean>(false)
+  const displayCreateOfferButton =
+    !isNewSideBarNavigation && !isAdmin && isOffererValidated
 
   useEffect(() => {
     const loadValidatedUserOfferers = async () => {
@@ -128,16 +133,15 @@ const Offers = ({
     }
   }, [])
 
-  const actionLink =
-    isAdmin || !isOffererValidated ? undefined : (
-      <ButtonLink
-        variant={ButtonVariant.PRIMARY}
-        link={{ isExternal: false, to: '/offre/creation' }}
-        icon={fullPlusIcon}
-      >
-        Créer une offre
-      </ButtonLink>
-    )
+  const actionLink = displayCreateOfferButton ? (
+    <ButtonLink
+      variant={ButtonVariant.PRIMARY}
+      link={{ isExternal: false, to: '/offre/creation' }}
+      icon={fullPlusIcon}
+    >
+      Créer une offre
+    </ButtonLink>
+  ) : undefined
 
   const nbSelectedOffers = areAllOffersSelected
     ? offers.length

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -772,4 +772,40 @@ describe('screen Offers', () => {
       })
     )
   })
+
+  it('should display the create offer button by default for non admins with validated offerers', async () => {
+    vi.spyOn(api, 'listOfferersNames').mockResolvedValueOnce({
+      offerersNames: [
+        {
+          id: 1,
+          name: 'Mon super cinéma',
+        },
+      ],
+    })
+
+    renderOffers(props)
+    await waitFor(() => {
+      expect(api.listOfferersNames).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByText(/Créer une offre/)).toBeInTheDocument()
+  })
+
+  it('should not display the create offer button with the WIP_ENABLE_PRO_SIDE_NAV FF enabled', async () => {
+    vi.spyOn(api, 'listOfferersNames').mockResolvedValueOnce({
+      offerersNames: [
+        {
+          id: 1,
+          name: 'Mon super cinéma',
+        },
+      ],
+    })
+
+    renderOffers(props, {
+      features: ['WIP_ENABLE_PRO_SIDE_NAV'],
+    })
+    await waitFor(() => {
+      expect(api.listOfferersNames).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.queryByText(/Créer une offre/)).not.toBeInTheDocument()
+  })
 })

--- a/pro/src/screens/VenueForm/VenueEditionFormScreen.tsx
+++ b/pro/src/screens/VenueForm/VenueEditionFormScreen.tsx
@@ -65,6 +65,7 @@ export const VenueEditionFormScreen = ({
   const isNewBankDetailsEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
+  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
 
   const handleCancelWithdrawalDialog = () => {
     setShouldSendMail(false)
@@ -191,11 +192,15 @@ export const VenueEditionFormScreen = ({
         <div className={style['title-page']}>
           <Title level={1}>Lieu</Title>
 
-          <a href={`/offre/creation?lieu=${initialId}&structure=${offerer.id}`}>
-            <Button variant={ButtonVariant.PRIMARY} icon={fullPlusIcon}>
-              <span>Créer une offre</span>
-            </Button>
-          </a>
+          {!isNewSideBarNavigation && (
+            <a
+              href={`/offre/creation?lieu=${initialId}&structure=${offerer.id}`}
+            >
+              <Button variant={ButtonVariant.PRIMARY} icon={fullPlusIcon}>
+                <span>Créer une offre</span>
+              </Button>
+            </a>
+          )}
         </div>
         <Title level={2} className={style['venue-name']}>
           {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26869

Ne pas afficher les boutons "Créer une offre" si le FF `WIP_ENABLE_PRO_SIDE_NAV` est activé, sauf celui de la home pour les admin.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques