### PR TITLE
(PC-27651)[PRO] feat: Add redirect links to adage offers cards.

### DIFF
--- a/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
@@ -33,6 +33,8 @@ vi.mock(
   }
 )
 
+window.scrollTo = vi.fn().mockImplementation(() => {})
+
 vi.mock('react-instantsearch', async () => {
   return {
     ...((await vi.importActual('react-instantsearch')) ?? {}),

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -1,5 +1,11 @@
 import classNames from 'classnames'
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import {
+  Navigate,
+  Route,
+  Routes,
+  ScrollRestoration,
+  useLocation,
+} from 'react-router-dom'
 
 import { AdageFrontRoles } from 'apiClient/adage'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -44,6 +50,7 @@ export const AppLayout = (): JSX.Element => {
         })}
         id="content"
       >
+        <ScrollRestoration />
         <Routes>
           <Route
             path=""

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/__specs__/AppLayout.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/__specs__/AppLayout.spec.tsx
@@ -98,6 +98,8 @@ vi.mock('hooks/useIsElementVisible', () => ({
   default: vi.fn().mockImplementation(() => [false, false]),
 }))
 
+window.scrollTo = vi.fn().mockImplementation(() => {})
+
 const renderAppLayout = (
   options?: RenderWithProvidersOptions,
   user = defaultAdageUser

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -12,6 +12,7 @@ import useActiveFeature from 'hooks/useActiveFeature'
 import strokePassIcon from 'icons/stroke-pass.svg'
 import strokeSearchIcon from 'icons/stroke-search.svg'
 import strokeStarIcon from 'icons/stroke-star.svg'
+import strokeVenueIcon from 'icons/stroke-venue.svg'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import Spinner from 'ui-kit/Spinner/Spinner'
@@ -72,14 +73,23 @@ export const OfferInfos = () => {
       },
       icon: strokeStarIcon,
     },
+    ['mon-etablissement']: {
+      title: 'Mon établissement',
+      link: {
+        isExternal: false,
+        to: `/adage-iframe/mon-etablissement?token=${adageAuthToken}`,
+      },
+      icon: strokeVenueIcon,
+    },
   }
 
-  const originCrumb: Crumb =
-    crumbForCurrentRoute[
-      adageUser.role === AdageFrontRoles.READONLY
-        ? 'recherche'
-        : parentRouteInUrl
-    ]
+  const originCrumb: Crumb = isOfferTemplate
+    ? crumbForCurrentRoute[
+        adageUser.role === AdageFrontRoles.READONLY
+          ? 'recherche'
+          : parentRouteInUrl
+      ]
+    : crumbForCurrentRoute['mon-etablissement']
 
   useEffect(() => {
     async function getOffer() {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.module.scss
@@ -76,7 +76,7 @@ $offer-image-width: rem.torem(176px);
   }
 
   &-details-container {
-    padding: rem.torem(16px) rem.torem(16px) rem.torem(16px) rem.torem(0);
+    padding: rem.torem(16px) rem.torem(16px) 0 0;
     position: relative;
     width: 100%;
 
@@ -151,7 +151,7 @@ $offer-image-width: rem.torem(176px);
   }
 
   &-description {
-    margin: 0 0 rem.torem(24px);
+    margin: 0 0 rem.torem(20px);
     white-space: pre-line;
   }
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 
 import { AdageFrontRoles, OfferAddressType } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
+import useActiveFeature from 'hooks/useActiveFeature'
 import fullLinkIcon from 'icons/full-link.svg'
 import fullUpIcon from 'icons/full-up.svg'
 import strokeFranceIcon from 'icons/stroke-france.svg'
@@ -50,6 +51,10 @@ const Offer = ({
 }: OfferProps): JSX.Element => {
   const [displayDetails, setDisplayDetails] = useState(openDetails)
   const { adageUser } = useAdageUser()
+
+  const isNewOfferInfoEnabled = useActiveFeature(
+    'WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN'
+  )
 
   const canAddOfferToFavorites =
     offer.isTemplate && adageUser.role !== AdageFrontRoles.READONLY
@@ -236,24 +241,45 @@ const Offer = ({
           <p className={style['offer-description']}>
             {formatDescription(offer.description)}
           </p>
-          <div className={style['offer-footer']}>
-            <button
-              className={style['offer-see-more']}
-              onClick={() => openOfferDetails(offer)}
-              type="button"
+          {isNewOfferInfoEnabled ? (
+            <ButtonLink
+              variant={
+                offer.isTemplate
+                  ? ButtonVariant.PRIMARY
+                  : ButtonVariant.SECONDARY
+              }
+              link={{
+                isExternal: true,
+                to: `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`,
+                target: '_blank',
+              }}
+              icon={fullLinkIcon}
+              svgAlt="Nouvelle fenêtre"
             >
-              <SvgIcon
-                alt=""
-                src={fullUpIcon}
-                className={cn(style['offer-see-more-icon'], {
-                  [style['offer-see-more-icon-closed']]: !displayDetails,
-                })}
-                width="16"
-              />
-              en savoir plus
-            </button>
-          </div>
-          {displayDetails && <OfferDetails offer={offer} />}
+              Découvrir l’offre
+            </ButtonLink>
+          ) : (
+            <>
+              <div className={style['offer-footer']}>
+                <button
+                  className={style['offer-see-more']}
+                  onClick={() => openOfferDetails(offer)}
+                  type="button"
+                >
+                  <SvgIcon
+                    alt=""
+                    src={fullUpIcon}
+                    className={cn(style['offer-see-more-icon'], {
+                      [style['offer-see-more-icon-closed']]: !displayDetails,
+                    })}
+                    width="16"
+                  />
+                  en savoir plus
+                </button>
+              </div>
+              {displayDetails && <OfferDetails offer={offer} />}
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -575,4 +575,48 @@ describe('offer', () => {
       screen.queryByText('Partager l’offre par email')
     ).not.toBeInTheDocument()
   })
+
+  it('should show the redirect button instead of the expand button when the ff is enabled', () => {
+    renderOffer(
+      {
+        ...offerProps,
+        offer: {
+          ...defaultCollectiveTemplateOffer,
+          isTemplate: true,
+        },
+      },
+      undefined,
+      {
+        features: ['WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN'],
+      }
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'en savoir plus' })
+    ).not.toBeInTheDocument()
+
+    const redirectLink = screen.getByRole('link', {
+      name: 'Nouvelle fenêtre Découvrir l’offre',
+    })
+
+    expect(redirectLink).toBeInTheDocument()
+
+    expect(redirectLink.getAttribute('href')).toContain(
+      `offerid/${defaultCollectiveTemplateOffer.id}`
+    )
+  })
+
+  it('should redirect to the bookable offer url with the "B-" when the offer is bookable', () => {
+    renderOffer(offerProps, undefined, {
+      features: ['WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN'],
+    })
+
+    const redirectLink = screen.getByRole('link', {
+      name: 'Nouvelle fenêtre Découvrir l’offre',
+    })
+
+    expect(redirectLink.getAttribute('href')).toContain(
+      `offerid/B-${offerProps.offer.id}`
+    )
+  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27651

**FF a activer**
WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN

**Objectif**
Remplacer l'ancien bouton "en savoir plus" par un bouton qui redirige vers l'offre dans une nouvelle fenêtre (bouton différent pour une offre vitrine dans la recherche, et pour une offre réservable dans l'onglet "Pour mon établissement")

<img width="1033" alt="Capture d’écran 2024-02-20 à 16 28 32" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/87ac839c-4d52-432b-9cee-2d43d2642d11">
<img width="1032" alt="Capture d’écran 2024-02-20 à 16 28 39" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/a553c3b5-6478-4818-ba73-dce6b8bb5a47">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques