### PR TITLE
(PC-26083)[PRO] feat: Make booking table thead icons visible without …

### DIFF
--- a/pro/src/components/StocksEventList/SortArrow.tsx
+++ b/pro/src/components/StocksEventList/SortArrow.tsx
@@ -19,25 +19,38 @@ export const SortArrow = ({
   onClick,
   children,
 }: SortArrowProps) => (
-  <button type="button" className={styles['sorting-icons']} onClick={onClick}>
+  <button
+    type="button"
+    className={styles['sorting-icons']}
+    onClick={onClick}
+    title={
+      sortingMode === SortingMode.NONE
+        ? 'Trier'
+        : sortingMode === SortingMode.DESC
+          ? 'Ne plus trier'
+          : 'Trier par ordre décroissant'
+    }
+  >
     {sortingMode !== SortingMode.NONE ? (
       sortingMode === SortingMode.DESC ? (
         <SvgIcon
           className={styles['sort-icon']}
           src={fullUpIcon}
           alt="Ne plus trier"
+          width="10"
         />
       ) : (
         <SvgIcon
           className={styles['sort-icon']}
           src={fullDownIcon}
           alt="Trier par ordre décroissant"
+          width="10"
         />
       )
     ) : (
       <span className={cn(styles['sort-icon'], styles['both-icons'])}>
-        <SvgIcon src={fullUpIcon} alt="Trier par ordre croissant" />
-        <SvgIcon src={fullDownIcon} alt="" />
+        <SvgIcon src={fullUpIcon} alt="Trier par ordre croissant" width="10" />
+        <SvgIcon src={fullDownIcon} alt="" width="10" />
       </span>
     )}
     {children}


### PR DESCRIPTION
…css.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26083

**Objectif**
Quand on désactive le css dans la page des réservations, on veut que les icons de tri du tableau soient visibles. Au passage ajout d'un attribut `title` pour expliciter l'effet de ces boutons.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques