### PR TITLE
(PC-28458)[API] fix: Don't use inactive non free offer for buisness l…

### DIFF
--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -683,6 +683,8 @@ def get_venues_with_non_free_offers_without_bank_accounts(offerer_id: int) -> li
                         offers_models.Stock.offerId == offers_models.Offer.id,
                         offers_models.Offer.venueId == models.Venue.id,
                         offers_models.Stock.price > 0,
+                        offers_models.Stock.isSoftDeleted.is_(False),
+                        offers_models.Offer.isActive.is_(True),
                     ),
                 ).exists(),
                 CollectiveStock.query.join(
@@ -691,6 +693,7 @@ def get_venues_with_non_free_offers_without_bank_accounts(offerer_id: int) -> li
                         CollectiveStock.collectiveOfferId == CollectiveOffer.id,
                         CollectiveOffer.venueId == models.Venue.id,
                         CollectiveStock.price > 0,
+                        CollectiveOffer.isActive.is_(True),
                     ),
                 ).exists(),
             ),


### PR DESCRIPTION
…ogic

We don't want to use inactive non free offer to encourage user to attach
a venue to a bankAccount (because they won't expect any reimbursements, because
such offers can't be booked)

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28458

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques