### PR TITLE
(PC-28407)[API] feat: 'Marseille en grand' in invoices

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 17bbd580c848 (pre) (head)
-23fa7b1b692e (post) (head)
+3784f1bb8d9e (post) (head)

--- a/api/src/pcapi/alembic/versions/20240307T154918_3784f1bb8d9e_unique_program_for_an_educational_institution.py
+++ b/api/src/pcapi/alembic/versions/20240307T154918_3784f1bb8d9e_unique_program_for_an_educational_institution.py
@@ -1,0 +1,48 @@
+"""Unique program for an educational institution
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "3784f1bb8d9e"
+down_revision = "23fa7b1b692e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_educational_institution_program_association_institutionId",
+            table_name="educational_institution_program_association",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            op.f("ix_educational_institution_program_association_institutionId"),
+            "educational_institution_program_association",
+            ["institutionId"],
+            unique=True,
+            if_not_exists=True,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            op.f("ix_educational_institution_program_association_institutionId"),
+            table_name="educational_institution_program_association",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_educational_institution_program_association_institutionId",
+            "educational_institution_program_association",
+            ["institutionId"],
+            unique=False,
+            if_not_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1643,7 +1643,16 @@ class EducationalInstitutionProgramAssociation(Base, Model):
     """
 
     institutionId: int = sa.Column(
-        sa.BigInteger, sa.ForeignKey("educational_institution.id", ondelete="CASCADE"), index=True, primary_key=True
+        sa.BigInteger,
+        sa.ForeignKey("educational_institution.id", ondelete="CASCADE"),
+        index=True,
+        primary_key=True,
+        # Unique constraint has been added to ensure that an institution is not associated with more than one program.
+        # This is because of invoices generation in finance/api.py: there is no other way to guess that a collective
+        # booking relates to a program.
+        # If you wish to remove this constraint, please ensure that a relationship can be made between a collective
+        # booking and a program, then fix generate_invoice_file().
+        unique=True,
     )
     programId: int = sa.Column(
         sa.BigInteger,

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -2044,6 +2044,8 @@ def generate_invoice_file_legacy(batch: models.CashflowBatch) -> pathlib.Path:
                     == educational_models.EducationalInstitution.id,
                 ),
             )
+            # max 1 program because of unique constraint on EducationalInstitutionProgramAssociation.institutionId
+            .outerjoin(educational_models.EducationalInstitution.programs)
             .filter(models.Cashflow.batchId == batch.id)
             .group_by(
                 models.Invoice.id,
@@ -2052,6 +2054,7 @@ def generate_invoice_file_legacy(batch: models.CashflowBatch) -> pathlib.Path:
                 models.Invoice.reimbursementPointId,
                 models.PricingLine.category,
                 educational_models.EducationalDeposit.ministry,
+                educational_models.EducationalInstitutionProgram.id,
             )
             .with_entities(
                 models.Invoice.id,
@@ -2059,7 +2062,10 @@ def generate_invoice_file_legacy(batch: models.CashflowBatch) -> pathlib.Path:
                 models.Invoice.reference.label("invoice_reference"),
                 models.Invoice.reimbursementPointId.label("reimbursement_point_id"),
                 models.PricingLine.category.label("pricing_line_category"),
-                educational_models.EducationalDeposit.ministry.label("ministry"),
+                sqla.func.coalesce(
+                    educational_models.EducationalInstitutionProgram.label,
+                    educational_models.EducationalDeposit.ministry.cast(sqla.String),
+                ).label("ministry"),
                 sqla_func.sum(models.PricingLine.amount).label("pricing_line_amount"),
             )
         )
@@ -2192,6 +2198,8 @@ def generate_invoice_file(batch: models.CashflowBatch) -> pathlib.Path:
                     == educational_models.EducationalInstitution.id,
                 ),
             )
+            # max 1 program because of unique constraint on EducationalInstitutionProgramAssociation.institutionId
+            .outerjoin(educational_models.EducationalInstitution.programs)
             .filter(models.Cashflow.batchId == batch.id)
             .group_by(
                 models.Invoice.id,
@@ -2200,6 +2208,7 @@ def generate_invoice_file(batch: models.CashflowBatch) -> pathlib.Path:
                 models.Invoice.bankAccountId,
                 models.PricingLine.category,
                 educational_models.EducationalDeposit.ministry,
+                educational_models.EducationalInstitutionProgram.id,
             )
             .with_entities(
                 models.Invoice.id,
@@ -2207,7 +2216,10 @@ def generate_invoice_file(batch: models.CashflowBatch) -> pathlib.Path:
                 models.Invoice.reference.label("invoice_reference"),
                 models.Invoice.bankAccountId.label("bank_account_id"),
                 models.PricingLine.category.label("pricing_line_category"),
-                educational_models.EducationalDeposit.ministry.label("ministry"),
+                sqla.func.coalesce(
+                    educational_models.EducationalInstitutionProgram.label,
+                    educational_models.EducationalDeposit.ministry.cast(sqla.String),
+                ).label("ministry"),
                 sqla_func.sum(models.PricingLine.amount).label("pricing_line_amount"),
             )
         )

--- a/api/tests/core/educational/test_models.py
+++ b/api/tests/core/educational/test_models.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest import mock
 
 import pytest
+from sqlalchemy import exc as sa_exc
 
 from pcapi.core.educational import exceptions
 from pcapi.core.educational import factories
@@ -517,10 +518,21 @@ class HasImageMixinTest:
         delete_public_object.assert_any_call(folder=image.FOLDER, object_id="image/123456_original.jpg")
 
 
-class CollectiveOffeTemplateIsEligibleForSearchTest:
+class CollectiveOfferTemplateIsEligibleForSearchTest:
     def test_is_eligible_for_search(self):
         searchable_offer = factories.CollectiveOfferTemplateFactory()
         virtual_venue = offerers_factories.VirtualVenueFactory()
         unsearchable_offer = factories.CollectiveOfferTemplateFactory(venue=virtual_venue)
         assert searchable_offer.is_eligible_for_search
         assert not unsearchable_offer.is_eligible_for_search
+
+
+class EducationalInstitutionProgramTest:
+    def test_unique_program_for_an_educational_institution(self):
+        program1 = factories.EducationalInstitutionProgramFactory()
+        program2 = factories.EducationalInstitutionProgramFactory()
+        institution = factories.EducationalInstitutionFactory(programs=[program1])
+
+        with pytest.raises(sa_exc.IntegrityError):
+            institution.programs = [program1, program2]
+            db.session.commit()

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -2044,6 +2044,24 @@ def test_generate_invoice_file_legacy_journey():
         category=models.PricingLineCategory.OFFERER_CONTRIBUTION,
     )
 
+    # eac related to a program
+    educational_program = educational_factories.EducationalInstitutionProgramFactory(label="Marseille en grand")
+    educational_institution_with_program = EducationalInstitutionFactory(programs=[educational_program])
+    deposit_with_program = EducationalDepositFactory(
+        educationalInstitution=educational_institution_with_program,
+        educationalYear=year1,
+        ministry=Ministry.AGRICULTURE.name,
+    )
+    pricing4 = factories.CollectivePricingFactory(
+        amount=-2345,
+        collectiveBooking__collectiveStock__collectiveOffer__venue=venue,
+        collectiveBooking__collectiveStock__beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=8),
+        collectiveBooking__educationalInstitution=educational_institution_with_program,
+        collectiveBooking__educationalYear=deposit_with_program.educationalYear,
+        status=models.PricingStatus.VALIDATED,
+    )
+    pline4 = factories.PricingLineFactory(pricing=pricing4, amount=-2345)
+
     # Create booking for overpayment finance incident
     incident_booking = bookings_factories.ReimbursedBookingFactory(
         amount=18,
@@ -2081,7 +2099,7 @@ def test_generate_invoice_file_legacy_journey():
     cashflow1 = factories.CashflowFactory(
         bankInformation=bank_info1,
         reimbursementPoint=reimbursement_point1,
-        pricings=[pricing1, pricing_with_same_values_as_pricing_1, pricing2, pricing3, *incidents_pricings],
+        pricings=[pricing1, pricing_with_same_values_as_pricing_1, pricing2, pricing3, pricing4, *incidents_pricings],
         status=models.CashflowStatus.ACCEPTED,
     )
     invoice1 = factories.InvoiceFactory(
@@ -2101,12 +2119,12 @@ def test_generate_invoice_file_legacy_journey():
         pricing_point=pricing_point2,
         reimbursement_point=reimbursement_point2,
     )
-    pline4 = factories.PricingLineFactory()
-    pricing4 = pline4.pricing
+    pline5 = factories.PricingLineFactory()
+    pricing5 = pline5.pricing
     cashflow2 = factories.CashflowFactory(
         bankInformation=bank_info2,
         reimbursementPoint=reimbursement_point2,
-        pricings=[pricing4],
+        pricings=[pricing5],
         status=models.CashflowStatus.ACCEPTED,
     )
     factories.InvoiceFactory(
@@ -2125,7 +2143,7 @@ def test_generate_invoice_file_legacy_journey():
             reader = csv.DictReader(csv_textfile, quoting=csv.QUOTE_NONNUMERIC)
             rows = list(reader)
 
-    assert len(rows) == 4
+    assert len(rows) == 5
     assert rows[0] == {
         "Identifiant du point de remboursement": human_ids.humanize(reimbursement_point1.id),
         "Date du justificatif": datetime.date.today().isoformat(),
@@ -2165,6 +2183,15 @@ def test_generate_invoice_file_legacy_journey():
         "Type de réservation": "EACC",
         "Ministère": "AGRICULTURE",
         "Somme des tickets de facturation": pline32.amount,
+    }
+    assert rows[4] == {
+        "Identifiant du point de remboursement": human_ids.humanize(reimbursement_point1.id),
+        "Date du justificatif": datetime.date.today().isoformat(),
+        "Référence du justificatif": invoice1.reference,
+        "Type de ticket de facturation": pline4.category.value,
+        "Type de réservation": "EACC",
+        "Ministère": educational_program.label,
+        "Somme des tickets de facturation": pline4.amount,
     }
 
 
@@ -2236,6 +2263,24 @@ def test_generate_invoice_file_new_journey():
         category=models.PricingLineCategory.OFFERER_CONTRIBUTION,
     )
 
+    # eac related to a program
+    educational_program = educational_factories.EducationalInstitutionProgramFactory(label="Marseille en grand")
+    educational_institution_with_program = EducationalInstitutionFactory(programs=[educational_program])
+    deposit_with_program = EducationalDepositFactory(
+        educationalInstitution=educational_institution_with_program,
+        educationalYear=year1,
+        ministry=Ministry.AGRICULTURE.name,
+    )
+    pricing4 = factories.CollectivePricingFactory(
+        amount=-2345,
+        collectiveBooking__collectiveStock__collectiveOffer__venue=venue,
+        collectiveBooking__collectiveStock__beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=8),
+        collectiveBooking__educationalInstitution=educational_institution_with_program,
+        collectiveBooking__educationalYear=deposit_with_program.educationalYear,
+        status=models.PricingStatus.VALIDATED,
+    )
+    pline4 = factories.PricingLineFactory(pricing=pricing4, amount=-2345)
+
     # Create booking for overpayment finance incident
     incident_booking = bookings_factories.ReimbursedBookingFactory(
         amount=18,
@@ -2272,7 +2317,7 @@ def test_generate_invoice_file_new_journey():
 
     cashflow1 = factories.CashflowFactory(
         bankAccount=bank_account_1,
-        pricings=[pricing1, pricing_with_same_values_as_pricing_1, pricing2, pricing3, *incidents_pricings],
+        pricings=[pricing1, pricing_with_same_values_as_pricing_1, pricing2, pricing3, pricing4, *incidents_pricings],
         status=models.CashflowStatus.ACCEPTED,
     )
     invoice1 = factories.InvoiceFactory(
@@ -2287,11 +2332,11 @@ def test_generate_invoice_file_new_journey():
     offerer2 = venue2.managingOfferer
     bank_account_2 = factories.BankAccountFactory(offerer=offerer2)
     offerers_factories.VenueBankAccountLinkFactory(venue=venue2, bankAccount=bank_account_2)
-    pline4 = factories.PricingLineFactory()
-    pricing4 = pline4.pricing
+    pline5 = factories.PricingLineFactory()
+    pricing5 = pline5.pricing
     cashflow2 = factories.CashflowFactory(
         bankAccount=bank_account_2,
-        pricings=[pricing4],
+        pricings=[pricing5],
         status=models.CashflowStatus.ACCEPTED,
     )
     factories.InvoiceFactory(
@@ -2310,7 +2355,7 @@ def test_generate_invoice_file_new_journey():
             reader = csv.DictReader(csv_textfile, quoting=csv.QUOTE_NONNUMERIC)
             rows = list(reader)
 
-    assert len(rows) == 4
+    assert len(rows) == 5
     assert rows[0] == {
         "Identifiant des coordonnées bancaires": human_ids.humanize(bank_account_1.id),
         "Date du justificatif": datetime.date.today().isoformat(),
@@ -2350,6 +2395,15 @@ def test_generate_invoice_file_new_journey():
         "Type de réservation": "EACC",
         "Ministère": "AGRICULTURE",
         "Somme des tickets de facturation": pline32.amount,
+    }
+    assert rows[4] == {
+        "Identifiant des coordonnées bancaires": human_ids.humanize(bank_account_1.id),
+        "Date du justificatif": datetime.date.today().isoformat(),
+        "Référence du justificatif": invoice1.reference,
+        "Type de ticket de facturation": pline4.category.value,
+        "Type de réservation": "EACC",
+        "Ministère": educational_program.label,
+        "Somme des tickets de facturation": pline4.amount,
     }
 
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28407

À la demande de la compta, séparer dans les _invoices_ les dépenses pour le programme « Marseille en Grand » des dépenses classiques du ministère.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques