### PR TITLE
(PC-25897)[API] feat: synchronize boost stocks with allocine products

### DIFF
--- a/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
@@ -253,19 +253,6 @@ class BoostStocks(LocalProvider):
         return client_boost.get_cinemas_attributs()
 
 
-def _find_showtimes_by_movie_id(showtimes_information: list[dict], movie_id: int) -> list[dict]:
-    return list(
-        filter(
-            lambda showtime: showtime["show_information"].media.id == movie_id,
-            showtimes_information,
-        )
-    )
-
-
-def _get_showtimes_uuid_by_idAtProvider(id_at_provider: str) -> str:
-    return id_at_provider.split("#")[1]
-
-
 def _build_movie_uuid(film_id: int, venue: Venue) -> str:
     return f"{film_id}%{venue.id}%Boost"
 

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -123,6 +123,9 @@ class FeatureToggle(enum.Enum):
         "Activer la prévisualisation d'une offre adage lors de la création/édition sur le portail pro"
     )
     WIP_ENABLE_NEW_NAV_AB_TEST = "Activer l'A/B test de la nouvelle navigation du portail pro."
+    WIP_SYNCHRONIZE_CINEMA_STOCKS_WITH_ALLOCINE_PRODUCTS = (
+        "Synchroniser les offres et stocks de cinéma avec les produits allociné"
+    )
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -190,6 +193,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ENABLE_COLLECTIVE_CUSTOM_CONTACT,
     FeatureToggle.WIP_ENABLE_ADAGE_PREVIEW_OFFER_IN_PRO,
     FeatureToggle.WIP_ENABLE_NEW_NAV_AB_TEST,
+    FeatureToggle.WIP_SYNCHRONIZE_CINEMA_STOCKS_WITH_ALLOCINE_PRODUCTS,
 )
 
 if settings.IS_PROD or settings.IS_STAGING:
@@ -203,6 +207,7 @@ if settings.IS_TESTING:
         FeatureToggle.ENABLE_CHARLIE_BOOKINGS_API,
         FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API,
         FeatureToggle.WIP_ENABLE_OFFER_CREATION_API_V1,
+        FeatureToggle.WIP_SYNCHRONIZE_CINEMA_STOCKS_WITH_ALLOCINE_PRODUCTS,
     }
 
     FEATURES_DISABLED_BY_DEFAULT = tuple(testing_features_disabled_by_default - features_to_enable)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25897

- Association des offres et stocks Boost avec un produit Allociné s'il existe
- Conditionnement par un feature flag.
    - S'il est inactif, les offres sont créées sans être associées à un produit.
    - S'il est actif, les offres pour lesquelles le produit n'est pas trouvé ne sont pas créées
    - Ce feature flag est destiné à être aussi utilisé pour les autres synchronisations d'offres et stocks cinémas, sauf celle d'Allociné. Le but est de le supprimer lorsque le catalogue est assez complet et donc que les offres non créées soient marginales.
- Suppression de deux fonction privées inutilisées

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques