### PR TITLE
(PC-28104)[API] fix: Fix use of SCAN in `clean_indexation_processing_queues` command

### DIFF
--- a/api/tests/core/search/test_backend_algolia.py
+++ b/api/tests/core/search/test_backend_algolia.py
@@ -322,8 +322,17 @@ class ProcessingQueueTest:
         processing_too_recent = f"{main_queue}:processing:{timestamp_too_recent}"
         redis.sadd(processing_too_recent, "4", "5", "6")
 
+        # Populate Redis so that we trigger pagination over Redis keys.
+        dummy_keys = [f"test_clean_processing_queues:dummy:{i}" for i in range(100)]
+        for key in dummy_keys:
+            redis.sadd(key, 1)
+
         assert redis.scard(main_queue) == 0
         backend.clean_processing_queues()
+
+        # Remove dummy keys to simplify tests below.
+        for key in dummy_keys:
+            redis.delete(key)
 
         # Items of the old processing queue have been moved to the
         # main queue. The recent processing queue has been left


### PR DESCRIPTION
We misused the SCAN command. Documentation says:

    It is important to note that the MATCH filter is applied after
    elements are retrieved from the collection, just before returning
    data to the client. This means that if the pattern matches very
    little elements inside the collection, SCAN will likely return no
    elements in most iterations.

That's exactly what happened. We performed a _single_ SCAN command. It
worked in tests (and when developing) because there was no (or very
few) keys in Redis. All keys were retrieved, the filter was applied
and the processing queues were found. On production, though, there are
many keys. So the first SCAN command likely returned a small batch of
keys that did not include any processing queue.

Now we paginate through the results.