### PR TITLE
(PC-28000)[PRO] fix: refresh offerer infos when (un)linking venue to …

### DIFF
--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -29,7 +29,7 @@ const BankInformations = (): JSX.Element => {
 
   const [showAddBankInformationsDialog, setShowAddBankInformationsDialog] =
     useState(false)
-  const { selectedOfferer } = useReimbursementContext()
+  const { selectedOfferer, setSelectedOfferer } = useReimbursementContext()
 
   const [isOffererBankAccountsLoading, setIsOffererBankAccountsLoading] =
     useState<boolean>(false)
@@ -69,8 +69,20 @@ const BankInformations = (): JSX.Element => {
     return <Spinner />
   }
 
-  function closeDialog() {
+  const updateOfferer = async (newOffererId: string) => {
+    if (newOffererId !== '') {
+      setIsOffererBankAccountsLoading(true)
+      const offerer = await api.getOfferer(Number(newOffererId))
+      setSelectedOfferer(offerer)
+      setIsOffererBankAccountsLoading(false)
+    }
+  }
+
+  async function closeDialog(update?: boolean) {
     if (selectedOfferer !== null) {
+      if (update) {
+        await updateOfferer(selectedOfferer.id.toString())
+      }
       setSelectedBankAccount(null)
     }
   }

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -12,7 +12,11 @@ import {
 import { BankAccountEvents } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
 import BankInformations from 'pages/Reimbursements/BankInformations/BankInformations'
-import { defaultGetOffererResponseModel } from 'utils/apiFactories'
+import {
+  defaultBankAccountResponseModel,
+  defaultGetOffererResponseModel,
+  defaultManagedVenues,
+} from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 const renderBankInformations = (
@@ -244,5 +248,35 @@ describe('BankInformations page', () => {
         offererId: 1,
       }
     )
+  })
+
+  it('should update displayed link venue after closing link venue dialog', async () => {
+    vi.spyOn(api, 'getOffererBankAccountsAndAttachedVenues').mockResolvedValue({
+      id: 1,
+      bankAccounts: [{ ...defaultBankAccountResponseModel }],
+      managedVenues: [{ ...defaultManagedVenues }],
+    })
+
+    renderBankInformations(
+      {
+        ...customContext,
+        selectedOfferer: {
+          ...defaultGetOffererResponseModel,
+          hasValidBankAccount: true,
+        },
+      },
+      store
+    )
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Modifier' }))
+
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'Mon super lieu' })
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Enregistrer' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Confirmer' }))
+
+    expect(api.getOfferer).toHaveBeenCalledWith(1)
   })
 })


### PR DESCRIPTION
…bankInfos

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28000

Mettre à jour l'affichage de la page informations bancaires après avoir lié/délié un lieu à un compte bancaire

![Capture d’écran 2024-02-16 à 10 55 13](https://github.com/pass-culture/pass-culture-main/assets/71768799/a1173089-2972-4e1c-9afe-fb753a18d4c6)

**Recette** : 


Sur la page information bancaire, attaché/déttaché un lieu d'un compte bancaire. Vérifier ensuite que l'affichage est bien mise à jour une fois la pop-in de rattachement fermée. 

FF : `WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY`