### PR TITLE
(BSR)[PRO] refactor: remove Offerer custom type and fix factories naming

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferLocationSection/__specs__/CollectiveOfferLocationSection.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferLocationSection/__specs__/CollectiveOfferLocationSection.spec.tsx
@@ -6,7 +6,7 @@ import { OfferAddressType } from 'apiClient/v1'
 import * as getInterventionAreaLabels from 'pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferInterventionArea/OfferInterventionArea'
 import {
   collectiveOfferTemplateFactory,
-  defaultVenueResponseModel,
+  defaultGetVenue,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -22,7 +22,7 @@ vi.mock('apiClient/api', () => ({
 describe('CollectiveOfferLocationSection', () => {
   beforeEach(() => {
     vi.spyOn(api, 'getVenue').mockResolvedValue({
-      ...defaultVenueResponseModel,
+      ...defaultGetVenue,
     })
   })
 

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferStockSection/__specs__/CollectiveOfferStockSection.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferStockSection/__specs__/CollectiveOfferStockSection.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { TOTAL_PRICE_LABEL } from 'screens/OfferEducationalStock/constants/labels'
-import { collectiveStockFactory } from 'utils/collectiveApiFactories'
+import { getCollectiveOfferCollectiveStockFactory } from 'utils/collectiveApiFactories'
 
 import CollectiveOfferStockSection, {
   CollectiveOfferStockSectionProps,
@@ -17,7 +17,7 @@ const renderCollectiveOfferStockSection = (
 describe('CollectiveOfferStockSection', () => {
   it('render component', () => {
     const props = {
-      stock: collectiveStockFactory(),
+      stock: getCollectiveOfferCollectiveStockFactory(),
     }
     renderCollectiveOfferStockSection(props)
 

--- a/pro/src/components/CollectiveOfferSummary/components/utils/__specs__/formatOfferEventAddress.spec.ts
+++ b/pro/src/components/CollectiveOfferSummary/components/utils/__specs__/formatOfferEventAddress.spec.ts
@@ -1,6 +1,6 @@
 import { OfferAddressType } from 'apiClient/v1'
 import { EVENT_ADDRESS_SCHOOL_LABEL } from 'screens/OfferEducational/constants/labels'
-import { defaultVenueResponseModel } from 'utils/collectiveApiFactories'
+import { defaultGetVenue } from 'utils/collectiveApiFactories'
 
 import { formatOfferEventAddress } from '../formatOfferEventAddress'
 
@@ -14,7 +14,7 @@ describe('formatOfferEventAddress', () => {
           venueId: 12,
         },
         {
-          ...defaultVenueResponseModel,
+          ...defaultGetVenue,
           name: 'Offerer venue',
           publicName: '',
           postalCode: '75000',
@@ -34,7 +34,7 @@ describe('formatOfferEventAddress', () => {
           venueId: null,
         },
         {
-          ...defaultVenueResponseModel,
+          ...defaultGetVenue,
           name: 'Offerer venue',
           publicName: '',
           postalCode: '75000',
@@ -54,7 +54,7 @@ describe('formatOfferEventAddress', () => {
           venueId: 12,
         },
         {
-          ...defaultVenueResponseModel,
+          ...defaultGetVenue,
           name: 'Offerer venue',
           publicName: '',
           postalCode: '75000',

--- a/pro/src/components/IndividualOfferForm/Categories/__specs__/Categories.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/Categories/__specs__/Categories.spec.tsx
@@ -9,8 +9,8 @@ import { IndividualOfferFormValues } from 'components/IndividualOfferForm'
 import { INDIVIDUAL_OFFER_SUBTYPE } from 'core/Offers/constants'
 import { SubmitButton } from 'ui-kit'
 import {
-  individualOfferCategoryFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  subcategoryFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -69,21 +69,21 @@ describe('IndividualOffer section: Categories', () => {
   beforeEach(() => {
     initialValues = { ...CATEGORIES_DEFAULT_VALUES }
     categories = [
-      individualOfferCategoryFactory({ id: 'A' }),
-      individualOfferCategoryFactory({ id: 'B' }),
-      individualOfferCategoryFactory({ id: 'C' }),
+      categoryFactory({ id: 'A' }),
+      categoryFactory({ id: 'B' }),
+      categoryFactory({ id: 'C' }),
     ]
     subCategories = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'A-A',
         categoryId: 'A',
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'B-A',
         categoryId: 'B',
         conditionalFields: ['gtl_id'],
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'C-A',
         categoryId: 'C',
         conditionalFields: ['showType', 'showSubType'],

--- a/pro/src/components/IndividualOfferForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.tracker.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.tracker.spec.tsx
@@ -7,8 +7,8 @@ import { UploaderModeEnum } from 'components/ImageUploader/types'
 import { IndividualOfferContext } from 'context/IndividualOfferContext'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
-import { individualOfferContextFactory } from 'utils/individualApiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
+import { individualOfferContextValuesFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ImageUploaderOffer, {
@@ -20,9 +20,9 @@ const mockLogEvent = vi.fn()
 const TEST_OFFER_ID = 12
 
 const renderImageUploaderOffer = (props: ImageUploaderOfferProps) => {
-  const contextValue = individualOfferContextFactory({
+  const contextValue = individualOfferContextValuesFactory({
     offerId: TEST_OFFER_ID,
-    offer: GetIndividualOfferFactory({ id: TEST_OFFER_ID }),
+    offer: getIndividualOfferFactory({ id: TEST_OFFER_ID }),
   })
 
   return renderWithProviders(

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
@@ -14,7 +14,7 @@ import { CATEGORY_STATUS } from 'core/Offers/constants'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 import { SubmitButton } from 'ui-kit'
 import {
-  individualOfferSubCategoryFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -103,7 +103,7 @@ describe('IndividualOffer section: UsefulInformations', () => {
   it('should submit valid form', async () => {
     initialValues.subcategoryId = 'CONCERT'
     initialValues.subCategoryFields = ['withdrawalType', 'bookingContact']
-    props.offerSubCategory = individualOfferSubCategoryFactory({
+    props.offerSubCategory = subcategoryFactory({
       id: 'CONCERT',
       canBeWithdrawable: true,
     })
@@ -245,7 +245,7 @@ describe('IndividualOffer section: UsefulInformations', () => {
   describe('When venue is virtual', () => {
     beforeEach(() => {
       props.isVenueVirtual = true
-      props.offerSubCategory = individualOfferSubCategoryFactory({
+      props.offerSubCategory = subcategoryFactory({
         id: 'VIRTUAL_SUB_CATEGORY',
         onlineOfflinePlatform: CATEGORY_STATUS.ONLINE,
       })
@@ -342,7 +342,7 @@ describe('IndividualOffer section: UsefulInformations', () => {
   describe('banners', () => {
     it('should display not reimbursment banner when subcategory is not reimbursed', () => {
       initialValues.subcategoryId = 'ANOTHER_SUB_CATEGORY'
-      props.offerSubCategory = individualOfferSubCategoryFactory({
+      props.offerSubCategory = subcategoryFactory({
         reimbursementRule: REIMBURSEMENT_RULES.NOT_REIMBURSED,
       })
       renderUsefulInformations({
@@ -366,7 +366,7 @@ describe('IndividualOffer section: UsefulInformations', () => {
 
     it('should not display not reimbursment banner when subcategory is reimbursed', () => {
       initialValues.subcategoryId = 'ANOTHER_SUB_CATEGORY'
-      props.offerSubCategory = individualOfferSubCategoryFactory({
+      props.offerSubCategory = subcategoryFactory({
         reimbursementRule: REIMBURSEMENT_RULES.BOOK,
       })
       renderUsefulInformations({
@@ -384,7 +384,7 @@ describe('IndividualOffer section: UsefulInformations', () => {
 
     it('should display withdrawal banner when subcategory is on physical thing (not event, not virtual)', () => {
       initialValues.subcategoryId = 'ANOTHER_SUB_CATEGORY'
-      props.offerSubCategory = individualOfferSubCategoryFactory({
+      props.offerSubCategory = subcategoryFactory({
         isEvent: false,
         onlineOfflinePlatform: CATEGORY_STATUS.ONLINE_OR_OFFLINE,
       })
@@ -407,7 +407,7 @@ describe('IndividualOffer section: UsefulInformations', () => {
 
     it('should not display withdrawal banner when subcategory is an event', () => {
       initialValues.subcategoryId = 'ANOTHER_SUB_CATEGORY'
-      props.offerSubCategory = individualOfferSubCategoryFactory({
+      props.offerSubCategory = subcategoryFactory({
         isEvent: true,
       })
       props.isVenueVirtual = false

--- a/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.BannerAddVenue.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.BannerAddVenue.spec.tsx
@@ -10,8 +10,8 @@ import {
 import { CATEGORY_STATUS } from 'core/Offers/constants'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 import {
-  individualOfferCategoryFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -60,16 +60,16 @@ describe('IndividualOfferForm', () => {
 
   beforeEach(() => {
     categories = [
-      individualOfferCategoryFactory({ id: 'virtual' }),
-      individualOfferCategoryFactory({ id: 'physical' }),
+      categoryFactory({ id: 'virtual' }),
+      categoryFactory({ id: 'physical' }),
     ]
     subCategories = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'physical',
         categoryId: 'physical',
         onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'virtual',
         categoryId: 'virtual',
         onlineOfflinePlatform: CATEGORY_STATUS.ONLINE,

--- a/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/__specs__/IndividualOfferForm.spec.tsx
@@ -19,11 +19,11 @@ import {
 } from 'core/Offers/constants'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 import { SubmitButton } from 'ui-kit'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import {
-  individualOfferCategoryFactory,
-  individualOfferContextFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  individualOfferContextValuesFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -51,7 +51,7 @@ const renderIndividualOfferForm = ({
   const storeOverrides = {
     user: { currentUser: { isAdmin: false } },
   }
-  const contextValues = individualOfferContextFactory(contextOverride)
+  const contextValues = individualOfferContextValuesFactory(contextOverride)
 
   return renderWithProviders(
     <IndividualOfferContext.Provider value={contextValues}>
@@ -84,17 +84,17 @@ describe('IndividualOfferForm', () => {
 
   beforeEach(() => {
     categories = [
-      individualOfferCategoryFactory({ id: 'virtual' }),
-      individualOfferCategoryFactory({ id: 'physical' }),
+      categoryFactory({ id: 'virtual' }),
+      categoryFactory({ id: 'physical' }),
     ]
     subCategories = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'physical',
         categoryId: 'physical',
         canBeDuo: true,
         onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'virtual',
         categoryId: 'virtual',
         canBeDuo: false,
@@ -146,7 +146,7 @@ describe('IndividualOfferForm', () => {
   })
 
   const imageSectionDataset: (GetIndividualOfferResponseModel | undefined)[] = [
-    GetIndividualOfferFactory(),
+    getIndividualOfferFactory(),
     undefined,
   ]
   it.each(imageSectionDataset)(

--- a/pro/src/components/IndividualOfferForm/utils/__specs__/getFilteredVenueList.spec.ts
+++ b/pro/src/components/IndividualOfferForm/utils/__specs__/getFilteredVenueList.spec.ts
@@ -1,7 +1,7 @@
 import { SubcategoryResponseModel } from 'apiClient/v1'
 import { CATEGORY_STATUS } from 'core/Offers/constants'
 import {
-  individualOfferSubCategoryFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 
@@ -16,15 +16,15 @@ describe('getFilteredVenueList', () => {
   const thirdVenueId = 3
 
   const subCategories: SubcategoryResponseModel[] = [
-    individualOfferSubCategoryFactory({
+    subcategoryFactory({
       id: 'ONLINE_ONLY',
       onlineOfflinePlatform: CATEGORY_STATUS.ONLINE,
     }),
-    individualOfferSubCategoryFactory({
+    subcategoryFactory({
       id: 'OFFLINE_ONLY',
       onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
     }),
-    individualOfferSubCategoryFactory({
+    subcategoryFactory({
       id: 'ONLINE_OR_OFFLINE',
       onlineOfflinePlatform: CATEGORY_STATUS.ONLINE_OR_OFFLINE,
     }),

--- a/pro/src/components/IndividualOfferForm/utils/__specs__/setFormReadOnlyFields.spec.ts
+++ b/pro/src/components/IndividualOfferForm/utils/__specs__/setFormReadOnlyFields.spec.ts
@@ -7,7 +7,7 @@ import {
   OFFER_STATUS_PENDING,
   OFFER_STATUS_REJECTED,
 } from 'core/Offers/constants'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 
 import { FORM_DEFAULT_VALUES } from '../../constants'
 import setFormReadOnlyFields from '../setFormReadOnlyFields'
@@ -22,7 +22,7 @@ describe('setFormReadOnlyFields', () => {
   it.each(fullBlockedStatus)(
     'should return all form fields for %s offer status',
     (status) => {
-      const offer = GetIndividualOfferFactory({ status })
+      const offer = getIndividualOfferFactory({ status })
       const readOnlyFields = setFormReadOnlyFields(offer)
       expect(readOnlyFields.sort()).toStrictEqual(
         Object.keys(FORM_DEFAULT_VALUES).sort()
@@ -39,7 +39,7 @@ describe('setFormReadOnlyFields', () => {
   it.each(blockedStatus)(
     'should return standard blocked field for %s offer status',
     (status) => {
-      const offer = GetIndividualOfferFactory({ status })
+      const offer = getIndividualOfferFactory({ status })
       const readOnlyFields = setFormReadOnlyFields(offer)
       expect(readOnlyFields).toStrictEqual([
         'categoryId',
@@ -55,7 +55,7 @@ describe('setFormReadOnlyFields', () => {
       (field: string) =>
         !['accessibility', 'externalTicketOfficeUrl', 'isDuo'].includes(field)
     )
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       lastProvider: { name: 'AlLocINé' },
     })
     const readOnlyFields = setFormReadOnlyFields(offer)
@@ -67,7 +67,7 @@ describe('setFormReadOnlyFields', () => {
       (field: string) =>
         !['accessibility', 'externalTicketOfficeUrl'].includes(field)
     )
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       lastProvider: {
         name: 'AnySyncProviderName',
       },

--- a/pro/src/components/IndividualOfferForm/utils/__specs__/setInitialFormValues.spec.ts
+++ b/pro/src/components/IndividualOfferForm/utils/__specs__/setInitialFormValues.spec.ts
@@ -6,11 +6,11 @@ import {
 } from 'apiClient/v1'
 import { AccessiblityEnum } from 'core/shared'
 import {
-  GetIndividualOfferFactory,
-  offerVenueFactory,
-  offererFactory,
+  getIndividualOfferFactory,
+  getOfferVenueFactory,
+  getOfferManagingOffererFactory,
 } from 'utils/apiFactories'
-import { individualOfferSubCategoryFactory } from 'utils/individualApiFactories'
+import { subcategoryFactory } from 'utils/individualApiFactories'
 
 import setInitialFormValues from '../setInitialFormValues'
 
@@ -21,7 +21,7 @@ describe('setFormReadOnlyFields', () => {
   const offererId = 12
 
   beforeEach(() => {
-    offer = GetIndividualOfferFactory({
+    offer = getIndividualOfferFactory({
       id: 12,
       extraData: {
         author: 'Offer author',
@@ -52,13 +52,13 @@ describe('setFormReadOnlyFields', () => {
       withdrawalDetails: 'Offer withdrawalDetails',
       withdrawalDelay: 140,
       withdrawalType: WithdrawalTypeEnum.ON_SITE,
-      venue: offerVenueFactory({
+      venue: getOfferVenueFactory({
         id: venueId,
-        managingOfferer: offererFactory({ id: offererId }),
+        managingOfferer: getOfferManagingOffererFactory({ id: offererId }),
       }),
     })
     subCategoryList = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: SubcategoryIdEnum.CONCERT,
         categoryId: 'CID',
         isEvent: true,

--- a/pro/src/components/IndividualOfferNavigation/__specs__/IndividualOfferNavigation.spec.tsx
+++ b/pro/src/components/IndividualOfferNavigation/__specs__/IndividualOfferNavigation.spec.tsx
@@ -9,8 +9,8 @@ import {
 } from 'context/IndividualOfferContext'
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
-import { individualOfferContextFactory } from 'utils/individualApiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
+import { individualOfferContextValuesFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { OFFER_WIZARD_STEP_IDS } from '../constants'
@@ -26,7 +26,7 @@ const renderIndividualOfferNavigation = (
   }),
   storeOverrides = {}
 ) => {
-  const contextValues = individualOfferContextFactory(contextOverride)
+  const contextValues = individualOfferContextValuesFactory(contextOverride)
 
   renderWithProviders(
     <IndividualOfferContext.Provider value={contextValues}>
@@ -91,7 +91,7 @@ describe('test IndividualOfferNavigation', () => {
 
     it('should render steps when no offer is given', async () => {
       renderIndividualOfferNavigation({
-        offer: GetIndividualOfferFactory({ isEvent: false }),
+        offer: getIndividualOfferFactory({ isEvent: false }),
       })
 
       expect(screen.getByText('Détails de l’offre')).toBeInTheDocument()
@@ -109,7 +109,7 @@ describe('test IndividualOfferNavigation', () => {
     })
 
     it('should render steps when offer without stock is given', async () => {
-      const offer = GetIndividualOfferFactory({
+      const offer = getIndividualOfferFactory({
         hasStocks: false,
         isEvent: false,
       })
@@ -132,7 +132,7 @@ describe('test IndividualOfferNavigation', () => {
     })
 
     it('should render steps when offer and stock are given', async () => {
-      const offer = GetIndividualOfferFactory({
+      const offer = getIndividualOfferFactory({
         isEvent: false,
       })
 
@@ -155,7 +155,7 @@ describe('test IndividualOfferNavigation', () => {
 
     it('should render steps on Information', () => {
       renderIndividualOfferNavigation(
-        { offer: GetIndividualOfferFactory({ isEvent: false }) },
+        { offer: getIndividualOfferFactory({ isEvent: false }) },
         generatePath(
           getIndividualOfferPath({
             step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
@@ -174,7 +174,7 @@ describe('test IndividualOfferNavigation', () => {
 
     it('should render steps on Stocks', () => {
       renderIndividualOfferNavigation(
-        { offer: GetIndividualOfferFactory({ isEvent: false }) },
+        { offer: getIndividualOfferFactory({ isEvent: false }) },
         generatePath(
           getIndividualOfferPath({
             step: OFFER_WIZARD_STEP_IDS.STOCKS,
@@ -193,7 +193,7 @@ describe('test IndividualOfferNavigation', () => {
 
     it('should render steps on Summary', () => {
       renderIndividualOfferNavigation(
-        { offer: GetIndividualOfferFactory({ isEvent: false }) },
+        { offer: getIndividualOfferFactory({ isEvent: false }) },
         generatePath(
           getIndividualOfferPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
@@ -214,7 +214,7 @@ describe('test IndividualOfferNavigation', () => {
       renderIndividualOfferNavigation(
         {
           offer: {
-            ...GetIndividualOfferFactory(),
+            ...getIndividualOfferFactory(),
             isEvent: true,
           },
         },
@@ -241,7 +241,7 @@ describe('test IndividualOfferNavigation', () => {
       renderIndividualOfferNavigation(
         {
           offer: {
-            ...GetIndividualOfferFactory(),
+            ...getIndividualOfferFactory(),
             isEvent: false,
           },
         },
@@ -266,7 +266,7 @@ describe('test IndividualOfferNavigation', () => {
 
   describe('in edition', () => {
     it('should render tabs navigation in edition', () => {
-      const offer = GetIndividualOfferFactory({
+      const offer = getIndividualOfferFactory({
         id: offerId,
         isEvent: true,
       })
@@ -289,7 +289,7 @@ describe('test IndividualOfferNavigation', () => {
     })
 
     it('should render steps on Information', () => {
-      const offer = GetIndividualOfferFactory({
+      const offer = getIndividualOfferFactory({
         id: offerId,
         isEvent: false,
       })
@@ -315,7 +315,7 @@ describe('test IndividualOfferNavigation', () => {
     })
 
     it('should render steps on Stocks', () => {
-      const offer = GetIndividualOfferFactory({
+      const offer = getIndividualOfferFactory({
         id: offerId,
         isEvent: false,
       })

--- a/pro/src/components/OfferAppPreview/OfferAppPreview.stories.tsx
+++ b/pro/src/components/OfferAppPreview/OfferAppPreview.stories.tsx
@@ -1,7 +1,7 @@
 import { Story } from '@storybook/react'
 import React from 'react'
 
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 
 import testImg from './__specs__/offer_storie_image.jpg'
 import { OfferAppPreviewProps } from './OfferAppPreview'
@@ -28,22 +28,22 @@ const Template: Story<OfferAppPreviewProps> = (args) => (
 export const Default = Template.bind({})
 
 Default.args = {
-  offer: GetIndividualOfferFactory(baseOfferData),
+  offer: getIndividualOfferFactory(baseOfferData),
 }
 
 export const NoImage = Template.bind({})
 NoImage.args = {
-  offer: GetIndividualOfferFactory({ ...baseOfferData }),
+  offer: getIndividualOfferFactory({ ...baseOfferData }),
 }
 
 export const NotDuo = Template.bind({})
 NotDuo.args = {
-  offer: GetIndividualOfferFactory({ ...baseOfferData, isDuo: false }),
+  offer: getIndividualOfferFactory({ ...baseOfferData, isDuo: false }),
 }
 
 export const TextTooLong = Template.bind({})
 TextTooLong.args = {
-  offer: GetIndividualOfferFactory({
+  offer: getIndividualOfferFactory({
     ...baseOfferData,
     name: `Les douze moutons, aux nombre de pattes variable voulant participer aux jeux olympique. Instant préérique ou la compétition bàààààhéé sont plein.
     Ce titre semble bien trop long pour apparaitre en entier sur cette prévisualisation, mais etonnament, c'est le comportement que nous avons actuelement. Voulons nous le changer ? Cela peut il faire débat, durant combient de temps ?

--- a/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
+++ b/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
@@ -11,7 +11,7 @@ import * as useNotification from 'hooks/useNotification'
 import {
   collectiveOfferFactory,
   collectiveOfferTemplateFactory,
-  collectiveStockFactory,
+  getCollectiveOfferCollectiveStockFactory,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -191,7 +191,7 @@ describe('OfferEducationalActions', () => {
       ...defaultValues,
       offer: collectiveOfferFactory({
         isActive: false,
-        collectiveStock: collectiveStockFactory({
+        collectiveStock: getCollectiveOfferCollectiveStockFactory({
           bookingLimitDatetime: '1900-10-15T00:00:00Z',
         }),
       }),
@@ -224,7 +224,7 @@ describe('OfferEducationalActions', () => {
       offer: collectiveOfferFactory({
         id: offerId,
         isActive: false,
-        collectiveStock: collectiveStockFactory({
+        collectiveStock: getCollectiveOfferCollectiveStockFactory({
           bookingLimitDatetime: bookingLimitDateTomorrow.toDateString(),
         }),
       }),

--- a/pro/src/components/StocksEventList/__specs__/StocksEventList.spec.tsx
+++ b/pro/src/components/StocksEventList/__specs__/StocksEventList.spec.tsx
@@ -5,9 +5,9 @@ import * as router from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { GetOfferStockResponseModel, StocksOrderedBy } from 'apiClient/v1'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import {
-  individualGetOfferStockResponseModelFactory,
+  getOfferStockFactory,
   priceCategoryFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -34,15 +34,15 @@ vi.mock('react-router-dom', async () => ({
 
 const offerId = 1
 const filteredPriceCategoryId = 3
-const stock1 = individualGetOfferStockResponseModelFactory({
+const stock1 = getOfferStockFactory({
   beginningDatetime: new Date('2021-10-15T12:00:00Z').toISOString(),
   priceCategoryId: 1,
 })
-const stock2 = individualGetOfferStockResponseModelFactory({
+const stock2 = getOfferStockFactory({
   beginningDatetime: new Date('2021-10-14T13:00:00Z').toISOString(),
   priceCategoryId: 2,
 })
-const stock3 = individualGetOfferStockResponseModelFactory({
+const stock3 = getOfferStockFactory({
   beginningDatetime: new Date('2021-10-14T12:00:00Z').toISOString(),
   priceCategoryId: filteredPriceCategoryId,
 })
@@ -64,7 +64,7 @@ const renderStocksEventList = async (
         priceCategoryFactory({ label: 'Label', price: 30.5, id: 3 }),
       ]}
       departmentCode={props.departmentCode ?? '78'}
-      offer={GetIndividualOfferFactory({ id: offerId })}
+      offer={getIndividualOfferFactory({ id: offerId })}
       {...props}
     />
   )
@@ -91,7 +91,7 @@ describe('StocksEventList', () => {
 
   it('should render Illimité', async () => {
     await renderStocksEventList([
-      individualGetOfferStockResponseModelFactory({
+      getOfferStockFactory({
         priceCategoryId: 1,
         quantity: null,
       }),
@@ -319,15 +319,15 @@ describe('StocksEventList', () => {
   })
 
   it('should bulk delete lines with filters and use UTC for hour filter when clicking on button on action bar', async () => {
-    const stockTime1 = individualGetOfferStockResponseModelFactory({
+    const stockTime1 = getOfferStockFactory({
       priceCategoryId: 1,
       beginningDatetime: '2021-09-15T10:00:00.000Z',
     })
-    const stockTime2 = individualGetOfferStockResponseModelFactory({
+    const stockTime2 = getOfferStockFactory({
       priceCategoryId: 1,
       beginningDatetime: '2021-10-15T10:00:00.000Z',
     })
-    const stockTime3 = individualGetOfferStockResponseModelFactory({
+    const stockTime3 = getOfferStockFactory({
       priceCategoryId: 1,
       beginningDatetime: '2021-10-15T11:00:00.000Z',
     })

--- a/pro/src/components/VenueForm/BankAccountInfos/BankAccountInfos.spec.tsx
+++ b/pro/src/components/VenueForm/BankAccountInfos/BankAccountInfos.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import { Formik } from 'formik'
 
 import { BankAccountResponseModel } from 'apiClient/v1'
-import { defaultBankAccountResponseModel } from 'utils/apiFactories'
+import { defaultBankAccount } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import BankAccountInfos from './BankAccountInfos'
@@ -23,7 +23,7 @@ const renderBankAccountInfos = (
 describe('BankAccountInfos', () => {
   it('should display bankAccount infos if venue has one', () => {
     const bankAccount = {
-      ...defaultBankAccountResponseModel,
+      ...defaultBankAccount,
       label: 'CB #1',
       obfuscatedIban: '123456',
     }
@@ -35,7 +35,7 @@ describe('BankAccountInfos', () => {
   })
 
   it('should display modification banner if venue has a bank account', () => {
-    renderBankAccountInfos(defaultBankAccountResponseModel)
+    renderBankAccountInfos(defaultBankAccount)
 
     expect(
       screen.getByText(

--- a/pro/src/components/VenueForm/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { DMSApplicationForEAC, DMSApplicationstatus } from 'apiClient/v1'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { defaultCollectiveDmsApplication } from 'utils/collectiveApiFactories'
+import { defaultDMSApplicationForEAC } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { CollectiveDmsTimeline } from '../CollectiveDmsTimeline'
@@ -45,21 +45,21 @@ describe('CollectiveDmsTimeline', () => {
   const testCases: TestCaseProps[] = [
     {
       collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
+        ...defaultDMSApplicationForEAC,
         state: DMSApplicationstatus.EN_CONSTRUCTION,
       },
       expectedLabel: 'Votre dossier a été déposé',
     },
     {
       collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
+        ...defaultDMSApplicationForEAC,
         state: DMSApplicationstatus.EN_INSTRUCTION,
       },
       expectedLabel: 'Votre dossier est en cours d’instruction',
     },
     {
       collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
+        ...defaultDMSApplicationForEAC,
         state: DMSApplicationstatus.ACCEPTE,
       },
       expectedLabel: 'Votre demande de référencement a été acceptée',
@@ -67,7 +67,7 @@ describe('CollectiveDmsTimeline', () => {
 
     {
       collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
+        ...defaultDMSApplicationForEAC,
         state: DMSApplicationstatus.ACCEPTE,
       },
       hasAdageId: true,
@@ -76,14 +76,14 @@ describe('CollectiveDmsTimeline', () => {
     },
     {
       collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
+        ...defaultDMSApplicationForEAC,
         state: DMSApplicationstatus.REFUSE,
       },
       expectedLabel: 'Votre demande de référencement a été refusée',
     },
     {
       collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
+        ...defaultDMSApplicationForEAC,
         state: DMSApplicationstatus.ACCEPTE,
       },
       hasAdageId: true,
@@ -92,7 +92,7 @@ describe('CollectiveDmsTimeline', () => {
     },
     {
       collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
+        ...defaultDMSApplicationForEAC,
         state: DMSApplicationstatus.EN_CONSTRUCTION,
       },
       hasAdageId: true,
@@ -100,7 +100,7 @@ describe('CollectiveDmsTimeline', () => {
     },
     {
       collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
+        ...defaultDMSApplicationForEAC,
         state: DMSApplicationstatus.SANS_SUITE,
       },
       expectedLabel: 'Votre demande de référencement a été classée sans suite',
@@ -141,7 +141,7 @@ describe('CollectiveDmsTimeline', () => {
     async (dmsState: DMSApplicationstatus) => {
       renderCollectiveDmsTimeline({
         collectiveDmsApplication: {
-          ...defaultCollectiveDmsApplication,
+          ...defaultDMSApplicationForEAC,
           state: dmsState,
         },
       })

--- a/pro/src/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
+++ b/pro/src/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
@@ -13,7 +13,10 @@ import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { ApiError } from 'apiClient/v2'
 import Notification from 'components/Notification/Notification'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared/constants'
-import { GetIndividualOfferFactory, offererFactory } from 'utils/apiFactories'
+import {
+  getIndividualOfferFactory,
+  getOfferManagingOffererFactory,
+} from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -21,8 +24,8 @@ import {
   IndividualOfferContextProviderProps,
 } from '../IndividualOfferContext'
 
-const offerer = offererFactory()
-const apiOffer: GetIndividualOfferResponseModel = GetIndividualOfferFactory()
+const offerer = getOfferManagingOffererFactory()
+const apiOffer: GetIndividualOfferResponseModel = getIndividualOfferFactory()
 
 vi.mock('react-router-dom', async () => ({
   ...((await vi.importActual('react-router-dom')) ?? {}),

--- a/pro/src/context/IndividualOfferContext/adapters/getWizardData/__specs__/getWizardData.spec.ts
+++ b/pro/src/context/IndividualOfferContext/adapters/getWizardData/__specs__/getWizardData.spec.ts
@@ -1,14 +1,14 @@
 import { api } from 'apiClient/api'
 import { VenueListItemResponseModel } from 'apiClient/v1'
 import {
-  individualOfferCategoryFactory,
-  individualOfferGetVenuesFactory,
-  individualOfferSubCategoryResponseModelFactory,
+  categoryFactory,
+  subcategoryFactory,
+  venueListItemFactory,
 } from 'utils/individualApiFactories'
 
 import getWizardData from '../getWizardData'
 
-const venue1: VenueListItemResponseModel = individualOfferGetVenuesFactory({
+const venue1: VenueListItemResponseModel = venueListItemFactory({
   id: 2,
   isVirtual: false,
   managingOffererId: 3,
@@ -16,7 +16,7 @@ const venue1: VenueListItemResponseModel = individualOfferGetVenuesFactory({
   offererName: 'ma structure',
 })
 
-const venue2: VenueListItemResponseModel = individualOfferGetVenuesFactory({
+const venue2: VenueListItemResponseModel = venueListItemFactory({
   id: 3,
   isVirtual: false,
   managingOffererId: 4,
@@ -37,11 +37,9 @@ const offererName2 = {
 describe('getWizardData', () => {
   it('should return empty data when user is admin and offerer not specified', async () => {
     vi.spyOn(api, 'getCategories').mockResolvedValueOnce({
-      categories: [
-        individualOfferCategoryFactory({ id: 'A', proLabel: 'catégorie 1' }),
-      ],
+      categories: [categoryFactory({ id: 'A', proLabel: 'catégorie 1' })],
       subcategories: [
-        individualOfferSubCategoryResponseModelFactory({
+        subcategoryFactory({
           id: '1',
           proLabel: 'sous-catégorie 1',
         }),
@@ -136,13 +134,13 @@ describe('getWizardData', () => {
 
   it('should return all offerers and venue list when user is admin and offerer not given', async () => {
     vi.spyOn(api, 'getCategories').mockResolvedValueOnce({
-      categories: [
-        individualOfferCategoryFactory({ id: 'A', proLabel: 'catégorie 1' }),
-      ],
+      categories: [categoryFactory({ id: 'A', proLabel: 'catégorie 1' })],
       subcategories: [
-        individualOfferSubCategoryResponseModelFactory({
+        subcategoryFactory({
           id: '1',
           proLabel: 'sous-catégorie 1',
+          appLabel: 'app label',
+          isDigitalDeposit: true,
         }),
       ],
     })
@@ -171,7 +169,7 @@ describe('getWizardData', () => {
           ],
           subCategories: [
             {
-              appLabel: 'appLabel',
+              appLabel: 'app label',
               canExpire: true,
               canBeDuo: false,
               canBeEducational: false,

--- a/pro/src/core/OfferEducational/utils/__specs__/extractInitialStockValues.spec.ts
+++ b/pro/src/core/OfferEducational/utils/__specs__/extractInitialStockValues.spec.ts
@@ -4,7 +4,7 @@ import {
   CollectiveOffer,
   CollectiveOfferTemplate,
 } from 'core/OfferEducational/types'
-import { defaultRequestResponseModel } from 'utils/collectiveApiFactories'
+import { defaultGetCollectiveOfferRequest } from 'utils/collectiveApiFactories'
 
 import { extractInitialStockValues } from '../extractInitialStockValues'
 
@@ -67,7 +67,7 @@ describe('extractInitialVisibilityValues', () => {
           educationalPriceDetail: 'initialStockValues',
         } as CollectiveOfferTemplate,
         {
-          ...defaultRequestResponseModel,
+          ...defaultGetCollectiveOfferRequest,
           requestedDate: '2030-07-30',
           totalStudents: 10,
           totalTeachers: 10,
@@ -94,7 +94,7 @@ describe('extractInitialVisibilityValues', () => {
           educationalPriceDetail: 'initialStockValues',
         } as CollectiveOfferTemplate,
         {
-          ...defaultRequestResponseModel,
+          ...defaultGetCollectiveOfferRequest,
           requestedDate: null,
           totalStudents: null,
           totalTeachers: null,
@@ -121,7 +121,7 @@ describe('extractInitialVisibilityValues', () => {
           educationalPriceDetail: 'initialStockValues',
         } as CollectiveOfferTemplate,
         {
-          ...defaultRequestResponseModel,
+          ...defaultGetCollectiveOfferRequest,
           totalStudents: 8,
         }
       )
@@ -146,7 +146,7 @@ describe('extractInitialVisibilityValues', () => {
           educationalPriceDetail: 'initialStockValues',
         } as CollectiveOfferTemplate,
         {
-          ...defaultRequestResponseModel,
+          ...defaultGetCollectiveOfferRequest,
           totalTeachers: 6,
         }
       )

--- a/pro/src/core/Offers/adapters/getOffererAdapter.ts
+++ b/pro/src/core/Offers/adapters/getOffererAdapter.ts
@@ -1,8 +1,8 @@
 import { api } from 'apiClient/api'
-import { Offerer } from 'core/Offers/types'
+import { GetOffererResponseModel } from 'apiClient/v1'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
 
-type Payload = Offerer
+type Payload = GetOffererResponseModel
 
 type GetOffererAdapter = Adapter<string, Payload, null>
 
@@ -19,10 +19,7 @@ const getOffererAdapter: GetOffererAdapter = async (offererId: string) => {
     return {
       isOk: true,
       message: null,
-      payload: {
-        id: offerer.id,
-        name: offerer.name,
-      },
+      payload: offerer,
     }
   } catch (e) {
     return FAILING_RESPONSE

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
@@ -3,7 +3,7 @@ import { PatchOfferBodyModel } from 'apiClient/v1'
 import { IndividualOfferFormValues } from 'components/IndividualOfferForm'
 import { OfferExtraData } from 'core/Offers/types'
 import { AccessiblityEnum } from 'core/shared'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 
 import {
   serializeDurationMinutes,
@@ -112,7 +112,7 @@ describe('test updateIndividualOffer::serializers', () => {
 
     it('should serialize patchBody', () => {
       expect(
-        serializePatchOffer({ offer: GetIndividualOfferFactory(), formValues })
+        serializePatchOffer({ offer: getIndividualOfferFactory(), formValues })
       ).toEqual(patchBody)
     })
     it('should serialize patchBody with default', () => {
@@ -131,7 +131,7 @@ describe('test updateIndividualOffer::serializers', () => {
         url: undefined,
       }
       expect(
-        serializePatchOffer({ offer: GetIndividualOfferFactory(), formValues })
+        serializePatchOffer({ offer: getIndividualOfferFactory(), formValues })
       ).toEqual(patchBody)
     })
   })

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -18,11 +18,6 @@ export type SearchFiltersParams = {
   page?: number
 }
 
-export type Offerer = {
-  id: number
-  name: string
-}
-
 export interface CategorySubtypeItem {
   code: number
   label: string

--- a/pro/src/core/Providers/utils/__specs__/isAllocineOffer.spec.ts
+++ b/pro/src/core/Providers/utils/__specs__/isAllocineOffer.spec.ts
@@ -1,4 +1,4 @@
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 
 import { isAllocineOffer } from '../localProvider'
 
@@ -6,7 +6,7 @@ describe('isAllocineOffer', () => {
   it('should return true if last provider name is Allociné', () => {
     expect(
       isAllocineOffer(
-        GetIndividualOfferFactory({
+        getIndividualOfferFactory({
           lastProvider: {
             name: 'Allociné',
           },
@@ -18,7 +18,7 @@ describe('isAllocineOffer', () => {
   it('should return false if last provider name does not contain Allociné', () => {
     expect(
       isAllocineOffer(
-        GetIndividualOfferFactory({
+        getIndividualOfferFactory({
           lastProvider: {
             name: 'Anyotherprovider',
           },
@@ -30,7 +30,7 @@ describe('isAllocineOffer', () => {
   it('should return false if last provider is null', () => {
     expect(
       isAllocineOffer(
-        GetIndividualOfferFactory({
+        getIndividualOfferFactory({
           lastProvider: null,
         })
       )
@@ -39,7 +39,7 @@ describe('isAllocineOffer', () => {
 
   it('should return false if last provider is undefined', () => {
     expect(
-      isAllocineOffer(GetIndividualOfferFactory({ lastProvider: undefined }))
+      isAllocineOffer(getIndividualOfferFactory({ lastProvider: undefined }))
     ).toBe(false)
   })
 })

--- a/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -10,14 +10,12 @@ import {
 import Notification from 'components/Notification/Notification'
 import { DEFAULT_PRE_FILTERS } from 'core/Bookings/constants'
 import * as pcapi from 'repository/pcapi/pcapi'
-import {
-  bookingRecapFactory,
-  getVenueListItemFactory,
-} from 'utils/apiFactories'
+import { bookingRecapFactory } from 'utils/apiFactories'
 import {
   FORMAT_ISO_DATE_ONLY,
   formatBrowserTimezonedDateAsUTC,
 } from 'utils/date'
+import { venueListItemFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { Bookings } from '../Bookings'
@@ -116,7 +114,7 @@ describe('components | BookingsRecap | Pro user', () => {
       },
     }
     vi.spyOn(api, 'getProfile').mockResolvedValue(user)
-    venue = getVenueListItemFactory({})
+    venue = venueListItemFactory()
     vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: [venue] })
     vi.spyOn(api, 'getUserHasBookings').mockResolvedValue({ hasBookings: true })
   })
@@ -560,7 +558,7 @@ describe('components | BookingsRecap | Pro user', () => {
     // Given
     const booking = bookingRecapFactory()
     const otherVenueBooking = bookingRecapFactory()
-    const otherVenue = getVenueListItemFactory()
+    const otherVenue = venueListItemFactory()
     vi.spyOn(api, 'getVenues').mockResolvedValue({
       venues: [venue, otherVenue],
     })

--- a/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
@@ -7,12 +7,8 @@ import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { api } from 'apiClient/api'
-import type { GetCollectiveOfferResponseModel } from 'apiClient/v1'
 import { MandatoryCollectiveOfferFromParamsProps } from 'screens/OfferEducational/useCollectiveOfferFromParams'
-import {
-  defaultGetCollectiveOffer,
-  defaultGetOffererResponseModel,
-} from 'utils/apiFactories'
+import { defaultGetOffererResponseModel } from 'utils/apiFactories'
 import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
 import {
   RenderWithProvidersOptions,
@@ -92,9 +88,9 @@ describe('CollectiveOfferSummaryCreation', () => {
 
   it('Should show the redirect modal', async () => {
     vi.spyOn(api, 'patchCollectiveOfferPublication').mockResolvedValue({
-      ...defaultGetCollectiveOffer,
+      ...collectiveOfferFactory(),
       isNonFreeOffer: true,
-    } as GetCollectiveOfferResponseModel)
+    })
     await renderCollectiveOfferSummaryCreation(
       '/offre/A1/collectif/creation/recapitulatif',
       {

--- a/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
@@ -10,7 +10,7 @@ import { api } from 'apiClient/api'
 import type { GetCollectiveOfferResponseModel } from 'apiClient/v1'
 import { MandatoryCollectiveOfferFromParamsProps } from 'screens/OfferEducational/useCollectiveOfferFromParams'
 import {
-  defaultGetCollectiveOfferResponseModel,
+  defaultGetCollectiveOffer,
   defaultGetOffererResponseModel,
 } from 'utils/apiFactories'
 import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
@@ -92,7 +92,7 @@ describe('CollectiveOfferSummaryCreation', () => {
 
   it('Should show the redirect modal', async () => {
     vi.spyOn(api, 'patchCollectiveOfferPublication').mockResolvedValue({
-      ...defaultGetCollectiveOfferResponseModel,
+      ...defaultGetCollectiveOffer,
       isNonFreeOffer: true,
     } as GetCollectiveOfferResponseModel)
     await renderCollectiveOfferSummaryCreation(

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -2,12 +2,15 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
-import { CollectiveOfferResponseModel } from 'apiClient/v1'
+import {
+  CollectiveOfferResponseModel,
+  GetOffererResponseModel,
+} from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import { getOffererAdapter } from 'core/Offers/adapters'
 import { DEFAULT_PAGE, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQuerySearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
-import { Offerer, SearchFiltersParams } from 'core/Offers/types'
+import { SearchFiltersParams } from 'core/Offers/types'
 import { hasSearchFilters, computeCollectiveOffersUrl } from 'core/Offers/utils'
 import { Audience } from 'core/shared/types'
 import getVenuesForOffererAdapter from 'core/Venue/adapters/getVenuesForOffererAdapter'
@@ -29,7 +32,7 @@ export const CollectiveOffers = (): JSX.Element => {
   const { currentUser } = useCurrentUser()
   const dispatch = useDispatch()
 
-  const [offerer, setOfferer] = useState<Offerer | null>(null)
+  const [offerer, setOfferer] = useState<GetOffererResponseModel | null>(null)
   const [offers, setOffers] = useState<CollectiveOfferResponseModel[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [initialSearchFilters, setInitialSearchFilters] =

--- a/pro/src/pages/CollectiveOffers/utils/collectiveOffersFactories.ts
+++ b/pro/src/pages/CollectiveOffers/utils/collectiveOffersFactories.ts
@@ -7,7 +7,7 @@ import {
 let offerId = 1
 
 export const collectiveOfferFactory = (
-  customOffer: Partial<CollectiveOfferResponseModel> = {}
+  customCollectiveOffer: Partial<CollectiveOfferResponseModel> = {}
 ): CollectiveOfferResponseModel => {
   const currentId = offerId++
 
@@ -18,22 +18,22 @@ export const collectiveOfferFactory = (
     hasBookingLimitDatetimesPassed: true,
     isEducational: true,
     name: `offer name ${offerId}`,
-    venue: venueFactory(),
+    venue: listOffersVenueFactory(),
     stocks: [],
     isEditable: true,
     isPublicApi: false,
     interventionArea: [],
     isShowcase: false,
-    ...customOffer,
+    ...customCollectiveOffer,
   }
 }
 
-export const venueFactory = (
-  customVenue: Partial<ListOffersVenueResponseModel> = {}
+export const listOffersVenueFactory = (
+  customListOffersVenue: Partial<ListOffersVenueResponseModel> = {}
 ): ListOffersVenueResponseModel => ({
   id: 1,
   name: 'venue name',
   offererName: 'offerer name',
   isVirtual: false,
-  ...customVenue,
+  ...customListOffersVenue,
 })

--- a/pro/src/pages/Desk/BookingDetails/__specs__/BookingDetails.spec.tsx
+++ b/pro/src/pages/Desk/BookingDetails/__specs__/BookingDetails.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 
-import { defaultBookingResponse } from 'utils/apiFactories'
+import { defaultGetBookingResponse } from 'utils/apiFactories'
 
 import BookingDetails from '../BookingDetails'
 
@@ -9,7 +9,7 @@ describe('BookingDetails', () => {
     render(
       <BookingDetails
         {...{
-          booking: { ...defaultBookingResponse, quantity: 2 },
+          booking: { ...defaultGetBookingResponse, quantity: 2 },
         }}
       />
     )
@@ -22,7 +22,7 @@ describe('BookingDetails', () => {
       <BookingDetails
         {...{
           booking: {
-            ...defaultBookingResponse,
+            ...defaultGetBookingResponse,
             datetime: '2001-02-01T20:00:00Z',
           },
         }}
@@ -36,7 +36,7 @@ describe('BookingDetails', () => {
     render(
       <BookingDetails
         {...{
-          booking: { ...defaultBookingResponse, datetime: '' },
+          booking: { ...defaultGetBookingResponse, datetime: '' },
         }}
       />
     )
@@ -49,7 +49,7 @@ describe('BookingDetails', () => {
       <BookingDetails
         {...{
           booking: {
-            ...defaultBookingResponse,
+            ...defaultGetBookingResponse,
             venueDepartmentCode: undefined,
           },
         }}

--- a/pro/src/pages/Desk/__specs__/Desk.spec.tsx
+++ b/pro/src/pages/Desk/__specs__/Desk.spec.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
-import { defaultBookingResponse } from 'utils/apiFactories'
+import { defaultGetBookingResponse } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import * as getBookingAdapter from '../adapters/getBooking'
@@ -63,7 +63,7 @@ describe('src | components | Desk', () => {
 
     it('should check that token is valid and display booking details', async () => {
       vi.spyOn(getBookingAdapter, 'getBooking').mockResolvedValue({
-        booking: defaultBookingResponse,
+        booking: defaultGetBookingResponse,
       })
       renderDesk()
       const contremarque = screen.getByLabelText('Contremarque *')
@@ -75,7 +75,7 @@ describe('src | components | Desk', () => {
         )
       ).toBeInTheDocument()
       expect(
-        await screen.findByText(defaultBookingResponse.offerName)
+        await screen.findByText(defaultGetBookingResponse.offerName)
       ).toBeInTheDocument()
     })
 
@@ -97,7 +97,7 @@ describe('src | components | Desk', () => {
   describe('Should validate contremarque when the user submits the form', () => {
     beforeEach(() => {
       vi.spyOn(getBookingAdapter, 'getBooking').mockResolvedValueOnce({
-        booking: defaultBookingResponse,
+        booking: defaultGetBookingResponse,
       })
     })
     it('should display confirmation message and empty field when contremarque is validated', async () => {

--- a/pro/src/pages/Desk/adapters/__specs__/getBooking.spec.ts
+++ b/pro/src/pages/Desk/adapters/__specs__/getBooking.spec.ts
@@ -3,7 +3,7 @@ import { ApiError } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { MESSAGE_VARIANT } from 'pages/Desk/types'
-import { defaultBookingResponse } from 'utils/apiFactories'
+import { defaultGetBookingResponse } from 'utils/apiFactories'
 
 import { getBooking } from '..'
 
@@ -11,12 +11,12 @@ describe('getBooking', () => {
   describe('success', () => {
     it('should return serialized booking', async () => {
       vi.spyOn(apiContremarque, 'getBookingByTokenV2').mockResolvedValue(
-        defaultBookingResponse
+        defaultGetBookingResponse
       )
 
       const serializedBooking = await getBooking('test_booking_id')
       expect(serializedBooking).toStrictEqual({
-        booking: defaultBookingResponse,
+        booking: defaultGetBookingResponse,
       })
     })
   })

--- a/pro/src/pages/Home/Offerers/__specs__/PartnerPageCollectiveSection.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/PartnerPageCollectiveSection.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import * as router from 'react-router-dom'
 
 import { DMSApplicationstatus, VenueTypeCode } from 'apiClient/v1'
-import { defaultCollectiveDmsApplication } from 'utils/collectiveApiFactories'
+import { defaultDMSApplicationForEAC } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -15,7 +15,7 @@ const renderPartnerPageCollectiveSection = (
 ) => {
   renderWithProviders(
     <PartnerPageCollectiveSection
-      collectiveDmsApplications={[defaultCollectiveDmsApplication]}
+      collectiveDmsApplications={[defaultDMSApplicationForEAC]}
       venueId={7}
       hasAdageId={false}
       {...props}
@@ -50,7 +50,7 @@ describe('PartnerPages', () => {
     renderPartnerPageCollectiveSection({
       collectiveDmsApplications: [
         {
-          ...defaultCollectiveDmsApplication,
+          ...defaultDMSApplicationForEAC,
           state: DMSApplicationstatus.REFUSE,
         },
       ],
@@ -66,7 +66,7 @@ describe('PartnerPages', () => {
     renderPartnerPageCollectiveSection({
       collectiveDmsApplications: [
         {
-          ...defaultCollectiveDmsApplication,
+          ...defaultDMSApplicationForEAC,
           state: DMSApplicationstatus.SANS_SUITE,
         },
       ],
@@ -82,7 +82,7 @@ describe('PartnerPages', () => {
     renderPartnerPageCollectiveSection({
       collectiveDmsApplications: [
         {
-          ...defaultCollectiveDmsApplication,
+          ...defaultDMSApplicationForEAC,
           state: DMSApplicationstatus.EN_INSTRUCTION,
         },
       ],
@@ -95,7 +95,7 @@ describe('PartnerPages', () => {
     renderPartnerPageCollectiveSection({
       collectiveDmsApplications: [
         {
-          ...defaultCollectiveDmsApplication,
+          ...defaultDMSApplicationForEAC,
           state: DMSApplicationstatus.ACCEPTE,
         },
       ],

--- a/pro/src/pages/IndividualOfferWizard/Confirmation/__specs__/Confirmation.spec.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Confirmation/__specs__/Confirmation.spec.tsx
@@ -12,10 +12,10 @@ import {
 } from 'context/IndividualOfferContext'
 import { RootState } from 'store/rootReducer'
 import {
-  GetIndividualOfferFactory,
-  offerVenueFactory,
+  getIndividualOfferFactory,
+  getOfferVenueFactory,
 } from 'utils/apiFactories'
-import { individualOfferContextFactory } from 'utils/individualApiFactories'
+import { individualOfferContextValuesFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { Confirmation } from '../Confirmation'
@@ -33,7 +33,7 @@ const renderOffer = (
   contextOverride: Partial<IndividualOfferContextValues>,
   storeOverride?: Partial<RootState>
 ) => {
-  const contextValue = individualOfferContextFactory(contextOverride)
+  const contextValue = individualOfferContextValuesFactory(contextOverride)
 
   const storeOverrides = {
     user: {
@@ -81,8 +81,8 @@ describe('Confirmation', () => {
         },
       },
     }
-    offer = GetIndividualOfferFactory({
-      venue: offerVenueFactory({
+    offer = getIndividualOfferFactory({
+      venue: getOfferVenueFactory({
         id: venueId,
         managingOfferer: {
           id: offererId,

--- a/pro/src/pages/IndividualOfferWizard/PriceCategories/__specs__/PriceCategories.spec.tsx
+++ b/pro/src/pages/IndividualOfferWizard/PriceCategories/__specs__/PriceCategories.spec.tsx
@@ -6,7 +6,7 @@ import {
   IndividualOfferContextValues,
   IndividualOfferContext,
 } from 'context/IndividualOfferContext'
-import { individualOfferContextFactory } from 'utils/individualApiFactories'
+import { individualOfferContextValuesFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { PriceCategories } from '../PriceCategories'
@@ -15,7 +15,7 @@ const renderOffer = (
   contextOverride?: Partial<IndividualOfferContextValues>
 ) => {
   const contextValue: IndividualOfferContextValues =
-    individualOfferContextFactory(contextOverride)
+    individualOfferContextValuesFactory(contextOverride)
 
   return renderWithProviders(
     <Routes>

--- a/pro/src/pages/IndividualOfferWizard/Stocks/__specs__/Stocks.spec.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Stocks/__specs__/Stocks.spec.tsx
@@ -9,12 +9,12 @@ import {
 } from 'context/IndividualOfferContext'
 import { RootState } from 'store/rootReducer'
 import {
-  GetIndividualOfferFactory,
-  offerVenueFactory,
+  getIndividualOfferFactory,
+  getOfferVenueFactory,
 } from 'utils/apiFactories'
 import {
-  individualGetOfferStockResponseModelFactory,
-  individualOfferContextFactory,
+  getOfferStockFactory,
+  individualOfferContextValuesFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -24,7 +24,7 @@ const renderStocksScreen = (
   storeOverrides: Partial<RootState> = {},
   contextOverride: Partial<IndividualOfferContextValues>
 ) => {
-  const contextValue = individualOfferContextFactory(contextOverride)
+  const contextValue = individualOfferContextValuesFactory(contextOverride)
 
   return renderWithProviders(
     <IndividualOfferContext.Provider value={contextValue}>
@@ -41,27 +41,27 @@ describe('screens:Stocks', () => {
   const offerId = 12
 
   beforeEach(() => {
-    offer = GetIndividualOfferFactory({
+    offer = getIndividualOfferFactory({
       id: offerId,
-      venue: offerVenueFactory({
+      venue: getOfferVenueFactory({
         departementCode: '75',
       }),
     })
     storeOverrides = {}
-    contextOverride = individualOfferContextFactory({
+    contextOverride = individualOfferContextValuesFactory({
       offerId,
       offer,
     })
 
     vi.spyOn(api, 'getStocks').mockResolvedValue({
-      stocks: [individualGetOfferStockResponseModelFactory()],
+      stocks: [getOfferStockFactory()],
       hasStocks: true,
       stockCount: 1,
     })
   })
 
   it('should render stock thing', async () => {
-    contextOverride.offer = GetIndividualOfferFactory({
+    contextOverride.offer = getIndividualOfferFactory({
       ...contextOverride.offer,
       isEvent: false,
       isDigital: false,
@@ -76,7 +76,7 @@ describe('screens:Stocks', () => {
   })
 
   it('should render stock event', async () => {
-    contextOverride.offer = GetIndividualOfferFactory({
+    contextOverride.offer = getIndividualOfferFactory({
       ...contextOverride.offer,
       isEvent: true,
     })
@@ -95,7 +95,7 @@ describe('screens:Stocks', () => {
   it.each(offerStatusWithoutBanner)(
     'should not render stock description banner',
     async (offerStatus) => {
-      contextOverride.offer = GetIndividualOfferFactory({
+      contextOverride.offer = getIndividualOfferFactory({
         ...contextOverride.offer,
         isEvent: true,
         status: offerStatus,
@@ -122,7 +122,7 @@ describe('screens:Stocks', () => {
   it.each(offerStatusWithBanner)(
     'should render stock description banner',
     async (offerStatus) => {
-      contextOverride.offer = GetIndividualOfferFactory({
+      contextOverride.offer = getIndividualOfferFactory({
         ...contextOverride.offer,
         isEvent: true,
         status: offerStatus,

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataEdition.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataEdition.spec.tsx
@@ -18,9 +18,9 @@ import {
 } from 'core/shared/interventionOptions'
 import * as useNotification from 'hooks/useNotification'
 import {
-  defaultCollectiveDmsApplication,
-  defaultVenueResponseModel,
-  venueCollectiveDataFactory,
+  defaultDMSApplicationForEAC,
+  defaultGetVenue,
+  getCollectiveVenueFactory,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -84,7 +84,7 @@ const renderCollectiveDataEdition = (
 ) =>
   renderWithProviders(
     <CollectiveDataEdition
-      venue={{ ...defaultVenueResponseModel, hasAdageId: true }}
+      venue={{ ...defaultGetVenue, hasAdageId: true }}
       {...props}
     />
   )
@@ -112,7 +112,7 @@ describe('CollectiveDataEdition', () => {
     ])
     vi.spyOn(api, 'getEducationalPartners').mockResolvedValue({ partners: [] })
     vi.spyOn(api, 'editVenueCollectiveData').mockResolvedValue({
-      ...defaultVenueResponseModel,
+      ...defaultGetVenue,
     })
 
     vi.spyOn(useNotification, 'default').mockImplementation(() => ({
@@ -124,7 +124,7 @@ describe('CollectiveDataEdition', () => {
     }))
 
     vi.spyOn(api, 'getVenueCollectiveData').mockResolvedValue(
-      venueCollectiveDataFactory()
+      getCollectiveVenueFactory()
     )
 
     vi.spyOn(api, 'getEducationalPartner').mockRejectedValue({})
@@ -170,10 +170,10 @@ describe('CollectiveDataEdition', () => {
     it('should display dms timeline if venue has dms application and ff active', async () => {
       renderCollectiveDataEdition({
         venue: {
-          ...defaultVenueResponseModel,
+          ...defaultGetVenue,
           id: 1,
           hasAdageId: false,
-          collectiveDmsApplications: [{ ...defaultCollectiveDmsApplication }],
+          collectiveDmsApplications: [{ ...defaultDMSApplicationForEAC }],
         },
       })
 
@@ -489,7 +489,7 @@ describe('CollectiveDataEdition', () => {
         domaineIds: [1, 2],
       })
       vi.spyOn(api, 'getVenueCollectiveData').mockResolvedValue(
-        venueCollectiveDataFactory()
+        getCollectiveVenueFactory()
       )
 
       renderCollectiveDataEdition()
@@ -522,7 +522,7 @@ describe('CollectiveDataEdition', () => {
 
     it('should not call educational partner if venue has no siret and no collective data', async () => {
       vi.spyOn(api, 'getVenueCollectiveData').mockResolvedValue(
-        venueCollectiveDataFactory({
+        getCollectiveVenueFactory({
           siret: undefined,
         })
       )

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/adapters/__specs__/editVenueCollectiveDataAdapter.spec.ts
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/adapters/__specs__/editVenueCollectiveDataAdapter.spec.ts
@@ -2,7 +2,7 @@ import { api } from 'apiClient/api'
 import { ApiError } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
-import { defaultVenueResponseModel } from 'utils/collectiveApiFactories'
+import { defaultGetVenue } from 'utils/collectiveApiFactories'
 
 import { COLLECTIVE_DATA_FORM_INITIAL_VALUES } from '../../CollectiveDataForm/initialValues'
 import editVenueCollectiveDataAdapter from '../editVenueCollectiveDataAdapter'
@@ -31,7 +31,7 @@ describe('editVenueCollectiveDataAdapter', () => {
   it('should return success message', async () => {
     const venueId = 1
     vi.spyOn(api, 'editVenueCollectiveData').mockResolvedValueOnce({
-      ...defaultVenueResponseModel,
+      ...defaultGetVenue,
     })
     const response = await editVenueCollectiveDataAdapter({
       venueId: venueId,
@@ -45,7 +45,7 @@ describe('editVenueCollectiveDataAdapter', () => {
 
     expect(response).toStrictEqual({
       isOk: true,
-      payload: { ...defaultVenueResponseModel, id: venueId },
+      payload: { ...defaultGetVenue, id: venueId },
       message: 'Vos informations ont bien été enregistrées',
     })
     expect(api.editVenueCollectiveData).toHaveBeenCalledWith(venueId, {

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/__specs__/PricingPoint.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/__specs__/PricingPoint.spec.tsx
@@ -8,7 +8,7 @@ import {
   defaultGetOffererResponseModel,
   defaultGetOffererVenueResponseModel,
 } from 'utils/apiFactories'
-import { defaultVenueResponseModel } from 'utils/collectiveApiFactories'
+import { defaultGetVenue } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import PricingPoint, { PricingPointProps } from '../PricingPoint'
@@ -27,7 +27,7 @@ describe('PricingPoint', () => {
         { ...defaultGetOffererVenueResponseModel, siret: '12345678900001' },
       ],
     },
-    venue: { ...defaultVenueResponseModel, pricingPoint: null },
+    venue: { ...defaultGetVenue, pricingPoint: null },
     setVenueHasPricingPoint: vi.fn(),
   }
 

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.tsx
@@ -7,7 +7,7 @@ import {
   GetOffererResponseModel,
   GetOffererVenueResponseModel,
 } from 'apiClient/v1'
-import { defaultVenueResponseModel } from 'utils/collectiveApiFactories'
+import { defaultGetVenue } from 'utils/collectiveApiFactories'
 import {
   RenderWithProvidersOptions,
   renderWithProviders,
@@ -46,7 +46,7 @@ vi.mock('apiClient/api', () => ({
 
 describe('ReimbursementFields', () => {
   const venue = {
-    ...defaultVenueResponseModel,
+    ...defaultGetVenue,
     id: 1,
     name: 'fake venue name',
   }

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -15,7 +15,7 @@ import * as useNotification from 'hooks/useNotification'
 import * as pcapi from 'repository/pcapi/pcapi'
 import {
   collectiveOfferFactory,
-  defaultVenueResponseModel,
+  defaultGetVenue,
 } from 'utils/collectiveApiFactories'
 import * as localStorageAvailable from 'utils/localStorageAvailable'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -187,7 +187,7 @@ describe('DuplicateOfferCell', () => {
       vi.spyOn(router, 'useNavigate').mockReturnValue(mockNavigate)
 
       vi.spyOn(api, 'getVenue').mockResolvedValue({
-        ...defaultVenueResponseModel,
+        ...defaultGetVenue,
       })
 
       vi.spyOn(api, 'getNationalPrograms').mockResolvedValue([])

--- a/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
@@ -18,10 +18,10 @@ import { Audience } from 'core/shared'
 import * as useAnalytics from 'hooks/useAnalytics'
 import {
   collectiveOfferFactory,
-  venueFactory,
+  listOffersVenueFactory,
 } from 'pages/CollectiveOffers/utils/collectiveOffersFactories'
 import {
-  individualOfferFactory,
+  listOffersOfferFactory,
   listOffersStockFactory,
 } from 'screens/Offers/utils/individualOffersFactories'
 import { getToday } from 'utils/date'
@@ -55,7 +55,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
   const offerId = 12
 
   beforeEach(() => {
-    offer = individualOfferFactory({
+    offer = listOffersOfferFactory({
       id: offerId,
       hasBookingLimitDatetimesPassed: false,
       name: 'My little offer',
@@ -83,7 +83,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       })
 
       it('should render an image with an empty url when offer does not have a thumb url', () => {
-        props.offer = individualOfferFactory({ thumbUrl: null })
+        props.offer = listOffersOfferFactory({ thumbUrl: null })
 
         renderOfferItem(props)
 
@@ -204,7 +204,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     })
 
     it('should display the venue name when venue public name is not given', () => {
-      props.offer.venue = venueFactory({
+      props.offer.venue = listOffersVenueFactory({
         name: 'Paris',
         isVirtual: false,
         offererName: 'Offerer name',
@@ -216,7 +216,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     })
 
     it('should display the venue public name when is given', () => {
-      props.offer.venue = venueFactory({
+      props.offer.venue = listOffersVenueFactory({
         name: 'Paris',
         publicName: 'lieu de ouf',
         isVirtual: false,
@@ -229,7 +229,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     })
 
     it('should display the offerer name with "- Offre numérique" when venue is virtual', () => {
-      props.offer.venue = venueFactory({
+      props.offer.venue = listOffersVenueFactory({
         isVirtual: true,
         name: 'Gaumont Montparnasse',
         offererName: 'Gaumont',
@@ -244,7 +244,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     })
 
     it('should display the ean when given', () => {
-      props.offer = individualOfferFactory({ productIsbn: '123456789' })
+      props.offer = listOffersOfferFactory({ productIsbn: '123456789' })
 
       renderOfferItem(props)
 
@@ -333,7 +333,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
 
     describe('when offer is an event product', () => {
       it('should display the correct text "2 dates"', () => {
-        props.offer.venue = venueFactory({ departementCode: '973' })
+        props.offer.venue = listOffersVenueFactory({ departementCode: '973' })
         props.offer.stocks = [
           listOffersStockFactory({
             beginningDatetime: '01-01-2001',
@@ -351,7 +351,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       })
 
       it('should display the beginning date time when only one date', () => {
-        props.offer.venue = venueFactory({ departementCode: '973' })
+        props.offer.venue = listOffersVenueFactory({ departementCode: '973' })
         props.offer.stocks = [
           listOffersStockFactory({
             beginningDatetime: '2021-05-27T20:00:00Z',

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -3,12 +3,15 @@ import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import { ListOffersOfferResponseModel } from 'apiClient/v1'
+import {
+  GetOffererResponseModel,
+  ListOffersOfferResponseModel,
+} from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import { getOffererAdapter } from 'core/Offers/adapters'
 import { DEFAULT_PAGE, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQuerySearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
-import { Offerer, SearchFiltersParams } from 'core/Offers/types'
+import { SearchFiltersParams } from 'core/Offers/types'
 import { hasSearchFilters, computeOffersUrl } from 'core/Offers/utils'
 import { Audience } from 'core/shared'
 import getVenuesForOffererAdapter from 'core/Venue/adapters/getVenuesForOffererAdapter'
@@ -31,7 +34,7 @@ export const OffersRoute = (): JSX.Element => {
   const { currentUser } = useCurrentUser()
   const dispatch = useDispatch()
 
-  const [offerer, setOfferer] = useState<Offerer | null>(null)
+  const [offerer, setOfferer] = useState<GetOffererResponseModel | null>(null)
   const [offers, setOffers] = useState<ListOffersOfferResponseModel[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [initialSearchFilters, setInitialSearchFilters] =

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -19,7 +19,7 @@ import { Audience } from 'core/shared'
 import {
   defaultGetOffererResponseModel,
   getVenueListItemFactory,
-  listOffersOfferResponseModelFactory,
+  listOffersOfferFactory,
 } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -109,9 +109,7 @@ describe('route Offers', () => {
         searchFilters: DEFAULT_SEARCH_FILTERS,
       },
     }
-    offersRecap = [
-      listOffersOfferResponseModelFactory({ customVenue: proVenues[0] }),
-    ]
+    offersRecap = [listOffersOfferFactory({ customVenue: proVenues[0] })]
     vi.spyOn(api, 'listOffers').mockResolvedValue(offersRecap)
     vi.spyOn(api, 'getCategories').mockResolvedValueOnce(
       categoriesAndSubcategories
@@ -532,7 +530,7 @@ describe('route Offers', () => {
   describe('url query params', () => {
     it('should have page value when page value is not first page', async () => {
       const offersRecap = Array.from({ length: 11 }, () =>
-        listOffersOfferResponseModelFactory()
+        listOffersOfferFactory()
       )
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offersRecap)
       await renderOffers(store)
@@ -641,7 +639,7 @@ describe('route Offers', () => {
 
     it('should have status value when user filters by status', async () => {
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce([
-        listOffersOfferResponseModelFactory({
+        listOffersOfferFactory({
           customOffer: {
             status: OfferStatus.ACTIVE,
           },
@@ -672,7 +670,7 @@ describe('route Offers', () => {
 
     it('should have status value be removed when user ask for all status', async () => {
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce([
-        listOffersOfferResponseModelFactory({
+        listOffersOfferFactory({
           customOffer: {
             status: OfferStatus.ACTIVE,
           },
@@ -789,9 +787,7 @@ describe('route Offers', () => {
     })
 
     it('should display next page when clicking on right arrow', async () => {
-      const offers = Array.from({ length: 11 }, () =>
-        listOffersOfferResponseModelFactory()
-      )
+      const offers = Array.from({ length: 11 }, () => listOffersOfferFactory())
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offers)
       await renderOffers(store)
       const nextIcon = screen.getByRole('button', { name: 'Page suivante' })
@@ -803,9 +799,7 @@ describe('route Offers', () => {
     })
 
     it('should display previous page when clicking on left arrow', async () => {
-      const offers = Array.from({ length: 11 }, () =>
-        listOffersOfferResponseModelFactory()
-      )
+      const offers = Array.from({ length: 11 }, () => listOffersOfferFactory())
 
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offers)
       await renderOffers(store)
@@ -824,7 +818,7 @@ describe('route Offers', () => {
     describe('when 501 offers are fetched', () => {
       beforeEach(() => {
         offersRecap = Array.from({ length: 501 }, () =>
-          listOffersOfferResponseModelFactory({ customStocksList: [] })
+          listOffersOfferFactory({ customStocksList: [] })
         )
       })
 

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -18,9 +18,9 @@ import { computeOffersUrl } from 'core/Offers/utils'
 import { Audience } from 'core/shared'
 import {
   defaultGetOffererResponseModel,
-  getVenueListItemFactory,
   listOffersOfferFactory,
 } from 'utils/apiFactories'
+import { venueListItemFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { OffersRoute } from '../../../pages/Offers/OffersRoute'
@@ -35,14 +35,14 @@ const categoriesAndSubcategories = {
 }
 
 const proVenues = [
-  getVenueListItemFactory({
+  venueListItemFactory({
     id: 1,
     name: 'Ma venue',
     offererName: 'Mon offerer',
     publicName: undefined,
     isVirtual: false,
   }),
-  getVenueListItemFactory({
+  venueListItemFactory({
     id: 2,
     name: 'Ma venue virtuelle',
     offererName: 'Mon offerer',

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -16,10 +16,8 @@ import {
 import { SearchFiltersParams } from 'core/Offers/types'
 import { computeOffersUrl } from 'core/Offers/utils'
 import { Audience } from 'core/shared'
-import {
-  defaultGetOffererResponseModel,
-  listOffersOfferFactory,
-} from 'utils/apiFactories'
+import { listOffersOfferFactory } from 'screens/Offers/utils/individualOffersFactories'
+import { defaultGetOffererResponseModel } from 'utils/apiFactories'
 import { venueListItemFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -109,7 +107,7 @@ describe('route Offers', () => {
         searchFilters: DEFAULT_SEARCH_FILTERS,
       },
     }
-    offersRecap = [listOffersOfferFactory({ customVenue: proVenues[0] })]
+    offersRecap = [listOffersOfferFactory({ venue: proVenues[0] })]
     vi.spyOn(api, 'listOffers').mockResolvedValue(offersRecap)
     vi.spyOn(api, 'getCategories').mockResolvedValueOnce(
       categoriesAndSubcategories
@@ -640,10 +638,8 @@ describe('route Offers', () => {
     it('should have status value when user filters by status', async () => {
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce([
         listOffersOfferFactory({
-          customOffer: {
-            status: OfferStatus.ACTIVE,
-          },
-          customStocksList: [],
+          status: OfferStatus.ACTIVE,
+          stocks: [],
         }),
       ])
 
@@ -671,10 +667,8 @@ describe('route Offers', () => {
     it('should have status value be removed when user ask for all status', async () => {
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce([
         listOffersOfferFactory({
-          customOffer: {
-            status: OfferStatus.ACTIVE,
-          },
-          customStocksList: [],
+          status: OfferStatus.ACTIVE,
+          stocks: [],
         }),
       ])
       await renderOffers(store)
@@ -818,7 +812,7 @@ describe('route Offers', () => {
     describe('when 501 offers are fetched', () => {
       beforeEach(() => {
         offersRecap = Array.from({ length: 501 }, () =>
-          listOffersOfferFactory({ customStocksList: [] })
+          listOffersOfferFactory({ stocks: [] })
         )
       })
 

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -13,7 +13,7 @@ import { BankAccountEvents } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
 import BankInformations from 'pages/Reimbursements/BankInformations/BankInformations'
 import {
-  defaultBankAccountResponseModel,
+  defaultBankAccount,
   defaultGetOffererResponseModel,
   defaultManagedVenues,
 } from 'utils/apiFactories'
@@ -253,7 +253,7 @@ describe('BankInformations page', () => {
   it('should update displayed link venue after closing link venue dialog', async () => {
     vi.spyOn(api, 'getOffererBankAccountsAndAttachedVenues').mockResolvedValue({
       id: 1,
-      bankAccounts: [{ ...defaultBankAccountResponseModel }],
+      bankAccounts: [{ ...defaultBankAccount }],
       managedVenues: [{ ...defaultManagedVenues }],
     })
 

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/LinkVenuesDialog.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/LinkVenuesDialog.spec.tsx
@@ -4,10 +4,7 @@ import { userEvent } from '@testing-library/user-event'
 import { api } from 'apiClient/api'
 import { BankAccountResponseModel, ManagedVenues } from 'apiClient/v1'
 import * as useNotification from 'hooks/useNotification'
-import {
-  defaultBankAccountResponseModel,
-  defaultManagedVenues,
-} from 'utils/apiFactories'
+import { defaultBankAccount, defaultManagedVenues } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import LinkVenuesDialog from '../LinkVenuesDialog'
@@ -40,7 +37,7 @@ describe('LinkVenueDialog', () => {
       { ...defaultManagedVenues, id: 2, commonName: 'Lieu 2' },
     ]
 
-    renderLinkVenuesDialog(1, defaultBankAccountResponseModel, managedVenues)
+    renderLinkVenuesDialog(1, defaultBankAccount, managedVenues)
 
     await userEvent.click(
       screen.getByRole('checkbox', { name: 'Tout sélectionner' })
@@ -55,7 +52,7 @@ describe('LinkVenueDialog', () => {
       { ...defaultManagedVenues, id: 2, hasPricingPoint: false },
     ]
 
-    renderLinkVenuesDialog(1, defaultBankAccountResponseModel, managedVenues)
+    renderLinkVenuesDialog(1, defaultBankAccount, managedVenues)
 
     expect(
       screen.getAllByRole('button', { name: 'Sélectionner un SIRET' }).length
@@ -67,7 +64,7 @@ describe('LinkVenueDialog', () => {
       { ...defaultManagedVenues, id: 1, hasPricingPoint: false },
     ]
 
-    renderLinkVenuesDialog(1, defaultBankAccountResponseModel, managedVenues)
+    renderLinkVenuesDialog(1, defaultBankAccount, managedVenues)
 
     const selectSiretButton = screen.getByRole('button', {
       name: 'Sélectionner un SIRET',
@@ -94,7 +91,7 @@ describe('LinkVenueDialog', () => {
       },
     ]
 
-    renderLinkVenuesDialog(1, defaultBankAccountResponseModel, managedVenues)
+    renderLinkVenuesDialog(1, defaultBankAccount, managedVenues)
 
     const venueWithoutSiretCheckBox = screen.getByRole('checkbox', {
       name: 'Lieu sans siret',
@@ -140,7 +137,7 @@ describe('LinkVenueDialog', () => {
       },
     ]
 
-    renderLinkVenuesDialog(1, defaultBankAccountResponseModel, managedVenues)
+    renderLinkVenuesDialog(1, defaultBankAccount, managedVenues)
 
     await userEvent.click(
       screen.getByRole('button', {
@@ -167,7 +164,7 @@ describe('LinkVenueDialog', () => {
       { ...defaultManagedVenues, id: 2, hasPricingPoint: false },
     ]
 
-    renderLinkVenuesDialog(1, defaultBankAccountResponseModel, managedVenues)
+    renderLinkVenuesDialog(1, defaultBankAccount, managedVenues)
 
     expect(
       screen.getByText('Certains de vos lieux n’ont pas de SIRET')

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementDetails.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementDetails.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { api } from 'apiClient/api'
 import { InvoiceResponseModel, VenueListItemResponseModel } from 'apiClient/v1'
-import { individualOfferGetVenuesFactory } from 'utils/individualApiFactories'
+import { venueListItemFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ReimbursementsDetails from '../ReimbursementsDetails/ReimbursementsDetails'
@@ -16,12 +16,12 @@ vi.mock('utils/date', async () => ({
 
 const venueId = 12
 const BASE_VENUES: VenueListItemResponseModel[] = [
-  individualOfferGetVenuesFactory({
+  venueListItemFactory({
     isVirtual: true,
     offererName: 'Offerer name venue 2',
     id: 2,
   }),
-  individualOfferGetVenuesFactory({
+  venueListItemFactory({
     isVirtual: false,
     publicName: 'Public Name venue 1',
     id: venueId,

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
@@ -5,7 +5,7 @@ import { api } from 'apiClient/api'
 import { BankAccountResponseModel } from 'apiClient/v1'
 import { ReimbursementContext } from 'context/ReimbursementContext/ReimbursementContext'
 import {
-  defaultBankAccountResponseModel,
+  defaultBankAccount,
   defaultGetOffererResponseModel,
 } from 'utils/apiFactories'
 import {
@@ -92,12 +92,12 @@ const BASE_REIMBURSEMENT_POINTS = [
 
 const BASE_BANK_ACCOUNTS: Array<BankAccountResponseModel> = [
   {
-    ...defaultBankAccountResponseModel,
+    ...defaultBankAccount,
     id: 1,
     label: 'My first bank account',
   },
   {
-    ...defaultBankAccountResponseModel,
+    ...defaultBankAccount,
     id: 2,
     label: 'My second bank account',
   },

--- a/pro/src/pages/VenueEdition/__specs__/VenueEdition.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEdition.spec.tsx
@@ -13,7 +13,7 @@ import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { Providers } from 'core/Venue/types'
 import * as pcapi from 'repository/pcapi/pcapi'
-import { defaultVenueResponseModel } from 'utils/collectiveApiFactories'
+import { defaultGetVenue } from 'utils/collectiveApiFactories'
 import {
   RenderWithProvidersOptions,
   renderWithProviders,
@@ -73,7 +73,7 @@ describe('route VenueEdition', () => {
 
   beforeEach(() => {
     venue = {
-      ...defaultVenueResponseModel,
+      ...defaultGetVenue,
       id: 12,
       publicName: 'Cinéma des iles',
       dmsToken: 'dms-token-12345',

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
@@ -7,7 +7,7 @@ import { UploaderModeEnum } from 'components/ImageUploader/types'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
 import { defaultGetOffererResponseModel } from 'utils/apiFactories'
-import { defaultVenueResponseModel } from 'utils/collectiveApiFactories'
+import { defaultGetVenue } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -21,7 +21,7 @@ const renderPartnerPages = (props: Partial<VenueEditionHeaderProps>) => {
   renderWithProviders(
     <VenueEditionHeader
       offerer={{ ...defaultGetOffererResponseModel }}
-      venue={{ ...defaultVenueResponseModel }}
+      venue={{ ...defaultGetVenue }}
       venueTypes={[{ value: VenueTypeCode.FESTIVAL, label: 'Festival' }]}
       {...props}
     />
@@ -47,7 +47,7 @@ describe('PartnerPages', () => {
 
     renderPartnerPages({
       venue: {
-        ...defaultVenueResponseModel,
+        ...defaultGetVenue,
         venueTypeCode: VenueTypeCode.FESTIVAL,
       },
     })
@@ -56,7 +56,7 @@ describe('PartnerPages', () => {
     await userEvent.click(screen.getByText(/Ajouter une image/))
 
     expect(mockLogEvent).toHaveBeenCalledWith(Events.CLICKED_ADD_IMAGE, {
-      venueId: defaultVenueResponseModel.id,
+      venueId: defaultGetVenue.id,
       imageType: UploaderModeEnum.VENUE,
       isEdition: true,
     })
@@ -65,7 +65,7 @@ describe('PartnerPages', () => {
   it('should display the image if its present', () => {
     renderPartnerPages({
       venue: {
-        ...defaultVenueResponseModel,
+        ...defaultGetVenue,
         venueTypeCode: VenueTypeCode.FESTIVAL,
         bannerUrl: 'https://www.example.com/image.png',
         bannerMeta: {

--- a/pro/src/pages/VenueEdition/utils/__specs__/offerHasBookingQuantity.spec.ts
+++ b/pro/src/pages/VenueEdition/utils/__specs__/offerHasBookingQuantity.spec.ts
@@ -1,6 +1,6 @@
 import { ListOffersOfferResponseModel } from 'apiClient/v1'
 import {
-  individualOfferFactory,
+  listOffersOfferFactory,
   listOffersStockFactory,
 } from 'screens/Offers/utils/individualOffersFactories'
 
@@ -10,7 +10,7 @@ describe('offerHasBookingQuantity', () => {
   let offers: ListOffersOfferResponseModel[] = []
 
   beforeEach(() => {
-    const offer = individualOfferFactory()
+    const offer = listOffersOfferFactory()
     offers = [
       { ...offer, stocks: [listOffersStockFactory({ remainingQuantity: 0 })] },
       { ...offer, stocks: [listOffersStockFactory({ remainingQuantity: 0 })] },

--- a/pro/src/repository/__specs__/venuesService.spec.ts
+++ b/pro/src/repository/__specs__/venuesService.spec.ts
@@ -1,17 +1,17 @@
-import { individualOfferGetVenuesFactory } from 'utils/individualApiFactories'
+import { venueListItemFactory } from 'utils/individualApiFactories'
 
 import { computeVenueDisplayName, formatAndOrderVenues } from '../venuesService'
 
 describe('formatAndOrderVenues', () => {
   it('should sort venues alphabetically', () => {
     const venues = [
-      individualOfferGetVenuesFactory({
+      venueListItemFactory({
         id: 1,
         name: 'Offre numérique',
         offererName: 'gilbert Joseph',
         isVirtual: true,
       }),
-      individualOfferGetVenuesFactory({
+      venueListItemFactory({
         id: 1,
         name: 'a venue name',
         publicName: 'Librairie Fnac',
@@ -36,7 +36,7 @@ describe('formatAndOrderVenues', () => {
 
   it('should format venue option with "offerer name - offre numérique" when venue is virtual', () => {
     const venues = [
-      individualOfferGetVenuesFactory({
+      venueListItemFactory({
         id: 1,
         name: 'Offre numérique',
         offererName: 'gilbert Joseph',

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/__specs__/BookingOfferCell.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/__specs__/BookingOfferCell.spec.tsx
@@ -3,7 +3,7 @@ import { add } from 'date-fns'
 import React from 'react'
 
 import { bookingRecapFactory } from 'utils/apiFactories'
-import { collectiveBookingRecapFactory } from 'utils/collectiveApiFactories'
+import { collectiveBookingFactory } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { BookingOfferCell, BookingOfferCellProps } from '../BookingOfferCell'
@@ -15,7 +15,7 @@ describe('bookings offer cell', () => {
   const offerId = 1
   it('offer name and ean with a link to the offer when stock is a book', () => {
     const props: BookingOfferCellProps = {
-      booking: collectiveBookingRecapFactory({
+      booking: collectiveBookingFactory({
         stock: {
           offerId: offerId,
           offerIsbn: '97834567654',
@@ -38,7 +38,7 @@ describe('bookings offer cell', () => {
 
   it('offer name with a link to the offer when stock is a thing', () => {
     const props: BookingOfferCellProps = {
-      booking: collectiveBookingRecapFactory({
+      booking: collectiveBookingFactory({
         stock: {
           offerId: offerId,
           offerName: 'Guitare acoustique',
@@ -58,7 +58,7 @@ describe('bookings offer cell', () => {
 
   it('offer name and event beginning datetime in venue timezone when stock is an event', () => {
     const props: BookingOfferCellProps = {
-      booking: collectiveBookingRecapFactory({
+      booking: collectiveBookingFactory({
         stock: {
           eventBeginningDatetime: '2020-05-12T11:03:28.564687+04:00',
           offerId: offerId,
@@ -82,7 +82,7 @@ describe('bookings offer cell', () => {
       days: 1,
     })
 
-    const booking = collectiveBookingRecapFactory({
+    const booking = collectiveBookingFactory({
       stock: {
         bookingLimitDatetime: tomorrowFns.toISOString(),
         eventBeginningDatetime: new Date().toISOString(),
@@ -106,7 +106,7 @@ describe('bookings offer cell', () => {
       days: 8,
     })
 
-    const booking = collectiveBookingRecapFactory({
+    const booking = collectiveBookingFactory({
       stock: {
         bookingLimitDatetime: eightDaysFns.toISOString(),
         eventBeginningDatetime: new Date().toISOString(),

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/__specs__/CollectiveBookingStatusCell.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/__specs__/CollectiveBookingStatusCell.spec.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react'
 import React from 'react'
 
-import { collectiveBookingRecapFactory } from 'utils/collectiveApiFactories'
+import { collectiveBookingFactory } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -16,7 +16,7 @@ const renderCollectiveBookingStatusCell = (
 describe('CollectiveBookingStatusCell', () => {
   it('should display the status label', () => {
     renderCollectiveBookingStatusCell({
-      booking: collectiveBookingRecapFactory(),
+      booking: collectiveBookingFactory(),
     })
 
     expect(screen.getByText('préréservée')).toBeInTheDocument()

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons/__specs__/CollectiveActionButtons.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons/__specs__/CollectiveActionButtons.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { BOOKING_STATUS } from 'core/Bookings/constants'
 import {
-  collectiveBookingRecapFactory,
+  collectiveBookingFactory,
   defaultCollectiveBookingStock,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -18,7 +18,7 @@ const renderCollectiveActionButtons = (props: CollectiveActionButtonsProps) => {
 
 describe('CollectiveActionButtons', () => {
   it('should display modify offer button for pending booking', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.PENDING,
     })
     renderCollectiveActionButtons({
@@ -34,7 +34,7 @@ describe('CollectiveActionButtons', () => {
     )
   })
   it('should not display modify offer button for validated booking for more than 2 days', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.VALIDATED,
       stock: {
         ...defaultCollectiveBookingStock,

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
@@ -14,8 +14,8 @@ import { BOOKING_STATUS } from 'core/Bookings/constants'
 import { CollectiveBookingsEvents } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
 import {
-  collectiveBookingDetailsFactory,
-  collectiveBookingRecapFactory,
+  collectiveBookingByIdFactory,
+  collectiveBookingFactory,
   defaultCollectiveBookingStock,
 } from 'utils/collectiveApiFactories'
 import {
@@ -39,9 +39,9 @@ const renderCollectiveTimeLine = (
   )
 
 describe('collective timeline', () => {
-  let bookingDetails = collectiveBookingDetailsFactory()
+  let bookingDetails = collectiveBookingByIdFactory()
   it('should render steps for pending booking', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.PENDING,
     })
     renderCollectiveTimeLine(bookingRecap, bookingDetails)
@@ -50,7 +50,7 @@ describe('collective timeline', () => {
     ).toBeInTheDocument()
   })
   it('should render steps for booked booking', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.BOOKED,
     })
     renderCollectiveTimeLine(bookingRecap, bookingDetails)
@@ -59,7 +59,7 @@ describe('collective timeline', () => {
     ).toBeInTheDocument()
   })
   it('should render steps for confirmed booking', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.CONFIRMED,
     })
     renderCollectiveTimeLine(bookingRecap, bookingDetails)
@@ -67,7 +67,7 @@ describe('collective timeline', () => {
   })
 
   it('should render steps for reimbursed booking', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.REIMBURSED,
       bookingStatusHistory: [
         { date: new Date().toISOString(), status: BOOKING_STATUS.PENDING },
@@ -80,7 +80,7 @@ describe('collective timeline', () => {
     expect(screen.getByText('25 mars 2023')).toBeInTheDocument()
   })
   it('should render steps for cancelled booking', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.CANCELLED,
       bookingConfirmationDate: null,
       bookingCancellationReason: CollectiveBookingCancellationReasons.OFFERER,
@@ -95,7 +95,7 @@ describe('collective timeline', () => {
     ).toBeInTheDocument()
   })
   it('should render steps for cancelled booking by fraud', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.CANCELLED,
       bookingConfirmationDate: null,
       bookingCancellationReason: CollectiveBookingCancellationReasons.FRAUD,
@@ -110,7 +110,7 @@ describe('collective timeline', () => {
     ).toBeInTheDocument()
   })
   it('should render steps for cancelled booking expired', () => {
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.CANCELLED,
       bookingConfirmationDate: null,
       bookingConfirmationLimitDate: '01/01/2023',
@@ -134,7 +134,7 @@ describe('collective timeline', () => {
       ...vi.importActual('hooks/useAnalytics'),
       logEvent: mockLogEvent,
     }))
-    const bookingRecap = collectiveBookingRecapFactory({
+    const bookingRecap = collectiveBookingFactory({
       bookingStatus: BOOKING_STATUS.PENDING,
     })
     renderCollectiveTimeLine(bookingRecap, bookingDetails)
@@ -154,7 +154,7 @@ describe('collective timeline', () => {
   })
   describe('validated booking', () => {
     it('should render steps for validated booking and accepted bankInformation', () => {
-      const bookingRecap = collectiveBookingRecapFactory({
+      const bookingRecap = collectiveBookingFactory({
         bookingStatus: BOOKING_STATUS.VALIDATED,
       })
       renderCollectiveTimeLine(bookingRecap, bookingDetails)
@@ -174,10 +174,10 @@ describe('collective timeline', () => {
     })
 
     it('should render steps for validated booking and pending bankInformation', () => {
-      const bookingRecap = collectiveBookingRecapFactory({
+      const bookingRecap = collectiveBookingFactory({
         bookingStatus: BOOKING_STATUS.VALIDATED,
       })
-      bookingDetails = collectiveBookingDetailsFactory({
+      bookingDetails = collectiveBookingByIdFactory({
         bankInformationStatus: CollectiveBookingBankInformationStatus.DRAFT,
       })
       renderCollectiveTimeLine(bookingRecap, bookingDetails)
@@ -195,10 +195,10 @@ describe('collective timeline', () => {
     })
 
     it('should render steps for validated booking and missing bankInformation', () => {
-      const bookingRecap = collectiveBookingRecapFactory({
+      const bookingRecap = collectiveBookingFactory({
         bookingStatus: BOOKING_STATUS.VALIDATED,
       })
-      bookingDetails = collectiveBookingDetailsFactory({
+      bookingDetails = collectiveBookingByIdFactory({
         bankInformationStatus: CollectiveBookingBankInformationStatus.MISSING,
       })
       renderCollectiveTimeLine(bookingRecap, bookingDetails)
@@ -215,10 +215,10 @@ describe('collective timeline', () => {
     })
 
     it('should render steps for validated booking and missing bankInformation when FF bank details enable', () => {
-      const bookingRecap = collectiveBookingRecapFactory({
+      const bookingRecap = collectiveBookingFactory({
         bookingStatus: BOOKING_STATUS.VALIDATED,
       })
-      bookingDetails = collectiveBookingDetailsFactory({
+      bookingDetails = collectiveBookingByIdFactory({
         bankInformationStatus: null,
         bankAccountStatus: CollectiveBookingBankAccountStatus.MISSING,
       })
@@ -244,7 +244,7 @@ describe('collective timeline', () => {
 
   describe('confirmed booking', () => {
     it('should render steps for confirmed booking when event is not passed yet', () => {
-      const bookingRecap = collectiveBookingRecapFactory({
+      const bookingRecap = collectiveBookingFactory({
         bookingStatus: BOOKING_STATUS.CONFIRMED,
         stock: {
           ...defaultCollectiveBookingStock,
@@ -264,7 +264,7 @@ describe('collective timeline', () => {
       ).toBeInTheDocument()
     })
     it('should render steps for confirmed booking when event is passed', () => {
-      const bookingRecap = collectiveBookingRecapFactory({
+      const bookingRecap = collectiveBookingFactory({
         bookingStatus: BOOKING_STATUS.CONFIRMED,
         stock: {
           ...defaultCollectiveBookingStock,

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/__specs__/CollectiveTableRow.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/__specs__/CollectiveTableRow.spec.tsx
@@ -9,8 +9,8 @@ import {
 } from 'apiClient/v1'
 import {
   collectiveBookingCollectiveStockFactory,
-  collectiveBookingDetailsFactory,
-  collectiveBookingRecapFactory,
+  collectiveBookingByIdFactory,
+  collectiveBookingFactory,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -50,13 +50,13 @@ describe('CollectiveTableRow', () => {
     } as MediaQueryList)
 
     vi.spyOn(api, 'getCollectiveBookingById').mockResolvedValue(
-      collectiveBookingDetailsFactory()
+      collectiveBookingByIdFactory()
     )
   })
 
   it('should not render booking details if row is not expanded', () => {
     const props: CollectiveTableRowProps = {
-      booking: collectiveBookingRecapFactory({
+      booking: collectiveBookingFactory({
         stock: collectiveBookingCollectiveStockFactory(),
         bookingStatus: 'booked',
       }),
@@ -73,7 +73,7 @@ describe('CollectiveTableRow', () => {
 
   it('should render loader while fetching data', async () => {
     const props: CollectiveTableRowProps = {
-      booking: collectiveBookingRecapFactory({
+      booking: collectiveBookingFactory({
         stock: collectiveBookingCollectiveStockFactory(),
         bookingStatus: 'booked',
       }),
@@ -84,7 +84,7 @@ describe('CollectiveTableRow', () => {
     vi.spyOn(api, 'getCollectiveBookingById').mockImplementationOnce(() => {
       return new CancelablePromise<CollectiveBookingByIdResponseModel>(
         (resolve) =>
-          setTimeout(() => resolve(collectiveBookingDetailsFactory()), 500)
+          setTimeout(() => resolve(collectiveBookingByIdFactory()), 500)
       )
     })
 
@@ -98,7 +98,7 @@ describe('CollectiveTableRow', () => {
   it('should display booking details if row is expanded', async () => {
     Element.prototype.scrollIntoView = scrollIntoViewMock
     const props: CollectiveTableRowProps = {
-      booking: collectiveBookingRecapFactory({ bookingId: '123' }),
+      booking: collectiveBookingFactory({ bookingId: '123' }),
       reloadBookings: vi.fn(),
       defaultOpenedBookingId: '123',
     }

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/__specs__/IndividualBookingsTable.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/__specs__/IndividualBookingsTable.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import React from 'react'
 
 import {
-  GetIndividualOfferFactory,
+  getIndividualOfferFactory,
   bookingRecapFactory,
 } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -17,7 +17,7 @@ const renderIndividualBookingTable = (props: IndividualBookingsTableProps) =>
 
 describe('CollectiveTableRow', () => {
   it('should render a table with bookings', () => {
-    const offer = GetIndividualOfferFactory({ name: 'Offre de test' })
+    const offer = getIndividualOfferFactory({ name: 'Offre de test' })
 
     const props: IndividualBookingsTableProps = {
       bookings: [

--- a/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
@@ -9,8 +9,8 @@ import * as bookingDetailsAdapter from 'screens/Bookings/BookingsRecapTable/Book
 import * as filterBookingsRecap from 'screens/Bookings/BookingsRecapTable/utils/filterBookingsRecap'
 import { bookingRecapFactory } from 'utils/apiFactories'
 import {
-  collectiveBookingDetailsFactory,
-  collectiveBookingRecapFactory,
+  collectiveBookingByIdFactory,
+  collectiveBookingFactory,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -131,13 +131,13 @@ describe('components | BookingsRecapTable', () => {
     vi.spyOn(bookingDetailsAdapter, 'default').mockResolvedValue({
       isOk: true,
       message: '',
-      payload: collectiveBookingDetailsFactory(),
+      payload: collectiveBookingByIdFactory(),
     })
     // Given
     const props: Props = {
       ...defaultProps,
       audience: Audience.COLLECTIVE,
-      bookingsRecap: [collectiveBookingRecapFactory({ bookingId: '123' })],
+      bookingsRecap: [collectiveBookingFactory({ bookingId: '123' })],
       locationState: {
         statuses: ['booked', 'cancelled'],
       },
@@ -187,7 +187,7 @@ describe('components | BookingsRecapTable', () => {
 
   it('should render the expected table for collective audience', () => {
     // Given
-    const bookingRecap = collectiveBookingRecapFactory(bookingInstitutionCustom)
+    const bookingRecap = collectiveBookingFactory(bookingInstitutionCustom)
     vi.spyOn(filterBookingsRecap, 'default').mockReturnValue([bookingRecap])
     const props: Props = {
       ...defaultProps,
@@ -264,13 +264,13 @@ describe('components | BookingsRecapTable', () => {
   it('should log event when cliking collective row', async () => {
     // Given
     const bookingsRecap = [
-      collectiveBookingRecapFactory({ bookingId: 'mon booking id' }),
+      collectiveBookingFactory({ bookingId: 'mon booking id' }),
     ]
     vi.spyOn(filterBookingsRecap, 'default').mockReturnValue(bookingsRecap)
     vi.spyOn(bookingDetailsAdapter, 'default').mockResolvedValue({
       isOk: true,
       message: '',
-      payload: collectiveBookingDetailsFactory(),
+      payload: collectiveBookingByIdFactory(),
     })
 
     const mockLogEvent = vi.fn()
@@ -304,7 +304,7 @@ describe('components | BookingsRecapTable', () => {
   it('should update currentPage when clicking on next page button', async () => {
     const bookingsRecap = []
     for (let i = 0; i < 40; i++) {
-      bookingsRecap.push(collectiveBookingRecapFactory())
+      bookingsRecap.push(collectiveBookingFactory())
     }
 
     const props: Props = {

--- a/pro/src/screens/Bookings/BookingsRecapTable/utils/__specs__/sortingFunctions.spec.ts
+++ b/pro/src/screens/Bookings/BookingsRecapTable/utils/__specs__/sortingFunctions.spec.ts
@@ -1,7 +1,7 @@
 import { bookingRecapFactory } from 'utils/apiFactories'
 import {
   collectiveBookingCollectiveStockFactory,
-  collectiveBookingRecapFactory,
+  collectiveBookingFactory,
 } from 'utils/collectiveApiFactories'
 
 import {
@@ -12,12 +12,12 @@ import {
 
 describe('sortByOfferName', () => {
   it('should return 1 when first row offer name comes after second row offer name', () => {
-    const bookingA = collectiveBookingRecapFactory({
+    const bookingA = collectiveBookingFactory({
       stock: collectiveBookingCollectiveStockFactory({
         offerName: 'Zebre du Bengal',
       }),
     })
-    const bookingB = collectiveBookingRecapFactory({
+    const bookingB = collectiveBookingFactory({
       stock: collectiveBookingCollectiveStockFactory({
         offerName: 'Babar, mon ami éléphant',
       }),
@@ -29,12 +29,12 @@ describe('sortByOfferName', () => {
   })
 
   it('should return -1 when first row offer name comes before second row offer name', () => {
-    const bookingA = collectiveBookingRecapFactory({
+    const bookingA = collectiveBookingFactory({
       stock: collectiveBookingCollectiveStockFactory({
         offerName: 'Babar, mon ami éléphant',
       }),
     })
-    const bookingB = collectiveBookingRecapFactory({
+    const bookingB = collectiveBookingFactory({
       stock: collectiveBookingCollectiveStockFactory({
         offerName: 'Zebre du Bengal',
       }),
@@ -46,12 +46,12 @@ describe('sortByOfferName', () => {
   })
 
   it('should return 0 when first row offer name is the same as second row offer name', () => {
-    const bookingA = collectiveBookingRecapFactory({
+    const bookingA = collectiveBookingFactory({
       stock: collectiveBookingCollectiveStockFactory({
         offerName: 'Babar, mon ami éléphant',
       }),
     })
-    const bookingB = collectiveBookingRecapFactory({
+    const bookingB = collectiveBookingFactory({
       stock: collectiveBookingCollectiveStockFactory({
         offerName: 'Babar, mon ami éléphant',
       }),
@@ -65,10 +65,10 @@ describe('sortByOfferName', () => {
 
 describe('sortByBookingDate', () => {
   it('should return -1 when first row bookingDate comes before second row bookingDate', () => {
-    const bookingA = collectiveBookingRecapFactory({
+    const bookingA = collectiveBookingFactory({
       bookingDate: '2020-04-22T11:17:12+02:00',
     })
-    const bookingB = collectiveBookingRecapFactory({
+    const bookingB = collectiveBookingFactory({
       bookingDate: '2020-04-23T13:17:12+02:00',
     })
 
@@ -78,10 +78,10 @@ describe('sortByBookingDate', () => {
   })
 
   it('should return 1 when first row bookingDate comes after second row bookingDate', () => {
-    const bookingA = collectiveBookingRecapFactory({
+    const bookingA = collectiveBookingFactory({
       bookingDate: '2020-04-22T11:17:12+02:00',
     })
-    const bookingB = collectiveBookingRecapFactory({
+    const bookingB = collectiveBookingFactory({
       bookingDate: '2020-04-22T12:16:12+03:00',
     })
 
@@ -91,10 +91,10 @@ describe('sortByBookingDate', () => {
   })
 
   it('should return 0 when first row bookingDate is the same as second row bookingDate', () => {
-    const bookingA = collectiveBookingRecapFactory({
+    const bookingA = collectiveBookingFactory({
       bookingDate: '2020-04-22T11:17:12+02:00',
     })
-    const bookingB = collectiveBookingRecapFactory({
+    const bookingB = collectiveBookingFactory({
       bookingDate: '2020-04-22T11:17:12+02:00',
     })
 

--- a/pro/src/screens/Bookings/PreFilters/FilterByBookingStatusPeriod/__specs__/FilterByBookingStatusPeriod.spec.tsx
+++ b/pro/src/screens/Bookings/PreFilters/FilterByBookingStatusPeriod/__specs__/FilterByBookingStatusPeriod.spec.tsx
@@ -3,7 +3,7 @@ import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { DEFAULT_PRE_FILTERS } from 'core/Bookings/constants'
-import { offerVenueFactory } from 'utils/apiFactories'
+import { getOfferVenueFactory } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import PreFilters, { PreFiltersProps } from '../../PreFilters'
@@ -30,7 +30,7 @@ describe('filter bookings by bookings period', () => {
     props = {
       appliedPreFilters: { ...DEFAULT_PRE_FILTERS },
       applyPreFilters: vi.fn(),
-      venues: [offerVenueFactory()].map(({ id, name }) => ({
+      venues: [getOfferVenueFactory()].map(({ id, name }) => ({
         id: id.toString(),
         displayName: name,
       })),

--- a/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
@@ -20,7 +20,7 @@ import * as useAnalytics from 'hooks/useAnalytics'
 import * as useNotification from 'hooks/useNotification'
 import {
   collectiveOfferTemplateFactory,
-  defaultVenueResponseModel,
+  defaultGetVenue,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -77,7 +77,7 @@ describe('CollectiveOfferSummary', () => {
       logEvent: mockLogEvent,
     }))
 
-    vi.spyOn(api, 'getVenue').mockResolvedValue(defaultVenueResponseModel)
+    vi.spyOn(api, 'getVenue').mockResolvedValue(defaultGetVenue)
 
     vi.spyOn(api, 'getCollectiveOfferTemplate').mockResolvedValue(offer)
 

--- a/pro/src/screens/IndividualOffer/BookingsSummary/__specs__/BookingsSummary.spec.tsx
+++ b/pro/src/screens/IndividualOffer/BookingsSummary/__specs__/BookingsSummary.spec.tsx
@@ -5,16 +5,16 @@ import { api } from 'apiClient/api'
 import { GetIndividualOfferResponseModel } from 'apiClient/v1'
 import { IndividualOfferContext } from 'context/IndividualOfferContext'
 import {
-  GetIndividualOfferFactory,
+  getIndividualOfferFactory,
   bookingRecapFactory,
 } from 'utils/apiFactories'
-import { individualOfferContextFactory } from 'utils/individualApiFactories'
+import { individualOfferContextValuesFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { BookingsSummaryScreen } from '../BookingsSummary'
 
 const render = (offer: GetIndividualOfferResponseModel) => {
-  const contextValue = individualOfferContextFactory({ offer })
+  const contextValue = individualOfferContextValuesFactory({ offer })
 
   renderWithProviders(
     <IndividualOfferContext.Provider value={contextValue}>
@@ -25,7 +25,7 @@ const render = (offer: GetIndividualOfferResponseModel) => {
 
 describe('BookingsSummary', () => {
   it('should render a list of bookings', async () => {
-    const offer = GetIndividualOfferFactory({ name: 'Offre de test' })
+    const offer = getIndividualOfferFactory({ name: 'Offre de test' })
 
     vi.spyOn(api, 'getBookingsPro').mockResolvedValue({
       bookingsRecap: [
@@ -49,7 +49,7 @@ describe('BookingsSummary', () => {
   })
 
   it('should render a message when no bookings', async () => {
-    const offer = GetIndividualOfferFactory({ name: 'Offre de test' })
+    const offer = getIndividualOfferFactory({ name: 'Offre de test' })
 
     vi.spyOn(api, 'getBookingsPro').mockResolvedValue({
       bookingsRecap: [],

--- a/pro/src/screens/IndividualOffer/IndivualOfferLayout/__specs__/IndivualOfferLayout.spec.tsx
+++ b/pro/src/screens/IndividualOffer/IndivualOfferLayout/__specs__/IndivualOfferLayout.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { OfferStatus } from 'apiClient/v1'
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import IndivualOfferLayout, {
@@ -13,7 +13,7 @@ import IndivualOfferLayout, {
 const renderIndivualOfferLayout = ({
   title = 'layout title',
   withStepper = true,
-  offer = GetIndividualOfferFactory(),
+  offer = getIndividualOfferFactory(),
   mode = OFFER_WIZARD_MODE.EDITION,
   children = <div>Template child</div>,
 }: Partial<IndivualOfferLayoutProps>) => {
@@ -39,7 +39,7 @@ describe('IndivualOfferLayout', () => {
   })
 
   it('should render when offer is given', () => {
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       name: 'offer name',
     })
 
@@ -60,7 +60,7 @@ describe('IndivualOfferLayout', () => {
   })
 
   it('should not display stepper nor status when no stepper', () => {
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       isActive: true,
       status: OfferStatus.ACTIVE,
     })
@@ -76,7 +76,7 @@ describe('IndivualOfferLayout', () => {
   })
 
   it('should display status and button in edition', () => {
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       isActive: true,
       status: OfferStatus.ACTIVE,
     })
@@ -93,7 +93,7 @@ describe('IndivualOfferLayout', () => {
   })
 
   it('should display status but not let activate offer when offer is not activable', () => {
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       isActivable: false,
     })
 
@@ -108,7 +108,7 @@ describe('IndivualOfferLayout', () => {
   })
 
   it('should not display status in creation', () => {
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       isActive: false,
       status: OfferStatus.DRAFT,
     })
@@ -125,7 +125,7 @@ describe('IndivualOfferLayout', () => {
   })
 
   it('should display provider banner', () => {
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       lastProvider: { name: 'boost' },
     })
 
@@ -139,7 +139,7 @@ describe('IndivualOfferLayout', () => {
   })
 
   it('should not display provider banner when no provider is provided', () => {
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       lastProvider: { name: '' },
     })
 

--- a/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
@@ -16,11 +16,11 @@ import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 import * as useAnalytics from 'hooks/useAnalytics'
 import { ButtonLink } from 'ui-kit'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import {
-  individualOfferCategoryFactory,
-  individualOfferContextFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  individualOfferContextValuesFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -61,7 +61,7 @@ const renderInformationsScreen = (
       },
     },
   }
-  const contextValue = individualOfferContextFactory(contextOverride)
+  const contextValue = individualOfferContextValuesFactory(contextOverride)
 
   return renderWithProviders(
     <>
@@ -114,25 +114,25 @@ describe('screens:IndividualOffer::Informations::creation', () => {
 
   beforeEach(() => {
     Element.prototype.scrollIntoView = scrollIntoViewMock
-    offer = GetIndividualOfferFactory()
+    offer = getIndividualOfferFactory()
 
     const categories = [
-      individualOfferCategoryFactory({ id: 'A' }),
+      categoryFactory({ id: 'A' }),
       // we need two categories otherwise the first one is preselected and the form is dirty
-      individualOfferCategoryFactory({ id: 'B' }),
+      categoryFactory({ id: 'B' }),
     ]
     const subCategories = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'virtual',
         categoryId: 'A',
         onlineOfflinePlatform: CATEGORY_STATUS.ONLINE,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'physical',
         categoryId: 'A',
         onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'physicalB',
         categoryId: 'B',
         onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
@@ -144,7 +144,7 @@ describe('screens:IndividualOffer::Informations::creation', () => {
       isVirtual: true,
     })
 
-    contextOverride = individualOfferContextFactory({
+    contextOverride = individualOfferContextValuesFactory({
       venueList: [venue1, venue2],
       offererNames: [{ id: 1, name: 'mon offerer A' }],
       categories,

--- a/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.creation.spec.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.creation.spec.tsx
@@ -21,9 +21,9 @@ import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 import * as pcapi from 'repository/pcapi/pcapi'
 import {
-  individualOfferCategoryFactory,
-  individualOfferContextFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  individualOfferContextValuesFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -60,7 +60,7 @@ const renderInformationsScreen = (
       },
     },
   }
-  const contextValue = individualOfferContextFactory(contextOverride)
+  const contextValue = individualOfferContextValuesFactory(contextOverride)
 
   return renderWithProviders(
     <>
@@ -108,16 +108,16 @@ describe('screens:IndividualOffer::Informations::creation', () => {
 
   beforeEach(() => {
     Element.prototype.scrollIntoView = scrollIntoViewMock
-    const categories = [individualOfferCategoryFactory({ id: 'A' })]
+    const categories = [categoryFactory({ id: 'A' })]
     const subCategories: SubcategoryResponseModel[] = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'virtual',
         categoryId: 'A',
         isEvent: false,
         onlineOfflinePlatform: CATEGORY_STATUS.ONLINE,
         isSelectable: true,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'physical',
         categoryId: 'A',
         isEvent: false,
@@ -134,7 +134,7 @@ describe('screens:IndividualOffer::Informations::creation', () => {
       isVirtual: true,
     })
 
-    contextOverride = individualOfferContextFactory({
+    contextOverride = individualOfferContextValuesFactory({
       venueList: [venue1, venue2],
       offererNames: [{ id: offererId, name: 'mon offerer A' }],
       categories,
@@ -274,16 +274,16 @@ describe('screens:IndividualOffer::Informations::creation', () => {
   })
 
   it('should submit offer when several offerer and offer type set', async () => {
-    const categories = [individualOfferCategoryFactory({ id: 'A' })]
+    const categories = [categoryFactory({ id: 'A' })]
     const subCategories: SubcategoryResponseModel[] = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'virtual',
         categoryId: 'A',
         isEvent: false,
         onlineOfflinePlatform: CATEGORY_STATUS.ONLINE,
         isSelectable: true,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'physical',
         categoryId: 'A',
         isEvent: false,
@@ -316,7 +316,7 @@ describe('screens:IndividualOffer::Informations::creation', () => {
         managingOffererId: offererId2,
       })
 
-    const contextOverride = individualOfferContextFactory({
+    const contextOverride = individualOfferContextValuesFactory({
       venueList: [
         venue1Offerer1,
         venue2Offerer1,

--- a/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.edition.spec.tsx
@@ -23,13 +23,13 @@ import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 import * as pcapi from 'repository/pcapi/pcapi'
 import {
-  GetIndividualOfferFactory,
-  offerVenueFactory,
+  getIndividualOfferFactory,
+  getOfferVenueFactory,
 } from 'utils/apiFactories'
 import {
-  individualOfferCategoryFactory,
-  individualOfferContextFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  individualOfferContextValuesFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -65,7 +65,7 @@ const renderInformationsScreen = (
       },
     },
   }
-  const contextValue = individualOfferContextFactory(contextOverride)
+  const contextValue = individualOfferContextValuesFactory(contextOverride)
 
   return renderWithProviders(
     <>
@@ -117,14 +117,14 @@ describe('screens:IndividualOffer::Informations:edition', () => {
 
   beforeEach(() => {
     Element.prototype.scrollIntoView = scrollIntoViewMock
-    const categories = [individualOfferCategoryFactory({ id: 'CID' })]
+    const categories = [categoryFactory({ id: 'CID' })]
     subCategories = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: SubcategoryIdEnum.ABO_JEU_VIDEO,
         categoryId: 'CID',
         onlineOfflinePlatform: CATEGORY_STATUS.ONLINE,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: SubcategoryIdEnum.CONCERT,
         categoryId: 'CID',
         onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
@@ -136,7 +136,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
       isVirtual: true,
     })
 
-    offer = GetIndividualOfferFactory({
+    offer = getIndividualOfferFactory({
       id: offerId,
       extraData: {
         author: 'Offer author',
@@ -168,7 +168,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
       status: OfferStatus.ACTIVE,
     })
 
-    contextOverride = individualOfferContextFactory({
+    contextOverride = individualOfferContextValuesFactory({
       offerId: offer.id,
       offer: offer,
       venueList: [venue1, venue2],
@@ -246,7 +246,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
   it('should submit minimal virtual offer and redirect to summary', async () => {
     contextOverride.offer = {
       ...offer,
-      venue: offerVenueFactory({ id: virtualVenueId }),
+      venue: getOfferVenueFactory({ id: virtualVenueId }),
       subcategoryId: SubcategoryIdEnum.ABO_JEU_VIDEO,
       isEvent: false,
       withdrawalDelay: undefined,
@@ -420,7 +420,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
     it('should submit when user click onCancel button, but should not send mail', async () => {
       contextOverride.offer = {
         ...offer,
-        venue: offerVenueFactory({ id: virtualVenueId }),
+        venue: getOfferVenueFactory({ id: virtualVenueId }),
         subcategoryId: SubcategoryIdEnum.ABO_JEU_VIDEO,
         isEvent: false,
         bookingsCount: 1,
@@ -488,7 +488,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
     it('should not submit when user click on close withdrawal dialog button', async () => {
       contextOverride.offer = {
         ...offer,
-        venue: offerVenueFactory({ id: virtualVenueId }),
+        venue: getOfferVenueFactory({ id: virtualVenueId }),
         subcategoryId: SubcategoryIdEnum.ABO_JEU_VIDEO,
         isEvent: false,
         bookingsCount: 1,
@@ -571,7 +571,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
       async (condition) => {
         contextOverride.offer = {
           ...offer,
-          venue: offerVenueFactory({ id: virtualVenueId }),
+          venue: getOfferVenueFactory({ id: virtualVenueId }),
           subcategoryId: SubcategoryIdEnum.ABO_JEU_VIDEO,
           isEvent: true,
           withdrawalDelay: undefined,
@@ -627,7 +627,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
     it('should not open widthdrawal dialog if offer is not active', async () => {
       contextOverride.offer = {
         ...offer,
-        venue: offerVenueFactory({ id: virtualVenueId }),
+        venue: getOfferVenueFactory({ id: virtualVenueId }),
         subcategoryId: SubcategoryIdEnum.ABO_JEU_VIDEO,
         isEvent: true,
         withdrawalDelay: undefined,
@@ -703,7 +703,7 @@ describe('screens:IndividualOffer::Informations:edition', () => {
       async (withdrawalInformations) => {
         contextOverride.offer = {
           ...offer,
-          venue: offerVenueFactory({ id: virtualVenueId }),
+          venue: getOfferVenueFactory({ id: virtualVenueId }),
           subcategoryId: SubcategoryIdEnum.ABO_JEU_VIDEO,
           isEvent: false,
           withdrawalType: WithdrawalTypeEnum.ON_SITE,

--- a/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.spec.tsx
@@ -11,9 +11,9 @@ import { CATEGORY_STATUS } from 'core/Offers/constants'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 import * as filterCategories from 'screens/IndividualOffer/InformationsScreen/utils/filterCategories/filterCategories'
 import {
-  individualOfferCategoryFactory,
-  individualOfferContextFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  individualOfferContextValuesFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -72,14 +72,14 @@ describe('screens:IndividualOffer::Informations', () => {
   beforeEach(() => {
     Element.prototype.scrollIntoView = scrollIntoViewMock
     const categories = [
-      individualOfferCategoryFactory({
+      categoryFactory({
         id: 'A',
         proLabel: 'Catégorie A',
         isSelectable: true,
       }),
     ]
     const subCategories = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'virtual',
         categoryId: 'A',
         proLabel: 'Sous catégorie online de A',
@@ -92,7 +92,7 @@ describe('screens:IndividualOffer::Informations', () => {
         reimbursementRule: REIMBURSEMENT_RULES.STANDARD,
         isSelectable: true,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'physical',
         categoryId: 'A',
         proLabel: 'Sous catégorie offline de A',
@@ -112,7 +112,7 @@ describe('screens:IndividualOffer::Informations', () => {
       offererId: '',
     }
 
-    contextValue = individualOfferContextFactory({
+    contextValue = individualOfferContextValuesFactory({
       categories,
       subCategories,
       offer: null,

--- a/pro/src/screens/IndividualOffer/InformationsScreen/utils/filterCategories/__specs__/filterCategories.spec.ts
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/utils/filterCategories/__specs__/filterCategories.spec.ts
@@ -4,8 +4,8 @@ import {
   INDIVIDUAL_OFFER_SUBTYPE,
 } from 'core/Offers/constants'
 import {
-  individualOfferCategoryFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  subcategoryFactory,
 } from 'utils/individualApiFactories'
 
 import {
@@ -78,47 +78,47 @@ describe('filterCategories', () => {
 
   beforeEach(() => {
     categories = [
-      individualOfferCategoryFactory({ id: 'A' }),
-      individualOfferCategoryFactory({ id: 'B' }),
-      individualOfferCategoryFactory({ id: 'C' }),
-      individualOfferCategoryFactory({ id: 'D' }),
+      categoryFactory({ id: 'A' }),
+      categoryFactory({ id: 'B' }),
+      categoryFactory({ id: 'C' }),
+      categoryFactory({ id: 'D' }),
     ]
     subCategories = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'A-A',
         categoryId: 'A',
         isEvent: true,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'A-B',
         categoryId: 'A',
         isEvent: false,
         isSelectable: false,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'B-A',
         categoryId: 'B',
         isEvent: false,
         onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'C-A',
         categoryId: 'C',
         isEvent: true,
         onlineOfflinePlatform: CATEGORY_STATUS.ONLINE_OR_OFFLINE,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'C-B',
         categoryId: 'C',
         isEvent: true,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'C-C',
         categoryId: 'C',
         isEvent: true,
         onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
       }),
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: 'C-D',
         categoryId: 'C',
         isEvent: true,

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategories.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategories.RouteLeavingGuard.spec.tsx
@@ -9,7 +9,7 @@ import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/cons
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
 import { ButtonLink } from 'ui-kit'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -103,7 +103,7 @@ describe('PriceCategories', () => {
   })
 
   it('should let going to information when clicking on previous step in creation', async () => {
-    renderPriceCategories({ offer: GetIndividualOfferFactory() })
+    renderPriceCategories({ offer: getIndividualOfferFactory() })
 
     await userEvent.click(screen.getByText('Retour'))
 
@@ -113,7 +113,7 @@ describe('PriceCategories', () => {
   })
 
   it('should let going to stock when form has been filled in creation', async () => {
-    renderPriceCategories({ offer: GetIndividualOfferFactory() })
+    renderPriceCategories({ offer: getIndividualOfferFactory() })
     await userEvent.type(
       screen.getByLabelText('Intitulé du tarif *'),
       'Mon tarif'
@@ -128,7 +128,7 @@ describe('PriceCategories', () => {
 
   it('should let going to recap when form has been filled in edition', async () => {
     renderPriceCategories(
-      { offer: GetIndividualOfferFactory() },
+      { offer: getIndividualOfferFactory() },
       generatePath(
         getIndividualOfferPath({
           step: OFFER_WIZARD_STEP_IDS.TARIFS,
@@ -151,7 +151,7 @@ describe('PriceCategories', () => {
 
   it('should go back to summary when clicking on "Annuler et quitter" in Edition', async () => {
     renderPriceCategories(
-      { offer: GetIndividualOfferFactory() },
+      { offer: getIndividualOfferFactory() },
       generatePath(
         getIndividualOfferPath({
           step: OFFER_WIZARD_STEP_IDS.TARIFS,

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategories.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategories.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import React from 'react'
 
 import { OfferStatus } from 'apiClient/v1'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -15,14 +15,14 @@ const renderPriceCategories = (props: PriceCategoriesScreenProps) =>
 
 describe('PriceCategories', () => {
   it('should render without error', () => {
-    renderPriceCategories({ offer: GetIndividualOfferFactory() })
+    renderPriceCategories({ offer: getIndividualOfferFactory() })
 
     expect(screen.getByText('Tarifs')).toBeInTheDocument()
   })
 
   it('should not disabled field for allociné', () => {
     renderPriceCategories({
-      offer: GetIndividualOfferFactory({ lastProvider: { name: 'allociné' } }),
+      offer: getIndividualOfferFactory({ lastProvider: { name: 'allociné' } }),
     })
 
     expect(screen.getByLabelText('Prix par personne *')).not.toBeDisabled()
@@ -30,7 +30,7 @@ describe('PriceCategories', () => {
 
   it('should disabled field for provider', () => {
     renderPriceCategories({
-      offer: GetIndividualOfferFactory({
+      offer: getIndividualOfferFactory({
         lastProvider: { name: 'provider' },
       }),
     })
@@ -40,7 +40,7 @@ describe('PriceCategories', () => {
 
   it('should disabled field for pending offer', () => {
     renderPriceCategories({
-      offer: GetIndividualOfferFactory({ status: OfferStatus.PENDING }),
+      offer: getIndividualOfferFactory({ status: OfferStatus.PENDING }),
     })
 
     expect(screen.getByLabelText('Prix par personne *')).toBeDisabled()
@@ -48,7 +48,7 @@ describe('PriceCategories', () => {
 
   it('should disabled field for rejected offer', () => {
     renderPriceCategories({
-      offer: GetIndividualOfferFactory({ status: OfferStatus.REJECTED }),
+      offer: getIndividualOfferFactory({ status: OfferStatus.REJECTED }),
     })
 
     expect(screen.getByLabelText('Prix par personne *')).toBeDisabled()

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategories.submit.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategories.submit.spec.tsx
@@ -10,7 +10,7 @@ import Notification from 'components/Notification/Notification'
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
 import { PATCH_SUCCESS_MESSAGE } from 'core/shared'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import { priceCategoryFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -50,7 +50,7 @@ const renderPriceCategories = (
 
 describe('PriceCategories', () => {
   beforeEach(() => {
-    vi.spyOn(api, 'getOffer').mockResolvedValue(GetIndividualOfferFactory())
+    vi.spyOn(api, 'getOffer').mockResolvedValue(getIndividualOfferFactory())
     vi.spyOn(api, 'patchOffer').mockResolvedValue(
       {} as GetIndividualOfferResponseModel
     )
@@ -61,7 +61,7 @@ describe('PriceCategories', () => {
 
   it('should notify and submit when clicking on Enregistrer et continuer in creation', async () => {
     renderPriceCategories({
-      offer: GetIndividualOfferFactory({ hasStocks: false }),
+      offer: getIndividualOfferFactory({ hasStocks: false }),
     })
     await userEvent.type(
       screen.getByLabelText('Intitulé du tarif *'),
@@ -79,7 +79,7 @@ describe('PriceCategories', () => {
 
   it('should display price modification modal', async () => {
     renderPriceCategories({
-      offer: GetIndividualOfferFactory({
+      offer: getIndividualOfferFactory({
         bookingsCount: 0,
         priceCategories: [priceCategoryFactory({ id: 666 })],
       }),
@@ -110,7 +110,7 @@ describe('PriceCategories', () => {
 
   it('should display price modification modal with booking', async () => {
     renderPriceCategories({
-      offer: GetIndividualOfferFactory({
+      offer: getIndividualOfferFactory({
         priceCategories: [priceCategoryFactory({ id: 666 })],
         bookingsCount: 10,
       }),
@@ -141,7 +141,7 @@ describe('PriceCategories', () => {
 
   it('should notify and submit when clicking on Enregistrer les modifications in edition', async () => {
     renderPriceCategories(
-      { offer: GetIndividualOfferFactory({ hasStocks: false }) },
+      { offer: getIndividualOfferFactory({ hasStocks: false }) },
       generatePath(
         getIndividualOfferPath({
           step: OFFER_WIZARD_STEP_IDS.TARIFS,
@@ -167,7 +167,7 @@ describe('PriceCategories', () => {
     vi.spyOn(api, 'postPriceCategories').mockRejectedValue({})
 
     renderPriceCategories(
-      { offer: GetIndividualOfferFactory({ hasStocks: false }) },
+      { offer: getIndividualOfferFactory({ hasStocks: false }) },
       generatePath(
         getIndividualOfferPath({
           step: OFFER_WIZARD_STEP_IDS.TARIFS,

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategoriesForm.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategoriesForm.spec.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { api } from 'apiClient/api'
 import { GetIndividualOfferResponseModel } from 'apiClient/v1'
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -37,7 +37,7 @@ const renderPriceCategoriesForm = (
   return renderWithProviders(
     <Formik initialValues={values} onSubmit={vi.fn()}>
       <PriceCategoriesForm
-        offer={GetIndividualOfferFactory({
+        offer={getIndividualOfferFactory({
           id: 42,
           hasStocks: false,
           priceCategories: [],
@@ -55,7 +55,7 @@ describe('PriceCategories', () => {
     vi.spyOn(api, 'postPriceCategories').mockResolvedValue(
       {} as GetIndividualOfferResponseModel
     )
-    vi.spyOn(api, 'getOffer').mockResolvedValue(GetIndividualOfferFactory())
+    vi.spyOn(api, 'getOffer').mockResolvedValue(getIndividualOfferFactory())
   })
 
   it('should render without error', () => {
@@ -186,7 +186,7 @@ describe('PriceCategories', () => {
     }
 
     renderPriceCategoriesForm(values, {
-      offer: GetIndividualOfferFactory({ id: 42, hasStocks: true }),
+      offer: getIndividualOfferFactory({ id: 42, hasStocks: true }),
     })
 
     // I can cancel

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/form/__specs__/computeInitialValues.spec.ts
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/form/__specs__/computeInitialValues.spec.ts
@@ -1,4 +1,4 @@
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 
 import { computeInitialValues } from '../computeInitialValues'
 
@@ -6,7 +6,7 @@ describe('computeInitialValues', () => {
   it('should sort prices', () => {
     expect(
       computeInitialValues(
-        GetIndividualOfferFactory({
+        getIndividualOfferFactory({
           priceCategories: [
             { id: 1, price: 10, label: 'Cat 1' },
             { id: 2, price: 20, label: 'Cat 2' },

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
@@ -15,9 +15,9 @@ import {
   getIndividualOfferUrl,
 } from 'core/Offers/utils/getIndividualOfferUrl'
 import { ButtonLink } from 'ui-kit'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import { FORMAT_ISO_DATE_ONLY } from 'utils/date'
-import { individualGetOfferStockResponseModelFactory } from 'utils/individualApiFactories'
+import { getOfferStockFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -102,7 +102,7 @@ describe('StocksEventCreation', () => {
 
   it('should notify when clicking on Enregistrer et continuer without stock', async () => {
     await renderStockEventCreation([], {
-      offer: GetIndividualOfferFactory(),
+      offer: getIndividualOfferFactory(),
     })
     expect(screen.getByText('Comment faire ?')).toBeInTheDocument()
 
@@ -115,8 +115,8 @@ describe('StocksEventCreation', () => {
 
   it('should not show help section if there are stocks already and show table', async () => {
     await renderStockEventCreation(
-      [individualGetOfferStockResponseModelFactory({ priceCategoryId: 1 })],
-      { offer: GetIndividualOfferFactory() }
+      [getOfferStockFactory({ priceCategoryId: 1 })],
+      { offer: getIndividualOfferFactory() }
     )
 
     expect(screen.queryByText('Comment faire ?')).not.toBeInTheDocument()
@@ -124,7 +124,7 @@ describe('StocksEventCreation', () => {
   })
 
   it('should display new stocks banner for several stocks', async () => {
-    await renderStockEventCreation([], { offer: GetIndividualOfferFactory() })
+    await renderStockEventCreation([], { offer: getIndividualOfferFactory() })
 
     await userEvent.click(screen.getByText('Ajouter une ou plusieurs dates'))
 
@@ -139,10 +139,7 @@ describe('StocksEventCreation', () => {
 
     vi.spyOn(api, 'upsertStocks').mockResolvedValue({ stocks_count: 2 })
     vi.spyOn(api, 'getStocks').mockResolvedValueOnce({
-      stocks: [
-        individualGetOfferStockResponseModelFactory(),
-        individualGetOfferStockResponseModelFactory(),
-      ],
+      stocks: [getOfferStockFactory(), getOfferStockFactory()],
       stockCount: 2,
       hasStocks: true,
     })
@@ -157,7 +154,7 @@ describe('StocksEventCreation', () => {
   })
 
   it('should redirect to previous page on click to Retour', async () => {
-    await renderStockEventCreation([], { offer: GetIndividualOfferFactory() })
+    await renderStockEventCreation([], { offer: getIndividualOfferFactory() })
 
     await userEvent.click(screen.getByText('Retour'))
 
@@ -165,12 +162,9 @@ describe('StocksEventCreation', () => {
   })
 
   it('should submit and redirect to next page on Enregistrer et continuer click', async () => {
-    await renderStockEventCreation(
-      [individualGetOfferStockResponseModelFactory()],
-      {
-        offer: GetIndividualOfferFactory(),
-      }
-    )
+    await renderStockEventCreation([getOfferStockFactory()], {
+      offer: getIndividualOfferFactory(),
+    })
 
     await userEvent.click(screen.getByText('Enregistrer et continuer'))
 
@@ -180,7 +174,7 @@ describe('StocksEventCreation', () => {
   it('should notify when there is not yet stocks', async () => {
     vi.spyOn(api, 'upsertStocks').mockRejectedValueOnce({})
 
-    await renderStockEventCreation([], { offer: GetIndividualOfferFactory() })
+    await renderStockEventCreation([], { offer: getIndividualOfferFactory() })
 
     await userEvent.click(screen.getByText('Enregistrer et continuer'))
 

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/form/__specs__/onSubmit.spec.ts
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/form/__specs__/onSubmit.spec.ts
@@ -1,6 +1,6 @@
 import { api } from 'apiClient/api'
 import { StocksEvent } from 'components/StocksEventList/StocksEventList'
-import { individualStockEventFactory } from 'utils/individualApiFactories'
+import { StocksEventFactory } from 'utils/individualApiFactories'
 
 import { onSubmit } from '../onSubmit'
 import {
@@ -44,25 +44,25 @@ describe('onSubmit', () => {
         monthlyOption: null,
       },
       expectedStocks: [
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-03T09:00:00Z',
           bookingLimitDatetime: '2020-03-01T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-03T09:00:00Z',
           bookingLimitDatetime: '2020-03-01T09:00:00Z',
           priceCategoryId: 2,
           quantity: null,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-03T09:30:00Z',
           bookingLimitDatetime: '2020-03-01T09:30:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-03T09:30:00Z',
           bookingLimitDatetime: '2020-03-01T09:30:00Z',
           priceCategoryId: 2,
@@ -84,25 +84,25 @@ describe('onSubmit', () => {
         monthlyOption: null,
       },
       expectedStocks: [
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-03T09:00:00Z',
           bookingLimitDatetime: '2020-03-01T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-04T09:00:00Z',
           bookingLimitDatetime: '2020-03-02T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-05T09:00:00Z',
           bookingLimitDatetime: '2020-03-03T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-06T09:00:00Z',
           bookingLimitDatetime: '2020-03-04T09:00:00Z',
           priceCategoryId: 1,
@@ -124,25 +124,25 @@ describe('onSubmit', () => {
         monthlyOption: null,
       },
       expectedStocks: [
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-07T09:00:00Z',
           bookingLimitDatetime: '2020-03-05T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-08T09:00:00Z',
           bookingLimitDatetime: '2020-03-06T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-14T09:00:00Z',
           bookingLimitDatetime: '2020-03-12T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-15T09:00:00Z',
           bookingLimitDatetime: '2020-03-13T09:00:00Z',
           priceCategoryId: 1,
@@ -165,25 +165,25 @@ describe('onSubmit', () => {
         monthlyOption: MonthlyOption.X_OF_MONTH,
       },
       expectedStocks: [
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-03T09:00:00Z',
           bookingLimitDatetime: '2020-03-01T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-04-03T08:00:00Z',
           bookingLimitDatetime: '2020-04-01T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-05-03T08:00:00Z',
           bookingLimitDatetime: '2020-05-01T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-06-03T08:00:00Z',
           bookingLimitDatetime: '2020-06-01T08:00:00Z',
           priceCategoryId: 1,
@@ -205,13 +205,13 @@ describe('onSubmit', () => {
         monthlyOption: MonthlyOption.X_OF_MONTH,
       },
       expectedStocks: [
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-31T08:00:00Z',
           bookingLimitDatetime: '2020-03-29T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-05-31T08:00:00Z',
           bookingLimitDatetime: '2020-05-29T08:00:00Z',
           priceCategoryId: 1,
@@ -235,25 +235,25 @@ describe('onSubmit', () => {
         monthlyOption: MonthlyOption.BY_FIRST_DAY,
       },
       expectedStocks: [
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-03T09:00:00Z',
           bookingLimitDatetime: '2020-03-01T09:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-04-07T08:00:00Z',
           bookingLimitDatetime: '2020-04-05T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-05-05T08:00:00Z',
           bookingLimitDatetime: '2020-05-03T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-06-02T08:00:00Z',
           bookingLimitDatetime: '2020-05-31T08:00:00Z',
           priceCategoryId: 1,
@@ -276,19 +276,19 @@ describe('onSubmit', () => {
         monthlyOption: MonthlyOption.BY_FIRST_DAY,
       },
       expectedStocks: [
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-03-31T08:00:00Z',
           bookingLimitDatetime: '2020-03-29T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-06-30T08:00:00Z',
           bookingLimitDatetime: '2020-06-28T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2020-09-29T08:00:00Z',
           bookingLimitDatetime: '2020-09-27T08:00:00Z',
           priceCategoryId: 1,
@@ -310,19 +310,19 @@ describe('onSubmit', () => {
         monthlyOption: MonthlyOption.BY_LAST_DAY,
       },
       expectedStocks: [
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2023-03-31T08:00:00Z',
           bookingLimitDatetime: '2023-03-29T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2023-04-28T08:00:00Z',
           bookingLimitDatetime: '2023-04-26T08:00:00Z',
           priceCategoryId: 1,
           quantity: 5,
         }),
-        individualStockEventFactory({
+        StocksEventFactory({
           beginningDatetime: '2023-05-26T08:00:00Z',
           bookingLimitDatetime: '2023-05-24T08:00:00Z',
           priceCategoryId: 1,

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
@@ -31,9 +31,9 @@ import {
 import { PATCH_SUCCESS_MESSAGE } from 'core/shared'
 import { Stocks } from 'pages/IndividualOfferWizard/Stocks/Stocks'
 import { ButtonLink } from 'ui-kit'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import { FORMAT_ISO_DATE_ONLY } from 'utils/date'
-import { individualGetOfferStockResponseModelFactory } from 'utils/individualApiFactories'
+import { getOfferStockFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 vi.mock('utils/date', async () => {
@@ -158,11 +158,11 @@ describe('screens:StocksEventEdition', () => {
 
   beforeEach(() => {
     apiStocks = [
-      individualGetOfferStockResponseModelFactory({
+      getOfferStockFactory({
         bookingsQuantity: 4,
       }),
     ]
-    apiOffer = GetIndividualOfferFactory({
+    apiOffer = getIndividualOfferFactory({
       bookingEmail: 'test@example.com',
       description: 'A passionate description of product 80',
       durationMinutes: null,
@@ -229,8 +229,8 @@ describe('screens:StocksEventEdition', () => {
   })
 
   it('should allow user to delete a stock', async () => {
-    const stock1 = individualGetOfferStockResponseModelFactory()
-    const stock2 = individualGetOfferStockResponseModelFactory()
+    const stock1 = getOfferStockFactory()
+    const stock2 = getOfferStockFactory()
 
     await renderStockEventScreen(apiOffer, [stock1, stock2])
     vi.clearAllMocks()
@@ -258,7 +258,7 @@ describe('screens:StocksEventEdition', () => {
   it('should reload the page if deleting last stock of the page', async () => {
     await renderStockEventScreen(
       apiOffer,
-      [individualGetOfferStockResponseModelFactory()],
+      [getOfferStockFactory()],
       STOCKS_PER_PAGE * 5 + 10,
       '?page=3'
     )
@@ -287,7 +287,7 @@ describe('screens:StocksEventEdition', () => {
   it('should go to previous page if deleting last stock of the last page', async () => {
     await renderStockEventScreen(
       apiOffer,
-      [individualGetOfferStockResponseModelFactory()],
+      [getOfferStockFactory()],
       STOCKS_PER_PAGE * 5 + 1,
       '?page=6'
     )
@@ -481,7 +481,7 @@ describe('screens:StocksEventEdition', () => {
   })
 
   it('should save the offer without warning on "Enregistrer les modifications" button click', async () => {
-    const testedStock = individualGetOfferStockResponseModelFactory({
+    const testedStock = getOfferStockFactory({
       bookingsQuantity: 0,
     })
 
@@ -602,7 +602,7 @@ describe('screens:StocksEventEdition', () => {
   it('should display blocker when form is dirty', async () => {
     await renderStockEventScreen(
       apiOffer,
-      [individualGetOfferStockResponseModelFactory()],
+      [getOfferStockFactory()],
       STOCKS_PER_PAGE * 5 + 10,
       '?page=3'
     )

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -24,7 +24,7 @@ import {
 import { PATCH_SUCCESS_MESSAGE } from 'core/shared'
 import { Stocks } from 'pages/IndividualOfferWizard/Stocks/Stocks'
 import { RootState } from 'store/rootReducer'
-import { individualGetOfferStockResponseModelFactory } from 'utils/individualApiFactories'
+import { getOfferStockFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 vi.mock('screens/IndividualOffer/Informations/utils', () => {
@@ -94,7 +94,7 @@ const renderStockThingScreen = (storeOverrides: Partial<RootState> = {}) =>
 describe('screens:StocksThing', () => {
   let storeOverride: Partial<RootState>
   let apiOffer: GetIndividualOfferResponseModel
-  const stockToDelete = individualGetOfferStockResponseModelFactory({
+  const stockToDelete = getOfferStockFactory({
     beginningDatetime: '2022-05-23T08:25:31.009799Z',
     bookingLimitDatetime: '2022-05-23T07:25:31.009799Z',
     bookingsQuantity: 4,

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
@@ -26,14 +26,14 @@ import {
 } from 'core/Offers/utils/getIndividualOfferUrl'
 import { ButtonLink } from 'ui-kit'
 import {
-  GetIndividualOfferFactory,
-  offerVenueFactory,
+  getIndividualOfferFactory,
+  getOfferVenueFactory,
 } from 'utils/apiFactories'
 import { FORMAT_ISO_DATE_ONLY } from 'utils/date'
 import {
-  individualGetOfferStockResponseModelFactory,
-  individualOfferContextFactory,
-  individualOfferSubCategoryFactory,
+  getOfferStockFactory,
+  individualOfferContextValuesFactory,
+  subcategoryFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -112,9 +112,9 @@ describe('screens:StocksThing', () => {
   const offerId = 1
 
   beforeEach(() => {
-    offer = GetIndividualOfferFactory({
+    offer = getIndividualOfferFactory({
       id: offerId,
-      venue: offerVenueFactory({
+      venue: getOfferVenueFactory({
         departementCode: '75',
       }),
       subcategoryId: SubcategoryIdEnum.CINE_PLEIN_AIR,
@@ -122,11 +122,11 @@ describe('screens:StocksThing', () => {
     props = {
       offer,
     }
-    contextValue = individualOfferContextFactory({
+    contextValue = individualOfferContextValuesFactory({
       offerId: offerId,
       offer,
       subCategories: [
-        individualOfferSubCategoryFactory({
+        subcategoryFactory({
           id: SubcategoryIdEnum.CINE_PLEIN_AIR,
           canBeDuo: true,
         }),
@@ -412,7 +412,7 @@ describe('screens:StocksThing', () => {
       }
       await renderStockThingScreen(
         [
-          individualGetOfferStockResponseModelFactory({
+          getOfferStockFactory({
             bookingsQuantity: 1,
             price: 12,
             hasActivationCode: true,

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/validationSchema.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/validationSchema.spec.tsx
@@ -1,7 +1,7 @@
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { getYupValidationSchemaErrors } from 'utils/yupValidationTestHelpers'
 
-import { stockThingFactory } from '../stockThingFactory'
+import { stockThingFormValuesFactory } from '../stockThingFormValuesFactory'
 import { StockThingFormValues } from '../types'
 import { getValidationSchema } from '../validationSchema'
 
@@ -14,7 +14,7 @@ describe('validationSchema', () => {
   }[] = [
     {
       description: 'valid form',
-      formValues: stockThingFactory(),
+      formValues: stockThingFormValuesFactory(),
       expectedErrors: [],
       minQuantity: null,
     },

--- a/pro/src/screens/IndividualOffer/StocksThing/stockThingFormValuesFactory.ts
+++ b/pro/src/screens/IndividualOffer/StocksThing/stockThingFormValuesFactory.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file: Those are test helpers, their coverage is not relevant */
 import { StockThingFormValues } from './types'
 
-export const stockThingFactory = (
+export const stockThingFormValuesFactory = (
   customStockThing: Partial<StockThingFormValues> = {}
 ): StockThingFormValues => ({
   stockId: 1,

--- a/pro/src/screens/IndividualOffer/StocksThing/utils/__specs__/buildInitialValues.spec.ts
+++ b/pro/src/screens/IndividualOffer/StocksThing/utils/__specs__/buildInitialValues.spec.ts
@@ -1,9 +1,9 @@
 import { GetIndividualOfferResponseModel } from 'apiClient/v1'
 import {
-  GetIndividualOfferFactory,
-  offerVenueFactory,
+  getIndividualOfferFactory,
+  getOfferVenueFactory,
 } from 'utils/apiFactories'
-import { individualGetOfferStockResponseModelFactory } from 'utils/individualApiFactories'
+import { getOfferStockFactory } from 'utils/individualApiFactories'
 
 import { STOCK_THING_FORM_DEFAULT_VALUES } from '../../constants'
 import buildInitialValues from '../buildInitialValues'
@@ -11,8 +11,8 @@ import buildInitialValues from '../buildInitialValues'
 describe('StockThingForm::utils::buildInitialValues', () => {
   let offer: GetIndividualOfferResponseModel
   beforeEach(() => {
-    offer = GetIndividualOfferFactory({
-      venue: offerVenueFactory({ departementCode: '93' }),
+    offer = getIndividualOfferFactory({
+      venue: getOfferVenueFactory({ departementCode: '93' }),
     })
   })
 
@@ -23,7 +23,7 @@ describe('StockThingForm::utils::buildInitialValues', () => {
 
   it('should build form initial values from offer', () => {
     const initialValues = buildInitialValues(offer, [
-      individualGetOfferStockResponseModelFactory({
+      getOfferStockFactory({
         id: 1,
         remainingQuantity: 10,
         bookingsQuantity: 20,
@@ -47,7 +47,7 @@ describe('StockThingForm::utils::buildInitialValues', () => {
 
   it('should normalize null values', () => {
     const initialValues = buildInitialValues(offer, [
-      individualGetOfferStockResponseModelFactory({
+      getOfferStockFactory({
         id: 1,
         bookingsQuantity: 20,
         remainingQuantity: undefined,

--- a/pro/src/screens/IndividualOffer/StocksThing/utils/__specs__/setFormReadOnlyFields.spec.ts
+++ b/pro/src/screens/IndividualOffer/StocksThing/utils/__specs__/setFormReadOnlyFields.spec.ts
@@ -1,6 +1,6 @@
 import { GetIndividualOfferResponseModel, OfferStatus } from 'apiClient/v1'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
-import { individualGetOfferStockResponseModelFactory } from 'utils/individualApiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
+import { getOfferStockFactory } from 'utils/individualApiFactories'
 
 import { StockThingFormValues } from '../../types'
 import setFormReadOnlyFields from '../setFormReadOnlyFields'
@@ -9,7 +9,7 @@ describe('StockThingForm::utils::setFormReadOnlyFields', () => {
   let offer: GetIndividualOfferResponseModel
   let currentStock: StockThingFormValues
   beforeEach(() => {
-    offer = GetIndividualOfferFactory()
+    offer = getIndividualOfferFactory()
     currentStock = {} as StockThingFormValues
   })
   const disabledStatus = [OfferStatus.REJECTED, OfferStatus.PENDING]
@@ -19,7 +19,7 @@ describe('StockThingForm::utils::setFormReadOnlyFields', () => {
       offer.status = status
       const readOnlyFields = setFormReadOnlyFields(
         offer,
-        [individualGetOfferStockResponseModelFactory()],
+        [getOfferStockFactory()],
         currentStock
       )
       expect(readOnlyFields).toEqual([
@@ -42,7 +42,7 @@ describe('StockThingForm::utils::setFormReadOnlyFields', () => {
     }
     const readOnlyFields = setFormReadOnlyFields(
       offer,
-      [individualGetOfferStockResponseModelFactory()],
+      [getOfferStockFactory()],
       currentStock
     )
     expect(readOnlyFields).toEqual([
@@ -65,7 +65,7 @@ describe('StockThingForm::utils::setFormReadOnlyFields', () => {
     } as StockThingFormValues
     const readOnlyFields = setFormReadOnlyFields(
       offer,
-      [individualGetOfferStockResponseModelFactory()],
+      [getOfferStockFactory()],
       currentStock
     )
     expect(readOnlyFields).toEqual([])

--- a/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/__specs__/serializer.spec.ts
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/__specs__/serializer.spec.ts
@@ -7,8 +7,8 @@ import {
   WithdrawalTypeEnum,
 } from 'apiClient/v1'
 import { CATEGORY_STATUS } from 'core/Offers/constants'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
-import { individualOfferSubCategoryFactory } from 'utils/individualApiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
+import { subcategoryFactory } from 'utils/individualApiFactories'
 
 import { serializeOfferSectionData } from '../serializer'
 
@@ -18,7 +18,7 @@ describe('routes::Summary::serializers', () => {
   let subCategoryList: SubcategoryResponseModel[]
 
   beforeEach(() => {
-    offer = GetIndividualOfferFactory({
+    offer = getIndividualOfferFactory({
       id: 12,
       extraData: {
         author: 'Offer author',
@@ -52,7 +52,7 @@ describe('routes::Summary::serializers', () => {
       },
     ]
     subCategoryList = [
-      individualOfferSubCategoryFactory({
+      subcategoryFactory({
         id: SubcategoryIdEnum.CONCERT,
         categoryId: 'CID',
         proLabel: 'sub-category proLabel',

--- a/pro/src/screens/IndividualOffer/SummaryScreen/PriceCategoriesSection/__specs__/PriceCategoriesSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/PriceCategoriesSection/__specs__/PriceCategoriesSection.spec.tsx
@@ -1,14 +1,14 @@
 import { screen } from '@testing-library/react'
 import React from 'react'
 
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { PriceCategoriesSection } from '../PriceCategoriesSection'
 
 describe('StockEventSection', () => {
   it('should render correctly', () => {
-    const offer = GetIndividualOfferFactory()
+    const offer = getIndividualOfferFactory()
 
     renderWithProviders(<PriceCategoriesSection offer={offer} canBeDuo />)
 
@@ -19,7 +19,7 @@ describe('StockEventSection', () => {
   })
 
   it('should render correctly when offer cannot be duo', () => {
-    const offer = GetIndividualOfferFactory()
+    const offer = getIndividualOfferFactory()
 
     renderWithProviders(
       <PriceCategoriesSection offer={offer} canBeDuo={false} />

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/__specs__/StockThingSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/StockThingSection/__specs__/StockThingSection.spec.tsx
@@ -1,13 +1,13 @@
 import { screen } from '@testing-library/react'
 
-import { individualGetOfferStockResponseModelFactory } from 'utils/individualApiFactories'
+import { getOfferStockFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StockThingSection from '../StockThingSection'
 
 describe('StockThingSection', () => {
   it('should render correctly', () => {
-    const stock = individualGetOfferStockResponseModelFactory()
+    const stock = getOfferStockFactory()
 
     renderWithProviders(
       <StockThingSection stock={stock} canBeDuo={false} isDuo={false} />
@@ -27,7 +27,7 @@ describe('StockThingSection', () => {
   })
 
   it('should render duo informations for can be duo things (like ESCAPE_GAME or CARTE_MUSEE)', () => {
-    const stock = individualGetOfferStockResponseModelFactory()
+    const stock = getOfferStockFactory()
 
     renderWithProviders(
       <StockThingSection stock={stock} canBeDuo={true} isDuo={true} />

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/__specs__/StockSection.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/__specs__/StockSection.spec.tsx
@@ -12,8 +12,8 @@ import { OfferStatus } from 'apiClient/v1'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
-import { individualGetOfferStockResponseModelFactory } from 'utils/individualApiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
+import { getOfferStockFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StockSection, { StockSectionProps } from '../StockSection'
@@ -66,7 +66,7 @@ describe('Summary stock section', () => {
         hasStocks: true,
         stockCount: 1,
         stocks: [
-          individualGetOfferStockResponseModelFactory({
+          getOfferStockFactory({
             quantity: 0,
             price: 20,
             bookingLimitDatetime: null,
@@ -75,7 +75,7 @@ describe('Summary stock section', () => {
       })
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           isEvent: false,
           status: OfferStatus.SOLD_OUT,
         }),
@@ -105,11 +105,11 @@ describe('Summary stock section', () => {
       vi.spyOn(api, 'getStocks').mockResolvedValueOnce({
         hasStocks: true,
         stockCount: 1,
-        stocks: [individualGetOfferStockResponseModelFactory()],
+        stocks: [getOfferStockFactory()],
       })
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           status: OfferStatus.EXPIRED,
           isEvent: false,
         }),
@@ -142,7 +142,7 @@ describe('Summary stock section', () => {
       })
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           status: OfferStatus.SOLD_OUT,
           isEvent: false,
           hasStocks: false,
@@ -177,7 +177,7 @@ describe('Summary stock section', () => {
         hasStocks: true,
         stockCount: 1,
         stocks: [
-          individualGetOfferStockResponseModelFactory({
+          getOfferStockFactory({
             quantity: 10,
             price: 20,
             bookingLimitDatetime: null,
@@ -186,7 +186,7 @@ describe('Summary stock section', () => {
       })
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           status: OfferStatus.ACTIVE,
           isEvent: false,
         }),
@@ -223,7 +223,7 @@ describe('Summary stock section', () => {
         hasStocks: true,
         stockCount: 1,
         stocks: [
-          individualGetOfferStockResponseModelFactory({
+          getOfferStockFactory({
             quantity: 10,
             price: 20,
             bookingLimitDatetime: null,
@@ -232,7 +232,7 @@ describe('Summary stock section', () => {
       })
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           status: OfferStatus.ACTIVE,
           isEvent: false,
         }),
@@ -258,7 +258,7 @@ describe('Summary stock section', () => {
         hasStocks: true,
         stockCount: 1,
         stocks: [
-          individualGetOfferStockResponseModelFactory({
+          getOfferStockFactory({
             quantity: 10,
             price: 20,
             bookingLimitDatetime: '2001-06-12',
@@ -267,7 +267,7 @@ describe('Summary stock section', () => {
       })
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           status: OfferStatus.EXPIRED,
           isEvent: false,
         }),
@@ -284,13 +284,11 @@ describe('Summary stock section', () => {
       vi.spyOn(api, 'getStocks').mockResolvedValueOnce({
         hasStocks: true,
         stockCount: 1,
-        stocks: [
-          individualGetOfferStockResponseModelFactory({ quantity: null }),
-        ],
+        stocks: [getOfferStockFactory({ quantity: null })],
       })
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           status: OfferStatus.ACTIVE,
           isEvent: false,
         }),
@@ -309,7 +307,7 @@ describe('Summary stock section', () => {
       vi.spyOn(api, 'getStocksStats').mockResolvedValueOnce({})
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           status: OfferStatus.ACTIVE,
           isEvent: true,
           hasStocks: false,
@@ -351,7 +349,7 @@ describe('Summary stock section', () => {
       vi.spyOn(api, 'getStocksStats').mockResolvedValueOnce({})
 
       const props = {
-        offer: GetIndividualOfferFactory({
+        offer: getIndividualOfferFactory({
           status: OfferStatus.ACTIVE,
           isEvent: true,
         }),

--- a/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/__specs__/getStockWarningText.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/StockSection/__specs__/getStockWarningText.spec.tsx
@@ -1,5 +1,5 @@
 import { OfferStatus } from 'apiClient/v1'
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 
 import { getStockWarningText } from '../StockSection'
 
@@ -40,7 +40,7 @@ describe('getStockWarningText', () => {
     'should render $expected',
     ({ offerStatus, hasStocks, expected }) => {
       const result = getStockWarningText(
-        GetIndividualOfferFactory({ status: offerStatus, hasStocks })
+        getIndividualOfferFactory({ status: offerStatus, hasStocks })
       )
 
       expect(result).toStrictEqual(expected)

--- a/pro/src/screens/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
@@ -25,14 +25,14 @@ import { getIndividualOfferPath } from 'core/Offers/utils/getIndividualOfferUrl'
 import * as useAnalytics from 'hooks/useAnalytics'
 import {
   defaultGetOffererResponseModel,
-  GetIndividualOfferFactory,
-  offererFactory,
-  offerVenueFactory,
+  getIndividualOfferFactory,
+  getOfferManagingOffererFactory,
+  getOfferVenueFactory,
 } from 'utils/apiFactories'
 import {
-  individualOfferCategoryFactory,
-  individualOfferContextFactory,
-  individualOfferSubCategoryFactory,
+  categoryFactory,
+  individualOfferContextValuesFactory,
+  subcategoryFactory,
   individualOfferVenueItemFactory,
 } from 'utils/individualApiFactories'
 import {
@@ -52,7 +52,7 @@ const renderSummary = (
   }),
   options?: RenderWithProvidersOptions
 ) => {
-  const contextValues = individualOfferContextFactory(customContext)
+  const contextValues = individualOfferContextValuesFactory(customContext)
 
   return renderWithProviders(
     <>
@@ -87,14 +87,14 @@ const renderSummary = (
   )
 }
 
-const categories = [individualOfferCategoryFactory({ id: 'A' })]
+const categories = [categoryFactory({ id: 'A' })]
 
 const subCategories = [
-  individualOfferSubCategoryFactory({
+  subcategoryFactory({
     id: String(SubcategoryIdEnum.CONCERT),
     categoryId: 'A',
   }),
-  individualOfferSubCategoryFactory({ categoryId: 'A' }),
+  subcategoryFactory({ categoryId: 'A' }),
 ]
 
 describe('Summary', () => {
@@ -127,7 +127,7 @@ describe('Summary', () => {
       },
     ]
     customContext = {
-      offer: GetIndividualOfferFactory({
+      offer: getIndividualOfferFactory({
         isEvent: false,
         name: 'mon offre',
         lastProvider: {
@@ -143,11 +143,13 @@ describe('Summary', () => {
         withdrawalDetails: 'détails de retrait',
         externalTicketOfficeUrl: 'https://grand-public-url.example.com',
         bookingEmail: 'booking@example.com',
-        venue: offerVenueFactory({
+        venue: getOfferVenueFactory({
           name: 'ma venue',
           publicName: 'ma venue (nom public)',
           isVirtual: true,
-          managingOfferer: offererFactory({ name: 'mon offerer' }),
+          managingOfferer: getOfferManagingOffererFactory({
+            name: 'mon offerer',
+          }),
         }),
       }),
       subCategories,
@@ -158,7 +160,7 @@ describe('Summary', () => {
       logEvent: mockLogEvent,
     }))
     vi.spyOn(api, 'patchPublishOffer').mockResolvedValue(
-      GetIndividualOfferFactory()
+      getIndividualOfferFactory()
     )
     vi.spyOn(api, 'getEventMusicTypes').mockResolvedValue(eventMusicTypes)
     vi.spyOn(api, 'getAllMusicTypes').mockResolvedValue(allMusicTypes)
@@ -309,7 +311,7 @@ describe('Summary', () => {
       const mockResponse =
         new CancelablePromise<GetIndividualOfferResponseModel>((resolve) =>
           setTimeout(() => {
-            resolve(GetIndividualOfferFactory())
+            resolve(getIndividualOfferFactory())
           }, 200)
         )
       vi.spyOn(api, 'patchPublishOffer').mockImplementationOnce(
@@ -361,8 +363,8 @@ describe('Summary', () => {
     it('should display redirect modal if first offer', async () => {
       const venueId = 1
       const context = {
-        offer: GetIndividualOfferFactory({
-          venue: offerVenueFactory({ id: venueId }),
+        offer: getIndividualOfferFactory({
+          venue: getOfferVenueFactory({ id: venueId }),
         }),
         offerOfferer: { name: 'offerOffererName', id: 1 },
         showVenuePopin: {
@@ -398,7 +400,7 @@ describe('Summary', () => {
 
     it('should display redirect modal if first non free offer', async () => {
       const context = {
-        offer: GetIndividualOfferFactory(),
+        offer: getIndividualOfferFactory(),
         offerOfferer: { name: 'offerOffererName', id: 1 },
         venueList: [individualOfferVenueItemFactory()],
       }
@@ -411,7 +413,7 @@ describe('Summary', () => {
       })
 
       vi.spyOn(api, 'patchPublishOffer').mockResolvedValue(
-        GetIndividualOfferFactory({ isNonFreeOffer: true })
+        getIndividualOfferFactory({ isNonFreeOffer: true })
       )
 
       renderSummary(
@@ -448,7 +450,7 @@ describe('Summary', () => {
 
     it('should not display redirect modal if hasPendingBankAccount is true', async () => {
       const context = {
-        offer: GetIndividualOfferFactory(),
+        offer: getIndividualOfferFactory(),
         offerOfferer: { name: 'offerOffererName', id: 1 },
         venueList: [individualOfferVenueItemFactory()],
       }
@@ -460,7 +462,7 @@ describe('Summary', () => {
       })
 
       vi.spyOn(api, 'patchPublishOffer').mockResolvedValue(
-        GetIndividualOfferFactory({ isNonFreeOffer: false })
+        getIndividualOfferFactory({ isNonFreeOffer: false })
       )
 
       renderSummary(
@@ -491,7 +493,7 @@ describe('Summary', () => {
 
     it('should not display redirect modal if offer is free', async () => {
       const context = {
-        offer: GetIndividualOfferFactory(),
+        offer: getIndividualOfferFactory(),
         venueList: [individualOfferVenueItemFactory()],
       }
 
@@ -523,7 +525,7 @@ describe('Summary', () => {
 
     it('should not display redirect modal if venue hasNonFreeOffers', async () => {
       const context = {
-        offer: GetIndividualOfferFactory(),
+        offer: getIndividualOfferFactory(),
         venueList: [individualOfferVenueItemFactory()],
       }
 

--- a/pro/src/screens/IndividualOffer/utils/__specs__/getIndividualOfferImage.spec.ts
+++ b/pro/src/screens/IndividualOffer/utils/__specs__/getIndividualOfferImage.spec.ts
@@ -1,4 +1,4 @@
-import { GetIndividualOfferFactory } from 'utils/apiFactories'
+import { getIndividualOfferFactory } from 'utils/apiFactories'
 
 import { getIndividualOfferImage } from '../getIndividualOfferImage'
 
@@ -40,7 +40,7 @@ describe('getIndividualOfferImage', () => {
   it.each(serializeOfferApiImageDataSet)(
     'using image from mediation',
     ({ activeMediation, expectedImage }) => {
-      const offerApi = GetIndividualOfferFactory({
+      const offerApi = getIndividualOfferFactory({
         activeMediation,
       })
 
@@ -49,7 +49,7 @@ describe('getIndividualOfferImage', () => {
   )
 
   it('using image from thumbUrl', () => {
-    const offer = GetIndividualOfferFactory({
+    const offer = getIndividualOfferFactory({
       thumbUrl: 'https://image.url',
       activeMediation: undefined,
     })

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormPracticalInformation/__specs__/FormPracticalInformation.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormPracticalInformation/__specs__/FormPracticalInformation.spec.tsx
@@ -8,7 +8,10 @@ import {
   EVENT_ADDRESS_OTHER_ADDRESS_LABEL,
   INTERVENTION_AREA_LABEL,
 } from 'screens/OfferEducational/constants/labels'
-import { offerVenueFactory, offererFactory } from 'utils/apiFactories'
+import {
+  getOfferVenueFactory,
+  getOfferManagingOffererFactory,
+} from 'utils/apiFactories'
 
 import FormPracticalInformation, {
   FormPracticalInformationProps,
@@ -46,17 +49,17 @@ describe('FormPracticalInformation', () => {
         { label: 'VENUE_2', value: 'V2' },
       ],
       currentOfferer: {
-        ...offererFactory({}),
+        ...getOfferManagingOffererFactory({}),
         managedVenues: [
           {
-            ...offerVenueFactory({
+            ...getOfferVenueFactory({
               publicName: 'Venue1',
               name: 'Venue1',
             }),
             id: 1,
           },
           {
-            ...offerVenueFactory({
+            ...getOfferVenueFactory({
               publicName: 'Venue2',
               name: 'Venue2',
             }),

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { Mode } from 'core/OfferEducational'
 import {
   collectiveOfferFactory,
-  collectiveOfferVenueFactory,
+  getCollectiveOfferVenueFactory,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -48,7 +48,7 @@ describe('screens | OfferEducational', () => {
       offer: collectiveOfferFactory(
         undefined,
         undefined,
-        collectiveOfferVenueFactory({})
+        getCollectiveOfferVenueFactory({})
       ),
       mode: Mode.READ_ONLY,
     }

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalEditionOffererStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalEditionOffererStep.spec.tsx
@@ -5,8 +5,8 @@ import { CollectiveBookingStatus } from 'apiClient/v1'
 import { Mode } from 'core/OfferEducational'
 import {
   collectiveOfferFactory,
-  collectiveOfferOffererFactory,
-  collectiveOfferVenueFactory,
+  getCollectiveOfferManagingOffererFactory,
+  getCollectiveOfferVenueFactory,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -53,9 +53,9 @@ describe('screens | OfferEducational : edition offerer step', () => {
         {
           id: thirdVenueId,
           venue: {
-            ...collectiveOfferVenueFactory({
+            ...getCollectiveOfferVenueFactory({
               id: thirdVenueId,
-              managingOfferer: collectiveOfferOffererFactory({
+              managingOfferer: getCollectiveOfferManagingOffererFactory({
                 id: secondOffererId,
               }),
             }),
@@ -63,7 +63,7 @@ describe('screens | OfferEducational : edition offerer step', () => {
           },
         },
         undefined,
-        collectiveOfferVenueFactory({ id: secondOffererId })
+        getCollectiveOfferVenueFactory({ id: secondOffererId })
       ),
     }
 
@@ -110,8 +110,8 @@ describe('screens | OfferEducational : edition offerer step', () => {
         {
           id: thirdVenueId,
           venue: {
-            ...collectiveOfferVenueFactory({
-              managingOfferer: collectiveOfferOffererFactory({
+            ...getCollectiveOfferVenueFactory({
+              managingOfferer: getCollectiveOfferManagingOffererFactory({
                 id: secondOffererId,
               }),
             }),
@@ -120,7 +120,7 @@ describe('screens | OfferEducational : edition offerer step', () => {
           lastBookingStatus: CollectiveBookingStatus.USED,
         },
         undefined,
-        collectiveOfferVenueFactory({})
+        getCollectiveOfferVenueFactory({})
       ),
     }
     renderWithProviders(<OfferEducational {...props} />)

--- a/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.navigation.spec.tsx
@@ -5,9 +5,9 @@ import * as router from 'react-router-dom'
 import { api } from 'apiClient/api'
 import { SubcategoryIdEnum, VenueTypeCode } from 'apiClient/v1'
 import {
-  individualOfferCategoryFactory,
-  individualOfferSubCategoryResponseModelFactory,
-  individualOfferVenueResponseModelFactory,
+  categoryFactory,
+  getVenueFactory,
+  subcategoryFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -51,9 +51,9 @@ describe('screens:IndividualOffer::OfferType', () => {
 
   beforeEach(() => {
     vi.spyOn(api, 'getCategories').mockResolvedValue({
-      categories: [individualOfferCategoryFactory()],
+      categories: [categoryFactory()],
       subcategories: [
-        individualOfferSubCategoryResponseModelFactory({
+        subcategoryFactory({
           // id should match venueType in venueTypeSubcategoriesMapping
           id: SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
           proLabel: 'Ma sous-catégorie préférée',
@@ -61,7 +61,7 @@ describe('screens:IndividualOffer::OfferType', () => {
       ],
     })
     vi.spyOn(api, 'getVenue').mockResolvedValue({
-      ...individualOfferVenueResponseModelFactory({
+      ...getVenueFactory({
         venueTypeCode: 'OTHER' as VenueTypeCode, // cast is needed because VenueTypeCode in apiClient is defined in french, but sent by api in english
       }),
     })

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -12,7 +12,7 @@ import {
   defaultGetOffererVenueResponseModel,
   defaultGetOffererResponseModel,
 } from 'utils/apiFactories'
-import { defaultCollectiveDmsApplication } from 'utils/collectiveApiFactories'
+import { defaultDMSApplicationForEAC } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OfferType from '../OfferType'
@@ -183,7 +183,7 @@ describe('OfferType', () => {
           ...defaultGetOffererVenueResponseModel,
           collectiveDmsApplications: [
             {
-              ...defaultCollectiveDmsApplication,
+              ...defaultDMSApplicationForEAC,
               application: 1,
               lastChangeDate: '2021-01-01T00:00:00Z',
             },

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -7,8 +7,8 @@ import { CancelablePromise, GetOffererResponseModel } from 'apiClient/v1'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
 import * as useNotification from 'hooks/useNotification'
+import { collectiveOfferFactory } from 'pages/CollectiveOffers/utils/collectiveOffersFactories'
 import {
-  collectiveOfferFactory,
   defaultGetOffererVenueResponseModel,
   defaultGetOffererResponseModel,
 } from 'utils/apiFactories'
@@ -261,9 +261,7 @@ describe('OfferType', () => {
 
   it('should select duplicate template offer', async () => {
     const offersRecap = [collectiveOfferFactory()]
-    vi.spyOn(api, 'getCollectiveOffers')
-      // @ts-expect-error FIX ME
-      .mockResolvedValueOnce(offersRecap)
+    vi.spyOn(api, 'getCollectiveOffers').mockResolvedValueOnce(offersRecap)
 
     renderOfferTypes()
 

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 
 import {
   CollectiveOfferResponseModel,
+  GetOffererResponseModel,
   ListOffersOfferResponseModel,
   UserRole,
 } from 'apiClient/v1'
@@ -13,7 +14,7 @@ import {
   NUMBER_OF_OFFERS_PER_PAGE,
   OFFER_STATUS_DRAFT,
 } from 'core/Offers/constants'
-import { Offerer, SearchFiltersParams } from 'core/Offers/types'
+import { SearchFiltersParams } from 'core/Offers/types'
 import {
   computeCollectiveOffersUrl,
   computeOffersUrl,
@@ -43,9 +44,9 @@ export interface OffersProps {
   }
   isLoading: boolean
   loadAndUpdateOffers: (filters: SearchFiltersParams) => Promise<void>
-  offerer: Offerer | null
+  offerer: GetOffererResponseModel | null
   offers: CollectiveOfferResponseModel[] | ListOffersOfferResponseModel[]
-  setOfferer: (offerer: Offerer | null) => void
+  setOfferer: (offerer: GetOffererResponseModel | null) => void
   initialSearchFilters: SearchFiltersParams
   audience: Audience
   redirectWithUrlFilters: (

--- a/pro/src/screens/Offers/SearchFilters/SearchFilters.tsx
+++ b/pro/src/screens/Offers/SearchFilters/SearchFilters.tsx
@@ -1,6 +1,6 @@
 import React, { FormEvent } from 'react'
 
-import { EacFormat } from 'apiClient/v1'
+import { EacFormat, GetOffererResponseModel } from 'apiClient/v1'
 import FormLayout from 'components/FormLayout/FormLayout'
 import {
   ALL_CATEGORIES_OPTION,
@@ -10,7 +10,7 @@ import {
   CREATION_MODES_OPTIONS,
   DEFAULT_SEARCH_FILTERS,
 } from 'core/Offers/constants'
-import { Offerer, SearchFiltersParams } from 'core/Offers/types'
+import { SearchFiltersParams } from 'core/Offers/types'
 import { hasSearchFilters } from 'core/Offers/utils'
 import { Audience } from 'core/shared'
 import { SelectOption } from 'custom_types/form'
@@ -27,7 +27,7 @@ import styles from './SearchFilters.module.scss'
 
 interface SearchFiltersProps {
   applyFilters: () => void
-  offerer: Offerer | null
+  offerer: GetOffererResponseModel | null
   removeOfferer: () => void
   selectedFilters: SearchFiltersParams
   setSearchFilters: (

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -27,7 +27,7 @@ import * as useNotification from 'hooks/useNotification'
 import { collectiveOfferFactory } from 'pages/CollectiveOffers/utils/collectiveOffersFactories'
 import {
   defaultGetOffererResponseModel,
-  offererFactory,
+  getOfferManagingOffererFactory,
 } from 'utils/apiFactories'
 import {
   renderWithProviders,
@@ -35,7 +35,7 @@ import {
 } from 'utils/renderWithProviders'
 
 import Offers, { OffersProps } from '../Offers'
-import { individualOfferFactory } from '../utils/individualOffersFactories'
+import { listOffersOfferFactory } from '../utils/individualOffersFactories'
 
 const renderOffers = (
   props: OffersProps,
@@ -107,7 +107,7 @@ describe('screen Offers', () => {
       name: 'Current User',
       roles: [UserRole.PRO],
     }
-    offersRecap = [individualOfferFactory()]
+    offersRecap = [listOffersOfferFactory()]
 
     props = {
       currentPageNumber: 1,
@@ -165,8 +165,8 @@ describe('screen Offers', () => {
   })
 
   it('should render as much offers as returned by the api', () => {
-    const firstOffer = individualOfferFactory()
-    const secondOffer = individualOfferFactory()
+    const firstOffer = listOffersOfferFactory()
+    const secondOffer = listOffersOfferFactory()
 
     renderOffers({
       ...props,
@@ -178,8 +178,8 @@ describe('screen Offers', () => {
   })
 
   it('should display an unchecked by default checkbox to select all offers when user is not admin', () => {
-    const firstOffer = individualOfferFactory()
-    const secondOffer = individualOfferFactory()
+    const firstOffer = listOffersOfferFactory()
+    const secondOffer = listOffersOfferFactory()
 
     renderOffers({
       ...props,
@@ -196,7 +196,7 @@ describe('screen Offers', () => {
   it('should display total number of offers in plural if multiple offers', () => {
     renderOffers({
       ...props,
-      offers: [...offersRecap, individualOfferFactory()],
+      offers: [...offersRecap, listOffersOfferFactory()],
     })
 
     screen.getByLabelText(offersRecap[0].name)
@@ -211,7 +211,7 @@ describe('screen Offers', () => {
   })
 
   it('should display 500+ for total number of offers if more than 500 offers are fetched', async () => {
-    offersRecap = Array.from({ length: 501 }, () => individualOfferFactory())
+    offersRecap = Array.from({ length: 501 }, () => listOffersOfferFactory())
 
     renderOffers({ ...props, offers: offersRecap })
 
@@ -553,15 +553,15 @@ describe('screen Offers', () => {
   it('should disabled checkbox when offer is rejected or pending for validation', () => {
     props.currentUser.isAdmin = false
     const offers = [
-      individualOfferFactory({
+      listOffersOfferFactory({
         isActive: false,
         status: OfferStatus.REJECTED,
       }),
-      individualOfferFactory({
+      listOffersOfferFactory({
         isActive: true,
         status: OfferStatus.PENDING,
       }),
-      individualOfferFactory({
+      listOffersOfferFactory({
         isActive: true,
         status: OfferStatus.ACTIVE,
       }),
@@ -603,7 +603,7 @@ describe('screen Offers', () => {
   })
 
   it('should display the button to create an offer when user is not an admin', async () => {
-    const individualOffererNames = offererFactory()
+    const individualOffererNames = getOfferManagingOffererFactory()
     vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
       offerersNames: [individualOffererNames],
     })
@@ -658,7 +658,7 @@ describe('screen Offers', () => {
   describe('on click on select all offers checkbox', () => {
     it('should display display error message when trying to activate draft offers', async () => {
       const offers = [
-        individualOfferFactory({
+        listOffersOfferFactory({
           isActive: false,
           status: OfferStatus.DRAFT,
         }),
@@ -694,7 +694,7 @@ describe('screen Offers', () => {
 
     it('should display success message activate inactive collective offer', async () => {
       const offers = [
-        individualOfferFactory({
+        listOffersOfferFactory({
           isActive: false,
           hasBookingLimitDatetimesPassed: false,
         }),
@@ -711,13 +711,13 @@ describe('screen Offers', () => {
     it('should check all validated offers checkboxes', async () => {
       // Given
       const offers = [
-        individualOfferFactory(),
-        individualOfferFactory(),
-        individualOfferFactory({
+        listOffersOfferFactory(),
+        listOffersOfferFactory(),
+        listOffersOfferFactory({
           isActive: false,
           status: OfferStatus.REJECTED,
         }),
-        individualOfferFactory({
+        listOffersOfferFactory({
           status: OfferStatus.PENDING,
         }),
       ]

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -25,7 +25,10 @@ import {
 import { Audience } from 'core/shared'
 import * as useNotification from 'hooks/useNotification'
 import { collectiveOfferFactory } from 'pages/CollectiveOffers/utils/collectiveOffersFactories'
-import { offererFactory } from 'utils/apiFactories'
+import {
+  defaultGetOffererResponseModel,
+  offererFactory,
+} from 'utils/apiFactories'
 import {
   renderWithProviders,
   RenderWithProvidersOptions,
@@ -111,7 +114,7 @@ describe('screen Offers', () => {
       currentUser,
       isLoading: false,
       loadAndUpdateOffers: vi.fn().mockResolvedValue(offersRecap),
-      offerer: offererFactory(),
+      offerer: { ...defaultGetOffererResponseModel },
       offers: offersRecap,
       setIsLoading: vi.fn(),
       setOfferer: vi.fn(),

--- a/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
@@ -6,7 +6,10 @@ import { api } from 'apiClient/api'
 import { UserRole } from 'apiClient/v1'
 import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { Audience } from 'core/shared'
-import { offererFactory } from 'utils/apiFactories'
+import {
+  defaultGetOffererResponseModel,
+  offererFactory,
+} from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Offers, { OffersProps } from '../Offers'
@@ -31,7 +34,7 @@ describe('tracker screen Offers', () => {
         roles: [UserRole.PRO],
       },
       loadAndUpdateOffers: vi.fn(),
-      offerer: offererFactory(),
+      offerer: { ...defaultGetOffererResponseModel },
       offers: [],
       setIsLoading: vi.fn(),
       setOfferer: vi.fn(),

--- a/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
@@ -8,7 +8,7 @@ import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { Audience } from 'core/shared'
 import {
   defaultGetOffererResponseModel,
-  offererFactory,
+  getOfferManagingOffererFactory,
 } from 'utils/apiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -47,7 +47,7 @@ describe('tracker screen Offers', () => {
       categories: [],
     }
 
-    const individualOffererNames = offererFactory()
+    const individualOffererNames = getOfferManagingOffererFactory()
     vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
       offerersNames: [individualOffererNames],
     })

--- a/pro/src/screens/Offers/utils/individualOffersFactories.ts
+++ b/pro/src/screens/Offers/utils/individualOffersFactories.ts
@@ -4,7 +4,7 @@ import {
   OfferStatus,
   SubcategoryIdEnum,
 } from 'apiClient/v1'
-import { venueFactory } from 'pages/CollectiveOffers/utils/collectiveOffersFactories'
+import { listOffersVenueFactory } from 'pages/CollectiveOffers/utils/collectiveOffersFactories'
 
 let offerId = 1
 let stockId = 1
@@ -21,8 +21,8 @@ export const listOffersStockFactory = (
   }
 }
 
-export const individualOfferFactory = (
-  customOffer: Partial<ListOffersOfferResponseModel> = {}
+export const listOffersOfferFactory = (
+  customListOffersOffer: Partial<ListOffersOfferResponseModel> = {}
 ): ListOffersOfferResponseModel => {
   const currentOfferId = offerId++
 
@@ -36,9 +36,9 @@ export const individualOfferFactory = (
     name: `offer name ${offerId}`,
     isEvent: true,
     isThing: false,
-    venue: venueFactory(),
+    venue: listOffersVenueFactory(),
     stocks: [],
     isEditable: true,
-    ...customOffer,
+    ...customListOffersOffer,
   }
 }

--- a/pro/src/screens/VenueForm/__specs__/VenueEditionFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueEditionFormScreen.spec.tsx
@@ -19,7 +19,7 @@ import { VenueFormValues } from 'components/VenueForm'
 import { PATCH_SUCCESS_MESSAGE } from 'core/shared'
 import { SelectOption } from 'custom_types/form'
 import { defaultGetOffererResponseModel } from 'utils/apiFactories'
-import { defaultVenueResponseModel } from 'utils/collectiveApiFactories'
+import { defaultGetVenue } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { VenueEditionFormScreen } from '../VenueEditionFormScreen'
@@ -299,7 +299,7 @@ describe('VenueFormScreen', () => {
     }
 
     venue = {
-      ...defaultVenueResponseModel,
+      ...defaultGetVenue,
       hasPendingBankInformationApplication: false,
       demarchesSimplifieesApplicationId: '',
       collectiveDomains: [],
@@ -549,7 +549,7 @@ describe('VenueFormScreen', () => {
 
       const editVenue = vi
         .spyOn(api, 'editVenue')
-        .mockResolvedValue({ ...defaultVenueResponseModel, id: 1 })
+        .mockResolvedValue({ ...defaultGetVenue, id: 1 })
 
       await waitFor(() => {
         expect(
@@ -607,7 +607,7 @@ describe('VenueFormScreen', () => {
 
       const editVenue = vi
         .spyOn(api, 'editVenue')
-        .mockResolvedValue({ ...defaultVenueResponseModel, id: 1 })
+        .mockResolvedValue({ ...defaultGetVenue, id: 1 })
 
       await waitFor(() => {
         expect(
@@ -665,7 +665,7 @@ describe('VenueFormScreen', () => {
 
       const editVenue = vi
         .spyOn(api, 'editVenue')
-        .mockResolvedValue({ ...defaultVenueResponseModel, id: 1 })
+        .mockResolvedValue({ ...defaultGetVenue, id: 1 })
 
       await waitFor(() => {
         expect(
@@ -697,7 +697,7 @@ describe('VenueFormScreen', () => {
 
       const editVenue = vi
         .spyOn(api, 'editVenue')
-        .mockResolvedValue({ ...defaultVenueResponseModel, id: 1 })
+        .mockResolvedValue({ ...defaultGetVenue, id: 1 })
 
       await waitFor(() => {
         expect(

--- a/pro/src/utils/__specs__/getLastCollectiveDmsApplication.spec.tsx
+++ b/pro/src/utils/__specs__/getLastCollectiveDmsApplication.spec.tsx
@@ -3,7 +3,7 @@ import {
   defaultGetOffererVenueResponseModel,
   defaultGetOffererResponseModel,
 } from 'utils/apiFactories'
-import { defaultCollectiveDmsApplication } from 'utils/collectiveApiFactories'
+import { defaultDMSApplicationForEAC } from 'utils/collectiveApiFactories'
 import {
   getLastCollectiveDmsApplication,
   getLastDmsApplicationForOfferer,
@@ -12,15 +12,15 @@ import {
 describe('getLastCollectiveDmsApplication', () => {
   it('should return collective dms application with most recent last change date', () => {
     const firstDmsApplication = {
-      ...defaultCollectiveDmsApplication,
+      ...defaultDMSApplicationForEAC,
       lastChangeDate: '2021-02-01T00:00:00Z',
     }
     const lastDmsApplication = {
-      ...defaultCollectiveDmsApplication,
+      ...defaultDMSApplicationForEAC,
       lastChangeDate: '2023-12-25T00:00:00Z',
     }
     const otherDmsApplication = {
-      ...defaultCollectiveDmsApplication,
+      ...defaultDMSApplicationForEAC,
       lastChangeDate: '2022-12-25T00:00:00Z',
     }
     expect(
@@ -43,7 +43,7 @@ describe('getLastCollectiveDmsApplication', () => {
             id: venueId,
             collectiveDmsApplications: [
               {
-                ...defaultCollectiveDmsApplication,
+                ...defaultDMSApplicationForEAC,
                 venueId: venueId,
                 application: 1,
                 lastChangeDate: '2021-01-01T00:00:00Z',
@@ -55,7 +55,7 @@ describe('getLastCollectiveDmsApplication', () => {
             id: venueId + 1, // not the same venue
             collectiveDmsApplications: [
               {
-                ...defaultCollectiveDmsApplication,
+                ...defaultDMSApplicationForEAC,
                 venueId: venueId + 1, // not the same venue
                 application: 2,
                 lastChangeDate: '2023-01-01T00:00:00Z',
@@ -80,7 +80,7 @@ describe('getLastCollectiveDmsApplication', () => {
             ...defaultGetOffererVenueResponseModel,
             collectiveDmsApplications: [
               {
-                ...defaultCollectiveDmsApplication,
+                ...defaultDMSApplicationForEAC,
                 application: 1,
                 lastChangeDate: '2021-01-01T00:00:00Z',
               },
@@ -90,7 +90,7 @@ describe('getLastCollectiveDmsApplication', () => {
             ...defaultGetOffererVenueResponseModel,
             collectiveDmsApplications: [
               {
-                ...defaultCollectiveDmsApplication,
+                ...defaultDMSApplicationForEAC,
                 application: 2,
                 lastChangeDate: '2020-01-01T00:00:00Z',
               },

--- a/pro/src/utils/apiFactories.ts
+++ b/pro/src/utils/apiFactories.ts
@@ -37,47 +37,6 @@ let offererId = 1
 let stockId = 1
 let bookingId = 1
 
-// TODO factories: type this
-export const collectiveOfferFactory = (
-  customCollectiveOffer = {},
-  customStock = collectiveStockFactory() || null,
-  customVenue = getOfferVenueFactory()
-) => {
-  const stocks = customStock === null ? [] : [customStock]
-  const currentOfferId = offerId++
-
-  return {
-    name: `Le nom de l’offre ${currentOfferId}`,
-    isActive: true,
-    isEditable: true,
-    isEvent: true,
-    isFullyBooked: false,
-    isThing: false,
-    id: currentOfferId,
-    status: OfferStatus.ACTIVE,
-    stocks,
-    venue: customVenue,
-    hasBookingLimitDatetimesPassed: false,
-    isEducational: true,
-    ...customCollectiveOffer,
-  }
-}
-
-// TODO factories: type this
-const collectiveStockFactory = (customStock = {}) => {
-  return {
-    bookingsQuantity: 0,
-    id: `STOCK${stockId++}`,
-    offerId: `OFFER${offerId}`,
-    price: 100,
-    quantity: 1,
-    remainingQuantity: 1,
-    beginningDatetime: new Date('2021-10-15T12:00:00Z'),
-    bookingLimitdatetime: new Date('2021-09-15T12:00:00Z'),
-    ...customStock,
-  }
-}
-
 export const getIndividualOfferFactory = (
   customGetIndividualOffer: Partial<GetIndividualOfferResponseModel> = {}
 ): GetIndividualOfferResponseModel => {

--- a/pro/src/utils/apiFactories.ts
+++ b/pro/src/utils/apiFactories.ts
@@ -16,7 +16,6 @@ import {
   OfferAddressType,
   OfferStatus,
   SubcategoryIdEnum,
-  VenueListItemResponseModel,
   VenueTypeCode,
   type CollectiveOfferOfferVenueResponseModel,
   type GetCollectiveOfferManagingOffererResponseModel,
@@ -78,26 +77,6 @@ export const getIndividualOfferFactory = (
       visa: 'USA',
     },
     ...customGetIndividualOffer,
-  }
-}
-
-// TODO factories: should remove customOfferer as an argument
-export const getVenueListItemFactory = (
-  customVenue = {},
-  customOfferer = getOfferManagingOffererFactory()
-): VenueListItemResponseModel => {
-  const currentVenueId = venueId++
-  return {
-    id: currentVenueId,
-    isVirtual: false,
-    name: `Le nom du lieu ${currentVenueId}`,
-    managingOffererId: customOfferer.id,
-    publicName: 'Mon Lieu',
-    hasCreatedOffer: true,
-    hasMissingReimbursementPoint: true,
-    offererName: 'offerer',
-    venueTypeCode: VenueTypeCode.AUTRE,
-    ...customVenue,
   }
 }
 

--- a/pro/src/utils/apiFactories.ts
+++ b/pro/src/utils/apiFactories.ts
@@ -37,10 +37,11 @@ let offererId = 1
 let stockId = 1
 let bookingId = 1
 
+// TODO factories: type this
 export const collectiveOfferFactory = (
   customCollectiveOffer = {},
   customStock = collectiveStockFactory() || null,
-  customVenue = offerVenueFactory()
+  customVenue = getOfferVenueFactory()
 ) => {
   const stocks = customStock === null ? [] : [customStock]
   const currentOfferId = offerId++
@@ -62,6 +63,7 @@ export const collectiveOfferFactory = (
   }
 }
 
+// TODO factories: type this
 const collectiveStockFactory = (customStock = {}) => {
   return {
     bookingsQuantity: 0,
@@ -76,8 +78,8 @@ const collectiveStockFactory = (customStock = {}) => {
   }
 }
 
-export const GetIndividualOfferFactory = (
-  customOffer: Partial<GetIndividualOfferResponseModel> = {}
+export const getIndividualOfferFactory = (
+  customGetIndividualOffer: Partial<GetIndividualOfferResponseModel> = {}
 ): GetIndividualOfferResponseModel => {
   const currentOfferId = offerId++
 
@@ -90,7 +92,7 @@ export const GetIndividualOfferFactory = (
     isThing: true,
     id: currentOfferId,
     status: OfferStatus.ACTIVE,
-    venue: offerVenueFactory(),
+    venue: getOfferVenueFactory(),
     hasBookingLimitDatetimesPassed: false,
     hasStocks: true,
     dateCreated: '2020-04-12T19:31:12Z',
@@ -116,13 +118,14 @@ export const GetIndividualOfferFactory = (
       speaker: "Chuck Norris n'a pas besoin de doubleur",
       visa: 'USA',
     },
-    ...customOffer,
+    ...customGetIndividualOffer,
   }
 }
 
+// TODO factories: should remove customOfferer as an argument
 export const getVenueListItemFactory = (
   customVenue = {},
-  customOfferer = offererFactory()
+  customOfferer = getOfferManagingOffererFactory()
 ): VenueListItemResponseModel => {
   const currentVenueId = venueId++
   return {
@@ -139,20 +142,20 @@ export const getVenueListItemFactory = (
   }
 }
 
-export const offererFactory = (
-  customOfferer = {}
+export const getOfferManagingOffererFactory = (
+  customGetOfferManagingOfferer: Partial<GetOfferManagingOffererResponseModel> = {}
 ): GetOfferManagingOffererResponseModel => {
   const currentOffererId = offererId++
 
   return {
     id: 3,
     name: `Le nom de la structure ${currentOffererId}`,
-    ...customOfferer,
+    ...customGetOfferManagingOfferer,
   }
 }
 
-export const offerVenueFactory = (
-  customVenue: Partial<GetOfferVenueResponseModel> = {}
+export const getOfferVenueFactory = (
+  customGetOfferVenue: Partial<GetOfferVenueResponseModel> = {}
 ): GetOfferVenueResponseModel => {
   const currentVenueId = venueId++
 
@@ -169,16 +172,17 @@ export const offerVenueFactory = (
     mentalDisabilityCompliant: true,
     motorDisabilityCompliant: true,
     audioDisabilityCompliant: true,
-    managingOfferer: offererFactory(),
-    ...customVenue,
+    managingOfferer: getOfferManagingOffererFactory(),
+    ...customGetOfferVenue,
   }
 }
 
+// TODO factories: should remove customOffer as an argument
 export const bookingRecapFactory = (
   customBookingRecap = {},
   customOffer = {}
 ): BookingRecapResponseModel => {
-  const offer = GetIndividualOfferFactory(customOffer)
+  const offer = getIndividualOfferFactory(customOffer)
 
   return {
     beneficiary: {
@@ -249,7 +253,7 @@ export const defaultGetOffererVenueResponseModel: GetOffererVenueResponseModel =
     bannerMeta: null,
   }
 
-export const defaultBookingResponse: GetBookingResponse = {
+export const defaultGetBookingResponse: GetBookingResponse = {
   bookingId: 'test_booking_id',
   dateOfBirth: '1980-02-01T20:00:00Z',
   email: 'test@email.com',
@@ -280,7 +284,8 @@ type ListOffersOfferResponseModelFactory = {
   customVenue?: Partial<ListOffersVenueResponseModel>
 }
 
-export const listOffersOfferResponseModelFactory = ({
+// TODO factories: should remove customSotcksList and customVenue as arguments
+export const listOffersOfferFactory = ({
   customOffer,
   customStocksList,
   customVenue,
@@ -296,14 +301,14 @@ export const listOffersOfferResponseModelFactory = ({
   name: `mon offre ${offerId}`,
   productIsbn: null,
   status: OfferStatus.ACTIVE,
-  stocks: customStocksList ?? [listOffersStockResponseModelFactory()],
+  stocks: customStocksList ?? [listOffersStockFactory()],
   subcategoryId: SubcategoryIdEnum.CINE_PLEIN_AIR,
   thumbUrl: 'https://www.example.com',
-  venue: listOffersVenueResponseModelFactory(customVenue),
+  venue: listOffersVenueFactory(customVenue),
   ...customOffer,
 })
 
-const listOffersStockResponseModelFactory = (
+const listOffersStockFactory = (
   customStock?: Partial<ListOffersStockResponseModel>
 ): ListOffersStockResponseModel => ({
   id: stockId++,
@@ -312,7 +317,7 @@ const listOffersStockResponseModelFactory = (
   ...customStock,
 })
 
-const listOffersVenueResponseModelFactory = (
+const listOffersVenueFactory = (
   customVenue?: Partial<ListOffersVenueResponseModel>
 ): ListOffersVenueResponseModel => ({
   id: venueId++,
@@ -323,7 +328,7 @@ const listOffersVenueResponseModelFactory = (
   ...customVenue,
 })
 
-export const defaultBankAccountResponseModel: BankAccountResponseModel = {
+export const defaultBankAccount: BankAccountResponseModel = {
   bic: 'CCOPFRPP',
   dateCreated: '2020-05-07',
   dsApplicationId: 1,
@@ -347,44 +352,42 @@ export const defaultManagedVenues: ManagedVenues = {
   hasPricingPoint: true,
 }
 
-const defaultCollectiveOfferOfferVenueResponseModel: CollectiveOfferOfferVenueResponseModel =
+const defaultCollectiveOfferOfferVenue: CollectiveOfferOfferVenueResponseModel =
   {
     addressType: OfferAddressType.OFFERER_VENUE,
     otherAddress: 'other',
   }
 
-const defaultGetCollectiveOfferManagingOffererResponseModel: GetCollectiveOfferManagingOffererResponseModel =
+const defaultGetCollectiveOfferManagingOfferer: GetCollectiveOfferManagingOffererResponseModel =
   {
     id: 1,
     name: 'nom',
   }
 
-const defaultGetCollectiveOfferVenueResponseModel: GetCollectiveOfferVenueResponseModel =
-  {
-    id: 1,
-    managingOfferer: defaultGetCollectiveOfferManagingOffererResponseModel,
-    name: 'nom',
-  }
+const defaultGetCollectiveOfferVenue: GetCollectiveOfferVenueResponseModel = {
+  id: 1,
+  managingOfferer: defaultGetCollectiveOfferManagingOfferer,
+  name: 'nom',
+}
 
-export const defaultGetCollectiveOfferResponseModel: GetCollectiveOfferResponseModel =
-  {
-    bookingEmails: [],
-    contactEmail: 'contact@contact.contact',
-    dateCreated: '10/18/2000',
-    description: 'description',
-    domains: [],
-    hasBookingLimitDatetimesPassed: false,
-    id: 1,
-    interventionArea: [],
-    isActive: false,
-    isBookable: false,
-    isCancellable: false,
-    isEditable: false,
-    isPublicApi: false,
-    isVisibilityEditable: false,
-    name: 'offre',
-    offerVenue: defaultCollectiveOfferOfferVenueResponseModel,
-    status: OfferStatus.ACTIVE,
-    students: [],
-    venue: defaultGetCollectiveOfferVenueResponseModel,
-  }
+export const defaultGetCollectiveOffer: GetCollectiveOfferResponseModel = {
+  bookingEmails: [],
+  contactEmail: 'contact@contact.contact',
+  dateCreated: '10/18/2000',
+  description: 'description',
+  domains: [],
+  hasBookingLimitDatetimesPassed: false,
+  id: 1,
+  interventionArea: [],
+  isActive: false,
+  isBookable: false,
+  isCancellable: false,
+  isEditable: false,
+  isPublicApi: false,
+  isVisibilityEditable: false,
+  name: 'offre',
+  offerVenue: defaultCollectiveOfferOfferVenue,
+  status: OfferStatus.ACTIVE,
+  students: [],
+  venue: defaultGetCollectiveOfferVenue,
+}

--- a/pro/src/utils/apiFactories.ts
+++ b/pro/src/utils/apiFactories.ts
@@ -3,20 +3,15 @@ import {
   BankAccountApplicationStatus,
   BankAccountResponseModel,
   BookingRecapResponseModel,
-  GetCollectiveOfferResponseModel,
   GetIndividualOfferResponseModel,
   GetOfferManagingOffererResponseModel,
   GetOfferVenueResponseModel,
   GetOffererResponseModel,
   GetOffererVenueResponseModel,
   ManagedVenues,
-  OfferAddressType,
   OfferStatus,
   SubcategoryIdEnum,
   VenueTypeCode,
-  type CollectiveOfferOfferVenueResponseModel,
-  type GetCollectiveOfferManagingOffererResponseModel,
-  type GetCollectiveOfferVenueResponseModel,
 } from 'apiClient/v1'
 import { BookingRecapStatus } from 'apiClient/v1/models/BookingRecapStatus'
 import {
@@ -234,44 +229,4 @@ export const defaultManagedVenues: ManagedVenues = {
   id: 1,
   siret: '123456789',
   hasPricingPoint: true,
-}
-
-const defaultCollectiveOfferOfferVenue: CollectiveOfferOfferVenueResponseModel =
-  {
-    addressType: OfferAddressType.OFFERER_VENUE,
-    otherAddress: 'other',
-  }
-
-const defaultGetCollectiveOfferManagingOfferer: GetCollectiveOfferManagingOffererResponseModel =
-  {
-    id: 1,
-    name: 'nom',
-  }
-
-const defaultGetCollectiveOfferVenue: GetCollectiveOfferVenueResponseModel = {
-  id: 1,
-  managingOfferer: defaultGetCollectiveOfferManagingOfferer,
-  name: 'nom',
-}
-
-export const defaultGetCollectiveOffer: GetCollectiveOfferResponseModel = {
-  bookingEmails: [],
-  contactEmail: 'contact@contact.contact',
-  dateCreated: '10/18/2000',
-  description: 'description',
-  domains: [],
-  hasBookingLimitDatetimesPassed: false,
-  id: 1,
-  interventionArea: [],
-  isActive: false,
-  isBookable: false,
-  isCancellable: false,
-  isEditable: false,
-  isPublicApi: false,
-  isVisibilityEditable: false,
-  name: 'offre',
-  offerVenue: defaultCollectiveOfferOfferVenue,
-  status: OfferStatus.ACTIVE,
-  students: [],
-  venue: defaultGetCollectiveOfferVenue,
 }

--- a/pro/src/utils/apiFactories.ts
+++ b/pro/src/utils/apiFactories.ts
@@ -9,9 +9,6 @@ import {
   GetOfferVenueResponseModel,
   GetOffererResponseModel,
   GetOffererVenueResponseModel,
-  ListOffersOfferResponseModel,
-  ListOffersStockResponseModel,
-  ListOffersVenueResponseModel,
   ManagedVenues,
   OfferAddressType,
   OfferStatus,
@@ -33,7 +30,6 @@ import { priceCategoryFactory } from './individualApiFactories'
 let offerId = 1
 let venueId = 1
 let offererId = 1
-let stockId = 1
 let bookingId = 1
 
 export const getIndividualOfferFactory = (
@@ -215,56 +211,6 @@ export const defaultGetBookingResponse: GetBookingResponse = {
   venueDepartmentCode: '75',
   priceCategoryLabel: 'price label',
 }
-
-type ListOffersOfferResponseModelFactory = {
-  customOffer?: Partial<ListOffersOfferResponseModel>
-  customStocksList?: ListOffersStockResponseModel[]
-  customVenue?: Partial<ListOffersVenueResponseModel>
-}
-
-// TODO factories: should remove customSotcksList and customVenue as arguments
-export const listOffersOfferFactory = ({
-  customOffer,
-  customStocksList,
-  customVenue,
-}: ListOffersOfferResponseModelFactory = {}): ListOffersOfferResponseModel => ({
-  hasBookingLimitDatetimesPassed: true,
-  id: offerId++,
-  isActive: true,
-  isEditable: true,
-  isEducational: false,
-  isEvent: true,
-  isShowcase: false,
-  isThing: false,
-  name: `mon offre ${offerId}`,
-  productIsbn: null,
-  status: OfferStatus.ACTIVE,
-  stocks: customStocksList ?? [listOffersStockFactory()],
-  subcategoryId: SubcategoryIdEnum.CINE_PLEIN_AIR,
-  thumbUrl: 'https://www.example.com',
-  venue: listOffersVenueFactory(customVenue),
-  ...customOffer,
-})
-
-const listOffersStockFactory = (
-  customStock?: Partial<ListOffersStockResponseModel>
-): ListOffersStockResponseModel => ({
-  id: stockId++,
-  hasBookingLimitDatetimePassed: false,
-  remainingQuantity: 10,
-  ...customStock,
-})
-
-const listOffersVenueFactory = (
-  customVenue?: Partial<ListOffersVenueResponseModel>
-): ListOffersVenueResponseModel => ({
-  id: venueId++,
-  name: 'mon lieu azmefhzihfmiùazer',
-  isVirtual: false,
-  offererName: 'mon offerer',
-  departementCode: '75',
-  ...customVenue,
-})
 
 export const defaultBankAccount: BankAccountResponseModel = {
   bic: 'CCOPFRPP',

--- a/pro/src/utils/collectiveApiFactories.ts
+++ b/pro/src/utils/collectiveApiFactories.ts
@@ -66,11 +66,12 @@ const sharedCollectiveOfferData = {
   formats: [EacFormat.ATELIER_DE_PRATIQUE],
 }
 
+// TODO factories: remove customStock & customVenue as an argument
 export const collectiveOfferFactory = (
   customCollectiveOffer: Partial<CollectiveOffer> = {},
-  customStock: GetCollectiveOfferCollectiveStockResponseModel = collectiveStockFactory() ||
+  customStock: GetCollectiveOfferCollectiveStockResponseModel = getCollectiveOfferCollectiveStockFactory() ||
     null,
-  customVenue: GetCollectiveOfferVenueResponseModel = collectiveOfferVenueFactory()
+  customVenue: GetCollectiveOfferVenueResponseModel = getCollectiveOfferVenueFactory()
 ): CollectiveOffer => {
   const stock = customStock === null ? null : customStock
   const currentOfferId = offerId++
@@ -86,8 +87,8 @@ export const collectiveOfferFactory = (
   }
 }
 
-export const collectiveStockFactory = (
-  customStock: Partial<GetCollectiveOfferCollectiveStockResponseModel> = {}
+export const getCollectiveOfferCollectiveStockFactory = (
+  customGetCollectiveOfferCollectiveStock: Partial<GetCollectiveOfferCollectiveStockResponseModel> = {}
 ): GetCollectiveOfferCollectiveStockResponseModel => {
   const currentStockId = stockId++
   return {
@@ -98,13 +99,14 @@ export const collectiveStockFactory = (
     isBooked: false,
     isCancellable: false,
     isEducationalStockEditable: true,
-    ...customStock,
+    ...customGetCollectiveOfferCollectiveStock,
   }
 }
 
+// TODO factories: remove customVenue as an argument
 export const collectiveOfferTemplateFactory = (
   customCollectiveOfferTemplate: Partial<CollectiveOfferTemplate> = {},
-  customVenue: GetCollectiveOfferVenueResponseModel = collectiveOfferVenueFactory()
+  customVenue: GetCollectiveOfferVenueResponseModel = getCollectiveOfferVenueFactory()
 ): CollectiveOfferTemplate => ({
   ...sharedCollectiveOfferData,
   id: offerId++,
@@ -117,9 +119,10 @@ export const collectiveOfferTemplateFactory = (
   ...customCollectiveOfferTemplate,
 })
 
-export const collectiveOfferVenueFactory = (
-  customVenue: Partial<GetCollectiveOfferVenueResponseModel> = {},
-  customOfferer: GetCollectiveOfferManagingOffererResponseModel = collectiveOfferOffererFactory()
+// TODO factories: remove customOfferer as an argument
+export const getCollectiveOfferVenueFactory = (
+  customGetCollectiveOfferVenue: Partial<GetCollectiveOfferVenueResponseModel> = {},
+  customOfferer: GetCollectiveOfferManagingOffererResponseModel = getCollectiveOfferManagingOffererFactory()
 ): GetCollectiveOfferVenueResponseModel => {
   const currentVenueId = venueId++
   return {
@@ -128,23 +131,23 @@ export const collectiveOfferVenueFactory = (
     publicName: 'Mon Lieu',
     id: currentVenueId,
     departementCode: '973',
-    ...customVenue,
+    ...customGetCollectiveOfferVenue,
   }
 }
 
-export const collectiveOfferOffererFactory = (
-  customOfferer: Partial<GetCollectiveOfferManagingOffererResponseModel> = {}
+export const getCollectiveOfferManagingOffererFactory = (
+  customGetCollectiveOfferManagingOfferer: Partial<GetCollectiveOfferManagingOffererResponseModel> = {}
 ): GetCollectiveOfferManagingOffererResponseModel => {
   const currentOffererId = offererId++
   return {
     id: currentOffererId,
     name: `La nom de la structure ${currentOffererId}`,
-    ...customOfferer,
+    ...customGetCollectiveOfferManagingOfferer,
   }
 }
 
 export const collectiveBookingCollectiveStockFactory = (
-  customStock: Partial<CollectiveBookingCollectiveStockResponseModel> = {}
+  customCollectiveBookingCollectiveStock: Partial<CollectiveBookingCollectiveStockResponseModel> = {}
 ): CollectiveBookingCollectiveStockResponseModel => ({
   bookingLimitDatetime: new Date().toISOString(),
   eventBeginningDatetime: new Date().toISOString(),
@@ -153,11 +156,11 @@ export const collectiveBookingCollectiveStockFactory = (
   offerIsEducational: true,
   offerIsbn: null,
   offerName: 'ma super offre collective',
-  ...customStock,
+  ...customCollectiveBookingCollectiveStock,
 })
 
-export const collectiveBookingRecapFactory = (
-  customBookingRecap: Partial<CollectiveBookingResponseModel> = {}
+export const collectiveBookingFactory = (
+  customCollectiveBooking: Partial<CollectiveBookingResponseModel> = {}
 ): CollectiveBookingResponseModel => {
   const currentBookingId = bookingId++
   return {
@@ -183,9 +186,11 @@ export const collectiveBookingRecapFactory = (
       phoneNumber: '0601020304',
     },
     stock: collectiveBookingCollectiveStockFactory(),
-    ...customBookingRecap,
+    ...customCollectiveBooking,
   }
 }
+
+// TODO factories: type this
 export const defaultCollectiveBookingStock = {
   bookingLimitDatetime: new Date().toISOString(),
   eventBeginningDatetime: new Date().toISOString(),
@@ -197,8 +202,8 @@ export const defaultCollectiveBookingStock = {
   offerName: 'ma super offre collective',
 }
 
-export const collectiveBookingDetailsFactory = (
-  customBookingDetails?: Partial<CollectiveBookingByIdResponseModel>
+export const collectiveBookingByIdFactory = (
+  customCollectiveBookingById?: Partial<CollectiveBookingByIdResponseModel>
 ): CollectiveBookingByIdResponseModel => {
   const currentBookingDetailsId = bookingDetailsId++
   return {
@@ -235,12 +240,12 @@ export const collectiveBookingDetailsFactory = (
     venueDMSApplicationId: 1,
     venueId: 1,
     venuePostalCode: '75000',
-    ...customBookingDetails,
+    ...customCollectiveBookingById,
   }
 }
 
-export const venueCollectiveDataFactory = (
-  customCollectiveData: Partial<GetCollectiveVenueResponseModel> = {}
+export const getCollectiveVenueFactory = (
+  customGetCollectiveVenue: Partial<GetCollectiveVenueResponseModel> = {}
 ): GetCollectiveVenueResponseModel => {
   return {
     collectiveDomains: [],
@@ -253,7 +258,7 @@ export const venueCollectiveDataFactory = (
     collectiveStudents: [],
     collectiveWebsite: '',
     siret: '1234567890',
-    ...customCollectiveData,
+    ...customGetCollectiveVenue,
   }
 }
 
@@ -275,7 +280,7 @@ export const defaultEducationalRedactor: EducationalRedactorResponseModel = {
   lastName: 'Dupont',
 }
 
-export const defaultCollectiveDmsApplication: DMSApplicationForEAC = {
+export const defaultDMSApplicationForEAC: DMSApplicationForEAC = {
   application: 123,
   depositDate: new Date().toISOString(),
   lastChangeDate: new Date().toISOString(),
@@ -284,7 +289,7 @@ export const defaultCollectiveDmsApplication: DMSApplicationForEAC = {
   venueId: 1,
 }
 
-export const defaultVenueResponseModel: GetVenueResponseModel = {
+export const defaultGetVenue: GetVenueResponseModel = {
   dateCreated: new Date().toISOString(),
   dmsToken: 'fakeDmsToken',
   hasAdageId: true,
@@ -308,7 +313,7 @@ export const defaultVenueResponseModel: GetVenueResponseModel = {
   timezone: 'Europe/Paris',
 }
 
-export const defaultRequestResponseModel: GetCollectiveOfferRequestResponseModel =
+export const defaultGetCollectiveOfferRequest: GetCollectiveOfferRequestResponseModel =
   {
     comment: 'comment',
     institution: {
@@ -325,6 +330,7 @@ export const defaultRequestResponseModel: GetCollectiveOfferRequestResponseModel
     },
   }
 
+// TODO factories: type this
 export const defaultCollectifOfferResponseModel = {
   isActive: true,
   offerId: 1,

--- a/pro/src/utils/individualApiFactories.ts
+++ b/pro/src/utils/individualApiFactories.ts
@@ -15,7 +15,7 @@ import { REIMBURSEMENT_RULES } from 'core/Finances'
 import { CATEGORY_STATUS } from 'core/Offers/constants'
 import { IndividualOfferVenueItem } from 'core/Venue/types'
 
-import { GetIndividualOfferFactory } from './apiFactories'
+import { getIndividualOfferFactory } from './apiFactories'
 
 let stockId = 1
 let stockResponseId = 1
@@ -25,7 +25,7 @@ let offerCategoryId = 1
 let offerSubCategoryId = 1
 
 export const individualOfferVenueItemFactory = (
-  customVenue: Partial<IndividualOfferVenueItem> = {}
+  customIndividualOfferVenueItem: Partial<IndividualOfferVenueItem> = {}
 ): IndividualOfferVenueItem => {
   const currentVenueId = venueId++
 
@@ -45,12 +45,12 @@ export const individualOfferVenueItemFactory = (
     hasMissingReimbursementPoint: false,
     withdrawalDetails: null,
     venueType: VenueTypeCode.AUTRE,
-    ...customVenue,
+    ...customIndividualOfferVenueItem,
   }
 }
 
-export const individualOfferVenueResponseModelFactory = (
-  customVenue: Partial<GetVenueResponseModel> = {}
+export const getVenueFactory = (
+  customGetVenue: Partial<GetVenueResponseModel> = {}
 ): GetVenueResponseModel => {
   const currentVenueId = venueId++
 
@@ -78,12 +78,12 @@ export const individualOfferVenueResponseModelFactory = (
     dmsToken: 'token',
     hasAdageId: false,
     venueTypeCode: VenueTypeCode.AUTRE,
-    ...customVenue,
+    ...customGetVenue,
   }
 }
 
-export const individualOfferGetVenuesFactory = (
-  customVenue: Partial<VenueListItemResponseModel> = {}
+export const venueListItemFactory = (
+  customVenueListItem: Partial<VenueListItemResponseModel> = {}
 ): VenueListItemResponseModel => {
   const currentVenueId = venueId++
 
@@ -97,30 +97,30 @@ export const individualOfferGetVenuesFactory = (
     hasMissingReimbursementPoint: false,
     managingOffererId: 1,
     offererName: 'la structure de Michel',
-    ...customVenue,
+    ...customVenueListItem,
   }
 }
 
 export const priceCategoryFactory = (
-  customPriceCategories: Partial<PriceCategoryResponseModel> = {}
+  customPriceCategory: Partial<PriceCategoryResponseModel> = {}
 ): PriceCategoryResponseModel => ({
   id: priceCategoryId++,
   label: 'mon label',
   price: 66.6,
-  ...customPriceCategories,
+  ...customPriceCategory,
 })
 
-export const individualOfferCategoryFactory = (
-  customOfferCategory: Partial<CategoryResponseModel> = {}
+export const categoryFactory = (
+  customCategory: Partial<CategoryResponseModel> = {}
 ): CategoryResponseModel => ({
   id: String(offerCategoryId++),
   proLabel: `catégorie ${offerCategoryId}`,
   isSelectable: true,
-  ...customOfferCategory,
+  ...customCategory,
 })
 
-export const individualOfferSubCategoryFactory = (
-  customOfferSubCategory: Partial<SubcategoryResponseModel> = {}
+export const subcategoryFactory = (
+  customSubcategory: Partial<SubcategoryResponseModel> = {}
 ): SubcategoryResponseModel => ({
   id: String(offerSubCategoryId++),
   categoryId: 'A',
@@ -137,32 +137,11 @@ export const individualOfferSubCategoryFactory = (
   canExpire: true,
   isDigitalDeposit: false,
   isPhysicalDeposit: true,
-  ...customOfferSubCategory,
+  ...customSubcategory,
 })
 
-export const individualOfferSubCategoryResponseModelFactory = (
-  customOfferSubCategory: Partial<SubcategoryResponseModel> = {}
-): SubcategoryResponseModel => ({
-  id: String(offerSubCategoryId++),
-  categoryId: 'A',
-  proLabel: `sous catégorie ${offerSubCategoryId}`,
-  isEvent: false,
-  conditionalFields: [],
-  canBeDuo: false,
-  canBeEducational: false,
-  canBeWithdrawable: false,
-  onlineOfflinePlatform: CATEGORY_STATUS.ONLINE,
-  reimbursementRule: REIMBURSEMENT_RULES.STANDARD,
-  isSelectable: true,
-  appLabel: 'appLabel',
-  canExpire: true,
-  isDigitalDeposit: true,
-  isPhysicalDeposit: true,
-  ...customOfferSubCategory,
-})
-
-export const individualStockEventFactory = (
-  customStock: Partial<StocksEvent> = {}
+export const StocksEventFactory = (
+  customStocksEvent: Partial<StocksEvent> = {}
 ): StocksEvent => {
   return {
     id: stockId++,
@@ -172,12 +151,12 @@ export const individualStockEventFactory = (
     quantity: 18,
     bookingsQuantity: 0,
     isEventDeletable: true,
-    ...customStock,
+    ...customStocksEvent,
   }
 }
 
-export const individualGetOfferStockResponseModelFactory = (
-  customStock: Partial<GetOfferStockResponseModel> = {}
+export const getOfferStockFactory = (
+  customGetOfferStock: Partial<GetOfferStockResponseModel> = {}
 ): GetOfferStockResponseModel => {
   return {
     id: stockResponseId++,
@@ -190,14 +169,14 @@ export const individualGetOfferStockResponseModelFactory = (
     quantity: 18,
     bookingsQuantity: 0,
     isEventDeletable: true,
-    ...customStock,
+    ...customGetOfferStock,
   }
 }
 
-export const individualOfferContextFactory = (
-  customContext: Partial<IndividualOfferContextValues> = {}
+export const individualOfferContextValuesFactory = (
+  customIndividualOfferContextValues: Partial<IndividualOfferContextValues> = {}
 ): IndividualOfferContextValues => {
-  const offer = GetIndividualOfferFactory()
+  const offer = getIndividualOfferFactory()
 
   return {
     offerId: offer.id,
@@ -208,6 +187,6 @@ export const individualOfferContextFactory = (
     subCategories: [],
     setSubcategory: () => {},
     showVenuePopin: {},
-    ...customContext,
+    ...customIndividualOfferContextValues,
   }
 }


### PR DESCRIPTION
## But de la pull request

Encore une simplification pour faciliter la suppression des adapters

Pour le naming, j'aligne sur la majorité des cas : 

- si le type s'appelle `TropTopXYZMachin` => `defaultTropTopXYZMachin` ou `tropTopXYZMachinFactory` suivant les 2 façons de faire
- si le type contient "ResponseModel", on l'ommet dans le nom de la factory