### PR TITLE
(PC-28251)[PRO] feat: create ff preview adage offer in pro

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -121,6 +121,9 @@ class FeatureToggle(enum.Enum):
         "Activer les nouvelles règles de création et d'édition d'offres collecrives pour l'API publique (collective)"
     )
     WIP_ENABLE_COLLECTIVE_CUSTOM_CONTACT = "Activer le contact personnalisé pour les offres collectives"
+    WIP_ENABLE_ADAGE_PREVIEW_OFFER_IN_PRO = (
+        "Activer la prévisualisation d'une offre adage lors de la création/édition sur le portail pro"
+    )
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -188,6 +191,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_CONNECT_AS,
     FeatureToggle.WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN,
     FeatureToggle.WIP_ENABLE_COLLECTIVE_CUSTOM_CONTACT,
+    FeatureToggle.WIP_ENABLE_ADAGE_PREVIEW_OFFER_IN_PRO,
 )
 
 if settings.IS_PROD or settings.IS_STAGING:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28251

Ajout d'un FF pour le sujet de la prévisualisation côté pro d'une offre adage pendant la création/édition

WIP_ENABLE_ADAGE_PREVIEW_OFFER_IN_PRO