### PR TITLE
(PC-28208)[BO] fix: Set TTL on phone validation token when sent from back-office

### DIFF
--- a/api/src/pcapi/core/subscription/phone_validation/api.py
+++ b/api/src/pcapi/core/subscription/phone_validation/api.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import time
 
@@ -138,7 +137,6 @@ def _send_sms_with_retry(phone_number: str, message: str, max_attempt: int = 3) 
 def send_phone_validation_code(
     user: users_models.User,
     phone_number: str | None,
-    expiration: datetime.datetime | None = None,
     ignore_limit: bool = False,
 ) -> None:
     if not phone_number:
@@ -158,7 +156,6 @@ def send_phone_validation_code(
     phone_validation_token = users_api.create_phone_validation_token(
         user,
         phone_data.phone_number,
-        expiration=expiration,
     )
     content = f"{phone_validation_token.encoded_token} est ton code de confirmation pass Culture"
 

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -92,14 +92,12 @@ def create_reset_password_token(user: models.User, expiration: datetime.datetime
 def create_phone_validation_token(
     user: models.User,
     phone_number: str,
-    expiration: datetime.datetime | None = None,
 ) -> token_utils.SixDigitsToken:
-    if expiration:
-        ttl = expiration - datetime.datetime.utcnow()
-    else:
-        ttl = None
     return token_utils.SixDigitsToken.create(
-        type_=token_utils.TokenType.PHONE_VALIDATION, user_id=user.id, ttl=ttl, data={"phone_number": phone_number}
+        type_=token_utils.TokenType.PHONE_VALIDATION,
+        user_id=user.id,
+        ttl=constants.PHONE_VALIDATION_TOKEN_LIFE_TIME,
+        data={"phone_number": phone_number},
     )
 
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -319,9 +319,7 @@ def _log_failure_code(phone_number: str, code: str) -> None:
 @authenticated_and_active_user_required
 def send_phone_validation_code(user: users_models.User, body: serializers.SendPhoneValidationRequest) -> None:
     try:
-        phone_validation_api.send_phone_validation_code(
-            user, body.phoneNumber, expiration=datetime.utcnow() + constants.PHONE_VALIDATION_TOKEN_LIFE_TIME
-        )
+        phone_validation_api.send_phone_validation_code(user, body.phoneNumber)
 
     except phone_validation_exceptions.SMSSendingLimitReached:
         error = {"code": "TOO_MANY_SMS_SENT", "message": "Nombre de tentatives maximal dépassé"}

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -1245,7 +1245,12 @@ class SendValidationCodeTest(PostEndpointHelper):
         assert sms_testing.requests[0]["recipient"] == user.phoneNumber
 
         assert token_utils.Token.token_exists(token_utils.TokenType.PHONE_VALIDATION, user.id)
-        assert token_utils.SixDigitsToken.get_expiration_date(token_utils.TokenType.PHONE_VALIDATION, user.id) is None
+        assert token_utils.SixDigitsToken.get_expiration_date(
+            token_utils.TokenType.PHONE_VALIDATION, user.id
+        ).timestamp() == pytest.approx(
+            (datetime.datetime.utcnow() + users_constants.PHONE_VALIDATION_TOKEN_LIFE_TIME).timestamp(),
+            1,
+        )
 
     def test_phone_validation_code_sending_ignores_limit(self, authenticated_client):
         user = users_factories.UserFactory(phoneValidationStatus=None, phoneNumber="+33612345678")

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1818,9 +1818,7 @@ class ValidatePhoneNumberTest:
             phoneNumber="+33607080900", dateOfBirth=datetime.utcnow() - relativedelta(years=18)
         )
         client.with_token(email=user.email)
-        token = create_phone_validation_token(
-            user, "+33607080900", expiration=datetime.utcnow() + users_constants.PHONE_VALIDATION_TOKEN_LIFE_TIME
-        )
+        token = create_phone_validation_token(user, "+33607080900")
 
         # try one attempt with wrong code
         client.post("/native/v1/validate_phone_number", {"code": "wrong code"})
@@ -1873,9 +1871,7 @@ class ValidatePhoneNumberTest:
         fraud_factories.ProfileCompletionFraudCheckFactory(user=user)
 
         client.with_token(email=user.email)
-        token = create_phone_validation_token(
-            user, "+33607080900", expiration=datetime.utcnow() + users_constants.PHONE_VALIDATION_TOKEN_LIFE_TIME
-        )
+        token = create_phone_validation_token(user, "+33607080900")
 
         response = client.post("/native/v1/validate_phone_number", {"code": token.encoded_token})
 
@@ -1891,9 +1887,7 @@ class ValidatePhoneNumberTest:
             dateOfBirth=datetime.utcnow() - relativedelta(years=18, days=5),
         )
         client.with_token(email=user.email)
-        token = create_phone_validation_token(
-            user, "+33607080900", expiration=datetime.utcnow() + users_constants.PHONE_VALIDATION_TOKEN_LIFE_TIME
-        )
+        token = create_phone_validation_token(user, "+33607080900")
 
         response = client.post("/native/v1/validate_phone_number", {"code": "wrong code"})
         response = client.post("/native/v1/validate_phone_number", {"code": token.encoded_token})
@@ -1943,9 +1937,7 @@ class ValidatePhoneNumberTest:
     def test_wrong_code(self, client):
         user = users_factories.UserFactory(phoneNumber="+33607080900")
         client.with_token(email=user.email)
-        create_phone_validation_token(
-            user, "+33607080900", expiration=datetime.utcnow() + users_constants.PHONE_VALIDATION_TOKEN_LIFE_TIME
-        )
+        create_phone_validation_token(user, "+33607080900")
 
         response = client.post("/native/v1/validate_phone_number", {"code": "mauvais-code"})
 
@@ -1979,9 +1971,7 @@ class ValidatePhoneNumberTest:
     def test_expired_code(self, client):
         with mock.patch("flask.current_app.redis_client", self.mock_redis_client):
             user = users_factories.UserFactory(phoneNumber="+33607080900")
-            token = create_phone_validation_token(
-                user, "+33607080900", expiration=datetime.utcnow() + users_constants.PHONE_VALIDATION_TOKEN_LIFE_TIME
-            )
+            token = create_phone_validation_token(user, "+33607080900")
 
             with freeze_time(datetime.utcnow() + timedelta(hours=15)):
                 client.with_token(email=user.email)
@@ -2001,9 +1991,7 @@ class ValidatePhoneNumberTest:
         )
         user = users_factories.UserFactory(phoneNumber="+33607080900")
         client.with_token(email=user.email)
-        token = create_phone_validation_token(
-            user, "+33607080900", expiration=datetime.utcnow() + users_constants.PHONE_VALIDATION_TOKEN_LIFE_TIME
-        )
+        token = create_phone_validation_token(user, "+33607080900")
 
         # try one attempt with wrong code
         response = client.post("/native/v1/validate_phone_number", {"code": token.encoded_token})


### PR DESCRIPTION
In fact, force the TTL to be the same (12 hours), whichever way we
generate the token.