### PR TITLE
Pc 28176 enable side nav if user has new nav date

### DIFF
--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -131,6 +131,16 @@ class LoginUserBodyModel(BaseModel):
         alias_generator = to_camel
 
 
+class NavStateResponseModel(BaseModel):
+    newNavDate: datetime | None
+    eligibilityDate: datetime | None
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+        orm_mode = True
+
+
 class SharedLoginUserResponseModel(BaseModel):
     activity: str | None
     address: str | None
@@ -155,6 +165,7 @@ class SharedLoginUserResponseModel(BaseModel):
     phoneNumber: str | None
     postalCode: str | None
     roles: list[users_models.UserRole]
+    navState: NavStateResponseModel | None
 
     class Config:
         json_encoders = {datetime: format_into_utc_date}
@@ -168,6 +179,7 @@ class SharedLoginUserResponseModel(BaseModel):
     def from_orm(cls, user: users_models.User) -> "SharedLoginUserResponseModel":
         user.isAdmin = user.has_admin_role
         user.hasUserOfferer = user.has_user_offerer
+        user.navState = NavStateResponseModel.from_orm(user.pro_new_nav_state)
         result = super().from_orm(user)
         return result
 
@@ -198,6 +210,7 @@ class SharedCurrentUserResponseModel(BaseModel):
     phoneValidationStatus: users_models.PhoneValidationStatusType | None
     postalCode: str | None
     roles: list[users_models.UserRole]
+    navState: NavStateResponseModel | None
 
     class Config:
         json_encoders = {datetime: format_into_utc_date}
@@ -208,6 +221,7 @@ class SharedCurrentUserResponseModel(BaseModel):
     def from_orm(cls, user: users_models.User) -> "SharedCurrentUserResponseModel":
         user.isAdmin = user.has_admin_role
         user.hasUserOfferer = user.has_user_offerer
+        user.navState = NavStateResponseModel.from_orm(user.pro_new_nav_state)
         result = super().from_orm(user)
         return result
 

--- a/api/tests/routes/pro/get_user_profile_test.py
+++ b/api/tests/routes/pro/get_user_profile_test.py
@@ -56,6 +56,7 @@ class Returns200Test:
             "phoneValidationStatus": None,
             "postalCode": None,
             "roles": ["BENEFICIARY"],
+            "navState": {"eligibilityDate": None, "newNavDate": None},
         }
 
 

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -157,6 +157,7 @@ export type { LoginUserBodyModel } from './models/LoginUserBodyModel';
 export type { ManagedVenues } from './models/ManagedVenues';
 export type { MusicTypeResponse } from './models/MusicTypeResponse';
 export type { NationalProgramModel } from './models/NationalProgramModel';
+export type { NavStateResponseModel } from './models/NavStateResponseModel';
 export type { NewPasswordBodyModel } from './models/NewPasswordBodyModel';
 export { OfferAddressType } from './models/OfferAddressType';
 export { OfferContactFormEnum } from './models/OfferContactFormEnum';

--- a/pro/src/apiClient/v1/models/NavStateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/NavStateResponseModel.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type NavStateResponseModel = {
+  eligibilityDate?: string | null;
+  newNavDate?: string | null;
+};
+

--- a/pro/src/apiClient/v1/models/SharedCurrentUserResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SharedCurrentUserResponseModel.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { GenderEnum } from './GenderEnum';
+import type { NavStateResponseModel } from './NavStateResponseModel';
 import type { PhoneValidationStatusType } from './PhoneValidationStatusType';
 import type { UserRole } from './UserRole';
 export type SharedCurrentUserResponseModel = {
@@ -25,6 +26,7 @@ export type SharedCurrentUserResponseModel = {
   isEmailValidated: boolean;
   lastConnectionDate?: string | null;
   lastName?: string | null;
+  navState?: NavStateResponseModel | null;
   needsToFillCulturalSurvey?: boolean | null;
   notificationSubscriptions?: Record<string, any> | null;
   phoneNumber?: string | null;

--- a/pro/src/apiClient/v1/models/SharedLoginUserResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SharedLoginUserResponseModel.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { GenderEnum } from './GenderEnum';
+import type { NavStateResponseModel } from './NavStateResponseModel';
 import type { UserRole } from './UserRole';
 export type SharedLoginUserResponseModel = {
   activity?: string | null;
@@ -22,6 +23,7 @@ export type SharedLoginUserResponseModel = {
   isEmailValidated: boolean;
   lastConnectionDate?: string | null;
   lastName?: string | null;
+  navState?: NavStateResponseModel | null;
   needsToFillCulturalSurvey?: boolean | null;
   phoneNumber?: string | null;
   postalCode?: string | null;

--- a/pro/src/app/AppLayout.tsx
+++ b/pro/src/app/AppLayout.tsx
@@ -6,7 +6,7 @@ import Footer from 'components/Footer/Footer'
 import Header from 'components/Header/Header'
 import SideNavLinks from 'components/SideNavLinks/SideNavLinks'
 import SkipLinks from 'components/SkipLinks'
-import useActiveFeature from 'hooks/useActiveFeature'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import logoPassCultureProIcon from 'icons/logo-pass-culture-pro.svg'
 import strokeCloseIcon from 'icons/stroke-close.svg'
 import { Button } from 'ui-kit'
@@ -28,7 +28,7 @@ export const AppLayout = ({
   pageName = 'Accueil',
   layout = 'basic',
 }: AppLayoutProps) => {
-  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+  const isNewSideBarNavigation = useIsNewInterfaceActive()
   const [lateralPanelOpen, setLateralPanelOpen] = useState(false)
 
   const openButtonRef = useRef<HTMLButtonElement>(null)

--- a/pro/src/app/__specs__/AppLayout.spec.tsx
+++ b/pro/src/app/__specs__/AppLayout.spec.tsx
@@ -57,6 +57,9 @@ describe('src | AppLayout', () => {
   describe('side navigation', () => {
     it('should render the new header when the WIP_ENABLE_PRO_SIDE_NAV is active', () => {
       options.features = ['WIP_ENABLE_PRO_SIDE_NAV']
+      options.storeOverrides.user.currentUser.navState = {
+        newNavDate: '2021-01-01',
+      }
       renderApp(props, options)
 
       expect(screen.getByText('Se déconnecter')).toBeInTheDocument()
@@ -66,6 +69,9 @@ describe('src | AppLayout', () => {
     describe('on smaller screen sizes', () => {
       beforeEach(() => {
         options.features = ['WIP_ENABLE_PRO_SIDE_NAV']
+        options.storeOverrides.user.currentUser.navState = {
+          newNavDate: '2021-01-01',
+        }
         renderApp(props, options)
 
         global.innerWidth = 500

--- a/pro/src/components/Footer/Footer.tsx
+++ b/pro/src/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 
-import useActiveFeature from 'hooks/useActiveFeature'
 import useCurrentUser from 'hooks/useCurrentUser'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { initCookieConsent } from 'utils/cookieConsentModal'
@@ -12,9 +12,9 @@ type FooterProps = {
   layout?: 'basic' | 'funnel' | 'without-nav' | 'sticky-actions'
 }
 export default function Footer({ layout }: FooterProps) {
-  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
-
   const { currentUser } = useCurrentUser()
+  const isNewSideBarNavigation = useIsNewInterfaceActive()
+
   if (!isNewSideBarNavigation) {
     return
   }

--- a/pro/src/components/Footer/__specs__/Footer.spec.tsx
+++ b/pro/src/components/Footer/__specs__/Footer.spec.tsx
@@ -9,7 +9,8 @@ import Footer from '../Footer'
 
 const renderFooter = (
   isConnected: boolean = true,
-  options?: RenderWithProvidersOptions
+  options?: RenderWithProvidersOptions,
+  hasNewNav: boolean = false
 ) => {
   const storeOverrides = {
     user: {
@@ -17,6 +18,9 @@ const renderFooter = (
         ? {
             isAdmin: false,
             hasSeenProTutorials: true,
+            navState: {
+              newNavDate: hasNewNav ? '2021-01-01' : null,
+            },
           }
         : null,
       initialized: true,
@@ -30,9 +34,13 @@ const renderFooter = (
 
 describe('Footer', () => {
   it('should  render footer if ff is active', () => {
-    renderFooter(true, {
-      features: ['WIP_ENABLE_PRO_SIDE_NAV'],
-    })
+    renderFooter(
+      true,
+      {
+        features: ['WIP_ENABLE_PRO_SIDE_NAV'],
+      },
+      true
+    )
 
     expect(
       screen.queryByRole('link', { name: 'CGU professionnels' })

--- a/pro/src/components/Header/Header.tsx
+++ b/pro/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import { NavLink, useLocation } from 'react-router-dom'
 import { Events } from 'core/FirebaseEvents/constants'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import fullBurgerIcon from 'icons/full-burger.svg'
 import fullLogoutIcon from 'icons/full-logout.svg'
 import logoPassCultureProIcon from 'icons/logo-pass-culture-pro.svg'
@@ -42,7 +43,7 @@ const Header = forwardRef(
     const { logEvent } = useAnalytics()
     const location = useLocation()
     const isOffererStatsActive = useActiveFeature('ENABLE_OFFERER_STATS')
-    const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+    const isNewSideBarNavigation = useIsNewInterfaceActive()
 
     if (isNewSideBarNavigation && isTopMenuVisible) {
       return (

--- a/pro/src/hooks/__specs__/useIsNewInterfaceActive.spec.tsx
+++ b/pro/src/hooks/__specs__/useIsNewInterfaceActive.spec.tsx
@@ -1,0 +1,96 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
+import {
+  RenderWithProvidersOptions,
+  renderWithProviders,
+} from 'utils/renderWithProviders'
+
+const TestComponent = () => {
+  const isSideNavActive = useIsNewInterfaceActive()
+
+  return <div>{isSideNavActive ? 'Active' : 'Inactive'}</div>
+}
+
+const defaultOptions: RenderWithProvidersOptions = {
+  storeOverrides: {
+    user: { currentUser: { isAdmin: false } },
+  },
+  features: [],
+}
+
+const renderUseIsNewInterfaceActive = (
+  options: RenderWithProvidersOptions = defaultOptions
+) => {
+  return renderWithProviders(<TestComponent />, { ...options })
+}
+
+describe('useIsNewInterfaceActive', () => {
+  it('should return true if the feature is active and user has new nav date', () => {
+    const options = {
+      features: ['WIP_ENABLE_PRO_SIDE_NAV'],
+      storeOverrides: {
+        user: {
+          currentUser: {
+            isAdmin: false,
+            navState: {
+              newNavDate: '2021-01-01',
+            },
+          },
+        },
+      },
+    }
+    renderUseIsNewInterfaceActive(options)
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('should return false if user is not connected', () => {
+    const options = {
+      features: ['WIP_ENABLE_PRO_SIDE_NAV'],
+      storeOverrides: {
+        user: {
+          currentUser: null,
+        },
+      },
+    }
+    renderUseIsNewInterfaceActive(options)
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+
+  it('should return false if the feature is inactive', () => {
+    const options = {
+      features: [],
+      storeOverrides: {
+        user: {
+          currentUser: {
+            isAdmin: false,
+            navState: {
+              newNavDate: '2021-01-01',
+            },
+          },
+        },
+      },
+    }
+    renderUseIsNewInterfaceActive(options)
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+
+  it('should return false if user connected but as no new nav date', () => {
+    const options = {
+      features: ['WIP_ENABLE_PRO_SIDE_NAV'],
+      storeOverrides: {
+        user: {
+          currentUser: {
+            isAdmin: false,
+            navState: {
+              newNavDate: null,
+            },
+          },
+        },
+      },
+    }
+    renderUseIsNewInterfaceActive(options)
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+})

--- a/pro/src/hooks/useIsNewInterfaceActive.tsx
+++ b/pro/src/hooks/useIsNewInterfaceActive.tsx
@@ -1,0 +1,11 @@
+import useActiveFeature from './useActiveFeature'
+import useCurrentUser from './useCurrentUser'
+
+const useIsNewInterfaceActive = (): boolean => {
+  const { currentUser } = useCurrentUser()
+  const isNewNavActive = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+
+  return isNewNavActive && Boolean(currentUser?.navState?.newNavDate)
+}
+
+export default useIsNewInterfaceActive

--- a/pro/src/pages/CookiesFooter/CookiesFooter.tsx
+++ b/pro/src/pages/CookiesFooter/CookiesFooter.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames'
 import React from 'react'
 
-import useActiveFeature from 'hooks/useActiveFeature'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import { Button } from 'ui-kit'
 import ButtonLink from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -10,7 +10,7 @@ import { initCookieConsent } from 'utils/cookieConsentModal'
 import styles from './CookiesFooter.module.scss'
 
 const CookiesFooter = ({ className }: { className?: string }) => {
-  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+  const isNewSideBarNavigation = useIsNewInterfaceActive()
 
   if (isNewSideBarNavigation) {
     return

--- a/pro/src/pages/Home/ProfileAndSupport/Support.tsx
+++ b/pro/src/pages/Home/ProfileAndSupport/Support.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { Events } from 'core/FirebaseEvents/constants'
-import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import fullLinkIcon from 'icons/full-link.svg'
 import fullMailIcon from 'icons/full-mail.svg'
 import fullParametersIcon from 'icons/full-parameters.svg'
@@ -18,7 +18,7 @@ import styles from './Support.module.scss'
 export const Support: () => JSX.Element | null = () => {
   const { logEvent } = useAnalytics()
   const location = useLocation()
-  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+  const isNewSideBarNavigation = useIsNewInterfaceActive()
 
   return (
     <Card>

--- a/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
@@ -7,8 +7,8 @@ import {
   GetOffererResponseModel,
   GetOffererStatsResponseModel,
 } from 'apiClient/v1'
-import useActiveFeature from 'hooks/useActiveFeature'
 import useCurrentUser from 'hooks/useCurrentUser'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import fullMoreIcon from 'icons/full-more.svg'
 import strokeNoBookingIcon from 'icons/stroke-no-booking.svg'
 import { ButtonLink } from 'ui-kit/Button'
@@ -33,7 +33,7 @@ export const StatisticsDashboard = ({ offerer }: StatisticsDashboardProps) => {
 
   const { currentUser } = useCurrentUser()
 
-  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+  const isNewSideBarNavigation = useIsNewInterfaceActive()
 
   const displayCreateOfferButton =
     (isNewSideBarNavigation && currentUser.isAdmin) || !isNewSideBarNavigation

--- a/pro/src/pages/Home/StatisticsDashboard/__specs__/StatisticsDashboard.spec.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/__specs__/StatisticsDashboard.spec.tsx
@@ -17,7 +17,8 @@ vi.mock('apiClient/api', () => ({
 const renderStatisticsDashboard = (
   hasActiveOffer = true,
   features: string[] = [],
-  isAdmin = false
+  isAdmin = false,
+  hasNewNav = false
 ) =>
   renderWithProviders(
     <StatisticsDashboard
@@ -33,6 +34,9 @@ const renderStatisticsDashboard = (
           currentUser: {
             id: 12,
             isAdmin,
+            navState: {
+              newNavDate: hasNewNav ? '2021-01-01' : null,
+            },
           },
         },
       },
@@ -139,7 +143,7 @@ describe('StatisticsDashboard', () => {
   })
 
   it("should not display the create offer button with the WIP_ENABLE_PRO_SIDE_NAV FF enabled and the user isn't Admin", () => {
-    renderStatisticsDashboard(false, ['WIP_ENABLE_PRO_SIDE_NAV'], false)
+    renderStatisticsDashboard(false, ['WIP_ENABLE_PRO_SIDE_NAV'], false, true)
 
     expect(screen.queryByText(/Créer une offre/)).not.toBeInTheDocument()
   })

--- a/pro/src/screens/Bookings/Bookings.tsx
+++ b/pro/src/screens/Bookings/Bookings.tsx
@@ -20,9 +20,9 @@ import {
 import { Events } from 'core/FirebaseEvents/constants'
 import { Audience } from 'core/shared/types'
 import { SelectOption } from 'custom_types/form'
-import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
 import useCurrentUser from 'hooks/useCurrentUser'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import useNotification from 'hooks/useNotification'
 import strokeLibraryIcon from 'icons/stroke-library.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
@@ -78,7 +78,7 @@ const Bookings = <
   const [urlParams, setUrlParams] =
     useState<PreFiltersParams>(DEFAULT_PRE_FILTERS)
 
-  const isNewSideNavActive = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+  const isNewSideNavActive = useIsNewInterfaceActive()
 
   const resetPreFilters = useCallback(() => {
     setWereBookingsRequested(false)

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -23,7 +23,7 @@ import {
 import { Audience } from 'core/shared'
 import getUserValidatedOfferersNamesAdapter from 'core/shared/adapters/getUserValidatedOfferersNamesAdapter'
 import { SelectOption } from 'custom_types/form'
-import useActiveFeature from 'hooks/useActiveFeature'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import fullPlusIcon from 'icons/full-plus.svg'
 import strokeLibraryIcon from 'icons/stroke-library.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
@@ -81,8 +81,7 @@ const Offers = ({
 
   const [areAllOffersSelected, setAreAllOffersSelected] = useState(false)
   const [selectedOfferIds, setSelectedOfferIds] = useState<string[]>([])
-
-  const isNewSideBarNavigation = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+  const isNewSideBarNavigation = useIsNewInterfaceActive()
 
   const { isAdmin } = currentUser
   const currentPageOffersSubset = offers.slice(

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -38,9 +38,23 @@ import Offers, { OffersProps } from '../Offers'
 
 const renderOffers = (
   props: OffersProps,
-  options?: RenderWithProvidersOptions
+  options?: RenderWithProvidersOptions,
+  hasNewNav: boolean = false
 ) => {
-  renderWithProviders(<Offers {...props} />, options)
+  renderWithProviders(<Offers {...props} />, {
+    storeOverrides: {
+      user: {
+        currentUser: {
+          id: 12,
+          isAdmin: false,
+          navState: {
+            newNavDate: hasNewNav ? '2021-01-01' : null,
+          },
+        },
+      },
+    },
+    ...options,
+  })
 }
 
 const categoriesAndSubcategories = {
@@ -744,9 +758,13 @@ describe('screen Offers', () => {
       offerersNames: [getOffererNameFactory()],
     })
 
-    renderOffers(props, {
-      features: ['WIP_ENABLE_PRO_SIDE_NAV'],
-    })
+    renderOffers(
+      props,
+      {
+        features: ['WIP_ENABLE_PRO_SIDE_NAV'],
+      },
+      true
+    )
     await waitFor(() => {
       expect(api.listOfferersNames).toHaveBeenCalledTimes(1)
     })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28176

Afficher la nouvelle navigation pour les utilisateurs qui ont le champs `newNavDate` valorisé

**Stratégie :** 

- Retourner l'information navState dans la sérialisation des routes signin et get_profile
- Changer la condition d'affichage de la nouvelle nav

