### PR TITLE
(PC-28075)[BO] fix: display proper 'not found' message in autocomplete select fields

### DIFF
--- a/api/src/pcapi/static/backoffice/js/addons/pc-tom-select-field.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-tom-select-field.js
@@ -35,6 +35,11 @@ class PcTomSelectField extends PcAddOn {
     plugins: ['dropdown_input', 'clear_button', 'checkbox_options'],
     persist: false,
     create: false,
+    render: {
+      no_results: function(data, escape) {
+        return '<div class="no-results">Aucun résultat pour "' + escape(data.input) + '"</div>'
+      },
+    },
   }
 
   state = {
@@ -112,11 +117,6 @@ class PcTomSelectField extends PcAddOn {
           .then((response) => response.json())
           .then((json) => callback(json.items))
           .catch((error) => callback(undefined, error))
-      },
-      render: {
-        no_results: (data, escape) => {
-          return '<div class="no-results">Aucun résultat pour "' + escape(data.input) + '"</div>'
-        },
       },
       ...(tomselectOptions ? { options: JSON.parse(tomselectOptions) } : {}),
       ...(tomselectItems ? { items: JSON.parse(tomselectItems) } : {}),


### PR DESCRIPTION

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28075

Avant : 

<img width="841" alt="before" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/6f5d0cd3-396f-41fd-ac40-e931fbb93987">

Après : 

<img width="842" alt="after" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/e60d40d1-75c2-43ef-89a7-6c937e6160fa">

## Vérifications

- [ ] ~J'ai écrit les tests nécessaires~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques