### PR TITLE
(PC-27995)[PRO] style: Ajout Callout aux structures en validation

### DIFF
--- a/pro/src/pages/Home/Offerers/OffererBanners.tsx
+++ b/pro/src/pages/Home/Offerers/OffererBanners.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
 import { GetOffererResponseModel } from 'apiClient/v1'
-import { Banner } from 'ui-kit'
+import Callout from 'components/Callout/Callout'
+import { CalloutVariant } from 'components/Callout/types'
 
 import { hasOffererAtLeastOnePhysicalVenue } from '../venueUtils'
 
@@ -20,14 +21,13 @@ export const OffererBanners = ({
 
   if (!isUserOffererValidated) {
     return (
-      <Banner
-        type="notification-info"
+      <Callout
+        variant={CalloutVariant.INFO}
         className={styles['banner']}
         links={[
           {
             href: `https://aide.passculture.app/hc/fr/articles/4514252662172--Acteurs-Culturels-S-inscrire-et-comprendre-le-fonctionnement-du-pass-Culture-cr%C3%A9ation-d-offres-gestion-des-r%C3%A9servations-remboursements-etc-`,
             label: 'En savoir plus',
-            isExternal: true,
             'aria-label':
               'Acteurs Culturels: s’inscrire et comprendre le fonctionnement (Nouvelle fenêtre, site https://aide.passculture.app)',
           },
@@ -41,20 +41,19 @@ export const OffererBanners = ({
         Un email vous sera envoyé lors de la validation de votre rattachement.
         Vous aurez alors accès à l’ensemble des fonctionnalités du pass Culture
         Pro.
-      </Banner>
+      </Callout>
     )
   }
 
   if (!offerer.isValidated) {
     return (
-      <Banner
-        type="notification-info"
+      <Callout
+        variant={CalloutVariant.INFO}
         className={styles['banner']}
         links={[
           {
             href: `https://aide.passculture.app/hc/fr/articles/4514252662172--Acteurs-Culturels-S-inscrire-et-comprendre-le-fonctionnement-du-pass-Culture-cr%C3%A9ation-d-offres-gestion-des-r%C3%A9servations-remboursements-etc-`,
             label: 'En savoir plus sur le fonctionnement du pass Culture',
-            isExternal: true,
           },
         ]}
       >
@@ -78,14 +77,14 @@ export const OffererBanners = ({
             de votre structure.
           </>
         )}
-      </Banner>
+      </Callout>
     )
   }
 
   if (!hasAtLeastOnePhysicalVenue) {
     return (
-      <Banner
-        type="notification-info"
+      <Callout
+        variant={CalloutVariant.INFO}
         className={styles['banner']}
         links={[
           {
@@ -93,7 +92,6 @@ export const OffererBanners = ({
             label: 'En savoir plus sur la création d’un lieu',
             'aria-label':
               'Acteurs Culturels: Comment ajouter de nouveaux lieux sur votre espace et les paramétrer ? (Nouvelle fenêtre, site https://aide.passculture.app)',
-            isExternal: true,
           },
         ]}
       >
@@ -106,7 +104,7 @@ export const OffererBanners = ({
           Vous avez la possibilité de créer dès maintenant des offres
           numériques.
         </p>
-      </Banner>
+      </Callout>
     )
   }
 


### PR DESCRIPTION
## But de la pull request - Ajout de 3 callout "info" aux structures en validation

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27995

Voici la structure avec callout, variant "info"-1,  pour label: 'En savoir plus sur le fonctionnement du pass Culture': http://localhost:3001/accueil?structure=926 

Voici [figma](https://www.figma.com/file/AEXCkb4KbUyPmB4BRFa88s/PRO---Library?type=design&node-id=8661-52286&mode=design&t=pm35zw8YFDdMrF4q-0) pour se retrouver: 

- Callout label: 'En savoir plus', (Un email vous sera envoyé lors de la validation de votre rattachement.)

- Callout label: 'En savoir plus sur la création d’un lieu'.


<img width="854" alt="Capture d’écran 2024-02-26 à 15 27 09" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/a6a0fcc1-4548-45c7-91dd-941225fbcc43">

Anciens:

<img width="444" alt="Capture d’écran 2024-02-27 à 15 06 30" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/10efb597-47eb-4f4a-baac-3f84b5547181">

<img width="873" alt="Capture d’écran 2024-02-27 à 15 19 19" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/a40cd0ec-253e-42f4-980e-fbe1f92413a4">

<img width="898" alt="Capture d’écran 2024-02-27 à 15 22 30" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/d17dbf06-75e3-44f0-bc97-8b834e2a79bc">



