### PR TITLE
(BSR)[API] chore: Remove `UserOfferer.first_user`

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -1062,18 +1062,6 @@ class Offerer(
             code = label = "Donnée indisponible"
         return {"code": code, "label": label}
 
-    @property
-    def first_user(self) -> "users_models.User | None":
-        # Currently there is no way to mark a UserOfferer as the owner/creator, so we consider that this first user
-        # is the oldest entry in the table. When creator leaves the offerer, next registered user becomes the "first".
-        # The relation being preserved during a rejection or deletion, we always keep an active user
-        if not self.UserOfferers:
-            return None
-        for user_offerer in self.UserOfferers:
-            if not (user_offerer.isRejected or user_offerer.isDeleted):
-                return user_offerer.user
-        return None
-
 
 class UserOfferer(PcObject, Base, Model, ValidationStatusMixin):
     __table_name__ = "user_offerer"

--- a/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
@@ -198,7 +198,7 @@ def list_offerers_to_be_validated(
     )
 
     # Ensure that we join with a single user, not on all attached users (would also multiply the number of rows)
-    # Same as User.first_user: the oldest entry in the table
+    # the oldest entry in the table
     creator_user_offerer_id = (
         db.session.query(offerers_models.UserOfferer.id)
         .filter(

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -358,54 +358,6 @@ class HasPendingBankInformationApplicationTest:
         assert venue.hasPendingBankInformationApplication is False
 
 
-class OffererFirstUserPropertyTest:
-    def test_first_user_when_none(self):
-        offerer = factories.OffererFactory()
-
-        assert offerer.first_user is None
-
-    def test_first_user_when_only_one(self):
-        offerer = factories.OffererFactory()
-        user_offerer = factories.UserOffererFactory(offerer=offerer)
-
-        assert offerer.first_user == user_offerer.user
-
-    def test_first_user_when_multiple(self):
-        offerer = factories.OffererFactory()
-        first = factories.UserOffererFactory(offerer=offerer)
-        factories.UserOffererFactory.create_batch(3, offerer=offerer)
-
-        assert offerer.first_user == first.user
-
-    def test_first_user_when_only_user_is_rejected(self):
-        offerer = factories.OffererFactory()
-        factories.RejectedUserOffererFactory(offerer=offerer)
-
-        assert offerer.first_user is None
-
-    def test_first_user_when_only_user_is_deleted(self):
-        offerer = factories.OffererFactory()
-        factories.DeletedUserOffererFactory(offerer=offerer)
-
-        assert offerer.first_user is None
-
-    def test_first_user_when_first_user_is_rejected_and_other_users(self):
-        offerer = factories.OffererFactory()
-        rejected_user_offerer = factories.RejectedUserOffererFactory(offerer=offerer)
-        factories.UserOffererFactory.create_batch(3, offerer=offerer)
-
-        assert offerer.first_user is not None
-        assert offerer.first_user != rejected_user_offerer.user
-
-    def test_first_user_when_first_user_is_deleted_and_other_users(self):
-        offerer = factories.OffererFactory()
-        deleted_user_offerer = factories.DeletedUserOffererFactory(offerer=offerer)
-        factories.UserOffererFactory.create_batch(3, offerer=offerer)
-
-        assert offerer.first_user is not None
-        assert offerer.first_user != deleted_user_offerer.user
-
-
 class VenueDmsAdageStatusTest:
     def test_dms_adage_status_when_no_dms_application(self):
         venue = factories.VenueFactory()

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1423,8 +1423,8 @@ class GetFilteredCollectiveOffersTest:
         )
 
         offers = repository.get_collective_offers_by_filters(
-            collective_offer_prebooked.venue.managingOfferer.first_user.id,
-            False,
+            user_offerer.userId,
+            user_is_admin=False,
             status=educational_models.CollectiveOfferDisplayedStatus.PREBOOKED.value,
         )
         assert offers.all() == [collective_offer_prebooked]
@@ -1442,8 +1442,8 @@ class GetFilteredCollectiveOffersTest:
         )
 
         offers = repository.get_collective_offers_by_filters(
-            collective_offer_ended.venue.managingOfferer.first_user.id,
-            False,
+            user_offerer.userId,
+            user_is_admin=False,
             status=educational_models.CollectiveOfferDisplayedStatus.ENDED.value,
         )
         assert offers.all() == [collective_offer_ended]
@@ -1458,8 +1458,8 @@ class GetFilteredCollectiveOffersTest:
         )
 
         offers = repository.get_collective_offers_by_filters(
-            collective_offer.venue.managingOfferer.first_user.id,
-            False,
+            user_offerer.userId,
+            user_is_admin=False,
             formats=[subcategories.EacFormat.CONCERT],
         )
         assert offers.one() == collective_offer

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -1295,8 +1295,8 @@ class ListOfferersToValidateTest(GetEndpointHelper):
             assert rows[0]["Date de la demande"] == "03/10/2022"
             assert rows[0]["Dernier commentaire"] == "Houlala"
             assert rows[0]["SIREN"] == user_offerer.offerer.siren
-            assert rows[0]["Email"] == user_offerer.offerer.first_user.email
-            assert rows[0]["Responsable Structure"] == user_offerer.offerer.first_user.full_name
+            assert rows[0]["Email"] == user_offerer.user.email
+            assert rows[0]["Responsable Structure"] == user_offerer.user.full_name
             assert rows[0]["Ville"] == user_offerer.offerer.city
 
             dms_adage_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")


### PR DESCRIPTION
Unused since bd26dd9d242e960 (except in tests, where it can be
replaced).