### PR TITLE
(PC-26868)[PRO] feat: Adding the create offer button to the side nav.

### DIFF
--- a/pro/src/components/SideNavLinks/SideNavLinks.module.scss
+++ b/pro/src/components/SideNavLinks/SideNavLinks.module.scss
@@ -36,16 +36,25 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-top: rem.torem(16px);
+  padding-top: rem.torem(24px);
   height: 100%;
 
   &-open {
-    height: calc(100% - size.$top-menu-height);
+    height: calc(100% - #{size.$top-menu-height});
   }
 
   &-first-group {
     display: flex;
     flex-direction: column;
+  }
+
+  &-create-offer-wrapper {
+    display: flex;
+
+    a {
+      flex-grow: 1;
+      margin: 0 size.$header-nav-item-padding size.$header-nav-item-padding;
+    }
   }
 
   &-last-group {

--- a/pro/src/components/SideNavLinks/SideNavLinks.tsx
+++ b/pro/src/components/SideNavLinks/SideNavLinks.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavLink, useLocation } from 'react-router-dom'
 
+import { SAVED_OFFERER_ID_KEY } from 'core/shared'
 import useActiveFeature from 'hooks/useActiveFeature'
 import fullDownIcon from 'icons/full-down.svg'
 import fullUpIcon from 'icons/full-up.svg'
@@ -20,9 +21,13 @@ import {
   selectIsCollectiveSectionOpen,
   selectIsIndividualSectionOpen,
 } from 'store/nav/selector'
+import { ButtonLink } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+import { localStorageAvailable } from 'utils/localStorageAvailable'
 
 import styles from './SideNavLinks.module.scss'
+
 const NAV_ITEM_ICON_SIZE = '20'
 
 interface SideNavLinksProps {
@@ -47,6 +52,12 @@ const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
     }
   }, [dispatch, location.pathname])
 
+  const offererId = localStorageAvailable()
+    ? localStorage.getItem(SAVED_OFFERER_ID_KEY)
+    : null
+  const createOfferPageUrl =
+    '/offre/creation' + (offererId ? `?structure=${offererId}` : '')
+
   return (
     <ul
       className={classnames({
@@ -55,6 +66,14 @@ const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
       })}
     >
       <div className={styles['nav-links-first-group']}>
+        <li className={styles['nav-links-create-offer-wrapper']}>
+          <ButtonLink
+            variant={ButtonVariant.PRIMARY}
+            link={{ isExternal: false, to: createOfferPageUrl }}
+          >
+            Créer une offre
+          </ButtonLink>
+        </li>
         <li>
           <NavLink
             to={'/accueil'}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26868

- Rajouter le bouton créer une offre dans la barre de navigation latérale.
- Utiliser le offererId du localStorage.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques