### PR TITLE
(PC-28315)[API] fix: rework pro contact options

### DIFF
--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -621,6 +621,24 @@ def create_collective_offer_template(
             {"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_NOT_FOUND"},
             status_code=400,
         )
+    except offers_exceptions.UrlandFormBothSetError:
+        logger.info(
+            "Could not set both contact url and contact form",
+            extra={"offer_name": body.name},
+        )
+        raise ApiErrors(
+            {"code": "COLLECTIVE_OFFER_URL_AND_FORM_BOTH_SET"},
+            status_code=400,
+        )
+    except offers_exceptions.AllNullContactRequestDataError:
+        logger.info(
+            "At least one contact method should be set",
+            extra={"offer_name": body.name},
+        )
+        raise ApiErrors(
+            {"code": "COLLECTIVE_OFFER_CONTACT_NOT_SET"},
+            status_code=400,
+        )
 
     return collective_offers_serialize.CollectiveOfferResponseIdModel.from_orm(offer)
 

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -4,6 +4,7 @@ import enum
 import typing
 
 import flask
+from pydantic.v1 import AnyHttpUrl
 from pydantic.v1 import ConstrainedStr
 from pydantic.v1 import EmailStr
 from pydantic.v1 import Field
@@ -540,6 +541,9 @@ class PostCollectiveOfferBodyModel(BaseModel):
 
 class PostCollectiveOfferTemplateBodyModel(PostCollectiveOfferBodyModel):
     price_detail: PriceDetail | None
+    contact_email: EmailStr | None  # type: ignore [assignment]
+    contact_url: AnyHttpUrl | None
+    contact_form: OfferContactFormEnum | None
 
     # TODO(jeremieb) | None is temporary
     # when the frontend clients are up to date, dateRange should

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
@@ -5,12 +5,15 @@
 import type { CollectiveOfferVenueBodyModel } from './CollectiveOfferVenueBodyModel';
 import type { DateRangeOnCreateModel } from './DateRangeOnCreateModel';
 import type { EacFormat } from './EacFormat';
+import type { OfferContactFormEnum } from './OfferContactFormEnum';
 import type { StudentLevels } from './StudentLevels';
 export type PostCollectiveOfferTemplateBodyModel = {
   audioDisabilityCompliant?: boolean;
   bookingEmails: Array<string>;
-  contactEmail: string;
+  contactEmail?: string | null;
+  contactForm?: OfferContactFormEnum | null;
   contactPhone?: string | null;
+  contactUrl?: string | null;
   dates?: DateRangeOnCreateModel | null;
   description: string;
   domains?: Array<number> | null;

--- a/pro/src/core/OfferEducational/adapters/postCollectiveOfferAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/postCollectiveOfferAdapter.ts
@@ -35,7 +35,7 @@ const postCollectiveOfferAdapter: PostOfferAdapter = async ({
   offerTemplateId,
 }) => {
   try {
-    const payload = createCollectiveOfferPayload(offer, false, offerTemplateId)
+    const payload = createCollectiveOfferPayload(offer, offerTemplateId)
 
     const response = await api.createCollectiveOffer(payload)
 

--- a/pro/src/core/OfferEducational/adapters/postCollectiveOfferTemplateAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/postCollectiveOfferTemplateAdapter.ts
@@ -2,7 +2,7 @@ import { api } from 'apiClient/api'
 import { isErrorAPIError } from 'apiClient/helpers'
 import { OfferEducationalFormValues } from 'core/OfferEducational'
 
-import { createCollectiveOfferPayload } from '../utils/createOfferPayload'
+import { createCollectiveOfferTemplatePayload } from '../utils/createOfferPayload'
 
 type Params = {
   offer: OfferEducationalFormValues
@@ -33,7 +33,7 @@ const postCollectiveOfferTemplateAdapter: PostOfferAdapter = async ({
   offer,
 }) => {
   try {
-    const payload = createCollectiveOfferPayload(offer, true)
+    const payload = createCollectiveOfferTemplatePayload(offer)
 
     const response = await api.createCollectiveOfferTemplate(payload)
 

--- a/pro/src/core/OfferEducational/utils/__specs__/createOfferPayload.spec.ts
+++ b/pro/src/core/OfferEducational/utils/__specs__/createOfferPayload.spec.ts
@@ -1,45 +1,41 @@
 import { DEFAULT_EAC_FORM_VALUES } from 'core/OfferEducational/constants'
 
-import { createCollectiveOfferPayload } from '../createOfferPayload'
+import {
+  createCollectiveOfferPayload,
+  createCollectiveOfferTemplatePayload,
+} from '../createOfferPayload'
 
 describe('createOfferPayload', () => {
   it('should remove dates from a template offer to create a non-template offer', () => {
     expect(
-      createCollectiveOfferPayload(
-        {
+      Object.keys(
+        createCollectiveOfferPayload({
           ...DEFAULT_EAC_FORM_VALUES,
           beginningDate: '2021-09-01',
           endingDate: '2021-09-10',
-        },
-        false
+        })
       )
-    ).toEqual(expect.objectContaining({ dates: undefined }))
+    ).toEqual(expect.not.arrayContaining(['dates']))
   })
 
   it('should not remove dates from an offer to create a template offer', () => {
     expect(
-      createCollectiveOfferPayload(
-        {
-          ...DEFAULT_EAC_FORM_VALUES,
-          beginningDate: '2021-09-01',
-          endingDate: '2021-09-10',
-          datesType: 'specific_dates',
-        },
-        true
-      ).dates
+      createCollectiveOfferTemplatePayload({
+        ...DEFAULT_EAC_FORM_VALUES,
+        beginningDate: '2021-09-01',
+        endingDate: '2021-09-10',
+        datesType: 'specific_dates',
+      }).dates
     ).toBeTruthy()
   })
 
   it('should remove dates from an offer that has no valid dates to create a template offer', () => {
     expect(
-      createCollectiveOfferPayload(
-        {
-          ...DEFAULT_EAC_FORM_VALUES,
-          beginningDate: undefined,
-          endingDate: undefined,
-        },
-        true
-      )
-    ).toEqual(expect.objectContaining({ dates: undefined }))
+      createCollectiveOfferTemplatePayload({
+        ...DEFAULT_EAC_FORM_VALUES,
+        beginningDate: undefined,
+        endingDate: undefined,
+      }).dates
+    ).toBeFalsy()
   })
 })

--- a/pro/src/core/OfferEducational/utils/createOfferPayload.ts
+++ b/pro/src/core/OfferEducational/utils/createOfferPayload.ts
@@ -2,6 +2,7 @@ import {
   DateRangeOnCreateModel,
   OfferAddressType,
   PostCollectiveOfferTemplateBodyModel,
+  PostCollectiveOfferBodyModel,
 } from 'apiClient/v1'
 import { buildDateTime } from 'screens/IndividualOffer/StocksEventEdition/adapters/serializers'
 import {
@@ -50,11 +51,9 @@ export const serializeDates = (
   }
 }
 
-export const createCollectiveOfferPayload = (
-  offer: OfferEducationalFormValues,
-  isTemplate: boolean,
-  offerTemplateId?: number
-): PostCollectiveOfferTemplateBodyModel => {
+function getCommonOfferPayload(
+  offer: OfferEducationalFormValues
+): PostCollectiveOfferBodyModel & PostCollectiveOfferTemplateBodyModel {
   return {
     venueId: Number(offer.venueId),
     subcategoryId: null,
@@ -75,16 +74,34 @@ export const createCollectiveOfferPayload = (
       offer.eventAddress.addressType === OfferAddressType.OFFERER_VENUE
         ? []
         : offer.interventionArea,
-    templateId: offerTemplateId,
-    priceDetail: isTemplate ? offer.priceDetail : undefined,
     nationalProgramId: Number(offer.nationalProgramId),
+    formats: offer.formats,
+  }
+}
+
+export const createCollectiveOfferTemplatePayload = (
+  offer: OfferEducationalFormValues,
+  offerTemplateId?: number
+): PostCollectiveOfferTemplateBodyModel => {
+  return {
+    ...getCommonOfferPayload(offer),
+    templateId: offerTemplateId,
     dates:
-      isTemplate &&
       offer.datesType === 'specific_dates' &&
       offer.beginningDate &&
       offer.endingDate
         ? serializeDates(offer.beginningDate, offer.endingDate, offer.hour)
         : undefined,
-    formats: offer.formats,
+    priceDetail: offer.priceDetail,
+  }
+}
+
+export const createCollectiveOfferPayload = (
+  offer: OfferEducationalFormValues,
+  offerTemplateId?: number
+): PostCollectiveOfferBodyModel => {
+  return {
+    ...getCommonOfferPayload(offer),
+    templateId: offerTemplateId,
   }
 }


### PR DESCRIPTION
The contactEmail field should be optional on collective offer template Rules are:
1. contactUrl and contactForm can not be both active
2. at least one contact should be there

Commit 1b86a27628ce7b6f0924464e6dd16fddb4194998 only covered the PATCH request, this one covers the POST one

## But de la pull request

**Front**
Objectif:
Puisque le model du payload des offres vitrine et réservable n'est plus le même (contactEmail optiolnel dans les offres vitrine), il y a des problèmes de type sur la fonction `createCollectiveOfferPayload` qui est utilisée pour les 2 types d'offre.


Ticket Jira : https://passculture.atlassian.net/browse/PC-28315

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques