### PR TITLE
(PC-27026)[API] feat: switch api request to new widget route

### DIFF
--- a/api/src/pcapi/connectors/acceslibre.py
+++ b/api/src/pcapi/connectors/acceslibre.py
@@ -332,6 +332,7 @@ class AcceslibreBackend(BaseBackend):
     def _send_request_with_slug(
         self,
         slug: str,
+        request_widget_infos: bool | None = False,
     ) -> dict:
         """
         Acceslibre has a specific GET route /api/erps/{slug} that
@@ -340,6 +341,8 @@ class AcceslibreBackend(BaseBackend):
         """
         api_key = settings.ACCESLIBRE_API_KEY
         url = settings.ACCESLIBRE_API_URL + slug
+        if request_widget_infos:
+            url += "/widget"
         headers = {"Authorization": f"Api-Key {api_key}"}
         try:
             response = requests.get(url, headers=headers, timeout=ACCESLIBRE_REQUEST_TIMEOUT)
@@ -423,5 +426,5 @@ class AcceslibreBackend(BaseBackend):
         return created_at
 
     def get_accessibility_infos(self, slug: str) -> AccessibilityInfo:
-        accesslibre_data = self._send_request_with_slug(slug=slug)
+        accesslibre_data = self._send_request_with_slug(slug=slug, request_widget_infos=True)
         return acceslibre_to_accessibility_infos(accesslibre_data)

--- a/api/tests/connectors/acceslibre/acceslibre_test.py
+++ b/api/tests/connectors/acceslibre/acceslibre_test.py
@@ -76,7 +76,7 @@ class AcceslibreTest:
     def test_get_accessibility_infos_from_widget(self, requests_mock):
         slug = "mon-super-slug"
         requests_mock.get(
-            f"https://acceslibre.beta.gouv.fr/api/erps/{slug}",
+            f"https://acceslibre.beta.gouv.fr/api/erps/{slug}/widget",
             json=fixtures.ACCESLIBRE_WIDGET_RESULT,
         )
         accessibility_infos = acceslibre.get_accessibility_infos(slug)


### PR DESCRIPTION
## But de la pull request

Maintenant que la route /widget est en prod côté acceslibre, on switch la récupération d'infos sur cette route

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27026

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques