### PR TITLE
(PC-28055)[EAC] feat: expose venue name to adage route

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -365,6 +365,7 @@ def get_paginated_collective_bookings_for_educational_year(
             # ... to fetch its venue...
             sa.orm.joinedload(educational_models.CollectiveOffer.venue, innerjoin=True).load_only(
                 offerers_models.Venue.id,
+                offerers_models.Venue.name,
                 offerers_models.Venue.timezone,
             )
             # ... to fetch its offerer.

--- a/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
+++ b/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
@@ -113,6 +113,7 @@ class EducationalBookingPerYearResponse(AdageBaseResponseModel):
     domainIds: list[int]
     domainLabels: list[str]
     venueId: int | None
+    venueName: str | None
     offererName: str | None
 
 
@@ -133,6 +134,7 @@ def get_collective_bookings_per_year_response(
             domainIds=[domain.id for domain in booking.collectiveStock.collectiveOffer.domains],
             domainLabels=[domain.name for domain in booking.collectiveStock.collectiveOffer.domains],
             venueId=booking.collectiveStock.collectiveOffer.venueId,
+            venueName=booking.collectiveStock.collectiveOffer.venue.name,
             offererName=booking.collectiveStock.collectiveOffer.venue.managingOfferer.name,
         )
         for booking in bookings

--- a/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
+++ b/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
@@ -21,6 +21,7 @@ def expected_serialized_booking(booking) -> dict:
         "domainIds": [domain.id for domain in booking.collectiveStock.collectiveOffer.domains],
         "domainLabels": [domain.name for domain in booking.collectiveStock.collectiveOffer.domains],
         "venueId": booking.collectiveStock.collectiveOffer.venueId,
+        "venueName": booking.collectiveStock.collectiveOffer.venue.name,
         "offererName": booking.collectiveStock.collectiveOffer.venue.managingOfferer.name,
     }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28055

Ajouter le nom du lieu à la réponse d'une des route de l'api exposée à Adage.