### PR TITLE
(BSR)[API] ci: Run mypy-cop workflow only on feature branches

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -70,7 +70,9 @@ jobs:
   run-mypy-cop:
     name: "MyPy cop"
     needs: check-api
-    if: github.ref != 'refs/heads/master' && needs.check-api.outputs.folder_changed == 'true'
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.check-api.outputs.folder_changed == 'true'
     uses: ./.github/workflows/dev_on_workflow_mypy_cop.yml
 
   update-api-client-template:


### PR DESCRIPTION
This workflow is only relevant for feature branches (pull requests).
The previous condition made it run on maintenance branches too, which
we don't want.

---

J'ai ajouté dans cette pull request un commit de test (qui sera supprimé avant le merge) montrant que mypy-cop est bien lancé quand on fait des modifications dans le code Python : https://github.com/pass-culture/pass-culture-main/actions/runs/8079686259/job/22074709350?pr=10968 (et on voit le commentaire laissé par mypy-cop dans la pull request)