### PR TITLE
(PC-28555)[PRO] fix: Dont display pass contact form in old adage cont…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/NewRequestFormDialog.module.scss
@@ -5,18 +5,13 @@
 .dialog-container {
   align-items: flex-start;
   text-align: left;
+  max-width: rem.torem(576px);
 }
 
-.contact-callout {
-  margin-bottom: rem.torem(16px);
-  max-width: rem.torem(460px);
-}
-
+.contact-callout,
 .contact-readonly {
-  margin-top: rem.torem(16px);
-  max-width: rem.torem(460px);
+  margin-bottom: rem.torem(16px);
 }
-
 
 .contact-info-container {
   display: flex;
@@ -49,53 +44,52 @@
     width: 100%;
 
     &-link {
-        display: flex;
+      display: flex;
+      align-items: center;
+      white-space: break-spaces;
+
+      &-text {
+        gap: rem.torem(8px);
         align-items: center;
-        white-space: break-spaces;
+      }
 
-        &-text {
-            gap: rem.torem(8px);
-            align-items: center;
-        }
-
-        &-site {
-          display: block;
-          margin-top: rem.torem(32px);
-          margin-bottom: rem.torem(16px);
-        }
+      &-site {
+        display: block;
+        margin-top: rem.torem(32px);
+        margin-bottom: rem.torem(16px);
+      }
     }
 
-
     &-list {
-        display: flex;
-        flex-direction: column;
-        list-style: disc;
-        margin-left: rem.torem(16px);
-        margin-top: rem.torem(16px);
+      display: flex;
+      flex-direction: column;
+      list-style: disc;
+      margin-left: rem.torem(16px);
+      margin-top: rem.torem(16px);
 
-        li {
-            padding: 0 0 rem.torem(8px) rem.torem(8px);
-        }
+      li {
+        padding: 0 0 rem.torem(8px) rem.torem(8px);
+      }
 
-        li::marker {
-            font-size: rem.torem(8px);
-        }
+      li::marker {
+        font-size: rem.torem(8px);
+      }
     }
 
     &-text {
-        &-value {
-            @include fonts.body-important;
-            
-            color: colors.$primary;
-        }
+      &-value {
+        @include fonts.body-important;
 
-        &-contact {     
-          @include fonts.body-important;
-                 
-          display: block;
-          margin-top: rem.torem(16px);
-          color: colors.$primary;
-        }
+        color: colors.$primary;
+      }
+
+      &-contact {
+        @include fonts.body-important;
+
+        display: block;
+        margin-top: rem.torem(16px);
+        color: colors.$primary;
+      }
     }
   }
 
@@ -110,10 +104,10 @@
 }
 
 .buttons-container {
-    display: flex;
-    margin-top: rem.torem(32px);
-    gap: rem.torem(24px);
-    justify-content: space-between;
+  display: flex;
+  margin-top: rem.torem(32px);
+  gap: rem.torem(24px);
+  justify-content: space-between;
 }
 
 hr {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
@@ -2,8 +2,6 @@ import { useFormik } from 'formik'
 
 import { AdageFrontRoles } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
-import Callout from 'components/Callout/Callout'
-import { CalloutVariant } from 'components/Callout/types'
 import Dialog from 'components/Dialog/Dialog'
 import MandatoryInfo from 'components/FormLayout/FormLayoutMandatoryInfo'
 import useNotification from 'hooks/useNotification'
@@ -86,17 +84,7 @@ const RequestFormDialog = ({
         <a href={`mailto:${contactEmail}`}>{contactEmail}</a>
         {contactPhone}
       </div>
-      {!isPreview && (
-        <Callout
-          variant={CalloutVariant.DEFAULT}
-          className={styles['contact-callout']}
-        >
-          <p>Vous ne pouvez pas envoyer de demande de contact</p>
-          <p>car ceci est un aperçu de test du formulaire que </p>
-          <p>verront les enseignants une fois l’offre publiée.</p>
-        </Callout>
-      )}
-      {userRole === AdageFrontRoles.REDACTOR && (
+      {userRole === AdageFrontRoles.REDACTOR && !isPreview && (
         <>
           <div className={styles['form-description']}>
             <div className={styles['form-description-text']}>

--- a/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -47,6 +47,10 @@ const CollectiveOfferPreviewCreationScreen = ({
 
   return (
     <div>
+      <p>
+        Voici à quoi ressemblera votre offre une fois publiée sur la plateforme
+        ADAGE.
+      </p>
       <AdagePreviewLayout offer={offer} />
       <ActionsBarSticky>
         <ActionsBarSticky.Left>


### PR DESCRIPTION
…act dialog.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28555

**Objectif**
- Commit 1: Si le FF WIP_ENABLE_COLLECTIVE_CUSTOM_CONTACT est désactivé, on ne doit quand-même pas voir le message disant qu'il s'agit d'une preview dans le dialog de contact des offres vitrine adage.
Pour régler le pb a la source, j'ai supprimé le message de l'ancien dialog complètement, et le formulaire de l'ancien dialog ne s'affichera que lorsqu'on est pas en mode preview.

- Commit 2 & 3 : Ajouter un texte explicatif avant l'aperçu dans la page aperçu & ajuster la largeur des callouts du dalog à la largeur du dialog

<img width="891" alt="Capture d’écran 2024-03-19 à 09 55 50" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/a33d76a8-97fb-4473-ae1e-6d13b74be7db">
<img width="703" alt="Capture d’écran 2024-03-19 à 09 55 43" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/cfa75fb9-a3a5-4cf2-97a0-6374d6ca1f7f">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques