### PR TITLE
(PC-28270)[PRO] feat: make read only OpeningHours

### DIFF
--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.module.scss
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.module.scss
@@ -1,32 +1,17 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_colors.scss" as colors;
+
 
 .day-and-hours {
   margin: rem.torem(8px) 0;
   padding: rem.torem(8px) 0;
-
-  & > * {
-    display: inline-block;
-    width: rem.torem(20px);
-    margin-right: rem.torem(16px);
-  }
 }
 
-.hour {
+.important {
   @include fonts.body-important;
-
-  width: rem.torem(45px);
-  margin-right: rem.torem(16px);
-}
-
-.noon-separator {
-  width: rem.torem(40px);
-  margin-left: rem.torem(8px);
 }
 
 .day {
-  @include fonts.body-important;
-
-  width: rem.torem(80px);
-  margin-right: rem.torem(32px);
+  color: colors.$grey-dark;
 }

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.module.scss
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.module.scss
@@ -1,0 +1,32 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_rem.scss" as rem;
+
+.day-and-hours {
+  margin: rem.torem(8px) 0;
+  padding: rem.torem(8px) 0;
+
+  & > * {
+    display: inline-block;
+    width: rem.torem(20px);
+    margin-right: rem.torem(16px);
+  }
+}
+
+.hour {
+  @include fonts.body-important;
+
+  width: rem.torem(45px);
+  margin-right: rem.torem(16px);
+}
+
+.noon-separator {
+  width: rem.torem(40px);
+  margin-left: rem.torem(8px);
+}
+
+.day {
+  @include fonts.body-important;
+
+  width: rem.torem(80px);
+  margin-right: rem.torem(32px);
+}

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.module.scss
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.module.scss
@@ -3,11 +3,6 @@
 @use "styles/variables/_colors.scss" as colors;
 
 
-.day-and-hours {
-  margin: rem.torem(8px) 0;
-  padding: rem.torem(8px) 0;
-}
-
 .important {
   @include fonts.body-important;
 }

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.stories.tsx
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.stories.tsx
@@ -1,0 +1,46 @@
+import { StoryObj } from '@storybook/react'
+
+import { OpeningHoursReadOnly } from './OpeningHoursReadOnly'
+
+export default {
+  title: 'components/OpeningHoursReadOnly',
+  component: OpeningHoursReadOnly,
+}
+
+const openingHours = [
+  { MONDAY: [{ open: '14:00', close: '19:30' }] },
+  {
+    TUESDAY: [
+      { open: '10:00', close: '13:00' },
+      { open: '14:00', close: '19:30' },
+    ],
+  },
+  {
+    WEDNESDAY: [
+      { open: '10:00', close: '13:00' },
+      { open: '14:00', close: '19:30' },
+    ],
+  },
+  {
+    THURSDAY: [
+      { open: '10:00', close: '13:00' },
+      { open: '14:00', close: '19:30' },
+    ],
+  },
+  {
+    FRIDAY: [
+      { open: '10:00', close: '13:00' },
+      { open: '14:00', close: '19:30' },
+    ],
+  },
+  {
+    SATURDAY: [
+      { open: '10:00', close: '13:00' },
+      { open: '14:00', close: '19:30' },
+    ],
+  },
+  { SUNDAY: null },
+]
+export const Default: StoryObj<typeof OpeningHoursReadOnly> = {
+  args: { openingHours },
+}

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
@@ -1,0 +1,83 @@
+import styles from './OpeningHoursReadOnly.module.scss'
+
+type OpeningHours = {
+  openingHours: Array<Record<string, any>>
+}
+
+export function OpeningHoursReadOnly({ openingHours }: OpeningHours) {
+  return openingHours.map((row) => (
+    <DayAndHours
+      day={Object.keys(row)[0]}
+      hours={Object.values(row)[0]}
+      key={Object.keys(row)[0]}
+    />
+  ))
+}
+
+export function DayAndHours({ day, hours }: DayAndHours) {
+  const displayedDay = mapDayToFrench(day)
+  if (!hours) {
+    return <></>
+  }
+
+  return (
+    <>
+      {hours.length === 1 ? (
+        <p className={styles['day-and-hours']}>
+          <span className={styles['day']}>{displayedDay}</span> <span>De</span>{' '}
+          <span className={styles['hour']}>{hours[0].open}</span> <span>à</span>{' '}
+          <span className={styles['hour']}>{hours[0].close}</span>
+        </p>
+      ) : (
+        <p className={styles['day-and-hours']}>
+          <span className={styles['day']}>{displayedDay}</span> <span>De</span>{' '}
+          <span className={styles['hour']}>{hours[0].open}</span> <span>à</span>{' '}
+          <span className={styles['hour']}>{hours[0].close}</span>{' '}
+          <span className={styles['noon-separator']}>et de</span>{' '}
+          <span className={styles['hour']}>{hours[1].open}</span> <span>à</span>{' '}
+          <span className={styles['hour']}>{hours[1].close}</span>{' '}
+        </p>
+      )}
+    </>
+  )
+}
+
+type openClose = {
+  open: string
+  close: string
+}
+
+type DayAndHours = {
+  day: string
+  hours: Array<openClose> | null
+}
+
+function mapDayToFrench(
+  day: string
+):
+  | 'Lundi'
+  | 'Mardi'
+  | 'Mercredi'
+  | 'Jeudi'
+  | 'Vendredi'
+  | 'Samedi'
+  | 'Dimanche' {
+  switch (day) {
+    case 'MONDAY':
+      return 'Lundi'
+    case 'TUESDAY':
+      return 'Mardi'
+    case 'WEDNESDAY':
+      return 'Mercredi'
+    case 'THURSDAY':
+      return 'Jeudi'
+    case 'FRIDAY':
+      return 'Vendredi'
+    case 'SATURDAY':
+      return 'Samedi'
+    case 'SUNDAY':
+      return 'Dimanche'
+    default:
+      return 'Dimanche'
+  }
+}

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
@@ -24,18 +24,23 @@ export function DayAndHours({ day, hours }: DayAndHours) {
     <>
       {hours.length === 1 ? (
         <p className={styles['day-and-hours']}>
-          <span className={styles['day']}>{displayedDay}</span> <span>De</span>{' '}
-          <span className={styles['hour']}>{hours[0].open}</span> <span>à</span>{' '}
-          <span className={styles['hour']}>{hours[0].close}</span>
+          <span className={styles['day']}>
+            {displayedDay}
+            {' : '}
+          </span>{' '}
+          de <span className={styles['important']}>{hours[0].open}</span> à{' '}
+          <span className={styles['important']}>{hours[0].close}</span>
         </p>
       ) : (
         <p className={styles['day-and-hours']}>
-          <span className={styles['day']}>{displayedDay}</span> <span>De</span>{' '}
-          <span className={styles['hour']}>{hours[0].open}</span> <span>à</span>{' '}
-          <span className={styles['hour']}>{hours[0].close}</span>{' '}
-          <span className={styles['noon-separator']}>et de</span>{' '}
-          <span className={styles['hour']}>{hours[1].open}</span> <span>à</span>{' '}
-          <span className={styles['hour']}>{hours[1].close}</span>{' '}
+          <span className={styles['day']}>
+            {displayedDay}
+            {' : '}
+          </span>{' '}
+          de <span className={styles['important']}>{hours[0].open}</span> à{' '}
+          <span className={styles['important']}>{hours[0].close}</span> et de{' '}
+          <span className={styles['important']}>{hours[1].open}</span> à{' '}
+          <span className={styles['important']}>{hours[1].close}</span>{' '}
         </p>
       )}
     </>

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
@@ -1,3 +1,6 @@
+import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
+
 import styles from './OpeningHoursReadOnly.module.scss'
 
 type OpeningHours = {
@@ -5,43 +8,37 @@ type OpeningHours = {
 }
 
 export function OpeningHoursReadOnly({ openingHours }: OpeningHours) {
-  return openingHours.map((row) => (
-    <DayAndHours
-      day={Object.keys(row)[0]}
-      hours={Object.values(row)[0]}
-      key={Object.keys(row)[0]}
-    />
-  ))
+  return (
+    <SummarySubSection title={'Horaires d’ouverture'}>
+      <SummaryDescriptionList
+        descriptions={openingHours
+          .filter((dateAndHour) => dateAndHour && Object.values(dateAndHour)[0])
+          .map((dateAndHour) => {
+            return {
+              title: mapDayToFrench(Object.keys(dateAndHour)[0]),
+              text: <Hours hours={Object.values(dateAndHour)[0]} />,
+            }
+          })}
+      />
+    </SummarySubSection>
+  )
 }
 
-export function DayAndHours({ day, hours }: DayAndHours) {
-  const displayedDay = mapDayToFrench(day)
-  if (!hours) {
-    return <></>
-  }
-
+export function Hours({ hours }: Hours) {
   return (
     <>
       {hours.length === 1 ? (
-        <p className={styles['day-and-hours']}>
-          <span className={styles['day']}>
-            {displayedDay}
-            {' : '}
-          </span>{' '}
+        <>
           de <span className={styles['important']}>{hours[0].open}</span> à{' '}
           <span className={styles['important']}>{hours[0].close}</span>
-        </p>
+        </>
       ) : (
-        <p className={styles['day-and-hours']}>
-          <span className={styles['day']}>
-            {displayedDay}
-            {' : '}
-          </span>{' '}
+        <>
           de <span className={styles['important']}>{hours[0].open}</span> à{' '}
           <span className={styles['important']}>{hours[0].close}</span> et de{' '}
           <span className={styles['important']}>{hours[1].open}</span> à{' '}
           <span className={styles['important']}>{hours[1].close}</span>{' '}
-        </p>
+        </>
       )}
     </>
   )
@@ -52,9 +49,8 @@ type openClose = {
   close: string
 }
 
-type DayAndHours = {
-  day: string
-  hours: Array<openClose> | null
+type Hours = {
+  hours: Array<openClose>
 }
 
 function mapDayToFrench(

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/__specs__/OpeningHoursReadOnly.spec.tsx
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/__specs__/OpeningHoursReadOnly.spec.tsx
@@ -1,0 +1,80 @@
+import { screen, render } from '@testing-library/react'
+
+import { DayAndHours, OpeningHoursReadOnly } from '../OpeningHoursReadOnly'
+
+describe('OpeningHoursReadOnly', () => {
+  it('should display each necessary days', () => {
+    const openingHours = [
+      { MONDAY: [{ open: '14:00', close: '19:30' }] },
+      {
+        TUESDAY: [
+          { open: '10:00', close: '13:00' },
+          { open: '14:00', close: '19:30' },
+        ],
+      },
+      {
+        WEDNESDAY: [
+          { open: '10:00', close: '13:00' },
+          { open: '14:00', close: '19:30' },
+        ],
+      },
+      {
+        THURSDAY: [
+          { open: '10:00', close: '13:00' },
+          { open: '14:00', close: '19:30' },
+        ],
+      },
+      {
+        FRIDAY: [
+          { open: '10:00', close: '13:00' },
+          { open: '14:00', close: '19:30' },
+        ],
+      },
+      {
+        SATURDAY: [
+          { open: '10:00', close: '13:00' },
+          { open: '14:00', close: '19:30' },
+        ],
+      },
+      { SUNDAY: null },
+    ]
+    render(<OpeningHoursReadOnly openingHours={openingHours} />)
+
+    expect(screen.getByText('Lundi')).toBeInTheDocument()
+    expect(screen.getByText('Mardi')).toBeInTheDocument()
+    expect(screen.getByText('Mercredi')).toBeInTheDocument()
+    expect(screen.getByText('Jeudi')).toBeInTheDocument()
+    expect(screen.getByText('Vendredi')).toBeInTheDocument()
+    expect(screen.getByText('Samedi')).toBeInTheDocument()
+    expect(screen.queryByText('Dimanche')).not.toBeInTheDocument()
+  })
+})
+
+describe('DayAndHours', () => {
+  it('should display each hours and day when half a day', () => {
+    const openingHours = [{ open: '14:00', close: '19:30' }]
+
+    render(<DayAndHours day="MONDAY" hours={openingHours} />)
+
+    expect(screen.getByText('Lundi')).toBeInTheDocument()
+    expect(screen.getByText('14:00')).toBeInTheDocument()
+    expect(screen.getByText('19:30')).toBeInTheDocument()
+    expect(screen.queryByText('et de')).not.toBeInTheDocument()
+  })
+
+  it('should display each hours and day when the whole day', () => {
+    const openingHours = [
+      { open: '10:00', close: '12:30' },
+      { open: '14:00', close: '19:30' },
+    ]
+
+    render(<DayAndHours day="SUNDAY" hours={openingHours} />)
+
+    expect(screen.getByText('Dimanche')).toBeInTheDocument()
+    expect(screen.getByText('10:00')).toBeInTheDocument()
+    expect(screen.getByText('12:30')).toBeInTheDocument()
+    expect(screen.getByText('14:00')).toBeInTheDocument()
+    expect(screen.getByText('19:30')).toBeInTheDocument()
+    expect(screen.getByText('et de')).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/__specs__/OpeningHoursReadOnly.spec.tsx
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/__specs__/OpeningHoursReadOnly.spec.tsx
@@ -1,6 +1,6 @@
 import { screen, render } from '@testing-library/react'
 
-import { DayAndHours, OpeningHoursReadOnly } from '../OpeningHoursReadOnly'
+import { Hours, OpeningHoursReadOnly } from '../OpeningHoursReadOnly'
 
 describe('OpeningHoursReadOnly', () => {
   it('should display each necessary days', () => {
@@ -54,9 +54,8 @@ describe('DayAndHours', () => {
   it('should display each hours and day when half a day', () => {
     const openingHours = [{ open: '14:00', close: '19:30' }]
 
-    render(<DayAndHours day="MONDAY" hours={openingHours} />)
+    render(<Hours hours={openingHours} />)
 
-    expect(screen.getByText('Lundi :')).toBeInTheDocument()
     expect(screen.getByText('14:00')).toBeInTheDocument()
     expect(screen.getByText('19:30')).toBeInTheDocument()
     expect(screen.queryByText(/et de/)).not.toBeInTheDocument()
@@ -68,9 +67,8 @@ describe('DayAndHours', () => {
       { open: '14:00', close: '19:30' },
     ]
 
-    render(<DayAndHours day="SUNDAY" hours={openingHours} />)
+    render(<Hours hours={openingHours} />)
 
-    expect(screen.getByText('Dimanche :')).toBeInTheDocument()
     expect(screen.getByText('10:00')).toBeInTheDocument()
     expect(screen.getByText('12:30')).toBeInTheDocument()
     expect(screen.getByText('14:00')).toBeInTheDocument()

--- a/pro/src/pages/VenueCreation/OpeningHoursReadOnly/__specs__/OpeningHoursReadOnly.spec.tsx
+++ b/pro/src/pages/VenueCreation/OpeningHoursReadOnly/__specs__/OpeningHoursReadOnly.spec.tsx
@@ -40,13 +40,13 @@ describe('OpeningHoursReadOnly', () => {
     ]
     render(<OpeningHoursReadOnly openingHours={openingHours} />)
 
-    expect(screen.getByText('Lundi')).toBeInTheDocument()
-    expect(screen.getByText('Mardi')).toBeInTheDocument()
-    expect(screen.getByText('Mercredi')).toBeInTheDocument()
-    expect(screen.getByText('Jeudi')).toBeInTheDocument()
-    expect(screen.getByText('Vendredi')).toBeInTheDocument()
-    expect(screen.getByText('Samedi')).toBeInTheDocument()
-    expect(screen.queryByText('Dimanche')).not.toBeInTheDocument()
+    expect(screen.getByText(/Lundi/)).toBeInTheDocument()
+    expect(screen.getByText(/Mardi/)).toBeInTheDocument()
+    expect(screen.getByText(/Mercredi/)).toBeInTheDocument()
+    expect(screen.getByText(/Jeudi/)).toBeInTheDocument()
+    expect(screen.getByText(/Vendredi/)).toBeInTheDocument()
+    expect(screen.getByText(/Samedi/)).toBeInTheDocument()
+    expect(screen.queryByText(/Dimanche/)).not.toBeInTheDocument()
   })
 })
 
@@ -56,10 +56,10 @@ describe('DayAndHours', () => {
 
     render(<DayAndHours day="MONDAY" hours={openingHours} />)
 
-    expect(screen.getByText('Lundi')).toBeInTheDocument()
+    expect(screen.getByText('Lundi :')).toBeInTheDocument()
     expect(screen.getByText('14:00')).toBeInTheDocument()
     expect(screen.getByText('19:30')).toBeInTheDocument()
-    expect(screen.queryByText('et de')).not.toBeInTheDocument()
+    expect(screen.queryByText(/et de/)).not.toBeInTheDocument()
   })
 
   it('should display each hours and day when the whole day', () => {
@@ -70,11 +70,11 @@ describe('DayAndHours', () => {
 
     render(<DayAndHours day="SUNDAY" hours={openingHours} />)
 
-    expect(screen.getByText('Dimanche')).toBeInTheDocument()
+    expect(screen.getByText('Dimanche :')).toBeInTheDocument()
     expect(screen.getByText('10:00')).toBeInTheDocument()
     expect(screen.getByText('12:30')).toBeInTheDocument()
     expect(screen.getByText('14:00')).toBeInTheDocument()
     expect(screen.getByText('19:30')).toBeInTheDocument()
-    expect(screen.getByText('et de')).toBeInTheDocument()
+    expect(screen.getByText(/et de/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28270

Le responsive suivra quand les maquettes seront là,
visible sur storybook en attendant sa page d'accueil 

![image](https://github.com/pass-culture/pass-culture-main/assets/15941528/763e5680-da27-4846-8aa4-ef88320fa51c)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques