### PR TITLE
(BSR)[API] chore: Bump Helm chart to 0.25.0

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -24,10 +24,10 @@ environments:
       - chartVersion: 0.25.0
   integration:
     values:
-      - chartVersion: 0.24.0
+      - chartVersion: 0.25.0
   production:
     values:
-      - chartVersion: 0.24.0
+      - chartVersion: 0.25.0
   ops:
     values:
       - chartVersion: 0.25.0


### PR DESCRIPTION
À merger **avant** la MES, une fois confirmé le bon fonctionnement sur testing.

---

This version adds a new deployment/service/ingress for the new API
recommendation proxy routes.