### PR TITLE
(PC-28362)[BO] feat: allow cashflow/invoice generation with amount = 0

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-4eeaf83a2a07 (pre) (head)
+33c2838cfb4a (pre) (head)
 a613c5bc707a (post) (head)

--- a/api/src/pcapi/alembic/versions/20240319T102111_33c2838cfb4a_allow_zero_cashflow.py
+++ b/api/src/pcapi/alembic/versions/20240319T102111_33c2838cfb4a_allow_zero_cashflow.py
@@ -1,0 +1,29 @@
+"""
+Remove non-zero constraint from amount column of Cashflow table
+"""
+
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "33c2838cfb4a"
+down_revision = "4eeaf83a2a07"
+branch_labels: tuple | None = None
+depends_on: tuple | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        constraint_name="non_zero_amount_check",
+        table_name="cashflow",
+    )
+
+
+def downgrade() -> None:
+    op.create_check_constraint(
+        constraint_name="non_zero_amount_check",
+        table_name="cashflow",
+        condition='("amount" != 0)',
+        postgresql_not_valid=True,
+    )

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -687,7 +687,7 @@ class Cashflow(Base, Model):
     """A cashflow represents a specific amount money that is transferred
     between us and a third party. It may be outgoing or incoming.
 
-    By definition a cashflow cannot be zero.
+    Cashflows with zero amount are there to enable generating invoices lines with 100% offerer contribution
     """
 
     id: int = sqla.Column(sqla.BigInteger, primary_key=True, autoincrement=True)
@@ -726,8 +726,6 @@ class Cashflow(Base, Model):
     invoices: list["Invoice"] = sqla_orm.relationship(
         "Invoice", secondary="invoice_cashflow", back_populates="cashflows"
     )
-
-    __table_args__ = (sqla.CheckConstraint('("amount" != 0)', name="non_zero_amount_check"),)
 
 
 class CashflowLog(Base, Model):

--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -256,6 +256,7 @@
     sens de l’article 267 du code général des impôts, et qu’à ce
     titre, les offreurs pourront ainsi régulariser leur base imposable (article 267 du CGI).
 </p>
+{% if cashflows %}
 <h3>Règlements effectués correspondant au montant remboursé</h3>
 <table class="totalAccountTable">
     <thead>
@@ -283,6 +284,7 @@
     </tr>
     </tbody>
 </table>
+{% endif %}
 <h3>Montant des remboursements par lieu et détail de la part individuelle et collective</h3>
 <table class="reimbursmentByVenueTable">
     <thead>

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -367,6 +367,7 @@
     sens de l’article 267 du code général des impôts, et qu’à ce
     titre, les offreurs pourront ainsi régulariser leur base imposable (article 267 du CGI).
 </p>
+
 <h3>Règlements effectués correspondant au montant remboursé</h3>
 <table class="totalAccountTable">
     <thead>
@@ -394,6 +395,7 @@
     </tr>
     </tbody>
 </table>
+
 <h3>Montant des remboursements par lieu et détail de la part individuelle et collective</h3>
 <table class="reimbursmentByVenueTable">
     <thead>


### PR DESCRIPTION
## But de la pull request

 - Génération de cashflows à 0€
 - Intégrer dans les justificatifs de remboursements les contributions offreur à 100%

<img width="731" alt="Capture d’écran 2024-03-19 à 14 07 26" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/2332f50b-63fa-4d98-bf25-59279c323292">

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28362

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques