### PR TITLE
(BSR)[API] fix: Do not log user input error on bogus image upload

### DIFF
--- a/api/src/pcapi/routes/error_handlers/thumbnails_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/thumbnails_error_handlers.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def handle_create_a_thumbnail(exception: Exception) -> tuple[Response, int]:
     mark_transaction_as_invalid()
     error_message = exception.args[0] if exception.args else "L'image n'est pas valide"
-    logger.error(
+    logger.info(
         "When creating the offer thumbnail, this error was encountered: %s: %s",
         exception.__class__.__name__,
         error_message,


### PR DESCRIPTION
Logging "this error was encountered: FileSizeExceeded" at the ERROR
level is useless. We cannot do anything about it. I guess that we
wanted to log for debugging purposes: INFO level is enough, then.

---

Exemple sur Sentry : https://sentry.passculture.team/organizations/sentry/issues/416900/events