### PR TITLE
[do not merge] (PC-28434)[EAC] script: fill missing formats from subcategories

### DIFF
--- a/api/src/pcapi/scripts/educational/fill_missing_formats_from_subcategories.py
+++ b/api/src/pcapi/scripts/educational/fill_missing_formats_from_subcategories.py
@@ -1,0 +1,55 @@
+import typing
+
+import sqlalchemy as sa
+
+from pcapi.core.educational.models import CollectiveOffer
+from pcapi.models import db
+
+
+def fetch_collective_offers() -> typing.Sequence[CollectiveOffer]:
+    query = CollectiveOffer.query.filter(
+        sa.and_(
+            sa.or_(sa.func.cardinality(CollectiveOffer.formats) == 0, CollectiveOffer.formats == None),
+            CollectiveOffer.subcategoryId != None,
+        )
+    ).options(sa.orm.load_only(CollectiveOffer.id, CollectiveOffer.formats, CollectiveOffer.subcategoryId))
+
+    return query.all()
+
+
+def set_formats(offers: typing.Sequence[CollectiveOffer]) -> None:
+    for offer in offers:
+        offer.formats = offer.get_formats()
+        db.session.add(offer)
+
+
+def run(dry_run: bool = False, out_path: str | None = None) -> typing.Collection[int]:
+    offers = fetch_collective_offers()
+
+    try:
+        set_formats(offers)
+    except Exception:
+        db.session.rollback()
+        raise
+
+    try:
+        if not dry_run:
+            db.session.commit()
+        else:
+            db.session.rollback()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    print(f"{len(offers)} offers updated (dry_run: {dry_run})")
+
+    ids = {offer.id for offer in offers}
+    if out_path:
+        try:
+            with open(out_path, encoding="utf-8", mode="w") as f:
+                f.write(",".join({str(x) for x in ids}))
+        except Exception:
+            print(ids)
+            raise
+
+    return ids

--- a/api/tests/scripts/educational/test_fill_missing_formats_from_subcategories.py
+++ b/api/tests/scripts/educational/test_fill_missing_formats_from_subcategories.py
@@ -1,0 +1,89 @@
+import os
+
+import pytest
+
+from pcapi.core.categories.subcategories_v2 import EVENEMENT_CINE
+from pcapi.core.categories.subcategories_v2 import EacFormat
+from pcapi.core.categories.subcategories_v2 import SEANCE_CINE
+from pcapi.core.educational.factories import CollectiveOfferFactory
+from pcapi.models import db
+from pcapi.scripts.educational.fill_missing_formats_from_subcategories import run
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def test_run_one_offer(tmp_path) -> None:
+    out_path = tmp_path / "offer.ids"
+    offer = CollectiveOfferFactory(formats=None, subcategoryId=SEANCE_CINE.id)
+
+    ids = run(out_path=out_path)
+    assert ids == {offer.id}
+
+    db.session.refresh(offer)
+    assert offer.formats == SEANCE_CINE.formats
+    assert out_path.read_text() == f"{offer.id}"
+
+
+def test_run_update_many_ignore_many(tmp_path) -> None:
+    out_path = tmp_path / "offer.ids"
+
+    offer1 = CollectiveOfferFactory(formats=None, subcategoryId=SEANCE_CINE.id)
+    offer2 = CollectiveOfferFactory(formats=None, subcategoryId=EVENEMENT_CINE.id)
+
+    ignored = CollectiveOfferFactory.create_batch(2, formats=[EacFormat.CONCERT])
+
+    ids = run(out_path=out_path)
+    assert ids == {offer1.id, offer2.id}
+
+    db.session.refresh(offer1)
+    db.session.refresh(offer2)
+    assert offer1.formats == SEANCE_CINE.formats
+    assert offer1.formats == EVENEMENT_CINE.formats
+
+    content = out_path.read_text()
+    assert not any(str(offer.id) in content for offer in ignored)
+
+
+def test_run_no_offer_to_update(tmp_path) -> None:
+    out_path = tmp_path / "offer.ids"
+    offer = CollectiveOfferFactory(formats=SEANCE_CINE.formats, subcategoryId=SEANCE_CINE.id)
+
+    ids = run(out_path=out_path)
+    assert ids == set()
+
+    db.session.refresh(offer)
+    assert offer.formats == SEANCE_CINE.formats
+    assert out_path.read_text() == ""
+
+
+def test_run_no_offer_at_all(tmp_path) -> None:
+    out_path = tmp_path / "offer.ids"
+
+    ids = run(out_path=out_path)
+    assert ids == set()
+    assert out_path.read_text() == ""
+
+
+def test_run_dry_run_enabled(tmp_path) -> None:
+    out_path = tmp_path / "offer.ids"
+    offer = CollectiveOfferFactory(formats=None, subcategoryId=SEANCE_CINE.id)
+
+    ids = run(dry_run=True, out_path=out_path)
+    assert ids == {offer.id}
+
+    db.session.refresh(offer)
+    assert offer.formats is None
+    assert out_path.read_text() == f"{offer.id}"
+
+
+def test_run_no_output_path(tmp_path) -> None:
+    out_path = tmp_path / "offer.ids"
+    offer = CollectiveOfferFactory(formats=None, subcategoryId=SEANCE_CINE.id)
+
+    ids = run(out_path=None)
+    assert ids == {offer.id}
+
+    db.session.refresh(offer)
+    assert offer.formats == SEANCE_CINE.formats
+    assert not os.path.exists(out_path)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28434

Script dont le but est de renseigner les formats d'offres collectives qui n'en ont pas (les offres vitrines ne sont pas concernées par ce problème).
