### PR TITLE
(BSR)[API] chore: use lighter postgis image for docker compose

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: cimg/postgres:15.5-postgis
+        image: postgis/postgis:15-3.4-alpine
         ports:
           - 5432:5432
         options: >-
@@ -364,7 +364,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: cimg/postgres:15.5-postgis
+        image: postgis/postgis:15-3.4-alpine
         ports:
           - 5432:5432
         options: >-

--- a/api/README.md
+++ b/api/README.md
@@ -74,7 +74,7 @@ Une base de données de test et un cache redis sont nécessaires à l'exécution
 docker run -d --name postgres -p 5434:5432 \
 --env-file ../env_file \
 -v postgres_local_data:/var/lib/postgresql/data \
-cimg/postgres:12.9-postgis
+postgis/postgis:15-3.4-alpine
 
 docker run -d --name redis -p 6379:6379 \
     -v redis_local_data:/data \

--- a/api/src/pcapi/alembic/versions/sql/schema_init.sql
+++ b/api/src/pcapi/alembic/versions/sql/schema_init.sql
@@ -20,7 +20,7 @@ SET row_security = off;
 -- Name: tiger; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA tiger;
+CREATE SCHEMA IF NOT EXISTS tiger;
 
 
 
@@ -28,7 +28,7 @@ CREATE SCHEMA tiger;
 -- Name: tiger_data; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA tiger_data;
+CREATE SCHEMA IF NOT EXISTS tiger_data;
 
 
 
@@ -36,7 +36,7 @@ CREATE SCHEMA tiger_data;
 -- Name: topology; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA topology;
+CREATE SCHEMA IF NOT EXISTS topology;
 
 
 
@@ -12726,3 +12726,4 @@ ALTER TABLE ONLY public.venue
 -- PostgreSQL database dump complete
 --
 
+reset search_path

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -509,8 +509,9 @@ class GetOffererTest:
 
         response = client.get(f"/offerers/{offerer_id}")
         assert response.status_code == 200
-        assert response.json["managedVenues"][0]["hasVenueProviders"] is False
-        assert response.json["managedVenues"][1]["hasVenueProviders"] is True
+        sorted_managed_venues = sorted(response.json["managedVenues"], key=lambda x: x["name"])
+        assert sorted_managed_venues[0]["hasVenueProviders"] is True
+        assert sorted_managed_venues[1]["hasVenueProviders"] is False
         assert response.json["hasValidBankAccount"] is False
         assert response.json["hasPendingBankAccount"] is False
         assert response.json["venuesWithNonFreeOffersWithoutBankAccounts"] == []

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   postgres:
-    image: cimg/postgres:15.5-postgis
+    image: postgis/postgis:15-3.4-alpine
     container_name: pc-postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -15,7 +15,7 @@ services:
     command: postgres -c logging_collector=on -c log_destination=stderr -c log_min_duration_statement=0 -c log_statement=all -c log_duration=on
 
   postgres-test:
-    image: cimg/postgres:15.5-postgis
+    image: postgis/postgis:15-3.4-alpine
     container_name: pc-postgres-pytest
     volumes:
       - postgres_data_test:/var/lib/postgresql-test/data
@@ -35,7 +35,7 @@ services:
       target: api-flask
     working_dir: /usr/src/app
     container_name: pc-api
-    command: ["./start-api-when-database-is-ready.sh"]
+    command: [ "./start-api-when-database-is-ready.sh" ]
     volumes:
       - ./api:/usr/src/app
     env_file:
@@ -59,7 +59,7 @@ services:
       target: api-flask
     working_dir: /usr/src/app
     container_name: pc-backoffice
-    command: ["./start-backoffice-when-api-is-ready.sh"]
+    command: [ "./start-backoffice-when-api-is-ready.sh" ]
     volumes:
       - ./api:/usr/src/app
     env_file:


### PR DESCRIPTION
## But de la pull request
Use lighter postgres image
Dans l'image utilisé les tables tiger et topology (nécessaires pour postgis) sont déjà crées.
Il faut reset le search path parceque sinon postgres ne trouve pas nos tables: https://www.postgresql.org/docs/16/extend-extensions.html#EXTEND-EXTENSIONS-RELOCATION
Je ne comprends pas vraiment pourquoi, possiblement vu que initialement la db est vide à part les tables de postgis, donc le search path est resté lié à l'extension.
A priori il n'y a pas de risque à reset le search path.
L'image utilisée contient déjà postgis, donc il n'est plus nécessaire de l'installer.