### PR TITLE
(PC-27959)[ADAGE] feat: don't sentry when cancellation is expected

### DIFF
--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -188,7 +188,7 @@ def refuse_collective_booking(educational_booking_id: int) -> educational_models
             exceptions.EducationalBookingNotRefusable,
             exceptions.CollectiveBookingAlreadyCancelled,
         ) as exception:
-            logger.error(
+            logger.info(
                 "User from adage trying to refuse collective booking that cannot be refused",
                 extra={
                     "collective_booking_id": collective_booking.id,


### PR DESCRIPTION
Lower the log level when someone tries to cancel a collective offer is beyond the cancellation date/time.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27959

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques