### PR TITLE
(PC-28247)[PRO] feat: adapt offer for preview

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
@@ -4,6 +4,7 @@
 @use "styles/variables/_size.scss" as size;
 
 .offer {
+  container: offer / inline-size;
   position: relative;
 
   &::before {
@@ -86,7 +87,7 @@
   }
 }
 
-@media (min-width: size.$tablet) {
+@container offer (min-width: #{size.$tablet}) {
   .offer-body {
     flex-direction: row;
   }
@@ -97,7 +98,7 @@
   }
 }
 
-@media (min-width: size.$mobile) {
+@container offer (width >= #{size.$mobile}) {
   .offer-header {
     flex-direction: row;
     align-items: unset;

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
@@ -1,6 +1,7 @@
 import {
   CollectiveOfferTemplateResponseModel,
   CollectiveOfferResponseModel,
+  AuthenticatedResponse,
 } from 'apiClient/adage'
 import strokeArticleIcon from 'icons/stroke-article.svg'
 import strokeInfoIcon from 'icons/stroke-info.svg'
@@ -18,17 +19,27 @@ import AdageOfferHeader from './AdageOfferHeader/AdageOfferHeader'
 import AdageOfferInstitutionPanel from './AdageOfferInstitutionPanel/AdageOfferInstitutionPanel'
 import AdageOfferPartnerPanel from './AdageOfferPartnerPanel/AdageOfferPartnerPanel'
 
-type AdageOfferProps = {
+export type AdageOfferProps = {
   offer: CollectiveOfferTemplateResponseModel | CollectiveOfferResponseModel
+  adageUser: AuthenticatedResponse
+  isPreview?: boolean
 }
 
-export default function AdageOffer({ offer }: AdageOfferProps) {
+export default function AdageOffer({
+  offer,
+  adageUser,
+  isPreview = false,
+}: AdageOfferProps) {
   const isOfferBookable = isCollectiveOfferBookable(offer)
 
   return (
     <div className={styles['offer']}>
       <div className={styles['offer-header']}>
-        <AdageOfferHeader offer={offer} />
+        <AdageOfferHeader
+          offer={offer}
+          adageUser={adageUser}
+          isPreview={isPreview}
+        />
       </div>
       <div className={styles['offer-body']}>
         <div className={styles['offer-main']}>
@@ -87,10 +98,14 @@ export default function AdageOffer({ offer }: AdageOfferProps) {
         <div className={styles['offer-side']}>
           {isOfferBookable ? (
             (offer.teacher || offer.educationalInstitution) && (
-              <AdageOfferInstitutionPanel offer={offer} />
+              <AdageOfferInstitutionPanel offer={offer} adageUser={adageUser} />
             )
           ) : (
-            <AdageOfferPartnerPanel offer={offer} />
+            <AdageOfferPartnerPanel
+              offer={offer}
+              adageUser={adageUser}
+              isPreview={isPreview}
+            />
           )}
         </div>
       </div>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.module.scss
@@ -88,7 +88,7 @@
   }
 }
 
-@media (min-width: size.$mobile) {
+@container (min-width: #{size.$mobile}) {
   .offer-header-title {
     @include fonts.title3;
   }
@@ -107,7 +107,7 @@
   }
 }
 
-@media (min-width: size.$tablet) {
+@container (min-width: #{size.$tablet}) {
   .offer-header-title {
     @include fonts.title1;
   }

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/AdageOfferHeader.tsx
@@ -1,21 +1,17 @@
-import {
-  CollectiveOfferTemplateResponseModel,
-  CollectiveOfferResponseModel,
-  AdageFrontRoles,
-} from 'apiClient/adage'
+import { AdageFrontRoles } from 'apiClient/adage'
 import { OfferAddressType } from 'apiClient/v1'
 import strokeCalendarIcon from 'icons/stroke-calendar.svg'
 import strokeEuroIcon from 'icons/stroke-euro.svg'
 import strokeLocationIcon from 'icons/stroke-location.svg'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
-import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { isCollectiveOfferBookable } from 'pages/AdageIframe/app/types/offers'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import OfferFavoriteButton from '../../../OffersInstantSearch/OffersSearch/Offers/OfferFavoriteButton/OfferFavoriteButton'
 import OfferShareLink from '../../../OffersInstantSearch/OffersSearch/Offers/OfferShareLink/OfferShareLink'
 import { getOfferVenueAndOffererName } from '../../../OffersInstantSearch/OffersSearch/Offers/utils/getOfferVenueAndOffererName'
+import { AdageOfferProps } from '../AdageOffer'
 import {
   getFormattedDatesForBookableOffer,
   getFormattedDatesForTemplateOffer,
@@ -25,12 +21,11 @@ import { getBookableOfferStockPrice } from '../utils/adageOfferStocks'
 
 import styles from './AdageOfferHeader.module.scss'
 
-export type AdageOfferProps = {
-  offer: CollectiveOfferTemplateResponseModel | CollectiveOfferResponseModel
-}
-
-export default function AdageOfferHeader({ offer }: AdageOfferProps) {
-  const { adageUser } = useAdageUser()
+export default function AdageOfferHeader({
+  offer,
+  adageUser,
+  isPreview,
+}: AdageOfferProps) {
   const isOfferBookable = isCollectiveOfferBookable(offer)
 
   const venueAndOffererName = getOfferVenueAndOffererName(offer.venue)
@@ -67,7 +62,7 @@ export default function AdageOfferHeader({ offer }: AdageOfferProps) {
         <div className={styles['offer-header-title-container']}>
           <h1 className={styles['offer-header-title']}>{offer.name}</h1>
 
-          {offer.isTemplate && (
+          {!isPreview && offer.isTemplate && (
             <div className={styles['offer-header-actions']}>
               {adageUser.role === AdageFrontRoles.REDACTOR && (
                 <OfferFavoriteButton

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
@@ -10,14 +10,17 @@ import {
 } from 'utils/adageFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
-import AdageOfferHeader, { AdageOfferProps } from '../AdageOfferHeader'
+import { AdageOfferProps } from '../../AdageOffer'
+import AdageOfferHeader from '../AdageOfferHeader'
 
 function renderAdageOfferHeader(
-  props: AdageOfferProps = { offer: defaultCollectiveTemplateOffer },
-  user = defaultAdageUser
+  props: AdageOfferProps = {
+    offer: defaultCollectiveTemplateOffer,
+    adageUser: defaultAdageUser,
+  }
 ) {
   return renderWithProviders(
-    <AdageUserContextProvider adageUser={user}>
+    <AdageUserContextProvider adageUser={defaultAdageUser}>
       <AdageOfferHeader {...props} />
     </AdageUserContextProvider>
   )
@@ -35,6 +38,7 @@ describe('AdageOfferHeader', () => {
   it('should show the offer image if it has one', () => {
     renderAdageOfferHeader({
       offer: { ...defaultCollectiveTemplateOffer, imageUrl: 'test_url' },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.getByRole('img')).toHaveAttribute('src', 'test_url')
@@ -43,6 +47,7 @@ describe('AdageOfferHeader', () => {
   it('should not show an image if the offer has no image', () => {
     renderAdageOfferHeader({
       offer: { ...defaultCollectiveTemplateOffer, imageUrl: undefined },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
@@ -60,7 +65,10 @@ describe('AdageOfferHeader', () => {
   })
 
   it('should not show the action buttons if the offer is bookable', () => {
-    renderAdageOfferHeader({ offer: defaultCollectiveOffer })
+    renderAdageOfferHeader({
+      offer: defaultCollectiveOffer,
+      adageUser: defaultAdageUser,
+    })
 
     expect(
       screen.queryByRole('button', { name: 'Enregistrer en favoris' })
@@ -71,10 +79,10 @@ describe('AdageOfferHeader', () => {
   })
 
   it('should not show the favorite button if the user is not admin', () => {
-    renderAdageOfferHeader(
-      { offer: defaultCollectiveTemplateOffer },
-      { ...defaultAdageUser, role: AdageFrontRoles.READONLY }
-    )
+    renderAdageOfferHeader({
+      offer: defaultCollectiveTemplateOffer,
+      adageUser: { ...defaultAdageUser, role: AdageFrontRoles.READONLY },
+    })
 
     expect(
       screen.queryByRole('button', { name: 'Enregistrer en favoris' })
@@ -92,6 +100,7 @@ describe('AdageOfferHeader', () => {
           city: 'Ville test',
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.getByText(/Test venue name/)).toBeInTheDocument()
@@ -107,6 +116,7 @@ describe('AdageOfferHeader', () => {
           addressType: OfferAddressType.SCHOOL,
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(
@@ -124,6 +134,7 @@ describe('AdageOfferHeader', () => {
           otherAddress: '123 this is a very specific address',
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(
@@ -140,6 +151,7 @@ describe('AdageOfferHeader', () => {
           start: '2024-01-23T23:00:28.040547Z',
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(
@@ -153,6 +165,7 @@ describe('AdageOfferHeader', () => {
         ...defaultCollectiveTemplateOffer,
         dates: undefined,
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(
@@ -168,6 +181,7 @@ describe('AdageOfferHeader', () => {
         ...defaultCollectiveTemplateOffer,
         students: [StudentLevels.CAP_1RE_ANN_E, StudentLevels.COLL_GE_3E],
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.getByText('Multiniveaux')).toBeInTheDocument()
@@ -189,6 +203,7 @@ describe('AdageOfferHeader', () => {
           price: 12000,
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.getByText('120 € pour 100 élèves')).toBeInTheDocument()

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/AdageOfferInstitutionPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/AdageOfferInstitutionPanel.tsx
@@ -1,7 +1,10 @@
-import { AdageFrontRoles, CollectiveOfferResponseModel } from 'apiClient/adage'
+import {
+  AdageFrontRoles,
+  AuthenticatedResponse,
+  CollectiveOfferResponseModel,
+} from 'apiClient/adage'
 import fullDeskIcon from 'icons/full-desk.svg'
 import strokeTeacherIcon from 'icons/stroke-teacher.svg'
-import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { getDateTimeToFrenchText, toDateStrippedOfTimezone } from 'utils/date'
 
@@ -12,12 +15,13 @@ import styles from './AdageOfferInstitutionPanel.module.scss'
 
 export type AdageOfferInstitutionPanelProps = {
   offer: CollectiveOfferResponseModel
+  adageUser: AuthenticatedResponse
 }
 
 export default function AdageOfferInstitutionPanel({
   offer,
+  adageUser,
 }: AdageOfferInstitutionPanelProps) {
-  const { adageUser } = useAdageUser()
   return (
     <div className={styles['institution-panel']}>
       <div className={styles['institution-panel-header']}>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/__specs__/AdageOfferInstitutionPanel.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/__specs__/AdageOfferInstitutionPanel.spec.tsx
@@ -11,11 +11,11 @@ import AdageOfferInstitutionPanel, {
 function renderAdageOfferInstitutionPanel(
   props: AdageOfferInstitutionPanelProps = {
     offer: defaultCollectiveOffer,
-  },
-  user = defaultAdageUser
+    adageUser: defaultAdageUser,
+  }
 ) {
   return renderWithProviders(
-    <AdageUserContextProvider adageUser={user}>
+    <AdageUserContextProvider adageUser={defaultAdageUser}>
       <AdageOfferInstitutionPanel {...props} />
     </AdageUserContextProvider>
   )
@@ -45,6 +45,7 @@ describe('AdageOfferPartnerPanel', () => {
           bookingLimitDatetime: undefined,
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.queryByText('À préréserver')).not.toBeInTheDocument()

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
@@ -1,10 +1,12 @@
-import { CollectiveOfferTemplateResponseModel } from 'apiClient/adage'
+import {
+  AuthenticatedResponse,
+  CollectiveOfferTemplateResponseModel,
+} from 'apiClient/adage'
 import Callout from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
 import fullLinkIcon from 'icons/full-link.svg'
 import fullMailIcon from 'icons/full-mail.svg'
 import strokeInstitutionIcon from 'icons/stroke-institution.svg'
-import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -16,13 +18,16 @@ import styles from './AdageOfferPartnerPanel.module.scss'
 
 export type AdageOfferPartnerPanelProps = {
   offer: CollectiveOfferTemplateResponseModel
+  adageUser: AuthenticatedResponse
+  isPreview?: boolean
 }
 
 export default function AdageOfferPartnerPanel({
   offer,
+  adageUser,
+  isPreview = false,
 }: AdageOfferPartnerPanelProps) {
   const venue = offer.venue
-  const { adageUser } = useAdageUser()
 
   const distanceToSchool =
     venue.coordinates.latitude !== null &&
@@ -67,7 +72,7 @@ export default function AdageOfferPartnerPanel({
 
         <div>
           <p className={styles['partner-panel-info-name']}>{venue.name}</p>
-          {venue.adageId && (
+          {venue.adageId && !isPreview && (
             <ButtonLink
               link={{
                 isExternal: true,
@@ -112,6 +117,7 @@ export default function AdageOfferPartnerPanel({
           queryId={''}
           userEmail={adageUser.email}
           userRole={adageUser.role}
+          isPreview={isPreview}
         >
           <SvgIcon
             src={fullMailIcon}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/__specs__/AdageOfferPartnerPanel.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/__specs__/AdageOfferPartnerPanel.spec.tsx
@@ -14,11 +14,12 @@ import AdageOfferPartnerPanel, {
 function renderAdageOfferPartnerPanel(
   props: AdageOfferPartnerPanelProps = {
     offer: defaultCollectiveTemplateOffer,
-  },
-  user = defaultAdageUser
+    adageUser: defaultAdageUser,
+    isPreview: false,
+  }
 ) {
   return renderWithProviders(
-    <AdageUserContextProvider adageUser={user}>
+    <AdageUserContextProvider adageUser={defaultAdageUser}>
       <AdageOfferPartnerPanel {...props} />
     </AdageUserContextProvider>
   )
@@ -39,6 +40,7 @@ describe('AdageOfferPartnerPanel', () => {
         ...defaultCollectiveTemplateOffer,
         venue: { ...defaultCollectiveTemplateOffer.venue, adageId: '123' },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(
@@ -54,6 +56,7 @@ describe('AdageOfferPartnerPanel', () => {
         ...defaultCollectiveTemplateOffer,
         venue: { ...defaultCollectiveTemplateOffer.venue, adageId: undefined },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(
@@ -73,6 +76,7 @@ describe('AdageOfferPartnerPanel', () => {
           postalCode: '75000',
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.getByText(/à Paris 75000/)).toBeInTheDocument()
@@ -88,6 +92,7 @@ describe('AdageOfferPartnerPanel', () => {
           postalCode: undefined,
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.getByText(/à Paris/)).toBeInTheDocument()
@@ -103,26 +108,25 @@ describe('AdageOfferPartnerPanel', () => {
           postalCode: '75000',
         },
       },
+      adageUser: defaultAdageUser,
     })
 
     expect(screen.getByText(/75000/)).toBeInTheDocument()
   })
 
   it('should show the partner distance to school', () => {
-    renderAdageOfferPartnerPanel(
-      {
-        offer: {
-          ...defaultCollectiveTemplateOffer,
-          venue: {
-            ...defaultCollectiveTemplateOffer.venue,
-            coordinates: { latitude: 1, longitude: 1 },
-            city: undefined,
-            postalCode: undefined,
-          },
+    renderAdageOfferPartnerPanel({
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        venue: {
+          ...defaultCollectiveTemplateOffer.venue,
+          coordinates: { latitude: 1, longitude: 1 },
+          city: undefined,
+          postalCode: undefined,
         },
       },
-      { ...defaultAdageUser, lat: 2, lon: 2 }
-    )
+      adageUser: { ...defaultAdageUser, lat: 2, lon: 2 },
+    })
 
     expect(
       screen.getByText(/à 157 km de votre établissement scolaire/)

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/__specs__/AdageOffer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/__specs__/AdageOffer.spec.tsx
@@ -12,7 +12,10 @@ import AdageOffer from '../AdageOffer'
 function renderAdageOffer() {
   return renderWithProviders(
     <AdageUserContextProvider adageUser={defaultAdageUser}>
-      <AdageOffer offer={defaultCollectiveTemplateOffer} />
+      <AdageOffer
+        offer={defaultCollectiveTemplateOffer}
+        adageUser={defaultAdageUser}
+      />
     </AdageUserContextProvider>
   )
 }

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -132,7 +132,7 @@ export const OfferInfos = () => {
             />
           </div>
           {isNewOfferInfoEnabled ? (
-            <AdageOffer offer={offer} />
+            <AdageOffer offer={offer} adageUser={adageUser} />
           ) : (
             <div className={styles['offer-container']}>
               <Offer offer={offer} position={0} queryId="" openDetails={true} />

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
@@ -22,6 +22,7 @@ export interface ContactButtonProps {
   userRole: AdageFrontRoles
   isInSuggestions?: boolean
   children?: React.ReactNode
+  isPreview?: boolean
 }
 
 const ContactButton = ({
@@ -37,6 +38,7 @@ const ContactButton = ({
   userRole,
   isInSuggestions,
   children,
+  isPreview = false,
 }: ContactButtonProps): JSX.Element => {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -47,15 +49,17 @@ const ContactButton = ({
   const handleButtonClick = () => {
     setIsModalOpen(true)
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    apiAdage.logContactModalButtonClick({
-      iframeFrom: location.pathname,
-      offerId,
-      queryId: queryId,
-      isFromNoResult: isInSuggestions,
-    })
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    logClickOnOffer(offerId.toString(), position, queryId)
+    if (!isPreview) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      apiAdage.logContactModalButtonClick({
+        iframeFrom: location.pathname,
+        offerId,
+        queryId: queryId,
+        isFromNoResult: isInSuggestions,
+      })
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      logClickOnOffer(offerId.toString(), position, queryId)
+    }
   }
 
   const closeModal = () => {
@@ -80,6 +84,7 @@ const ContactButton = ({
             contactPhone={contactPhone ?? ''}
             contactUrl={contactUrl ?? ''}
             contactForm={contactForm ?? ''}
+            isPreview={isPreview}
           />
         ) : (
           <RequestFormDialog
@@ -89,6 +94,7 @@ const ContactButton = ({
             offerId={offerId}
             userEmail={userEmail}
             userRole={userRole}
+            isPreview={isPreview}
           />
         ))}
     </>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/DefaultFormContact.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/DefaultFormContact.tsx
@@ -12,11 +12,13 @@ import { RequestFormValues } from './type'
 type DefaultFormContactProps = {
   closeRequestFormDialog: () => void
   formik: FormikContextType<RequestFormValues>
+  isPreview: boolean
 }
 
 const DefaultFormContact = ({
   closeRequestFormDialog,
   formik,
+  isPreview,
 }: DefaultFormContactProps) => {
   return (
     <FormikProvider value={formik}>
@@ -77,6 +79,7 @@ const DefaultFormContact = ({
             <SubmitButton
               iconPosition={IconPositionEnum.LEFT}
               icon={fullMailIcon}
+              disabled={isPreview}
             >
               Envoyer ma demande
             </SubmitButton>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.module.scss
@@ -7,6 +7,17 @@
   text-align: left;
 }
 
+.contact-callout {
+  margin-bottom: rem.torem(16px);
+  max-width: rem.torem(460px);
+}
+
+.contact-readonly {
+  margin-top: rem.torem(16px);
+  max-width: rem.torem(460px);
+}
+
+
 .contact-info-container {
   display: flex;
   flex-direction: column;

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.tsx
@@ -2,6 +2,8 @@ import { useFormik } from 'formik'
 
 import { AdageFrontRoles } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
+import Callout from 'components/Callout/Callout'
+import { CalloutVariant } from 'components/Callout/types'
 import Dialog from 'components/Dialog/Dialog'
 import MandatoryInfo from 'components/FormLayout/FormLayoutMandatoryInfo'
 import useNotification from 'hooks/useNotification'
@@ -26,6 +28,7 @@ export interface NewRequestFormDialogProps {
   contactPhone: string
   contactForm: string
   contactUrl: string
+  isPreview: boolean
 }
 
 const NewRequestFormDialog = ({
@@ -37,6 +40,7 @@ const NewRequestFormDialog = ({
   contactPhone,
   contactForm,
   contactUrl,
+  isPreview,
 }: NewRequestFormDialogProps): JSX.Element => {
   const notify = useNotification()
 
@@ -60,17 +64,19 @@ const NewRequestFormDialog = ({
   }
 
   const closeRequestFormDialog = async () => {
-    await apiAdage.logRequestFormPopinDismiss({
-      iframeFrom: location.pathname,
-      collectiveOfferTemplateId: offerId,
-      comment: formik.values.description,
-      phoneNumber: formik.values.teacherPhone,
-      requestedDate: isDateValid(formik.values.offerDate)
-        ? new Date(formik.values.offerDate).toISOString()
-        : undefined,
-      totalStudents: formik.values.nbStudents,
-      totalTeachers: formik.values.nbTeachers,
-    })
+    if (!isPreview) {
+      await apiAdage.logRequestFormPopinDismiss({
+        iframeFrom: location.pathname,
+        collectiveOfferTemplateId: offerId,
+        comment: formik.values.description,
+        phoneNumber: formik.values.teacherPhone,
+        requestedDate: isDateValid(formik.values.offerDate)
+          ? new Date(formik.values.offerDate).toISOString()
+          : undefined,
+        totalStudents: formik.values.nbStudents,
+        totalTeachers: formik.values.nbTeachers,
+      })
+    }
     closeModal()
   }
 
@@ -167,7 +173,7 @@ const NewRequestFormDialog = ({
           </li>
         )}
 
-        {isDefaultForm && (
+        {isDefaultForm && userRole === AdageFrontRoles.REDACTOR && (
           <li>
             en renseignant{' '}
             <span className={styles['form-description-text-value']}>
@@ -176,13 +182,22 @@ const NewRequestFormDialog = ({
           </li>
         )}
       </ul>
-      {isDefaultForm && (
+      {isDefaultForm && userRole === AdageFrontRoles.REDACTOR && (
         <>
           <hr />
           <MandatoryInfo className={styles['form-mandatory']} />
+          <Callout
+            variant={CalloutVariant.DEFAULT}
+            className={styles['contact-callout']}
+          >
+            Vous ne pouvez pas envoyer de demande de contact car ceci est un
+            aperçu de test du formulaire que verront les enseignants une fois
+            l’offre publiée.
+          </Callout>
           <DefaultFormContact
             closeRequestFormDialog={closeRequestFormDialog}
             formik={formik}
+            isPreview={isPreview}
           />
         </>
       )}
@@ -211,14 +226,37 @@ const NewRequestFormDialog = ({
 
   const renderDefaultFormElement = () => (
     <div>
-      <span className={styles['form-description']}>
-        Vous pouvez le contacter en renseignant les informations ci-dessous.
-      </span>
-      <MandatoryInfo className={styles['form-mandatory']} />
-      <DefaultFormContact
-        closeRequestFormDialog={closeRequestFormDialog}
-        formik={formik}
-      />
+      {userRole === AdageFrontRoles.REDACTOR || isPreview ? (
+        <>
+          <span className={styles['form-description']}>
+            Vous pouvez le contacter en renseignant les informations ci-dessous.
+          </span>
+          <MandatoryInfo className={styles['form-mandatory']} />
+          {isPreview && (
+            <Callout
+              variant={CalloutVariant.DEFAULT}
+              className={styles['contact-callout']}
+            >
+              Vous ne pouvez pas envoyer de demande de contact car ceci est un
+              aperçu de test du formulaire que verront les enseignants une fois
+              l’offre publiée.
+            </Callout>
+          )}
+          <DefaultFormContact
+            closeRequestFormDialog={closeRequestFormDialog}
+            formik={formik}
+            isPreview={isPreview}
+          />
+        </>
+      ) : (
+        <Callout
+          variant={CalloutVariant.DEFAULT}
+          className={styles['contact-readonly']}
+        >
+          Vous ne pouvez voir les informations de contact du partenaire car vous
+          n’avez pas les droits ADAGE adaptés
+        </Callout>
+      )}
     </div>
   )
 
@@ -232,7 +270,7 @@ const NewRequestFormDialog = ({
       <span className={styles['form-title']}>
         Vous souhaitez contacter ce partenaire ?
       </span>
-      {userRole === AdageFrontRoles.REDACTOR && <>{getDescriptionElement()}</>}
+      {getDescriptionElement()}
     </Dialog>
   )
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.module.scss
@@ -23,6 +23,12 @@
   @include fonts.body-important;
 }
 
+.contact-callout {
+  margin-top: rem.torem(32px);
+  margin-bottom: rem.torem(16px);
+  text-align: left;
+}
+
 .form {
   &-description {
     @include fonts.body;

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
@@ -2,6 +2,8 @@ import { useFormik } from 'formik'
 
 import { AdageFrontRoles } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
+import Callout from 'components/Callout/Callout'
+import { CalloutVariant } from 'components/Callout/types'
 import Dialog from 'components/Dialog/Dialog'
 import MandatoryInfo from 'components/FormLayout/FormLayoutMandatoryInfo'
 import useNotification from 'hooks/useNotification'
@@ -20,6 +22,7 @@ export interface RequestFormDialogProps {
   offerId: number
   userEmail?: string | null
   userRole: AdageFrontRoles
+  isPreview: boolean
 }
 
 const RequestFormDialog = ({
@@ -29,6 +32,7 @@ const RequestFormDialog = ({
   offerId,
   userEmail,
   userRole,
+  isPreview,
 }: RequestFormDialogProps): JSX.Element => {
   const notify = useNotification()
   const initialValues = {
@@ -50,17 +54,19 @@ const RequestFormDialog = ({
     closeModal()
   }
   const closeRequestFormDialog = async () => {
-    await apiAdage.logRequestFormPopinDismiss({
-      iframeFrom: location.pathname,
-      collectiveOfferTemplateId: offerId,
-      comment: formik.values.description,
-      phoneNumber: formik.values.teacherPhone,
-      requestedDate: isDateValid(formik.values.offerDate)
-        ? new Date(formik.values.offerDate).toISOString()
-        : undefined,
-      totalStudents: formik.values.nbStudents,
-      totalTeachers: formik.values.nbTeachers,
-    })
+    if (!isPreview) {
+      await apiAdage.logRequestFormPopinDismiss({
+        iframeFrom: location.pathname,
+        collectiveOfferTemplateId: offerId,
+        comment: formik.values.description,
+        phoneNumber: formik.values.teacherPhone,
+        requestedDate: isDateValid(formik.values.offerDate)
+          ? new Date(formik.values.offerDate).toISOString()
+          : undefined,
+        totalStudents: formik.values.nbStudents,
+        totalTeachers: formik.values.nbTeachers,
+      })
+    }
     closeModal()
   }
 
@@ -80,6 +86,16 @@ const RequestFormDialog = ({
         <a href={`mailto:${contactEmail}`}>{contactEmail}</a>
         {contactPhone}
       </div>
+      {!isPreview && (
+        <Callout
+          variant={CalloutVariant.DEFAULT}
+          className={styles['contact-callout']}
+        >
+          <p>Vous ne pouvez pas envoyer de demande de contact</p>
+          <p>car ceci est un aperçu de test du formulaire que </p>
+          <p>verront les enseignants une fois l’offre publiée.</p>
+        </Callout>
+      )}
       {userRole === AdageFrontRoles.REDACTOR && (
         <>
           <div className={styles['form-description']}>
@@ -92,6 +108,7 @@ const RequestFormDialog = ({
           <DefaultFormContact
             closeRequestFormDialog={closeRequestFormDialog}
             formik={formik}
+            isPreview={isPreview}
           />
         </>
       )}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/NewRequestFormDialog.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/NewRequestFormDialog.spec.tsx
@@ -26,6 +26,7 @@ const renderNewRequestFormDialog = (
       contactForm="form"
       contactPhone=""
       contactUrl=""
+      isPreview={false}
       {...props}
     />
   )

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/RequestFormDialog.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/RequestFormDialog.spec.tsx
@@ -19,6 +19,7 @@ const renderRequestFormDialog = (props?: Partial<RequestFormDialogProps>) => {
       userEmail={'contact@example.com'}
       userRole={AdageFrontRoles.REDACTOR}
       {...props}
+      isPreview={false}
     />
   )
 }

--- a/pro/src/utils/adageFactories.ts
+++ b/pro/src/utils/adageFactories.ts
@@ -111,8 +111,8 @@ export const defaultAdageUser: AuthenticatedResponse = {
   institutionName: 'Mon établissement',
   role: AdageFrontRoles.REDACTOR,
   uai: '1234567A',
-  lat: null,
-  lon: null,
+  lat: 1,
+  lon: 2,
 }
 
 export const defaultEducationalInstitution: EducationalInstitutionWithBudgetResponseModel =


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28247

Adapter l'offre pour l'affichage sur pro en mode preview

- ne plus afficher les boutons partager et favoris
- disabled le bouton qui envoie la demande dans le formulaire de contact
- ajout d'un callout pour préciser que l'on ait sur un mode preview
- changer les media queries en container queries pour que l'offre s'affiche normalement dans le portail pro

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques