### PR TITLE
Pc 28447 enable invoice filter when offerer has one

### DIFF
--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -1026,3 +1026,11 @@ def get_invoices_query(
         invoices = invoices.filter(models.Invoice.date < datetime_until)
 
     return invoices
+
+
+def has_invoice(offerer_id: int) -> bool:
+    return db.session.query(
+        models.Invoice.query.join(models.Invoice.bankAccount)
+        .filter(models.BankAccount.offererId == offerer_id)
+        .exists()
+    ).scalar()

--- a/api/src/pcapi/routes/pro/finance.py
+++ b/api/src/pcapi/routes/pro/finance.py
@@ -10,6 +10,7 @@ import pcapi.core.offerers.models as offerers_models
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import finance_serialize
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils import rest
 
 from . import blueprint
 
@@ -63,6 +64,16 @@ def get_invoices_v2(query: finance_serialize.InvoiceListV2QueryModel) -> finance
     return finance_serialize.InvoiceListV2ResponseModel(
         __root__=[finance_serialize.InvoiceResponseV2Model.from_orm(invoice) for invoice in invoices]
     )
+
+
+@private_api.route("/v2/finance/has-invoice", methods=["GET"])
+@login_required
+@spectree_serialize(response_model=finance_serialize.HasInvoiceResponseModel, api=blueprint.pro_private_schema)
+def has_invoice(query: finance_serialize.HasInvoiceQueryModel) -> finance_serialize.HasInvoiceResponseModel:
+    rest.check_user_has_access_to_offerer(current_user, offerer_id=query.offererId)
+    offerer_has_invoice = finance_repository.has_invoice(query.offererId)
+
+    return finance_serialize.HasInvoiceResponseModel(hasInvoice=offerer_has_invoice)
 
 
 @private_api.route("/finance/reimbursement-points", methods=["GET"])

--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -181,3 +181,11 @@ class BankAccountResponseModel(BaseModel):
     @classmethod
     def _obfuscate_iban(cls, iban: str) -> str:
         return f"XXXX XXXX XXXX {iban[-4:]}"
+
+
+class HasInvoiceQueryModel(BaseModel):
+    offererId: int
+
+
+class HasInvoiceResponseModel(BaseModel):
+    hasInvoice: bool

--- a/api/src/pcapi/utils/rest.py
+++ b/api/src/pcapi/utils/rest.py
@@ -6,7 +6,7 @@ def check_user_has_access_to_offerer(user: User, offerer_id: int) -> None:
     if not user.has_access(offerer_id):
         raise ApiErrors(
             errors={
-                "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."],
+                "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."],
             },
             status_code=403,
         )

--- a/api/tests/core/finance/test_repository.py
+++ b/api/tests/core/finance/test_repository.py
@@ -276,6 +276,21 @@ class GetInvoicesQueryTest:
         invoices = repository.get_invoices_query(admin)
         assert invoices.count() == 0
 
+    def test_has_invoice(self):
+        offerer = offerers_factories.OffererFactory()
+        bank_account = factories.BankAccountFactory(offerer=offerer)
+        factories.InvoiceFactory(bankAccount=bank_account)
+
+        assert repository.has_invoice(offerer.id)
+
+    def test_has_no_invoices(self):
+        offerer = offerers_factories.OffererFactory()
+        offerer_2 = offerers_factories.OffererFactory()
+        bank_account = factories.BankAccountFactory(offerer=offerer_2)
+        factories.InvoiceFactory(bankAccount=bank_account)
+
+        assert not repository.has_invoice(offerer.id)
+
 
 class HasReimbursementTest:
     def test_booking_status(self):

--- a/api/tests/routes/pro/get_offerer_stats_v2_test.py
+++ b/api/tests/routes/pro/get_offerer_stats_v2_test.py
@@ -145,7 +145,7 @@ def test_get_offerer_stats_returns_403_if_user_has_no_rights_on_offerer(client):
 
     assert response.status_code == 403
     assert response.json == {
-        "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."]
+        "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
     }
 
 

--- a/api/tests/routes/pro/get_offerers_bank_accounts_test.py
+++ b/api/tests/routes/pro/get_offerers_bank_accounts_test.py
@@ -32,7 +32,7 @@ class OfferersBankAccountTest:
 
         # Then
         assert response.status_code == 403
-        assert "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information." in str(response.json)
+        assert "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information." in str(response.json)
 
     @pytest.mark.usefixtures("db_session")
     def test_accessing_inexisting_offerer_return_proper_404_error(self, client):

--- a/api/tests/routes/pro/get_venue_stats_test.py
+++ b/api/tests/routes/pro/get_venue_stats_test.py
@@ -78,5 +78,5 @@ class Returns403Test:
         # then
         assert response.status_code == 403
         assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -406,5 +406,5 @@ class Returns403Test:
         # then
         assert response.status_code == 403
         assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]

--- a/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
+++ b/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
@@ -87,7 +87,7 @@ class Returns403Test:
 
         assert response.status_code == 403
         assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."]
+            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
         }
         assert len(adage_api_testing.adage_requests) == 0
 

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -477,7 +477,7 @@ class Returns403Test:
 
         assert response.status_code == 403
         assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]
         assert CollectiveOfferTemplate.query.get(offer.id).name == "Old name"
 

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -505,7 +505,7 @@ class Returns403Test:
         # Then
         assert response.status_code == 403
         assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]
         assert CollectiveOffer.query.get(offer.id).name == "Old name"
 

--- a/api/tests/routes/pro/patch_collective_stock_test.py
+++ b/api/tests/routes/pro/patch_collective_stock_test.py
@@ -276,7 +276,7 @@ class Return403Test:
         # Then
         assert response.status_code == 403
         assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."]
+            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
         }
 
     def test_edit_collective_stocks_should_not_be_possible_when_offer_created_by_public_api(self, client):

--- a/api/tests/routes/pro/patch_offer_test.py
+++ b/api/tests/routes/pro/patch_offer_test.py
@@ -361,7 +361,7 @@ class Returns403Test:
         # Then
         assert response.status_code == 403
         assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]
         assert Offer.query.get(offer.id).name == "Old name"
 

--- a/api/tests/routes/pro/post_collective_stock_test.py
+++ b/api/tests/routes/pro/post_collective_stock_test.py
@@ -103,7 +103,7 @@ class Return400Test:
         # Then
         # assert response.status_code == 403
         assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."]
+            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
         }
 
     @time_machine.travel("2020-11-17 15:00:00")

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -461,5 +461,5 @@ class Returns403Test:
         # Then
         assert response.status_code == 403
         assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]

--- a/api/tests/routes/pro/post_stocks_test.py
+++ b/api/tests/routes/pro/post_stocks_test.py
@@ -1174,5 +1174,5 @@ class Returns403Test:
         # Then
         assert response.status_code == 403
         assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."]
+            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
         }

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -251,5 +251,5 @@ class Returns403Test:
 
         assert response.status_code == 403
         assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]

--- a/api/tests/routes/public/booking_token/v2/patch_cancel_booking_by_token_test.py
+++ b/api/tests/routes/public/booking_token/v2/patch_cancel_booking_by_token_test.py
@@ -278,7 +278,7 @@ class Returns403Test:
         # Then
         assert response.status_code == 403
         assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]
 
     @pytest.mark.usefixtures("db_session")

--- a/api/tests/utils/rest_test.py
+++ b/api/tests/utils/rest_test.py
@@ -26,6 +26,6 @@ class CheckUserHasAccessToOffererTest:
             check_user_has_access_to_offerer(user, offerer.id)
 
         assert error.value.errors["global"] == [
-            "Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."
+            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]
         assert error.value.status_code == 403

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -125,6 +125,8 @@ export type { GetVenueManagingOffererResponseModel } from './models/GetVenueMana
 export type { GetVenuePricingPointResponseModel } from './models/GetVenuePricingPointResponseModel';
 export type { GetVenueResponseModel } from './models/GetVenueResponseModel';
 export type { GetVenuesOfOffererFromSiretResponseModel } from './models/GetVenuesOfOffererFromSiretResponseModel';
+export type { HasInvoiceQueryModel } from './models/HasInvoiceQueryModel';
+export type { HasInvoiceResponseModel } from './models/HasInvoiceResponseModel';
 export type { InviteMemberQueryModel } from './models/InviteMemberQueryModel';
 export type { InvoiceListQueryModel } from './models/InvoiceListQueryModel';
 export type { InvoiceListResponseModel } from './models/InvoiceListResponseModel';

--- a/pro/src/apiClient/v1/models/HasInvoiceQueryModel.ts
+++ b/pro/src/apiClient/v1/models/HasInvoiceQueryModel.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type HasInvoiceQueryModel = {
+  offererId: number;
+};
+

--- a/pro/src/apiClient/v1/models/HasInvoiceResponseModel.ts
+++ b/pro/src/apiClient/v1/models/HasInvoiceResponseModel.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type HasInvoiceResponseModel = {
+  hasInvoice: boolean;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -55,6 +55,7 @@ import type { GetStocksResponseModel } from '../models/GetStocksResponseModel';
 import type { GetVenueListResponseModel } from '../models/GetVenueListResponseModel';
 import type { GetVenueResponseModel } from '../models/GetVenueResponseModel';
 import type { GetVenuesOfOffererFromSiretResponseModel } from '../models/GetVenuesOfOffererFromSiretResponseModel';
+import type { HasInvoiceResponseModel } from '../models/HasInvoiceResponseModel';
 import type { InviteMemberQueryModel } from '../models/InviteMemberQueryModel';
 import type { InvoiceListResponseModel } from '../models/InvoiceListResponseModel';
 import type { InvoiceListV2ResponseModel } from '../models/InvoiceListV2ResponseModel';
@@ -2202,6 +2203,27 @@ export class DefaultService {
       url: '/users/validate_email',
       body: requestBody,
       mediaType: 'application/json',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
+   * has_invoice <GET>
+   * @param offererId
+   * @returns HasInvoiceResponseModel OK
+   * @throws ApiError
+   */
+  public hasInvoice(
+    offererId: number,
+  ): CancelablePromise<HasInvoiceResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v2/finance/has-invoice',
+      query: {
+        'offererId': offererId,
+      },
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Entity`,

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
@@ -117,6 +117,7 @@ describe('reimbursementsWithFilters', () => {
       bankAccounts: BASE_BANK_ACCOUNTS,
       managedVenues: [],
     })
+    vi.spyOn(api, 'hasInvoice').mockResolvedValueOnce({ hasInvoice: true })
   })
 
   it('shoud render a table with invoices', async () => {
@@ -198,6 +199,7 @@ describe('reimbursementsWithFilters', () => {
 
   it('shoud render no invoice yet information block', async () => {
     vi.spyOn(api, 'getInvoices').mockResolvedValueOnce([])
+    vi.spyOn(api, 'hasInvoice').mockResolvedValueOnce({ hasInvoice: false })
     renderReimbursementsInvoices()
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
@@ -208,19 +210,6 @@ describe('reimbursementsWithFilters', () => {
         'Aucun justificatif de remboursement trouvé pour votre recherche'
       )
     ).not.toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'Vous n’avez pas encore de justificatifs de remboursement disponibles'
-      )
-    ).toBeInTheDocument()
-  })
-
-  it('shoud render no result block', async () => {
-    vi.spyOn(api, 'getInvoices').mockResolvedValueOnce([])
-    renderReimbursementsInvoices()
-
-    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
-
     expect(
       screen.getByText(
         'Vous n’avez pas encore de justificatifs de remboursement disponibles'
@@ -356,5 +345,30 @@ describe('reimbursementsWithFilters', () => {
 
     expect(screen.getByLabelText('Compte bancaire *')).toBeInTheDocument()
     expect(screen.getByText('Tous les comptes bancaires')).toBeInTheDocument()
+  })
+
+  it('should disable filter if no invoices', async () => {
+    vi.spyOn(api, 'hasInvoice').mockResolvedValueOnce({ hasInvoice: false })
+    renderReimbursementsInvoices({
+      features: ['WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'],
+    })
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getByLabelText('Compte bancaire *')).toBeDisabled()
+    expect(screen.getByLabelText('Début de la période')).toBeDisabled()
+    expect(screen.getByLabelText('Fin de la période')).toBeDisabled()
+  })
+
+  it('should not disable filter if has invoices', async () => {
+    renderReimbursementsInvoices({
+      features: ['WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'],
+    })
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getByLabelText('Compte bancaire *')).toBeEnabled()
+    expect(screen.getByLabelText('Début de la période')).toBeEnabled()
+    expect(screen.getByLabelText('Fin de la période')).toBeEnabled()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28447

Disable les filtres de la page Justificatifs de remboursements quand la structure sélectionné n'a pas d'invoices. Au contraire activer ces filtres si la structure a des invoices, même pour une période différente que celle sélectionnée par défaut.


![Capture d’écran 2024-03-11 à 11 10 29](https://github.com/pass-culture/pass-culture-main/assets/71768799/ea983062-c385-41f3-b9de-2e35650002b2)
