### PR TITLE
(BSR) doc: update squawk part: ignore next statement

### DIFF
--- a/api/src/pcapi/alembic/CONTRIBUTING.md
+++ b/api/src/pcapi/alembic/CONTRIBUTING.md
@@ -115,9 +115,11 @@ Pour désactiver le lint sur une seule expression SQL, le commentaire `-- squawk
 
 ```python
 def upgrade() -> None:
-    op.execute("-- squawk:ignore-next-statement")
+    op.execute("select 1 -- squawk:ignore-next-statement")
     op.execute(sql_statement_that_would_upset_squawk)
 ```
+
+Note : le `select 1` permet d'éviter une requête vide, ce que SQLAlchemy n'apprécie pas du tout.
 
 # Squasher les migrations
 


### PR DESCRIPTION
## But de la pull request

Mise à jour de la doc, concernant la partie `squawk` (comment ignorer une instruction).