### PR TITLE
(PC-27849)[PRO] fix: Replace collective offer edition back button wit…

### DIFF
--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -311,16 +311,19 @@ const CollectiveOfferVisibility = ({
                 <ButtonLink
                   variant={ButtonVariant.SECONDARY}
                   link={{
-                    to: `/offre/${offer.id}/collectif/stocks${
-                      requestId ? `?requete=${requestId}` : ''
-                    }`,
+                    to:
+                      mode === Mode.CREATION
+                        ? `/offre/${offer.id}/collectif/stocks${
+                            requestId ? `?requete=${requestId}` : ''
+                          }`
+                        : '/offres/collectives',
                     isExternal: false,
                   }}
                 >
-                  Étape précédente
+                  {mode === Mode.CREATION
+                    ? 'Étape précédente'
+                    : 'Annuler et quitter'}
                 </ButtonLink>
-              </ActionsBarSticky.Left>
-              <ActionsBarSticky.Right>
                 <SubmitButton
                   disabled={
                     buttonPressed ||
@@ -331,9 +334,9 @@ const CollectiveOfferVisibility = ({
                 >
                   {mode === Mode.CREATION
                     ? 'Étape suivante'
-                    : 'Valider et enregistrer l’offre'}
+                    : 'Enregistrer les modifications'}
                 </SubmitButton>
-              </ActionsBarSticky.Right>
+              </ActionsBarSticky.Left>
             </ActionsBarSticky>
           </FormLayout>
         </form>

--- a/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -125,7 +125,7 @@ describe('CollectiveOfferVisibility', () => {
         /Nom de l’établissement scolaire ou code UAI/
       )
     ).toBeDisabled()
-    expect(screen.getByText(/Valider et enregistrer l’offre/)).toBeDisabled()
+    expect(screen.getByText(/Enregistrer les modifications/)).toBeDisabled()
   })
 
   it('should disable submit button if the user did not select an institution', () => {
@@ -438,5 +438,16 @@ describe('CollectiveOfferVisibility', () => {
         expect(notifyError).toHaveBeenCalledTimes(1)
       })
     })
+  })
+
+  it('should have a cancel button instead of the previous step button when editing the offer', () => {
+    renderVisibilityStep({ ...props, mode: Mode.EDITION })
+    expect(
+      screen.queryByRole('button', { name: /Étape suivante/ })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: 'Annuler et quitter' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -191,13 +191,18 @@ const OfferEducationalStock = <
                 <ButtonLink
                   variant={ButtonVariant.SECONDARY}
                   link={{
-                    to: `/offre/collectif/${offer.id}/creation${
-                      requestId ? `?requete=${requestId}` : ''
-                    }`,
+                    to:
+                      mode === Mode.CREATION
+                        ? `/offre/collectif/${offer.id}/creation${
+                            requestId ? `?requete=${requestId}` : ''
+                          }`
+                        : '/offres/collectives',
                     isExternal: false,
                   }}
                 >
-                  Étape précédente
+                  {mode === Mode.CREATION
+                    ? 'Étape précédente'
+                    : 'Annuler et quitter'}
                 </ButtonLink>
                 <SubmitButton
                   className=""
@@ -207,7 +212,7 @@ const OfferEducationalStock = <
                   }
                   isLoading={isLoading}
                 >
-                  {mode === Mode.EDITION
+                  {mode !== Mode.CREATION
                     ? 'Enregistrer les modifications'
                     : 'Étape suivante'}
                 </SubmitButton>

--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -209,4 +209,20 @@ describe('OfferEducationalStock', () => {
       screen.getByText("L'heure doit être postérieure à l'heure actuelle")
     ).toBeInTheDocument()
   })
+
+  it('should have a cancel button instead of the previous step button when editing the offer', () => {
+    const testProps: OfferEducationalStockProps = {
+      ...defaultProps,
+      mode: Mode.EDITION,
+    }
+
+    renderWithProviders(<OfferEducationalStock {...testProps} />)
+    expect(
+      screen.queryByRole('button', { name: /Étape suivante/ })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: 'Annuler et quitter' })
+    ).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
…h a cancel button.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27849

**Objectif**
Quand on est en édition sur une offre collective réservable, dans la sticky bar on ne doit plus avoir un bouton "Etape précédente" qui revoyait vers le formulaire de création, mais un bouton "Annuler et quitter" qui revoit vers la liste des offres collectives

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques