### PR TITLE
(BSR)[API] fix: enable user with trusted device deletion

### DIFF
--- a/api/src/pcapi/routes/backoffice/test_users/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/test_users/blueprint.py
@@ -139,7 +139,7 @@ def delete_user() -> utils.BackofficeResponse:
         return render_template("admin/users_deletion.html", form=form), 400
 
     try:
-        db.session.delete(user)
+        users_models.User.query.filter_by(id=user.id).delete()
         db.session.flush()
     except IntegrityError as e:
         logger.info(e)

--- a/api/tests/routes/backoffice/user_deletion_test.py
+++ b/api/tests/routes/backoffice/user_deletion_test.py
@@ -20,6 +20,7 @@ class UserDeletionPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermissi
     def test_sso_user_deletion(self, authenticated_client):
         user = users_factories.UserFactory()
         users_factories.SingleSignOnFactory(user=user)
+        users_factories.TrustedDeviceFactory(user=user)
 
         response = self.post_to_endpoint(authenticated_client, form={"email": user.email})
 


### PR DESCRIPTION
## But de la pull request

La fonctionnalité de suppression d'utilisateurs est présente pour aider l'équipe QA à recetter la création de compte via SSO Google. La protection via appareil de confiance étant activée en staging, il faut aussi les supprimer avec la suppression de compte.