### PR TITLE
(BSR) feat: add allocine id to offer response extra data

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -145,6 +145,7 @@ class GtlLabels(BaseModel):
 
 
 class OfferExtraData(BaseModel):
+    allocineId: int | None
     author: str | None
     durationMinutes: int | None
     ean: str | None

--- a/api/tests/routes/native/openapi_test.py
+++ b/api/tests/routes/native/openapi_test.py
@@ -1007,6 +1007,7 @@ def test_public_api(client):
                 },
                 "OfferExtraData": {
                     "properties": {
+                        "allocineId": {"nullable": True, "title": "Allocineid", "type": "integer"},
                         "author": {"nullable": True, "title": "Author", "type": "string"},
                         "cast": {"items": {"type": "string"}, "nullable": True, "title": "Cast", "type": "array"},
                         "durationMinutes": {"nullable": True, "title": "Durationminutes", "type": "integer"},

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -35,6 +35,7 @@ class OffersTest:
     @freeze_time("2020-01-01")
     def test_get_event_offer(self, client):
         extra_data = {
+            "allocineId": 12345,
             "author": "mandibule",
             "ean": "3838",
             "musicSubType": "502",
@@ -189,6 +190,7 @@ class OffersTest:
         assert response.json["externalTicketOfficeUrl"] == "https://url.com"
         assert response.json["expenseDomains"] == ["all"]
         assert response.json["extraData"] == {
+            "allocineId": 12345,
             "author": "mandibule",
             "ean": "3838",
             "durationMinutes": 33,


### PR DESCRIPTION
## But de la pull request

Ajout de l'`allocineId` dans les `extraData` pour qu'il soit remonté dans la route `/native/v1/offer/{offerId}`

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques