### PR TITLE
(PC-28033)[PRO] fix: Undo the float right of the dialog close button.

### DIFF
--- a/pro/src/components/DialogBox/DialogBox.module.scss
+++ b/pro/src/components/DialogBox/DialogBox.module.scss
@@ -1,6 +1,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/variables/_z-index.scss" as zIndex;
 @use "styles/variables/_size.scss" as size;
+@use "styles/variables/_colors.scss" as colors;
 
 .dialog-box-overlay {
   display: grid;
@@ -11,7 +12,7 @@
   [data-reach-dialog-content] {
     width: initial;
     margin: rem.torem(32px) auto;
-    padding: 1rem;
+    padding: rem.torem(16px);
   }
 }
 
@@ -22,8 +23,9 @@
 }
 
 .dialog-box-close-container {
-  display: block;
-  float: right;
+  position: absolute;
+  top: rem.torem(16px);
+  right: rem.torem(16px);
 }
 
 .dialog-box-close {
@@ -32,12 +34,16 @@
   border: none;
   display: inline-flex;
   justify-content: center;
-  margin: rem.torem(-2px) rem.torem(-2px) rem.torem(-9px) 0;
-  width: rem.torem(44px);
+  cursor: pointer;
 
   &-icon {
     width: rem.torem(24px);
     height: rem.torem(24px);
+  }
+
+  &:focus-visible {
+    outline: rem.torem(1px) solid colors.$black;
+    outline-offset: rem.torem(2px);
   }
 }
 
@@ -46,6 +52,11 @@
     [data-reach-dialog-content] {
       padding: size.$dialog-box-padding;
     }
+  }
+
+  .dialog-box-close-container {
+    top: size.$dialog-box-padding;
+    right: size.$dialog-box-padding;
   }
 }
 

--- a/pro/src/components/DialogBox/DialogBox.tsx
+++ b/pro/src/components/DialogBox/DialogBox.tsx
@@ -32,9 +32,9 @@ const DialogBox: FunctionComponent<DialogProps> = ({
       })}
     >
       {hasCloseButton && (
-        <span className={styles['dialog-box-close-container']}>
+        <div className={styles['dialog-box-close-container']}>
           <CloseButton onCloseClick={onDismiss} />
-        </span>
+        </div>
       )}
       <section className={extraClassNames}>{children}</section>
     </DialogContent>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28033

**Objectif**
S'assurer que les boutons de fermeture de dlialog ne décalent pas tout le contenu.

Quand on avait fait le précedent rework des dialogs on avait repéré que certains titres passaient par dessus le bouton de fermeture du dialog (ex dialog des infos bancaires). Pour régler le pb on avait mis le bouton en float. Mais dans la plupart des dialogs, le contenu est sous la forme d'un bloc general en flex, ce qui est incompatible avec l'ajout d'un élément en float.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques