### PR TITLE
(PC-28225)[BO] fix: do not hide lines if an offer has multiple stocks

### DIFF
--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -149,6 +149,7 @@ def _get_collective_offer_ids_query(form: forms.InternalSearchForm) -> BaseQuery
             search_parameters=form.search.data,
             fields_definition=SEARCH_FIELD_TO_PYTHON,
             joins_definition=JOIN_DICT,
+            subqueries_definition={},
             operators_definition=OPERATOR_DICT,
         )
         for warning in warnings:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28225

aussi ien experiemntalement que d'apres le explain la nouvelle requete est environ 3 fois plus cher dans le cas pratique du bug et remonte 6 fois plus d'informations. Je pense que le prix supplémentaire est dut au fait qu'on a vraiment besoin des 100 lignes (alors qu'avant on ne scannais que 16 lignes dans la table offer).

Le fait de passer par un `EXISTS` a la place de `DISTINCT` accelere la solution d'un facteur 2 environ mais on reste 2 fois plus lent qu'avant.