### PR TITLE
(PC-27563)[PRO] feat: Create the cultural partner panel on adage temp…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
@@ -29,12 +29,22 @@
 
   &-body {
     padding: rem.torem(24px);
+    display: flex;
+    flex-direction: column;
+    gap: rem.torem(24px);
   }
 
   &-main {
     display: flex;
+    flex-grow: 1;
     flex-direction: column;
     gap: rem.torem(32px);
+  }
+
+  &-side {
+    width: 100%;
+    max-width: 100%;
+    flex-shrink: 0;
   }
 }
 
@@ -73,6 +83,17 @@
         color: colors.$grey-medium;
       }
     }
+  }
+}
+
+@media (min-width: size.$tablet) {
+  .offer-body {
+    flex-direction: row;
+  }
+
+  .offer-side {
+    width: rem.torem(480px);
+    max-width: 50%;
   }
 }
 

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
@@ -2,6 +2,7 @@ import {
   CollectiveOfferTemplateResponseModel,
   CollectiveOfferResponseModel,
 } from 'apiClient/adage'
+import { isCollectiveOfferTemplate } from 'core/OfferEducational'
 import strokeArticleIcon from 'icons/stroke-article.svg'
 import strokeInfoIcon from 'icons/stroke-info.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
@@ -12,6 +13,7 @@ import AdageOfferDetailsSection from './AdageOfferDetailsSection/AdageOfferDetai
 import AdageOfferInfoSection from './AdageOfferDetailsSection/AdageOfferInfoSection'
 import AdageOfferPublicSection from './AdageOfferDetailsSection/AdageOfferPublicSection'
 import AdageOfferHeader from './AdageOfferHeader/AdageOfferHeader'
+import AdageOfferPartnerPanel from './AdageOfferPartnerPanel/AdageOfferPartnerPanel'
 
 type AdageOfferProps = {
   offer: CollectiveOfferTemplateResponseModel | CollectiveOfferResponseModel
@@ -63,9 +65,15 @@ export default function AdageOffer({ offer }: AdageOfferProps) {
             </div>
           </section>
         </div>
-      </div>
-      <div className={styles['offer-side']}>
-        {/* TODO : Here will go the side panel */}
+        <div className={styles['offer-side']}>
+          {isCollectiveOfferTemplate(offer) ? (
+            <AdageOfferPartnerPanel offer={offer} />
+          ) : (
+            <>
+              {/* TODO : Here will go the school infos for a bookable offer */}
+            </>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.module.scss
@@ -91,16 +91,11 @@
 
   .offer-header-actions {
     justify-content: unset;
+    gap: rem.torem(8px);
   }
 
   .offer-header-share-button-tooltip-content {
     width: auto;
-  }
-}
-
-@media (min-width: size.$mobile) {
-  .offer-header-actions {
-    gap: rem.torem(8px);
   }
 }
 

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.tsx
@@ -39,7 +39,8 @@ export default function AdageOfferHeader({ offer }: AdageOfferProps) {
       )) ||
       'Tout au long de l’année scolaire (l’offre est permanente)')
 
-  const studentLevels = offer.students.join(', ')
+  const studentLevels =
+    offer.students.length > 1 ? 'Multiniveaux' : offer.students[0]
 
   let offerVenueLabel = `${offer.venue.postalCode}, ${offer.venue.city}`
   if (offer.offerVenue) {

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react'
 
-import { AdageFrontRoles } from 'apiClient/adage'
+import { AdageFrontRoles, StudentLevels } from 'apiClient/adage'
 import { OfferAddressType } from 'apiClient/v1'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
 import {
@@ -160,5 +160,16 @@ describe('AdageOfferHeader', () => {
         'Tout au long de l’année scolaire (l’offre est permanente)'
       )
     ).toBeInTheDocument()
+  })
+
+  it('should show "Multiniveaux" instead of the list of student levels when there are more than 1', () => {
+    renderAdageOfferHeader({
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        students: [StudentLevels.CAP_1RE_ANN_E, StudentLevels.COLL_GE_3E],
+      },
+    })
+
+    expect(screen.getByText('Multiniveaux')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.module.scss
@@ -1,0 +1,73 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_colors.scss" as colors;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.partner-panel {
+  width: 100%;
+  border-radius: rem.torem(16px);
+  box-shadow: 0 rem.torem(2px) rem.torem(16px) 0 colors.$large-shadow;
+  padding: rem.torem(24px);
+
+  &-header {
+    display: flex;
+    align-items: center;
+    gap: rem.torem(8px);
+
+    &-title {
+      @include fonts.title3;
+    }
+  }
+
+  &-info {
+    margin-top: rem.torem(24px);
+    display: flex;
+    gap: rem.torem(24px);
+
+    &-image-fallback,
+    &-image {
+      min-width: rem.torem(99px);
+      height: rem.torem(66px);
+      border-radius: rem.torem(4px);
+    }
+
+    &-image {
+      object-fit: cover;
+    }
+
+    &-image-fallback {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: colors.$grey-light;
+      color: colors.$grey-semi-dark;
+    }
+  }
+
+  &-info-name {
+    display: block;
+  }
+
+  &-location {
+    margin-top: rem.torem(16px);
+
+    &-bold {
+      @include fonts.body-important;
+    }
+  }
+
+  &-contact {
+    margin-top: rem.torem(16px);
+
+    &-icon {
+      margin-right: rem.torem(8px);
+    }
+  }
+}
+
+@media (min-height: rem.torem(500px)) {
+  //  Make sure the pannel is only sticky when the screen has a big enough height. Otherwise it might not be fully visible.
+  .partner-panel {
+    position: sticky;
+    top: rem.torem(24px);
+  }
+}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
@@ -1,0 +1,126 @@
+import { CollectiveOfferTemplateResponseModel } from 'apiClient/adage'
+import Callout from 'components/Callout/Callout'
+import { CalloutVariant } from 'components/Callout/types'
+import fullLinkIcon from 'icons/full-link.svg'
+import fullMailIcon from 'icons/full-mail.svg'
+import strokeInstitutionIcon from 'icons/stroke-institution.svg'
+import strokeVenueIcon from 'icons/stroke-venue.svg'
+import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
+import { ButtonLink } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+import { getHumanizeRelativeDistance } from 'utils/getDistance'
+
+import ContactButton from '../../../OffersInstantSearch/OffersSearch/Offers/ContactButton'
+
+import styles from './AdageOfferPartnerPanel.module.scss'
+
+export type AdageOfferPartnerPanelProps = {
+  offer: CollectiveOfferTemplateResponseModel
+}
+
+export default function AdageOfferPartnerPanel({
+  offer,
+}: AdageOfferPartnerPanelProps) {
+  const venue = offer.venue
+  const { adageUser } = useAdageUser()
+
+  const distanceToSchool =
+    venue.coordinates.latitude !== null &&
+    venue.coordinates.latitude !== undefined &&
+    venue.coordinates.longitude !== null &&
+    venue.coordinates.longitude !== undefined &&
+    adageUser.lat !== null &&
+    adageUser.lat !== undefined &&
+    adageUser.lon !== null &&
+    adageUser.lon !== undefined &&
+    getHumanizeRelativeDistance(
+      {
+        latitude: venue.coordinates.latitude,
+        longitude: venue.coordinates.longitude,
+      },
+      {
+        latitude: adageUser.lat,
+        longitude: adageUser.lon,
+      }
+    )
+
+  return (
+    <div className={styles['partner-panel']}>
+      <div className={styles['partner-panel-header']}>
+        <SvgIcon src={strokeInstitutionIcon} alt="" width="20" />
+        <h2 className={styles['partner-panel-header-title']}>
+          Partenaire culturel
+        </h2>
+      </div>
+      <div className={styles['partner-panel-info']}>
+        {venue.imgUrl ? (
+          <img
+            src={venue.imgUrl}
+            alt=""
+            className={styles['partner-panel-info-image']}
+          />
+        ) : (
+          <div className={styles['partner-panel-info-image-fallback']}>
+            <SvgIcon src={strokeVenueIcon} alt="" width="32" />
+          </div>
+        )}
+
+        <div>
+          <p className={styles['partner-panel-info-name']}>{venue.name}</p>
+          {venue.adageId && (
+            <ButtonLink
+              link={{
+                isExternal: true,
+                to: `${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`,
+                target: '_blank',
+              }}
+              variant={ButtonVariant.TERNARY}
+              className={styles['partner-panel-info-link']}
+              icon={fullLinkIcon}
+              svgAlt="Nouvelle fenêtre"
+            >
+              Voir la page partenaire
+            </ButtonLink>
+          )}
+        </div>
+      </div>
+
+      <div className={styles['partner-panel-location']}>
+        {(venue.city || venue.postalCode || distanceToSchool) && (
+          <Callout variant={CalloutVariant.INFO}>
+            Ce partenaire est situé{' '}
+            <b className={styles['partner-panel-location-bold']}>
+              {(venue.city || venue.postalCode) &&
+                `à ${venue.city ?? ''} ${venue.postalCode ?? ''}`}
+              {distanceToSchool &&
+                `, à ${distanceToSchool} de votre
+            établissement scolaire`}
+              .
+            </b>
+          </Callout>
+        )}
+      </div>
+
+      <div className={styles['partner-panel-contact']}>
+        <ContactButton
+          contactEmail={offer.contactEmail}
+          contactPhone={offer.contactPhone}
+          offerId={offer.id}
+          position={0}
+          queryId={''}
+          userEmail={adageUser.email}
+          userRole={adageUser.role}
+        >
+          <SvgIcon
+            src={fullMailIcon}
+            alt=""
+            width="20"
+            className={styles['partner-panel-contact-icon']}
+          />{' '}
+          Contacter le partenaire
+        </ContactButton>
+      </div>
+    </div>
+  )
+}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/__specs__/AdageOfferPartnerPanel.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/__specs__/AdageOfferPartnerPanel.spec.tsx
@@ -1,0 +1,139 @@
+import { screen } from '@testing-library/react'
+
+import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
+import {
+  defaultAdageUser,
+  defaultCollectiveTemplateOffer,
+} from 'utils/adageFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import AdageOfferPartnerPanel, {
+  AdageOfferPartnerPanelProps,
+} from '../AdageOfferPartnerPanel'
+
+function renderAdageOfferPartnerPanel(
+  props: AdageOfferPartnerPanelProps = {
+    offer: defaultCollectiveTemplateOffer,
+  },
+  user = defaultAdageUser
+) {
+  return renderWithProviders(
+    <AdageUserContextProvider adageUser={user}>
+      <AdageOfferPartnerPanel {...props} />
+    </AdageUserContextProvider>
+  )
+}
+
+describe('AdageOfferPartnerPanel', () => {
+  it('should render the cultural partner panel', () => {
+    renderAdageOfferPartnerPanel()
+
+    expect(
+      screen.getByRole('heading', { name: 'Partenaire culturel' })
+    ).toBeInTheDocument()
+  })
+
+  it('should show the partner page link if the offer venue has an adageId', () => {
+    renderAdageOfferPartnerPanel({
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        venue: { ...defaultCollectiveTemplateOffer.venue, adageId: '123' },
+      },
+    })
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Nouvelle fenêtre Voir la page partenaire',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('should not show the partner page link if the offer venue no adageId', () => {
+    renderAdageOfferPartnerPanel({
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        venue: { ...defaultCollectiveTemplateOffer.venue, adageId: undefined },
+      },
+    })
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'Nouvelle fenêtre Voir la page partenaire',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should show the partner city and postal code', () => {
+    renderAdageOfferPartnerPanel({
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        venue: {
+          ...defaultCollectiveTemplateOffer.venue,
+          city: 'Paris',
+          postalCode: '75000',
+        },
+      },
+    })
+
+    expect(screen.getByText(/à Paris 75000/)).toBeInTheDocument()
+  })
+
+  it('should only show the partner city if there is no postal code', () => {
+    renderAdageOfferPartnerPanel({
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        venue: {
+          ...defaultCollectiveTemplateOffer.venue,
+          city: 'Paris',
+          postalCode: undefined,
+        },
+      },
+    })
+
+    expect(screen.getByText(/à Paris/)).toBeInTheDocument()
+  })
+
+  it('should only show the partner postal code if there is no city', () => {
+    renderAdageOfferPartnerPanel({
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        venue: {
+          ...defaultCollectiveTemplateOffer.venue,
+          city: undefined,
+          postalCode: '75000',
+        },
+      },
+    })
+
+    expect(screen.getByText(/75000/)).toBeInTheDocument()
+  })
+
+  it('should show the partner distance to school', () => {
+    renderAdageOfferPartnerPanel(
+      {
+        offer: {
+          ...defaultCollectiveTemplateOffer,
+          venue: {
+            ...defaultCollectiveTemplateOffer.venue,
+            coordinates: { latitude: 1, longitude: 1 },
+            city: undefined,
+            postalCode: undefined,
+          },
+        },
+      },
+      { ...defaultAdageUser, lat: 2, lon: 2 }
+    )
+
+    expect(
+      screen.getByText(/à 157 km de votre établissement scolaire/)
+    ).toBeInTheDocument()
+  })
+
+  it('should show the cultural partner contact button', () => {
+    renderAdageOfferPartnerPanel()
+
+    expect(
+      screen.getByRole('button', { name: 'Contacter le partenaire' })
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/__specs__/AdageOffer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/__specs__/AdageOffer.spec.tsx
@@ -9,13 +9,17 @@ import { renderWithProviders } from 'utils/renderWithProviders'
 
 import AdageOffer from '../AdageOffer'
 
+function renderAdageOffer() {
+  return renderWithProviders(
+    <AdageUserContextProvider adageUser={defaultAdageUser}>
+      <AdageOffer offer={defaultCollectiveTemplateOffer} />
+    </AdageUserContextProvider>
+  )
+}
+
 describe('AdageOffer', () => {
   it('should display the offer information sections', () => {
-    renderWithProviders(
-      <AdageUserContextProvider adageUser={defaultAdageUser}>
-        <AdageOffer offer={defaultCollectiveTemplateOffer} />
-      </AdageUserContextProvider>
-    )
+    renderAdageOffer()
 
     expect(
       screen.getByRole('heading', { name: 'Détails de l’offre' })
@@ -25,6 +29,14 @@ describe('AdageOffer', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: 'Public concerné' })
+    ).toBeInTheDocument()
+  })
+
+  it('should show the offer cultural partner infos for a collective offer', () => {
+    renderAdageOffer()
+
+    expect(
+      screen.getByRole('heading', { name: 'Partenaire culturel' })
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
@@ -17,6 +17,7 @@ export interface ContactButtonProps {
   userEmail?: string | null
   userRole: AdageFrontRoles
   isInSuggestions?: boolean
+  children?: React.ReactNode
 }
 
 const ContactButton = ({
@@ -29,6 +30,7 @@ const ContactButton = ({
   userEmail,
   userRole,
   isInSuggestions,
+  children,
 }: ContactButtonProps): JSX.Element => {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -54,7 +56,7 @@ const ContactButton = ({
     <>
       <div className={`prebooking-button-container ${className}`}>
         <Button className="prebooking-button" onClick={handleButtonClick}>
-          Contacter
+          {children ?? 'Contacter'}
         </Button>
       </div>
       {isModalOpen && (

--- a/pro/src/ui-kit/Tooltip/Tooltip.module.scss
+++ b/pro/src/ui-kit/Tooltip/Tooltip.module.scss
@@ -42,3 +42,7 @@ $arrow-triangle-height: rem.torem(8px);
     transform: translate(-50%);
   }
 }
+
+.tooltip-hidden {
+  @include a11y.visually-hidden;
+}

--- a/pro/src/ui-kit/Tooltip/Tooltip.tsx
+++ b/pro/src/ui-kit/Tooltip/Tooltip.tsx
@@ -29,7 +29,7 @@ const Tooltip = ({
         className={cn(
           styles['tooltip'],
           {
-            ['visually-hidden']: visuallyHidden,
+            [styles['tooltip-hidden']]: visuallyHidden,
           },
           tooltipContentClassName
         )}


### PR DESCRIPTION
…late offer page.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27563

**Pour voir l'UI**
- Activer le FF WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN
- Aller sur "/adage-iframe/recherche/offre/[un id d'offre de votre env]?token=[votre token adage]"

**Objectif**
Créer le panneau latéral contenant les détails de la venue sur la page de l'offre template adage. J'ai aussi un mini commit concernant le Tooltip pour que le style visually-hidden prenne le pas sur les styles .tooltip. (Sinon ça me pose des pb pour que la width du tooltip soit à 0 tant qu'il est pas visible).

<img width="549" alt="Capture d’écran 2024-02-12 à 15 44 21" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/ffb482cc-f11b-441d-8d70-ea98dffdc377">
<img width="1173" alt="Capture d’écran 2024-02-12 à 15 44 02" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/77401d00-c623-4658-8223-443845420f95">
<img width="1173" alt="Capture d’écran 2024-02-12 à 15 43 55" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/d3196c3c-e870-45f0-b3be-db3d34d8799e">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques