### PR TITLE
(PC-27842)[ADAGE] fix: collective offer patches with no contact info

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -292,18 +292,16 @@ def check_contact_request(offer: AnyCollectiveOffer, in_data: dict) -> None:
         # collective offers are not concerned, for now.
         return
 
+    set_email = in_data["contactEmail"] if "contactEmail" in in_data else offer.contactEmail
     set_phone = in_data["contactPhone"] if "contactPhone" in in_data else offer.contactPhone
     set_url = in_data["contactUrl"] if "contactUrl" in in_data else offer.contactUrl
     set_form = in_data["contactForm"] if "contactForm" in in_data else offer.contactForm
 
-    if not any((set_phone, set_url)):
+    if not any((set_email, set_phone, set_url, set_form)):
         raise exceptions.AllNullContactRequestDataError()
 
     if not set_url and not set_form:
         raise exceptions.UrlandFormBothSetError()
-
-    if set_url and any((set_phone, set_form)):
-        raise exceptions.UrlSetError()
 
 
 def check_offer_is_digital(offer: models.Offer) -> None:

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -659,12 +659,10 @@ class PatchCollectiveOfferTemplateBodyModel(PatchCollectiveOfferBodyModel):
 
     @root_validator
     def validate_contact_fields(cls, values: dict) -> dict:
-        email = values.get("contactEmail")
-        phone = values.get("contactPhone")
         url = values.get("contactUrl")
         form = values.get("contactForm")
 
-        if url and any([email, phone, form]):
+        if url and form:
             raise ValueError("error: url and form are both not null")
 
         return values


### PR DESCRIPTION
Missed the fact that PATCH on collective offer template is perfectly fine with no contact info and it should be fine as long as the model already has a contact data.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27842

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques