### PR TITLE
(PC-28605)[API] feat: Limit length of password to hash

### DIFF
--- a/api/src/pcapi/utils/crypto.py
+++ b/api/src/pcapi/utils/crypto.py
@@ -6,6 +6,11 @@ from cryptography.fernet import Fernet
 from pcapi import settings
 
 
+# Only the first 100 characters of a password are relevant. This
+# avoids exhaustion of resources if a huge password is provided.
+MAX_PASSWORD_LENGTH = 100
+
+
 def _hash_password_with_bcrypt(clear_text: str) -> bytes:
     return bcrypt.hashpw(clear_text.encode("utf-8"), bcrypt.gensalt())
 
@@ -32,7 +37,7 @@ def hash_password(clear_text: str) -> bytes:
         hasher = _hash_password_with_md5
     else:
         hasher = _hash_password_with_bcrypt
-    return hasher(clear_text)
+    return hasher(clear_text[:MAX_PASSWORD_LENGTH])
 
 
 def check_password(clear_text: str, hashed: bytes) -> bool:
@@ -40,7 +45,7 @@ def check_password(clear_text: str, hashed: bytes) -> bool:
         checker = _check_password_with_md5
     else:
         checker = _check_password_with_bcrypt
-    return checker(clear_text, hashed)
+    return checker(clear_text[:MAX_PASSWORD_LENGTH], hashed)
 
 
 def encrypt(clear_text: str) -> str:

--- a/api/tests/utils/crypto_test.py
+++ b/api/tests/utils/crypto_test.py
@@ -25,6 +25,12 @@ class ProdEnvironmentPasswordHasherTest:
         assert not crypto.check_password("wrong", hashed)
         assert crypto.check_password("secret", hashed)
 
+    def test_hash_and_check_long_password(self):
+        secret = "a" * 200
+        hashed = crypto.hash_password(secret)
+        assert hashed != secret
+        assert crypto.check_password(secret, hashed)
+
 
 class EncryptDataTest:
     def test_we_can_cipher_sensitive_data(self):


### PR DESCRIPTION
An attacker could provide a huge password, for which bcrypt would use
a lot of resources (CPU and memory) to hash. This could be used for a
denial of service attack.

We have mechanisms in place that block this kind of attack, but some
defense in depth looks like a good idea, here.

---

Ticket avec les détails : https://passculture.atlassian.net/browse/PC-28605