### PR TITLE
(PC-28310)[PRO] fix:display 500+ when reaching ceiling # in stats block

### DIFF
--- a/pro/src/pages/Home/StatisticsDashboard/__specs__/OfferStats.spec.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/__specs__/OfferStats.spec.tsx
@@ -89,7 +89,7 @@ describe('OfferStats', () => {
 
   it('should render when the count is too high', async () => {
     vi.spyOn(api, 'getOffererV2Stats').mockResolvedValueOnce({
-      publishedPublicOffers: 10000,
+      publishedPublicOffers: 500,
       publishedEducationalOffers: 0,
       pendingPublicOffers: 0,
       pendingEducationalOffers: 0,

--- a/pro/src/pages/Offers/domain/getOffersCountToDisplay.ts
+++ b/pro/src/pages/Offers/domain/getOffersCountToDisplay.ts
@@ -1,6 +1,5 @@
 import { MAX_OFFERS_TO_DISPLAY } from 'core/Offers/constants'
-
 export const getOffersCountToDisplay = (offersCount: number) =>
-  offersCount <= MAX_OFFERS_TO_DISPLAY
+  offersCount < MAX_OFFERS_TO_DISPLAY
     ? offersCount.toString()
     : `${MAX_OFFERS_TO_DISPLAY}+`


### PR DESCRIPTION
## But de la pull request
Afficher 500+ lorsque le back renvoie la valeur maximale pour `publishedPublicOffers` = 500 cf https://github.com/pass-culture/pass-culture-main/blob/88910ff2e9e0859b7155ecaeb3b8198dedfeac97/api/src/pcapi/core/offerers/repository.py#L717 
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28310