### PR TITLE
(PC-28414)[API] feat: Increase TTL of pro email validation token

### DIFF
--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -8,7 +8,9 @@ ACCOUNT_CREATION_TOKEN_LIFE_TIME = datetime.timedelta(hours=1)
 OAUTH_STATE_TOKEN_LIFE_TIME = datetime.timedelta(hours=1)
 RESET_PASSWORD_TOKEN_LIFE_TIME = datetime.timedelta(hours=24)
 EMAIL_VALIDATION_TOKEN_LIFE_TIME = datetime.timedelta(minutes=30)
-EMAIL_VALIDATION_TOKEN_FOR_PRO_LIFE_TIME = datetime.timedelta(days=5)
+# FIXME (dbaty, 2024-03-07): decrease TTL (to something like 1 day or
+# less) once users have a proper way to generate a new token.
+EMAIL_VALIDATION_TOKEN_FOR_PRO_LIFE_TIME = datetime.timedelta(days=90)
 EMAIL_VALIDATION_TOKEN_UPON_MANUAL_CREATION_LIFE_TIME = datetime.timedelta(days=1)
 EMAIL_CHANGE_TOKEN_LIFE_TIME = datetime.timedelta(seconds=settings.EMAIL_CHANGE_TOKEN_LIFE_TIME)
 PHONE_VALIDATION_TOKEN_LIFE_TIME = datetime.timedelta(hours=12)


### PR DESCRIPTION
We previously set the token TTL to 5 days. But it's believed not be
long enough: some users really take their time to validate their
e-mail address. They have no way to re-generate a token if it has
expired. These users are then blocked. We don't want users to be
blocked... So here we extend the TTL... until we implement a way
for users to generate a new token.


## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28414