### PR TITLE
(PC-26905)[API] fix: Skip showtimes with negative remaining places

### DIFF
--- a/api/tests/local_providers/cinema_providers/cgr/fixtures.py
+++ b/api/tests/local_providers/cinema_providers/cgr/fixtures.py
@@ -108,6 +108,22 @@ SEANCE_177182 = {
     "libTarif": "Tarif Standard ICE",
 }
 
+SEANCE_177182_WITH_INCONSISTENT_QUANTITY = {
+    "IDSeance": 177182,
+    "Date": "2023-01-29",
+    "Heure": "14:00:00.000",
+    "NbPlacesRestantes": -3,  # Yes, it happened !
+    "bAvecPlacement": True,
+    "bAvecDuo": True,
+    "bICE": True,
+    "Relief": "2D",
+    "Version": "VF",
+    "bAVP": False,
+    "PrixUnitaire": 6.9,
+    "libTarif": "Tarif Standard ICE",
+}
+
+
 SEANCE_177182_NEW_DATE = {
     "IDSeance": 177182,
     "Date": "2023-01-19",
@@ -148,6 +164,18 @@ FILM_138473 = {
     "Affiche": "https://example.com/149341.jpg",
     "TypeFilm": "CNC",
     "Seances": [SEANCE_177182],
+}
+
+FILM_138473_WITH_INCONSISTENT_QUANTITY_STOCK = {
+    "IDFilm": 138473,
+    "IDFilmAlloCine": 138473,
+    "Titre": "Venom",
+    "NumVisa": 149341,
+    "Duree": 112,
+    "Synopsis": "Possédé par un symbiote qui agit de manière autonome, le journaliste Eddie Brock devient le protecteur létal Venom.",
+    "Affiche": "https://example.com/149341.jpg",
+    "TypeFilm": "CNC",
+    "Seances": [SEANCE_177182_WITH_INCONSISTENT_QUANTITY],
 }
 
 FILM_138473_NEW_DATE = {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26905

Fix https://sentry.passculture.team/organizations/sentry/issues/1254484/events/latest/?environment=production&project=5&query=is%3Aunresolved+CGR&statsPeriod=90d

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques