### PR TITLE
(PC-28128)[PRO] feat: Adage offers small UI adjustments.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferPublicSection.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferPublicSection.tsx
@@ -52,7 +52,7 @@ export default function AdageOfferPublicSection({
               {studentLevels.map((level, i) => (
                 <li key={level}>
                   {level}{' '}
-                  {i < level.length - 1 && (
+                  {i < studentLevels.length - 1 && (
                     <span className={styles['offer-section-group-list-pipe']}>
                       |
                     </span>
@@ -76,7 +76,7 @@ export default function AdageOfferPublicSection({
               {a11yLevels.map((level, i) => (
                 <li key={level}>
                   {level}{' '}
-                  {i < level.length - 1 && (
+                  {i < a11yLevels.length - 1 && (
                     <span className={styles['offer-section-group-list-pipe']}>
                       |
                     </span>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
@@ -109,6 +109,6 @@ describe('AdageOfferInfoSection', () => {
 
     expect(screen.getByRole('heading', { name: 'Prix' })).toBeInTheDocument()
 
-    expect(screen.getByText('140 000 € pour 10 élèves')).toBeInTheDocument()
+    expect(screen.getByText('1 400 € pour 10 élèves')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
@@ -191,7 +191,7 @@ describe('AdageOfferHeader', () => {
       },
     })
 
-    expect(screen.getByText('12 000 € pour 100 élèves')).toBeInTheDocument()
+    expect(screen.getByText('120 € pour 100 élèves')).toBeInTheDocument()
     expect(screen.getByText(/My institution/)).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferStocks.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferStocks.spec.ts
@@ -15,7 +15,7 @@ describe('adageOfferStocks', () => {
         },
       })
 
-      expect(stockText).toEqual('100\xa0€ pour 20 élèves')
+      expect(stockText).toEqual('1\xa0€ pour 20 élèves')
     })
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferStocks.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferStocks.ts
@@ -7,5 +7,7 @@ export function getBookableOfferStockPrice(
     style: 'currency',
     currency: 'EUR',
     minimumFractionDigits: 0,
-  }).format(offer.stock.price)} pour ${offer.stock.numberOfTickets} élèves`
+  }).format(
+    offer.stock.price / 100
+  )} pour ${offer.stock.numberOfTickets} élèves`
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -66,22 +66,31 @@ const Offer = ({
   const openOfferDetails = (
     offer: CollectiveOfferResponseModel | CollectiveOfferTemplateResponseModel
   ) => {
-    const isTemplate = isCollectiveOfferTemplate(offer)
-
     setDisplayDetails(!displayDetails)
+
+    triggerOfferDetailClickLog(offer)
+  }
+
+  function triggerOfferDetailClickLog(
+    offer: CollectiveOfferResponseModel | CollectiveOfferTemplateResponseModel
+  ) {
     if (!LOGS_DATA) {
       return
     }
 
+    const isTemplate = isCollectiveOfferTemplate(offer)
+
     if (!isTemplate) {
-      void apiAdage.logOfferDetailsButtonClick({
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      apiAdage.logOfferDetailsButtonClick({
         iframeFrom: location.pathname,
         stockId: offer.stock.id,
         queryId: queryId,
         isFromNoResult: isInSuggestions,
       })
     } else {
-      void apiAdage.logOfferTemplateDetailsButtonClick({
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      apiAdage.logOfferTemplateDetailsButtonClick({
         iframeFrom: location.pathname,
         offerId: offer.id,
         queryId: queryId,
@@ -256,6 +265,7 @@ const Offer = ({
                   ? ButtonVariant.PRIMARY
                   : ButtonVariant.SECONDARY
               }
+              onClick={() => triggerOfferDetailClickLog(offer)}
               link={{
                 isExternal: true,
                 to: `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28128

**Objectif**
- Le prix du stock d'une offre réservable étant enregistré en centimes, on le divise par 100 pour l'affichage en euros
- Certaines listes de la page offre sur adage ont un pipe "|" en trop à la fin parce que je checkais la mauvaise length
- Ajout du los de clic sur le bouton "en savoir plus" aussi sur le bouton de redirection vers l'offre adage

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques