### PR TITLE
(BSR)[BO] fix: don't crash the js when displaying a batch action form with no form

### DIFF
--- a/api/src/pcapi/static/backoffice/js/addons/pc-batch-action-form.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-batch-action-form.js
@@ -120,7 +120,7 @@ class PcBatchActionForm extends PcAddOn {
   }
 
   #onBatchButtonClick = async (event) => {
-    const { useConfirmationModal, pcTableMultiSelectId, toggleId, url, mode, fetchUrl } = event.target.dataset
+    const { useConfirmationModal, pcTableMultiSelectId, toggleId, url, mode, fetchUrl, modalSelector } = event.target.dataset
     const { inputIdsName } = this.state[toggleId]
     const tableMultiSelectState = this.app.addons.PcTableMultiSelectId.state[pcTableMultiSelectId]
     const idsStr = [...tableMultiSelectState.selectedRowsIds].join(',')
@@ -140,12 +140,14 @@ class PcBatchActionForm extends PcAddOn {
       $form.submit()
       return
     }
-    const $modal = document.querySelector(event.target.dataset.modalSelector)
+    const $modal = document.querySelector(modalSelector)
     const $form = $modal.querySelector('form') // no support for turbo loading="lazy" yet
-    const $objectIds = $form.querySelector(`input[name="${inputIdsName}"]`)
-    $objectIds.value = idsStr
+    if ($form) {
+      const $objectIds = $form.querySelector(`input[name="${inputIdsName}"]`)
+      $objectIds.value = idsStr
+    }
 
-    if (mode === 'fetch' && fetchUrl) {
+    if (mode === 'fetch' && fetchUrl && $form) {
       try {
         const $turboFrame = $modal.querySelector('turbo-frame')
         const formData = new FormData()


### PR DESCRIPTION

## But de la pull request

Ticket Jira (ou description si BSR) : 

Fix de l'erreur js lors de l'affichage de modal d'action batch s'il y'a juste un message à la place du formulaire.

Avant :

https://github.com/pass-culture/pass-culture-main/assets/155538488/0d49b077-9368-404b-9405-5f18b15119ac

Après : 

https://github.com/pass-culture/pass-culture-main/assets/155538488/f6650243-ee21-46d3-99fa-f6a2f756d4cb


## Vérifications

- [ ] ~J'ai écrit les tests nécessaires~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques