### PR TITLE
(BSR)[PRO] fix: sentry reporting

### DIFF
--- a/pro/src/app/App/hook/useLoadFeatureFlags.ts
+++ b/pro/src/app/App/hook/useLoadFeatureFlags.ts
@@ -20,7 +20,7 @@ export function useLoadFeatureFlags() {
         const response = await api.listFeatures()
         dispatch(updateFeatures(response))
       } catch (e) {
-        sendSentryCustomError(`error when fetching features ${e}`)
+        sendSentryCustomError(e)
       }
     }
     if (!lastLoaded || lastLoaded < Date.now() - THIRTY_MINUTES) {

--- a/pro/src/context/IndividualOfferContext/adapters/getWizardData/getWizardData.ts
+++ b/pro/src/context/IndividualOfferContext/adapters/getWizardData/getWizardData.ts
@@ -68,7 +68,7 @@ const getWizardData: GetIndividualOfferAdapter = async ({
       subCategories: categoriesResponse.subcategories,
     }
   } catch (e) {
-    sendSentryCustomError(`error when fetching categories ${e}`)
+    sendSentryCustomError(e)
     return Promise.resolve(FAILING_RESPONSE)
   }
 

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -45,9 +45,7 @@ export const AdageHeader = () => {
       } catch (e) {
         notify.error(GET_DATA_ERROR_MESSAGE)
 
-        sendSentryCustomError(
-          `error when retrieving educational institution budget ${adageUser.uai} ${e}`
-        )
+        sendSentryCustomError(e, { uai: adageUser.uai })
       } finally {
         setIsLoading(false)
       }

--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
@@ -36,9 +36,7 @@ const OffersForMyInstitution = (): JSX.Element => {
           }))
         )
       } catch (e) {
-        sendSentryCustomError(
-          `error when fetching offers for my institution ${e}`
-        )
+        sendSentryCustomError(e)
       } finally {
         setLoadingOffers(false)
       }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -116,7 +116,7 @@ export const OfferFilters = ({
           }))
         )
       } catch (e) {
-        sendSentryCustomError(`error when retrieving academies options ${e}`)
+        sendSentryCustomError(e)
       }
     }
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -126,9 +126,7 @@ export const Offers = ({
               }
             }
           } catch (e) {
-            sendSentryCustomError(
-              `error when retrieving adage offer ${hit.objectID} ${e}`
-            )
+            sendSentryCustomError(e, { adageOfferId: hit.objectID })
 
             return {}
           }
@@ -156,10 +154,7 @@ export const Offers = ({
         setFetchedOffers(offersFromHitsMap)
       })
       .catch((e) => {
-        sendSentryCustomError(
-          `error when filtering offer results ${e}`,
-          'data-processing'
-        )
+        sendSentryCustomError(e, undefined, 'data-processing')
       })
       .finally(() => {
         setQueriesAreLoading(false)

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataEdition.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataEdition.tsx
@@ -54,9 +54,7 @@ const fetchCulturalPartnerIfVenueHasNoCollectiveData = async (
       })),
     }
   } catch (e) {
-    sendSentryCustomError(
-      `error when fetching cultural educational partner ${e}`
-    )
+    sendSentryCustomError(e)
 
     return null
   }

--- a/pro/src/utils/sendSentryCustomError.ts
+++ b/pro/src/utils/sendSentryCustomError.ts
@@ -1,12 +1,20 @@
 import * as Sentry from '@sentry/react'
 
 export function sendSentryCustomError(
-  msg: string,
-  tag: 'api' | 'data-processing' | (string & NonNullable<unknown>) = 'api',
-  type: Sentry.SeverityLevel = 'error'
+  error: unknown, // error are typed as unknown in catch blocks
+  extraData?: Record<string, unknown>,
+  tag: 'api' | 'data-processing' | (string & NonNullable<unknown>) = 'api'
 ) {
   Sentry.withScope((scope) => {
     scope.setTag('custom-error-type', tag)
-    Sentry.captureMessage(msg, type)
+
+    if (extraData !== undefined) {
+      Sentry.addBreadcrumb({
+        message: 'Additional error data',
+        level: 'info',
+        data: extraData,
+      })
+    }
+    Sentry.captureException(error)
   })
 }


### PR DESCRIPTION
## But de la pull request

PR pour fix deux choses : 

- on perd la stacktrace originelle de l'erreur en utilisant captureMessage au lieu de captureException
- mettre une variable dans le message de l'issue reportée sur Sentry a créé +200 erreurs en prod ces 2 dernières semaines