### PR TITLE
BSR: owners dev team on ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-### DevOps team should be notified if a modification on workflow is done
+### DevOps team is notified to guarantee consistency and security good practices
+### ci-owners team is notified to maintain and improve
 
-/.github/workflows/ @pass-culture/sherif-ops @pass-culture/sherif-devlead
+/.github/workflows/ @pass-culture/sherif-ops @pass-culture/main-ci-owners


### PR DESCRIPTION
## But de la pull request

Permettre à la team github `ci-owners` de maintenir et améliorer la CI.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques