### PR TITLE
(BSR)[API] chore: remove unused move siret command

### DIFF
--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -7,11 +7,9 @@ import sqlalchemy.orm as sqla_orm
 
 from pcapi import settings
 from pcapi.core.finance import ds
-from pcapi.core.finance import siret_api
 import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.models as finance_models
 import pcapi.core.finance.utils as finance_utils
-import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
 from pcapi.models.feature import FeatureToggle
 from pcapi.notifications.internal import send_internal_message
@@ -150,43 +148,6 @@ def add_custom_offer_reimbursement_rule(
         end_date=valid_until_dt,
     )
     print(f"Created new rule: {rule.id}")
-
-
-@blueprint.cli.command("move_siret")
-@click.option("--src-venue-id", type=int, required=True)
-@click.option("--dst-venue-id", type=int, required=True)
-@click.option("--siret", required=True)
-@click.option("--comment", required=True)
-@click.option("--apply-changes", is_flag=True, default=False, required=False)
-@click.option("--override-revenue-check", is_flag=True, default=False, required=False)
-def move_siret(
-    src_venue_id: int,
-    dst_venue_id: int,
-    siret: str,
-    comment: str,
-    apply_changes: bool = False,
-    override_revenue_check: bool = False,
-) -> None:
-    source = offerers_models.Venue.query.get(src_venue_id)
-    target = offerers_models.Venue.query.get(dst_venue_id)
-
-    try:
-        siret_api.move_siret(
-            source,
-            target,
-            siret,
-            comment,
-            apply_changes=apply_changes,
-            override_revenue_check=override_revenue_check,
-        )
-    except siret_api.CheckError as exc:
-        print(str(exc))
-        return
-
-    if apply_changes:
-        print("Siret has been moved.")
-    else:
-        print("DRY RUN: NO CHANGES HAVE BEEN MADE")
 
 
 @blueprint.cli.command("recredit_underage_users")

--- a/api/src/pcapi/core/finance/siret_api.py
+++ b/api/src/pcapi/core/finance/siret_api.py
@@ -61,7 +61,6 @@ def move_siret(
     target_venue: offerers_models.Venue,
     siret: str,
     comment: str,
-    apply_changes: bool = False,
     override_revenue_check: bool = False,
     author_user_id: int | None = None,
 ) -> None:
@@ -160,10 +159,7 @@ def move_siret(
         db.session.rollback()
         raise
 
-    if apply_changes:
-        db.session.commit()
-    else:
-        db.session.rollback()
+    db.session.commit()
 
 
 def has_pending_pricings(pricing_point: offerers_models.Venue) -> bool:

--- a/api/src/pcapi/routes/backoffice/move_siret.py
+++ b/api/src/pcapi/routes/backoffice/move_siret.py
@@ -131,7 +131,6 @@ def apply_move_siret() -> utils.BackofficeResponse:
             target_venue,
             form.siret.data,
             form.comment.data,
-            apply_changes=True,
             override_revenue_check=bool(form.override_revenue_check.data),
             author_user_id=current_user.id,
         )

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pcapi.core.finance.factories as finance_factories
 import pcapi.core.finance.models as finance_models
 import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
@@ -80,37 +79,6 @@ class AddCustomOfferReimbursementRuleTest:
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offer.id == offer_id
         assert rule.amount == 1234
-
-
-@clean_database
-def test_move_siret(app):
-    offerer = offerers_factories.OffererFactory()
-    siret = offerer.siren + "00001"
-
-    src_venue_id = offerers_factories.VenueFactory(siret=siret, managingOfferer=offerer).id
-    dst_venue_id = offerers_factories.VenueWithoutSiretFactory(managingOfferer=offerer).id
-
-    result = run_command(
-        app,
-        "move_siret",
-        "--src-venue-id",
-        src_venue_id,
-        "--dst-venue-id",
-        dst_venue_id,
-        "--siret",
-        siret,
-        "--comment",
-        "test move siret",
-        "--apply-changes",
-    )
-
-    src_venue = offerers_models.Venue.query.get(src_venue_id)
-    dst_venue = offerers_models.Venue.query.get(dst_venue_id)
-
-    assert "Siret has been moved." in result.stdout
-
-    assert not src_venue.siret
-    assert dst_venue.siret == siret
 
 
 @override_settings(SLACK_GENERATE_INVOICES_FINISHED_CHANNEL="channel")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : cette commande est maintenant dans le backoffice, elle n'est donc plus utile 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques