### PR TITLE
(PC-28071)[BO] fix: restore soft-deleted stocks in sync process

### DIFF
--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -402,6 +402,7 @@ def _get_stocks_to_upsert(
                     "rawProviderQuantity": stock_detail.available_quantity,
                     "price": stock_detail.price,
                     "lastProviderId": provider_id,
+                    "isSoftDeleted": False,
                 }
             )
             if _should_reindex_offer(stock_detail.available_quantity, stock_detail.price, stock):


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28071

Dé-supprimer les stocks existants lors de la re-synchronisation 

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~