### PR TITLE
(PC-28459)[API] chore: validate contraint for collective offer

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 ccd86b897e7a (pre) (head)
-4df45e259f14 (post) (head)
+25c43258caab (post) (head)

--- a/api/src/pcapi/alembic/versions/20240311T142757_25c43258caab_validate_contact_request_form_switch_constraint.py
+++ b/api/src/pcapi/alembic/versions/20240311T142757_25c43258caab_validate_contact_request_form_switch_constraint.py
@@ -1,0 +1,23 @@
+"""Validate contact_request_form_switch constraint
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "25c43258caab"
+down_revision = "4df45e259f14"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            'ALTER TABLE "collective_offer_template" VALIDATE CONSTRAINT "collective_offer_tmpl_contact_request_form_switch_constraint"'
+        )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Validates the constraint on the choice between contact form and contact url on collective offer templates.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28459

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques