### PR TITLE
(BSR)[EAC] fix: some adage iframe datetimes were not properly formatted

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/serialization/favorites.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/favorites.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 import logging
 
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers.repository import get_venue_by_id
 from pcapi.routes.adage_iframe.serialization import offers as serialize_offers
 from pcapi.routes.serialization import BaseModel
+from pcapi.utils.date import format_into_utc_date
 
 
 logger = logging.getLogger(__name__)
@@ -40,3 +42,6 @@ def serialize_collective_offer_template(
 class FavoritesResponseModel(BaseModel):
     favoritesOffer: list[serialize_offers.CollectiveOfferResponseModel]
     favoritesTemplate: list[serialize_offers.CollectiveOfferTemplateResponseModel]
+
+    class Config:
+        json_encoders = {datetime: format_into_utc_date}

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -46,6 +46,7 @@ class OfferStockResponse(BaseModel):
         orm_mode = True
         alias_generator = to_camel
         allow_population_by_field_name = True
+        json_encoders = {datetime: format_into_utc_date}
 
 
 class OfferVenueResponse(BaseModel):
@@ -244,6 +245,9 @@ class CollectiveOfferResponseModel(BaseModel, common_models.AccessibilityComplia
 
 class ListCollectiveOffersResponseModel(BaseModel):
     collectiveOffers: list[CollectiveOfferResponseModel]
+
+    class Config:
+        json_encoders = {datetime: format_into_utc_date}
 
 
 class TemplateDatesModel(BaseModel):

--- a/api/tests/routes/adage_iframe/get_favorites_test.py
+++ b/api/tests/routes/adage_iframe/get_favorites_test.py
@@ -7,6 +7,7 @@ from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.testing import assert_num_queries
+from pcapi.utils.date import format_into_utc_date
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -67,8 +68,8 @@ class GetFavoriteOfferTest:
                     "name": "offer name",
                     "stock": {
                         "id": stock.id,
-                        "beginningDatetime": "2021-05-15T00:00:00",
-                        "bookingLimitDatetime": "2021-05-14T23:00:00",
+                        "beginningDatetime": format_into_utc_date(stock.beginningDatetime),
+                        "bookingLimitDatetime": format_into_utc_date(stock.bookingLimitDatetime),
                         "isBookable": True,
                         "price": 1000,
                         "numberOfTickets": 25,
@@ -188,8 +189,8 @@ class GetFavoriteOfferTest:
                     "imageUrl": None,
                     "nationalProgram": None,
                     "dates": {
-                        "start": collective_offer_template.start.isoformat(),
-                        "end": collective_offer_template.end.isoformat(),
+                        "start": format_into_utc_date(collective_offer_template.start),
+                        "end": format_into_utc_date(collective_offer_template.end),
                     },
                     "formats": [fmt.value for fmt in subcategories.EVENEMENT_CINE.formats],
                     "isTemplate": True,


### PR DESCRIPTION
## But de la pull request

Fix : faire en sorte que les datetimes de l'iframe adage soient tous
formattés correctement (grâce à `format_into_utc_date`).