### PR TITLE
(PC-28250)[PRO] feat: preview edition

### DIFF
--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -218,6 +218,14 @@ const routes: RouteConfig[] = [
   },
   {
     lazy: () =>
+      import(
+        'pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition'
+      ),
+    path: '/offre/:offerId/collectif/preview',
+    title: 'Aperçu - Prévisualisation d’une offre collective vitrine',
+  },
+  {
+    lazy: () =>
       import('pages/CollectiveOfferStockEdition/CollectiveOfferStockEdition'),
     path: '/offre/:offerId/collectif/stocks/edition',
     title: 'Date et prix - Modifier une offre collective réservable',

--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
@@ -17,7 +17,7 @@
   }
 
   &-headings {
-    margin-bottom: rem.torem(32px);
+    margin-bottom: rem.torem(24px);
   }
 
   &-heading {

--- a/pro/src/pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.module.scss
+++ b/pro/src/pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.module.scss
@@ -1,0 +1,5 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.preview-info {
+    margin: rem.torem(32px) 0;
+}

--- a/pro/src/pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.tsx
@@ -1,0 +1,50 @@
+import { AppLayout } from 'app/AppLayout'
+import ActionsBarSticky from 'components/ActionsBarSticky'
+import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
+import AdagePreviewLayout from 'pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout'
+import {
+  MandatoryCollectiveOfferFromParamsProps,
+  withCollectiveOfferFromParams,
+} from 'screens/OfferEducational/useCollectiveOfferFromParams'
+import { ButtonLink } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
+
+import styles from './CollectiveOfferPreviewEdition.module.scss'
+
+export const CollectiveOfferPreviewEdition = ({
+  offer,
+}: MandatoryCollectiveOfferFromParamsProps) => {
+  const backRedirectionUrl = `/offre/T-${offer.id}/collectif/recapitulatif`
+
+  return (
+    <AppLayout layout={'sticky-actions'}>
+      <div>
+        <h1>Aperçu de l’offre</h1>
+        <p className={styles['preview-info']}>
+          Voici à quoi ressemble votre offre une fois publiée sur ADAGE.
+        </p>
+        <AdagePreviewLayout offer={offer} />
+        <ActionsBarSticky>
+          <ActionsBarSticky.Left>
+            <ButtonLink
+              variant={ButtonVariant.PRIMARY}
+              link={{
+                to: backRedirectionUrl,
+                isExternal: false,
+              }}
+            >
+              Retour vers l’offre
+            </ButtonLink>
+          </ActionsBarSticky.Left>
+        </ActionsBarSticky>
+      </div>
+      <RouteLeavingGuardCollectiveOfferCreation />
+    </AppLayout>
+  )
+}
+
+// Lazy-loaded by react-router-dom
+// ts-unused-exports:disable-next-line
+export const Component = withCollectiveOfferFromParams(
+  CollectiveOfferPreviewEdition
+)

--- a/pro/src/pages/CollectiveOfferPreviewEdition/__specs__/CollectiveOfferPreviewEdition.spec.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewEdition/__specs__/CollectiveOfferPreviewEdition.spec.tsx
@@ -1,0 +1,64 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+
+import { api } from 'apiClient/api'
+import { MandatoryCollectiveOfferFromParamsProps } from 'screens/OfferEducational/useCollectiveOfferFromParams'
+import {
+  defaultGetVenue,
+  getCollectiveOfferTemplateFactory,
+} from 'utils/collectiveApiFactories'
+import {
+  RenderWithProvidersOptions,
+  renderWithProviders,
+} from 'utils/renderWithProviders'
+
+import { CollectiveOfferPreviewEdition } from '../CollectiveOfferPreviewEdition'
+
+vi.mock('react-router-dom', async () => ({
+  ...((await vi.importActual('react-router-dom')) ?? {}),
+  useParams: () => ({
+    requestId: vi.fn(),
+    requete: '1',
+  }),
+  useNavigate: vi.fn(),
+  default: vi.fn(),
+}))
+
+const renderCollectiveOfferPreviewCreation = (
+  path: string,
+  props: MandatoryCollectiveOfferFromParamsProps,
+  options?: RenderWithProvidersOptions
+) => {
+  renderWithProviders(<CollectiveOfferPreviewEdition {...props} />, {
+    ...options,
+    initialRouterEntries: [path],
+  })
+}
+
+const defaultProps = {
+  offer: getCollectiveOfferTemplateFactory(),
+  setOffer: vi.fn(),
+  reloadCollectiveOffer: vi.fn(),
+  isTemplate: false,
+  offerer: undefined,
+}
+
+describe('CollectiveOfferPreviewCreation', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'getVenue').mockResolvedValue(defaultGetVenue)
+  })
+
+  it('should render collective offer preview edition', async () => {
+    renderCollectiveOfferPreviewCreation(
+      '/offre/T-A1/collectif/preview',
+      defaultProps
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Aperçu de l’offre',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.module.scss
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.module.scss
@@ -7,9 +7,9 @@
 }
 
 .duplicate-offer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: rem.torem(8px);
   margin-bottom: rem.torem(32px);
-
-  &-description {
-    margin-bottom: rem.torem(24px);
-  }
 }

--- a/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -22,6 +22,9 @@ import { computeCollectiveOffersUrl } from 'core/Offers/utils'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
+import fullEditIcon from 'icons/full-edit.svg'
+import fullMoreIcon from 'icons/full-more.svg'
+import fullShowIcon from 'icons/full-show.svg'
 import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -54,6 +57,11 @@ const CollectiveOfferSummaryEdition = ({
     offer.isTemplate
   )}/collectif/stocks/edition`
 
+  const previewLink = `/offre/${computeURLCollectiveOfferId(
+    offer.id,
+    offer.isTemplate
+  )}/collectif/preview`
+
   const visibilityEditLink = `/offre/${offer.id}/collectif/visibilite/edition`
   const { logEvent } = useAnalytics()
 
@@ -73,17 +81,27 @@ const CollectiveOfferSummaryEdition = ({
 
       {offer.isTemplate && (
         <div className={styles['duplicate-offer']}>
-          <p className={styles['duplicate-offer-description']}>
-            Vous pouvez dupliquer cette offre autant de fois que vous le
-            souhaitez pour l’associer aux établissements scolaires qui vous
-            contactent. <br />
-            &nbsp;· L’offre vitrine restera visible sur ADAGE <br />
-            &nbsp;· L’offre associée à l’établissement devra être préréservée
-            par l’enseignant(e) qui vous a contacté
-          </p>
-
+          <ButtonLink
+            link={{
+              to: offerEditLink,
+              isExternal: false,
+            }}
+            icon={fullEditIcon}
+          >
+            Modifier l’offre
+          </ButtonLink>
+          <ButtonLink
+            link={{
+              to: previewLink,
+              isExternal: false,
+            }}
+            icon={fullShowIcon}
+          >
+            Aperçu dans ADAGE
+          </ButtonLink>
           <Button
-            variant={ButtonVariant.PRIMARY}
+            variant={ButtonVariant.TERNARY}
+            icon={fullMoreIcon}
             onClick={() => {
               logEvent?.(Events.CLICKED_DUPLICATE_TEMPLATE_OFFER, {
                 from: OFFER_FROM_TEMPLATE_ENTRIES.OFFER_TEMPLATE_RECAP,
@@ -98,7 +116,7 @@ const CollectiveOfferSummaryEdition = ({
               )
             }}
           >
-            Créer une offre réservable pour un établissement scolaire
+            Créer une offre réservable
           </Button>
         </div>
       )}

--- a/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
@@ -123,7 +123,7 @@ describe('CollectiveOfferSummary', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
     const duplicateOffer = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement scolaire',
+      name: 'Créer une offre réservable',
     })
     await userEvent.click(duplicateOffer)
 
@@ -144,7 +144,7 @@ describe('CollectiveOfferSummary', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
     const duplicateOffer = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement scolaire',
+      name: 'Créer une offre réservable',
     })
     await userEvent.click(duplicateOffer)
 
@@ -166,7 +166,7 @@ describe('CollectiveOfferSummary', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
     const duplicateOffer = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement scolaire',
+      name: 'Créer une offre réservable',
     })
 
     await userEvent.click(duplicateOffer)
@@ -184,7 +184,7 @@ describe('CollectiveOfferSummary', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
     const duplicateOffer = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement scolaire',
+      name: 'Créer une offre réservable',
     })
 
     await userEvent.click(duplicateOffer)
@@ -205,7 +205,7 @@ describe('CollectiveOfferSummary', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
     const duplicateOffer = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement scolaire',
+      name: 'Créer une offre réservable',
     })
 
     await userEvent.click(duplicateOffer)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28250

Ajout d'un bouton + lien pour aller sur l'aperçu depuis l'édition d'une offre vitrine

<img width="1511" alt="Capture d’écran 2024-03-14 à 15 55 47" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/8da73c24-6d33-4125-91b8-0f134abee55b">

