### PR TITLE
(PC-27818)[API] feat: Forward our timeout value to CGR

### DIFF
--- a/api/src/pcapi/connectors/cgr/cgr.py
+++ b/api/src/pcapi/connectors/cgr/cgr.py
@@ -68,19 +68,12 @@ def reservation_pass_culture(
     return parse_obj_as(cgr_serializers.ReservationPassCultureResponse, response)
 
 
-def annulation_pass_culture(
-    cinema_details: providers_models.CGRCinemaDetails, qr_code: str | None = None, token: str | None = None
-) -> None:
-    if not qr_code and not token:
-        raise AssertionError("Either QRCode or token is mandatory")
-    payload = {
-        "User": settings.CGR_API_USER,
-        "mdp": decrypt(cinema_details.password),
-        "pQrCode": qr_code or token,
-    }
+def annulation_pass_culture(cinema_details: providers_models.CGRCinemaDetails, qr_code: str) -> None:
+    user = settings.CGR_API_USER
+    password = decrypt(cinema_details.password)
     cinema_url = cinema_details.cinemaUrl
     service = get_cgr_service_proxy(cinema_url)
-    response = service.AnnulationPassCulture(**payload)
+    response = service.AnnulationPassCulture(User=user, mdp=password, pQrCode=qr_code)
     response = json.loads(response)
     _check_response_is_ok(response, "AnnulationPassCulture")
 

--- a/api/src/pcapi/core/external_bookings/cgr/client.py
+++ b/api/src/pcapi/core/external_bookings/cgr/client.py
@@ -14,7 +14,6 @@ import pcapi.core.bookings.models as bookings_models
 import pcapi.core.external_bookings.models as external_bookings_models
 from pcapi.core.providers.repository import get_cgr_cinema_details
 import pcapi.core.users.models as users_models
-from pcapi.utils.decorators import retry
 from pcapi.utils.queue import add_to_queue
 
 from . import constants
@@ -64,9 +63,7 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
         try:
             response = reservation_pass_culture(self.cgr_cinema_details, book_show_body)
         except ReadTimeout as exc:
-            decorator = retry(exception=ReadTimeout, max_attempts=2)
-            annulation_with_retry_on_timeout = decorator(annulation_pass_culture)
-            annulation_with_retry_on_timeout(self.cgr_cinema_details, token=booking.token)
+            annulation_pass_culture(self.cgr_cinema_details, token=booking.token)
             logger.info(
                 "ReadTimeout on CGR side while booking an offer, token has been sent to prevent booking creation on their side",
                 extra={"booking_token": booking.token},

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -92,6 +92,7 @@ class FeatureToggle(enum.Enum):
     ENABLE_CGR_INTEGRATION = "Active la synchonisation de stocks et la réservation via CGR"
     ENABLE_SWITCH_ALLOCINE_SYNC_TO_EMS_SYNC = "Activer le passage automatique des synchronisations Allociné à EMS"
     LOG_EMS_CINEMAS_AVAILABLE_FOR_SYNC = "Stocker dans Google Drive les cinémas EMS activables"
+    ENABLE_CGR_TIMEOUT = "Envoyer la valeur de notre timeout lors d'une réservation CGR"
     # For features under construction, a temporary feature flag must be named with the `WIP_` prefix
     WIP_BEHIND_L7_LOAD_BALANCER = "À activer/désactiver en même temps que le load balancer L7"
     WIP_ENABLE_OFFER_CREATION_API_V1 = "Active la création d'offres via l'API v1"
@@ -166,6 +167,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.SYNCHRONIZE_TITELIVE_API_MUSIC_PRODUCTS,
     FeatureToggle.LOG_EMS_CINEMAS_AVAILABLE_FOR_SYNC,
     FeatureToggle.ENABLE_SWITCH_ALLOCINE_SYNC_TO_EMS_SYNC,
+    FeatureToggle.ENABLE_CGR_TIMEOUT,
     FeatureToggle.WIP_ENABLE_COMPLIANCE_CALL,
     FeatureToggle.WIP_ENABLE_DIFFUSE_HELP,
     FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API,

--- a/api/tests/connectors/cgr/soap_definitions.py
+++ b/api/tests/connectors/cgr/soap_definitions.py
@@ -125,3 +125,132 @@ WEB_SERVICE_DEFINITION = """<?xml version="1.0" encoding="UTF-8"?>
     </service>
 </definitions>
 """
+
+WEB_SERVICE_DEFINITION_WITH_TIMEOUT = """<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:s0="urn:GestionCinemaWS"
+             xmlns="http://schemas.xmlsoap.org/wsdl/" targetNamespace="urn:GestionCinemaWS">
+    <types>
+        <xsd:schema elementFormDefault="unqualified" targetNamespace="urn:GestionCinemaWS">
+            <xsd:complexType name="tGetSeancesPassCulture">
+                <xsd:sequence>
+                    <xsd:element name="User" type="xsd:string"/>
+                    <xsd:element name="mdp" type="xsd:string"/>
+                    <xsd:element name="IDFilmAllocine" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetSeancesPassCulture" type="s0:tGetSeancesPassCulture"/>
+            <xsd:complexType name="tGetSeancesPassCultureResponse">
+                <xsd:sequence>
+                    <xsd:element name="GetSeancesPassCultureResult" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetSeancesPassCultureResponse" type="s0:tGetSeancesPassCultureResponse"/>
+            <xsd:complexType name="tReservationPassCulture">
+                <xsd:sequence>
+                    <xsd:element name="User" type="xsd:string"/>
+                    <xsd:element name="mdp" type="xsd:string"/>
+                    <xsd:element name="pIDSeances" type="xsd:int"/>
+                    <xsd:element name="pNumCinema" type="xsd:int"/>
+                    <xsd:element name="pPUTTC" type="xsd:string"/>
+                    <xsd:element name="pNBPlaces" type="xsd:int"/>
+                    <xsd:element name="pNom" type="xsd:string"/>
+                    <xsd:element name="pPrenom" type="xsd:string"/>
+                    <xsd:element name="pEmail" type="xsd:string"/>
+                    <xsd:element name="pToken" type="xsd:string"/>
+                    <xsd:element name="pDateLimiteAnnul" type="xsd:string"/>
+                    <xsd:element name="pTimeoutReservation" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="ReservationPassCulture" type="s0:tReservationPassCulture"/>
+            <xsd:complexType name="tReservationPassCultureResponse">
+                <xsd:sequence>
+                    <xsd:element name="ReservationPassCultureResult" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="ReservationPassCultureResponse" type="s0:tReservationPassCultureResponse"/>
+            <xsd:complexType name="tAnnulationPassCulture">
+                <xsd:sequence>
+                    <xsd:element name="User" type="xsd:string"/>
+                    <xsd:element name="mdp" type="xsd:string"/>
+                    <xsd:element name="pQrCode" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AnnulationPassCulture" type="s0:tAnnulationPassCulture"/>
+            <xsd:complexType name="tAnnulationPassCultureResponse">
+            <xsd:sequence>
+                <xsd:element name="AnnulationPassCultureResult" type="xsd:string"/>
+                </xsd:sequence>
+                </xsd:complexType>
+            <xsd:element name="AnnulationPassCultureResponse" type="s0:tAnnulationPassCultureResponse"/>
+        </xsd:schema>
+    </types>
+    <message name="GestionCinemaWS_GetSeancesPassCulture_MessageIn">
+        <part name="parameters" element="s0:GetSeancesPassCulture"/>
+    </message>
+    <message name="GestionCinemaWS_GetSeancesPassCulture_MessageOut">
+        <part name="parameters" element="s0:GetSeancesPassCultureResponse"/>
+    </message>
+    <message name="GestionCinemaWS_ReservationPassCulture_MessageIn">
+        <part name="parameters" element="s0:ReservationPassCulture"/>
+    </message>
+    <message name="GestionCinemaWS_ReservationPassCulture_MessageOut">
+        <part name="parameters" element="s0:ReservationPassCultureResponse"/>
+    </message>
+    <message name="GestionCinemaWS_AnnulationPassCulture_MessageIn">
+        <part name="parameters" element="s0:AnnulationPassCulture"/>
+    </message>
+    <message name="GestionCinemaWS_AnnulationPassCulture_MessageOut">
+        <part name="parameters" element="s0:AnnulationPassCultureResponse"/>
+    </message>
+    <portType name="GestionCinemaWSSOAPPortType">
+        <operation name="GetSeancesPassCulture">
+            <input message="s0:GestionCinemaWS_GetSeancesPassCulture_MessageIn"/>
+            <output message="s0:GestionCinemaWS_GetSeancesPassCulture_MessageOut"/>
+        </operation>
+        <operation name="ReservationPassCulture">
+            <input message="s0:GestionCinemaWS_ReservationPassCulture_MessageIn"/>
+            <output message="s0:GestionCinemaWS_ReservationPassCulture_MessageOut"/>
+        </operation>
+        <operation name="AnnulationPassCulture">
+            <input message="s0:GestionCinemaWS_AnnulationPassCulture_MessageIn"/>
+            <output message="s0:GestionCinemaWS_AnnulationPassCulture_MessageOut"/>
+        </operation>
+    </portType>
+    <binding name="GestionCinemaWSSOAPBinding" type="s0:GestionCinemaWSSOAPPortType">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <operation name="GetSeancesPassCulture">
+            <soap:operation soapAction="urn:GestionCinemaWS/GetSeancesPassCulture" style="document"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="ReservationPassCulture">
+        <soap:operation soapAction="urn:GestionCinemaWS/ReservationPassCulture" style="document"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="AnnulationPassCulture">
+            <soap:operation soapAction="urn:GestionCinemaWS/AnnulationPassCulture" style="document"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+    <service name="GestionCinemaWS">
+        <port name="GestionCinemaWSSOAPPort" binding="s0:GestionCinemaWSSOAPBinding">
+            <soap:address location="http://192.168.1.1/GESTIONCINEMAWS_WEB/awws/GestionCinemaWS.awws"/>
+        </port>
+    </service>
+</definitions>
+"""


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27818

This is to ensure that when the process of external booking is taking too much longer
(more than our timeout), they cancel their transaction on their side.
In that way, they won't have anymore bookings that exists on their side but that doesn't
on our own (because if their response exceed our timeout, the transaction is rollbacked
and the booking is never created)

This replace the former mecanism where when catching a timeout during the booking we were
calling for a cancellation.
(https://github.com/pass-culture/pass-culture-main/commit/f529d11beba9ae0914b7162108ff357050c38418, https://github.com/pass-culture/pass-culture-main/commit/99259265e30bb1951544067cc282da0e8da62a92)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques