### PR TITLE
(PC-27007)[PRO] feat: add test e2e for discovery page adage

### DIFF
--- a/pro/cypress/e2e/adageDiscovery.cy.ts
+++ b/pro/cypress/e2e/adageDiscovery.cy.ts
@@ -1,13 +1,134 @@
 describe('Adage discovery', () => {
   beforeEach(() => {
     cy.visit('/connexion')
-    cy.setFeatureFlags([{ name: 'WIP_ENABLE_DISCOVERY', isActive: true }])
     cy.getFakeAdageToken()
+
+    cy.intercept({
+      method: 'GET',
+      url: 'adage-iframe/playlists/new_template_offers',
+    }).as('getNewTemplateOffersPlaylist')
   })
 
   it('should redirect to adage discovery', () => {
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe?token=${adageToken}`)
+
+    cy.url().should('include', '/decouverte')
+    cy.findByRole('link', { name: 'Découvrir' }).should(
+      'have.attr',
+      'aria-current',
+      'page'
+    )
     cy.contains('Découvrez la part collective du pass Culture')
+  })
+
+  it('should redirect to adage search page with filtered venue', () => {
+    const adageToken = Cypress.env('adageToken')
+    cy.visit(`/adage-iframe?token=${adageToken}&venue=1`)
+    cy.url().should('include', '/recherche')
+    cy.findByRole('link', { name: 'Rechercher' }).should(
+      'have.attr',
+      'aria-current',
+      'page'
+    )
+    cy.findByRole('button', { name: /Lieu : Librairie des GTls/ })
+  })
+
+  it('should redirect to a page dedicated to the offer with an active header on the discovery tab', () => {
+    const adageToken = Cypress.env('adageToken')
+    cy.visit(`/adage-iframe?token=${adageToken}`)
+
+    cy.findAllByTestId('card-offer-link').first().click()
+
+    cy.findAllByRole('link', { name: 'Découvrir' }).should(
+      'have.attr',
+      'aria-current',
+      'page'
+    )
+  })
+
+  it('should redirect to search page with filtered domain on click in domain card', () => {
+    const adageToken = Cypress.env('adageToken')
+    cy.visit(`/adage-iframe?token=${adageToken}`)
+
+    cy.findAllByTestId('card-domain-link').first().click()
+
+    cy.findByRole('link', { name: 'Rechercher' }).should(
+      'have.attr',
+      'aria-current',
+      'page'
+    )
+
+    cy.findByRole('button', { name: /Architecture/ })
+  })
+
+  it('should redirect to search page with filtered venue on click in venue card', () => {
+    const adageToken = Cypress.env('adageToken')
+    cy.visit(`/adage-iframe?token=${adageToken}`)
+
+    cy.findAllByTestId('card-venue-link').first().scrollIntoView()
+
+    cy.findAllByTestId('card-venue-link').first().click()
+
+    cy.findByRole('link', { name: 'Rechercher' }).should(
+      'have.attr',
+      'aria-current',
+      'page'
+    )
+
+    cy.get(
+      'button[title="Supprimer Lieu :  real_venue 1 eac_2_lieu [BON EAC]"]'
+    )
+  })
+
+  it('should not keep filters after page change', () => {
+    const adageToken = Cypress.env('adageToken')
+    cy.visit(`/adage-iframe?token=${adageToken}`)
+
+    cy.findAllByTestId('card-venue-link').first().scrollIntoView()
+    cy.findAllByTestId('card-venue-link').first().click()
+
+    cy.findByRole('link', { name: 'Rechercher' }).should(
+      'have.attr',
+      'aria-current',
+      'page'
+    )
+
+    cy.get(
+      'button[title="Supprimer Lieu :  real_venue 1 eac_2_lieu [BON EAC]"]'
+    )
+
+    cy.findByRole('link', { name: 'Découvrir' }).click()
+
+    cy.findByRole('link', { name: 'Rechercher' }).click()
+
+    cy.get(
+      'button[title="Supprimer Lieu :  real_venue 1 eac_2_lieu [BON EAC]"]'
+    ).should('not.exist')
+  })
+
+  it('should put an offer in favorite', () => {
+    const adageToken = Cypress.env('adageToken')
+    cy.visit(`/adage-iframe?token=${adageToken}`)
+
+    cy.wait('@getNewTemplateOffersPlaylist')
+
+    cy.findAllByTestId('card-offer')
+      .first()
+      .invoke('text')
+      .then((text: string) => {
+        cy.findAllByTestId('favorite-inactive').first().click()
+        cy.contains('Ajouté à vos favoris')
+
+        cy.contains('Mes Favoris').click()
+
+        cy.contains(text)
+
+        cy.findByRole('link', { name: 'Découvrir' }).click()
+
+        cy.reload()
+
+        cy.findAllByTestId('favorite-active').first().click()
+      })
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.tsx
@@ -20,6 +20,7 @@ const DomainsCard = ({
 }: DomainsCardProps) => {
   return (
     <NavLink
+      data-testid="card-domain-link"
       className={cn(styles['container'], styles[`container-${color}`])}
       to={href}
       onClick={() => handlePlaylistElementTracking()}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -99,7 +99,11 @@ const OfferCardComponent = ({
           })}
         </div>
 
-        <div className={styles['offer-name']} title={offer.name}>
+        <div
+          className={styles['offer-name']}
+          title={offer.name}
+          data-testid="card-offer"
+        >
           {offer.name}
         </div>
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferFavoriteButton/OfferFavoriteButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferFavoriteButton/OfferFavoriteButton.tsx
@@ -117,6 +117,7 @@ const OfferFavoriteButton = ({
         [styles['favorite-button-loading']]: isLoading,
         [styles['favorite-button-active']]: isFavorite,
       })}
+      dataTestid={`favorite-${isFavorite ? 'active' : 'inactive'}`}
       onClick={handleFavoriteClick}
     >
       {buttonText}

--- a/pro/src/ui-kit/ListIconButton/ListIconButton.tsx
+++ b/pro/src/ui-kit/ListIconButton/ListIconButton.tsx
@@ -17,6 +17,7 @@ interface ListIconButtonProps extends React.HTMLProps<HTMLButtonElement> {
   onClick?: () => void
   url?: string
   isExternal?: boolean
+  dataTestid?: string
 }
 
 const LIST_ICON_SIZE = '16'
@@ -30,6 +31,7 @@ const ListIconButton = ({
   onClick,
   url,
   isExternal = true,
+  dataTestid,
   ...buttonAttrs
 }: ListIconButtonProps): JSX.Element => {
   const { isTooltipHidden, ...tooltipProps } = useTooltipProps(buttonAttrs)
@@ -62,6 +64,7 @@ const ListIconButton = ({
       {...buttonAttrs}
       onClick={onClick}
       type="button"
+      data-testid={dataTestid}
       {...tooltipProps}
     >
       {content}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27007

Ajout de test e2e pour la page découverte : 

Accès à / redirige vers la découverte
Accès à /?token=…&venue=[quelque chose] redirige sur /recherche avec le bon filtre sur la venue
Défilement des 3 playlists et de la liste des domains
Mise en favoris d'une offre (l'étoile est rouge + aller dans mes favoris vérifier la présence de l'offre + recharger la page sur la découverte pour vérifier que l'offre est toujours en favoris)
Redirection vers une page offre au clic sur une offre d'une playlist et vérifier que header actif au bon endroit
Redirection vers la recherche au clic sur un domaine (avec le bon filtre actif)
Redirection vers la recherche au clic sur un lieu (avec le bon filtre)
## Vérifications

- [x] J'ai écrit les tests nécessaires