### PR TITLE
(BSR)[API] ci: Simplify steps that call `dev_on_workflow_update_api_client_template` workflow

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -75,7 +75,7 @@ jobs:
       needs.check-api.outputs.folder_changed == 'true'
     uses: ./.github/workflows/dev_on_workflow_mypy_cop.yml
 
-  update-api-client-template:
+  update-api-client-template:  # for pull requests only
     name: "Update api client template"
     needs: build-api
     uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
@@ -84,7 +84,7 @@ jobs:
       group: update-api-client-template-${{ github.ref }}
       cancel-in-progress: true
     with:
-      PCAPI_DOCKER_TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      PCAPI_DOCKER_TAG: ${{ github.event.pull_request.head.sha }}
       TRIGGER_ONLY_ON_API_CHANGE: true
       TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
@@ -92,13 +92,13 @@ jobs:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
-  prepare-cache-master:
+  prepare-cache-master:  # on "master" branch only
     name: "Reset cache on master on dependency update"
     needs: build-api
     uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
     if: github.ref == 'refs/heads/master'
     with:
-      PCAPI_DOCKER_TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      PCAPI_DOCKER_TAG: ${{ github.sha }}
       TRIGGER_ONLY_ON_API_CHANGE: false
       TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"


### PR DESCRIPTION
The `update-api-client-template` step is only used on a pull
request (as per the `if` directive: `github.base_ref` is defined only
in the context of a pull request).

On the other hand, the `prepare-cache-master` step is only used on
master (that's what the `if` directive says).

As such, we can simplify the expression that fetches the docker tag to
fetch.