### PR TITLE
(PC-28465) [PRO] test : unsuccessful sign in for wrong password

### DIFF
--- a/pro/cypress/e2e/signIn/unsuccessfulSignInForWrongPasswordTest.cy.ts
+++ b/pro/cypress/e2e/signIn/unsuccessfulSignInForWrongPasswordTest.cy.ts
@@ -12,11 +12,11 @@ describe('signin page', () => {
 
     cy.get(CONSTANTS.emailErrorId)
       .should('be.visible')
-      .should('have.text', 'Identifiant ou mot de passe incorrect.')
+      .should('have.text', CONSTANTS.incorrectUsernameOrPasswordText)
 
     cy.get(CONSTANTS.passwordErrorId)
       .should('be.visible')
-      .should('have.text', 'Identifiant ou mot de passe incorrect.')
+      .should('have.text', CONSTANTS.incorrectUsernameOrPasswordText)
 
     cy.contains(CONSTANTS.signInButton).should('be.disabled')
 

--- a/pro/cypress/e2e/signIn/unsuccessfulSignInForWrongPasswordTest.cy.ts
+++ b/pro/cypress/e2e/signIn/unsuccessfulSignInForWrongPasswordTest.cy.ts
@@ -1,0 +1,25 @@
+import { CONSTANTS } from '../../support/constants'
+
+describe('signin page', () => {
+  it('verify unsuccessful signin for wrong password', () => {
+    cy.visit(CONSTANTS.signIn)
+
+    cy.get(CONSTANTS.emailId).type(CONSTANTS.emailProAccount)
+
+    cy.get(CONSTANTS.passwordId).type(CONSTANTS.passwordTestData)
+
+    cy.get('button[type=submit]').click()
+
+    cy.get(CONSTANTS.emailErrorId)
+      .should('be.visible')
+      .should('have.text', 'Identifiant ou mot de passe incorrect.')
+
+    cy.get(CONSTANTS.passwordErrorId)
+      .should('be.visible')
+      .should('have.text', 'Identifiant ou mot de passe incorrect.')
+
+    cy.contains(CONSTANTS.signInButton).should('be.disabled')
+
+    cy.url().should('include', CONSTANTS.signIn)
+  })
+})

--- a/pro/cypress/support/constants.ts
+++ b/pro/cypress/support/constants.ts
@@ -19,6 +19,7 @@ export const CONSTANTS = {
   cookieManagementWindow: 'Gestion des cookies',
   emailErrorId: '#error-details-email',
   passwordErrorId: '#error-details-password',
+  incorrectUsernameOrPasswordText: 'Identifiant ou mot de passe incorrect.',
   emailTestData: Date.now().toString() + '@passculture.app',
   passwordTestData: Date.now().toString(),
   emailProAccount: 'pro_adage_eligible@example.com',

--- a/pro/cypress/support/constants.ts
+++ b/pro/cypress/support/constants.ts
@@ -21,6 +21,7 @@ export const CONSTANTS = {
   passwordErrorId: '#error-details-password',
   emailTestData: Date.now().toString() + '@passculture.app',
   passwordTestData: Date.now().toString(),
+  emailProAccount: 'pro_adage_eligible@example.com',
   // inscription page //
   iAlreadyHaveAnAccountButton: 'J’ai déjà un compte',
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28465

## Vérifications
unsuccessful sign in for wrong password (Connexion impossible en cas de mot de passe erroné)


- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques