### PR TITLE
PC 28214 eac student level update

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-8ed029bd05a6 (pre) (head)
+8d4e8ebb573c (pre) (head)
 c8e741468d2a (post) (head)

--- a/api/src/pcapi/alembic/versions/20240229T144043_8d4e8ebb573c_eac_update_student_levels_rename_and_add.py
+++ b/api/src/pcapi/alembic/versions/20240229T144043_8d4e8ebb573c_eac_update_student_levels_rename_and_add.py
@@ -1,0 +1,58 @@
+"""
+eac update student levels rename and add
+"""
+
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "8d4e8ebb573c"
+down_revision = "8ed029bd05a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TYPE
+            studentlevels
+        RENAME VALUE
+            'ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE'
+        TO
+            'ECOLES_MARSEILLE_MATERNELLE';
+
+        ALTER TYPE
+            studentlevels
+        RENAME VALUE
+            'ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_ELEMENTAIRE'
+        TO
+            'ECOLES_MARSEILLE_CP_CE1_CE2';
+
+        ALTER TYPE
+            studentlevels
+        ADD VALUE IF NOT EXISTS
+            'ECOLES_MARSEILLE_CM1_CM2';
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TYPE
+            studentlevels
+        RENAME VALUE
+            'ECOLES_MARSEILLE_MATERNELLE'
+        TO
+            'ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE';
+
+        ALTER TYPE
+            studentlevels
+        RENAME VALUE
+            'ECOLES_MARSEILLE_CP_CE1_CE2'
+        TO
+            'ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_ELEMENTAIRE';
+    """
+    )

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -54,8 +54,9 @@ if typing.TYPE_CHECKING:
 
 
 class StudentLevels(enum.Enum):
-    ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE = "Écoles innovantes Marseille en Grand : maternelle"
-    ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_ELEMENTAIRE = "Écoles innovantes Marseille en Grand : élémentaire"
+    ECOLES_MARSEILLE_MATERNELLE = "Écoles Marseille - Maternelle"
+    ECOLES_MARSEILLE_CP_CE1_CE2 = "Écoles Marseille - CP, CE1, CE2"
+    ECOLES_MARSEILLE_CM1_CM2 = "Écoles Marseille - CM1, CM2"
     COLLEGE6 = "Collège - 6e"
     COLLEGE5 = "Collège - 5e"
     COLLEGE4 = "Collège - 4e"
@@ -69,8 +70,9 @@ class StudentLevels(enum.Enum):
     @classmethod
     def primary_levels(cls) -> set:
         return {
-            cls.ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE,
-            cls.ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_ELEMENTAIRE,
+            cls.ECOLES_MARSEILLE_MATERNELLE,
+            cls.ECOLES_MARSEILLE_CP_CE1_CE2,
+            cls.ECOLES_MARSEILLE_CM1_CM2,
         }
 
 

--- a/api/tests/routes/pro/post_collective_offers_test.py
+++ b/api/tests/routes/pro/post_collective_offers_test.py
@@ -177,14 +177,14 @@ class Returns200Test:
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
 
-        data = {**base_offer_payload(venue=venue), "students": ["Écoles innovantes Marseille en Grand : maternelle"]}
+        data = {**base_offer_payload(venue=venue), "students": ["Écoles Marseille - Maternelle"]}
         with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 201
 
         offer = CollectiveOffer.query.get(response.json["id"])
-        assert offer.students == [models.StudentLevels.ECOLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE]
+        assert offer.students == [models.StudentLevels.ECOLES_MARSEILLE_MATERNELLE]
 
     @override_features(WIP_ENABLE_MARSEILLE=False)
     def test_create_collective_offer_primary_level_FF_disabled(self, client):
@@ -192,7 +192,7 @@ class Returns200Test:
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
 
-        data = {**base_offer_payload(venue=venue), "students": ["Écoles innovantes Marseille en Grand : maternelle"]}
+        data = {**base_offer_payload(venue=venue), "students": ["Écoles Marseille - Maternelle"]}
         with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 

--- a/pro/src/apiClient/adage/models/StudentLevels.ts
+++ b/pro/src/apiClient/adage/models/StudentLevels.ts
@@ -6,8 +6,9 @@
  * An enumeration.
  */
 export enum StudentLevels {
-  _COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE = 'Écoles innovantes Marseille en Grand : maternelle',
-  _COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE = 'Écoles innovantes Marseille en Grand : élémentaire',
+  _COLES_MARSEILLE_MATERNELLE = 'Écoles Marseille - Maternelle',
+  _COLES_MARSEILLE_CP_CE1_CE2 = 'Écoles Marseille - CP, CE1, CE2',
+  _COLES_MARSEILLE_CM1_CM2 = 'Écoles Marseille - CM1, CM2',
   COLL_GE_6E = 'Collège - 6e',
   COLL_GE_5E = 'Collège - 5e',
   COLL_GE_4E = 'Collège - 4e',

--- a/pro/src/apiClient/v1/models/StudentLevels.ts
+++ b/pro/src/apiClient/v1/models/StudentLevels.ts
@@ -6,8 +6,9 @@
  * An enumeration.
  */
 export enum StudentLevels {
-  _COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE = 'Écoles innovantes Marseille en Grand : maternelle',
-  _COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE = 'Écoles innovantes Marseille en Grand : élémentaire',
+  _COLES_MARSEILLE_MATERNELLE = 'Écoles Marseille - Maternelle',
+  _COLES_MARSEILLE_CP_CE1_CE2 = 'Écoles Marseille - CP, CE1, CE2',
+  _COLES_MARSEILLE_CM1_CM2 = 'Écoles Marseille - CM1, CM2',
   COLL_GE_6E = 'Collège - 6e',
   COLL_GE_5E = 'Collège - 5e',
   COLL_GE_4E = 'Collège - 4e',

--- a/pro/src/core/OfferEducational/utils/__specs__/buildStudentLevelsMapWithDefaultValue.spec.ts
+++ b/pro/src/core/OfferEducational/utils/__specs__/buildStudentLevelsMapWithDefaultValue.spec.ts
@@ -28,15 +28,13 @@ describe('buildStudentLevelsMapWithDefaultValue', () => {
 
   it('should return the students levels without marseille levels', () => {
     const studentsMap = buildStudentLevelsMapWithDefaultValue(true)
-    expect(
-      studentsMap[StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE]
-    ).toBeFalsy()
+    expect(studentsMap[StudentLevels._COLES_MARSEILLE_CP_CE1_CE2]).toBeFalsy()
+    expect(studentsMap[StudentLevels._COLES_MARSEILLE_CM1_CM2]).toBeFalsy()
   })
 
   it('should return the students levels with marseille levels', () => {
     const studentsMap = buildStudentLevelsMapWithDefaultValue(true, true)
-    expect(
-      studentsMap[StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE]
-    ).toBeTruthy()
+    expect(studentsMap[StudentLevels._COLES_MARSEILLE_CP_CE1_CE2]).toBeTruthy()
+    expect(studentsMap[StudentLevels._COLES_MARSEILLE_CM1_CM2]).toBeTruthy()
   })
 })

--- a/pro/src/core/OfferEducational/utils/buildStudentLevelsMapWithDefaultValue.ts
+++ b/pro/src/core/OfferEducational/utils/buildStudentLevelsMapWithDefaultValue.ts
@@ -10,8 +10,9 @@ export const buildStudentLevelsMapWithDefaultValue = (
     if (
       !isMarseilleEnabled &&
       [
-        StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE,
-        StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE,
+        StudentLevels._COLES_MARSEILLE_MATERNELLE,
+        StudentLevels._COLES_MARSEILLE_CP_CE1_CE2,
+        StudentLevels._COLES_MARSEILLE_CM1_CM2,
       ].includes(level)
     ) {
       continue

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -44,8 +44,9 @@ export const algoliaSearchDefaultAttributesToRetrieve = [
 export const DEFAULT_GEO_RADIUS = 30000000 // 30 000 km ensure we get all results in the world
 
 const DEFAULT_MARSEILLE_STUDENTS = [
-  StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE,
-  StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE,
+  StudentLevels._COLES_MARSEILLE_MATERNELLE,
+  StudentLevels._COLES_MARSEILLE_CP_CE1_CE2,
+  StudentLevels._COLES_MARSEILLE_CM1_CM2,
 ]
 
 export const OffersInstantSearch = (): JSX.Element | null => {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -151,8 +151,9 @@ export const OfferFilters = ({
     ? studentsOptions
     : studentsOptions.filter(
         ({ value }) =>
-          value !== 'Écoles innovantes Marseille en Grand : maternelle' &&
-          value !== 'Écoles innovantes Marseille en Grand : élémentaire'
+          value !== 'Écoles Marseille - Maternelle' &&
+          value !== 'Écoles Marseille - CP, CE1, CE2' &&
+          value !== 'Écoles Marseille - CM1, CM2'
       )
 
   return (

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -326,9 +326,7 @@ describe('OfferFilters', () => {
     expect(options[0]).toHaveAccessibleName('Collège - 5e')
 
     //  Verify that non-selected options aren't sorted alphabetically
-    expect(options[1]).toHaveAccessibleName(
-      'Écoles innovantes Marseille en Grand : maternelle'
-    )
+    expect(options[1]).toHaveAccessibleName('Écoles Marseille - Maternelle')
     expect(options[options.length - 1]).toHaveAccessibleName('CAP - 2e année')
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/studentsOptions.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/studentsOptions.ts
@@ -1,11 +1,15 @@
 export const studentsOptions = [
   {
-    label: 'Écoles innovantes Marseille en Grand : maternelle',
-    value: 'Écoles innovantes Marseille en Grand : maternelle',
+    label: 'Écoles Marseille - Maternelle',
+    value: 'Écoles Marseille - Maternelle',
   },
   {
-    label: 'Écoles innovantes Marseille en Grand : élémentaire',
-    value: 'Écoles innovantes Marseille en Grand : élémentaire',
+    label: 'Écoles Marseille - CP, CE1, CE2',
+    value: 'Écoles Marseille - CP, CE1, CE2',
+  },
+  {
+    label: 'Écoles Marseille - CM1, CM2',
+    value: 'Écoles Marseille - CM1, CM2',
   },
   { label: 'Collège - 6e', value: 'Collège - 6e' },
   { label: 'Collège - 5e', value: 'Collège - 5e' },
@@ -20,12 +24,16 @@ export const studentsOptions = [
 
 export const studentsForData = [
   {
-    label: 'Écoles innovantes Marseille en Grand : maternelle',
-    value: 'Écoles innovantes Marseille en Grand : maternelle',
+    label: 'Écoles Marseille - Maternelle',
+    value: 'Écoles Marseille - Maternelle',
   },
   {
-    label: 'Écoles innovantes Marseille en Grand : élémentaire',
-    value: 'Écoles innovantes Marseille en Grand : élémentaire',
+    label: 'Écoles Marseille - CP, CE1, CE2',
+    value: 'Écoles Marseille - CP, CE1, CE2',
+  },
+  {
+    label: 'Écoles Marseille - CM1, CM2',
+    value: 'Écoles Marseille - CM1, CM2',
   },
   { label: 'Collège - 6e', valueForData: 'Collège sixième' },
   { label: 'Collège - 5e', valueForData: 'Collège cinquième' },

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -438,8 +438,9 @@ describe('offersSearch component', () => {
         ...props,
         initialFilters: {
           students: [
-            StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE,
-            StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE,
+            StudentLevels._COLES_MARSEILLE_CP_CE1_CE2,
+            StudentLevels._COLES_MARSEILLE_CM1_CM2,
+            StudentLevels._COLES_MARSEILLE_MATERNELLE,
           ],
         },
       },
@@ -450,13 +451,19 @@ describe('offersSearch component', () => {
 
     expect(
       await screen.findByRole('button', {
-        name: /Écoles innovantes Marseille en Grand : maternelle/,
+        name: /Écoles Marseille - Maternelle/,
       })
     ).toBeInTheDocument()
 
     expect(
       await screen.findByRole('button', {
-        name: /Écoles innovantes Marseille en Grand : élémentaire/,
+        name: /Écoles Marseille - CP, CE1, CE2/,
+      })
+    ).toBeInTheDocument()
+
+    expect(
+      await screen.findByRole('button', {
+        name: /Écoles Marseille - CM1, CM2/,
       })
     ).toBeInTheDocument()
   })

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
@@ -33,9 +33,11 @@ const FormParticipants = ({
     : defaultPartipantsOptions.filter(
         (option) =>
           option.name !==
-            `participants.${StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE}` &&
+            `participants.${StudentLevels._COLES_MARSEILLE_MATERNELLE}` &&
           option.name !==
-            `participants.${StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE}`
+            `participants.${StudentLevels._COLES_MARSEILLE_CP_CE1_CE2}` &&
+          option.name !==
+            `participants.${StudentLevels._COLES_MARSEILLE_CM1_CM2}`
       )
 
   return (

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
@@ -15,10 +15,9 @@ import { ALL_STUDENTS_LABEL } from '../useParticipantsOptions'
 
 const filteredParticipants = Object.values(StudentLevels).filter(
   (studentLevel) =>
-    studentLevel !==
-      StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE &&
-    studentLevel !==
-      StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE
+    studentLevel !== StudentLevels._COLES_MARSEILLE_MATERNELLE &&
+    studentLevel !== StudentLevels._COLES_MARSEILLE_CP_CE1_CE2 &&
+    studentLevel !== StudentLevels._COLES_MARSEILLE_CM1_CM2
 )
 
 const renderFormParticipants = (
@@ -194,12 +193,17 @@ describe('FormParticipants', () => {
 
     expect(
       screen.getByRole('checkbox', {
-        name: StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE,
+        name: StudentLevels._COLES_MARSEILLE_MATERNELLE,
       })
     ).toBeInTheDocument()
     expect(
       screen.getByRole('checkbox', {
-        name: StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE,
+        name: StudentLevels._COLES_MARSEILLE_CP_CE1_CE2,
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', {
+        name: StudentLevels._COLES_MARSEILLE_CM1_CM2,
       })
     ).toBeInTheDocument()
   })
@@ -209,12 +213,17 @@ describe('FormParticipants', () => {
 
     expect(
       screen.queryByRole('checkbox', {
-        name: StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_MATERNELLE,
+        name: StudentLevels._COLES_MARSEILLE_MATERNELLE,
       })
     ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('checkbox', {
-        name: StudentLevels._COLES_INNOVANTES_MARSEILLE_EN_GRAND_L_MENTAIRE,
+        name: StudentLevels._COLES_MARSEILLE_CP_CE1_CE2,
+      })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('checkbox', {
+        name: StudentLevels._COLES_MARSEILLE_CM1_CM2,
       })
     ).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28214

Les deux niveaux scolaires de Marseille en grand passent à trois : le premier est renommé et le suivant découpé en deux (CP, CE1 et CE2 d'un côté, et CM1 et CM2 de l'autre).