### PR TITLE
(PC-28061)[PRO] fix: fix set isduo false when update synchronized offer

### DIFF
--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
@@ -145,7 +145,7 @@ describe('updateIndividualOffer', () => {
       durationMinutes: undefined,
       externalTicketOfficeUrl: 'https://example.com',
       extraData: undefined,
-      isDuo: false,
+      isDuo: undefined,
       isNational: undefined,
       mentalDisabilityCompliant: true,
       motorDisabilityCompliant: true,

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -82,7 +82,7 @@ export const serializePatchOffer = ({
     description: sentValues.description,
     extraData: serializeExtraData(sentValues),
     isNational: sentValues.isNational,
-    isDuo: !!sentValues.isDuo,
+    isDuo: sentValues.isDuo,
     mentalDisabilityCompliant:
       sentValues.accessibility &&
       sentValues.accessibility[AccessiblityEnum.MENTAL],


### PR DESCRIPTION
## But de la pull request
Pour les offre synchronisé (offer.lastProvider != null), sentValues ne contient pas isDuo
Ce qui fait que !!isDuo = false, alors que c'est pas ce qu'on veut

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28061

## Vérifications

- [X] J'ai écrit les tests nécessaires
