### PR TITLE
(BSR) fix: fix squawk pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -144,8 +144,8 @@ if [[ "$ALEMBIC_STAGED_FILES" != "" ]]; then
 
     base_commit=$(git merge-base HEAD origin/master)
     base_alembic_versions=$(git --no-pager show "$base_commit":api/alembic_version_conflict_detection.txt)
-    base_pre=$(echo "$base_alembic_versions" | head --lines 1 | cut --fields 1 --delimiter " ")
-    base_post=$(echo "$base_alembic_versions" | tail --lines 1 | cut --fields 1 --delimiter " ")
+    base_pre=$(echo "$base_alembic_versions" | head --lines 1 | cut -f 1 -d " ")
+    base_post=$(echo "$base_alembic_versions" | tail --lines 1 | cut -f 1 -d " ")
     lint_alembic upgrade "$base_pre":pre@head
     lint_alembic upgrade "$base_post":post@head
     lint_alembic downgrade post@head:"$base_post"

--- a/api/src/pcapi/alembic/run_migrations.py
+++ b/api/src/pcapi/alembic/run_migrations.py
@@ -110,7 +110,7 @@ def run_online_migrations() -> None:
         )
 
 
-def run_offline_migrations():
+def run_offline_migrations() -> None:
     """Run migrations *without* a SQL connection."""
-    context.configure(url=settings.DATABASE_URL, literal_binds=True)
+    context.configure(url=settings.DATABASE_URL, literal_binds=True, transaction_per_migration=True)
     context.run_migrations()


### PR DESCRIPTION
MacOS' cut command does not support long arguments like `--fields`, and each migration in production is in its own transaction so the offline migrations should also be printed in their own migrations.