### PR TITLE
(BSR) fix squawk lint hint

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -292,7 +292,7 @@ jobs:
               status_code=1
             YELLOW='\033[0;33m'
             RESET='\033[0m'
-            if status_code=1;then
+            if [ ${status_code} -ne 0 ];then
               echo -e "${YELLOW}Hint: An SQL statement can be ignored if preceded by \`-- squawk:ignore-next-statement\`.${RESET}" 
               echo -e "${YELLOW}See https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/alembic/CONTRIBUTING.md#lint${RESET}";
             fi


### PR DESCRIPTION
## But de la pull request

Corriger la syntaxe d'un hint dans les logs de CI, bug introduit dans https://github.com/pass-culture/pass-culture-main/commit/b5366f1cc3ce11b2b259842e121f090972dfbd20

La bonne syntaxe a été façonnée par @dbaty , qu'il soit couvert de louanges et de remerciements.