### PR TITLE
(PC-28299)[PRO] feat: add tracker for custom form url in adage

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.tsx
@@ -80,6 +80,14 @@ const NewRequestFormDialog = ({
     validationSchema: validationSchema,
   })
 
+  const logContactUrl = () => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    apiAdage.logContactUrlClick({
+      iframeFrom: location.pathname,
+      offerId: offerId,
+    })
+  }
+
   const getDescriptionElement = () => {
     if (contactEmail && !contactPhone && !contactUrl && !contactForm) {
       return renderContactElement('par mail', contactEmail)
@@ -147,6 +155,7 @@ const NewRequestFormDialog = ({
             <div className={styles['form-description-link']}>
               <i>via</i> son site :
               <ButtonLink
+                onClick={logContactUrl}
                 variant={ButtonVariant.TERNARYPINK}
                 className={styles['form-description-link-text']}
                 link={{
@@ -195,6 +204,7 @@ const NewRequestFormDialog = ({
         Il vous propose de le faire <i>via</i> son site :
       </div>
       <ButtonLink
+        onClick={logContactUrl}
         variant={ButtonVariant.TERNARYPINK}
         className={styles['form-description-link-text']}
         link={{

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/NewRequestFormDialog.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/NewRequestFormDialog.spec.tsx
@@ -35,6 +35,7 @@ vi.mock('apiClient/api', () => ({
   apiAdage: {
     createCollectiveRequest: vi.fn(),
     logRequestFormPopinDismiss: vi.fn(),
+    logContactUrlClick: vi.fn(),
   },
 }))
 
@@ -275,6 +276,24 @@ describe('NewRequestFormDialog', () => {
       requestedDate: undefined,
       totalStudents: undefined,
       totalTeachers: undefined,
+    })
+  })
+
+  it('should log event when user click on custom link form', async () => {
+    renderNewRequestFormDialog({
+      contactEmail: '',
+      contactPhone: '',
+      contactForm: '',
+      contactUrl: 'https://example.com',
+    })
+
+    const buttonLink = screen.getByText('Aller sur le site')
+
+    await userEvent.click(buttonLink)
+
+    expect(apiAdage.logContactUrlClick).toHaveBeenCalledWith({
+      iframeFrom: '/',
+      offerId: 1,
     })
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28299

Ajout d'un tracker pour savoir si l'enseignant ouvre le lien de formulaire custom de l'AC

## Vérifications

- [x] J'ai écrit les tests nécessaires