### PR TITLE
(BSR)[API] fix: offererId query param should take precedence over adm…

### DIFF
--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -1002,16 +1002,15 @@ def get_invoices_query(
             offerers_models.UserOfferer,
             offerers_models.UserOfferer.offererId == models.BankAccount.offererId,
         ).filter(offerers_models.UserOfferer.user == user, offerers_models.UserOfferer.isValidated)
+    elif user.has_admin_role and not offerer_id and not bank_account_id:
+        # The following intentionally returns nothing for admin users,
+        # so that we do NOT return all invoices of all bank accounts
+        # for them. Admin users must select a bank account, or at least an offererId must be provided.
+        bank_account_subquery = bank_account_subquery.filter(False)
 
     if bank_account_id:
         bank_account_subquery = bank_account_subquery.filter(models.BankAccount.id == bank_account_id)
-    elif user.has_admin_role:
-        # The following intentionally returns nothing for admin users,
-        # so that we do NOT return all invoices of all bank accounts
-        # for them. Admin users must select a bank account.
-        bank_account_subquery = bank_account_subquery.filter(False)
-
-    if offerer_id:
+    elif offerer_id:
         bank_account_subquery = bank_account_subquery.filter(models.BankAccount.offererId == offerer_id)
 
     invoices = models.Invoice.query.filter(

--- a/api/tests/routes/pro/get_invoices_v2_test.py
+++ b/api/tests/routes/pro/get_invoices_v2_test.py
@@ -150,3 +150,57 @@ class GetInvoicesTest:
         assert response.status_code == 200
         invoices = response.json
         assert invoices == []
+
+    def test_admin_user_should_access_invoices_if_offerer_id_given(self, client):
+        offerer = offerers_factories.OffererFactory()
+        pro = users_factories.AdminFactory()
+
+        offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
+        bank_account1 = finance_factories.BankAccountFactory(offerer=offerer)
+        finance_factories.InvoiceFactory(bankAccount=bank_account1, amount=-1000)
+        bank_account2 = finance_factories.BankAccountFactory(offerer=offerer)
+        finance_factories.InvoiceFactory(bankAccount=bank_account2, amount=-1500)
+
+        client = client.with_session_auth(pro.email)
+        params = {"offererId": offerer.id}
+        response = client.get("/v2/finance/invoices", params=params)
+
+        assert response.status_code == 200
+        invoices = response.json
+        assert len(invoices) == 2
+
+    def test_filter_both_on_bank_account_and_offerer_should_consider_bank_account(self, client):
+        offerer = offerers_factories.OffererFactory()
+        pro = users_factories.ProFactory()
+
+        offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
+        bank_account1 = finance_factories.BankAccountFactory(offerer=offerer)
+        invoice1 = finance_factories.InvoiceFactory(bankAccount=bank_account1, amount=-1000)
+        bank_account2 = finance_factories.BankAccountFactory(offerer=offerer)
+        finance_factories.InvoiceFactory(bankAccount=bank_account2, amount=-1500)
+
+        client = client.with_session_auth(pro.email)
+        params = {"offererId": offerer.id, "bankAccountId": bank_account1.id}
+        response = client.get("/v2/finance/invoices", params=params)
+
+        assert response.status_code == 200
+        invoices = response.json
+        assert len(invoices) == 1
+        assert invoices[0]["reference"] == invoice1.reference
+
+    def test_do_not_return_invoices_for_admin_user_if_no_filter_on_offerer_or_bank_account(self, client):
+        offerer = offerers_factories.OffererFactory()
+        pro = users_factories.AdminFactory()
+
+        offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
+        bank_account1 = finance_factories.BankAccountFactory(offerer=offerer)
+        finance_factories.InvoiceFactory(bankAccount=bank_account1, amount=-1000)
+        bank_account2 = finance_factories.BankAccountFactory(offerer=offerer)
+        finance_factories.InvoiceFactory(bankAccount=bank_account2, amount=-1500)
+
+        client = client.with_session_auth(pro.email)
+        response = client.get("/v2/finance/invoices")
+
+        assert response.status_code == 200
+        invoices = response.json
+        assert len(invoices) == 0


### PR DESCRIPTION
…in role

This is acceptable as this is the nominal use case, the request is by default triggered with a period of time and a offererId, as if the admin user was a regular user offerer.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques