### PR TITLE
(PC-28179)[API] feat: enable new user to new nav according to id parity

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -885,6 +885,7 @@ class UserProNewNavState(PcObject, Base, Model):
         nullable=False,
     )
     user: User = orm.relationship(User, foreign_keys=[userId], back_populates="pro_new_nav_state", uselist=False)
-
+    # If set, it means that the user can choose to switch to the new nav from that date. Otherwise, they must stay on the old nav.
     eligibilityDate: datetime = sa.Column(sa.DateTime, nullable=True)
+    # If set, it means that the user has switched to the new nav at that date. Otherwise, it means that they are still on the old nav
     newNavDate: datetime = sa.Column(sa.DateTime, nullable=True)

--- a/api/src/pcapi/routes/pro/signup.py
+++ b/api/src/pcapi/routes/pro/signup.py
@@ -3,6 +3,7 @@ from pcapi.connectors.api_recaptcha import ReCaptchaException
 from pcapi.connectors.api_recaptcha import check_web_recaptcha_token
 from pcapi.core.subscription.phone_validation import exceptions as phone_exceptions
 from pcapi.core.users import api as users_api
+from pcapi.core.users import exceptions as users_exceptions
 from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import users as users_serialize
@@ -27,3 +28,5 @@ def signup_pro_V2(body: users_serialize.ProUserCreationBodyV2Model) -> None:
         users_api.create_pro_user_V2(body)
     except phone_exceptions.InvalidPhoneNumber:
         raise ApiErrors(errors={"phoneNumber": ["Le numéro de téléphone est invalide"]})
+    except users_exceptions.UserAlreadyExistsException:
+        raise ApiErrors(errors={"email": ["l'email existe déjà"]})


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28179
Activer la nouvelle navigation lors de la création
Pour les utilisateurs non invités l'activation se fait selon la parité de leur id.
Pour les utilisateurs invité, ils "héritent" du status de l'utilisateur qui envoi l'invitation. Seul l'attribut newNavDate est a considérer.
L'attribut eligibilityDate n'est pas a modifier. Il est utilisé surtout pour distinguer les testeurs beta des testeurs A/B/ 
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques