### PR TITLE
(PC-28435)[PRO] feat: Add intervention areas in adage template offer …

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferInfoSection.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferInfoSection.tsx
@@ -5,6 +5,7 @@ import {
 import { OfferAddressType } from 'apiClient/v1'
 import { isCollectiveOfferBookable } from 'pages/AdageIframe/app/types/offers'
 
+import { getInterventionAreaLabelsToDisplay } from '../../../OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferInterventionArea/OfferInterventionArea'
 import styles from '../AdageOffer.module.scss'
 import {
   getFormattedDatesForBookableOffer,
@@ -46,6 +47,8 @@ export default function AdageOfferInfoSection({
 
   const location = getLocationForOfferVenue(offerVenue)
 
+  const interventionArea = offer.interventionArea ?? []
+
   const isOfferBookable = isCollectiveOfferBookable(offer)
 
   return (
@@ -63,6 +66,31 @@ export default function AdageOfferInfoSection({
           ? getFormattedDatesForBookableOffer(offer)
           : getFormattedDatesForTemplateOffer(offer)}
       </div>
+
+      {!isOfferBookable &&
+        offer.offerVenue.addressType !== OfferAddressType.OFFERER_VENUE &&
+        interventionArea.length > 0 && (
+          <div className={styles['offer-section-group-item']}>
+            <h3 className={styles['offer-section-group-item-subtitle']}>
+              Zone de mobilité
+            </h3>
+            {getInterventionAreaLabelsToDisplay(interventionArea).map(
+              (area, i) => (
+                <span key={area}>
+                  {i > 0 ? (
+                    <span className={styles['offer-section-group-list-pipe']}>
+                      {' '}
+                      |{' '}
+                    </span>
+                  ) : (
+                    ''
+                  )}
+                  {area}
+                </span>
+              )
+            )}
+          </div>
+        )}
 
       {(isOfferBookable || offer.educationalPriceDetail) && (
         <div className={styles['offer-section-group-item']}>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
@@ -111,4 +111,23 @@ describe('AdageOfferInfoSection', () => {
 
     expect(screen.getByText('1 400 € pour 10 élèves')).toBeInTheDocument()
   })
+
+  it('should show the intervention areas', () => {
+    renderAdageOfferInfoSection({
+      offer: {
+        ...defaultCollectiveTemplateOffer,
+        interventionArea: ['56', '29'],
+        offerVenue: {
+          ...defaultCollectiveTemplateOffer.offerVenue,
+          addressType: OfferAddressType.OTHER,
+        },
+      },
+    })
+
+    expect(
+      screen.getByRole('heading', { name: 'Zone de mobilité' })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText('Morbihan (56)')).toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferDetails.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferDetails.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import './OfferDetails.scss'
 
 import {
@@ -7,7 +5,7 @@ import {
   CollectiveOfferTemplateResponseModel,
 } from 'apiClient/adage'
 
-import OfferInterventionArea from './OfferInterventionArea'
+import { getInterventionAreaLabels } from './OfferInterventionArea/OfferInterventionArea'
 import OfferSection from './OfferSection'
 import OfferVenue from './OfferVenue'
 
@@ -102,7 +100,7 @@ const OfferDetails = ({
 
       {interventionArea?.length > 0 && (
         <OfferSection title="Zone de Mobilité">
-          <OfferInterventionArea interventionArea={interventionArea} />
+          <div>{getInterventionAreaLabels(interventionArea)}</div>
         </OfferSection>
       )}
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferInterventionArea/OfferInterventionArea.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferInterventionArea/OfferInterventionArea.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import {
   ALL_FRANCE_OPTION_VALUE,
   MAINLAND_OPTION_VALUE,
@@ -8,9 +6,9 @@ import {
   domtomOptions,
 } from 'pages/AdageIframe/app/constants/departmentOptions'
 
-export const getInterventionAreaLabels = (
+export const getInterventionAreaLabelsToDisplay = (
   interventionArea: string[]
-): string => {
+): string[] => {
   const labels: string[] = []
 
   if (
@@ -27,7 +25,7 @@ export const getInterventionAreaLabels = (
       }
     })
 
-    return labels.join(' - ')
+    return labels
   }
 
   departmentOptions.forEach((interventionOption) => {
@@ -38,13 +36,9 @@ export const getInterventionAreaLabels = (
     }
   })
 
-  return labels.join(' - ')
+  return labels
 }
 
-const OfferInterventionArea = ({
-  interventionArea,
-}: {
-  interventionArea: string[]
-}): JSX.Element => <div>{getInterventionAreaLabels(interventionArea)}</div>
-
-export default OfferInterventionArea
+export function getInterventionAreaLabels(interventionAreas: string[]): string {
+  return getInterventionAreaLabelsToDisplay(interventionAreas).join(` - `)
+}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferInterventionArea/index.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferInterventionArea/index.ts
@@ -1,1 +1,0 @@
-export { default } from './OfferInterventionArea'


### PR DESCRIPTION
…page.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28435

**Objectif**
Ajouter l'info des zones d'intervention sur les pages offre vitrine dans le cas où l'acteur culturel est amené à se déplacer.

<img width="350" alt="Capture d’écran 2024-03-20 à 17 29 58" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/37d78306-2e42-40d1-93e2-13a49848198d">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques