### PR TITLE
(PC-27927)[PRO] feat: add elementId value in tracking domain playlist

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.tsx
@@ -142,6 +142,7 @@ export const AdageDiscovery = () => {
                     trackPlaylistElementClicked({
                       playlistId: DOMAINS_PLAYLIST,
                       playlistType: AdagePlaylistType.DOMAIN,
+                      elementId: elm.value,
                       index,
                     })
                   }

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/__specs__/AdageDiscovery.spec.tsx
@@ -143,7 +143,7 @@ describe('AdageDiscovery', () => {
 
     expect(apiAdage.logConsultPlaylistElement).toHaveBeenCalledWith(
       expect.objectContaining({
-        elementId: undefined,
+        elementId: 1,
         index: 0,
         playlistId: DOMAINS_PLAYLIST,
         playlistType: 'domain',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27927

Ajouter l'information de l'elementId dans le tracking pour la playlist des domaines sur adage

## Vérifications

- [x] J'ai écrit les tests nécessaires