### PR TITLE
(PC-28111)[API] perf: use sets in reindexation queues

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -752,8 +752,3 @@ def update_product_last_30_days_bookings() -> list[offers_models.Product]:
 def clean_processing_queues() -> None:
     backend = _get_backend()
     backend.clean_processing_queues()
-
-
-def remove_duplicates_from_venue_indexation_queue() -> None:
-    backend = _get_backend()
-    backend.remove_duplicates_from_venue_indexation_queue()

--- a/api/src/pcapi/core/search/backends/base.py
+++ b/api/src/pcapi/core/search/backends/base.py
@@ -99,6 +99,3 @@ class SearchBackend:
 
     def clean_processing_queues(self) -> None:
         raise NotImplementedError()
-
-    def remove_duplicates_from_venue_indexation_queue(self) -> None:
-        raise NotImplementedError()

--- a/api/src/pcapi/core/search/commands/indexation.py
+++ b/api/src/pcapi/core/search/commands/indexation.py
@@ -218,4 +218,5 @@ def clean_indexation_processing_queues() -> None:
 @blueprint.cli.command("remove_duplicates_from_venue_indexation_queue")
 @log_cron_with_transaction
 def remove_duplicates_from_venue_indexation_queue() -> None:
-    search.remove_duplicates_from_venue_indexation_queue()
+    # TODO (lixxday) : remove after cron is removed
+    pass

--- a/api/tests/core/search/test_commands_indexation.py
+++ b/api/tests/core/search/test_commands_indexation.py
@@ -101,10 +101,9 @@ def test_update_products_booking_count_and_reindex_offers_if_same_ean(mocked_asy
         mock_run_query.return_value = rows
         run_command(app, "update_products_booking_count_and_reindex_offers")
 
-    mocked_async_index_offer_ids.assert_called_once_with(
-        expected_to_be_reindexed,
-        reason=search.IndexationReason.BOOKING_COUNT_CHANGE,
-    )
+    args, kwargs = mocked_async_index_offer_ids.call_args
+    assert sorted(args[0]) == sorted(expected_to_be_reindexed)
+    assert kwargs == {"reason": search.IndexationReason.BOOKING_COUNT_CHANGE}
 
 
 @clean_database


### PR DESCRIPTION
We want to use sets to avoid duplicate ids in queues We can then remov the cron dedicated to this task

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28111

## Vérifications

- [x] J'ai écrit les tests nécessaires
- ~[ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- ~[ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques~