### PR TITLE
(PC-28475)[API] fix: Don't join on BankAccountStatusHistory

### DIFF
--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -465,7 +465,7 @@ class ImportBankAccountMixin:
         bank_account = (
             finance_models.BankAccount.query.filter_by(dsApplicationId=self.application_details.application_id)
             .options(sqla_orm.load_only(finance_models.BankAccount.id))
-            .join(
+            .outerjoin(
                 finance_models.BankAccountStatusHistory,
                 sqla.and_(
                     finance_models.BankAccountStatusHistory.bankAccountId == finance_models.BankAccount.id,


### PR DESCRIPTION
Legacy bankInformation that were turned into bankAccount doesn't have
BankAccountStatusHistory. Therefore, when we try to update the bankAccount
on a DS application change, we can't find it because of `join()` on BankAccountStatusHistory
and we try to create it (`api/src/pcapi/use_cases/save_venue_bank_informations.py +491`)
Which is fail because there is a unique constraint on the dsApplicationId field.

Hence this fix

Fix this [issue](https://sentry.passculture.team/organizations/sentry/issues/1510164/)

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28475

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques