### PR TITLE
(PC-28425)[API] fix: Avoid stuck processed pricings and wrong cashflow amount

### DIFF
--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1164,9 +1164,10 @@ class GenerateCashflowsLegacyTest:
                 1,  # check integration of pricings
                 1,  # compute sum of pricings
                 1,  # insert Cashflow
-                1,  # select pricings to...
+                1,  # select pricings to be linked to CashflowPricing's
+                1,  # insert CashflowPricing's
                 1,  # update Pricing.status
-                1,  # ... insert CashflowPricing
+                1,  # check sum of pricings = cashflow.amount
             )
         )
 
@@ -1447,9 +1448,10 @@ class GenerateCashflowsTest:
                 1,  # check integration of pricings
                 1,  # compute sum of pricings
                 1,  # insert Cashflow
-                1,  # select pricings to...
+                1,  # select pricings to be linked to CashflowPricing's
+                1,  # insert CashflowPricing's
                 1,  # update Pricing.status
-                1,  # ... insert CashflowPricing
+                1,  # check sum of pricings = cashflow.amount
             )
         )
 


### PR DESCRIPTION
A rare bug could occur (and did occur once) that caused a pricing to
be set as "processed" even though it was not linked to any cashflow.
As such, it stayed in this status.

The fix is somewhat incomplete (see comments) but the bug is rare
enough that this simple solution seems good enough.

There are no tests because the bug is not testable: it happens when a
pricing is created (by another process) at a particular point in time
during the execution of `_generate_cashflows()`.

---

Ticket : https://passculture.atlassian.net/browse/PC-28425