### PR TITLE
(PC-27877)[PRO] fix: In adage display dates in venue timzeone and not…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferHeader/__specs__/AdageOfferHeader.spec.tsx
@@ -160,15 +160,15 @@ describe('AdageOfferHeader', () => {
       offer: {
         ...defaultCollectiveTemplateOffer,
         dates: {
-          end: '2024-01-29T23:00:28.040559Z',
-          start: '2024-01-23T23:00:28.040547Z',
+          end: '2024-01-29T20:00:28.040559Z',
+          start: '2024-01-23T20:00:28.040547Z',
         },
       },
       adageUser: defaultAdageUser,
     })
 
     expect(
-      screen.getByText('Du 23 janvier au 29 janvier 2024 à 23h')
+      screen.getByText('Du 23 janvier au 29 janvier 2024 à 21h')
     ).toBeInTheDocument()
   })
 

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferDates.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/__specs__/adageOfferDates.spec.ts
@@ -19,7 +19,7 @@ describe('adageOfferDates', () => {
         },
       })
 
-      expect(datesText).toEqual('Du 23 janvier au 29 janvier 2024 à 23h')
+      expect(datesText).toEqual('Du 24 janvier au 30 janvier 2024')
     })
 
     it('should show that the offer is permanent if it has no dates', () => {
@@ -44,7 +44,7 @@ describe('adageOfferDates', () => {
         },
       })
 
-      expect(dateText).toEqual('Le 29 janvier 2024 à 23:00')
+      expect(dateText).toEqual('Le 30 janvier 2024 à 00:00')
     })
 
     it('should not return a date if the beginning of the offer does not exist', () => {

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferDates.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferDates.ts
@@ -2,11 +2,8 @@ import {
   CollectiveOfferResponseModel,
   CollectiveOfferTemplateResponseModel,
 } from 'apiClient/adage'
-import {
-  getDateTimeToFrenchText,
-  getRangeToFrenchText,
-  toDateStrippedOfTimezone,
-} from 'utils/date'
+import { getDateTimeToFrenchText, getRangeToFrenchText } from 'utils/date'
+import { getLocalDepartementDateTimeFromUtc } from 'utils/timezone'
 
 export function getFormattedDatesForTemplateOffer(
   offer: CollectiveOfferTemplateResponseModel
@@ -15,8 +12,14 @@ export function getFormattedDatesForTemplateOffer(
     (offer.dates?.start &&
       offer.dates?.end &&
       getRangeToFrenchText(
-        toDateStrippedOfTimezone(offer.dates.start),
-        toDateStrippedOfTimezone(offer.dates.end)
+        getLocalDepartementDateTimeFromUtc(
+          offer.dates.start,
+          offer.venue.departmentCode
+        ),
+        getLocalDepartementDateTimeFromUtc(
+          offer.dates.end,
+          offer.venue.departmentCode
+        )
       )) ||
     'Tout au long de l’année scolaire (l’offre est permanente)'
   )
@@ -27,7 +30,10 @@ export function getFormattedDatesForBookableOffer(
 ) {
   return offer.stock.beginningDatetime
     ? `Le ${getDateTimeToFrenchText(
-        toDateStrippedOfTimezone(offer.stock.beginningDatetime),
+        getLocalDepartementDateTimeFromUtc(
+          offer.stock.beginningDatetime,
+          offer.venue.departmentCode
+        ),
         { dateStyle: 'long', timeStyle: 'short' }
       )}`
     : null

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import {
   CollectiveOfferResponseModel,
   CollectiveOfferTemplateResponseModel,
@@ -14,44 +12,13 @@ import strokeOfferIcon from 'icons/stroke-offer.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
 import { isCollectiveOfferTemplate } from 'pages/AdageIframe/app/types/offers'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+import { getRangeToFrenchText } from 'utils/date'
 import {
-  getRangeToFrenchText,
-  toDateStrippedOfTimezone,
-  toISOStringWithoutMilliseconds,
-} from 'utils/date'
-import { formatLocalTimeDateString } from 'utils/timezone'
+  formatLocalTimeDateString,
+  getLocalDepartementDateTimeFromUtc,
+} from 'utils/timezone'
 
 import styles from './OfferSummary.module.scss'
-
-const extractDepartmentCode = (venuePostalCode: string): string => {
-  const departmentNumberBase: number = parseInt(venuePostalCode.slice(0, 2))
-  if (departmentNumberBase > 95) {
-    return venuePostalCode.slice(0, 3)
-  } else {
-    return venuePostalCode.slice(0, 2)
-  }
-}
-
-const getLocalBeginningDatetime = (
-  beginningDatetime: string,
-  venuePostalCode: string | null | undefined
-): string => {
-  if (!venuePostalCode) {
-    return ''
-  }
-
-  const departmentCode = extractDepartmentCode(venuePostalCode)
-  const stockBeginningDate = new Date(beginningDatetime)
-  const stockBeginningDateISOString =
-    toISOStringWithoutMilliseconds(stockBeginningDate)
-  const stockLocalBeginningDate = formatLocalTimeDateString(
-    stockBeginningDateISOString,
-    departmentCode,
-    'dd/MM/yyyy à HH:mm'
-  )
-
-  return stockLocalBeginningDate
-}
 
 export type OfferSummaryProps = {
   offer: CollectiveOfferResponseModel | CollectiveOfferTemplateResponseModel
@@ -75,8 +42,14 @@ const OfferSummary = ({ offer }: OfferSummaryProps): JSX.Element => {
     ((offer.dates?.start &&
       offer.dates?.end &&
       getRangeToFrenchText(
-        toDateStrippedOfTimezone(offer.dates.start),
-        toDateStrippedOfTimezone(offer.dates.end)
+        getLocalDepartementDateTimeFromUtc(
+          offer.dates.start,
+          venue.departmentCode
+        ),
+        getLocalDepartementDateTimeFromUtc(
+          offer.dates.end,
+          venue.departmentCode
+        )
       )) ||
       'Tout au long de l’année scolaire (l’offre est permanente)')
 
@@ -158,7 +131,11 @@ const OfferSummary = ({ offer }: OfferSummaryProps): JSX.Element => {
             />
           </dt>
           <dd>
-            {getLocalBeginningDatetime(beginningDatetime, venue.postalCode)}
+            {formatLocalTimeDateString(
+              beginningDatetime,
+              venue.departmentCode,
+              'dd/MM/yyyy à HH:mm'
+            )}
           </dd>
         </div>
       )}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
@@ -21,7 +21,7 @@ describe('offer summary', () => {
   it('should show the dates range of a template offers', () => {
     const offer: CollectiveOfferTemplateResponseModel = {
       ...defaultCollectiveTemplateOffer,
-      dates: { start: '2023-10-24T00:00:00', end: '2023-10-24T23:59:00' },
+      dates: { start: '2023-10-23T22:00:00Z', end: '2023-10-24T21:59:00Z' },
       isTemplate: true,
     }
     renderOfferSummary({ offer })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -169,7 +169,7 @@ describe('offer', () => {
 
       expect(screen.getByText('A la mairie')).toBeInTheDocument()
 
-      expect(screen.getByText('25/09/2021 à 19:00')).toBeInTheDocument()
+      expect(screen.getByText('26/09/2021 à 00:00')).toBeInTheDocument()
       expect(
         screen.queryByText('Jusqu’à', { exact: false })
       ).not.toBeInTheDocument()


### PR DESCRIPTION
… in UTC.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27877

**Objectif**
Dans ADAGE jusqu'a maintenant on affiche les dates en UTC. C'est à dire : une date est enregistrée dans pro en format standard UTC `2023-10-23T07:00:00Z`, et côté ADAGE on affiche `Le 23 octobre à 7h`.
Quand la date est enregistrée on utilise le `departmentCode` de la venue de l'offre pour passer de la date renseignée dans l'UI à la date UTC enregistrée en base. Il s'agit dans cette PR d'appliqué la transformation inverse à l'affichage sur ADAGE. C'est à dire convertir les dates reçues depuis la base en dates dans la timezone de la venue de l'offre.

A la place d'afficher `Le 23 octobre à 7h` on doit donc afficher `Le 23 octobre à 9h` (heure d'été donc 2h de décalage avec UTC pour une venue sur "Europe/Paris").

Pour tester : Aller sur la recherche ADAGE, sur une offre vitrine, sur une offre réservable, sur la page des offres de mon établissement ou sur la page des offres favories et vérifier que la date est bien convertie (venue.dates.start/end dans les offres vitrine, et venue.stock.beginningDatetime/bookingLimitDatetime dnas les offres réservables).

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques