### PR TITLE
(PC-27848)[PRO] feat: Fetch bookable offer if the id is prefixed with…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -26,11 +26,15 @@ import styles from './OfferInfos.module.scss'
 
 export const OfferInfos = () => {
   const { state, pathname } = useLocation()
-  const { offerId } = useParams()
+  const { offerId: offerIdInParams } = useParams()
   const [searchParams] = useSearchParams()
   const adageAuthToken = searchParams.get('token')
 
   const parentRouteInUrl = pathname.split('/')[2] ?? 'recherche'
+
+  const isOfferTemplate = !offerIdInParams?.startsWith('B-')
+  //  Bookable offers ids are prefixed with B- while template offers ids are prefixed with T-, or not prefixed for legacy reasons.
+  const offerId = offerIdInParams?.split('-')[1] ?? offerIdInParams
 
   const [offer, setOffer] = useState<
     CollectiveOfferTemplateResponseModel | CollectiveOfferResponseModel
@@ -81,9 +85,9 @@ export const OfferInfos = () => {
     async function getOffer() {
       setLoading(true)
       try {
-        const fetchedOffer = await apiAdage.getCollectiveOfferTemplate(
-          Number(offerId)
-        )
+        const fetchedOffer = isOfferTemplate
+          ? await apiAdage.getCollectiveOfferTemplate(Number(offerId))
+          : await apiAdage.getCollectiveOffer(Number(offerId))
         setOffer(fetchedOffer)
       } finally {
         setLoading(false)
@@ -94,7 +98,7 @@ export const OfferInfos = () => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       getOffer()
     }
-  }, [offerId, state?.offer])
+  }, [offerId, state?.offer, isOfferTemplate])
 
   if (loading) {
     return <Spinner />

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/__specs__/OfferInfos.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/__specs__/OfferInfos.spec.tsx
@@ -6,6 +6,7 @@ import { apiAdage } from 'apiClient/api'
 import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
 import {
   defaultAdageUser,
+  defaultCollectiveOffer,
   defaultCollectiveTemplateOffer,
 } from 'utils/adageFactories'
 import {
@@ -18,6 +19,7 @@ import { OfferInfos } from '../OfferInfos'
 vi.mock('apiClient/api', () => ({
   apiAdage: {
     getCollectiveOfferTemplate: vi.fn(),
+    getCollectiveOffer: vi.fn(),
   },
 }))
 
@@ -151,7 +153,7 @@ describe('OfferInfos', () => {
     expect(fetchOfferSpy).toHaveBeenCalledWith(1)
   })
 
-  it('should render the now offer info page sections if the ff is enabled', () => {
+  it('should render the new offer info page sections if the ff is enabled', () => {
     renderOfferInfos(defaultAdageUser, {
       features: ['WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN'],
     })
@@ -159,5 +161,34 @@ describe('OfferInfos', () => {
     expect(screen.getByRole('heading', { name: 'Détails de l’offre' }))
     expect(screen.getByRole('heading', { name: 'Informations pratiques' }))
     expect(screen.getByRole('heading', { name: 'Public concerné' }))
+  })
+
+  it('should fetch a bookable offer if the id in url is prefixed with "B-"', async () => {
+    vi.spyOn(router, 'useLocation').mockReturnValueOnce({
+      ...defaultUseLocationValue,
+      state: { offer: null },
+    })
+
+    vi.spyOn(router, 'useParams').mockImplementationOnce(() => {
+      return {
+        offerId: 'B-1',
+      }
+    })
+
+    const fetchOfferTemplateSpy = vi
+      .spyOn(apiAdage, 'getCollectiveOfferTemplate')
+      .mockResolvedValueOnce(defaultCollectiveTemplateOffer)
+
+    const fetchOfferSpy = vi
+      .spyOn(apiAdage, 'getCollectiveOffer')
+      .mockResolvedValueOnce(defaultCollectiveOffer)
+
+    renderOfferInfos()
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(fetchOfferTemplateSpy).not.toHaveBeenCalled()
+
+    expect(fetchOfferSpy).toHaveBeenCalledWith(1)
   })
 })


### PR DESCRIPTION
… B- in adage offer page.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27848

**Pour tester**
- Activer le FF WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN
- Aller sur /adage-iframe/decouverte/offre/9?token=... (en supposant que l'offre vitrine 9 existe) et vérifier le bon affichage de l'offre
- Aller sur /adage-iframe/decouverte/offre/B-9?token=... (en supposant que l'offre réservable 9 existe) et vérifier que c'est bien l'offre réservable qui a été requêtée

**Objectif**
Pour préparer la nouvelle page de l'offre adage à recevoir soit une offre template (done) soit une offre réservable, on a besoin de différencier la page via son url (pour savoir quelle api requêter). Donc quand on redirigera vers une offre réservable, on préfixera l'id de l'offre avec "B-", et "T-" pour les offres vitrines.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques