### PR TITLE
(PC-28486)[API] fix: reactivate updated offers

### DIFF
--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -277,7 +277,8 @@ def synchronize_stocks(
         offers_by_venue_reference = offers_repository.get_offers_map_by_venue_reference(products_references, venue.id)
 
     offers_update_mapping = [
-        {"id": offer_id, "lastProviderId": provider_id} for offer_id in offers_by_provider_reference.values()
+        {"id": offer_id, "lastProviderId": provider_id, "isActive": True}
+        for offer_id in offers_by_provider_reference.values()
     ]
     db.session.bulk_update_mappings(offers_models.Offer, offers_update_mapping)
 

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -94,8 +94,8 @@ def create_product(ean, **kwargs):
     )
 
 
-def create_offer(ean, venue: offerers_models.Venue):
-    return offers_factories.OfferFactory(product=create_product(ean), idAtProvider=ean, venue=venue)
+def create_offer(ean, venue: offerers_models.Venue, is_active=True):
+    return offers_factories.OfferFactory(product=create_product(ean), idAtProvider=ean, venue=venue, isActive=is_active)
 
 
 def create_stock(ean, siret, venue: offerers_models.Venue, **kwargs):
@@ -154,7 +154,7 @@ class SynchronizeStocksTest:
         )
         offer = create_offer(spec[1]["ref"], venue)
         product = create_product(spec[2]["ref"])
-        create_product(spec[4]["ref"])
+        offer_to_reactivate = create_offer(spec[4]["ref"], venue, is_active=False)
         create_product(spec[6]["ref"], isGcuCompatible=False)
         create_product(spec[7]["ref"], name=offers_models.UNRELEASED_OR_UNAVAILABLE_BOOK_MARKER)
 
@@ -233,6 +233,8 @@ class SynchronizeStocksTest:
             reason=search.IndexationReason.STOCK_SYNCHRONIZATION,
             log_extra={"provider_id": provider.id},
         )
+
+        assert offer_to_reactivate.isActive is True
 
     def test_build_new_offers_from_stock_details(self, db_session):
         # Given


### PR DESCRIPTION
Synchronized offers are deactivated when deleting or pausing a sync (deleteing a venueProvider or setting isActive to false) and we use to not reactivate them during legacy synchronisation.
