### PR TITLE
(PC-27681)[PRO] fix: some fields should not be displayed for partner in venue form

### DIFF
--- a/pro/src/pages/Home/Offerers/PartnerPage.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPage.tsx
@@ -139,13 +139,13 @@ export const PartnerPage = ({
       <PartnerPageIndividualSection
         venueId={venue.id}
         isVisibleInApp={Boolean(venue.isVisibleInApp)}
-        displayTitle
+        isDisplayedInHomepage
       />
       <PartnerPageCollectiveSection
         collectiveDmsApplications={venue.collectiveDmsApplications}
         venueId={venue.id}
         hasAdageId={venue.hasAdageId}
-        displayTitle
+        isDisplayedInHomepage
       />
     </Card>
   )

--- a/pro/src/pages/Home/Offerers/PartnerPageCollectiveSection.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPageCollectiveSection.tsx
@@ -14,14 +14,14 @@ export type PartnerPageCollectiveSectionProps = {
   collectiveDmsApplications: DMSApplicationForEAC[]
   venueId: number
   hasAdageId: boolean
-  displayTitle?: boolean
+  isDisplayedInHomepage?: boolean
 }
 
 export function PartnerPageCollectiveSection({
   collectiveDmsApplications,
   venueId,
   hasAdageId,
-  displayTitle = false,
+  isDisplayedInHomepage = false,
 }: PartnerPageCollectiveSectionProps) {
   const { logEvent } = useAnalytics()
 
@@ -41,7 +41,7 @@ export function PartnerPageCollectiveSection({
     })
   }
 
-  const header = displayTitle ? (
+  const header = isDisplayedInHomepage ? (
     <h4 className={styles['details-title']}>Enseignants</h4>
   ) : (
     <span className={styles['details-normal']}>
@@ -56,12 +56,13 @@ export function PartnerPageCollectiveSection({
           {header}
           <Tag variant={TagVariant.LIGHT_GREEN}>Référencé sur ADAGE</Tag>
         </div>
-
-        <p className={styles['details-description']}>
-          Les enseignants voient les offres vitrines et celles que vous adressez
-          à leur établissement sur ADAGE. Complétez vos informations à
-          destination des enseignants pour qu’ils vous contactent !
-        </p>
+        {isDisplayedInHomepage && (
+          <p className={styles['details-description']}>
+            Les enseignants voient les offres vitrines et celles que vous
+            adressez à leur établissement sur ADAGE. Complétez vos informations
+            à destination des enseignants pour qu’ils vous contactent !
+          </p>
+        )}
       </section>
     )
   } else if (lastDmsApplication === null) {

--- a/pro/src/pages/Home/Offerers/PartnerPageIndividualSection.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPageIndividualSection.tsx
@@ -14,13 +14,13 @@ import styles from './PartnerPage.module.scss'
 export type PartnerPageIndividualSectionProps = {
   venueId: number
   isVisibleInApp: boolean
-  displayTitle?: boolean
+  isDisplayedInHomepage?: boolean
 }
 
 export function PartnerPageIndividualSection({
   venueId,
   isVisibleInApp,
-  displayTitle = false,
+  isDisplayedInHomepage = false,
 }: PartnerPageIndividualSectionProps) {
   const notify = useNotification()
   const { logEvent } = useAnalytics()
@@ -43,7 +43,7 @@ export function PartnerPageIndividualSection({
   return (
     <section className={styles['details']}>
       <div>
-        {displayTitle ? (
+        {isDisplayedInHomepage ? (
           <h4 className={styles['details-title']}>Grand public</h4>
         ) : (
           <span className={styles['details-normal']}>
@@ -56,13 +56,13 @@ export function PartnerPageIndividualSection({
           <Tag variant={TagVariant.LIGHT_BLUE}>Non visible</Tag>
         )}
       </div>
-
-      <p className={styles['details-description']}>
-        {isVisibleInApp
-          ? 'Votre page partenaire est visible sur l’application pass Culture.'
-          : 'Votre page n’est pas visible par les utilisateurs de l’application pass Culture. Vos offres publiées restent cependant visibles et réservables par les bénéficiaires.'}
-      </p>
-
+      {isDisplayedInHomepage && (
+        <p className={styles['details-description']}>
+          {isVisibleInApp
+            ? 'Votre page partenaire est visible sur l’application pass Culture.'
+            : 'Votre page n’est pas visible par les utilisateurs de l’application pass Culture. Vos offres publiées restent cependant visibles et réservables par les bénéficiaires.'}
+        </p>
+      )}
       {isVisibleInApp && (
         <>
           <ButtonLink

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPageCollectiveSection.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPageCollectiveSection.spec.tsx
@@ -104,12 +104,29 @@ describe('PartnerPages', () => {
     expect(screen.getByText('Référencement en cours')).toBeInTheDocument()
   })
 
-  it('should display the EAC section when it has an adageId', () => {
+  it('should display the EAC section when it has an adageId in homepage', () => {
     renderPartnerPageCollectiveSection({
       collectiveDmsApplications: [],
       hasAdageId: true,
+      isDisplayedInHomepage: true,
     })
 
     expect(screen.getByText('Référencé sur ADAGE')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Les enseignants voient les offres vitrines/)
+    ).toBeInTheDocument()
+  })
+
+  it('should display the EAC section when it has an adageId in venue form', () => {
+    renderPartnerPageCollectiveSection({
+      collectiveDmsApplications: [],
+      hasAdageId: true,
+      isDisplayedInHomepage: false,
+    })
+
+    expect(screen.getByText('Référencé sur ADAGE')).toBeInTheDocument()
+    expect(
+      screen.queryByText(/es enseignants voient les offres vitrines/)
+    ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPageIndividualSection.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPageIndividualSection.spec.tsx
@@ -18,7 +18,7 @@ describe('PartnerPageIndividualSection', () => {
     const props = {
       venueId: 7,
       isVisibleInApp: true,
-      displayTitle: true,
+      isDisplayedInHomepage: true,
     }
 
     renderPartnerPageIndividualSection(props)
@@ -33,11 +33,32 @@ describe('PartnerPageIndividualSection', () => {
     expect(screen.getByText('Copier le lien de la page')).toBeInTheDocument()
   })
 
-  it('should display right info when not title', () => {
+  it('should display right info when is visible and in homepage', () => {
+    const props: PartnerPageIndividualSectionProps = {
+      venueId: 7,
+      isVisibleInApp: true,
+      isDisplayedInHomepage: true,
+    }
+
+    renderPartnerPageIndividualSection(props)
+
+    expect(screen.getByText('Grand public')).toBeInTheDocument()
+    expect(
+      screen.queryByText('État de votre page partenaire sur l’application :')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Votre page partenaire est visible sur l’application pass Culture.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByText('Copier le lien de la page')).toBeInTheDocument()
+  })
+
+  it('should display right info when is visible and in venue form', () => {
     const props = {
       venueId: 7,
       isVisibleInApp: true,
-      displayTitle: false,
+      isDisplayedInHomepage: false,
     }
 
     renderPartnerPageIndividualSection(props)
@@ -47,18 +68,18 @@ describe('PartnerPageIndividualSection', () => {
       screen.getByText('État de votre page partenaire sur l’application :')
     ).toBeInTheDocument()
     expect(
-      screen.getByText(
+      screen.queryByText(
         'Votre page partenaire est visible sur l’application pass Culture.'
       )
-    ).toBeInTheDocument()
+    ).not.toBeInTheDocument()
     expect(screen.getByText('Copier le lien de la page')).toBeInTheDocument()
   })
 
-  it('should display right info when not visible and not title', () => {
+  it('should display right info when not visible and not title and in venue form', () => {
     const props = {
       venueId: 7,
       isVisibleInApp: false,
-      displayTitle: false,
+      isDisplayedInHomepage: false,
     }
 
     renderPartnerPageIndividualSection(props)
@@ -67,10 +88,10 @@ describe('PartnerPageIndividualSection', () => {
       screen.getByText('État de votre page partenaire sur l’application :')
     ).toBeInTheDocument()
     expect(
-      screen.getByText(
+      screen.queryByText(
         'Votre page n’est pas visible par les utilisateurs de l’application pass Culture. Vos offres publiées restent cependant visibles et réservables par les bénéficiaires.'
       )
-    ).toBeInTheDocument()
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByText('Copier le lien de la page')
     ).not.toBeInTheDocument()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27681

deux blocs d'info ne doivent être affichés que sur le form venue

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques