### PR TITLE
(PC-27500)[BO] feat: add total revenue per year in venue/offerer pages

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -200,7 +200,7 @@ class Booking(PcObject, Base, Model):
             return self.dateCreated + BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY
         return self.dateCreated + BOOKINGS_AUTO_EXPIRY_DELAY
 
-    @property
+    @hybrid_property
     def total_amount(self) -> Decimal:
         return self.amount * self.quantity
 

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -260,6 +260,16 @@ def get_stats(offerer_id: int) -> utils.BackofficeResponse:
     return render_template(
         "offerer/get/stats.html",
         stats=data,
+        offerer_id=offerer_id,
+    )
+
+
+@offerer_blueprint.route("/revenue-details", methods=["GET"])
+def get_revenue_details(offerer_id: int) -> utils.BackofficeResponse:
+    details = offerers_repository.get_revenues_per_year(offererId=offerer_id)
+    return render_template(
+        "components/revenue_details.html",
+        details=details,
     )
 
 

--- a/api/src/pcapi/routes/backoffice/templates/components/revenue_details.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/revenue_details.html
@@ -1,0 +1,36 @@
+<turbo-frame id="turbo-display-revenue-details">
+<div class="modal-header">
+  <h5 class="modal-title">CA par année</h5>
+  <button type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Fermer"></button>
+</div>
+<div class="modal-body row">
+  <div class="d-flex flex-column">
+    <table>
+      <thead>
+        <tr>
+          <th>Année</th>
+          <th class="text-end">CA offres IND</th>
+          <th class="text-end">CA offres EAC</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for year, year_stats in details | dictsort(reverse=true) %}
+          <tr>
+            <td class="text-start">{{ year }}</td>
+            <td class="text-end">{{ year_stats.individual | format_amount | safe }}</td>
+            <td class="text-end">{{ year_stats.collective | format_amount | safe }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+<div class="modal-footer">
+  <button type="button"
+          class="btn btn-outline-primary"
+          data-bs-dismiss="modal">Fermer</button>
+</div>
+</turbo>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/stats.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/stats.html
@@ -1,3 +1,4 @@
+{% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 <turbo-frame data-turbo="false" id="total_revenue_frame">
 <div class="row">
   <div class="col-md-4">
@@ -12,7 +13,18 @@
             {{ stats.total_revenue | format_amount | safe }}
           {% endif %}
         </h6>
-        <p class="card-text fw-light small">de CA</p>
+        <div class="d-flex flex-row">
+          <div class="card-text fw-light small align-self-center">de CA</div>
+          <div class="p-auto">
+            {% if stats.total_revenue != stats.placeholder and stats.total_revenue > 0 %}
+              <button class="btn link-primary"
+                      data-bs-toggle="modal"
+                      data-bs-target="#display-revenue-details"
+                      type="button">plus de détails…</button>
+              {{ build_lazy_modal(url_for("backoffice_web.offerer.get_revenue_details", offerer_id=offerer_id) , "display-revenue-details") }}
+            {% endif %}
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice/templates/venue/get/stats.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get/stats.html
@@ -14,7 +14,18 @@
             {{ stats.total_revenue | format_amount | safe }}
           {% endif %}
         </h6>
-        <p class="card-text fw-light small">de CA</p>
+        <div class="d-flex flex-row">
+          <div class="card-text fw-light small align-self-center">de CA</div>
+          <div class="p-auto">
+            {% if stats.total_revenue != stats.placeholder and stats.total_revenue > 0 %}
+              <button class="btn link-primary"
+                      data-bs-toggle="modal"
+                      data-bs-target="#display-revenue-details"
+                      type="button">plus de détails…</button>
+              {{ build_lazy_modal(url_for("backoffice_web.venue.get_revenue_details", venue_id=venue.id) , "display-revenue-details") }}
+            {% endif %}
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -418,6 +418,15 @@ def get_stats(venue_id: int) -> utils.BackofficeResponse:
     )
 
 
+@venue_blueprint.route("/<int:venue_id>/revenue-details", methods=["GET"])
+def get_revenue_details(venue_id: int) -> utils.BackofficeResponse:
+    details = offerers_repository.get_revenues_per_year(venueId=venue_id)
+    return render_template(
+        "components/revenue_details.html",
+        details=details,
+    )
+
+
 @venue_blueprint.route("/<int:venue_id>/provider/<int:provider_id>/delete", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.ADVANCED_PRO_SUPPORT)
 def delete_venue_provider(venue_id: int, provider_id: int) -> utils.BackofficeResponse:

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -496,7 +496,7 @@ class GetOffererStatsTest(GetEndpointHelper):
             assert response.status_code == 200
 
         cards_text = html_parser.extract_cards_text(response.data)
-        assert f"{str(booking.amount).replace('.', ',')} € de CA" in cards_text
+        assert f"{str(booking.amount).replace('.', ',')} € de CA" in cards_text[0]
         assert "3 offres actives ( 1 IND / 2 EAC ) 0 offres inactives ( 0 IND / 0 EAC )" in cards_text
 
 


### PR DESCRIPTION
## But de la pull request

Ajout du CA par année dans les pages Lieu et Structure du BO.

<img width="407" alt="Capture d’écran 2024-03-05 à 10 01 23" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/af09f6f3-f8e7-4b06-9ff5-d4e99ba5db4c">

<img width="803" alt="Capture d’écran 2024-03-01 à 18 27 04" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/fdd16202-484b-4daa-a07c-9f34188cfaa0">


Ticket Jira : https://passculture.atlassian.net/browse/PC-27500

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques