### PR TITLE
Pc 28358 fs allow siret edition

### DIFF
--- a/api/src/pcapi/connectors/entreprise/sirene.py
+++ b/api/src/pcapi/connectors/entreprise/sirene.py
@@ -27,12 +27,12 @@ def get_siren(siren: str, with_address: bool = True, raise_if_non_public: bool =
 def get_siret(siret: str, raise_if_non_public: bool = True) -> models.SiretInfo:
     """Return information about the requested SIRET."""
     _check_feature_flag()
-    return get_backend(settings.SIRENE_BACKEND).get_siret(siret, raise_if_non_public=raise_if_non_public)
+    return get_backend(settings.SIRENE_BACKEND).get_siret(siret, raise_if_non_public)
 
 
-def siret_is_active(siret: str) -> bool:
+def siret_is_active(siret: str, raise_if_non_public: bool = True) -> bool:
     """Return whether the requested SIRET is active."""
-    siret_info = get_siret(siret)
+    siret_info = get_siret(siret, raise_if_non_public)
     return siret_info.active
 
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -104,7 +104,6 @@ def update_venue(
     reimbursement_point_id = attrs.pop("reimbursementPointId", UNCHANGED)
 
     modifications = {field: value for field, value in attrs.items() if venue.field_exists_and_has_changed(field, value)}
-
     if not admin_update:
         # run validation when the venue update is triggered by a pro
         # user. This can be bypassed when done by and admin/backoffice

--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -74,13 +74,13 @@ def check_venue_edition(modifications: dict[str, typing.Any], venue: models.Venu
     if managing_offerer_id:
         raise ApiErrors(errors={"managingOffererId": ["Vous ne pouvez pas changer la structure d'un lieu"]})
     # modifications.get("siret") may be False if there is no change (ok) OR if it has been cleared (forbidden!)
-    if "siret" in modifications and venue.siret and siret != venue.siret:
-        raise ApiErrors(errors={"siret": ["Vous ne pouvez pas modifier le siret d'un lieu"]})
+    if "siret" in modifications and not siret and "comment" not in modifications:
+        raise ApiErrors(errors={"siret": ["Vous ne pouvez pas supprimer le siret d'un lieu"]})
     if siret:
         venue_with_same_siret = models.Venue.query.filter_by(siret=siret).one_or_none()
         if venue_with_same_siret:
             raise ApiErrors(errors={"siret": ["Un lieu avec le même siret existe déjà"]})
-    if "name" in modifications and modifications["name"] != venue.name:
+    if "name" in modifications and modifications["name"] != venue.name and (siret is None or venue.siret == siret):
         raise ApiErrors(errors={"name": ["Vous ne pouvez pas modifier la raison sociale d'un lieu"]})
     if not venue.isVirtual and None in venue_disability_compliance and None in modifications_disability_compliance:
         raise ApiErrors(errors={"global": ["L'accessibilité du lieu doit être définie."]})

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -113,7 +113,8 @@ def edit_venue(venue_id: int, body: venues_serialize.EditVenueBodyModel) -> venu
     venue = Venue.query.get_or_404(venue_id)
 
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)
-    if body.siret and not sirene.siret_is_active(body.siret):
+    has_siret_changed = bool(body.siret and body.siret != venue.siret)
+    if body.siret and not sirene.siret_is_active(body.siret, raise_if_non_public=has_siret_changed):
         raise ApiErrors(errors={"siret": ["SIRET is no longer active"]})
 
     not_venue_fields = {

--- a/pro/src/pages/VenueCreation/SiretOrCommentFields/SiretOrCommentFields.tsx
+++ b/pro/src/pages/VenueCreation/SiretOrCommentFields/SiretOrCommentFields.tsx
@@ -16,7 +16,6 @@ export type SiretOrCommentInterface = {
   isCreatedEntity: boolean
   initialSiret?: string
   isToggleDisabled?: boolean
-  readOnly: boolean
   setIsFieldNameFrozen?: (isNameFrozen: boolean) => void
   // TODO Albéric: not sure why there are two states, could be refactored
   updateIsSiretValued: (isSiretValued: boolean) => void
@@ -29,7 +28,6 @@ export const SiretOrCommentFields = ({
   isCreatedEntity,
   isToggleDisabled = false,
   setIsFieldNameFrozen,
-  readOnly,
   updateIsSiretValued,
   setIsSiretValued,
   siren,
@@ -64,8 +62,7 @@ export const SiretOrCommentFields = ({
     if (
       !valideSiretLength(siret) ||
       !isSiretStartingWithSiren(siret, siren) ||
-      !isSiretSelected ||
-      readOnly
+      !isSiretSelected
     ) {
       setIsFieldNameFrozen && setIsFieldNameFrozen(false)
       return
@@ -120,7 +117,7 @@ export const SiretOrCommentFields = ({
           <Toggle
             label="Ce lieu possède un SIRET"
             isActiveByDefault={isSiretSelected}
-            isDisabled={readOnly || isToggleDisabled}
+            isDisabled={isToggleDisabled}
             handleClick={handleToggleClick}
           />
         </FormLayout.Row>
@@ -129,7 +126,6 @@ export const SiretOrCommentFields = ({
         <TextInput
           name="siret"
           label="SIRET du lieu"
-          disabled={readOnly}
           type="text"
           onChange={(e) => onSiretChange(e.target.value)}
         />

--- a/pro/src/pages/VenueCreation/SiretOrCommentFields/__specs__/SiretOrCommentFields.spec.tsx
+++ b/pro/src/pages/VenueCreation/SiretOrCommentFields/__specs__/SiretOrCommentFields.spec.tsx
@@ -74,7 +74,6 @@ describe('components | SiretOrCommentFields', () => {
     props = {
       isCreatedEntity: true,
       setIsFieldNameFrozen: setIsFieldNameFrozen,
-      readOnly: false,
       updateIsSiretValued: updateIsSiretValued,
       setIsSiretValued: setIsSiretValued,
       siren: '123456789',

--- a/pro/src/pages/VenueCreation/SiretOrCommentFields/validationSchema.ts
+++ b/pro/src/pages/VenueCreation/SiretOrCommentFields/validationSchema.ts
@@ -17,7 +17,8 @@ export const isSiretStartingWithSiren = (
 export const generateSiretValidationSchema = (
   isVenueVirtual: boolean,
   isSiretValued: boolean,
-  siren?: string | null
+  siren?: string | null,
+  initialSiret?: string
 ) => {
   const siretValidationSchema = {
     siret: isVenueVirtual
@@ -39,6 +40,9 @@ export const generateSiretValidationSchema = (
             'apiSiretValid',
             'Le code SIRET saisi n’est pas valide',
             async (siret) => {
+              if (siret === initialSiret) {
+                return true
+              }
               const response = await siretApiValidate(siret || '')
               return !response
             }

--- a/pro/src/pages/VenueCreation/VenueCreationForm.tsx
+++ b/pro/src/pages/VenueCreation/VenueCreationForm.tsx
@@ -69,7 +69,6 @@ export const VenueCreationForm = ({
           <FormLayout.Row>
             <SiretOrCommentFields
               initialSiret={initialValues.siret}
-              readOnly={Boolean(initialValues.siret)}
               isToggleDisabled={false}
               isCreatedEntity
               setIsFieldNameFrozen={setIsFieldNameFrozen}

--- a/pro/src/pages/VenueSettings/VenueSettingsForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueSettingsForm.tsx
@@ -64,7 +64,6 @@ export const VenueSettingsForm = ({
             <FormLayout.Row>
               <SiretOrCommentFields
                 initialSiret={initialValues.siret}
-                readOnly
                 isToggleDisabled
                 isCreatedEntity={false}
                 updateIsSiretValued={updateIsSiretValued}

--- a/pro/src/pages/VenueSettings/VenueSettingsScreen.tsx
+++ b/pro/src/pages/VenueSettings/VenueSettingsScreen.tsx
@@ -157,9 +157,13 @@ export const VenueSettingsFormScreen = ({
       })
     }
   }
-
   const formValidationSchema = getValidationSchema(venue.isVirtual).concat(
-    generateSiretValidationSchema(venue.isVirtual, isSiretValued, offerer.siren)
+    generateSiretValidationSchema(
+      venue.isVirtual,
+      isSiretValued,
+      offerer.siren,
+      initialValues.siret
+    )
   )
 
   const formik = useFormik({


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28358

_Contexte : Actuellement lorsqu'un acteur veut changer de SIRET il passe par le support pour effectuer cette action. Il s'avère que parfois le SIRET communiqué est non diffusible. Dans ce cas un fois l'action support effectuée, le lieu possède un SIRET non diffusible ce qui empêche toutes modifications de ce lieu car on re-valide le SIRET à chaque modification du lieu._ 

**Solution** 

- Autoriser la modification du SIRET sur la page d'édition d'un lieu pour permettre aux acteurs d'être autonome à ce sujet. On garde les règles de validation classique du SIRET dans ce cas. 

- Autoriser la modification d'un lieu possédant un SIRET non diffusible : Dans le cas ou lieu possède un SIRET non diffusible (rempli manuellement par le support), on veut permettre la modification d'autres informations du lieu (comme les données d'accessibilité, le mail, etc...). Dans ce cas on ne revalide plus le SIRET si le SIRET ne change pas lors de l'édition d'un lieu. 
