### PR TITLE
(PC-28316)[API] Généralisation du wrapper pour `requests` (pour usage par le client Algolia)

### DIFF
--- a/api/src/pcapi/utils/requests.py
+++ b/api/src/pcapi/utils/requests.py
@@ -47,18 +47,20 @@ def _wrapper(
     request_func: Callable,
     method: str | bytes,
     url: str | bytes,
-    log_at_warning_level: bool = True,
     **kwargs: Any,
 ) -> Response:
     timeout = kwargs.pop("timeout", REQUEST_TIMEOUT_IN_SECOND)
     try:
         response = request_func(method=method, url=url, timeout=timeout, **kwargs)
     except Exception as exc:
-        if log_at_warning_level:
-            logger_method = logger.warning
-        else:
-            logger_method = logger.info
-        logger_method("Call to external service failed with %s", exc, extra={"method": method, "url": _redact_url(url)})
+        logger.warning(
+            "Call to external service failed with %s",
+            exc,
+            extra={
+                "method": method,
+                "url": _redact_url(url),
+            },
+        )
         raise exc
 
     logger.info(


### PR DESCRIPTION
Notre wrapper `pcapi.utils.requests` n'est pas utilisé par le client Algolia, car celui-ci utilise `requests.Session.send`, qui n'est pas pris en charge par notre wrapper. Cette pull request fait les modifications nécessaires pour que ce soit le cas.

**3 commits, à relire séparément.** J'ai supprimé un argument inutilisé et j'en ai profité pour ré-écrire les tests du wrapper qui étaient... disons "peu pertinents".