### PR TITLE
(BSR)[API] fix: add OfferPriceLimitationRule to clean database

### DIFF
--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -102,6 +102,7 @@ tables_to_clean: list[flask_sqlalchemy.Model] = [
     fraud_models.BeneficiaryFraudReview,
     offers_models.OfferValidationSubRule,
     offers_models.OfferValidationRule,
+    offers_models.OfferPriceLimitationRule,
     users_models.SingleSignOn,
     users_models.User,
     users_models.UserSession,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : vider OfferPriceLimitationRule quand on clean la db

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques