### PR TITLE
(BSR)[API] fix: Include side effects of booking failure in `book_offer()`

### DIFF
--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -5,7 +5,6 @@ import pcapi.core.bookings.exceptions as bookings_exceptions
 from pcapi.core.bookings.models import Booking
 from pcapi.core.external_bookings import exceptions as external_bookings_exceptions
 import pcapi.core.finance.models as finance_models
-import pcapi.core.offers.api as offers_api
 from pcapi.core.offers.exceptions import StockDoesNotExist
 from pcapi.core.offers.exceptions import UnexpectedCinemaProvider
 from pcapi.core.offers.models import Stock
@@ -95,22 +94,8 @@ def book_offer(user: User, body: BookOfferRequest) -> BookOfferResponse:
         )
         raise ApiErrors({"code": "CINEMA_PROVIDER_BOOKING_FAILED"})
     except external_bookings_exceptions.ExternalBookingSoldOutError:
-        offers_api.edit_stock(stock, quantity=stock.dnBookedQuantity, editing_provider=stock.offer.lastProvider)
-        logger.info(
-            "Could not book offer: Event sold out",
-            extra={"offer_id": stock.offer.id, "provider_id": stock.offer.lastProviderId},
-        )
         raise ApiErrors({"code": "PROVIDER_STOCK_SOLD_OUT"})
-    except external_bookings_exceptions.ExternalBookingNotEnoughSeatsError as error:
-        offers_api.edit_stock(
-            stock,
-            quantity=(stock.dnBookedQuantity + error.remainingQuantity),
-            editing_provider=stock.offer.lastProvider,
-        )
-        logger.info(
-            "Could not book offer: Event has not enough seats left",
-            extra={"offer_id": stock.offer.id, "provider_id": stock.offer.lastProviderId},
-        )
+    except external_bookings_exceptions.ExternalBookingNotEnoughSeatsError:
         raise ApiErrors({"code": "PROVIDER_STOCK_NOT_ENOUGH_SEATS"})
     return BookOfferResponse(bookingId=booking.id)
 


### PR DESCRIPTION
The route called `edit_stock()` upon failure with external tickets,
but changes were not committed. The route could perform the commit,
but it seems more future-proof to call `edit_stock()` (and commit) in
`book_offer()` itself, because calling `edit_stock()` should be the
responsability of `book_offer()`, not its callers.