### PR TITLE
(PC-23550)[API] feat: send email to user when booking is cancelled because isCguIncompatible

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 def send_booking_cancellation_emails_to_user_and_offerer(
     booking: Booking,
     reason: BookingCancellationReasons | None,
+    is_gcu_incompatible: bool = False,
 ) -> None:
     if reason is None:
         logger.error(
@@ -34,7 +35,8 @@ def send_booking_cancellation_emails_to_user_and_offerer(
         send_booking_cancellation_by_pro_to_beneficiary_email(booking)
         send_booking_cancellation_confirmation_by_pro_to_pro_email(booking)
     elif reason == BookingCancellationReasons.FRAUD:
-        # TODO(PC-23550): SPIKE en cours avec marketing pour communication jeune via https://passculture.atlassian.net/browse/PC-23550
+        if is_gcu_incompatible:
+            send_booking_cancellation_by_pro_to_beneficiary_email(booking, is_gcu_incompatible)
         send_booking_cancellation_by_beneficiary_to_pro_email(booking)
 
 

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
@@ -10,6 +10,7 @@ from pcapi.utils.mailing import get_event_datetime
 
 def get_booking_cancellation_by_pro_to_beneficiary_email_data(
     booking: Booking,
+    is_gcu_incompatible: bool,
 ) -> models.TransactionalEmailData:
     stock = booking.stock
     offer = stock.offer
@@ -39,10 +40,11 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
             "USER_FIRST_NAME": booking.firstName,
             "USER_LAST_NAME": booking.lastName,
             "VENUE_NAME": venue_name,
+            "REJECTED": is_gcu_incompatible,
         },
     )
 
 
-def send_booking_cancellation_by_pro_to_beneficiary_email(booking: Booking) -> None:
-    data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
+def send_booking_cancellation_by_pro_to_beneficiary_email(booking: Booking, is_gcu_incompatible: bool = False) -> None:
+    data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking, is_gcu_incompatible)
     mails.send(recipients=[booking.email], data=data)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -937,7 +937,10 @@ def add_criteria_to_offers(
 
 
 def reject_inappropriate_product(
-    ean: str, author: users_models.User | None, send_booking_cancellation_emails: bool = True
+    ean: str,
+    author: users_models.User | None,
+    is_gcu_incompatible: bool = False,
+    send_booking_cancellation_emails: bool = True,
 ) -> bool:
     product = models.Product.query.filter(
         models.Product.extraData["ean"].astext == ean, models.Product.idAtProviders.is_not(None)
@@ -979,10 +982,11 @@ def reject_inappropriate_product(
     for offer in offers:
         offer_ids.append(offer.id)
         bookings = bookings_api.cancel_bookings_from_rejected_offer(offer)
+
         if send_booking_cancellation_emails:
             for booking in bookings:
                 transactional_mails.send_booking_cancellation_emails_to_user_and_offerer(
-                    booking, reason=BookingCancellationReasons.FRAUD
+                    booking, reason=BookingCancellationReasons.FRAUD, is_gcu_incompatible=is_gcu_incompatible
                 )
 
     logger.info(

--- a/api/src/pcapi/routes/backoffice/multiple_offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/multiple_offers/blueprint.py
@@ -142,7 +142,7 @@ def set_product_gcu_incompatible() -> utils.BackofficeResponse:
 
     if not form.validate():
         flash(utils.build_form_error_msg(form), "warning")
-    elif offers_api.reject_inappropriate_product(form.ean.data, current_user, send_booking_cancellation_emails=False):
+    elif offers_api.reject_inappropriate_product(form.ean.data, current_user, is_gcu_incompatible=True):
         flash("Le produit a été rendu incompatible aux CGU et les offres ont été désactivées", "success")
     else:
         flash("Une erreur s'est produite lors de l'opération", "warning")

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary_test.py
@@ -49,6 +49,7 @@ class SendinblueSendWarningToBeneficiaryAfterProBookingCancellationTest:
             "USER_FIRST_NAME": "Jeanne",
             "USER_LAST_NAME": "Doux",
             "VENUE_NAME": booking.venue.name,
+            "REJECTED": False,
         }
 
 
@@ -66,7 +67,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
         )
 
         # When
-        email_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
+        email_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking, is_gcu_incompatible=False)
 
         # Then
         assert email_data.params == {
@@ -83,6 +84,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
             "USER_FIRST_NAME": "Georges",
             "USER_LAST_NAME": "Moustiquos",
             "VENUE_NAME": booking.venue.name,
+            "REJECTED": False,
         }
 
     def test_should_return_thing_data_when_booking_is_on_a_thing(self):
@@ -95,7 +97,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
         )
 
         # When
-        email_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
+        email_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking, is_gcu_incompatible=False)
 
         # Then
         assert email_data.template == models.Template(
@@ -115,6 +117,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
             "USER_FIRST_NAME": "Georges",
             "USER_LAST_NAME": "Doux",
             "VENUE_NAME": booking.venue.name,
+            "REJECTED": False,
         }
 
     def test_should_return_thing_data_when_booking_is_on_an_online_offer(self):
@@ -127,7 +130,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
         )
 
         # When
-        email_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
+        email_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking, is_gcu_incompatible=False)
 
         # Then
         assert email_data.params == {
@@ -144,6 +147,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
             "USER_FIRST_NAME": "Georges",
             "USER_LAST_NAME": "Georges",
             "VENUE_NAME": booking.venue.name,
+            "REJECTED": False,
         }
 
     def test_should_not_display_the_price_when_booking_is_on_a_free_offer(self):
@@ -154,7 +158,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
         )
 
         # When
-        sendiblue_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
+        sendiblue_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking, is_gcu_incompatible=False)
 
         # Then
         assert sendiblue_data.params["IS_FREE_OFFER"] is True
@@ -169,7 +173,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
         )
 
         # When
-        sendiblue_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
+        sendiblue_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking, is_gcu_incompatible=False)
 
         # Then
         assert sendiblue_data.params["IS_FREE_OFFER"] is False

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1412,7 +1412,7 @@ class RejectInappropriateProductTest:
         assert bookings_models.Booking.query.count() == len(offers)
 
         # When
-        api.reject_inappropriate_product("ean-de-test", user, send_booking_cancellation_emails=True)
+        api.reject_inappropriate_product("ean-de-test", user)
 
         # Then
         mocked_send_booking_cancellation_emails_to_user_and_offerer.assert_called()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-23550

ticket refait apres commentaire de Patrick sur une autre PR ( fermé ) 
```
Je ne pense pas que la PR corresponde à la demande : selon ma compréhension, on souhaite adapter l'email, qui est déjà envoyé depuis la fonction reject_inappropriate_product via send_booking_cancellation_emails_to_user_and_offerer, et non ajouter un email supplémentaire au milieu de la logique.

Adapter l'email, c'est ajouter le paramètre « rejected » demandé dans la description du ticket, et dont je ne vois la trace nulle part dans le diff de cette PR.

Tu devrais mieux tester quels sont les emails envoyés dans la fonction de test que tu as ajoutée, et les paramètres qui sont envoyés. Notamment t'assurer de ne pas envoyer deux emails au même jeune pour la même réservation.

S'il y a divergence de compréhension sur le besoin, vois avec @elizoturner s'il est possible d'expliciter plus en détail la différence entre le comportement actuel et le comportement attendu.
```

