### PR TITLE
(BSR)[imageresizing] fix: add automatic scaling adjustment

### DIFF
--- a/app-engine/image-resizing/app.yaml
+++ b/app-engine/image-resizing/app.yaml
@@ -16,4 +16,8 @@ handlers:
   secure: always
 
 automatic_scaling:
+  min_idle_instances: automatic
+  max_idle_instances: automatic
+  min_pending_latency: automatic
+  max_pending_latency: automatic
   max_instances: 10


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

<img width="452" alt="image" src="https://github.com/pass-culture/pass-culture-main/assets/77674046/7fd20369-cd9e-45b4-a31e-8d9ac33ad744">


````
[1] resource.type="gae_app"
resource.labels.module_id="image-resizing"
(protoPayload.appId="h~passculture-metier-prod")
severity=ERROR

[2] https://cloud.google.com/appengine/docs/standard/troubleshooter/latency#autoscaler_settings

[3] automatic_scaling:
min_idle_instances: automatic
max_idle_instances: automatic
min_pending_latency: automatic
max_pending_latency: automatic
max_instances: 10

[4] https://medium.com/google-cloud/app-engine-scheduler-settings-and-instance-count-4d1e669f33d5 
````



## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques