### PR TITLE
(PC-28433)[PRO] fix: redirect user to gome after attachment to offerer

### DIFF
--- a/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/ConfirmedAttachment.tsx
+++ b/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/ConfirmedAttachment.tsx
@@ -33,7 +33,7 @@ const ConfirmedAttachment = (): JSX.Element => {
         onClick={logNavigation}
         className={styles['home-button']}
         variant={ButtonVariant.PRIMARY}
-        link={{ isExternal: false, to: '/' }}
+        link={{ isExternal: false, to: '/accueil' }}
       >
         Accéder à votre espace
       </ButtonLink>

--- a/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/__specs__/ConfirmedAttachment.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/__specs__/ConfirmedAttachment.spec.tsx
@@ -24,7 +24,7 @@ const renderConfirmedAttachmentScreen = () => {
         path="/parcours-inscription/structure/rattachement/confirmation"
         element={<ConfirmedAttachment />}
       />
-      <Route path="/" element={<div>Home screen</div>} />
+      <Route path="/accueil" element={<div>Home screen</div>} />
     </Routes>,
     {
       storeOverrides,

--- a/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
@@ -1,5 +1,6 @@
 import cn from 'classnames'
 import React, { useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
@@ -14,10 +15,12 @@ import { getVenuesOfOffererFromSiretAdapter } from 'core/Venue/adapters/getVenue
 import { useAdapter } from 'hooks'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
+import useCurrentUser from 'hooks/useCurrentUser'
 import useNotification from 'hooks/useNotification'
 import fullDownIcon from 'icons/full-down.svg'
 import fullUpIcon from 'icons/full-up.svg'
 import tempStrokeAddUserIcon from 'icons/temp-stroke-add-user.svg'
+import { updateUser } from 'store/user/reducer'
 import { Button } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import Spinner from 'ui-kit/Spinner/Spinner'
@@ -30,6 +33,9 @@ const Offerers = (): JSX.Element => {
   const { logEvent } = useAnalytics()
   const notify = useNotification()
   const navigate = useNavigate()
+  const dispatch = useDispatch()
+  const { currentUser } = useCurrentUser()
+
   const [isVenueListOpen, setIsVenueListOpen] = useState<boolean>(false)
   const [showLinkDialog, setShowLinkDialog] = useState<boolean>(false)
   const isNewOffererLinkEnabled = useActiveFeature(
@@ -98,6 +104,7 @@ const Offerers = (): JSX.Element => {
         siren: venuesOfOfferer?.offererSiren ?? '',
       }
       await api.createOfferer(request)
+      dispatch(updateUser({ ...currentUser, hasUserOfferer: true }))
       navigate('/parcours-inscription/structure/rattachement/confirmation')
     } catch (e) {
       notify.error('Impossible de lier votre compte à cette structure.')


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28433


Rediriger l'utilisateur vers la home après son rattachement à une structure. 

Ce fix fait suite au ticket redirigeant un utilisateur sans UserOfferer vers le parcours d'inscription. Il manquait un update du currentUser après le rattachement pour mettre à jour le user dans le store. 


**Pour recetter :** 

Créer un nouvel utilisateur
Dans le parcours d'inscription saisir un Siret déjà existant
Choisir le parcours de rattachement : Rejoindre cet espace
Vérifier qu'après validation on arrive bien sur la home de PC pro

