### PR TITLE
(PC-28073)[PRO] fix: change non visible siret message

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
@@ -242,7 +242,9 @@ describe('screens:SignupJourney::OffererForm', () => {
     )
     await userEvent.click(screen.getByText('Submit'))
     expect(
-      await screen.findByText('Le SIRET n’est pas visible')
+      await screen.findByText(
+        "Le propriétaire de ce SIRET s'oppose à la diffusion de ses données au public"
+      )
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/SignupJourneyForm/Offerer/validationSchema.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/validationSchema.tsx
@@ -15,14 +15,18 @@ export const validationSchema = (
         'Le SIRET doit comporter 14 caractères',
         (siret) => !!siret && valideSiretLength(siret)
       )
-      .test('apiSiretVisible', 'Le SIRET n’est pas visible', async (siret) => {
-        const response = await siretApiValidate(siret || '')
-        const isInvisible =
-          response ===
-          'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles.'
-        displayInvisibleSirenBanner(isInvisible)
-        return !isInvisible
-      })
+      .test(
+        'apiSiretVisible',
+        "Le propriétaire de ce SIRET s'oppose à la diffusion de ses données au public",
+        async (siret) => {
+          const response = await siretApiValidate(siret || '')
+          const isInvisible =
+            response ===
+            'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles.'
+          displayInvisibleSirenBanner(isInvisible)
+          return !isInvisible
+        }
+      )
       .test('apiSiretValid', 'Le SIRET n’existe pas', async (siret) => {
         const response = await siretApiValidate(siret || '')
         return !response


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28073

Changer le wording du message quand un SIRET n'est pas visible dans le parcours d'inscription 

Le SIRET n'est pas visible -> Le propriétaire de ce SIRET s'oppose à la diffusion de ses données au public


![Capture d’écran 2024-02-28 à 09 22 59](https://github.com/pass-culture/pass-culture-main/assets/71768799/53ee9ae1-24c1-48a8-9343-e9f61ca5a22d)
