### PR TITLE
(PC-27989)[ADAGE] feat: add allowedOnAdage at Offerer level

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-df028bd09c15 (pre) (head)
+8ed029bd05a6 (pre) (head)
 c8e741468d2a (post) (head)

--- a/api/src/pcapi/alembic/versions/20240229T101500_8ed029bd05a6_add_allowedonadage_to_offerer.py
+++ b/api/src/pcapi/alembic/versions/20240229T101500_8ed029bd05a6_add_allowedonadage_to_offerer.py
@@ -1,0 +1,19 @@
+"""add allowedOnAdage to Offerer"""
+
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "8ed029bd05a6"
+down_revision = "df028bd09c15"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""ALTER TABLE offerer ADD COLUMN IF NOT EXISTS "allowedOnAdage" BOOLEAN DEFAULT false NOT NULL;""")
+
+
+def downgrade() -> None:
+    op.execute("""ALTER TABLE offerer DROP COLUMN IF EXISTS "allowedOnAdage";""")

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -980,6 +980,8 @@ class Offerer(
         "IndividualOffererSubscription", back_populates="offerer", uselist=False
     )
 
+    allowedOnAdage: bool = Column(Boolean, nullable=False, default=False, server_default=sa.sql.expression.false())
+
     @property
     def bic(self) -> str | None:
         return self.bankInformation.bic if self.bankInformation else None

--- a/api/tests/core/educational/api/test_synchronize_adage_ids_on_venues.py
+++ b/api/tests/core/educational/api/test_synchronize_adage_ids_on_venues.py
@@ -1,12 +1,44 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from pydantic.v1 import parse_obj_as
 import requests_mock
 
 from pcapi.core.educational.api import adage as educational_api_adage
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offerers.repository import get_emails_by_venue
 from pcapi.core.testing import override_settings
+from pcapi.models import db
+from pcapi.routes.serialization import venues_serialize
+
+
+BASE_DATA = {
+    "siret": "",
+    "regionId": None,
+    "academieId": None,
+    "statutId": None,
+    "labelId": None,
+    "typeId": 8,
+    "communeId": "26324",
+    "libelle": "Fête du livre jeunesse de St Paul les trois Châteaux",
+    "adresse": "Place Charles Chausy",
+    "siteWeb": "http://www.fetedulivrejeunesse.fr/",
+    "latitude": 44.350457,
+    "longitude": 4.765918,
+    "actif": 1,
+    "dateModification": "2021-09-01T00:00:00",
+    "statutLibelle": None,
+    "labelLibelle": None,
+    "typeIcone": "town",
+    "typeLibelle": "Association ou fondation pour la promotion, le développement et la diffusion d\u0027oeuvres",
+    "communeLibelle": "SAINT-PAUL-TROIS-CHATEAUX",
+    "communeDepartement": "026",
+    "academieLibelle": "GRENOBLE",
+    "regionLibelle": "AUVERGNE-RHÔNE-ALPES",
+    "domaines": "Univers du livre, de la lecture et des écritures",
+    "domaineIds": "11",
+    "synchroPass": 1,
+}
 
 
 @override_settings(
@@ -21,34 +53,6 @@ def test_synchronize_adage_ids_on_venues(db_session):
     venue4 = offerers_factories.VenueFactory()
     venue5 = offerers_factories.VenueFactory(adageId="11", adageInscriptionDate=datetime.utcnow())
     venue6 = offerers_factories.VenueFactory(adageId="1252", adageInscriptionDate=datetime.utcnow())
-
-    BASE_DATA = {
-        "siret": "",
-        "regionId": None,
-        "academieId": None,
-        "statutId": None,
-        "labelId": None,
-        "typeId": 8,
-        "communeId": "26324",
-        "libelle": "Fête du livre jeunesse de St Paul les trois Châteaux",
-        "adresse": "Place Charles Chausy",
-        "siteWeb": "http://www.fetedulivrejeunesse.fr/",
-        "latitude": 44.350457,
-        "longitude": 4.765918,
-        "actif": 1,
-        "dateModification": "2021-09-01T00:00:00",
-        "statutLibelle": None,
-        "labelLibelle": None,
-        "typeIcone": "town",
-        "typeLibelle": "Association ou fondation pour la promotion, le développement et la diffusion d\u0027oeuvres",
-        "communeLibelle": "SAINT-PAUL-TROIS-CHATEAUX",
-        "communeDepartement": "026",
-        "academieLibelle": "GRENOBLE",
-        "regionLibelle": "AUVERGNE-RHÔNE-ALPES",
-        "domaines": "Univers du livre, de la lecture et des écritures",
-        "domaineIds": "11",
-        "synchroPass": 1,
-    }
 
     adage_id1 = 128028
     adage_id2 = 128029
@@ -127,3 +131,53 @@ def test_synchronize_adage_ids_on_venues(db_session):
 
     assert mock_activation_mail.call_args.args[0] == venue2
     assert set(mock_activation_mail.call_args.args[1]) == set(email2)
+
+
+@override_settings(
+    ADAGE_API_URL="https://adage-api-url",
+    ADAGE_API_KEY="adage-api-key",
+    ADAGE_BACKEND="pcapi.core.educational.adage_backends.adage.AdageHttpClient",
+)
+def test_synchronize_adage_ids_on_offerers(db_session):
+    venue1 = offerers_factories.VenueFactory()
+    venue2 = offerers_factories.VenueFactory()
+    venue3 = offerers_factories.VenueFactory()
+    venue4 = offerers_factories.VenueFactory()
+    venue5 = offerers_factories.VenueFactory(adageId="11", adageInscriptionDate=datetime.utcnow())
+    venue6 = offerers_factories.VenueFactory(adageId="1252", adageInscriptionDate=datetime.utcnow())
+
+    venue1_data = {**BASE_DATA, "id": 128028, "siret": venue1.siret, "venueId": venue1.id}
+    venue2_data = {**BASE_DATA, "id": 128029, "siret": venue2.siret, "venueId": venue2.id}
+    venue3_data = {**BASE_DATA, "id": 128030, "siret": venue3.siret, "venueId": venue3.id, "synchroPass": 0}
+    venue4_data = {**BASE_DATA, "id": 128031, "siret": venue4.siret, "venueId": None}
+    venue5_data = {
+        **BASE_DATA,
+        "id": 128030,
+        "siret": venue5.siret,
+        "venueId": venue5.id,
+        "synchroPass": 1,
+        "actif": None,
+    }
+    venue6_data = {
+        **BASE_DATA,
+        "id": 128030,
+        "siret": venue6.siret,
+        "venueId": venue6.id,
+        "synchroPass": 0,
+        "actif": None,
+    }
+
+    partners = parse_obj_as(
+        venues_serialize.AdageCulturalPartners,
+        {"partners": [venue1_data, venue2_data, venue3_data, venue4_data, venue5_data, venue6_data]},
+    ).partners
+
+    educational_api_adage.synchronize_adage_ids_on_offerers(partners)
+    db.session.commit()
+
+    assert venue1.managingOfferer.allowedOnAdage
+    assert venue1.managingOfferer.allowedOnAdage
+    assert venue3.managingOfferer.allowedOnAdage
+    assert venue4.managingOfferer.allowedOnAdage
+    assert not venue5.managingOfferer.allowedOnAdage
+    assert not venue6.managingOfferer.allowedOnAdage


### PR DESCRIPTION
The flag on Venue was unreliable to know whether or not an offerer was allowed to create/use collective features.
That leads to confusions and incorrect values on BO and PRO website. We now base the flag on SIREN which should be more reliable.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27989

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques