### PR TITLE
(BSR)[API] perf: Avoid N+1 SQL queries in `synchronize_venue_providers_apis` command

### DIFF
--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -134,14 +134,21 @@ class VenueProvider(PcObject, Base, Model, DeactivableMixin):
 
     isFromAllocineProvider = sa_orm.column_property(  # type: ignore [misc]
         sa.exists(
-            sa.select(Provider.id).where(sa.and_(Provider.id == providerId, Provider.localClass == "AllocineStocks"))
+            sa.select(Provider.id)
+            .where(sa.and_(Provider.id == providerId, Provider.localClass == "AllocineStocks"))
+            .correlate_except(Provider)
         )
     )
 
     isFromCinemaProvider = sa_orm.column_property(  # type: ignore [misc]
-        sa.exists(sa.select(Provider.id)).where(
-            sa.and_(Provider.id == providerId, Provider.localClass.in_(provider_constants.CINEMA_PROVIDER_NAMES))
+        sa.exists(sa.select(Provider.id))
+        .where(
+            sa.and_(
+                Provider.id == providerId,
+                Provider.localClass.in_(provider_constants.CINEMA_PROVIDER_NAMES),
+            )
         )
+        .correlate_except(Provider)
     )
 
     __mapper_args__ = {

--- a/api/tests/core/providers/test_commands.py
+++ b/api/tests/core/providers/test_commands.py
@@ -24,8 +24,14 @@ class SynchronizeVenueProvidersApisTest:
         parallel_venue_provider_1 = factories.VenueProviderFactory(provider=parallel_provider)
         parallel_venue_provider_2 = factories.VenueProviderFactory(provider=parallel_provider)
 
-        with testing.assert_num_queries(6):
-            # FIXME(viconnex): there is N+1 queries because we don't use joinedload
+        queries = 1  # select providers and their venue providers
+        # 1 select for each VenueProvider of not_parallel_provider,
+        # in `synchronize_venue_providers_task()`
+        queries += 2
+        # 1 select for all VenueProvider of parallel_provider,
+        # in `synchronize_venue_providers_task()`
+        queries += 1
+        with testing.assert_num_queries(queries):
             commands._synchronize_venue_providers_apis()
 
         assert len(mock_synchronize_venue_providers.call_args_list) == 3


### PR DESCRIPTION
As they were defined, the "column properties" of VenueProvider did not
allow to use `joinedload()`. SQLAlchemy raised the following error:

    Select statement '<sqlalchemy.sql.selectable.Select object at 0x7fb68ca6a0d0>'
    returned no FROM clauses due to auto-correlation; specify correlate(<tables>)
    to control correlation manually.

I could not find how to use `correlate()` on the column properties,
but `correlate_except()` achieves something similar and makes
SQLAlchemy happy.