### PR TITLE
(PC-27829)[BO] feat: add an action to the venue's history when deleting a pivot

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -67,6 +67,8 @@ class ActionType(enum.Enum):
     RULE_CREATED = "Création d'une règle de conformité"
     RULE_DELETED = "Suppression d'une règle de conformité"
     RULE_MODIFIED = "Modification d'une règle de conformité"
+    # Pivot changes
+    PIVOT_DELETED = "Suppression d'un pivot"
 
 
 ACTION_HISTORY_ORDER_BY = "ActionHistory.actionDate.asc().nulls_first()"

--- a/api/src/pcapi/routes/backoffice/pivots/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pivots/blueprint.py
@@ -154,5 +154,13 @@ def delete_pivot(name: str, pivot_id: int) -> utils.BackofficeResponse:
     else:
         if can_delete_pivot:
             flash("Le pivot a été supprimé", "success")
+        else:
+            flash(
+                (
+                    "Le pivot ne peut pas être supprimé si la synchronisation de ce cinéma est active. "
+                    "Supprimez la synchronisation et vous pourrez supprimer le pivot."
+                ),
+                "warning",
+            )
 
     return redirect(url_for(".get_pivots", active_tab=name), code=303)

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/allocine.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/allocine.py
@@ -13,6 +13,10 @@ from .base import PivotContext
 
 class AllocineContext(PivotContext):
     @classmethod
+    def pivot_name(cls) -> str:
+        return "AlloCine"
+
+    @classmethod
     def pivot_class(cls) -> typing.Type:
         return providers_models.AllocinePivot
 

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/boost.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/boost.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 class BoostContext(PivotContext):
     @classmethod
+    def pivot_name(cls) -> str:
+        return "Boost"
+
+    @classmethod
     def pivot_class(cls) -> typing.Type:
         return providers_models.BoostCinemaDetails
 
@@ -91,24 +95,6 @@ class BoostContext(PivotContext):
 
         db.session.add(pivot)
         cls.check_if_api_call_is_ok(pivot)
-        return True
-
-    @classmethod
-    def delete_pivot(cls, pivot_id: int) -> bool:
-        pivot = providers_models.BoostCinemaDetails.query.get_or_404(pivot_id)
-        cinema_provider_pivot = pivot.cinemaProviderPivot
-        assert cinema_provider_pivot  # helps mypy
-
-        venue_provider = providers_models.VenueProvider.query.filter_by(
-            venueId=cinema_provider_pivot.venueId, providerId=cinema_provider_pivot.providerId
-        ).one_or_none()
-
-        if venue_provider:
-            flash("Ce lieu est toujours synchronisé avec Boost, vous ne pouvez pas supprimer ce pivot Boost", "warning")
-            return False
-
-        db.session.delete(pivot)
-        db.session.delete(cinema_provider_pivot)
         return True
 
     @classmethod

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/cgr.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/cgr.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 
 class CGRContext(PivotContext):
     @classmethod
+    def pivot_name(cls) -> str:
+        return "CGR"
+
+    @classmethod
     def pivot_class(cls) -> typing.Type:
         return providers_models.CGRCinemaDetails
 
@@ -98,22 +102,6 @@ class CGRContext(PivotContext):
             pivot.numCinema = num_cinema
 
         db.session.add(pivot)
-        return True
-
-    @classmethod
-    def delete_pivot(cls, pivot_id: int) -> bool:
-        pivot = providers_models.CGRCinemaDetails.query.get_or_404(pivot_id)
-        cinema_provider_pivot = pivot.cinemaProviderPivot
-        assert cinema_provider_pivot  # helps mypy
-        venue_provider = providers_models.VenueProvider.query.filter_by(
-            venueId=cinema_provider_pivot.venueId, providerId=cinema_provider_pivot.providerId
-        ).one_or_none()
-
-        if venue_provider:
-            flash("Ce lieu est toujours synchronisé avec CGR, Vous ne pouvez pas supprimer ce pivot CGR", "warning")
-            return False
-        db.session.delete(pivot)
-        db.session.delete(cinema_provider_pivot)
         return True
 
     @classmethod

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/cineoffice.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/cineoffice.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 
 class CineofficeContext(PivotContext):
     @classmethod
+    def pivot_name(cls) -> str:
+        return "CDS"
+
+    @classmethod
     def pivot_class(cls) -> typing.Type:
         return providers_models.CDSCinemaDetails
 
@@ -93,22 +97,6 @@ class CineofficeContext(PivotContext):
         db.session.add(pivot)
 
         cls.check_if_api_call_is_ok(account_id=account_id, api_token=api_token)
-
-        return True
-
-    @classmethod
-    def delete_pivot(cls, pivot_id: int) -> bool:
-        pivot = providers_models.CDSCinemaDetails.query.get_or_404(pivot_id)
-        cinema_provider_pivot = pivot.cinemaProviderPivot
-        assert cinema_provider_pivot  # helps mypy
-        venue_provider = providers_models.VenueProvider.query.filter_by(
-            venueId=cinema_provider_pivot.venueId, providerId=cinema_provider_pivot.providerId
-        ).one_or_none()
-        if venue_provider:
-            flash("Ce lieu est toujours synchronisé avec CDS, Vous ne pouvez pas supprimer ce pivot CDS", "warning")
-            return False
-        db.session.delete(pivot)
-        db.session.delete(cinema_provider_pivot)
 
         return True
 

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/ems.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/ems.py
@@ -19,6 +19,10 @@ logger = logging.getLogger(__name__)
 
 class EMSContext(PivotContext):
     @classmethod
+    def pivot_name(cls) -> str:
+        return "EMS"
+
+    @classmethod
     def pivot_class(cls) -> type:
         return providers_models.EMSCinemaDetails
 
@@ -102,19 +106,4 @@ class EMSContext(PivotContext):
         cls.check_if_api_call_is_ok()
 
         db.session.add(pivot)
-        return True
-
-    @classmethod
-    def delete_pivot(cls, pivot_id: int) -> bool:
-        pivot = providers_models.EMSCinemaDetails.query.get_or_404(pivot_id)
-        cinema_provider_pivot = pivot.cinemaProviderPivot
-        venue_provider = providers_models.VenueProvider.query.filter_by(
-            venueId=cinema_provider_pivot.venueId, providerId=cinema_provider_pivot.providerId
-        ).one_or_none()
-
-        if venue_provider:
-            flash("Ce lieu est toujours synchronisé avec EMS, vous ne pouvez pas supprimer ce pivot.", "warning")
-            return False
-        db.session.delete(pivot)
-        db.session.delete(cinema_provider_pivot)
         return True

--- a/api/tests/routes/backoffice/helpers/post.py
+++ b/api/tests/routes/backoffice/helpers/post.py
@@ -28,7 +28,7 @@ class PostEndpointWithoutPermissionHelper(base.BaseHelper):
         # will generate a csrf token (for the logout button)
         client.get(url_for("backoffice_web.home"))
 
-    def post_to_endpoint(self, client, form=None, headers=None, **url_kwargs):
+    def post_to_endpoint(self, client, form=None, headers=None, follow_redirects=False, **url_kwargs):
         self.fetch_csrf_token(client)
 
         url = url_for(self.endpoint, **url_kwargs)
@@ -37,7 +37,7 @@ class PostEndpointWithoutPermissionHelper(base.BaseHelper):
             form = {}
 
         form.update(self.form)
-        return client.post(url, form=form, headers=headers)
+        return client.post(url, form=form, headers=headers, follow_redirects=follow_redirects)
 
     def test_not_logged_in(self, client):
         self.fetch_csrf_token(client)


### PR DESCRIPTION
## But de la pull request

Ajout d'une action à l'historique du lieu quand on supprime un pivot associé.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27829

<img width="1252" alt="Capture d’écran 2024-02-13 à 10 41 19" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/ef2d7f00-c8ab-45b5-a955-0b1037748741">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques