### PR TITLE
(PC-27866)[PRO] fix: set reimboursement link active on subroute

### DIFF
--- a/pro/src/app/AppRouter/subroutesReimbursements.tsx
+++ b/pro/src/app/AppRouter/subroutesReimbursements.tsx
@@ -1,6 +1,7 @@
 /* No need to test this file */
 /* istanbul ignore file */
 import React from 'react'
+import { Navigate } from 'react-router'
 
 import BankInformations from 'pages/Reimbursements/BankInformations/BankInformations'
 import ReimbursementsDetails from 'pages/Reimbursements/ReimbursementsDetails/ReimbursementsDetails'
@@ -11,6 +12,12 @@ import type { RouteConfig } from './routesMap'
 export const routesReimbursements: RouteConfig[] = [
   {
     element: <ReimbursementsInvoices />,
+    path: '/remboursements',
+    title: 'Gestion financière',
+  },
+  // We keep a redirection here in case this link is still used in mail
+  {
+    element: <Navigate to="/remboursements" />,
     path: '/remboursements/justificatifs',
     title: 'Gestion financière',
   },

--- a/pro/src/components/Header/Header.tsx
+++ b/pro/src/components/Header/Header.tsx
@@ -223,7 +223,7 @@ const Header = forwardRef(
                     from: location.pathname,
                   })
                 }}
-                to="/remboursements/justificatifs"
+                to="/remboursements"
               >
                 <SvgIcon
                   className={styles['nav-item-icon']}

--- a/pro/src/components/ReimbursementsTabs/ReimbursementsTabs.tsx
+++ b/pro/src/components/ReimbursementsTabs/ReimbursementsTabs.tsx
@@ -37,7 +37,7 @@ const ReimbursementsTabs = () => {
       {
         id: STEP_ID_INVOICES,
         label: 'Justificatifs',
-        url: '/remboursements/justificatifs',
+        url: '/remboursements',
       },
       {
         id: STEP_ID_DETAILS,

--- a/pro/src/components/ReimbursementsTabs/constants.ts
+++ b/pro/src/components/ReimbursementsTabs/constants.ts
@@ -16,7 +16,7 @@ export const OLD_STEP_LIST = [
   {
     id: STEP_ID_INVOICES,
     label: 'Justificatifs de remboursement',
-    url: '/remboursements/justificatifs',
+    url: '/remboursements',
   },
   {
     id: STEP_ID_DETAILS,

--- a/pro/src/pages/Reimbursements/__specs__/Reimbursements.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/Reimbursements.spec.tsx
@@ -40,7 +40,7 @@ const renderReimbursements = (options?: RenderWithProvidersOptions) => {
       </Routes>
     </ReimbursementContextProvider>,
     {
-      initialRouterEntries: ['/remboursements/justificatifs'],
+      initialRouterEntries: ['/remboursements'],
       storeOverrides,
       ...options,
     }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27866

Fix l'affichage de l'onglet `Gestion financière` quand une sous-route est active 

