### PR TITLE
(BSR)[CI] fix: prepare-cache-master needs pcapi image to run

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -94,6 +94,7 @@ jobs:
 
   prepare-cache-master:
     name: "Reset cache on master on dependency update"
+    needs: build-api
     uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
     if: github.ref == 'refs/heads/master'
     with:


### PR DESCRIPTION
To be able to reset cache we need to run pcapi image (and avoid those [errors](https://github.com/pass-culture/pass-culture-main/actions/runs/8265737740/job/22612784940)) which is build during build-api