### PR TITLE
(BSR)[API] fix|chore: start backend with a proxy

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -107,6 +107,9 @@ private.tar.gz
 private.key
 public.cert
 
+# Certificate to start the api with a proxy
+cacert.pem
+
 # Store
 src/pcapi/static/object_store_data
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,3 +1,4 @@
+ARG network_mode=default
 ########## BUILDER ##########
 
 FROM python:3.11-slim AS builder
@@ -21,6 +22,24 @@ COPY ./pyproject.toml ./poetry.lock ./
 
 ENV PATH=$PATH:/home/pcapi/.local/bin
 
+FROM builder AS builder-proxy
+
+COPY /cacert.pem /cacert.pem
+
+RUN REQUESTS_CA_BUNDLE=/cacert.pem PIP_CERT=/cacert.pem CURL_CA_BUNDLE=/cacert.pem pip install poetry
+
+WORKDIR /home/pcapi
+
+RUN poetry check --lock
+
+ENV VIRTUAL_ENV=/home/pcapi/.local
+
+RUN python -m venv $VIRTUAL_ENV
+
+RUN REQUESTS_CA_BUNDLE=/cacert.pem PIP_CERT=/cacert.pem CURL_CA_BUNDLE=/cacert.pem poetry install --without dev --no-root
+
+FROM builder AS builder-default
+
 RUN pip install poetry
 
 WORKDIR /home/pcapi
@@ -35,7 +54,13 @@ RUN poetry install --without dev --no-root
 
 ########## DEV BUILDER ##########
 
-FROM builder AS builder-dev
+FROM builder-${network_mode} AS builder-dev-proxy
+
+RUN poetry check --lock
+
+RUN REQUESTS_CA_BUNDLE=/cacert.pem PIP_CERT=/cacert.pem CURL_CA_BUNDLE=/cacert.pem poetry install --only dev
+
+FROM builder-${network_mode} AS builder-dev-default
 
 RUN poetry check --lock
 
@@ -87,6 +112,8 @@ FROM lib AS lib-prod
 COPY --from=builder /home/pcapi/.local /home/pcapi/.local
 
 ########## LIB DEV ##########
+
+FROM builder-dev-${network_mode} AS builder-dev
 
 FROM lib AS lib-dev
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -107,9 +107,11 @@ USER pcapi
 
 ########## LIB PROD ##########
 
+FROM builder-${network_mode} AS builder-prod
+
 FROM lib AS lib-prod
 
-COPY --from=builder /home/pcapi/.local /home/pcapi/.local
+COPY --from=builder-prod /home/pcapi/.local /home/pcapi/.local
 
 ########## LIB DEV ##########
 

--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -10,6 +10,10 @@ function start_backend {
     RUN='cd $ROOT_PATH && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
 }
 
+function start_proxy_backend {
+    RUN='cd $ROOT_PATH && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build --build-arg="network_mode=proxy" && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
+}
+
 function restart_backend {
     RUN='sudo rm -rf "$ROOT_PATH"/api/static/object_store_data;
     docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes;

--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -14,6 +14,12 @@ function start_proxy_backend {
     RUN='cd $ROOT_PATH && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build --build-arg="network_mode=proxy" && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
 }
 
+function restart_proxy_backend {
+    RUN='sudo rm -rf "$ROOT_PATH"/api/static/object_store_data;
+    docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes;
+    cd "$ROOT_PATH" && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build --build-arg="network_mode=proxy" && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up --force-recreate'
+}
+
 function restart_backend {
     RUN='sudo rm -rf "$ROOT_PATH"/api/static/object_store_data;
     docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes;

--- a/pc
+++ b/pc
@@ -197,15 +197,14 @@ elif [[ "$CMD" == "restore-db" ]]; then
     ./api/scalingo/anonymize_database.sh -p Password_ ;
     rm $backup_file'
 
-# Restore a postgresql database from file (non anonymized)
-elif [[ "$CMD" == "restore-db-intact" ]]; then
-  source "$INFRA_SCRIPTS_PATH"/restore_db.sh
-  restore_db_intact $1
-
 # Start API server with database and nginx server
 elif [[ "$CMD" == "start-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
   start_backend
+
+elif [[ "$CMD" == "start-proxy-backend" ]]; then
+  source "$INFRA_SCRIPTS_PATH"/start_backend.sh
+  start_proxy_backend
 
 # Start pro or adage application
 elif [[ "$CMD" == "start-pro" ]]; then

--- a/pc
+++ b/pc
@@ -175,6 +175,10 @@ elif [[ "$CMD" == "restart-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
   restart_backend
 
+elif [[ "$CMD" == "restart-proxy-backend" ]]; then
+  source "$INFRA_SCRIPTS_PATH"/start_backend.sh
+  restart_proxy_backend
+
 # Clear all data in postgresql database
 elif [[ "$CMD" == "reset-all-db" ]]; then
   RUN='docker exec -it '$FLASK_CONTAINER_NAME' bash -c "rm -rf /usr/src/app/static/object_store_data/*";


### PR DESCRIPTION
## But de la pull request

Start the backend with a proxy. 
In case you use a proxy (do not name it), you should put your key `cacert.pem` in /api repository
Then you can use `pc start-proxy-backend`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques