### PR TITLE
(BSR)[PRO] fix: front types after openapi-codegen bump

### DIFF
--- a/pro/src/apiClient/adage/AppClientAdage.ts
+++ b/pro/src/apiClient/adage/AppClientAdage.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/core/ApiError.ts
+++ b/pro/src/apiClient/adage/core/ApiError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/core/ApiRequestOptions.ts
+++ b/pro/src/apiClient/adage/core/ApiRequestOptions.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/core/ApiResult.ts
+++ b/pro/src/apiClient/adage/core/ApiResult.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/core/BaseHttpRequest.ts
+++ b/pro/src/apiClient/adage/core/BaseHttpRequest.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/core/CancelablePromise.ts
+++ b/pro/src/apiClient/adage/core/CancelablePromise.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -85,9 +85,9 @@ export class CancelablePromise<T> implements Promise<T> {
     });
   }
 
-   get [Symbol.toStringTag]() {
-            return "Cancellable Promise";
-     }
+  get [Symbol.toStringTag]() {
+    return "Cancellable Promise";
+  }
 
   public then<TResult1 = T, TResult2 = never>(
     onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,

--- a/pro/src/apiClient/adage/core/FetchHttpRequest.ts
+++ b/pro/src/apiClient/adage/core/FetchHttpRequest.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/core/OpenAPI.ts
+++ b/pro/src/apiClient/adage/core/OpenAPI.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/index.ts
+++ b/pro/src/apiClient/adage/index.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/AcademiesResponseModel.ts
+++ b/pro/src/apiClient/adage/models/AcademiesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/AdageBaseModel.ts
+++ b/pro/src/apiClient/adage/models/AdageBaseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/AdageFrontRoles.ts
+++ b/pro/src/apiClient/adage/models/AdageFrontRoles.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/AdageHeaderLink.ts
+++ b/pro/src/apiClient/adage/models/AdageHeaderLink.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/AdageHeaderLogBody.ts
+++ b/pro/src/apiClient/adage/models/AdageHeaderLogBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/AdagePlaylistType.ts
+++ b/pro/src/apiClient/adage/models/AdagePlaylistType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/AuthenticatedResponse.ts
+++ b/pro/src/apiClient/adage/models/AuthenticatedResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/BookCollectiveOfferRequest.ts
+++ b/pro/src/apiClient/adage/models/BookCollectiveOfferRequest.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/BookCollectiveOfferResponse.ts
+++ b/pro/src/apiClient/adage/models/BookCollectiveOfferResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/CatalogViewBody.ts
+++ b/pro/src/apiClient/adage/models/CatalogViewBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/CategoriesResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CategoriesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/CategoryResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CategoryResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/CollectiveOfferOfferVenue.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferOfferVenue.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferTemplateResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/CollectiveRequestBody.ts
+++ b/pro/src/apiClient/adage/models/CollectiveRequestBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/CollectiveRequestResponseModel.ts
+++ b/pro/src/apiClient/adage/models/CollectiveRequestResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/Coordinates.ts
+++ b/pro/src/apiClient/adage/models/Coordinates.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/EacFormat.ts
+++ b/pro/src/apiClient/adage/models/EacFormat.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/EacFormatsResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EacFormatsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/EducationalInstitutionProgramModel.ts
+++ b/pro/src/apiClient/adage/models/EducationalInstitutionProgramModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/EducationalInstitutionResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EducationalInstitutionResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/EducationalInstitutionWithBudgetResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EducationalInstitutionWithBudgetResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/EducationalRedactorResponseModel.ts
+++ b/pro/src/apiClient/adage/models/EducationalRedactorResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/FavoritesResponseModel.ts
+++ b/pro/src/apiClient/adage/models/FavoritesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/FeatureResponseModel.ts
+++ b/pro/src/apiClient/adage/models/FeatureResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/GetRelativeVenuesQueryModel.ts
+++ b/pro/src/apiClient/adage/models/GetRelativeVenuesQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/InstitutionRuralLevel.ts
+++ b/pro/src/apiClient/adage/models/InstitutionRuralLevel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/ListCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/adage/models/ListCollectiveOfferTemplateResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/ListCollectiveOffersResponseModel.ts
+++ b/pro/src/apiClient/adage/models/ListCollectiveOffersResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/ListFeatureResponseModel.ts
+++ b/pro/src/apiClient/adage/models/ListFeatureResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/LocalOfferersPlaylist.ts
+++ b/pro/src/apiClient/adage/models/LocalOfferersPlaylist.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/LocalOfferersPlaylistOffer.ts
+++ b/pro/src/apiClient/adage/models/LocalOfferersPlaylistOffer.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/NationalProgramModel.ts
+++ b/pro/src/apiClient/adage/models/NationalProgramModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/OfferAddressType.ts
+++ b/pro/src/apiClient/adage/models/OfferAddressType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/OfferContactFormEnum.ts
+++ b/pro/src/apiClient/adage/models/OfferContactFormEnum.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/OfferDomain.ts
+++ b/pro/src/apiClient/adage/models/OfferDomain.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/OfferFavoriteBody.ts
+++ b/pro/src/apiClient/adage/models/OfferFavoriteBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/OfferIdBody.ts
+++ b/pro/src/apiClient/adage/models/OfferIdBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/OfferManagingOffererResponse.ts
+++ b/pro/src/apiClient/adage/models/OfferManagingOffererResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/OfferStockResponse.ts
+++ b/pro/src/apiClient/adage/models/OfferStockResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/OfferVenueResponse.ts
+++ b/pro/src/apiClient/adage/models/OfferVenueResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/PlaylistBody.ts
+++ b/pro/src/apiClient/adage/models/PlaylistBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/PostCollectiveRequestBodyModel.ts
+++ b/pro/src/apiClient/adage/models/PostCollectiveRequestBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/RedactorPreferences.ts
+++ b/pro/src/apiClient/adage/models/RedactorPreferences.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/SearchBody.ts
+++ b/pro/src/apiClient/adage/models/SearchBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/StockIdBody.ts
+++ b/pro/src/apiClient/adage/models/StockIdBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/StudentLevels.ts
+++ b/pro/src/apiClient/adage/models/StudentLevels.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/SubcategoryResponseModel.ts
+++ b/pro/src/apiClient/adage/models/SubcategoryResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/SuggestionType.ts
+++ b/pro/src/apiClient/adage/models/SuggestionType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/TemplateDatesModel.ts
+++ b/pro/src/apiClient/adage/models/TemplateDatesModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/TrackingAutocompleteSuggestionBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingAutocompleteSuggestionBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/TrackingCTAShareBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingCTAShareBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/TrackingFilterBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingFilterBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/TrackingShowMoreBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingShowMoreBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/ValidationError.ts
+++ b/pro/src/apiClient/adage/models/ValidationError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/ValidationErrorElement.ts
+++ b/pro/src/apiClient/adage/models/ValidationErrorElement.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/models/VenueResponse.ts
+++ b/pro/src/apiClient/adage/models/VenueResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/AppClient.ts
+++ b/pro/src/apiClient/v1/AppClient.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/core/ApiError.ts
+++ b/pro/src/apiClient/v1/core/ApiError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/core/ApiRequestOptions.ts
+++ b/pro/src/apiClient/v1/core/ApiRequestOptions.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/core/ApiResult.ts
+++ b/pro/src/apiClient/v1/core/ApiResult.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/core/BaseHttpRequest.ts
+++ b/pro/src/apiClient/v1/core/BaseHttpRequest.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/core/CancelablePromise.ts
+++ b/pro/src/apiClient/v1/core/CancelablePromise.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -85,9 +85,9 @@ export class CancelablePromise<T> implements Promise<T> {
     });
   }
 
-   get [Symbol.toStringTag]() {
-            return "Cancellable Promise";
-     }
+  get [Symbol.toStringTag]() {
+    return "Cancellable Promise";
+  }
 
   public then<TResult1 = T, TResult2 = never>(
     onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,

--- a/pro/src/apiClient/v1/core/FetchHttpRequest.ts
+++ b/pro/src/apiClient/v1/core/FetchHttpRequest.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/core/OpenAPI.ts
+++ b/pro/src/apiClient/v1/core/OpenAPI.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/AdageCulturalPartnerResponseModel.ts
+++ b/pro/src/apiClient/v1/models/AdageCulturalPartnerResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/AdageCulturalPartnersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/AdageCulturalPartnersResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/Address.ts
+++ b/pro/src/apiClient/v1/models/Address.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/AttachImageFormModel.ts
+++ b/pro/src/apiClient/v1/models/AttachImageFormModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/AttachImageResponseModel.ts
+++ b/pro/src/apiClient/v1/models/AttachImageResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BankAccountApplicationStatus.ts
+++ b/pro/src/apiClient/v1/models/BankAccountApplicationStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BankAccountResponseModel.ts
+++ b/pro/src/apiClient/v1/models/BankAccountResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BannerMetaModel.ts
+++ b/pro/src/apiClient/v1/models/BannerMetaModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BookingExportType.ts
+++ b/pro/src/apiClient/v1/models/BookingExportType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BookingRecapResponseBeneficiaryModel.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapResponseBeneficiaryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BookingRecapResponseBookingStatusHistoryModel.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapResponseBookingStatusHistoryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BookingRecapResponseModel.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BookingRecapResponseStockModel.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapResponseStockModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BookingRecapStatus.ts
+++ b/pro/src/apiClient/v1/models/BookingRecapStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BookingStatusFilter.ts
+++ b/pro/src/apiClient/v1/models/BookingStatusFilter.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/BookingStatusHistoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/BookingStatusHistoryResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CategoriesResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CategoriesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CategoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CategoryResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ChangePasswordBodyModel.ts
+++ b/pro/src/apiClient/v1/models/ChangePasswordBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ChangeProEmailBody.ts
+++ b/pro/src/apiClient/v1/models/ChangeProEmailBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingBankAccountStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingBankAccountStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingBankInformationStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingBankInformationStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingByIdResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingByIdResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingCancellationReasons.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingCancellationReasons.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingCollectiveStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingCollectiveStockResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingEducationalRedactorResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingEducationalRedactorResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveBookingStatusFilter.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingStatusFilter.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferDisplayedStatus.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferDisplayedStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferInstitutionModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferInstitutionModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferOfferVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferOfferVenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferRedactorModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferRedactorModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseIdModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseIdModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferTemplateBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferTemplateResponseIdModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferTemplateResponseIdModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferType.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOfferVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferVenueBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOffersBookingResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOffersBookingResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveOffersStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOffersStockResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveStockCreationBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveStockCreationBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveStockEditionBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveStockEditionBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CollectiveStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveStockResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/Consent.ts
+++ b/pro/src/apiClient/v1/models/Consent.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CookieConsentRequest.ts
+++ b/pro/src/apiClient/v1/models/CookieConsentRequest.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CreateOffererQueryModel.ts
+++ b/pro/src/apiClient/v1/models/CreateOffererQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CreatePriceCategoryModel.ts
+++ b/pro/src/apiClient/v1/models/CreatePriceCategoryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CreateThumbnailBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CreateThumbnailBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CreateThumbnailResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CreateThumbnailResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CropParams.ts
+++ b/pro/src/apiClient/v1/models/CropParams.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/CulturalPartner.ts
+++ b/pro/src/apiClient/v1/models/CulturalPartner.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/DMSApplicationForEAC.ts
+++ b/pro/src/apiClient/v1/models/DMSApplicationForEAC.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/DMSApplicationstatus.ts
+++ b/pro/src/apiClient/v1/models/DMSApplicationstatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/DateRangeModel.ts
+++ b/pro/src/apiClient/v1/models/DateRangeModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/DateRangeOnCreateModel.ts
+++ b/pro/src/apiClient/v1/models/DateRangeOnCreateModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/DeleteFilteredStockListBody.ts
+++ b/pro/src/apiClient/v1/models/DeleteFilteredStockListBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/DeleteOfferRequestBody.ts
+++ b/pro/src/apiClient/v1/models/DeleteOfferRequestBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/DeleteStockListBody.ts
+++ b/pro/src/apiClient/v1/models/DeleteStockListBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EacFormat.ts
+++ b/pro/src/apiClient/v1/models/EacFormat.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EditPriceCategoryModel.ts
+++ b/pro/src/apiClient/v1/models/EditPriceCategoryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EditVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/EditVenueBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EditVenueCollectiveDataBodyModel.ts
+++ b/pro/src/apiClient/v1/models/EditVenueCollectiveDataBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalDomainResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalDomainResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalDomainsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalDomainsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalInstitutionResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalInstitutionResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalInstitutionsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalInstitutionsQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalInstitutionsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalInstitutionsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalRedactor.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactor.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalRedactorQueryModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactorQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalRedactorResponseModel.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactorResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/EducationalRedactors.ts
+++ b/pro/src/apiClient/v1/models/EducationalRedactors.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ExportBookingsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ExportBookingsQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/FeatureResponseModel.ts
+++ b/pro/src/apiClient/v1/models/FeatureResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/FinanceBankAccountListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/FinanceBankAccountListResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/FinanceBankAccountResponseModel.ts
+++ b/pro/src/apiClient/v1/models/FinanceBankAccountResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/FinanceReimbursementPointListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/FinanceReimbursementPointListResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/FinanceReimbursementPointResponseModel.ts
+++ b/pro/src/apiClient/v1/models/FinanceReimbursementPointResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GenderEnum.ts
+++ b/pro/src/apiClient/v1/models/GenderEnum.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GenerateOffererApiKeyResponse.ts
+++ b/pro/src/apiClient/v1/models/GenerateOffererApiKeyResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferCollectiveStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferCollectiveStockResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferManagingOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferManagingOffererResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferRequestResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferRequestResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferVenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetCollectiveVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveVenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetEducationalOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetEducationalOffererResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetEducationalOffererVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetEducationalOffererVenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetEducationalOfferersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/GetEducationalOfferersQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetEducationalOfferersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetEducationalOfferersResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetMusicTypesResponse.ts
+++ b/pro/src/apiClient/v1/models/GetMusicTypesResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOfferLastProviderResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferLastProviderResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOfferManagingOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferManagingOffererResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOfferMediationResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferMediationResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOfferStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferStockResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOfferVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferVenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOffererBankAccountsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererBankAccountsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOffererMemberResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererMemberResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOffererMembersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererMembersResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOffererNameResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererNameResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOffererStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererStatsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOffererV2StatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererV2StatsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOffererVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererVenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOfferersNamesQueryModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferersNamesQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetOfferersNamesResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOfferersNamesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetStocksResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetStocksResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetVenueDomainResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueDomainResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetVenueListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueListResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetVenueManagingOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueManagingOffererResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetVenuePricingPointResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenuePricingPointResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/GetVenuesOfOffererFromSiretResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenuesOfOffererFromSiretResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/HasInvoiceQueryModel.ts
+++ b/pro/src/apiClient/v1/models/HasInvoiceQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/HasInvoiceResponseModel.ts
+++ b/pro/src/apiClient/v1/models/HasInvoiceResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/InviteMemberQueryModel.ts
+++ b/pro/src/apiClient/v1/models/InviteMemberQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/InvoiceListQueryModel.ts
+++ b/pro/src/apiClient/v1/models/InvoiceListQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/InvoiceListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/InvoiceListResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/InvoiceListV2QueryModel.ts
+++ b/pro/src/apiClient/v1/models/InvoiceListV2QueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/InvoiceListV2ResponseModel.ts
+++ b/pro/src/apiClient/v1/models/InvoiceListV2ResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/InvoiceResponseModel.ts
+++ b/pro/src/apiClient/v1/models/InvoiceResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/InvoiceResponseV2Model.ts
+++ b/pro/src/apiClient/v1/models/InvoiceResponseV2Model.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/LegalStatusResponseModel.ts
+++ b/pro/src/apiClient/v1/models/LegalStatusResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/LinkVenueToBankAccountBodyModel.ts
+++ b/pro/src/apiClient/v1/models/LinkVenueToBankAccountBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/LinkVenueToPricingPointBodyModel.ts
+++ b/pro/src/apiClient/v1/models/LinkVenueToPricingPointBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/LinkedVenues.ts
+++ b/pro/src/apiClient/v1/models/LinkedVenues.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListBookingsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListBookingsQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListBookingsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListBookingsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListCollectiveBookingsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveBookingsQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListCollectiveBookingsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveBookingsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListCollectiveOffersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveOffersQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListCollectiveOffersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListCollectiveOffersResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListFeatureResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListFeatureResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListNationalProgramsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListNationalProgramsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListOffersOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersOfferResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListOffersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListOffersResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListOffersStockResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersStockResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListOffersVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersVenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListProviderResponse.ts
+++ b/pro/src/apiClient/v1/models/ListProviderResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListVenueProviderQuery.ts
+++ b/pro/src/apiClient/v1/models/ListVenueProviderQuery.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ListVenueProviderResponse.ts
+++ b/pro/src/apiClient/v1/models/ListVenueProviderResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/LoginUserBodyModel.ts
+++ b/pro/src/apiClient/v1/models/LoginUserBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ManagedVenues.ts
+++ b/pro/src/apiClient/v1/models/ManagedVenues.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/MusicTypeResponse.ts
+++ b/pro/src/apiClient/v1/models/MusicTypeResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/NationalProgramModel.ts
+++ b/pro/src/apiClient/v1/models/NationalProgramModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/NavStateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/NavStateResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/NewPasswordBodyModel.ts
+++ b/pro/src/apiClient/v1/models/NewPasswordBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OfferAddressType.ts
+++ b/pro/src/apiClient/v1/models/OfferAddressType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OfferContactFormEnum.ts
+++ b/pro/src/apiClient/v1/models/OfferContactFormEnum.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OfferDomain.ts
+++ b/pro/src/apiClient/v1/models/OfferDomain.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OfferImage.ts
+++ b/pro/src/apiClient/v1/models/OfferImage.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OfferStatus.ts
+++ b/pro/src/apiClient/v1/models/OfferStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OfferType.ts
+++ b/pro/src/apiClient/v1/models/OfferType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OffererApiKey.ts
+++ b/pro/src/apiClient/v1/models/OffererApiKey.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OffererMemberStatus.ts
+++ b/pro/src/apiClient/v1/models/OffererMemberStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OffererReimbursementPointListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/OffererReimbursementPointListResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OffererReimbursementPointResponseModel.ts
+++ b/pro/src/apiClient/v1/models/OffererReimbursementPointResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OffererStatsDataModel.ts
+++ b/pro/src/apiClient/v1/models/OffererStatsDataModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OffererStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/OffererStatsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/OffererViewsModel.ts
+++ b/pro/src/apiClient/v1/models/OffererViewsModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchAllCollectiveOffersActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchAllCollectiveOffersActiveStatusBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchAllOffersActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchAllOffersActiveStatusBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferActiveStatusBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferEducationalInstitution.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferEducationalInstitution.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchCollectiveOfferTemplateBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchOfferActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferActiveStatusBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PatchOfferPublishBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferPublishBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PhoneValidationStatusType.ts
+++ b/pro/src/apiClient/v1/models/PhoneValidationStatusType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PostOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostOfferBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PostOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/PostOffererResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PostVenueProviderBody.ts
+++ b/pro/src/apiClient/v1/models/PostVenueProviderBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PriceCategoryBody.ts
+++ b/pro/src/apiClient/v1/models/PriceCategoryBody.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/PriceCategoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/PriceCategoryResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ProFlagsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ProFlagsQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ProUserCreationBodyV2Model.ts
+++ b/pro/src/apiClient/v1/models/ProUserCreationBodyV2Model.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ProviderResponse.ts
+++ b/pro/src/apiClient/v1/models/ProviderResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ReimbursementCsvQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ReimbursementCsvQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ResetPasswordBodyModel.ts
+++ b/pro/src/apiClient/v1/models/ResetPasswordBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
+++ b/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/SharedCurrentUserResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SharedCurrentUserResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/SharedLoginUserResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SharedLoginUserResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/SirenInfo.ts
+++ b/pro/src/apiClient/v1/models/SirenInfo.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/SiretInfo.ts
+++ b/pro/src/apiClient/v1/models/SiretInfo.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StockCreationBodyModel.ts
+++ b/pro/src/apiClient/v1/models/StockCreationBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StockEditionBodyModel.ts
+++ b/pro/src/apiClient/v1/models/StockEditionBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StockIdResponseModel.ts
+++ b/pro/src/apiClient/v1/models/StockIdResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StockStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/StockStatsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StocksOrderedBy.ts
+++ b/pro/src/apiClient/v1/models/StocksOrderedBy.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StocksQueryModel.ts
+++ b/pro/src/apiClient/v1/models/StocksQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StocksResponseModel.ts
+++ b/pro/src/apiClient/v1/models/StocksResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StocksUpsertBodyModel.ts
+++ b/pro/src/apiClient/v1/models/StocksUpsertBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/StudentLevels.ts
+++ b/pro/src/apiClient/v1/models/StudentLevels.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/SubcategoryIdEnum.ts
+++ b/pro/src/apiClient/v1/models/SubcategoryIdEnum.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/SubcategoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SubcategoryResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/Target.ts
+++ b/pro/src/apiClient/v1/models/Target.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/TemplateDatesModel.ts
+++ b/pro/src/apiClient/v1/models/TemplateDatesModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/TopOffersResponseData.ts
+++ b/pro/src/apiClient/v1/models/TopOffersResponseData.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/UserEmailValidationResponseModel.ts
+++ b/pro/src/apiClient/v1/models/UserEmailValidationResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/UserHasBookingResponse.ts
+++ b/pro/src/apiClient/v1/models/UserHasBookingResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/UserIdentityBodyModel.ts
+++ b/pro/src/apiClient/v1/models/UserIdentityBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/UserIdentityResponseModel.ts
+++ b/pro/src/apiClient/v1/models/UserIdentityResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/UserPhoneBodyModel.ts
+++ b/pro/src/apiClient/v1/models/UserPhoneBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/UserPhoneResponseModel.ts
+++ b/pro/src/apiClient/v1/models/UserPhoneResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/UserResetEmailBodyModel.ts
+++ b/pro/src/apiClient/v1/models/UserResetEmailBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/UserRole.ts
+++ b/pro/src/apiClient/v1/models/UserRole.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ValidationError.ts
+++ b/pro/src/apiClient/v1/models/ValidationError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/ValidationErrorElement.ts
+++ b/pro/src/apiClient/v1/models/ValidationErrorElement.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueContactModel.ts
+++ b/pro/src/apiClient/v1/models/VenueContactModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueLabelListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueLabelListResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueLabelResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueLabelResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueListItemResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueListItemResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueListQueryModel.ts
+++ b/pro/src/apiClient/v1/models/VenueListQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueOfOffererFromSiretResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueOfOffererFromSiretResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueOpeningHoursModel.ts
+++ b/pro/src/apiClient/v1/models/VenueOpeningHoursModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueProviderResponse.ts
+++ b/pro/src/apiClient/v1/models/VenueProviderResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueStatsResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueStatsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueTypeCode.ts
+++ b/pro/src/apiClient/v1/models/VenueTypeCode.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueTypeListResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueTypeListResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenueTypeResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueTypeResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenuesEducationalStatusResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenuesEducationalStatusResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/VenuesEducationalStatusesResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenuesEducationalStatusesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/models/WithdrawalTypeEnum.ts
+++ b/pro/src/apiClient/v1/models/WithdrawalTypeEnum.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/AppClientV2.ts
+++ b/pro/src/apiClient/v2/AppClientV2.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/core/ApiError.ts
+++ b/pro/src/apiClient/v2/core/ApiError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/core/ApiRequestOptions.ts
+++ b/pro/src/apiClient/v2/core/ApiRequestOptions.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/core/ApiResult.ts
+++ b/pro/src/apiClient/v2/core/ApiResult.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/core/BaseHttpRequest.ts
+++ b/pro/src/apiClient/v2/core/BaseHttpRequest.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/core/CancelablePromise.ts
+++ b/pro/src/apiClient/v2/core/CancelablePromise.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -85,9 +85,9 @@ export class CancelablePromise<T> implements Promise<T> {
     });
   }
 
-   get [Symbol.toStringTag]() {
-            return "Cancellable Promise";
-     }
+  get [Symbol.toStringTag]() {
+    return "Cancellable Promise";
+  }
 
   public then<TResult1 = T, TResult2 = never>(
     onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,

--- a/pro/src/apiClient/v2/core/FetchHttpRequest.ts
+++ b/pro/src/apiClient/v2/core/FetchHttpRequest.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/core/OpenAPI.ts
+++ b/pro/src/apiClient/v2/core/OpenAPI.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/index.ts
+++ b/pro/src/apiClient/v2/index.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/AuthErrorResponseModel.ts
+++ b/pro/src/apiClient/v2/models/AuthErrorResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/BookingFormula.ts
+++ b/pro/src/apiClient/v2/models/BookingFormula.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/BookingOfferType.ts
+++ b/pro/src/apiClient/v2/models/BookingOfferType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveBookingResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveBookingResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveBookingStatus.ts
+++ b/pro/src/apiClient/v2/models/CollectiveBookingStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersCategoryResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersCategoryResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersDomainResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersDomainResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersEducationalInstitutionResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersEducationalInstitutionResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersListCategoriesResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListCategoriesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersListDomainsResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListDomainsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersListEducationalInstitutionResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListEducationalInstitutionResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersListResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersListStudentLevelsResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListStudentLevelsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersListSubCategoriesResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListSubCategoriesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersListVenuesResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListVenuesResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersStudentLevelResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersStudentLevelResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/CollectiveOffersSubCategoryResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersSubCategoryResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/EacFormat.ts
+++ b/pro/src/apiClient/v2/models/EacFormat.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/ErrorResponseModel.ts
+++ b/pro/src/apiClient/v2/models/ErrorResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/GetBookingResponse.ts
+++ b/pro/src/apiClient/v2/models/GetBookingResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/GetListEducationalInstitutionsQueryModel.ts
+++ b/pro/src/apiClient/v2/models/GetListEducationalInstitutionsQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/GetOffererVenuesResponse.ts
+++ b/pro/src/apiClient/v2/models/GetOffererVenuesResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/GetOfferersVenuesQuery.ts
+++ b/pro/src/apiClient/v2/models/GetOfferersVenuesQuery.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/GetOfferersVenuesResponse.ts
+++ b/pro/src/apiClient/v2/models/GetOfferersVenuesResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/GetPublicCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v2/models/GetPublicCollectiveOfferResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/ListCollectiveOffersQueryModel.ts
+++ b/pro/src/apiClient/v2/models/ListCollectiveOffersQueryModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/ListNationalProgramsResponseModel.ts
+++ b/pro/src/apiClient/v2/models/ListNationalProgramsResponseModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/NationalProgramModel.ts
+++ b/pro/src/apiClient/v2/models/NationalProgramModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/OfferAddressType.ts
+++ b/pro/src/apiClient/v2/models/OfferAddressType.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/OfferStatus.ts
+++ b/pro/src/apiClient/v2/models/OfferStatus.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/OfferVenueModel.ts
+++ b/pro/src/apiClient/v2/models/OfferVenueModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/OffererResponse.ts
+++ b/pro/src/apiClient/v2/models/OffererResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/PartialAccessibility.ts
+++ b/pro/src/apiClient/v2/models/PartialAccessibility.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/PatchCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v2/models/PatchCollectiveOfferBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/PostCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v2/models/PostCollectiveOfferBodyModel.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/ValidationError.ts
+++ b/pro/src/apiClient/v2/models/ValidationError.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/ValidationErrorElement.ts
+++ b/pro/src/apiClient/v2/models/ValidationErrorElement.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/VenueDigitalLocation.ts
+++ b/pro/src/apiClient/v2/models/VenueDigitalLocation.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/VenuePhysicalLocation.ts
+++ b/pro/src/apiClient/v2/models/VenuePhysicalLocation.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/VenueResponse.ts
+++ b/pro/src/apiClient/v2/models/VenueResponse.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/models/VenueTypeEnum.ts
+++ b/pro/src/apiClient/v2/models/VenueTypeEnum.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/services/ApiOffresCollectivesService.ts
+++ b/pro/src/apiClient/v2/services/ApiOffresCollectivesService.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/pro/src/apiClient/v2/services/DPrCiEApiContremarqueService.ts
+++ b/pro/src/apiClient/v2/services/DPrCiEApiContremarqueService.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */


### PR DESCRIPTION
bumps comes from https://github.com/pass-culture/pass-culture-main/commit/5246d3b86bc3943d91499ea880b8ee6e32dced3e . Since there was no backend changes the github action to regenerate types did not run

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques