### PR TITLE
(PC-27830)[API] fix: exception when trying to tag "siren-caduc" twice

### DIFF
--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -32,7 +32,7 @@ class CheckOffererSirenRequest(BaseModel):
     tag_when_inactive: bool
 
 
-@task(settings.GCP_CHECK_OFFERER_SIREN_QUEUE_NAME, "/offerers/check_offerer_is_active", task_request_timeout=3 * 60)  # type: ignore [arg-type]
+@task(settings.GCP_CHECK_OFFERER_SIREN_QUEUE_NAME, "/offerers/check_offerer", task_request_timeout=3 * 60)  # type: ignore [arg-type]
 def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
     try:
         siren_info = sirene.get_siren(payload.siren, with_address=False, raise_if_non_public=False)

--- a/api/tests/core/offerers/test_tasks.py
+++ b/api/tests/core/offerers/test_tasks.py
@@ -29,7 +29,7 @@ class CheckOffererIsActiveTest:
         offerer = offerers_factories.OffererFactory()
 
         response = client.post(
-            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer_is_active",
+            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
             json={"siren": offerer.siren, "tag_when_inactive": True},
             headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
         )
@@ -49,7 +49,7 @@ class CheckOffererIsActiveTest:
         offerer = offerers_factories.OffererFactory()
 
         response = client.post(
-            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer_is_active",
+            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
             json={"siren": offerer.siren, "tag_when_inactive": True},
             headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
         )
@@ -87,7 +87,7 @@ class CheckOffererIsActiveTest:
         offerer = offerers_factories.OffererFactory()
 
         response = client.post(
-            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer_is_active",
+            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
             json={"siren": offerer.siren, "tag_when_inactive": True},
             headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
         )
@@ -136,7 +136,7 @@ class CheckOffererIsActiveTest:
         offerer = offerers_factories.OffererFactory(siren="109500099")
 
         response = client.post(
-            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer_is_active",
+            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
             json={"siren": offerer.siren, "tag_when_inactive": True},
             headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
         )
@@ -181,7 +181,7 @@ class CheckOffererIsActiveTest:
         offerer = offerers_factories.OffererFactory(siren="109500099", tags=[siren_caduc_tag])
 
         response = client.post(
-            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer_is_active",
+            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
             json={"siren": offerer.siren, "tag_when_inactive": True},
             headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
         )
@@ -200,7 +200,7 @@ class CheckOffererIsActiveTest:
         user_offerer = offerers_factories.UserNotValidatedOffererFactory(offerer=offerer)
 
         response = client.post(
-            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer_is_active",
+            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
             json={"siren": offerer.siren, "tag_when_inactive": True},
             headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
         )
@@ -236,7 +236,7 @@ class CheckOffererIsActiveTest:
         offerer = offerers_factories.OffererFactory(siren="100000099")
 
         response = client.post(
-            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer_is_active",
+            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
             json={"siren": offerer.siren, "tag_when_inactive": False},
             headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
         )
@@ -251,7 +251,7 @@ class CheckOffererIsActiveTest:
         offerer = offerers_factories.OffererFactory(siren="000000000")
 
         response = client.post(
-            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer_is_active",
+            f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
             json={"siren": offerer.siren, "tag_when_inactive": True},
             headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
         )


### PR DESCRIPTION
## But de la pull request

Bug suite au ticket Jira : https://passculture.atlassian.net/browse/PC-27830

check_offerer_siren_task is now called even if "siren-caduc" tag is set,
because of codir report check when offerer is still active in the
database.

Exception was raised:
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "unique_offerer_tag"

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques