### PR TITLE
(PC-28211)[BO] fix: timeout when searching for bookings

### DIFF
--- a/api/src/pcapi/routes/backoffice/bookings/collective_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/collective_bookings_blueprint.py
@@ -103,8 +103,8 @@ def _get_collective_bookings(
             educational_models.EducationalInstitution.id,
         ],
         name_filters=[
-            (educational_models.EducationalInstitution.name, False),
-            (educational_models.CollectiveOffer.name, False),
+            educational_models.EducationalInstitution.name,
+            educational_models.CollectiveOffer.name,
         ],
     )
 

--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -160,7 +160,7 @@ class GetIndividualBookingListForm(BaseBookingListForm):
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
-        self.q.label.text = "Code contremarque ou liste, Nom, email ou ID (offre, bénéficiaire ou résa)"
+        self.q.label.text = "Code contremarque ou liste, nom d'offre, email ou ID (offre, jeune ou résa)"
         self.status.choices = utils.choices_from_enum(BookingStatus)
 
         self._fields.move_to_end("offerer")

--- a/api/src/pcapi/routes/backoffice/bookings/helpers.py
+++ b/api/src/pcapi/routes/backoffice/bookings/helpers.py
@@ -127,7 +127,11 @@ def get_bookings(
                     name_filter.ilike(f"%{clean_accents(search_query) if clean_name_accents else search_query}%")
                 )
 
-        query = base_query.filter(sa.or_(*or_filters) if len(or_filters) > 1 else or_filters[0])
+        query = base_query.filter(or_filters[0])
+
+        if len(or_filters) > 1:
+            # Performance is really better than .filter(sa.or_(...)) when searching for an id in different tables
+            query = query.union(*(base_query.filter(f) for f in or_filters[1:]))
     else:
         query = base_query
 

--- a/api/src/pcapi/routes/backoffice/bookings/helpers.py
+++ b/api/src/pcapi/routes/backoffice/bookings/helpers.py
@@ -16,7 +16,6 @@ from pcapi.routes.backoffice.bookings.forms import BaseBookingListForm
 from pcapi.routes.backoffice.bookings.forms import BookingStatus
 from pcapi.utils import date as date_utils
 from pcapi.utils import email as email_utils
-from pcapi.utils.clean_accents import clean_accents
 
 
 def get_bookings(
@@ -27,7 +26,7 @@ def get_bookings(
     offer_class: type[educational_models.CollectiveOffer | offers_models.Offer],
     search_by_email: bool = False,
     id_filters: typing.Iterable[sa.sql.elements.ColumnElement] = (),
-    name_filters: typing.Iterable[tuple[sa.sql.elements.ColumnElement, bool]] = (),
+    name_filters: typing.Iterable[sa.sql.elements.ColumnElement] = (),
     or_filters: list | None = None,
 ) -> list[bookings_models.Booking] | list[educational_models.CollectiveBooking]:
     if or_filters is None:
@@ -122,10 +121,8 @@ def get_bookings(
                 or_filters.append(users_models.User.email == sanitized_email)
 
         if not or_filters and name_filters:
-            for name_filter, clean_name_accents in name_filters:
-                or_filters.append(
-                    name_filter.ilike(f"%{clean_accents(search_query) if clean_name_accents else search_query}%")
-                )
+            for name_filter in name_filters:
+                or_filters.append(name_filter.ilike(f"%{search_query}%"))
 
         query = base_query.filter(or_filters[0])
 

--- a/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
@@ -127,8 +127,7 @@ def _get_individual_bookings(
             users_models.User.id,
         ],
         name_filters=[
-            (sa.func.immutable_unaccent(users_models.User.firstName + " " + users_models.User.lastName), True),
-            (offers_models.Offer.name, False),
+            offers_models.Offer.name,
         ],
         or_filters=or_filters,
     )

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -279,8 +279,6 @@ def _get_offer_ids_query(form: forms.InternalSearchForm) -> BaseQuery:
             if or_filters:
                 main_query = query.filter(or_filters[0])
                 if len(or_filters) > 1:
-                    # TODO (prouzet, 2024-03-05): check this query with UNION vs OR
-                    # TODO (prouzet, 2024-03-05): query plan is now better with OR on bookings with new indexes
                     # Same as for bookings, where union has better performance than or_
                     query = main_query.union(*(query.filter(f) for f in or_filters[1:]))
                 else:

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -273,7 +273,7 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         assert len(rows) >= 1
         assert bookings[1].token in set(row["Contremarque"] for row in rows)
 
-    @pytest.mark.parametrize("search_query", ["bonaparte", "Napoléon Bonaparte", "napo@leon.com", "Napo@Leon.com"])
+    @pytest.mark.parametrize("search_query", ["napo@leon.com", "Napo@Leon.com"])
     def test_list_bookings_by_user(self, authenticated_client, bookings, search_query):
         with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, q=search_query))


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28211

J'ai tout cassé dans la PR #11092 , donc je tente de réparer : 
- retour à UNION (qui au moins répond vite avec des ids)
- on arrête la recherche de résas par nom de bénéficiaire en même temps que nom d'offre, ça plombe le _query plan_ et le User ID ou l'adresse email sont plus fiables

À intégrer dans la MEP de lundi (#11092 étant dans la MES d'hier).

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques