### PR TITLE
(BSR)[API] fix: avoid using last digits of SIREN for special meaning

### DIFF
--- a/api/src/pcapi/connectors/entreprise/backends/testing.py
+++ b/api/src/pcapi/connectors/entreprise/backends/testing.py
@@ -63,12 +63,6 @@ class TestingBackend(BaseBackend):
                 return "1000"  # Entreprise individuelle
 
     @classmethod
-    def _is_active(cls, siren_or_siret: str) -> bool:
-        # allows to get a closed offerer in dev/testing environments:
-        # any SIREN which ends with "99" or SIRET in which SIREN part ends with "99"
-        return siren_or_siret[7:9] != "99"
-
-    @classmethod
     def _is_diffusible(cls, siren_or_siret: str) -> bool:
         # allows to get a non-diffusible offerer in dev/testing environments: any SIREN which starts with '9'
         return siren_or_siret[0] != "9"
@@ -82,6 +76,12 @@ class TestingBackend(BaseBackend):
     def _is_late_for_taxes(cls, siren_or_siret: str) -> bool:
         # allows to get companies registered at the RCS or not, depending on the third digit in the SIREN/SIRET
         return siren_or_siret[2] == "9"
+
+    @classmethod
+    def _is_active(cls, siren_or_siret: str) -> bool:
+        # allows to get a closed offerer in dev/testing environments:
+        # any SIREN which are like "xxxx99xxx"
+        return siren_or_siret[4:6] != "99"
 
     @classmethod
     def _get_urssaf_dates(cls) -> tuple[datetime.date, datetime.date]:

--- a/api/tests/connectors/api_entreprise_test.py
+++ b/api/tests/connectors/api_entreprise_test.py
@@ -118,7 +118,7 @@ def test_get_siren_with_non_public_data_do_not_raise():
 
 @override_settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_of_inactive_company():
-    siren = "777888999"
+    siren = "777899888"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}",
@@ -127,7 +127,7 @@ def test_get_siren_of_inactive_company():
         siren_info = api.get_siren(siren, with_address=False)
         assert siren_info.siren == siren
         assert siren_info.name == "LE RIDEAU FERME"
-        assert siren_info.head_office_siret == "77788899900021"
+        assert siren_info.head_office_siret == "77789988800021"
         assert siren_info.ape_code == "90.01Z"
         assert siren_info.ape_label == "Arts du spectacle vivant"
         assert siren_info.legal_category_code == "5499"
@@ -256,7 +256,7 @@ def test_get_siret_with_non_public_data_do_not_raise():
 
 @override_settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siret_of_inactive_company():
-    siret = "77788899900021"
+    siret = "77789988800021"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/{siret}",

--- a/api/tests/connectors/api_entreprise_test_data.py
+++ b/api/tests/connectors/api_entreprise_test_data.py
@@ -368,9 +368,9 @@ RESPONSE_SIRET_COMPANY_WITH_NON_PUBLIC_DATA = {
 
 RESPONSE_SIREN_INACTIVE_COMPANY = {
     "data": {
-        "siren": "777888999",
+        "siren": "777899888",
         "rna": None,
-        "siret_siege_social": "77788899900021",
+        "siret_siege_social": "77789988800021",
         "categorie_entreprise": None,
         "type": "personne_morale",
         "personne_morale_attributs": {"raison_sociale": "LE RIDEAU FERME", "sigle": None},
@@ -405,15 +405,15 @@ RESPONSE_SIREN_INACTIVE_COMPANY = {
         "date_creation": 1262300400,
     },
     "links": {
-        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/77788899900021",
-        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/77788899900021/adresse",
+        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/77789988800021",
+        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/77789988800021/adresse",
     },
     "meta": {"date_derniere_mise_a_jour": 1618178400, "redirect_from_siren": None},
 }
 
 RESPONSE_SIRET_INACTIVE_COMPANY = {
     "data": {
-        "siret": "77788899900021",
+        "siret": "77789988800021",
         "siege_social": True,
         "etat_administratif": "F",
         "date_fermeture": 1703977200,
@@ -430,9 +430,9 @@ RESPONSE_SIRET_INACTIVE_COMPANY = {
         "status_diffusion": "diffusible",
         "date_creation": 1262300400,
         "unite_legale": {
-            "siren": "777888999",
+            "siren": "777899888",
             "rna": None,
-            "siret_siege_social": "77788899900021",
+            "siret_siege_social": "77789988800021",
             "type": "personne_morale",
             "personne_morale_attributs": {"raison_sociale": "LE RIDEAU FERME", "sigle": None},
             "personne_physique_attributs": {
@@ -492,7 +492,7 @@ RESPONSE_SIRET_INACTIVE_COMPANY = {
             },
         },
     },
-    "links": {"unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/777888999"},
+    "links": {"unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/777899888"},
     "meta": {"date_derniere_mise_a_jour": 1618178400, "redirect_from_siret": None},
 }
 

--- a/api/tests/core/external/external_pro_test.py
+++ b/api/tests/core/external/external_pro_test.py
@@ -148,7 +148,7 @@ def test_update_external_pro_user_attributes(
 
     # Offerer not linked to user email but with the same booking email
     offerer3 = offerers_factories.OffererFactory(
-        siren="777888999", name="Plage Events", tags=[offerers_factories.OffererTagFactory(label="Collectivité")]
+        siren="777899888", name="Plage Events", tags=[offerers_factories.OffererTagFactory(label="Collectivité")]
     )
     venue3 = offerers_factories.VenueFactory(
         managingOfferer=offerer3,
@@ -157,7 +157,7 @@ def test_update_external_pro_user_attributes(
         postalCode="83700",
         city="Saint-Raphaël",
         bookingEmail=email,
-        siret="77788899900001",
+        siret="77789988800001",
         isPermanent=False,
         venueTypeCode=VenueTypeCode.PERFORMING_ARTS,
         venueLabelId=None,

--- a/api/tests/core/offerers/test_tasks.py
+++ b/api/tests/core/offerers/test_tasks.py
@@ -133,7 +133,7 @@ class CheckOffererIsActiveTest:
     def test_tag_inactive_offerer(self, mock_search_file, mock_append_to_spreadsheet, client, siren_caduc_tag):
         # Using TestingBackend:
         # SIREN makes offerer inactive (ends with 99), late for taxes (third digit is 9), SARL (fourth digit is 5)
-        offerer = offerers_factories.OffererFactory(siren="109500099")
+        offerer = offerers_factories.OffererFactory(siren="109599000")
 
         response = client.post(
             f"{settings.API_URL}/cloud-tasks/offerers/check_offerer",
@@ -196,7 +196,7 @@ class CheckOffererIsActiveTest:
     @override_features(ENABLE_CODIR_OFFERERS_REPORT=False)
     def test_reject_inactive_offerer_waiting_for_validation(self, client, siren_caduc_tag):
         # Using TestingBackend: SIREN makes offerer inactive (ends with 99), EI
-        offerer = offerers_factories.PendingOffererFactory(siren="100000099")
+        offerer = offerers_factories.PendingOffererFactory(siren="100099000")
         user_offerer = offerers_factories.UserNotValidatedOffererFactory(offerer=offerer)
 
         response = client.post(

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -3629,7 +3629,7 @@ class GetEntrepriseInfoRcsTest(GetEndpointHelper):
         assert content == "Activité commerciale : Non"
 
     def test_get_rcs_info_deregistered(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="030000099")
+        offerer = offerers_factories.OffererFactory(siren="030099000")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -833,7 +833,7 @@ class CreateOffererTest(PostEndpointHelper):
         "siret,expected_warning",
         [
             ("00000000000001", "Le SIRET 00000000000001 n'existe pas"),
-            ("90000009900001", "L'établissement portant le SIRET 90000009900001 est fermé"),
+            ("90009900000001", "L'établissement portant le SIRET 90009900000001 est fermé"),
             (
                 "12345678900001",
                 "L'établissement portant le SIRET 12345678900001 est diffusible, l'acteur culturel peut créer la structure sur PC Pro",


### PR DESCRIPTION
## But de la pull request

fix flacky tests by moving special SIREN meaning upward in number.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques