### PR TITLE
(PC-28496)[API] fix: Fix client timeout of Recommendation API

### DIFF
--- a/api/src/pcapi/connectors/recommendation.py
+++ b/api/src/pcapi/connectors/recommendation.py
@@ -4,7 +4,6 @@ This is a mere proxy. Input validation is done by the recommendation
 API, and this module returns the raw response.
 """
 
-import datetime
 import json
 import logging
 
@@ -15,7 +14,7 @@ from pcapi.utils import requests
 
 
 logger = logging.getLogger(__name__)
-HTTP_TIMEOUT = datetime.timedelta(seconds=5)
+HTTP_TIMEOUT = 5
 
 
 class RecommendationApiException(Exception):

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -18,10 +18,10 @@ releases:
 environments:
   testing:
     values:
-      - chartVersion: 0.24.0
+      - chartVersion: 0.25.0
   staging:
     values:
-      - chartVersion: 0.24.0
+      - chartVersion: 0.25.0
   integration:
     values:
       - chartVersion: 0.24.0
@@ -30,7 +30,7 @@ environments:
       - chartVersion: 0.24.0
   ops:
     values:
-      - chartVersion: 0.24.0
+      - chartVersion: 0.25.0
   perf:
     values:
-      - chartVersion: 0.24.0
+      - chartVersion: 0.25.0


### PR DESCRIPTION
`requests` expects a number of seconds as an integer, not a
`timedelta` object.