### PR TITLE
(PC-28611)[API] fix: mitigate account pre-hijacking on SSO login

### DIFF
--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -273,6 +273,10 @@ def google_auth(body: authentication.GoogleSigninRequest) -> authentication.Sign
 
     with transaction():
         if not user.isEmailValidated:
+            # An account registered with a password and with its email not validated is a symptom
+            # of an account pre-hijacking attack waiting for an email validation. To prevent this
+            # we disable the email + password login when a SSO is enabled.
+            user.password = None
             user.isEmailValidated = True
 
         if not single_sign_on:

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -395,7 +395,7 @@ class SSOSigninTest:
 
     @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)
-    def test_single_sign_on_validates_email(self, mocked_google_oauth, client, caplog):
+    def test_single_sign_on_validates_email_and_deletes_password(self, mocked_google_oauth, client, caplog):
         user = users_factories.UserFactory(email=self.valid_google_user.email, isEmailValidated=False)
         oauth_state_token = token_utils.UUIDToken.create(
             token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
@@ -409,6 +409,7 @@ class SSOSigninTest:
 
         assert response.status_code == 200, response.json
         assert user.isEmailValidated
+        assert user.password is None
 
     @patch("pcapi.connectors.google_oauth.get_google_user")
     @override_features(WIP_ENABLE_GOOGLE_SSO=True)


### PR DESCRIPTION
An account registered with a password and with its email not validated is a symptom of an account pre-hijacking attack waiting for an email validation. To prevent this we disable the email + password login when a SSO is enabled.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28611