### PR TITLE
(PC-26961)[API] fix: Catch when user belonging to an offerer try to (re)create it

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -767,9 +767,9 @@ def create_offerer(
         )
         if user_offerer:
             user_offerer.validationStatus = ValidationStatus.VALIDATED
+            db.session.add(user_offerer)
         else:
             user_offerer = grant_user_offerer_access(offerer, user)
-        db.session.add(user_offerer)
 
         if offerer.isRejected:
             # When offerer was rejected, it is considered as a new offerer in validation process;
@@ -828,7 +828,10 @@ def create_offerer(
 
 
 def grant_user_offerer_access(offerer: models.Offerer, user: users_models.User) -> models.UserOfferer:
-    return models.UserOfferer(offerer=offerer, user=user, validationStatus=ValidationStatus.VALIDATED)
+    user_offerer = models.UserOfferer(offerer=offerer, user=user, validationStatus=ValidationStatus.VALIDATED)
+    db.session.add(user_offerer)
+    db.session.flush()
+    return user_offerer
 
 
 def _format_tags(tags: typing.Iterable[models.OffererTag]) -> str:

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -834,6 +834,14 @@ def grant_user_offerer_access(offerer: models.Offerer, user: users_models.User) 
     return user_offerer
 
 
+def is_user_offerer_already_exist(user: users_models.User, siren: str) -> bool:
+    return db.session.query(
+        models.UserOfferer.query.join(models.UserOfferer.offerer)
+        .filter(models.UserOfferer.user == user, models.Offerer.siren == siren)
+        .exists()
+    ).scalar()
+
+
 def _format_tags(tags: typing.Iterable[models.OffererTag]) -> str:
     return ", ".join(sorted(tag.label for tag in tags))
 

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -155,6 +155,11 @@ def create_offerer(body: offerers_serialize.CreateOffererQueryModel) -> offerers
     if not siren_info.active:
         raise ApiErrors(errors={"siren": ["SIREN is no longer active"]})
     body.name = siren_info.name
+    if api.is_user_offerer_already_exist(current_user, body.siren):
+        # As this endpoint does not only allow to create an offerer, but also handles
+        # a large part of `user_offerer` buisness logic (see `api.create_offerer` below)
+        # That check is needed here. Otherwise, we might try to create an already existing user_offerer
+        raise ApiErrors(errors={"user_offerer": ["This user already belongs to this offerer"]})
     user_offerer = api.create_offerer(current_user, body)
 
     return offerers_serialize.PostOffererResponseModel.from_orm(user_offerer.offerer)

--- a/api/tests/routes/pro/post_offerer_test.py
+++ b/api/tests/routes/pro/post_offerer_test.py
@@ -64,6 +64,33 @@ def test_returned_data(client):
     }
 
 
+def test_user_cant_create_same_offerer_twice(client):
+    pro = users_factories.ProFactory()
+
+    body = {
+        "name": "MINISTERE DE LA CULTURE",
+        "siren": "418166096",
+        "address": "123 rue de Paris",
+        "postalCode": "93100",
+        "city": "Montreuil",
+    }
+
+    client = client.with_session_auth(pro.email)
+    first_response = client.post("/offerers", json=body)
+
+    created_offerer = offerers_models.Offerer.query.one()
+    assert first_response.json == {
+        "id": created_offerer.id,
+        "siren": "418166096",
+        "name": "MINISTERE DE LA CULTURE",
+    }
+
+    second_response = client.post("/offerers", json=body)
+
+    assert second_response.status_code == 400
+    assert "This user already belongs to this offerer" in str(second_response.data)
+
+
 def test_when_no_address_is_provided(client):
     # given
     pro = users_factories.ProFactory()

--- a/pro/src/pages/Offerers/OffererCreation/OffererCreation.tsx
+++ b/pro/src/pages/Offerers/OffererCreation/OffererCreation.tsx
@@ -47,10 +47,16 @@ export const OffererCreation = (): JSX.Element => {
         navigate(`/accueil?structure=${createdOfferer.id}`, { replace: true })
       }
     } catch (error) {
-      if (isErrorAPIError(error) && error.status == 400 && error.body.siren) {
-        notification.error('Le code SIREN saisi n’est pas valide.')
+      if (isErrorAPIError(error) && error.status == 400) {
+        if (error.body.siren) {
+          notification.error('Le code SIREN saisi n’est pas valide.')
+        } else if (error.body.user_offerer) {
+          notification.error('Vous êtes déjà rattaché à cette structure.')
+        }
       } else {
-        notification.error('Vous êtes déjà rattaché à cette structure.')
+        notification.error(
+          'Une erreur est survenue. Merci de réessayer plus tard.'
+        )
       }
       setIsSubmitting(false)
     }

--- a/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.tsx
+++ b/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.tsx
@@ -100,7 +100,7 @@ describe('src | components | OffererCreation', () => {
     expect(screen.getByText('I’m on homepage')).toBeInTheDocument()
   })
 
-  it('should display error on submit fail response', async () => {
+  it('should display error if user already belonging to the offerer', async () => {
     vi.spyOn(api, 'getSirenInfo').mockResolvedValue({
       name: 'Ma Petite structure',
       siren: '881457238',
@@ -116,8 +116,8 @@ describe('src | components | OffererCreation', () => {
       new ApiError(
         {} as ApiRequestOptions,
         {
-          status: 500,
-          body: [{ error: ['ERROR'] }],
+          status: 400,
+          body: { user_offerer: ['This user already belongs to this offerer'] },
         } as ApiResult,
         ''
       )
@@ -228,4 +228,39 @@ describe('src | components | OffererCreation', () => {
       expect(creationButton).toBeEnabled()
     })
   })
+})
+
+it('should display error on submit fail response', async () => {
+  vi.spyOn(api, 'getSirenInfo').mockResolvedValue({
+    name: 'Ma Petite structure',
+    siren: '881457238',
+    address: {
+      street: '4 rue du test',
+      city: 'Plessix-Balisson',
+      postalCode: '22350',
+    },
+    ape_code: '',
+  })
+
+  vi.spyOn(api, 'createOfferer').mockRejectedValue(
+    new ApiError(
+      {} as ApiRequestOptions,
+      {
+        status: 500,
+        body: { error: ['ERROR'] },
+      } as ApiResult,
+      ''
+    )
+  )
+
+  renderOffererCreation({})
+
+  await userEvent.type(screen.getByLabelText('SIREN *'), '881457238')
+  await userEvent.tab()
+
+  await userEvent.click(screen.getByText('Créer'))
+
+  expect(
+    screen.getByText('Une erreur est survenue. Merci de réessayer plus tard.')
+  ).toBeInTheDocument()
 })


### PR DESCRIPTION
## But de la pull request

fix: https://sentry.passculture.team/organizations/sentry/issues/1255572/?project=5&query=is%3Aunresolved+user_offerer&referrer=issue-stream&statsPeriod=14d&stream_index=0

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26961

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

![Capture d’écran 2024-02-28 à 15 12 23](https://github.com/pass-culture/pass-culture-main/assets/139759736/805cf569-9453-4d86-bce0-b86b8a8165c1)

![Capture d’écran 2024-02-28 à 15 12 48](https://github.com/pass-culture/pass-culture-main/assets/139759736/1e4abaac-54bd-49a4-974c-2c21eb1abcbb)
