### PR TITLE
(PC-28194)[API] fix: ensure proper display on adage swagger/openapi.json

### DIFF
--- a/api/src/pcapi/routes/adage/v1/blueprint.py
+++ b/api/src/pcapi/routes/adage/v1/blueprint.py
@@ -1,7 +1,7 @@
 from flask import Blueprint
 from spectree import SecurityScheme
-from spectree import SpecTree
 
+from pcapi.serialization.spec_tree import ExtendedSpecTree
 from pcapi.serialization.utils import before_handler
 
 
@@ -18,5 +18,5 @@ SECURITY_SCHEMES = [
 ]
 
 
-api = SpecTree("flask", MODE="strict", before=before_handler, PATH="/", security_schemes=SECURITY_SCHEMES)
+api = ExtendedSpecTree("flask", MODE="strict", before=before_handler, PATH="/", security_schemes=SECURITY_SCHEMES)
 api.register(adage_v1)


### PR DESCRIPTION
## But de la pull request

Ticket Jira: https://passculture.atlassian.net/browse/PC-28194

On dirait que le décorateur de vues ajoute un hash pour les models et le spectree de base ne le fait pas.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques