### PR TITLE
(PC-28657)[BO] fix: performance for collective offers query

### DIFF
--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -233,9 +233,6 @@ def _get_collective_offers(form: forms.InternalSearchForm) -> list[educational_m
             rules_subquery.label("rules"),
         )
         .filter(educational_models.CollectiveOffer.id.in_(_get_collective_offer_ids_query(form).subquery()))
-        # 1-1 relationships so join will not increase the number of SQL rows
-        .join(educational_models.CollectiveOffer.venue)
-        .join(offerers_models.Venue.managingOfferer)
         .options(
             sa.orm.load_only(
                 educational_models.CollectiveOffer.id,
@@ -248,14 +245,14 @@ def _get_collective_offers(form: forms.InternalSearchForm) -> list[educational_m
             sa.orm.joinedload(educational_models.CollectiveOffer.collectiveStock).load_only(
                 educational_models.CollectiveStock.beginningDatetime,
             ),
-            sa.orm.joinedload(educational_models.CollectiveOffer.venue).load_only(
+            sa.orm.joinedload(educational_models.CollectiveOffer.venue, innerjoin=True).load_only(
                 offerers_models.Venue.managingOffererId,
                 offerers_models.Venue.name,
                 offerers_models.Venue.publicName,
                 offerers_models.Venue.departementCode,
             )
             # needed to check if stock is bookable and compute initial/remaining stock:
-            .joinedload(offerers_models.Venue.managingOfferer).load_only(
+            .joinedload(offerers_models.Venue.managingOfferer, innerjoin=True).load_only(
                 offerers_models.Offerer.name, offerers_models.Offerer.isActive, offerers_models.Offerer.validationStatus
             ),
             sa.orm.joinedload(educational_models.CollectiveOffer.institution).load_only(


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28657

Deux jointures faites en double plombent les performances.
Avec une seule, on réduit le `cost` du _Query plan_ de 765834 à 37970 (-95%) pour la liste des offres collectives en attente.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques