### PR TITLE
(PC-26079)[PRO] feat: Make booking status tooltip accessible.

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus/FilterByBookingStatus.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus/FilterByBookingStatus.tsx
@@ -62,18 +62,37 @@ const FilterByBookingStatus = <
   const containerRef = useRef<HTMLDivElement | null>(null)
   const { logEvent } = useAnalytics()
 
-  const showFilter = () => {
+  const showTooltip = () => {
     setIsToolTipVisible(true)
     logEvent?.(Events.CLICKED_SHOW_STATUS_FILTER, {
       from: location.pathname,
     })
   }
 
-  const hideFilters = () => {
+  const hideTooltip = () => {
     setIsToolTipVisible(false)
   }
 
-  useOnClickOrFocusOutside(containerRef, hideFilters)
+  function toggleTooltip() {
+    if (isToolTipVisible) {
+      hideTooltip()
+    } else {
+      showTooltip()
+    }
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
+    switch (event.key) {
+      case 'Space':
+        toggleTooltip()
+        break
+      case 'Escape':
+        hideTooltip()
+        break
+    }
+  }
+
+  useOnClickOrFocusOutside(containerRef, hideTooltip)
 
   const handleCheckboxChange = (event: ChangeEvent<HTMLInputElement>) => {
     const statusId = event.target.name
@@ -96,9 +115,11 @@ const FilterByBookingStatus = <
     <div ref={containerRef}>
       <button
         className="bs-filter-button"
-        onClick={showFilter}
-        onFocus={showFilter}
+        onClick={toggleTooltip}
+        onKeyDown={handleKeyDown}
         type="button"
+        aria-expanded={isToolTipVisible}
+        aria-controls="booking-filter-tooltip"
       >
         <span className="table-head-label status-filter">Statut</span>
         <span className="status-container">
@@ -115,8 +136,7 @@ const FilterByBookingStatus = <
           )}
         </span>
       </button>
-
-      <span className="bs-filter">
+      <div className="bs-filter" id="booking-filter-tooltip">
         {isToolTipVisible && (
           <div className="bs-filter-tooltip">
             <fieldset>
@@ -137,7 +157,7 @@ const FilterByBookingStatus = <
             </fieldset>
           </div>
         )}
-      </span>
+      </div>
     </div>
   )
 }

--- a/pro/src/screens/Bookings/BookingsRecapTable/Filters/Filters.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/Filters/Filters.module.scss
@@ -8,6 +8,7 @@
 
 .bs-filter {
   position: relative;
+  display: inline-block;
 
   .bs-filter-label {
     @include fonts.caption;
@@ -62,7 +63,7 @@
 
 .status-container {
   position: relative;
-} 
+}
 
 .status-icon {
   width: rem.torem(16px);

--- a/pro/src/screens/Bookings/BookingsRecapTable/Filters/__specs__/FilterByBookingStatus.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/Filters/__specs__/FilterByBookingStatus.spec.tsx
@@ -155,5 +155,33 @@ describe('components | FilterByBookingStatus', () => {
         bookingStatus: ['validated', 'booked'],
       })
     })
+
+    it('should close the tooltip when the Escape key is pressed', async () => {
+      renderFilterByBookingStatus(props)
+      await userEvent.click(screen.getByRole('img'))
+
+      expect(screen.getByText('Afficher les réservations')).toBeInTheDocument()
+
+      await userEvent.keyboard('{Escape}')
+
+      expect(
+        screen.queryByText('Afficher les réservations')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should toggle the opening of the tooltip panel when the Space key is pressd', async () => {
+      renderFilterByBookingStatus(props)
+      await userEvent.click(screen.getByRole('img'))
+
+      await userEvent.keyboard('{Space}')
+
+      expect(
+        screen.queryByText('Afficher les réservations')
+      ).not.toBeInTheDocument()
+
+      await userEvent.keyboard('{Space}')
+
+      expect(screen.getByText('Afficher les réservations')).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26079

**Objectif**
Utiliser le [pattern Disclosure](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/) de W3C pour l'ouverture du tooltip du status des réservations indiv.
- Ouverture fermeture au Space ou Enter
- Fermeture au Escape
- Ajout du aria-expanded et aria-controls

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques