### PR TITLE
(PC-28558)[API] fix: TypeError when receiving error 429 from API Entreprise

### DIFF
--- a/api/src/pcapi/connectors/entreprise/backends/api_entreprise.py
+++ b/api/src/pcapi/connectors/entreprise/backends/api_entreprise.py
@@ -62,6 +62,8 @@ class EntrepriseBackend(BaseBackend):
                 except (ValueError, KeyError):
                     # If not, fallback to the generic error (common label for all APIs)
                     error_message = errors[0]["detail"]
+                except TypeError:
+                    error_message = errors[0]
             except json.JSONDecodeError:
                 errors = None
                 error_message = None

--- a/api/tests/connectors/api_entreprise_test.py
+++ b/api/tests/connectors/api_entreprise_test.py
@@ -154,6 +154,20 @@ def test_get_siren_invalid_parameter():
 
 
 @override_settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
+def test_get_siren_reached_rate_limit():
+    siren = settings.PASS_CULTURE_SIRET[:9]
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}/siege_social",
+            status_code=429,
+            json=api_entreprise_test_data.RESPONSE_SIREN_ERROR_429,
+        )
+        with pytest.raises(exceptions.RateLimitExceeded) as error:
+            api.get_siren(siren)
+        assert str(error.value) == "Vous avez effectué trop de requêtes"
+
+
+@override_settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siret():
     siret = "12345678900017"
     with requests_mock.Mocker() as mock:

--- a/api/tests/connectors/api_entreprise_test_data.py
+++ b/api/tests/connectors/api_entreprise_test_data.py
@@ -508,6 +508,9 @@ RESPONSE_SIREN_ERROR_422 = {
     ]
 }
 
+
+RESPONSE_SIREN_ERROR_429 = {"errors": ["Vous avez effectué trop de requêtes"]}
+
 RESPONSE_RCS_REGISTERED_COMPANY = {
     "data": {
         "siren": "123456789",


### PR DESCRIPTION
error_message = errors[0]["meta"]["provider_errors"][0]["description"]
E   TypeError: string indices must be integers, not 'str'

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28558

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques