### PR TITLE
(PC-28763)[API] feat: Add CSP report-only url in staging.

### DIFF
--- a/api/.env.staging
+++ b/api/.env.staging
@@ -94,6 +94,7 @@ SENDINBLUE_PRO_INACTIVE_90_DAYS_ID=36
 SENDINBLUE_PRO_NO_ACTIVE_OFFERS_40_DAYS_ID=40
 SENDINBLUE_PRO_NO_BOOKINGS_40_DAYS_ID=41
 SENTRY_SAMPLE_RATE=0.1
+SENTRY_CSP_REPORT_ONLY_URI=https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365
 SIRENE_BACKEND=pcapi.connectors.entreprise.backends.insee.InseeBackend
 SLACK_CHANGE_FEATURE_FLIP_CHANNEL=feature-flip-ehp
 SMS_NOTIFICATION_BACKEND=pcapi.notifications.sms.backends.sendinblue.ToDevSendinblueBackend


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28763

**Objectif**
Pour trouver les erreurs CSP en staging, on ajoute l'uri de rapport d'erreur en staging.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques