### PR TITLE
(PC-26360)[API] fix: only expire offers that actually have expired

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1,6 +1,5 @@
 from datetime import date
 from datetime import datetime
-from datetime import time
 import decimal
 from decimal import Decimal
 import enum
@@ -758,12 +757,11 @@ class CollectiveOfferTemplate(
     def hasEndDatePassed(self) -> bool:
         if not self.end:
             return False
-        return self.end <= datetime.combine(datetime.utcnow(), time.max)
+        return self.end < datetime.utcnow()
 
     @hasEndDatePassed.expression  # type: ignore[no-redef]
     def hasEndDatePassed(cls) -> Exists:  # pylint: disable=no-self-argument
-        today = datetime.combine(datetime.utcnow(), time.max)
-        return cls.dateRange.contained_by(psycopg2.extras.DateTimeRange(upper=today))
+        return cls.dateRange.contained_by(psycopg2.extras.DateTimeRange(upper=datetime.utcnow()))
 
     @hybrid_property
     def hasBookingLimitDatetimesPassed(self) -> bool:

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -154,7 +154,7 @@ class UnindexExpiredOffersTest:
             dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=9),
             dateRange=db_utils.make_timerange(
                 start=datetime.datetime.utcnow() - datetime.timedelta(days=7),
-                end=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+                end=datetime.datetime.utcnow() - datetime.timedelta(hours=1),
             ),
         )
         # Non expired template offer with dateRange overlapping today


### PR DESCRIPTION
hasEndDatePassed was not working well as the end date time is at 23:59 while it should have been 23:59:59.999999
Anyway, let's now assume we consider the end date as an datetime instead to figure out hasEndDatePassed

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26360

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques