### PR TITLE
(PC-28224)[PRO] fix: redirect non rattached pro to onboarding

### DIFF
--- a/pro/src/app/App/App.tsx
+++ b/pro/src/app/App/App.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
+import { UserRole } from 'apiClient/v1'
 import { findCurrentRoute } from 'app/AppRouter/findCurrentRoute'
 import Notification from 'components/Notification/Notification'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -111,6 +112,15 @@ const App = (): JSX.Element | null => {
       : `/connexion?de=${fromUrl}`
 
     return <Navigate to={loginUrl} replace />
+  }
+
+  if (
+    !currentRoute?.meta?.public &&
+    !currentRoute?.path.includes('/parcours-inscription') &&
+    currentUser !== null &&
+    currentUser.roles.includes(UserRole.NON_ATTACHED_PRO)
+  ) {
+    return <Navigate to="/parcours-inscription" replace />
   }
 
   return (

--- a/pro/src/app/__specs__/App.spec.tsx
+++ b/pro/src/app/__specs__/App.spec.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
+import { UserRole } from 'apiClient/v1'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { App } from '../App'
@@ -22,6 +23,10 @@ const renderApp = (storeOverrides: any, url = '/') =>
           <Route path="/" element={<p>Sub component</p>} />
           <Route path="/offres" element={<p>Offres</p>} />
           <Route path="/connexion" element={<p>Login page</p>} />
+          <Route
+            path="/parcours-inscription"
+            element={<p>Onboarding page</p>}
+          />
         </Route>
       </Routes>
     </>,
@@ -45,6 +50,7 @@ describe('App', () => {
         currentUser: {
           id: 12,
           isAdmin: false,
+          roles: [UserRole.PRO],
         },
       },
     }
@@ -76,5 +82,20 @@ describe('App', () => {
     renderApp(loggedOutStore, '/offres')
 
     expect(await screen.findByText('Login page')).toBeInTheDocument()
+  })
+
+  it('should redirect non rattached user to onboarding', async () => {
+    const nonRattachedStore = {
+      user: {
+        currentUser: {
+          id: 12,
+          isAdmin: false,
+          roles: [UserRole.NON_ATTACHED_PRO],
+        },
+      },
+    }
+    renderApp(nonRattachedStore, '/')
+
+    expect(await screen.findByText('Onboarding page')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28224

Rediriger un utilisateur non-rattaché à une structure vers le parcours d'onboarding quand il essaie d'accèder à une page du portail pro. 

**Pour tester :** 

- Créer un nouvel utilisateur
- Accéder au parcours d'inscription en se connectant
- Fermet l'onglet 
- Essayer d'accéder à `/accueil` -> Vérifier qu'on est bien redirigé sur `/parcours-inscription`
