### PR TITLE
(BSR)[API] fix: flask command update_sendinblue_pro did not include non attached pro

### DIFF
--- a/api/src/pcapi/core/external/commands/update_sendinblue_pro_attributes.py
+++ b/api/src/pcapi/core/external/commands/update_sendinblue_pro_attributes.py
@@ -5,6 +5,8 @@ This command should be run when a new attribute is added for pro users or when i
 
 import time
 
+import sqlalchemy as sa
+
 from pcapi.core.external.attributes.api import get_pro_attributes
 from pcapi.core.external.sendinblue import update_contact_attributes
 from pcapi.core.offerers.models import Venue
@@ -27,9 +29,9 @@ def get_all_pro_users_emails() -> set[str]:
     rows = (
         db.session.query(User.email)
         .filter(
-            User.isActive.is_(True),
-            User.has_pro_role.is_(True),  # type: ignore [attr-defined]
-            User.has_admin_role.is_(False),  # type: ignore [attr-defined]
+            User.isActive,
+            sa.or_(User.has_pro_role, User.has_non_attached_pro_role),  # type: ignore [type-var]
+            sa.not_(User.has_admin_role),
         )
         .all()
     )

--- a/api/tests/core/external/test_commands.py
+++ b/api/tests/core/external/test_commands.py
@@ -25,17 +25,21 @@ def test_update_sendinblue_batch_users(app):
 
 @clean_database
 def test_update_sendinblue_pro(app):
+    users_factories.UserFactory()  # excluded
+    users_factories.AdminFactory()  # excluded
     offerers_factories.UserOffererFactory(user__email="first@example.com")
     offerers_factories.UserOffererFactory(user__email="second@example.com")
     offerers_factories.VenueFactory(bookingEmail="third@example.com")
+    offerers_factories.UserNotValidatedOffererFactory(user__email="fourth@example.com")
 
     result = run_command(app, "update_sendinblue_pro")
 
-    assert len(testing.sendinblue_requests) == 3
+    assert len(testing.sendinblue_requests) == 4
     assert {request["email"] for request in testing.sendinblue_requests} == {
         "first@example.com",
         "second@example.com",
         "third@example.com",
+        "fourth@example.com",
     }
 
     assert "Exception" not in result.stdout


### PR DESCRIPTION
## But de la pull request

Correction dans la commande Flask de resynchro des attributs Brevo de tous les pro : les `NON_ATTACHED_PRO` n'étaient pas dans le filtre. Il est nécessaire de les mettre à jour pour que `IS_ACTIVE_PRO` soit fiable.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques