### PR TITLE
(PC-28671)[PRO] feat: Improve tutorial navigation accessibility.

### DIFF
--- a/pro/src/components/Tutorial/Tutorial.module.scss
+++ b/pro/src/components/Tutorial/Tutorial.module.scss
@@ -42,54 +42,55 @@
     }
   }
 
-  .nav-step-list-section {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-
-    .nav-step {
-      background: colors.$grey-medium;
-      border: none;
-      border-radius: 50%;
-      height: rem.torem(8px);
-      margin-left: rem.torem(8px);
-      width: rem.torem(8px);
-
-      &:focus {
-        outline: transparent;
-      }
-    }
-
-    .nav-step-active {
-      background: colors.$primary;
-      border-radius: 50%;
-      /* stylelint-disable-next-line color-function-notation */
-      box-shadow: 0 0 rem.torem(3px) 0 rgba(colors.$secondary, 0.21);
-      height: rem.torem(12px);
-      width: rem.torem(12px);
-    }
-
-    .nav-step-done {
-      background: colors.$valid;
-    }
-  }
-
   .nav-buttons-section {
     margin-top: rem.torem(28px);
 
     button {
       margin-left: rem.torem(20px);
-      min-width:
-        rem.torem(
-          103px
-        ); // we use similar width for all button to avoid them moving on click.
+      min-width: rem.torem(
+        103px
+      ); // we use similar width for all button to avoid them moving on click.
     }
   }
 
   @media (max-width: size.$tablet) {
-    .tutorial-footer {    
+    .tutorial-footer {
       margin-top: rem.torem(32px);
     }
+  }
+}
+
+.nav-step-list-section {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+
+.nav-step {
+  background: colors.$grey-medium;
+  border: none;
+  border-radius: 50%;
+  height: rem.torem(8px);
+  margin-left: rem.torem(8px);
+  width: rem.torem(8px);
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: rem.torem(2px) solid colors.$input-text-color;
+    outline-offset: rem.torem(2px);
+  }
+
+  &.nav-step-active {
+    background: colors.$primary;
+    border-radius: 50%;
+    /* stylelint-disable-next-line color-function-notation */
+    box-shadow: 0 0 rem.torem(3px) 0 rgba(colors.$secondary, 0.21);
+    height: rem.torem(16px);
+    width: rem.torem(16px);
+  }
+
+  &.nav-step-done {
+    background: colors.$valid;
   }
 }
 

--- a/pro/src/components/TutorialDialog/TutorialDialog.tsx
+++ b/pro/src/components/TutorialDialog/TutorialDialog.tsx
@@ -21,13 +21,14 @@ const TutorialDialog = (): JSX.Element => {
 
   const saveHasSeenProTutorials = useCallback(() => {
     logEvent?.(Events.FIRST_LOGIN)
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     api
       .patchUserTutoSeen()
       .then(() => {
         dispatch(updateUser({ ...currentUser, hasSeenProTutorials: true }))
       })
       .finally(() => setAreTutoDisplayed(false))
-  }, [currentUser, logEvent])
+  }, [currentUser, logEvent, dispatch])
 
   return areTutoDisplayed ? (
     <DialogBox


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28671

**Objectif**
Améliorer l'accessibilité du contenu du tutorial. J'ai rendu + accessible le groupe de boutons de navigation (les petit cercles). Mais c'est + du damage control qu'autre chose, dans le cadre d'un pattern carousel W3C recommande d'avoir les controles de navigation avant le contenu des pages. https://www.w3.org/WAI/ARIA/apg/patterns/carousel/. Donc toutes les pages seront KO

[J'ai créé un ticket Design ](https://www.notion.so/passcultureapp/3187d7264b6c446dace5c713b7309f8b?v=cab9f8d6853044a799487decdd47c0bc&p=65a162a2fa3146cdbfc6e446e864efa7&pm=s)dans notion pour ouvrir la discussion

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques