### PR TITLE
(PC-28517)[PRO] fix: Show contact form in template offer preview cont…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.tsx
@@ -182,36 +182,38 @@ const NewRequestFormDialog = ({
           </li>
         )}
 
-        {isDefaultForm && userRole === AdageFrontRoles.REDACTOR && (
-          <li>
-            en renseignant{' '}
-            <span className={styles['form-description-text-value']}>
-              le formulaire ci-dessous
-            </span>
-          </li>
-        )}
-      </ul>
-      {isDefaultForm && userRole === AdageFrontRoles.REDACTOR && (
-        <>
-          <hr />
-          <MandatoryInfo className={styles['form-mandatory']} />
-          {isPreview && (
-            <Callout
-              variant={CalloutVariant.DEFAULT}
-              className={styles['contact-callout']}
-            >
-              Vous ne pouvez pas envoyer de demande de contact car ceci est un
-              aperçu de test du formulaire que verront les enseignants une fois
-              l’offre publiée.
-            </Callout>
+        {isDefaultForm &&
+          (userRole === AdageFrontRoles.REDACTOR || isPreview) && (
+            <li>
+              en renseignant{' '}
+              <span className={styles['form-description-text-value']}>
+                le formulaire ci-dessous
+              </span>
+            </li>
           )}
-          <DefaultFormContact
-            closeRequestFormDialog={closeRequestFormDialog}
-            formik={formik}
-            isPreview={isPreview}
-          />
-        </>
-      )}
+      </ul>
+      {isDefaultForm &&
+        (userRole === AdageFrontRoles.REDACTOR || isPreview) && (
+          <>
+            <hr />
+            <MandatoryInfo className={styles['form-mandatory']} />
+            {isPreview && (
+              <Callout
+                variant={CalloutVariant.DEFAULT}
+                className={styles['contact-callout']}
+              >
+                Vous ne pouvez pas envoyer de demande de contact car ceci est un
+                aperçu de test du formulaire que verront les enseignants une
+                fois l’offre publiée.
+              </Callout>
+            )}
+            <DefaultFormContact
+              closeRequestFormDialog={closeRequestFormDialog}
+              formik={formik}
+              isPreview={isPreview}
+            />
+          </>
+        )}
     </div>
   )
 


### PR DESCRIPTION
…act dialog.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28517

**Objectif**
Quand on crée une offre vitrine, la nouvelle section Aperçu intègre le composant de l'offre d'Adage. Dans le cas où on a choisi plusieurs moyens de contact dont le formulaire pass culture, on doit aussi afficher le formulaire pass culture dans la pop-in au clic sur "Contacter le partenaire" de l'offre (mais avec le boutons de contact en disabled).

<img width="1090" alt="Capture d’écran 2024-03-14 à 14 29 28" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/bd157400-1f85-4024-ac84-3c699c06f142">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques