### PR TITLE
Pc 27841 adage bookable offer page

### DIFF
--- a/pro/src/core/OfferEducational/types.ts
+++ b/pro/src/core/OfferEducational/types.ts
@@ -1,4 +1,8 @@
-import { EacFormat } from 'apiClient/adage'
+import {
+  CollectiveOfferResponseModel,
+  CollectiveOfferTemplateResponseModel,
+  EacFormat,
+} from 'apiClient/adage'
 import {
   EducationalInstitutionResponseModel,
   OfferAddressType,
@@ -123,6 +127,10 @@ export const isCollectiveOfferTemplate = (
 ): value is CollectiveOfferTemplate =>
   // Could be enhanced to check that it is also a GetCollectiveOfferTemplateResponseModel
   hasProperty(value, 'isTemplate') && value.isTemplate === true
+
+export const isCollectiveOfferBookable = (
+  value: CollectiveOfferTemplateResponseModel | CollectiveOfferResponseModel
+): value is CollectiveOfferResponseModel => !value.isTemplate
 
 export type VisibilityFormValues = {
   visibility: 'all' | 'one'

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
@@ -2,15 +2,20 @@ import {
   CollectiveOfferTemplateResponseModel,
   CollectiveOfferResponseModel,
 } from 'apiClient/adage'
-import { isCollectiveOfferTemplate } from 'core/OfferEducational'
+import {
+  isCollectiveOfferTemplate,
+  isCollectiveOfferBookable,
+} from 'core/OfferEducational'
 import strokeArticleIcon from 'icons/stroke-article.svg'
 import strokeInfoIcon from 'icons/stroke-info.svg'
+import strokeInstitutionIcon from 'icons/stroke-institution.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './AdageOffer.module.scss'
 import AdageOfferDetailsSection from './AdageOfferDetailsSection/AdageOfferDetailsSection'
 import AdageOfferInfoSection from './AdageOfferDetailsSection/AdageOfferInfoSection'
+import AdageOfferPartnerSection from './AdageOfferDetailsSection/AdageOfferPartnerSection'
 import AdageOfferPublicSection from './AdageOfferDetailsSection/AdageOfferPublicSection'
 import AdageOfferHeader from './AdageOfferHeader/AdageOfferHeader'
 import AdageOfferPartnerPanel from './AdageOfferPartnerPanel/AdageOfferPartnerPanel'
@@ -20,6 +25,8 @@ type AdageOfferProps = {
 }
 
 export default function AdageOffer({ offer }: AdageOfferProps) {
+  const isOfferBookable = isCollectiveOfferBookable(offer)
+
   return (
     <div className={styles['offer']}>
       <div className={styles['offer-header']}>
@@ -64,6 +71,20 @@ export default function AdageOffer({ offer }: AdageOfferProps) {
               <AdageOfferPublicSection offer={offer} />
             </div>
           </section>
+          {isOfferBookable && (
+            <section className={styles['offer-section']}>
+              <div className={styles['offer-section-header']}>
+                <SvgIcon alt="" src={strokeInstitutionIcon} width="24" />
+                <h2 className={styles['offer-section-header-title']}>
+                  Contact du partenaire culturel
+                </h2>
+              </div>
+
+              <div className={styles['offer-section-group']}>
+                <AdageOfferPartnerSection offer={offer} />
+              </div>
+            </section>
+          )}
         </div>
         <div className={styles['offer-side']}>
           {isCollectiveOfferTemplate(offer) ? (

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
@@ -2,10 +2,7 @@ import {
   CollectiveOfferTemplateResponseModel,
   CollectiveOfferResponseModel,
 } from 'apiClient/adage'
-import {
-  isCollectiveOfferTemplate,
-  isCollectiveOfferBookable,
-} from 'core/OfferEducational'
+import { isCollectiveOfferBookable } from 'core/OfferEducational'
 import strokeArticleIcon from 'icons/stroke-article.svg'
 import strokeInfoIcon from 'icons/stroke-info.svg'
 import strokeInstitutionIcon from 'icons/stroke-institution.svg'
@@ -18,6 +15,7 @@ import AdageOfferInfoSection from './AdageOfferDetailsSection/AdageOfferInfoSect
 import AdageOfferPartnerSection from './AdageOfferDetailsSection/AdageOfferPartnerSection'
 import AdageOfferPublicSection from './AdageOfferDetailsSection/AdageOfferPublicSection'
 import AdageOfferHeader from './AdageOfferHeader/AdageOfferHeader'
+import AdageOfferInstitutionPanel from './AdageOfferInstitutionPanel/AdageOfferInstitutionPanel'
 import AdageOfferPartnerPanel from './AdageOfferPartnerPanel/AdageOfferPartnerPanel'
 
 type AdageOfferProps = {
@@ -87,12 +85,12 @@ export default function AdageOffer({ offer }: AdageOfferProps) {
           )}
         </div>
         <div className={styles['offer-side']}>
-          {isCollectiveOfferTemplate(offer) ? (
-            <AdageOfferPartnerPanel offer={offer} />
+          {isOfferBookable ? (
+            (offer.teacher || offer.educationalInstitution) && (
+              <AdageOfferInstitutionPanel offer={offer} />
+            )
           ) : (
-            <>
-              {/* TODO : Here will go the school infos for a bookable offer */}
-            </>
+            <AdageOfferPartnerPanel offer={offer} />
           )}
         </div>
       </div>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferInfoSection.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferInfoSection.tsx
@@ -3,10 +3,14 @@ import {
   CollectiveOfferTemplateResponseModel,
 } from 'apiClient/adage'
 import { OfferAddressType } from 'apiClient/v1'
-import { isCollectiveOfferTemplate } from 'core/OfferEducational'
-import { getRangeToFrenchText, toDateStrippedOfTimezone } from 'utils/date'
+import { isCollectiveOfferBookable } from 'core/OfferEducational'
 
 import styles from '../AdageOffer.module.scss'
+import {
+  getFormattedDatesForBookableOffer,
+  getFormattedDatesForTemplateOffer,
+} from '../utils/adageOfferDates'
+import { getBookableOfferStockPrice } from '../utils/adageOfferStocks'
 
 export type AdageOfferInfoSectionProps = {
   offer: CollectiveOfferTemplateResponseModel | CollectiveOfferResponseModel
@@ -42,15 +46,7 @@ export default function AdageOfferInfoSection({
 
   const location = getLocationForOfferVenue(offerVenue)
 
-  const dates =
-    isCollectiveOfferTemplate(offer) &&
-    ((offer.dates?.start &&
-      offer.dates?.end &&
-      getRangeToFrenchText(
-        toDateStrippedOfTimezone(offer.dates.start),
-        toDateStrippedOfTimezone(offer.dates.end)
-      )) ||
-      'Tout au long de l’année scolaire (l’offre est permanente)')
+  const isOfferBookable = isCollectiveOfferBookable(offer)
 
   return (
     <>
@@ -63,14 +59,17 @@ export default function AdageOfferInfoSection({
 
       <div className={styles['offer-section-group-item']}>
         <h3 className={styles['offer-section-group-item-subtitle']}>Date</h3>
-        {dates}
+        {isOfferBookable
+          ? getFormattedDatesForBookableOffer(offer)
+          : getFormattedDatesForTemplateOffer(offer)}
       </div>
 
-      {offer.educationalPriceDetail && (
+      {(isOfferBookable || offer.educationalPriceDetail) && (
         <div className={styles['offer-section-group-item']}>
           <h3 className={styles['offer-section-group-item-subtitle']}>
-            Information sur le prix
+            {isOfferBookable ? 'Prix' : 'Information sur le prix'}
           </h3>
+          {isOfferBookable && <p>{getBookableOfferStockPrice(offer)}</p>}
           {offer.educationalPriceDetail}
         </div>
       )}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferPartnerSection.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferPartnerSection.tsx
@@ -1,0 +1,29 @@
+import { CollectiveOfferResponseModel } from 'apiClient/adage'
+
+import styles from '../AdageOffer.module.scss'
+
+export type AdageOfferPartnerSectionProps = {
+  offer: CollectiveOfferResponseModel
+}
+
+export default function AdageOfferPartnerSection({
+  offer,
+}: AdageOfferPartnerSectionProps) {
+  return (
+    <>
+      {offer.contactPhone && (
+        <div className={styles['offer-section-group-item']}>
+          <h3 className={styles['offer-section-group-item-subtitle']}>
+            Téléphone
+          </h3>
+          {offer.contactPhone}
+        </div>
+      )}
+
+      <div className={styles['offer-section-group-item']}>
+        <h3 className={styles['offer-section-group-item-subtitle']}>E-mail</h3>
+        {offer.contactEmail}
+      </div>
+    </>
+  )
+}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
@@ -96,7 +96,7 @@ describe('AdageOfferInfoSection', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should show the prixe section when the offer is bookable', () => {
+  it('should show the price section when the offer is bookable', () => {
     renderAdageOfferInfoSection({
       offer: {
         ...defaultCollectiveOffer,

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from '@testing-library/react'
 
 import { OfferAddressType } from 'apiClient/adage'
-import { defaultCollectiveTemplateOffer } from 'utils/adageFactories'
+import {
+  defaultCollectiveTemplateOffer,
+  defaultCollectiveOffer,
+} from 'utils/adageFactories'
 
 import AdageOfferInfoSection, {
   AdageOfferInfoSectionProps,
@@ -66,37 +69,6 @@ describe('AdageOfferInfoSection', () => {
     expect(screen.getByText(/test venue address/)).toBeInTheDocument()
   })
 
-  it('should show the dates of a template offer that has specific dates', () => {
-    renderAdageOfferInfoSection({
-      offer: {
-        ...defaultCollectiveTemplateOffer,
-        dates: {
-          end: '2024-01-29T23:00:28.040559Z',
-          start: '2024-01-23T23:00:28.040547Z',
-        },
-      },
-    })
-
-    expect(
-      screen.getByText('Du 23 janvier au 29 janvier 2024 à 23h')
-    ).toBeInTheDocument()
-  })
-
-  it('should show that the offer is permanent if it has no dates', () => {
-    renderAdageOfferInfoSection({
-      offer: {
-        ...defaultCollectiveTemplateOffer,
-        dates: undefined,
-      },
-    })
-
-    expect(
-      screen.getByText(
-        'Tout au long de l’année scolaire (l’offre est permanente)'
-      )
-    ).toBeInTheDocument()
-  })
-
   it('should display the offer price details', () => {
     renderAdageOfferInfoSection({
       offer: {
@@ -122,5 +94,21 @@ describe('AdageOfferInfoSection', () => {
     expect(
       screen.queryByRole('heading', { name: 'Information sur le prix' })
     ).not.toBeInTheDocument()
+  })
+
+  it('should show the prixe section when the offer is bookable', () => {
+    renderAdageOfferInfoSection({
+      offer: {
+        ...defaultCollectiveOffer,
+      },
+    })
+
+    expect(
+      screen.queryByRole('heading', { name: 'Information sur le prix' })
+    ).not.toBeInTheDocument()
+
+    expect(screen.getByRole('heading', { name: 'Prix' })).toBeInTheDocument()
+
+    expect(screen.getByText('140 000 € pour 10 élèves')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferPartnerSection.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferPartnerSection.spec.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+
+import { defaultCollectiveOffer } from 'utils/adageFactories'
+
+import AdageOfferPartnerSection, {
+  AdageOfferPartnerSectionProps,
+} from '../AdageOfferPartnerSection'
+
+function renderAdageOfferInfoSection(
+  props: AdageOfferPartnerSectionProps = {
+    offer: defaultCollectiveOffer,
+  }
+) {
+  return render(<AdageOfferPartnerSection {...props} />)
+}
+
+describe('AdageOfferPartnerSection', () => {
+  it('should show the e-mail address', () => {
+    renderAdageOfferInfoSection({
+      offer: {
+        ...defaultCollectiveOffer,
+        contactEmail: 'test@test.co',
+      },
+    })
+
+    expect(screen.getByText('test@test.co')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'E-mail' })).toBeInTheDocument()
+  })
+
+  it('should show the phone number if it is available', () => {
+    renderAdageOfferInfoSection({
+      offer: {
+        ...defaultCollectiveOffer,
+        contactPhone: '1234554321',
+      },
+    })
+
+    expect(screen.getByText('1234554321')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Téléphone' })
+    ).toBeInTheDocument()
+  })
+
+  it('should not show the phone number if it is not available', () => {
+    renderAdageOfferInfoSection({
+      offer: {
+        ...defaultCollectiveOffer,
+        contactPhone: undefined,
+      },
+    })
+
+    expect(
+      screen.queryByRole('heading', { name: 'Téléphone' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.module.scss
@@ -51,6 +51,14 @@
   }
 }
 
+.offer-header-details-institution {
+  margin-top: rem.torem(8px);
+
+  &-name {
+    @include fonts.body-important;
+  }
+}
+
 .offer-header-details-infos {
   margin-top: rem.torem(32px);
   display: flex;

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.tsx
@@ -99,7 +99,7 @@ export default function AdageOfferHeader({ offer }: AdageOfferProps) {
         </div>
         {isOfferBookable && offer.educationalInstitution && (
           <div className={styles['offer-header-details-institution']}>
-            Adressé à{' '}
+            Adressée à{' '}
             <span className={styles['offer-header-details-institution-name']}>
               {getBookableOfferInstitutionAndTeacherName(offer)}
             </span>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.tsx
@@ -4,19 +4,25 @@ import {
   AdageFrontRoles,
 } from 'apiClient/adage'
 import { OfferAddressType } from 'apiClient/v1'
-import { isCollectiveOfferTemplate } from 'core/OfferEducational'
+import { isCollectiveOfferBookable } from 'core/OfferEducational'
 import strokeCalendarIcon from 'icons/stroke-calendar.svg'
+import strokeEuroIcon from 'icons/stroke-euro.svg'
 import strokeLocationIcon from 'icons/stroke-location.svg'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { HydratedCollectiveOfferTemplate } from 'pages/AdageIframe/app/types/offers'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
-import { getRangeToFrenchText, toDateStrippedOfTimezone } from 'utils/date'
 
 import OfferFavoriteButton from '../../../OffersInstantSearch/OffersSearch/Offers/OfferFavoriteButton/OfferFavoriteButton'
 import OfferShareLink from '../../../OffersInstantSearch/OffersSearch/Offers/OfferShareLink/OfferShareLink'
 import { getOfferVenueAndOffererName } from '../../../OffersInstantSearch/OffersSearch/Offers/utils/getOfferVenueAndOffererName'
+import {
+  getFormattedDatesForBookableOffer,
+  getFormattedDatesForTemplateOffer,
+} from '../utils/adageOfferDates'
+import { getBookableOfferInstitutionAndTeacherName } from '../utils/adageOfferInstitution'
+import { getBookableOfferStockPrice } from '../utils/adageOfferStocks'
 
 import styles from './AdageOfferHeader.module.scss'
 
@@ -26,18 +32,9 @@ export type AdageOfferProps = {
 
 export default function AdageOfferHeader({ offer }: AdageOfferProps) {
   const { adageUser } = useAdageUser()
+  const isOfferBookable = isCollectiveOfferBookable(offer)
 
   const venueAndOffererName = getOfferVenueAndOffererName(offer.venue)
-
-  const formattedDates =
-    isCollectiveOfferTemplate(offer) &&
-    ((offer.dates?.start &&
-      offer.dates?.end &&
-      getRangeToFrenchText(
-        toDateStrippedOfTimezone(offer.dates.start),
-        toDateStrippedOfTimezone(offer.dates.end)
-      )) ||
-      'Tout au long de l’année scolaire (l’offre est permanente)')
 
   const studentLevels =
     offer.students.length > 1 ? 'Multiniveaux' : offer.students[0]
@@ -100,6 +97,14 @@ export default function AdageOfferHeader({ offer }: AdageOfferProps) {
             {venueAndOffererName}
           </span>
         </div>
+        {isOfferBookable && offer.educationalInstitution && (
+          <div className={styles['offer-header-details-institution']}>
+            Adressé à{' '}
+            <span className={styles['offer-header-details-institution-name']}>
+              {getBookableOfferInstitutionAndTeacherName(offer)}
+            </span>
+          </div>
+        )}
         <ul className={styles['offer-header-details-infos']}>
           <li className={styles['offer-header-details-info']}>
             <SvgIcon src={strokeLocationIcon} alt="" width="16" />
@@ -108,8 +113,19 @@ export default function AdageOfferHeader({ offer }: AdageOfferProps) {
 
           <li className={styles['offer-header-details-info']}>
             <SvgIcon src={strokeCalendarIcon} alt="" width="16" />
-            <span>{formattedDates}</span>
+            <span>
+              {isOfferBookable
+                ? getFormattedDatesForBookableOffer(offer)
+                : getFormattedDatesForTemplateOffer(offer)}
+            </span>
           </li>
+
+          {isOfferBookable && (
+            <li className={styles['offer-header-details-info']}>
+              <SvgIcon src={strokeEuroIcon} alt="" width="16" />
+              <span>{getBookableOfferStockPrice(offer)}</span>
+            </li>
+          )}
 
           <li className={styles['offer-header-details-info']}>
             <SvgIcon src={strokeUserIcon} alt="" width="16" />

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
@@ -172,4 +172,26 @@ describe('AdageOfferHeader', () => {
 
     expect(screen.getByText('Multiniveaux')).toBeInTheDocument()
   })
+
+  it('should show the institution and the price if the offer is bookable', () => {
+    renderAdageOfferHeader({
+      offer: {
+        ...defaultCollectiveOffer,
+        educationalInstitution: {
+          name: 'My institution',
+          city: 'Paris',
+          postalCode: '75000',
+          id: 1,
+        },
+        stock: {
+          ...defaultCollectiveOffer.stock,
+          numberOfTickets: 100,
+          price: 12000,
+        },
+      },
+    })
+
+    expect(screen.getByText('12 000 € pour 100 élèves')).toBeInTheDocument()
+    expect(screen.getByText(/My institution/)).toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/AdageOfferInstitutionPanel.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/AdageOfferInstitutionPanel.module.scss
@@ -1,0 +1,54 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_colors.scss" as colors;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.institution-panel {
+  width: 100%;
+  border-radius: rem.torem(16px);
+  box-shadow: 0 rem.torem(2px) rem.torem(16px) 0 colors.$large-shadow;
+  padding: rem.torem(24px);
+
+  &-header {
+    display: flex;
+    align-items: center;
+    gap: rem.torem(8px);
+
+    &-title {
+      @include fonts.title3;
+    }
+  }
+
+  &-info {
+    margin-top: rem.torem(24px);
+    background-color: colors.$background-secondary;
+    border-radius: rem.torem(6px);
+    padding: rem.torem(8px);
+  }
+
+  &-prebooking {
+    text-align: center;
+    margin-top: rem.torem(16px);
+
+    &-icon {
+      margin-right: rem.torem(10px);
+    }
+
+    &-date {
+      @include fonts.caption;
+
+      margin-bottom: rem.torem(8px);
+
+      &-emphasis {
+        color: colors.$primary;
+      }
+    }
+  }
+}
+
+@media (min-height: rem.torem(500px)) {
+  //  Make sure the pannel is only sticky when the screen has a big enough height. Otherwise it might not be fully visible.
+  .institution-panel {
+    position: sticky;
+    top: rem.torem(24px);
+  }
+}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/AdageOfferInstitutionPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/AdageOfferInstitutionPanel.tsx
@@ -1,0 +1,67 @@
+import { AdageFrontRoles, CollectiveOfferResponseModel } from 'apiClient/adage'
+import fullDeskIcon from 'icons/full-desk.svg'
+import strokeTeacherIcon from 'icons/stroke-teacher.svg'
+import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+import { getDateTimeToFrenchText, toDateStrippedOfTimezone } from 'utils/date'
+
+import PrebookingButton from '../../../OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton'
+import { getBookableOfferInstitutionAndTeacherName } from '../utils/adageOfferInstitution'
+
+import styles from './AdageOfferInstitutionPanel.module.scss'
+
+export type AdageOfferInstitutionPanelProps = {
+  offer: CollectiveOfferResponseModel
+}
+
+export default function AdageOfferInstitutionPanel({
+  offer,
+}: AdageOfferInstitutionPanelProps) {
+  const { adageUser } = useAdageUser()
+  return (
+    <div className={styles['institution-panel']}>
+      <div className={styles['institution-panel-header']}>
+        <SvgIcon src={strokeTeacherIcon} alt="" width="20" />
+        <h2 className={styles['institution-panel-header-title']}>
+          Offre adressée à :
+        </h2>
+      </div>
+      <div className={styles['institution-panel-info']}>
+        {getBookableOfferInstitutionAndTeacherName(offer)}
+      </div>
+      <div className={styles['institution-panel-prebooking']}>
+        {offer.stock.bookingLimitDatetime && (
+          <div className={styles['institution-panel-prebooking-date']}>
+            À préréserver{' '}
+            <span
+              className={styles['institution-panel-prebooking-date-emphasis']}
+            >
+              avant le{' '}
+              {getDateTimeToFrenchText(
+                toDateStrippedOfTimezone(offer.stock.bookingLimitDatetime),
+                {
+                  dateStyle: 'short',
+                }
+              )}
+            </span>
+          </div>
+        )}
+        <PrebookingButton
+          canPrebookOffers={adageUser.role === AdageFrontRoles.REDACTOR}
+          offerId={offer.id}
+          queryId={''}
+          stock={offer.stock}
+          hideLimitDate={true}
+        >
+          <SvgIcon
+            src={fullDeskIcon}
+            width="20"
+            alt=""
+            className={styles['institution-panel-prebooking-icon']}
+          />
+          Préréserver l’offre
+        </PrebookingButton>
+      </div>
+    </div>
+  )
+}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/__specs__/AdageOfferInstitutionPanel.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/__specs__/AdageOfferInstitutionPanel.spec.tsx
@@ -1,0 +1,52 @@
+import { screen } from '@testing-library/react'
+
+import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageUserContext'
+import { defaultAdageUser, defaultCollectiveOffer } from 'utils/adageFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import AdageOfferInstitutionPanel, {
+  AdageOfferInstitutionPanelProps,
+} from '../AdageOfferInstitutionPanel'
+
+function renderAdageOfferInstitutionPanel(
+  props: AdageOfferInstitutionPanelProps = {
+    offer: defaultCollectiveOffer,
+  },
+  user = defaultAdageUser
+) {
+  return renderWithProviders(
+    <AdageUserContextProvider adageUser={user}>
+      <AdageOfferInstitutionPanel {...props} />
+    </AdageUserContextProvider>
+  )
+}
+
+describe('AdageOfferPartnerPanel', () => {
+  it('should render the instution panel', () => {
+    renderAdageOfferInstitutionPanel()
+
+    expect(
+      screen.getByRole('heading', { name: 'Offre adressée à :' })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText('À préréserver')).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: /Préréserver l’offre/ })
+    ).toBeInTheDocument()
+  })
+
+  it("should not show the booking limit date if it's not available", () => {
+    renderAdageOfferInstitutionPanel({
+      offer: {
+        ...defaultCollectiveOffer,
+        stock: {
+          ...defaultCollectiveOffer.stock,
+          bookingLimitDatetime: undefined,
+        },
+      },
+    })
+
+    expect(screen.queryByText('À préréserver')).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferDates.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferDates.spec.ts
@@ -1,0 +1,62 @@
+import {
+  defaultCollectiveTemplateOffer,
+  defaultCollectiveOffer,
+} from 'utils/adageFactories'
+
+import {
+  getFormattedDatesForBookableOffer,
+  getFormattedDatesForTemplateOffer,
+} from '../adageOfferDates'
+
+describe('adageOfferDates', () => {
+  describe('getFormattedDatesForTemplateOffer', () => {
+    it('should show the dates of a template offer that has specific dates', () => {
+      const datesText = getFormattedDatesForTemplateOffer({
+        ...defaultCollectiveTemplateOffer,
+        dates: {
+          end: '2024-01-29T23:00:28.040559Z',
+          start: '2024-01-23T23:00:28.040547Z',
+        },
+      })
+
+      expect(datesText).toEqual('Du 23 janvier au 29 janvier 2024 à 23h')
+    })
+
+    it('should show that the offer is permanent if it has no dates', () => {
+      const datesText = getFormattedDatesForTemplateOffer({
+        ...defaultCollectiveTemplateOffer,
+        dates: undefined,
+      })
+
+      expect(datesText).toEqual(
+        'Tout au long de l’année scolaire (l’offre est permanente)'
+      )
+    })
+  })
+
+  describe('getFormattedDatesForBookableOffer', () => {
+    it('should return the date of the beginning of the offer', () => {
+      const dateText = getFormattedDatesForBookableOffer({
+        ...defaultCollectiveOffer,
+        stock: {
+          ...defaultCollectiveOffer.stock,
+          beginningDatetime: '2024-01-29T23:00:28.040559Z',
+        },
+      })
+
+      expect(dateText).toEqual('Le 29 janvier 2024 à 23:00')
+    })
+
+    it('should not return a date if the beginning of the offer does not exist', () => {
+      const dateText = getFormattedDatesForBookableOffer({
+        ...defaultCollectiveOffer,
+        stock: {
+          ...defaultCollectiveOffer.stock,
+          beginningDatetime: undefined,
+        },
+      })
+
+      expect(dateText).toEqual(null)
+    })
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferInstitution.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferInstitution.spec.ts
@@ -1,0 +1,53 @@
+import { CollectiveOfferResponseModel } from 'apiClient/adage'
+import { defaultCollectiveOffer } from 'utils/adageFactories'
+
+import { getBookableOfferInstitutionAndTeacherName } from '../adageOfferInstitution'
+
+const institution: CollectiveOfferResponseModel['educationalInstitution'] = {
+  city: 'Paris',
+  id: 1,
+  name: 'Victor Hugo',
+  postalCode: '75001',
+  institutionType: 'Collège',
+}
+
+const teacher: CollectiveOfferResponseModel['teacher'] = {
+  firstName: 'Prof',
+  lastName: 'Sympa',
+  civility: 'M.',
+  email: 'prof.sympa@sympa.cool',
+}
+
+describe('adageOfferInstitution', () => {
+  describe('getBookableOfferInstitutionAndTeacherName', () => {
+    it('should return the offer institution and teacher names', () => {
+      const institutionText = getBookableOfferInstitutionAndTeacherName({
+        ...defaultCollectiveOffer,
+        educationalInstitution: institution,
+        teacher: teacher,
+      })
+
+      expect(institutionText).toEqual('Prof Sympa - Collège Victor Hugo')
+    })
+
+    it("should not return the teacher name if it's not available", () => {
+      const institutionText = getBookableOfferInstitutionAndTeacherName({
+        ...defaultCollectiveOffer,
+        educationalInstitution: institution,
+        teacher: undefined,
+      })
+
+      expect(institutionText).toEqual('Collège Victor Hugo')
+    })
+
+    it('should not return anything if the institution is not available', () => {
+      const institutionText = getBookableOfferInstitutionAndTeacherName({
+        ...defaultCollectiveOffer,
+        educationalInstitution: undefined,
+        teacher: teacher,
+      })
+
+      expect(institutionText).toEqual(null)
+    })
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferStocks.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferStocks.spec.ts
@@ -1,0 +1,21 @@
+import { defaultCollectiveOffer } from 'utils/adageFactories'
+
+import { getBookableOfferStockPrice } from '../adageOfferStocks'
+
+describe('adageOfferStocks', () => {
+  describe('getBookableOfferStockPrice', () => {
+    it('should return the offer price and number of students', () => {
+      const stockText = getBookableOfferStockPrice({
+        ...defaultCollectiveOffer,
+        stock: {
+          id: 1,
+          isBookable: true,
+          price: 100,
+          numberOfTickets: 20,
+        },
+      })
+
+      expect(stockText).toEqual('100\xa0€ pour 20 élèves')
+    })
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferDates.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferDates.ts
@@ -1,0 +1,34 @@
+import {
+  CollectiveOfferResponseModel,
+  CollectiveOfferTemplateResponseModel,
+} from 'apiClient/adage'
+import {
+  getDateTimeToFrenchText,
+  getRangeToFrenchText,
+  toDateStrippedOfTimezone,
+} from 'utils/date'
+
+export function getFormattedDatesForTemplateOffer(
+  offer: CollectiveOfferTemplateResponseModel
+) {
+  return (
+    (offer.dates?.start &&
+      offer.dates?.end &&
+      getRangeToFrenchText(
+        toDateStrippedOfTimezone(offer.dates.start),
+        toDateStrippedOfTimezone(offer.dates.end)
+      )) ||
+    'Tout au long de l’année scolaire (l’offre est permanente)'
+  )
+}
+
+export function getFormattedDatesForBookableOffer(
+  offer: CollectiveOfferResponseModel
+) {
+  return offer.stock.beginningDatetime
+    ? `Le ${getDateTimeToFrenchText(
+        toDateStrippedOfTimezone(offer.stock.beginningDatetime),
+        { dateStyle: 'long', timeStyle: 'short' }
+      )}`
+    : null
+}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferInstitution.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferInstitution.ts
@@ -1,0 +1,13 @@
+import { CollectiveOfferResponseModel } from 'apiClient/adage'
+
+export function getBookableOfferInstitutionAndTeacherName(
+  offer: CollectiveOfferResponseModel
+) {
+  return offer.educationalInstitution
+    ? `${offer.teacher ? `${getTeacherFullName(offer.teacher)} - ` : ''}${offer.educationalInstitution.institutionType || ''} ${offer.educationalInstitution.name}`
+    : null
+}
+
+function getTeacherFullName(teacher: CollectiveOfferResponseModel['teacher']) {
+  return `${teacher?.firstName || ''} ${teacher?.lastName || ''}`
+}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferStocks.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferStocks.ts
@@ -1,0 +1,11 @@
+import { CollectiveOfferResponseModel } from 'apiClient/adage'
+
+export function getBookableOfferStockPrice(
+  offer: CollectiveOfferResponseModel
+) {
+  return `${Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 0,
+  }).format(offer.stock.price)} pour ${offer.stock.numberOfTickets} élèves`
+}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
@@ -21,6 +21,8 @@ const PrebookingButton = ({
   offerId,
   queryId,
   isInSuggestions,
+  children,
+  hideLimitDate,
 }: {
   className?: string
   stock: OfferStockResponse
@@ -28,6 +30,8 @@ const PrebookingButton = ({
   offerId: number
   queryId: string
   isInSuggestions?: boolean
+  children?: React.ReactNode
+  hideLimitDate?: boolean
 }): JSX.Element | null => {
   const [hasPrebookedOffer, setHasPrebookedOffer] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -84,10 +88,10 @@ const PrebookingButton = ({
               className="prebooking-button"
               onClick={() => handleBookingModalButtonClick(stock.id)}
             >
-              Préréserver
+              {children ?? 'Préréserver'}
             </Button>
 
-            {stock.bookingLimitDatetime && (
+            {!hideLimitDate && stock.bookingLimitDatetime && (
               <span className="prebooking-button-booking-limit">
                 avant le :{' '}
                 {format(new Date(stock.bookingLimitDatetime), 'dd/MM/yyyy')}

--- a/pro/src/utils/date.ts
+++ b/pro/src/utils/date.ts
@@ -44,7 +44,7 @@ export const getDateToFrenchText = (dateIsoString: string) => {
   return format(noTimeZoneDate, FORMAT_DD_MMMM_YYYY, { locale: fr })
 }
 
-function getDateTimeToFrenchText(
+export function getDateTimeToFrenchText(
   date: Date,
   options: Intl.DateTimeFormatOptions = {
     day: '2-digit',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27841

**Pour voir l'interface**
- Activer le FF WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN
- Aller sur "/adage-iframe/recherche/offre/B-[un id d'offre de votre env]?token=[votre token adage]"


**Objectif**
- Adapter la page offre vitrine pour que'elle fonctionne aussi pour une offre réservable (quelques infos en + sur la page de l'offre réservable)
- Ajouter le bloc de l'établissement scolaire sur la page de l'offre réservable (à la place du bloc du partenaire culturel de la page offre vitrine)


<img width="414" alt="Capture d’écran 2024-02-16 à 17 27 22" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/c7ded4e2-1407-42ef-a3ad-2a7b240e68e5">
<img width="508" alt="Capture d’écran 2024-02-16 à 17 29 43" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/35712e11-e169-47e1-b746-73d7ed93befa">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques