### PR TITLE
(BSR)[API] fix: Brevo testing template 37 replaced with 161

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -13,7 +13,7 @@ class TransactionalEmail(Enum):
         id_prod=223, id_not_prod=33, tags=["jeunes_offre_annulee_jeune"]
     )
     BOOKING_CANCELLATION_BY_PRO_TO_BENEFICIARY = models.Template(
-        id_prod=225, id_not_prod=37, tags=["jeunes_offre_annulee_pros"], send_to_ehp=False
+        id_prod=225, id_not_prod=161, tags=["jeunes_offre_annulee_pros"], send_to_ehp=False
     )
     BOOKING_CONFIRMATION_BY_BENEFICIARY = models.Template(
         id_prod=725, id_not_prod=96, tags=["jeunes_reservation_confirmee_v3"]

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary_test.py
@@ -101,7 +101,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
 
         # Then
         assert email_data.template == models.Template(
-            id_prod=225, id_not_prod=37, tags=["jeunes_offre_annulee_pros"], send_to_ehp=False
+            id_prod=225, id_not_prod=161, tags=["jeunes_offre_annulee_pros"], send_to_ehp=False
         )
         assert email_data.params == {
             "EVENT_DATE": None,


### PR DESCRIPTION
## But de la pull request

Le _template_ d'email 161, copie de la version prod mise à jour, remplace le _template_ 37 sur le compte de test Brevo.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques