### PR TITLE
(PC-28502)[PRO] fix: redirect to collective offers when canceling edi…

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_users_and_offerers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_users_and_offerers.py
@@ -16,7 +16,14 @@ def create_users_offerers() -> list[offerers_models.Offerer]:
         offerer__siren="444608442",
         offerer__allowedOnAdage=True,
     )
+    user_offerer_new_nav = offerers_factories.UserOffererFactory(
+        user__email="eac_2_lieu_new_nav@example.com",
+        offerer__name="eac_2_lieu [BON EAC]",
+        offerer__siren="444608443",
+        offerer__allowedOnAdage=True,
+    )
     offerers.append(user_offerer.offerer)
+    offerers.append(user_offerer_new_nav.offerer)
     user_offerer = offerers_factories.UserOffererFactory(
         user__email="squad-eac@passculture.app",
         offerer=user_offerer.offerer,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_pro_users.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_pro_users.py
@@ -47,8 +47,9 @@ def create_industrial_pro_users(offerers_by_name: dict) -> dict[str, User]:
     users_by_name["pro retention structures"] = pro_retention_structures
     users_by_name["pro pro adage eligible"] = pro_adage_eligible
     pro_new_nav_state = users_factories.UserProNewNavStateFactory(user__email="activation_new_nav@example.com")
+    eac_new_nav_state = users_factories.UserProNewNavStateFactory(user__email="eac_2_lieu_new_nav@example.com")
 
-    repository.save(*users_by_name.values(), pro_new_nav_state)
+    repository.save(*users_by_name.values(), pro_new_nav_state, eac_new_nav_state)
 
     logger.info("created %d users", len(users_by_name))
 

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -14,7 +14,7 @@ import {
   OfferEducationalFormValues,
   isCollectiveOffer,
 } from 'core/OfferEducational'
-import { computeOffersUrl } from 'core/Offers/utils'
+import { computeCollectiveOffersUrl } from 'core/Offers/utils'
 import { SelectOption } from 'custom_types/form'
 import { useScrollToFirstErrorAfterSubmit } from 'hooks'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -194,7 +194,7 @@ const OfferEducationalForm = ({
         <ActionsBarSticky.Left>
           <ButtonLink
             variant={ButtonVariant.SECONDARY}
-            link={{ to: computeOffersUrl({}), isExternal: false }}
+            link={{ to: computeCollectiveOffersUrl({}), isExternal: false }}
           >
             Annuler et quitter
           </ButtonLink>


### PR DESCRIPTION
…tion

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28502

Changer le lien de redirection du bouton "Retour à la liste des offres" de la page d'édition d'une offre collectives, pour revenir à la liste des offres collectives et non individuelles

## Screenshot 

![Capture d’écran 2024-03-25 à 10 04 04](https://github.com/pass-culture/pass-culture-main/assets/71768799/5a024255-dd61-4745-9736-3e2f42267f04)

