### PR TITLE
(BSR)[API] chore: add docker compose file for M1/M2 chips

### DIFF
--- a/docker-compose-backend-arm.yml
+++ b/docker-compose-backend-arm.yml
@@ -1,0 +1,45 @@
+version: "3.7"
+
+services:
+  postgres:
+    image: imresamu/postgis-arm64:15-3.4
+    extends:
+      file: docker-compose-backend.yml
+      service: postgres
+
+  postgres-test:
+    image: imresamu/postgis-arm64:15-3.4
+    extends:
+      file: docker-compose-backend.yml
+      service: postgres-test
+
+  flask:
+    extends:
+      file: docker-compose-backend.yml
+      service: flask
+
+  backoffice:
+    extends:
+      file: docker-compose-backend.yml
+      service: backoffice
+
+  redis:
+    extends:
+      file: docker-compose-backend.yml
+      service: redis
+
+  nginx:
+    extends:
+      file: docker-compose-backend.yml
+      service: nginx
+
+networks:
+  db_nw:
+    driver: bridge
+  web_nw:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  postgres_data_test:
+  redis_data:


### PR DESCRIPTION
## But de la pull request

The default postgis image is unstable with M1/M2 arch because the build is for amd64 and it crashes the Qemu.
For more details about the issue, see:
https://github.com/postgis/docker-postgis/issues/216
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques