### PR TITLE
(PC-28278)[API] feat: Remove IP filtering on Brevo webhooks

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2145,17 +2145,6 @@ files = [
 ]
 
 [[package]]
-name = "ipaddress"
-version = "1.0.23"
-description = "IPv4/IPv6 manipulation library"
-optional = false
-python-versions = "*"
-files = [
-    {file = "ipaddress-1.0.23-py2.py3-none-any.whl", hash = "sha256:6e0f4a39e66cb5bb9a137b00276a2eff74f93b71dcbdad6f10ff7df9d3557fcc"},
-    {file = "ipaddress-1.0.23.tar.gz", hash = "sha256:b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2"},
-]
-
-[[package]]
 name = "ipython"
 version = "8.16.1"
 description = "IPython: Productive Interactive Computing"
@@ -4013,6 +4002,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -5589,4 +5579,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e62542bc3c99003d4c7417455c3422ed03f17390eca6f717958fa671659d0155"
+content-hash = "d5eceba049525f316f15708a344e9e8dc0c064745957623f55dab3a9cfc964d2"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,7 +33,6 @@ google-cloud-tasks = "2.16.2"
 google-cloud-bigquery = "3.17.2"
 gql = { extras = ["requests"], version = "^3.5.0" }
 gunicorn = "21.2.0"
-ipaddress = "^1.0.23"
 jinja2 = "3.1.3"
 markupsafe = "2.1.5"
 openpyxl = "^3.1.2"

--- a/api/src/pcapi/routes/external/sendinblue.py
+++ b/api/src/pcapi/routes/external/sendinblue.py
@@ -1,9 +1,7 @@
-import ipaddress
 import logging
 
 from flask import request
 
-from pcapi import settings
 from pcapi.core.external.attributes.api import update_external_user
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.models.api_errors import ApiErrors
@@ -12,58 +10,10 @@ from pcapi.routes.apis import public_api
 from pcapi.serialization.decorator import spectree_serialize
 
 
-# Defined from https://developers.sendinblue.com/docs/how-to-use-webhooks#securing-your-webhooks
-# and https://developers.sendinblue.com/docs/additional-ips-to-be-whitelisted
-SENDINBLUE_IP_RANGE = [
-    *ipaddress.IPv4Network("185.107.232.0/24"),
-    *ipaddress.IPv4Network("1.179.112.0/20"),
-    ipaddress.IPv4Address("195.154.30.169"),
-    ipaddress.IPv4Address("195.154.31.153"),
-    ipaddress.IPv4Address("195.154.31.142"),
-    ipaddress.IPv4Address("195.154.31.171"),
-    ipaddress.IPv4Address("195.154.31.129"),
-    ipaddress.IPv4Address("195.154.79.186"),
-    ipaddress.IPv4Address("163.172.23.50"),
-    ipaddress.IPv4Address("163.172.75.202"),
-    ipaddress.IPv4Address("163.172.75.222"),
-    ipaddress.IPv4Address("163.172.76.108"),
-    ipaddress.IPv4Address("163.172.77.49"),
-    ipaddress.IPv4Address("163.172.77.62"),
-    ipaddress.IPv4Address("163.172.77.137"),
-    ipaddress.IPv4Address("163.172.99.26"),
-    ipaddress.IPv4Address("163.172.99.58"),
-    ipaddress.IPv4Address("163.172.109.19"),
-    ipaddress.IPv4Address("163.172.109.49"),
-    ipaddress.IPv4Address("163.172.109.105"),
-    ipaddress.IPv4Address("163.172.109.130"),
-    ipaddress.IPv4Address("51.159.71.10"),
-    ipaddress.IPv4Address("51.159.71.12"),
-    ipaddress.IPv4Address("51.159.71.13"),
-    ipaddress.IPv4Address("51.159.71.15"),
-    ipaddress.IPv4Address("51.159.71.17"),
-    ipaddress.IPv4Address("51.159.71.41"),
-    ipaddress.IPv4Address("51.159.58.33"),
-    ipaddress.IPv4Address("51.159.58.37"),
-    ipaddress.IPv4Address("51.159.58.36"),
-    ipaddress.IPv4Address("51.159.58.214"),
-]
-
-
 logger = logging.getLogger(__name__)
 
 
-def _check_sendinblue_source_ip() -> None:
-    source_ip = ipaddress.IPv4Address(request.remote_addr)
-    if source_ip not in SENDINBLUE_IP_RANGE and not settings.IS_DEV:
-        raise ApiErrors(
-            {"IP": "Source IP address is not whitelisted"},
-            status_code=401,
-        )
-
-
 def _toggle_marketing_email_subscription(subscribe: bool) -> None:
-    _check_sendinblue_source_ip()
-
     user_email = request.json.get("email")  # type: ignore [union-attr]
     if not user_email:
         raise ApiErrors(
@@ -117,6 +67,4 @@ def sendinblue_notify_importcontacts(list_id: int, iteration: int) -> None:
     The id of the list in Sendinblue is added to the URL when set in notifyUrl so we can at least print the list id.
     This webhook is for investigation purpose only.
     """
-    _check_sendinblue_source_ip()
-
     logger.info("ContactsApi->import_contacts finished", extra={"list_id": list_id, "iteration": iteration})

--- a/api/tests/routes/external/sendinblue_test.py
+++ b/api/tests/routes/external/sendinblue_test.py
@@ -2,7 +2,6 @@ import logging
 
 import pytest
 
-from pcapi.core.testing import override_settings
 from pcapi.core.users.factories import UserFactory
 from pcapi.models import db
 
@@ -19,65 +18,29 @@ class SubscribeOrUnsubscribeUserTestHelper:
             email="lucy.ellingson@kennet.ca",
             notificationSubscriptions={"marketing_push": True, "marketing_email": self.initial_marketing_email},
         )
-        headers = {"X-Forwarded-For": "185.107.232.1"}
         data = {"email": "lucy.ellingson@kennet.ca"}
         assert existing_user.notificationSubscriptions["marketing_email"] is self.initial_marketing_email
 
         # When
-        with override_settings(IS_DEV=False):  # enforce source IP check
-            response = client.post(self.endpoint, json=data, headers=headers)
+        response = client.post(self.endpoint, json=data)
 
         # Then
         assert response.status_code == 204
         db.session.refresh(existing_user)
         assert existing_user.notificationSubscriptions["marketing_email"] is self.expected_marketing_email
 
-    def test_webhook_from_forbidden_ip(self, client):
-        # Given
-        existing_user = UserFactory(
-            email="lucy.ellingson@kennet.ca",
-            notificationSubscriptions={"marketing_push": True, "marketing_email": self.initial_marketing_email},
-        )
-        assert existing_user.notificationSubscriptions["marketing_email"] is self.initial_marketing_email
-
-        headers = {"X-Forwarded-For": "127.0.0.1"}
-        data = {"email": "lucy.ellingson@kennet.ca"}
-
-        # When
-        with override_settings(IS_DEV=False):  # enforce source IP check
-            response = client.post(self.endpoint, json=data, headers=headers)
-
-        # Then
-        assert response.status_code == 401
-        db.session.refresh(existing_user)
-        assert existing_user.notificationSubscriptions["marketing_email"] is self.initial_marketing_email
-
     def test_webhook_bad_request(self, client):
-        # Given
-        existing_user = UserFactory(
-            email="lucy.ellingson@kennet.ca",
-            notificationSubscriptions={"marketing_push": True, "marketing_email": self.initial_marketing_email},
-        )
-        assert existing_user.notificationSubscriptions["marketing_email"] is self.initial_marketing_email
-
-        headers = {"X-Forwarded-For": "185.107.232.1"}
         data = {}
+        response = client.post(self.endpoint, json=data)
 
-        # When
-        response = client.post(self.endpoint, json=data, headers=headers)
-
-        # Then
         assert response.status_code == 400
-        db.session.refresh(existing_user)
-        assert existing_user.notificationSubscriptions["marketing_email"] is self.initial_marketing_email
 
     def test_webhook_user_does_not_exist(self, client):
         # Given
-        headers = {"X-Forwarded-For": "185.107.232.1"}
         data = {"email": "lucy.ellingson@kennet.ca"}
 
         # When
-        response = client.post(self.endpoint, json=data, headers=headers)
+        response = client.post(self.endpoint, json=data)
 
         # Then
         assert response.status_code == 400
@@ -100,12 +63,9 @@ class SubscribeUserTest(SubscribeOrUnsubscribeUserTestHelper):
 @pytest.mark.usefixtures("db_session")
 class NotifyImportContactsTest:
     def test_notify_importcontacts(self, client, caplog):
-        # Given
-        headers = {"X-Forwarded-For": "1.179.112.9"}
-
         # When
         with caplog.at_level(logging.INFO):
-            response = client.post("/webhooks/sendinblue/importcontacts/18/1", headers=headers)
+            response = client.post("/webhooks/sendinblue/importcontacts/18/1")
 
         # Then
         assert response.status_code == 204


### PR DESCRIPTION
IP filtering is now done by a frontend.

Fun fact: we required the `ipaddress` third-party library, which was
not necessary: it's part of the standard library since Python 3.3.

---

Ticket : https://passculture.atlassian.net/browse/PC-28278