### PR TITLE
(BSR)[API] revert: remove rq_exporter

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -4473,22 +4473,6 @@ click = ">=5"
 redis = ">=3.5"
 
 [[package]]
-name = "rq-exporter"
-version = "2.1.2"
-description = "Prometheus exporter for Python RQ (Redis Queue)"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "rq-exporter-2.1.2.tar.gz", hash = "sha256:41ed9e833e2d7f6e1f35c4ffec6a7921cc7ab4d0ff26925d4d2fadb8843321fe"},
-    {file = "rq_exporter-2.1.2-py3-none-any.whl", hash = "sha256:79fd7c3fb6d047b884a3b2c27c8ec863c48d1cbca6025d76a78d2014bef7a174"},
-]
-
-[package.dependencies]
-prometheus-client = ">=0.8.0"
-redis = ">=3.5.3"
-rq = ">=1.8.0"
-
-[[package]]
 name = "rsa"
 version = "4.9"
 description = "Pure-Python RSA implementation"
@@ -5625,4 +5609,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "57c46450b9a3f003b111c30f6fe12cc62daac3c22d63375516a925fb9c5c4ebc"
+content-hash = "7175c2cdcf6793436be13ad31d13d0820fd86f549db7b91ae4f44fc476454593"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -60,7 +60,6 @@ pyyaml = "6.0.1"
 rapidfuzz = "^3.8.1"
 requests = "2.31.0"
 rq = "1.16.1"
-rq-exporter = "^2.1.2"
 schwifty = "2024.1.1.post0"
 semver = "3.0.2"
 sentry-sdk = { version = "1.45.0", extras = ["flask"] }

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -15,10 +15,8 @@ from flask_login import LoginManager
 from flask_login import current_user
 import prometheus_flask_exporter.multiprocess
 import redis
-import rq_exporter
 import sentry_sdk
 from sqlalchemy import orm
-from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -136,12 +134,6 @@ if settings.PROFILE_REQUESTS:
     app.wsgi_app = ProfilerMiddleware(
         app.wsgi_app,
         restrictions=profiling_restrictions,
-    )
-
-if int(os.environ.get("ENABLE_RQ_PROMETHEUS_EXPORTER", "0")):
-    app.wsgi_app = DispatcherMiddleware(
-        app.wsgi_app,
-        {"/rq_metrics": rq_exporter.create_app()},
     )
 
 


### PR DESCRIPTION
It won't work like that. 
To be able to export data to prometheus we need to create a new service to expose the new metrics route. 