### PR TITLE
(PC-28038)[API] feat: script to match permanent venues with acceslibre

### DIFF
--- a/api/src/pcapi/connectors/acceslibre.py
+++ b/api/src/pcapi/connectors/acceslibre.py
@@ -5,8 +5,10 @@ Further explanations at: https://schema.data.gouv.fr/MTES-MCT/acceslibre-schema/
 """
 
 from datetime import datetime
+import enum
 import json
 import logging
+import uuid
 
 from dateutil import parser
 import pydantic.v1 as pydantic_v1
@@ -21,7 +23,50 @@ logger = logging.getLogger(__name__)
 
 ACCESLIBRE_REQUEST_TIMEOUT = 3
 REQUEST_PAGE_SIZE = 50
-MATCHING_RATIO = 50
+ADDRESS_MATCHING_RATIO = 80
+NAME_MATCHING_RATIO = 45
+
+
+class AcceslibreActivity(enum.Enum):
+    """
+    The following are Acceslibre activities that we can use in our matching algorithm
+    """
+
+    ADMINISTRATION_PUBLIQUE = "administration-publique"
+    AQUARIUM = "aquarium"
+    ART = "art"
+    ARTISANAT = "artisanat"
+    ASSOCIATION = "association"
+    BIBLIOTHEQUE = "bibliotheque-mediatheque"
+    CENTRE_CULTUREL = "centre-culturel"
+    CHATEAU = "chateau"
+    CINEMA = "cinema"
+    COLLECTIVITE_TERRITORIALE = "collectivite-territoriale"
+    CONSERVATOIRE_ET_ECOLE_DE_MUSIQUE = "conservatoire-et-ecole-de-musique"
+    DISQUAIRE = "disquaire"
+    ECOLE_DE_DANSE = "ecole-de-danse"
+    ENCADREUR_ENLUMINEUR = "encadreur-enlumineur"
+    EVENEMENT_CULTUREL = "evenement-culturel"
+    GALERIE_D_ART = "salle-dexposition"
+    GYMNASE = "gymnase"
+    INSTRUMENT_ET_MATERIEL_DE_MUSIQUE = "instruments-et-materiel-de-musique"
+    JARDIN_BOTANIQUE_ETOU_ZOOLOGIQUE = "jardin-botanique-etou-zoologique"
+    LIBRAIRIE = "librairie"
+    LIEU_DE_VISITE = "lieu-de-visite"
+    LOISIRS_CREATIFS = "loisirs-creatifs"
+    MENUISERIE = "menuiserie-ebenisterie"
+    MONUMENT_HISTORIQUE = "monument-historique"
+    MUSEE = "musee"
+    MUSIQUE = "musique"
+    OFFICE_DU_TOURISME = "office-du-tourisme"
+    OPERA = "opera"
+    PAPETERIE_PRESSE_JOURNAUX = "papeterie-presse-journaux"
+    PARC_DES_EXPOSITIONS = "parc-des-expositions"
+    SALLE_DE_CONCERT = "salle-de-concert"
+    SALLE_DE_DANSE = "salle-de-danse"
+    SALLE_DES_FETES = "salle-des-fetes"
+    SALLE_DE_SPECTACLE = "salle-de-spectacle"
+    THEATRE = "theatre"
 
 
 class AccesLibreApiException(Exception):
@@ -61,9 +106,10 @@ def find_venue_at_accessibility_provider(
     ban_id: str | None = None,
     city: str | None = None,
     postal_code: str | None = None,
-) -> str | None:
+    address: str | None = None,
+) -> dict | None:
     """Try to find the entry at acceslibre that matches our venue
-    Returns acceslibre slug (which is unique and safe according to them)
+    Returns acceslibre venue
     """
     return _get_backend().find_venue_at_accessibility_provider(
         name=name,
@@ -72,6 +118,30 @@ def find_venue_at_accessibility_provider(
         ban_id=ban_id,
         city=city,
         postal_code=postal_code,
+        address=address,
+    )
+
+
+def get_id_at_accessibility_provider(
+    name: str,
+    public_name: str | None = None,
+    siret: str | None = None,
+    ban_id: str | None = None,
+    city: str | None = None,
+    postal_code: str | None = None,
+    address: str | None = None,
+) -> str | None:
+    """
+    Returns the slug (unique ID at acceslibre) of the venue at acceslibre
+    """
+    return _get_backend().get_id_at_accessibility_provider(
+        name=name,
+        public_name=public_name,
+        siret=siret,
+        ban_id=ban_id,
+        city=city,
+        postal_code=postal_code,
+        address=address,
     )
 
 
@@ -86,23 +156,61 @@ def get_accessibility_infos(slug: str) -> AccessibilityInfo:
     return _get_backend().get_accessibility_infos(slug=slug)
 
 
-def match_by_name(results_at_provider: list[dict[str, str]], name: str, public_name: str | None) -> str | None:
-    name = name.lower()
-    public_name = public_name.lower() if public_name else "PUBLIC_NAME_MISSING"
-    for erp in results_at_provider:
-        name_at_provider = erp["nom"].lower()
-        if (
-            name_at_provider in name
-            or name in name_at_provider
-            or public_name in name_at_provider
-            or name_at_provider in public_name
+def extract_street_name(address: str | None = None, city: str | None = None, postal_code: str | None = None) -> str:
+    if address and city and postal_code:
+        return address.lower().replace(postal_code, "").replace(city.lower(), "").rstrip()
+    return ""
+
+
+def match_venue_with_acceslibre(
+    acceslibre_results: list[dict],
+    venue_name: str,
+    venue_public_name: str | None,
+    venue_address: str | None,
+    venue_ban_id: str | None,
+    venue_siret: str | None,
+) -> dict[str, str] | None:
+    """
+    From the results we get from requesting acceslibre API, we try a match with our venue
+    by comparing the name and address using a fuzzy matching algorithm.
+    We also check that the activity of the venue at acceslibre is in the enum AcceslibreActivity
+    """
+    venue_name = venue_name.lower()
+    venue_public_name = venue_public_name.lower() if venue_public_name else "PUBLIC_NAME_MISSING"
+    venue_address = venue_address.lower() if venue_address else "ADDRESS_MISSING"
+
+    for result in acceslibre_results:
+        acceslibre_name = result["nom"].lower()
+        acceslibre_address = extract_street_name(result["adresse"], result["commune"], result["code_postal"])
+        acceslibre_activity = result["activite"]["slug"]
+        acceslibre_ban_id = result["ban_id"]
+        acceslibre_siret = result["siret"]
+        # check siret matching
+        if venue_siret and venue_siret == acceslibre_siret:
+            return result
+        if (  # pylint: disable=too-many-boolean-expressions
+            # check activity is valid
+            acceslibre_activity in [a.value for a in AcceslibreActivity]
+            # name matching
+            and (
+                acceslibre_name in venue_name
+                or venue_name in acceslibre_name
+                or venue_public_name in acceslibre_name
+                or acceslibre_name in venue_public_name
+                or fuzz.ratio(acceslibre_name, venue_name) > NAME_MATCHING_RATIO
+                or fuzz.ratio(acceslibre_name, venue_public_name) > NAME_MATCHING_RATIO
+            )
+            # check if BAN id or address matching
+            and (
+                (venue_ban_id and venue_ban_id == acceslibre_ban_id)
+                or (
+                    venue_address
+                    and acceslibre_address
+                    and fuzz.ratio(acceslibre_address, venue_address) > ADDRESS_MATCHING_RATIO
+                )
+            )
         ):
-            return erp["slug"]
-        if (
-            fuzz.ratio(name_at_provider, name) > MATCHING_RATIO
-            or fuzz.ratio(name_at_provider, public_name) > MATCHING_RATIO
-        ):
-            return erp["slug"]
+            return result
     return None
 
 
@@ -135,6 +243,19 @@ class BaseBackend:
         ban_id: str | None = None,
         city: str | None = None,
         postal_code: str | None = None,
+        address: str | None = None,
+    ) -> dict | None:
+        raise NotImplementedError()
+
+    def get_id_at_accessibility_provider(
+        self,
+        name: str,
+        public_name: str | None = None,
+        siret: str | None = None,
+        ban_id: str | None = None,
+        city: str | None = None,
+        postal_code: str | None = None,
+        address: str | None = None,
     ) -> str | None:
         raise NotImplementedError()
 
@@ -154,6 +275,27 @@ class TestingBackend(BaseBackend):
         ban_id: str | None = None,
         city: str | None = None,
         postal_code: str | None = None,
+        address: str | None = None,
+    ) -> dict | None:
+        return {
+            "slug": "mon-lieu-chez-acceslibre",
+            "uuid": str(uuid.uuid4()),
+            "nom": "Un lieu",
+            "adresse": "3 Rue de Valois 75001 Paris",
+            "activite": {"nom": "Bibliothèque Médiathèque", "slug": "bibliotheque-mediatheque"},
+            "siret": "",
+            "updated_at": "2023-04-13T15:10:25.612731+02:00",
+        }
+
+    def get_id_at_accessibility_provider(
+        self,
+        name: str,
+        public_name: str | None = None,
+        siret: str | None = None,
+        ban_id: str | None = None,
+        city: str | None = None,
+        postal_code: str | None = None,
+        address: str | None = None,
     ) -> str | None:
         return "mon-lieu-chez-acceslibre"
 
@@ -220,7 +362,8 @@ class AcceslibreBackend(BaseBackend):
         ban_id: str | None = None,
         city: str | None = None,
         postal_code: str | None = None,
-    ) -> str | None:
+        address: str | None = None,
+    ) -> dict | None:
         search_criteria: list[dict] = [
             {"siret": siret},
             {"ban_id": ban_id},
@@ -242,9 +385,33 @@ class AcceslibreBackend(BaseBackend):
             if all(v is not None for v in criterion.values()):
                 response = self._send_request(query_params=criterion)
                 if response["count"] and (
-                    slug := match_by_name(results_at_provider=response["results"], name=name, public_name=public_name)
+                    matching_venue := match_venue_with_acceslibre(
+                        acceslibre_results=response["results"],
+                        venue_name=name,
+                        venue_public_name=public_name,
+                        venue_address=address,
+                        venue_ban_id=ban_id,
+                        venue_siret=siret,
+                    )
                 ):
-                    return slug
+                    return matching_venue
+        return None
+
+    def get_id_at_accessibility_provider(
+        self,
+        name: str,
+        public_name: str | None = None,
+        siret: str | None = None,
+        ban_id: str | None = None,
+        city: str | None = None,
+        postal_code: str | None = None,
+        address: str | None = None,
+    ) -> str | None:
+        matching_venue = find_venue_at_accessibility_provider(
+            name, public_name, siret, ban_id, city, postal_code, address
+        )
+        if matching_venue:
+            return matching_venue["slug"]
         return None
 
     def get_last_update_at_provider(self, slug: str) -> datetime:

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2172,13 +2172,14 @@ def get_venue_opening_hours_by_weekday(venue: models.Venue, weekday: models.Week
 def set_accessibility_provider_id(venue: models.Venue) -> None:
     if not venue.accessibilityProvider:
         venue.accessibilityProvider = models.AccessibilityProvider(
-            externalAccessibilityId=accessibility_provider.find_venue_at_accessibility_provider(
+            externalAccessibilityId=accessibility_provider.get_id_at_accessibility_provider(
                 name=venue.name,
                 public_name=venue.publicName,
                 siret=venue.siret,
                 ban_id=venue.banId,
                 city=venue.city,
                 postal_code=venue.postalCode,
+                address=venue.address,
             )
         )
         db.session.add(venue.accessibilityProvider)

--- a/api/src/pcapi/scripts/venue/acceslibre/match_acceslibre.py
+++ b/api/src/pcapi/scripts/venue/acceslibre/match_acceslibre.py
@@ -1,0 +1,222 @@
+import csv
+from datetime import datetime
+import json
+import logging
+import pathlib
+
+import sqlalchemy.exc as sa_exc
+
+import pcapi.connectors.acceslibre as acceslibre_connector
+from pcapi.core.offerers import models
+from pcapi.models import db
+
+
+PATH = pathlib.Path(__file__).parent.resolve()
+CHUNK_SIZE = 100
+
+logger = logging.getLogger(__name__)
+
+
+def export_match_as_csv(match: list, filename: pathlib.Path) -> None:
+    output_file = PATH / filename
+    output_exists = pathlib.Path(output_file).is_file()
+    print(f"Writing matching venues in {filename}")
+    with open(output_file, "a", newline="", encoding="utf-8") as csv_file:
+        headers = [
+            "Venue ID",
+            "uuid AccesLibre",
+            "slug AccesLibre",
+            "Nom PassCulture",
+            "Nom Publique PassCulture",
+            "Nom AccesLibre",
+            "Ban ID PassCulture",
+            "Adresse PassCulture",
+            "Adresse AccesLibre",
+            "Activite PassCulture",
+            "Activite AccesLibre",
+            "Siret PassCulture",
+            "Siret AccesLibre",
+            "Last Update AccesLibre",
+        ]
+        writer = csv.DictWriter(csv_file, fieldnames=headers)
+        if not output_exists:
+            writer.writeheader()
+        writer.writerows(match)
+
+
+def export_no_match(output_file: pathlib.Path, venues_list: list[dict]) -> None:
+    print(f"Exporting venues with no match found in {output_file}")
+    output = []
+    for venue in venues_list:
+        output.append(
+            {
+                "Venue ID": venue["Venue ID"],
+                "Venue Name": venue["Venue Name"],
+                "Venue Public Name": venue["Venue Public Name"],
+                "Venue Address": f"{venue['Venue Address']} {venue['Venue City']} {venue['Venue Postal Code']}",
+                "Venue Ban ID": venue["Ban ID"],
+                "Venue Siret": venue["Venue Siret"],
+                "Venue Activity": venue["Venue Type Code"],
+            }
+        )
+    with open(output_file, "w", newline="", encoding="utf-8") as csv_file:
+        headers = [
+            "Venue ID",
+            "Venue Name",
+            "Venue Public Name",
+            "Venue Address",
+            "Venue Ban ID",
+            "Venue Siret",
+            "Venue Activity",
+        ]
+        writer = csv.DictWriter(csv_file, fieldnames=headers)
+        writer.writeheader()
+        writer.writerows(output)
+
+
+def update_venues_from_csv(filename: pathlib.Path, permanent_venues: list[models.Venue]) -> None:
+    # Read result csv and update slug
+    with open(filename, "r", encoding="utf-8") as file:
+        csv_reader = csv.DictReader(file)
+        permanent_venues_ids = {v.id: v for v in permanent_venues}
+        for line in csv_reader:
+            try:
+                venue_id = int(line["Venue ID"])
+                acceslibre_slug = line.get("slug AccesLibre", None)
+                acceslibre_last_update = line.get("Last Update AccesLibre")
+                venue = permanent_venues_ids.get(venue_id)
+                if venue and acceslibre_slug:
+                    if not venue.accessibilityProvider:
+                        venue.accessibilityProvider = models.AccessibilityProvider(
+                            externalAccessibilityId=acceslibre_slug
+                        )
+                    else:
+                        venue.accessibilityProvider.externalAccessibilityId = acceslibre_slug
+                if venue and acceslibre_last_update:
+                    if venue.accessibilityProvider:
+                        venue.accessibilityProvider.lastUpdateAtProvider = datetime.strptime(
+                            acceslibre_last_update, "%Y-%m-%d %H:%M:%S.%f%z"
+                        )
+            except KeyError:
+                print(f"ERROR: Venue ID is missing for this entry: {line}")
+    # Log infos of which venues have been updated
+    venues_with_acceslibre_slug = [v for v in permanent_venues if v.accessibilityProvider]
+    venues_without_acceslibre_slug = [v for v in permanent_venues if not v.accessibilityProvider]
+    print(
+        f"{len(venues_with_acceslibre_slug)} Venues have been updated \n"
+        f"{len(venues_without_acceslibre_slug)} Venues not updated. Check in DB with this command:\n"
+        f'> SELECT venue.id FROM venue JOIN accessibility_provider ON accessibility_provider."venueId" = venue.id '
+        f'WHERE venue."isPermanent" IS TRUE AND venue."isVirtual" IS FALSE AND accessibility_provider."externalAccessibilityId" IS NULL\n'
+        f"\n Don't forget to remove file from system when you are done:\n"
+        f"> rm {filename}\n"
+    )
+
+
+# If we want to use this script in dev context we need to uncomment following lines
+# and add ACCESLIBRE_API_KEY={your api key} in .env.local.secret
+# from pcapi.core.testing import override_settings
+# @override_settings(ACCESLIBRE_BACKEND="pcapi.connectors.acceslibre.AcceslibreBackend")
+def run_matching(export_not_matching_venues: bool = False) -> None:
+    matching_acceslibre_file = PATH / "match_acceslibre.csv"
+    print(f"Requesting acceslibre API and write matching venues in {matching_acceslibre_file} \n")
+    # To run locally, we use a metabase json export of Permanent AND Non Virtual Venues
+    permanent_venues_file = PATH / "data/pc_permanent_venues.json"
+    with open(permanent_venues_file, "r", encoding="utf-8") as file:
+        permanent_venues = json.load(file)
+    already_requested_venues_ids = set()
+
+    # We need to export missing match to validate matching algorithm
+    export_not_matching_filename = PATH / "venues_not_matching.csv"
+
+    # If file already exists, we skip already matching venues
+    if pathlib.Path(matching_acceslibre_file).is_file():
+        with open(matching_acceslibre_file, "r", encoding="utf-8") as file:
+            csv_reader = csv.DictReader(file)
+            already_requested_venues_ids = {int(line["Venue ID"]) for line in csv_reader}
+    venues_to_process = [v for v in permanent_venues if int(v["Venue ID"]) not in already_requested_venues_ids]
+    print(f"{len(venues_to_process)} permanent venues to update in DB \n")
+    batches = [venues_to_process[i : i + CHUNK_SIZE] for i in range(0, len(venues_to_process), CHUNK_SIZE)]
+    matching_venue_ids = set()
+    for i, batch in enumerate(batches, start=1):
+        match_list = []
+        for venue in batch:
+            # Request acceslibre API to find matching Venue
+            acceslibre_venue = acceslibre_connector.find_venue_at_accessibility_provider(
+                name=venue["Venue Name"],
+                public_name=venue["Venue Public Name"],
+                siret=venue["Venue Siret"],
+                ban_id=venue["Ban ID"],
+                city=venue["Venue City"],
+                postal_code=venue["Venue Postal Code"],
+                address=venue["Venue Address"],
+            )
+            if acceslibre_venue:
+                match_list.append(
+                    {
+                        "Venue ID": venue["Venue ID"],
+                        "uuid AccesLibre": acceslibre_venue["uuid"],
+                        "slug AccesLibre": acceslibre_venue["slug"],
+                        "Nom PassCulture": venue["Venue Name"],
+                        "Nom Publique PassCulture": venue["Venue Public Name"],
+                        "Nom AccesLibre": acceslibre_venue["nom"],
+                        "Ban ID PassCulture": venue["Ban ID"],
+                        "Adresse PassCulture": f"{venue['Venue Address']} {venue['Venue Postal Code']} {venue['Venue City']}",
+                        "Adresse AccesLibre": acceslibre_venue["adresse"],
+                        "Activite PassCulture": venue["Venue Type Code"],
+                        "Activite AccesLibre": acceslibre_venue["activite"]["nom"],
+                        "Siret PassCulture": venue["Venue Siret"],
+                        "Siret AccesLibre": acceslibre_venue["siret"],
+                        "Last Update AccesLibre": datetime.strptime(
+                            acceslibre_venue["updated_at"], "%Y-%m-%dT%H:%M:%S.%f%z"
+                        ),
+                    }
+                )
+                matching_venue_ids.add(venue["Venue ID"])
+        export_match_as_csv(match_list, matching_acceslibre_file)
+    venues_not_matching = [v for v in venues_to_process if v["Venue ID"] not in matching_venue_ids]
+    print(f"Number of permanent venues matching acceslibre found: {len(matching_venue_ids)}\n")
+    print(f"Number of permanent venues not matching acceslibre: {len(venues_not_matching)}\n")
+
+    if export_not_matching_venues:
+        export_no_match(output_file=export_not_matching_filename, venues_list=venues_not_matching)
+
+
+def run_update(dry_run: bool = True) -> None:
+    matching_acceslibre_file = PATH / "match_acceslibre.csv"
+    if not pathlib.Path(matching_acceslibre_file).is_file():
+        print(f"Matching file {matching_acceslibre_file} is missing ...")
+        return
+    permanent_venues = (
+        models.Venue.query.filter(models.Venue.isPermanent == True, models.Venue.isVirtual == False)
+        .order_by(models.Venue.id.asc())
+        .all()
+    )
+    update_venues_from_csv(matching_acceslibre_file, permanent_venues)
+    batches = [permanent_venues[i : i + 1000] for i in range(0, len(permanent_venues), 1000)]
+    for i, batch in enumerate(batches, start=1):
+        for venue in batch:
+            db.session.add(venue)
+        if not dry_run:
+            try:
+                db.session.commit()
+            except sa_exc.SQLAlchemyError:
+                logger.exception("Could not update batch %d", i)
+                db.session.rollback()
+
+
+def run_export_non_match() -> None:
+    matching_acceslibre_file = PATH / "match_acceslibre.csv"
+    permanent_venues_file = PATH / "data/pc_permanent_venues.json"
+    export_not_matching_filename = PATH / "venues_not_matching_export.csv"
+
+    with open(permanent_venues_file, "r", encoding="utf-8") as file:
+        permanent_venues = json.load(file)
+    matching_venue_ids = set()
+
+    # If file already exists, we skip already matching venues
+    if pathlib.Path(matching_acceslibre_file).is_file():
+        with open(matching_acceslibre_file, "r", encoding="utf-8") as file:
+            csv_reader = csv.DictReader(file)
+            matching_venue_ids = {int(line["Venue ID"]) for line in csv_reader}
+    venues_list = [v for v in permanent_venues if int(v["Venue ID"]) not in matching_venue_ids]
+    export_no_match(output_file=export_not_matching_filename, venues_list=venues_list)

--- a/api/tests/connectors/acceslibre/acceslibre_test.py
+++ b/api/tests/connectors/acceslibre/acceslibre_test.py
@@ -16,7 +16,7 @@ class AcceslibreTest:
             f"https://acceslibre.beta.gouv.fr/api/erps/?ban_id={ban_id}",
             json=fixtures.ACCESLIBRE_RESULTS,
         )
-        slug = acceslibre.find_venue_at_accessibility_provider(name=name, public_name=public_name, ban_id=ban_id)
+        slug = acceslibre.get_id_at_accessibility_provider(name=name, public_name=public_name, ban_id=ban_id)
         assert slug == "le-bateau-livre"
 
     def test_venue_has_siret_at_provider(self, requests_mock):
@@ -27,28 +27,30 @@ class AcceslibreTest:
             f"https://acceslibre.beta.gouv.fr/api/erps/?siret={siret}",
             json=fixtures.ACCESLIBRE_RESULTS,
         )
-        slug = acceslibre.find_venue_at_accessibility_provider(name=name, public_name=public_name, siret=siret)
+        slug = acceslibre.get_id_at_accessibility_provider(name=name, public_name=public_name, siret=siret)
         assert slug == "la-librairie-chouette"
 
-    def test_find_venue_based_on_name(self, requests_mock):
+    def test_find_venue_based_on_name_and_address(self, requests_mock):
         name = "La Belette Du Nord"
         public_name = None
         city = "Lille"
         postal_code = "59800"
+        address = "30 Fausse rue"
         requests_mock.get(
             "https://acceslibre.beta.gouv.fr/api/erps/?q=La+Belette+Du+Nord&commune=Lille&code_postal=59800&page_size=50",
             json=fixtures.ACCESLIBRE_RESULTS_BY_NAME,
         )
-        slug = acceslibre.find_venue_at_accessibility_provider(
-            name=name, public_name=public_name, city=city, postal_code=postal_code
+        slug = acceslibre.get_id_at_accessibility_provider(
+            name=name, public_name=public_name, city=city, postal_code=postal_code, address=address
         )
         assert slug == "belette-du-nord"
 
-    def test_find_venue_based_on_public_name(self, requests_mock):
+    def test_find_venue_based_on_public_name_and_address(self, requests_mock):
         name = "Un truc random qui échoue"
         public_name = "LA BELETTE DU NORD - LILLE"
         city = "Lille"
         postal_code = "59800"
+        address = "28 Fausse rue"  # wrong address on purpose
         requests_mock.get(
             "https://acceslibre.beta.gouv.fr/api/erps/?q=Un+truc+random+qui+%C3%A9choue&commune=Lille&code_postal=59800&page_size=50",
             json=fixtures.ACCESLIBRE_RESULTS_EMPTY,
@@ -57,8 +59,8 @@ class AcceslibreTest:
             "https://acceslibre.beta.gouv.fr/api/erps/?q=LA+BELETTE+DU+NORD+-+LILLE&commune=Lille&code_postal=59800&page_size=50",
             json=fixtures.ACCESLIBRE_RESULTS_BY_NAME,
         )
-        slug = acceslibre.find_venue_at_accessibility_provider(
-            name=name, public_name=public_name, city=city, postal_code=postal_code
+        slug = acceslibre.get_id_at_accessibility_provider(
+            name=name, public_name=public_name, city=city, postal_code=postal_code, address=address
         )
         assert slug == "belette-du-nord"
 


### PR DESCRIPTION
## But de la pull request

- Script en 2 parties : 
1. `run_matching` Le match qui effectue le matching avec acceslibre et sauvegarde les données dans un csv. Il peut être joué localement (cf. commentaire dans le code)
2. `run_update` La sauvegarde qui va écrire les slugs et la date de dernière mise à jour depuis le csv de match
 
- Ce script sera également relancé après la campagne Tally (durant laquelle potentiellement plusieurs partenaires culturels iront remplir leurs info chez acceslibre). On pourra le retirer de la basecode ensuite
- 
- Afin d'obtenir de meilleurs résultats de match, modification de la méthode `find_venue_at_accessibility_provider` (d'où les 2 commits)

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28038

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques