### PR TITLE
(PC-27689)[API] feat: add commercial gesture email and codir role

### DIFF
--- a/api/src/pcapi/core/mails/transactional/finance_incidents/finance_incident_notification.py
+++ b/api/src/pcapi/core/mails/transactional/finance_incidents/finance_incident_notification.py
@@ -1,18 +1,26 @@
 from pcapi.core import mails
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.finance import models as finance_models
+from pcapi.core.finance import utils as finance_utils
 from pcapi.core.mails import models as mails_models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offers import models as offers_models
+from pcapi.models.feature import FeatureToggle
 
 
 def send_finance_incident_emails(finance_incident: finance_models.FinanceIncident) -> None:
     venue = finance_incident.venue
 
-    if not venue.current_reimbursement_point or not venue.current_reimbursement_point.bookingEmail:
-        return
+    if not FeatureToggle.WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY.is_active():
+        if not venue.current_reimbursement_point or not venue.current_reimbursement_point.bookingEmail:
+            return
+        booking_email = venue.current_reimbursement_point.bookingEmail
+    else:
+        if not venue.current_bank_account_link or not venue.bookingEmail:
+            return
+        booking_email = venue.bookingEmail
 
-    if finance_incident.forceDebitNote:
+    if finance_incident.forceDebitNote or finance_incident.kind != finance_models.IncidentType.OVERPAYMENT:
         return
 
     offers = set()
@@ -41,6 +49,54 @@ def send_finance_incident_emails(finance_incident: finance_models.FinanceInciden
         )
 
         mails.send(
-            recipients=[venue.current_reimbursement_point.bookingEmail],
+            recipients=[booking_email],
             data=data,
         )
+
+
+def send_commercial_gesture_email(finance_incident: finance_models.FinanceIncident) -> None:
+    if finance_incident.kind != finance_models.IncidentType.COMMERCIAL_GESTURE:
+        return
+
+    venue = finance_incident.venue
+
+    if not FeatureToggle.WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY.is_active():
+        if not venue.current_reimbursement_point or not venue.current_reimbursement_point.bookingEmail:
+            return
+        booking_email = venue.current_reimbursement_point.bookingEmail
+    else:
+        if not venue.current_bank_account_link or not venue.bookingEmail:
+            return
+        booking_email = venue.bookingEmail
+
+    offers_incidents: dict[tuple, list[finance_models.BookingFinanceIncident]] = {}
+    for booking_finance_incident in finance_incident.booking_finance_incidents:
+        booking = booking_finance_incident.booking or booking_finance_incident.collectiveBooking
+        if isinstance(booking, bookings_models.Booking):
+            offer = booking.stock.offer
+        else:
+            offer = booking.collectiveStock.collectiveOffer
+
+        # if a given offer has multiple incidents, we need to group them under one key
+        offers_incidents.setdefault((offer.id, offer.name), []).extend([booking_finance_incident])
+
+    for (_, offer_name), offer_booking_incidents in offers_incidents.items():
+        data = mails_models.TransactionalEmailData(
+            template=TransactionalEmail.COMMERCIAL_GESTURE_REIMBURSEMENT.value,
+            params={
+                "OFFER_NAME": offer_name,
+                "VENUE_NAME": venue.common_name,
+                "MONTANT_REMBOURSEMENT": finance_utils.to_euros(
+                    sum(booking_incident.newTotalAmount for booking_incident in offer_booking_incidents)
+                ),
+                "TOKEN_LIST": ", ".join(
+                    [
+                        booking_incident.booking.token
+                        for booking_incident in offer_booking_incidents
+                        if booking_incident.booking
+                    ]
+                ),
+            },
+        )
+
+        mails.send(recipients=[booking_email], data=data)

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -209,3 +209,4 @@ class TransactionalEmail(Enum):
     # Finance incidents
     RETRIEVE_INCIDENT_AMOUNT_ON_INDIVIDUAL_BOOKINGS = models.Template(id_prod=1111, id_not_prod=150)
     RETRIEVE_INCIDENT_AMOUNT_ON_COLLECTIVE_BOOKINGS = models.Template(id_prod=1112, id_not_prod=151)
+    COMMERCIAL_GESTURE_REIMBURSEMENT = models.Template(id_prod=1187, id_not_prod=157)

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -145,6 +145,7 @@ class Roles(enum.Enum):
     """
 
     ADMIN = "admin"
+    CODIR_ADMIN = "codir_admin"
     SUPPORT_N1 = "support_n1"
     SUPPORT_N2 = "support_n2"
     SUPPORT_PRO = "support_pro"

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -13,6 +13,10 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.MANAGE_OFFERS_AND_VENUES_TAGS,
         perm_models.Permissions.ANONYMIZE_PUBLIC_ACCOUNT,
     ],
+    "codir_admin": [
+        perm_models.Permissions.READ_INCIDENTS,
+        perm_models.Permissions.MANAGE_INCIDENTS,
+    ],
     "support_n1": [
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
     ],

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -166,6 +166,10 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.MANAGE_PERMISSIONS,
         perm_models.Permissions.ANONYMIZE_PUBLIC_ACCOUNT,
     ],
+    "codir_admin": [
+        perm_models.Permissions.READ_INCIDENTS,
+        perm_models.Permissions.MANAGE_INCIDENTS,
+    ],
 }
 
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27689

- Envoi du mail lors de la validation d'un geste commercial
- Ajout du rôle CODIR chargé de valider ce type d'incidents

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques