### PR TITLE
(BSR)[API] fix: log only when allocine product is not found

### DIFF
--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -224,12 +224,13 @@ class AllocineStocks(LocalProvider):
                 product = create_product(movie)
                 db.session.add(product)
 
-        logger.info(
-            "Product created for allocine Id %d",
-            movie.internalId,
-            extra={"allocineId": movie.internalId, "theaterId": self.theater_id},
-            technical_message_id="allocineId.not_found",
-        )
+            logger.info(
+                "Product created for allocine Id %d",
+                movie.internalId,
+                extra={"allocineId": movie.internalId, "theaterId": self.theater_id},
+                technical_message_id="allocineId.not_found",
+            )
+
         return product
 
     def apply_allocine_price_rule(self, allocine_stock: offers_models.Stock) -> decimal.Decimal:


### PR DESCRIPTION
## But de la pull request

Correction : les logs ne sont censés remonter que dans le cas où le produit allociné n'existe pas.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques