### PR TITLE
(PC-27627)[PRO] fix: offer, hide banner with broken link if offerer not set

### DIFF
--- a/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
+++ b/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
@@ -29,7 +29,7 @@ export interface CategoriesProps {
   categories: CategoryResponseModel[]
   subCategories: SubcategoryResponseModel[]
   readOnlyFields?: string[]
-  showAddVenueBanner?: boolean
+  showAddVenueBanner: boolean
   offerSubtype: INDIVIDUAL_OFFER_SUBTYPE | null
   venueList: IndividualOfferVenueItem[]
   isEvent: boolean | null
@@ -60,7 +60,7 @@ const Categories = ({
   categories,
   subCategories,
   readOnlyFields = [],
-  showAddVenueBanner = false,
+  showAddVenueBanner,
   offerSubtype,
   venueList,
   isEvent,

--- a/pro/src/components/IndividualOfferForm/Categories/__specs__/Categories.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/Categories/__specs__/Categories.spec.tsx
@@ -95,6 +95,7 @@ describe('IndividualOffer section: Categories', () => {
       offerSubtype: INDIVIDUAL_OFFER_SUBTYPE.VIRTUAL_EVENT,
       venueList: [],
       isEvent: true,
+      showAddVenueBanner: true,
     }
   })
 

--- a/pro/src/components/IndividualOfferForm/IndividualOfferForm.tsx
+++ b/pro/src/components/IndividualOfferForm/IndividualOfferForm.tsx
@@ -83,10 +83,12 @@ const IndividualOfferForm = ({
     .filter(matchOffererId)
     .every((v) => v.isVirtual)
 
+  // we show the add venue banner only if we have offererId so the link is not broken
   const showAddVenueBanner =
     offerSubCategory &&
     offerSubCategory.onlineOfflinePlatform === CATEGORY_STATUS.OFFLINE &&
-    areAllVenuesVirtual
+    areAllVenuesVirtual &&
+    offererId
 
   return (
     <>
@@ -96,7 +98,7 @@ const IndividualOfferForm = ({
         categories={categories}
         subCategories={subCategories}
         readOnlyFields={readOnlyFields}
-        showAddVenueBanner={showAddVenueBanner}
+        showAddVenueBanner={Boolean(showAddVenueBanner)}
         offerSubtype={offerSubtype}
         // subcategory change will recompute the venue list
         // so we need to pass the full venue list here

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/Venue/Venue.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/Venue/Venue.tsx
@@ -47,7 +47,7 @@ const Venue = ({
     buildOffererOptions(offererNames)
 
   const { isDisabled: isVenueDisabled, venueOptions } = buildVenueOptions(
-    values.offererId,
+    values.offererId ?? '',
     venueList
   )
 

--- a/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.BannerAddVenue.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.BannerAddVenue.spec.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
-import React from 'react'
 
 import {
   CategoryResponseModel,
@@ -126,7 +125,29 @@ describe('IndividualOfferForm', () => {
       const subcategorySelect = await screen.findByLabelText('Sous-catégorie *')
       await userEvent.selectOptions(subcategorySelect, 'physical')
 
-      expect(screen.queryByText('+ Ajouter un lieu')).toBeInTheDocument()
+      expect(screen.getByText('+ Ajouter un lieu')).toBeInTheDocument()
+    })
+
+    it('should not display venue banner when offererId is not set', async () => {
+      const onlyVirtualVenueList = [
+        individualOfferVenueItemFactory({
+          isVirtual: true,
+        }),
+      ]
+      props = { ...props, venueList: onlyVirtualVenueList }
+
+      renderIndividualOfferForm({
+        initialValues: { ...initialValues, offererId: undefined },
+        onSubmit,
+        props,
+      })
+
+      const categorySelect = await screen.findByLabelText('Catégorie *')
+      await userEvent.selectOptions(categorySelect, 'physical')
+      const subcategorySelect = await screen.findByLabelText('Sous-catégorie *')
+      await userEvent.selectOptions(subcategorySelect, 'physical')
+
+      expect(screen.queryByText('+ Ajouter un lieu')).not.toBeInTheDocument()
     })
 
     it('should not display venue banner when subcategory is virtual', async () => {

--- a/pro/src/components/IndividualOfferForm/types.ts
+++ b/pro/src/components/IndividualOfferForm/types.ts
@@ -8,7 +8,7 @@ export interface IndividualOfferFormValues {
   subCategoryFields: string[]
   name: string
   description: string
-  offererId: string
+  offererId?: string
   venueId: string
   isNational: boolean
   categoryId: string


### PR DESCRIPTION
…

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27627

Ne pas afficher une bannière cassée (ne l'afficher que quand elle n'est pas cassée)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques