### PR TITLE
(PC-28328)[EAC] fix: filter unknown venues before updates

### DIFF
--- a/api/src/pcapi/core/educational/api/address.py
+++ b/api/src/pcapi/core/educational/api/address.py
@@ -4,7 +4,6 @@ import typing
 from pcapi.core.educational import models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
-from pcapi.utils import chunks as chunks_utils
 
 
 def new_venue_address(venue: offerers_models.Venue) -> models.AdageVenueAddress:
@@ -26,16 +25,13 @@ def get_venue_address_by_adage_id(adage_id: str) -> models.AdageVenueAddress | N
     return models.AdageVenueAddress.query.filter_by(adageId=adage_id).one_or_none()
 
 
-def unlink_unknown_venue_addresses(known_adage_ids: typing.Collection[str], save: bool = False) -> int:
+def unlink_unknown_venue_addresses(known_adage_ids: typing.Collection[str]) -> int:
     """Find unknown AdageVenueAddress (adageId not in known_adage_ids)
     and remove their adageId and adageInscriptionDate.
     """
     count = models.AdageVenueAddress.query.filter(models.AdageVenueAddress.adageId.not_in(known_adage_ids)).update(
-        {"adageId": None, "adageInscriptionDate": None}, synchronize_session=False
+        {"adageId": None, "adageInscriptionDate": None}, synchronize_session="evaluate"
     )
-
-    if save:
-        db.session.commit()
 
     return count
 
@@ -48,17 +44,13 @@ def upsert_venues_addresses(adage_ids_venues: typing.Mapping[str, int]) -> None:
     existing_ids = {row.adageId for row in existing}
 
     query = models.AdageVenueAddress.query.filter(models.AdageVenueAddress.adageId.in_(existing_ids))
-    for chunk in chunks_utils.get_chunks(query, chunk_size=1_000):
-        for ava in chunk:
-            ava.venueId = adage_ids_venues[ava.adageId]
-            db.session.add(ava)
+    for ava in query:
+        ava.venueId = adage_ids_venues[ava.adageId]
+        db.session.add(ava)
 
     now = datetime.utcnow()
     missing_ids = adage_ids_venues.keys() - existing_ids
-    for chunk in chunks_utils.get_chunks(missing_ids, chunk_size=1_000):
-        for missing_id in chunk:
-            db.session.add(
-                models.AdageVenueAddress(
-                    venueId=adage_ids_venues[missing_id], adageId=missing_id, adageInscriptionDate=now
-                )
-            )
+    for missing_id in missing_ids:
+        db.session.add(
+            models.AdageVenueAddress(venueId=adage_ids_venues[missing_id], adageId=missing_id, adageInscriptionDate=now)
+        )

--- a/api/tests/core/educational/api/test_address.py
+++ b/api/tests/core/educational/api/test_address.py
@@ -3,6 +3,7 @@ import pytest
 from pcapi.core.educational import models
 from pcapi.core.educational.api import address as api
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.repository import atomic
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -12,7 +13,8 @@ class UnlinkUnknownVenueAddressesTest:
     def test_unlink_many(self):
         venues = offerers_factories.CollectiveVenueFactory.create_batch(2)
 
-        api.unlink_unknown_venue_addresses([], save=True)
+        with atomic():
+            api.unlink_unknown_venue_addresses([])
 
         venue_addresses = get_venue_addresses([venue.id for venue in venues])
         assert len(venue_addresses) == len(venues)
@@ -23,7 +25,8 @@ class UnlinkUnknownVenueAddressesTest:
         to_unlink = offerers_factories.CollectiveVenueFactory.create_batch(2)
         to_keep = offerers_factories.CollectiveVenueFactory.create_batch(2)
 
-        api.unlink_unknown_venue_addresses([venue.adageId for venue in to_keep], save=True)
+        with atomic():
+            api.unlink_unknown_venue_addresses([venue.adageId for venue in to_keep])
 
         venue_addresses = get_venue_addresses([venue.id for venue in to_unlink + to_keep])
         assert {ava.adageId for ava in venue_addresses} == {venue.adageId for venue in to_keep} | {None}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28328

Bug : il peut arriver que l'on essaie d'insérer une ligne dans `adage_venue_address` avec une référence vers un lieu qui n'existe pas. Ceci peut arriver car on ne vérifie pas que les informations envoyées par le client sont exactes.

Fix : vérifier que les ids des lieux existent bien.

### Au passage

1. retirer les appels à `get_chunks` qui ne servent à rien. Ils auraient pu servir à faire des _commits_ toutes les N lignes mais ce n'est probablement pas nécessaire et tout avoir dans une transaction est probablement plus intéressant.
2. les insertions et les mises à jour dans `adage_venue_address` se font dans une transaction, via `atomic()`.