### PR TITLE
(PC-25372)[PRO] responsive confirmation + ActionBarSticky

### DIFF
--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -21,22 +21,34 @@
     margin: 0 auto;
     align-items: center;
     display: flex;
-    flex-wrap: wrap;
     justify-content: center;
+    flex-direction: column-reverse;
+    margin-top: rem.torem(16px);
 
     .left {
       display: flex;
       align-items: center;
       margin: 1rem;
       gap: rem.torem(16px);
+      width: 100%;
+      flex-direction: column-reverse;
+
+      > * {
+        width: 100%;
+      }
     }
 
     .right {
       display: flex;
       align-items: center;
-      flex-wrap: wrap;
+      flex-flow: column wrap;
       justify-content: center;
       gap: rem.torem(16px);
+      width: 100%;
+
+      > * {
+        width: 100%;
+      }
     }
   }
 }
@@ -49,13 +61,28 @@
 
     .actions-bar-content {
       justify-content: space-between;
+      flex-flow: row wrap;
+      margin-top: unset;
+
 
       .left {
         margin: 0;
+        width: unset;
+        flex-direction: row;
+
+        > * {
+          width: unset;
+        }
       }
 
       .right {
         margin-left: auto;
+        width: unset;
+        flex-direction: row;
+
+        > * {
+          width: unset;
+        }
       }
     }
   }

--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -50,6 +50,10 @@
         width: 100%;
       }
     }
+
+    .right-inverse {
+      flex-direction: column-reverse;
+    }
   }
 }
 

--- a/pro/src/components/ActionsBarSticky/ActionsBarStickyRight.tsx
+++ b/pro/src/components/ActionsBarSticky/ActionsBarStickyRight.tsx
@@ -1,15 +1,25 @@
-import React from 'react'
+import cn from 'classnames'
 
 import style from './ActionsBarSticky.module.scss'
 
 interface ActionsBarStickyRightProps {
   children: React.ReactNode
+  inverseWhenSmallerThanTablet?: boolean
 }
 
 const Right = ({
   children,
+  inverseWhenSmallerThanTablet = false,
 }: ActionsBarStickyRightProps): JSX.Element | null => {
-  return children ? <div className={style['right']}>{children}</div> : null
+  return children ? (
+    <div
+      className={cn(style['right'], {
+        [style['right-inverse']]: inverseWhenSmallerThanTablet,
+      })}
+    >
+      {children}
+    </div>
+  ) : null
 }
 
 export default Right

--- a/pro/src/components/VenueForm/VenueCreationForm.tsx
+++ b/pro/src/components/VenueForm/VenueCreationForm.tsx
@@ -156,9 +156,8 @@ export const VenueCreationForm = ({
         >
           <p>Les informations non enregistrées seront perdues.</p>
         </RouteLeavingGuard>
-
-        <VenueFormActionBar isCreatingVenue={true} />
       </FormLayout>
+      <VenueFormActionBar isCreatingVenue={true} />
     </div>
   )
 }

--- a/pro/src/components/VenueForm/VenueEditionForm.tsx
+++ b/pro/src/components/VenueForm/VenueEditionForm.tsx
@@ -107,9 +107,8 @@ export const VenueEditionForm = ({
         {isNewBankDetailsJourneyEnabled && (
           <BankAccountInfos venueBankAccount={venue.bankAccount} />
         )}
-
-        <VenueFormActionBar isCreatingVenue={false} />
       </FormLayout>
+      <VenueFormActionBar isCreatingVenue={false} />
     </div>
   )
 }

--- a/pro/src/components/VenueForm/VenueFormActionBar/VenueFormActionBar.tsx
+++ b/pro/src/components/VenueForm/VenueFormActionBar/VenueFormActionBar.tsx
@@ -2,7 +2,6 @@ import { useFormikContext } from 'formik'
 import React from 'react'
 
 import ActionsBarSticky from 'components/ActionsBarSticky'
-import FormLayout from 'components/FormLayout'
 import { ButtonLink, SubmitButton } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -16,27 +15,25 @@ const VenueFormActionBar = ({ isCreatingVenue }: VenueFormActionBarProps) => {
   const { isSubmitting } = useFormikContext<VenueFormValues>()
 
   return (
-    <FormLayout.Actions>
-      <ActionsBarSticky>
-        <ActionsBarSticky.Left>
-          <ButtonLink
-            variant={ButtonVariant.SECONDARY}
-            link={{
-              to: '/accueil',
-              isExternal: false,
-            }}
-          >
-            Annuler et quitter
-          </ButtonLink>
-        </ActionsBarSticky.Left>
-        <ActionsBarSticky.Right>
-          <SubmitButton isLoading={isSubmitting}>
-            Enregistrer et
-            {isCreatingVenue ? ' créer le lieu' : ' quitter'}
-          </SubmitButton>
-        </ActionsBarSticky.Right>
-      </ActionsBarSticky>
-    </FormLayout.Actions>
+    <ActionsBarSticky>
+      <ActionsBarSticky.Left>
+        <ButtonLink
+          variant={ButtonVariant.SECONDARY}
+          link={{
+            to: '/accueil',
+            isExternal: false,
+          }}
+        >
+          Annuler et quitter
+        </ButtonLink>
+      </ActionsBarSticky.Left>
+      <ActionsBarSticky.Right>
+        <SubmitButton isLoading={isSubmitting}>
+          Enregistrer et
+          {isCreatingVenue ? ' créer le lieu' : ' quitter'}
+        </SubmitButton>
+      </ActionsBarSticky.Right>
+    </ActionsBarSticky>
   )
 }
 

--- a/pro/src/pages/IndividualOfferWizard/Confirmation/Confirmation.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Confirmation/Confirmation.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { useIndividualOfferContext } from 'context/IndividualOfferContext'
 import { useOfferWizardMode } from 'hooks'
 import IndivualOfferLayout from 'screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout'

--- a/pro/src/screens/IndividualOffer/ActionBar/ActionBar.module.scss
+++ b/pro/src/screens/IndividualOffer/ActionBar/ActionBar.module.scss
@@ -1,9 +1,6 @@
 @use "styles/variables/_colors.scss" as colors;
 @use "styles/mixins/_rem.scss" as rem;
-
-.draft-indicator {
-  margin-right: rem.torem(32px);
-}
+@use "styles/variables/_size.scss" as size;
 
 .draft-saved-icon {
   color: colors.$valid;
@@ -21,4 +18,11 @@ $not-saved-size: rem.torem(16px);
   height: $not-saved-size;
   border-radius: 50%;
   background-color: colors.$alert-dark;
+}
+
+
+@media (min-width: size.$tablet) {
+  .draft-indicator {
+    margin-right: rem.torem(32px);
+  }
 }

--- a/pro/src/screens/IndividualOffer/ActionBar/ActionBar.tsx
+++ b/pro/src/screens/IndividualOffer/ActionBar/ActionBar.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector } from 'react-redux'
 
 import ActionsBarSticky from 'components/ActionsBarSticky'

--- a/pro/src/screens/IndividualOffer/ActionBar/ActionBar.tsx
+++ b/pro/src/screens/IndividualOffer/ActionBar/ActionBar.tsx
@@ -137,7 +137,11 @@ const ActionBar = ({
   return (
     <ActionsBarSticky>
       <ActionsBarSticky.Left>{Left()}</ActionsBarSticky.Left>
-      <ActionsBarSticky.Right>{Right()}</ActionsBarSticky.Right>
+      <ActionsBarSticky.Right
+        inverseWhenSmallerThanTablet={step === OFFER_WIZARD_STEP_IDS.SUMMARY}
+      >
+        {Right()}
+      </ActionsBarSticky.Right>
     </ActionsBarSticky>
   )
 }

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
@@ -54,19 +54,20 @@ export const StocksEventCreation = ({
   }
 
   return (
-    <div className={styles['container']}>
-      {hasStocks === false && (
-        <HelpSection className={styles['help-section']} />
-      )}
+    <>
+      <div className={styles['container']}>
+        {hasStocks === false && (
+          <HelpSection className={styles['help-section']} />
+        )}
 
-      <StocksEventList
-        priceCategories={offer.priceCategories ?? []}
-        departmentCode={offer.venue.departementCode}
-        offer={offer}
-        onStocksLoad={setHasStocks}
-        canAddStocks
-      />
-
+        <StocksEventList
+          priceCategories={offer.priceCategories ?? []}
+          departmentCode={offer.venue.departementCode}
+          offer={offer}
+          onStocksLoad={setHasStocks}
+          canAddStocks
+        />
+      </div>
       <ActionBar
         isDisabled={false}
         onClickPrevious={handlePreviousStep}
@@ -75,6 +76,6 @@ export const StocksEventCreation = ({
         // now we submit in RecurrenceForm, StocksEventCreation could not be dirty
         dirtyForm={false}
       />
-    </div>
+    </>
   )
 }

--- a/pro/src/screens/IndividualOfferConfirmationScreen/IndividualOfferConfirmationScreen.module.scss
+++ b/pro/src/screens/IndividualOfferConfirmationScreen/IndividualOfferConfirmationScreen.module.scss
@@ -33,17 +33,29 @@
 }
 
 .confirmation-actions {
-  >:first-child {
+  display: flex;
+  flex-direction: column-reverse;
+
+  >:last-child {
     margin-bottom: rem.torem(16px);
   }
 }
 
+.confirmation-action {
+  width: 100%;
+}
+
 @media (min-width: size.$tablet) {
   .confirmation-actions {
+    display: inline;
     padding-bottom: rem.torem(24px);
 
     >:first-child {
       margin-right: rem.torem(24px);
     }
+  }
+
+  .confirmation-action {
+    width: fit-content;
   }
 }

--- a/pro/src/screens/IndividualOfferConfirmationScreen/IndividualOfferConfirmationScreen.tsx
+++ b/pro/src/screens/IndividualOfferConfirmationScreen/IndividualOfferConfirmationScreen.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { GetIndividualOfferResponseModel } from 'apiClient/v1'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import {
@@ -93,6 +91,7 @@ const IndividualOfferConfirmationScreen = ({
             to: '/offre/creation' + queryString,
             isExternal: true,
           }}
+          className={styles['confirmation-action']}
           variant={ButtonVariant.SECONDARY}
         >
           Créer une nouvelle offre
@@ -102,6 +101,7 @@ const IndividualOfferConfirmationScreen = ({
             to: `/offres`,
             isExternal: false,
           }}
+          className={styles['confirmation-action']}
           variant={ButtonVariant.PRIMARY}
         >
           Voir la liste des offres


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-25372


- la partie gauche se met en dessous MAIS s'inverse pour que le bouton rouge soit devant
- la partie droite ce met au dessus dans le même ordre


offre création :
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/4c309bb5-9c9c-4bc1-94d1-4b9c9654cd75)

Rec : 
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/94da7b2d-7715-44b6-9334-7ee629a49513)

Récap : 
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/7a142d96-319b-4026-bb68-bd546b479ac5)

Confirmation :
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/5f6e9c89-eeb0-4c46-8b28-a3c60eeaf1de)


offre édition :
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/990911d4-f067-4c1a-9dec-4cb9bfa60628)

page lieu : 
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/22ed0766-9049-47dc-8f1e-61027f60ddfd)

offre eac : 
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/5fd69ade-14e4-4c71-b218-b5d577dfc715)

OffreS : 
![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/46c243c5-e94a-488b-a469-50262f89c410)




## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques