### PR TITLE
(PC-28115)[PRO] fix: uxui modification adage svg and padding

### DIFF
--- a/pro/src/components/Breadcrumb/Breadcrumb.module.scss
+++ b/pro/src/components/Breadcrumb/Breadcrumb.module.scss
@@ -9,6 +9,14 @@
     gap: rem.torem(8px);
     flex-wrap: wrap;
 
+    &-last {
+      @include fonts.caption;
+
+      display: inline-flex;
+      align-items: center;
+      white-space: break-spaces;
+    }
+
     &-item {
       display: flex;
       align-items: center;

--- a/pro/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/pro/src/components/Breadcrumb/Breadcrumb.tsx
@@ -24,26 +24,31 @@ export default function Breadcrumb({ crumbs }: BreadcrumbProps) {
           const isLast = i === crumbs.length - 1
           return (
             <li className={styles['breadcrumb-list-item']} key={crumb.link.to}>
-              <ButtonLink
-                link={{
-                  ...crumb.link,
-                  'aria-current': isLast ? 'page' : undefined,
-                }}
-                className={styles['breadcrumb-list-item-link']}
-                variant={ButtonVariant.QUATERNARYPINK}
-              >
-                <>
-                  {crumb.icon && (
-                    <SvgIcon
-                      src={crumb.icon}
-                      alt=""
-                      width="16"
-                      className={styles['breadcrumb-list-item-link-icon']}
-                    />
-                  )}
+              {isLast ? (
+                <span className={styles['breadcrumb-list-last']}>
                   {crumb.title}
-                </>
-              </ButtonLink>
+                </span>
+              ) : (
+                <ButtonLink
+                  link={{
+                    ...crumb.link,
+                  }}
+                  className={styles['breadcrumb-list-item-link']}
+                  variant={ButtonVariant.QUATERNARYPINK}
+                >
+                  <>
+                    {crumb.icon && (
+                      <SvgIcon
+                        src={crumb.icon}
+                        alt=""
+                        width="16"
+                        className={styles['breadcrumb-list-item-link-icon']}
+                      />
+                    )}
+                    {crumb.title}
+                  </>
+                </ButtonLink>
+              )}
               {!isLast && (
                 <SvgIcon
                   alt=""

--- a/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
+++ b/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
@@ -22,7 +22,7 @@ describe('Breadcrumb', () => {
       screen.getByRole('navigation', { name: 'Vous êtes ici:' })
     ).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Link 1' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Link 3' })).toBeInTheDocument()
+    expect(screen.getByText('Link 3')).toBeInTheDocument()
   })
 
   it('should announce the last link as the current page for assistive technologies', () => {
@@ -32,9 +32,6 @@ describe('Breadcrumb', () => {
       'aria-current',
       'page'
     )
-    expect(screen.getByRole('link', { name: 'Link 3' })).toHaveAttribute(
-      'aria-current',
-      'page'
-    )
+    expect(screen.getByText('Link 3')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { NavLink, useSearchParams } from 'react-router-dom'
 
 import { LocalOfferersPlaylistOffer } from 'apiClient/adage'
-import strokeVenueIcon from 'icons/stroke-venue.svg'
+import strokeInstitutionIcon from 'icons/stroke-institution.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './VenueCard.module.scss'
@@ -37,7 +37,7 @@ const VenueCard = ({
         <div
           className={`${styles['venue-image']} ${styles['venue-image-fallback']}`}
         >
-          <SvgIcon src={strokeVenueIcon} width="80" alt="" />
+          <SvgIcon src={strokeInstitutionIcon} width="80" alt="" />
         </div>
       )}
       <div className={styles['venue-infos']}>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.module.scss
@@ -45,6 +45,7 @@
 
   &-info-name {
     display: block;
+    margin-bottom: rem.torem(8px);
   }
 
   &-location {

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
@@ -4,7 +4,6 @@ import { CalloutVariant } from 'components/Callout/types'
 import fullLinkIcon from 'icons/full-link.svg'
 import fullMailIcon from 'icons/full-mail.svg'
 import strokeInstitutionIcon from 'icons/stroke-institution.svg'
-import strokeVenueIcon from 'icons/stroke-venue.svg'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -62,7 +61,7 @@ export default function AdageOfferPartnerPanel({
           />
         ) : (
           <div className={styles['partner-panel-info-image-fallback']}>
-            <SvgIcon src={strokeVenueIcon} alt="" width="32" />
+            <SvgIcon src={strokeInstitutionIcon} alt="" width="32" />
           </div>
         )}
 

--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.module.scss
@@ -2,7 +2,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .no-results {
-  margin-top: rem.torem(32px);
+  padding-bottom: rem.torem(32px);
   text-align: center;
 
   &-svg {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -165,17 +165,19 @@ const Offer = ({
                 {offer.isTemplate ? (
                   <>
                     <OfferShareLink offer={offer} />
-                    <ContactButton
-                      className={style['offer-prebooking-button']}
-                      contactEmail={offer.contactEmail}
-                      contactPhone={offer.contactPhone}
-                      offerId={offer.id}
-                      position={position}
-                      queryId={queryId}
-                      userEmail={adageUser.email}
-                      userRole={adageUser.role}
-                      isInSuggestions={isInSuggestions}
-                    />
+                    {!isNewOfferInfoEnabled && (
+                      <ContactButton
+                        className={style['offer-prebooking-button']}
+                        contactEmail={offer.contactEmail}
+                        contactPhone={offer.contactPhone}
+                        offerId={offer.id}
+                        position={position}
+                        queryId={queryId}
+                        userEmail={adageUser.email}
+                        userRole={adageUser.role}
+                        isInSuggestions={isInSuggestions}
+                      />
+                    )}
                   </>
                 ) : (
                   <PrebookingButton

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -619,4 +619,20 @@ describe('offer', () => {
       `offerid/B-${offerProps.offer.id}`
     )
   })
+
+  it('should not display contact button when FF is active', () => {
+    renderOffer(
+      {
+        ...offerProps,
+        offer: {
+          ...defaultCollectiveTemplateOffer,
+          isTemplate: true,
+        },
+      },
+      user,
+      { features: ['WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN'] }
+    )
+
+    expect(screen.queryByText('Contacter')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28115

L'espacement dans le bloc partenaire entre le nom du partenaire et le renvoie vers la fiche partenaire : ajouter 8px entre le nom du lieu et le button “voir la fiche partenaire”
Enlever le lien dans le fil d’ariane sur le nom de l’offre, ça n’est pas censé être cliquable
Picto dans la photo du lieu : mettre le picto “museum” en placeholder pour homogénéiser

## Vérifications

- [x] J'ai écrit les tests nécessaires