### PR TITLE
(PC-28381)[PRO] feat: use offererId param in reimbursement context

### DIFF
--- a/pro/src/pages/Reimbursements/ReimbursementsBanners.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsBanners.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { BannerReimbursementsInfo } from 'components/Banner'
@@ -8,6 +9,7 @@ import PendingBankAccountCallout from 'components/Callout/PendingBankAccountCall
 import { useReimbursementContext } from 'context/ReimbursementContext/ReimbursementContext'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useCurrentUser from 'hooks/useCurrentUser'
+import { queryParamsFromOfferer } from 'pages/Offers/utils/queryParamsFromOfferer'
 import Spinner from 'ui-kit/Spinner/Spinner'
 
 import styles from './ReimbursementBanners.module.scss'
@@ -17,6 +19,8 @@ const ReimbursementsBanners = (): JSX.Element => {
     'WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'
   )
   const { selectedOffererId } = useCurrentUser()
+  const location = useLocation()
+  const { structure: paramOffererId } = queryParamsFromOfferer(location)
 
   const [isOfferersLoading, setIsOfferersLoading] = useState<boolean>(false)
 
@@ -30,7 +34,7 @@ const ReimbursementsBanners = (): JSX.Element => {
 
         if (offerersNames.length >= 1) {
           const offerer = await api.getOfferer(
-            selectedOffererId || offerersNames[0].id
+            Number(paramOffererId) || selectedOffererId || offerersNames[0].id
           )
           setSelectedOfferer(offerer)
         }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28381

Lorsque l’id de la structure est précisé dans l’url, utilisé cette Id pour filtrer les données affichées dans les pages de la gestion financière.

**Contexte :** 

Certains liens du BO passe l'id de la structure dans l'url pour accéder à une page spécifique de la gestion financière