### PR TITLE
(BSR)[API] docs: update swagger url in readme

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -12,7 +12,7 @@ Une documentation Swagger des APIs est générée selon l'OpenAPI Specification 
 Spectree:
 
 * [API Contremarque](https://backend.passculture.app/v2/swagger)
-* [App Native](https://backend.passculture.app/native/v1/swagger)
+* [App Native](https://backend.passculture.app/native/swagger)
 * [Adage](https://backend.passculture.app/adage-iframe/swagger)
 * [API privée et API publique dépréciée](https://backend.passculture.app/apidoc/swagger)
 * [API pro publique v2](https://backend.passculture.app/v2/swagger)


### PR DESCRIPTION
## But de la pull request

Update de la doc oubliée quand on a changé la route de swagger

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques