### PR TITLE
(BSR)[API] style: Add a Pylint check for `import requests`

### DIFF
--- a/api/src/pcapi/connectors/ems.py
+++ b/api/src/pcapi/connectors/ems.py
@@ -6,8 +6,7 @@ import hmac
 import json
 
 import pydantic.v1 as pydantic_v1
-from requests import Response
-from requests.auth import HTTPBasicAuth
+from requests.auth import HTTPBasicAuth  # pylint: disable=wrong-requests-import
 import sentry_sdk
 
 from pcapi import settings
@@ -95,7 +94,7 @@ class EMSBookingConnector:
     shows_availability_endpoint = "SEANCE"
     cancelation_endpoint = "ANNULATION"
 
-    def do_request(self, endpoint: str, payload: dict) -> Response:
+    def do_request(self, endpoint: str, payload: dict) -> requests.Response:
         """
         Perform the actual request, using mandatory headers
         and hashed payload.
@@ -106,7 +105,7 @@ class EMSBookingConnector:
         url = self._build_url(endpoint, payload)
         return requests.post(url, headers=headers, json=payload)
 
-    def raise_for_status(self, response: Response) -> None:
+    def raise_for_status(self, response: requests.Response) -> None:
         response.raise_for_status()
         content = response.json()
 

--- a/api/src/pcapi/core/external/zendesk_sell_backends/logger.py
+++ b/api/src/pcapi/core/external/zendesk_sell_backends/logger.py
@@ -1,8 +1,7 @@
 import logging
 
-import requests
-
 from pcapi.core.offerers import models as offerers_models
+from pcapi.utils import requests
 
 from .base import BaseBackend
 

--- a/api/src/pcapi/core/external/zendesk_sell_backends/testing.py
+++ b/api/src/pcapi/core/external/zendesk_sell_backends/testing.py
@@ -1,9 +1,8 @@
 import logging
 
-import requests
-
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import testing
+from pcapi.utils import requests
 
 from .base import BaseBackend
 

--- a/api/src/pcapi/core/external/zendesk_sell_backends/zendesk_sell.py
+++ b/api/src/pcapi/core/external/zendesk_sell_backends/zendesk_sell.py
@@ -3,8 +3,6 @@ import json
 import logging
 import urllib.parse
 
-import requests
-
 from pcapi import settings
 from pcapi.core.external.zendesk_sell_backends.base import BaseBackend
 from pcapi.core.external.zendesk_sell_backends.base import ContactFoundMoreThanOneError
@@ -12,6 +10,7 @@ from pcapi.core.external.zendesk_sell_backends.base import ContactNotFoundError
 from pcapi.core.external.zendesk_sell_backends.base import ZendeskCustomFieldsNames
 from pcapi.core.external.zendesk_sell_backends.base import ZendeskCustomFieldsShort
 from pcapi.core.offerers import models as offerers_models
+from pcapi.utils import requests
 from pcapi.utils import urls
 from pcapi.utils.regions import get_region_name_from_department
 

--- a/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
+++ b/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
@@ -1,7 +1,5 @@
 import logging
 
-from requests.exceptions import RequestException
-
 from pcapi.core.providers.exceptions import ConnexionToProviderApiFailed
 from pcapi.utils import requests
 
@@ -124,7 +122,7 @@ class ProviderAPI:
 
         try:
             response = requests.get(url=api_url, headers=headers, timeout=REQUEST_TIMEOUT_FOR_PROVIDERS_IN_SECOND)
-        except RequestException as error:
+        except requests.exceptions.RequestException as error:
             extra_infos = {"siret": siret, "api_url": self.api_url, "error": str(error)}
             logger.exception("[PROVIDER] request failed", extra=extra_infos)
             raise ConnexionToProviderApiFailed

--- a/api/src/pcapi/routes/backoffice/external/zendesk_sell/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/external/zendesk_sell/blueprint.py
@@ -1,7 +1,6 @@
 from flask import flash
 from flask import url_for
 from markupsafe import Markup
-import requests
 import sqlalchemy as sa
 from werkzeug.exceptions import NotFound
 from werkzeug.utils import redirect
@@ -12,6 +11,7 @@ from pcapi.core.external.zendesk_sell_backends import BaseBackend
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.routes.backoffice import utils
+from pcapi.utils import requests
 from pcapi.utils.module_loading import import_string
 
 

--- a/api/src/pcapi/utils/pylint.py
+++ b/api/src/pcapi/utils/pylint.py
@@ -98,7 +98,35 @@ class DatetimeNowChecker(pylint.checkers.BaseChecker):
             self.add_message(MSG_USE_OF_DATETIME_NOW, node=node, line=node.lineno)
 
 
+MSG_REQUESTS_IMPORT = "wrong-requests-import"
+
+
+class RequestsImportChecker(pylint.checkers.BaseChecker):
+    name = "requests-import"
+    priority = -1
+    msgs = {
+        "W4004": (
+            "Likely wrong import of the original `requests` third-party package",
+            MSG_REQUESTS_IMPORT,
+            "There is a `pcapi.utils.requests` wrapper that should be used instead.",
+        ),
+    }
+    options = ()
+
+    def visit_import(self, node: astroid.nodes.Import) -> None:
+        names = [name.split(".")[0] for name, _alias in node.names]
+        if "requests" in names:
+            self.add_message(MSG_REQUESTS_IMPORT, node=node, line=node.lineno)
+            return
+
+    def visit_importfrom(self, node: astroid.nodes.ImportFrom) -> None:
+        if node.modname.split(".")[0] == "requests":
+            self.add_message(MSG_REQUESTS_IMPORT, node=node, line=node.lineno)
+            return
+
+
 def register(linter: pylint.lint.PyLinter) -> None:
     linter.register_checker(BaseModelImportChecker(linter))
     linter.register_checker(DatetimeNowChecker(linter))
     linter.register_checker(MarkupSafeChecker(linter))
+    linter.register_checker(RequestsImportChecker(linter))

--- a/api/src/pcapi/utils/requests.py
+++ b/api/src/pcapi/utils/requests.py
@@ -19,18 +19,18 @@ from typing import Callable
 
 import gql.transport.exceptions
 import gql.transport.requests
-import requests
-from requests import Response
-from requests.adapters import HTTPAdapter
+import requests  # pylint: disable=wrong-requests-import
+from requests.adapters import HTTPAdapter  # pylint: disable=wrong-requests-import
 from urllib3.util.retry import Retry
 import zeep
 
 
 # fmt: off
 # isort: off
-# Allow our code to access `requests` exceptions directly from this
-# wrapper module.
-from requests import exceptions  # pylint: disable=unused-import
+# Allow our code to access `requests` exceptions and models directly
+# from this wrapper module.
+from requests import Response  # pylint: disable=unused-import, wrong-requests-import
+from requests import exceptions  # pylint: disable=unused-import, wrong-requests-import
 # isort: on
 # fmt: on
 
@@ -61,7 +61,7 @@ def _wrapper(
     request_send_func: Callable,
     request: requests.PreparedRequest,
     **kwargs: Any,
-) -> Response:
+) -> requests.Response:
     if not kwargs.get("timeout"):
         kwargs["timeout"] = REQUEST_TIMEOUT_IN_SECOND
     try:
@@ -88,24 +88,26 @@ def _wrapper(
     return response
 
 
-def get(url: str, disable_synchronous_retry: bool = False, **kwargs: Any) -> Response:
+def get(url: str, disable_synchronous_retry: bool = False, **kwargs: Any) -> requests.Response:
     with Session(disable_synchronous_retry=disable_synchronous_retry) as session:
         return session.request(method="GET", url=url, **kwargs)
 
 
-def post(url: str, hmac: str | None = None, disable_synchronous_retry: bool = False, **kwargs: Any) -> Response:
+def post(
+    url: str, hmac: str | None = None, disable_synchronous_retry: bool = False, **kwargs: Any
+) -> requests.Response:
     with Session(disable_synchronous_retry=disable_synchronous_retry) as session:
         if hmac:
             kwargs.setdefault("headers", {}).update({"PassCulture-Signature": hmac})
         return session.request(method="POST", url=url, **kwargs)
 
 
-def put(url: str, disable_synchronous_retry: bool = False, **kwargs: Any) -> Response:
+def put(url: str, disable_synchronous_retry: bool = False, **kwargs: Any) -> requests.Response:
     with Session(disable_synchronous_retry=disable_synchronous_retry) as session:
         return session.request(method="PUT", url=url, **kwargs)
 
 
-def delete(url: str, disable_synchronous_retry: bool = False, **kwargs: Any) -> Response:
+def delete(url: str, disable_synchronous_retry: bool = False, **kwargs: Any) -> requests.Response:
     with Session(disable_synchronous_retry=disable_synchronous_retry) as session:
         return session.request(method="DELETE", url=url, **kwargs)
 

--- a/api/src/pcapi/workers/apps_flyer_job.py
+++ b/api/src/pcapi/workers/apps_flyer_job.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 import logging
 
-from requests.exceptions import RequestException
-
 from pcapi import settings
 from pcapi.core.users.models import User
 from pcapi.utils import requests
@@ -64,7 +62,7 @@ def log_user_becomes_beneficiary_event_job(user_id: int) -> None:
 
     try:
         response = requests.post(url, headers=headers, json=data)
-    except (ConnectionError, RequestException) as error:
+    except (ConnectionError, requests.exceptions.RequestException) as error:
         extra_infos = {"user": user.id, "user.apps_flyer_id": context.apps_flyer_user_id, "error": str(error)}
         logger.error("[APPS FLYER][BECOMES BENEFICIARY] request failed", extra=extra_infos)
         return

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -16,9 +16,7 @@ from flask import g
 from flask.testing import FlaskClient
 from flask_jwt_extended.utils import create_access_token
 import pytest
-from requests import Response
-from requests.auth import _basic_auth_str
-from requests.exceptions import ConnectionError as RequestConnectionError
+from requests.auth import _basic_auth_str  # pylint: disable=wrong-requests-import
 import requests_mock
 
 from pcapi import repository
@@ -39,6 +37,7 @@ from pcapi.notifications.push import testing as push_notifications_testing
 from pcapi.notifications.sms import testing as sms_notifications_testing
 from pcapi.repository.clean_database import clean_all_database
 from pcapi.routes.backoffice import install_routes
+from pcapi.utils import requests
 from pcapi.utils.module_loading import import_string
 
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_valid_token_with_email
@@ -262,7 +261,9 @@ def ubble_mock_connection_error(requests_mock):  # pylint: disable=redefined-out
         UBBLE_CLIENT_SECRET="client_secret",
     ):
         request_matcher = requests_mock.register_uri(
-            "POST", "https://api.example.com/identifications/", exc=RequestConnectionError
+            "POST",
+            "https://api.example.com/identifications/",
+            exc=requests.exceptions.ConnectionError,
         )
         yield request_matcher
 
@@ -548,7 +549,7 @@ class TestClient:
         self._print_spec("PUT", route, json, result)
         return result
 
-    def _print_spec(self, verb: str, route: str, request_body: dict, result: Response):
+    def _print_spec(self, verb: str, route: str, request_body: dict, result: requests.Response):
         if not TestClient.WITH_DOC:
             return
 

--- a/api/tests/connectors/beneficiaries/educonnect.py
+++ b/api/tests/connectors/beneficiaries/educonnect.py
@@ -1,11 +1,11 @@
 import shutil
 
 import pytest
-import requests
 
 from pcapi import settings
 from pcapi.connectors.beneficiaries.educonnect import educonnect_connector
 from pcapi.core.testing import override_settings
+from pcapi.utils import requests
 
 
 CERTIFICATE_CONTENT = ""

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -3,13 +3,12 @@ import logging
 from unittest import mock
 
 import pytest
-import requests
 
 from pcapi.connectors.beneficiaries import ubble
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.testing import override_settings
 from pcapi.core.users.models import GenderEnum
-from pcapi.utils import requests as requests_utils
+from pcapi.utils import requests
 
 from tests.core.subscription.test_factories import UbbleIdentificationResponseFactory
 from tests.test_utils import json_default
@@ -46,7 +45,7 @@ class StartIdentificationTest:
         assert record.message == "Valid response from Ubble"
 
     def test_start_identification_connection_error(self, ubble_mock_connection_error, caplog):
-        with pytest.raises(requests_utils.ExternalAPIException):
+        with pytest.raises(requests.ExternalAPIException):
             with caplog.at_level(logging.ERROR):
                 ubble.start_identification(
                     user_id=123,
@@ -64,7 +63,7 @@ class StartIdentificationTest:
         assert record.message == "Ubble start-identification: Network error"
 
     def test_start_identification_http_error_status(self, ubble_mock_http_error_status, caplog):
-        with pytest.raises(requests_utils.ExternalAPIException):
+        with pytest.raises(requests.ExternalAPIException):
             ubble.start_identification(
                 user_id=123,
                 first_name="prenom",
@@ -160,7 +159,7 @@ class GetContentTest:
         requests_mock.register_uri("GET", f"/identifications/{identification_id}/", status_code=401)
 
         with caplog.at_level(logging.ERROR):
-            with pytest.raises(requests_utils.ExternalAPIException) as exc_info:
+            with pytest.raises(requests.ExternalAPIException) as exc_info:
                 ubble.get_content(identification_id)
 
         assert len(caplog.records) == 1
@@ -177,7 +176,7 @@ class GetContentTest:
         requests_mock.register_uri("GET", f"/identifications/{identification_id}/", status_code=503)
 
         with caplog.at_level(logging.ERROR):
-            with pytest.raises(requests_utils.ExternalAPIException) as exc_info:
+            with pytest.raises(requests.ExternalAPIException) as exc_info:
                 ubble.get_content(identification_id)
 
         assert len(caplog.records) == 1

--- a/api/tests/files/pylint_requests.py
+++ b/api/tests/files/pylint_requests.py
@@ -1,0 +1,14 @@
+"""This is a test file for our checker in `pcapi.utils.pylint`.
+
+This file is NOT run by pytest, which is why it does not contain any
+assertion.
+"""
+
+import requests  # should yield a warning
+from requests import Session  # should yield a warning
+import requests.session as requests_session  # should yield a warning
+from requests.session import Session  # should yield a warning
+
+from pcapi.utils import requests
+import pcapi.utils.requests
+from pcapi.utils.requests import Session

--- a/api/tests/providers/titelive_search_test.py
+++ b/api/tests/providers/titelive_search_test.py
@@ -4,7 +4,6 @@ import pathlib
 import re
 
 import pytest
-import requests
 import time_machine
 
 from pcapi.connectors import titelive
@@ -18,7 +17,7 @@ import pcapi.core.providers.repository as providers_repository
 from pcapi.core.providers.titelive_music_search import TiteliveMusicSearch
 from pcapi.core.testing import override_settings
 from pcapi.domain import music_types
-from pcapi.utils.requests import ExternalAPIException
+from pcapi.utils import requests
 
 import tests
 from tests.connectors.titelive import fixtures
@@ -172,7 +171,7 @@ class TiteliveSearchTest:
             payload=titelive.TiteliveBase.MUSIC.value,
         )
 
-        with pytest.raises(ExternalAPIException):
+        with pytest.raises(requests.ExternalAPIException):
             TiteliveMusicSearch().synchronize_products()
 
         start_sync_events_query = providers_models.LocalProviderEvent.query.filter(

--- a/api/tests/routes/backoffice/zendesk_sell_tests.py
+++ b/api/tests/routes/backoffice/zendesk_sell_tests.py
@@ -2,13 +2,13 @@ from unittest import mock
 
 from flask import url_for
 import pytest
-import requests
 
 from pcapi.core.external.zendesk_sell_backends import base as zendesk_sell
 from pcapi.core.external.zendesk_sell_backends import testing as zendesk_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import testing
+from pcapi.utils import requests
 
 from .helpers import html_parser
 from .helpers.post import PostEndpointHelper

--- a/api/tests/utils/pylint_test.py
+++ b/api/tests/utils/pylint_test.py
@@ -33,3 +33,10 @@ class DatetimeNowCheckerTest(CheckerTestCaseBase):
     message_id = pcapi_pylint.MSG_USE_OF_DATETIME_NOW
     test_filename = "pylint_datetime.py"
     expected_error_lines = {11, 14, 15, 16, 17, 23, 26, 27, 28, 29}
+
+
+class RequestsImportCheckerTest(CheckerTestCaseBase):
+    CHECKER_CLASS = pcapi_pylint.RequestsImportChecker
+    message_id = pcapi_pylint.MSG_REQUESTS_IMPORT
+    test_filename = "pylint_requests.py"
+    expected_error_lines = {7, 8, 9, 10}

--- a/api/tests/utils/requests_test.py
+++ b/api/tests/utils/requests_test.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-import requests.models as real_requests_models
+import requests.models as real_requests_models  # pylint: disable=wrong-requests-import
 
 from pcapi.utils import requests
 


### PR DESCRIPTION
We should never import the third-party `requests` package. Instead, we
should import our `pcapi.utils.wrapper`. We have forgotten in the
past, now we won't.