### PR TITLE
(PC-28559)[API] fix: ReadTimeoutError often received when requesting attestations from API Entreprise

### DIFF
--- a/api/src/pcapi/connectors/entreprise/backends/api_entreprise.py
+++ b/api/src/pcapi/connectors/entreprise/backends/api_entreprise.py
@@ -29,7 +29,8 @@ PASS_CULTURE_CONTEXT = "Vérification des acteurs culturels inscrits sur le pass
 
 
 class EntrepriseBackend(BaseBackend):
-    timeout = 3
+    # less than 1-minute nginx timeout
+    timeout = 50
 
     def _get(self, subpath: str) -> dict:
         if not settings.ENTREPRISE_API_URL:


### PR DESCRIPTION
dgfip endpoint takes more than 3 seconds to get document. 3s timeout was a copy/paste from Insee backend.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28559

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques