### PR TITLE
(PC-28660)[API] feat: check SIREN or SIRET valid format

### DIFF
--- a/api/src/pcapi/connectors/entreprise/backends/testing.py
+++ b/api/src/pcapi/connectors/entreprise/backends/testing.py
@@ -4,6 +4,7 @@ import datetime
 from pcapi.connectors.entreprise import exceptions
 from pcapi.connectors.entreprise import models
 from pcapi.connectors.entreprise.backends.base import BaseBackend
+from pcapi.utils import siren as siren_utils
 
 
 class TestingBackend(BaseBackend):
@@ -97,7 +98,7 @@ class TestingBackend(BaseBackend):
             return models.SirenInfo(
                 siren=siren,
                 name="[ND]",
-                head_office_siret=siren + "00001",
+                head_office_siret=siren_utils.complete_siren_or_siret(siren + "0001"),
                 ape_code="90.01Z",
                 ape_label="Arts du spectacle vivant",
                 legal_category_code=self._legal_category_code(siren),
@@ -111,7 +112,7 @@ class TestingBackend(BaseBackend):
         return models.SirenInfo(
             siren=siren,
             name="MINISTERE DE LA CULTURE",
-            head_office_siret=siren + "00001",
+            head_office_siret=siren_utils.complete_siren_or_siret(siren + "0001"),
             ape_code=ape_code,
             ape_label=ape_label,
             legal_category_code=self._legal_category_code(siren),

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -7,6 +7,7 @@ from pcapi.core.factories import BaseFactory
 import pcapi.core.users.factories as users_factories
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.utils import crypto
+from pcapi.utils import siren as siren_utils
 from pcapi.utils.date import timespan_str_to_numrange
 import pcapi.utils.postal_code as postal_code_utils
 
@@ -30,7 +31,7 @@ class OffererFactory(BaseFactory):
     address = "1 boulevard Poissonnière"
     postalCode = "75000"
     city = "Paris"
-    siren = factory.Sequence(lambda n: f"{n + 1:09}")
+    siren = factory.Sequence(lambda n: siren_utils.complete_siren_or_siret(f"{n + 1:08}"))  # ensures valid format
     isActive = True
     validationStatus = ValidationStatus.VALIDATED
     allowedOnAdage = True
@@ -67,7 +68,9 @@ class VenueFactory(BaseFactory):
     departementCode = factory.LazyAttribute(lambda o: None if o.isVirtual else _get_department_code(o.postalCode))
     city = factory.LazyAttribute(lambda o: None if o.isVirtual else "Paris")
     publicName = factory.SelfAttribute("name")
-    siret = factory.LazyAttributeSequence(lambda o, n: f"{o.managingOfferer.siren}{n:05}")
+    siret = factory.LazyAttributeSequence(
+        lambda o, n: siren_utils.complete_siren_or_siret(f"{o.managingOfferer.siren}{n:04}")
+    )
     isVirtual = False
     isPermanent = factory.LazyAttribute(lambda o: o.venueTypeCode in models.PERMENANT_VENUE_TYPES)
     venueTypeCode = models.VenueTypeCode.OTHER

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -29,6 +29,7 @@ from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.routes.backoffice.pro import forms as pro_forms
 from pcapi.utils import regions as regions_utils
+from pcapi.utils.siren import is_valid_siren
 
 from . import forms as offerer_forms
 from . import serialization
@@ -876,6 +877,9 @@ def get_entreprise_info(offerer_id: int) -> utils.BackofficeResponse:
     if not offerer.siren:
         raise NotFound()
 
+    if not is_valid_siren(offerer.siren):
+        return render_template("offerer/get/details/entreprise_info.html", is_invalid_siren=True, offerer=offerer)
+
     data: dict[str, typing.Any] = {}
     siren_info = None
 
@@ -895,7 +899,7 @@ def get_entreprise_info(offerer_id: int) -> utils.BackofficeResponse:
     if siren_info and siren_info.legal_category_code:
         data["show_dgfip_card"] = not entreprise_api.siren_is_individual_or_public(siren_info)
 
-    return render_template("offerer/get/details/entreprise_info.html", offerer_id=offerer_id, **data)
+    return render_template("offerer/get/details/entreprise_info.html", offerer=offerer, **data)
 
 
 @offerer_blueprint.route("/api-entreprise/rcs", methods=["GET"])
@@ -903,7 +907,7 @@ def get_entreprise_info(offerer_id: int) -> utils.BackofficeResponse:
 def get_entreprise_rcs_info(offerer_id: int) -> utils.BackofficeResponse:
     offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
 
-    if not offerer.siren:
+    if not offerer.siren or not is_valid_siren(offerer.siren):
         raise NotFound()
 
     data: dict[str, typing.Any] = {}
@@ -921,7 +925,7 @@ def get_entreprise_rcs_info(offerer_id: int) -> utils.BackofficeResponse:
 def get_entreprise_urssaf_info(offerer_id: int) -> utils.BackofficeResponse:
     offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
 
-    if not offerer.siren:
+    if not offerer.siren or not is_valid_siren(offerer.siren):
         raise NotFound()
 
     data: dict[str, typing.Any] = {}
@@ -944,7 +948,7 @@ def get_entreprise_urssaf_info(offerer_id: int) -> utils.BackofficeResponse:
 def get_entreprise_dgfip_info(offerer_id: int) -> utils.BackofficeResponse:
     offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
 
-    if not offerer.siren:
+    if not offerer.siren or not is_valid_siren(offerer.siren):
         raise NotFound()
 
     data: dict[str, typing.Any] = {}

--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -108,6 +108,12 @@
        class="link-primary">{{ venue.siret }} <i class="bi bi-box-arrow-up-right"></i></a>
   {% endif %}
 {% endmacro %}
+{% macro build_search_company_external_link(terms) %}
+  <a href="https://annuaire-entreprises.data.gouv.fr/rechercher?terme={{ terms }}"
+     target="_blank"
+     title="Rechercher dans l'Annuaire des Entreprises"
+     class="link-primary">{{ terms }} <i class="bi bi-box-arrow-up-right"></i></a>
+{% endmacro %}
 {% macro build_dms_adage_application_external_link(venue) %}
   <a href="https://www.demarches-simplifiees.fr/procedures/{{ venue.last_collective_dms_application.procedure }}/dossiers/{{ venue.last_collective_dms_application.application }}"
      target="_blank"

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/entreprise_info.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/entreprise_info.html
@@ -1,69 +1,79 @@
+{% import "components/links.html" as links %}
 {% from "components/turbo/spinner.html" import build_loading_spinner with context %}
 <turbo-frame id="offerer_entreprise_frame">
 <div class="card my-1 border-0">
   <div class="card-body my-2">
-    <h5 class="card-title">Données INSEE</h5>
-    <div class="card-body">
-      {% if siren_info %}
-        <div class="row">
-          {% if not siren_info.diffusible %}
-            <p>
-              <span class="fw-bold">Attention !</span> Cette entreprise a choisi de rendre son nom et son adresse non-diffusibles.
-              <br />
-              Ces informations ne doivent être utilisées qu'à des fins de vérification et ne doivent en aucun cas être partagées.
-            </p>
-          {% endif %}
-          <div class="col-6">
-            <p class="mb-1">
-              <span class="fw-bold">Nom :</span> {{ siren_info.name }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">SIRET du siège social :</span>
-              {% if siren_info.head_office_siret %}
-                <a href="{{ url_for("backoffice_web.pro.search_pro", pro_type='VENUE', q=siren_info.head_office_siret) }}">
-                  {{ siren_info.head_office_siret }}
-                </a>
-              {% endif %}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Adresse :</span> {{ siren_info.address.street }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Code postal :</span> {{ siren_info.address.postal_code }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Ville :</span> {{ siren_info.address.city }}
-            </p>
+    {% if is_invalid_siren %}
+      <span class="mr-2 pb-1 badge rounded-pill text-bg-warning"><i class="bi bi-exclamation-triangle"></i> Erreur</span>
+      Le format du numéro SIREN est détecté comme invalide, nous ne pouvons pas récupérer de données sur l'entreprise.
+      <br />
+      Merci de vérifier qu'il n'y a pas erreur dans l'Annuaire des Entreprises&nbsp;:
+      à partir du SIREN {{ links.build_siren_to_external_link(offerer) }}
+      ou à partir du nom {{ links.build_search_company_external_link(offerer.name) }}.
+    {% else %}
+      <h5 class="card-title">Données INSEE</h5>
+      <div class="card-body">
+        {% if siren_info %}
+          <div class="row">
+            {% if not siren_info.diffusible %}
+              <p>
+                <span class="fw-bold">Attention !</span> Cette entreprise a choisi de rendre son nom et son adresse non-diffusibles.
+                <br />
+                Ces informations ne doivent être utilisées qu'à des fins de vérification et ne doivent en aucun cas être partagées.
+              </p>
+            {% endif %}
+            <div class="col-6">
+              <p class="mb-1">
+                <span class="fw-bold">Nom :</span> {{ siren_info.name }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">SIRET du siège social :</span>
+                {% if siren_info.head_office_siret %}
+                  <a href="{{ url_for("backoffice_web.pro.search_pro", pro_type='VENUE', q=siren_info.head_office_siret) }}">
+                    {{ siren_info.head_office_siret }}
+                  </a>
+                {% endif %}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Adresse :</span> {{ siren_info.address.street }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Code postal :</span> {{ siren_info.address.postal_code }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Ville :</span> {{ siren_info.address.city }}
+              </p>
+            </div>
+            <div class="col-6">
+              <p class="mb-1">
+                <span class="fw-bold">SIREN actif :</span> {{ siren_info.active | format_bool_badge }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Diffusible :</span> {{ siren_info.diffusible | format_bool_badge }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Catégorie juridique :</span> {{ siren_info.legal_category_code | format_legal_category_code }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Code APE :</span> {{ siren_info.ape_code }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Activité principale :</span> {{ siren_info.ape_label }}
+              </p>
+            </div>
           </div>
-          <div class="col-6">
-            <p class="mb-1">
-              <span class="fw-bold">SIREN actif :</span> {{ siren_info.active | format_bool_badge }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Diffusible :</span> {{ siren_info.diffusible | format_bool_badge }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Catégorie juridique :</span> {{ siren_info.legal_category_code | format_legal_category_code }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Code APE :</span> {{ siren_info.ape_code }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Activité principale :</span> {{ siren_info.ape_label }}
-            </p>
-          </div>
-        </div>
-      {% else %}
-        <span class="mr-2 pb-1 badge rounded-pill text-bg-warning"><i class="bi bi-exclamation-triangle"></i> Erreur</span>
-        {{ siren_error }}
-      {% endif %}
-    </div>
+        {% else %}
+          <span class="mr-2 pb-1 badge rounded-pill text-bg-warning"><i class="bi bi-exclamation-triangle"></i> Erreur</span>
+          {{ siren_error }}
+        {% endif %}
+      </div>
+    {% endif %}
   </div>
   {% if siren_info %}
     <div class="card-body my-2">
       <h5 class="card-title">Données RCS (Infogreffe)</h5>
       <div class="card-body">
-        <turbo-frame data-turbo="false" id="offerer_rcs_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_entreprise_rcs_info", offerer_id=offerer_id) }}">
+        <turbo-frame data-turbo="false" id="offerer_rcs_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_entreprise_rcs_info", offerer_id=offerer.id) }}">
         {{ build_loading_spinner() }}
         </turbo-frame>
       </div>
@@ -73,7 +83,7 @@
         <h5 class="card-title">Données URSSAF</h5>
         <div class="card-body">
           <turbo-frame data-turbo="true" id="offerer_urssaf_frame">
-          <a href="{{ url_for("backoffice_web.offerer.get_entreprise_urssaf_info", offerer_id=offerer_id) }}"
+          <a href="{{ url_for("backoffice_web.offerer.get_entreprise_urssaf_info", offerer_id=offerer.id) }}"
              class="btn btn-md btn-outline-primary fw-bold pc-hide-on-click"><i class="bi bi-arrow-clockwise"></i> Vérifier</a>
           <div class="d-none pc-show-on-click">{{ build_loading_spinner() }}</div>
           </turbo-frame>
@@ -84,7 +94,7 @@
           <h5 class="card-title">Données DGFIP</h5>
           <div class="card-body">
             <turbo-frame data-turbo="true" id="offerer_dgfip_frame">
-            <a href="{{ url_for("backoffice_web.offerer.get_entreprise_dgfip_info", offerer_id=offerer_id) }}"
+            <a href="{{ url_for("backoffice_web.offerer.get_entreprise_dgfip_info", offerer_id=offerer.id) }}"
                class="btn btn-md btn-outline-primary fw-bold pc-hide-on-click"><i class="bi bi-arrow-clockwise"></i> Vérifier</a>
             <div class="d-none pc-show-on-click">{{ build_loading_spinner() }}</div>
             </turbo-frame>

--- a/api/src/pcapi/routes/backoffice/templates/venue/get/entreprise_info.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get/entreprise_info.html
@@ -1,51 +1,63 @@
+{% import "components/links.html" as links %}
 <turbo-frame id="venue_entreprise_frame">
 <div class="card my-1 border-0">
   <div class="card-body my-2">
-    <h5 class="card-title">Données INSEE</h5>
-    <div class="card-body">
-      {% if siret_info %}
-        {% if not siret_info.diffusible %}
-          <p>
-            <span class="fw-bold">Attention !</span> Cette entreprise a choisi de rendre son nom et son adresse non-diffusibles.
-            <br />
-            Ces informations ne doivent être utilisées qu'à des fins de vérification et ne doivent en aucun cas être partagées.
-          </p>
+    {% if is_invalid_siret %}
+      <span class="mr-2 pb-1 badge rounded-pill text-bg-warning"><i class="bi bi-exclamation-triangle"></i> Erreur</span>
+      Le format du numéro SIRET est détecté comme invalide, nous ne pouvons pas récupérer de données sur l'établissement.
+      <br />
+      Merci de vérifier qu'il n'y a pas erreur dans l'Annuaire des Entreprises&nbsp;:
+      à partir du SIRET {{ links.build_siret_to_external_link(venue) }}
+      ou à partir du nom {{ links.build_search_company_external_link(venue.name) }}.
+      <br />
+      <b>Attention : Il s'agit peut-être d'un SIRET factice pour les synchronisations.</b>
+    {% else %}
+      <h5 class="card-title">Données INSEE</h5>
+      <div class="card-body">
+        {% if siret_info %}
+          {% if not siret_info.diffusible %}
+            <p>
+              <span class="fw-bold">Attention !</span> Cette entreprise a choisi de rendre son nom et son adresse non-diffusibles.
+              <br />
+              Ces informations ne doivent être utilisées qu'à des fins de vérification et ne doivent en aucun cas être partagées.
+            </p>
+          {% endif %}
+          <div class="row">
+            <div class="col-6">
+              <p class="mb-1">
+                <span class="fw-bold">Nom :</span> {{ siret_info.name }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Adresse :</span> {{ siret_info.address.street }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Code postal :</span> {{ siret_info.address.postal_code }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Ville :</span> {{ siret_info.address.city }}
+              </p>
+            </div>
+            <div class="col-6">
+              <p class="mb-1">
+                <span class="fw-bold">SIRET actif :</span> {{ siret_info.active | format_bool_badge }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Diffusible :</span> {{ siret_info.diffusible | format_bool_badge }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Code APE :</span> {{ siret_info.ape_code }}
+              </p>
+              <p class="mb-1">
+                <span class="fw-bold">Activité principale :</span> {{ siret_info.ape_label }}
+              </p>
+            </div>
+          </div>
+        {% else %}
+          <span class="mr-2 pb-1 badge rounded-pill text-bg-warning"><i class="bi bi-exclamation-triangle"></i> Erreur</span>
+          {{ siret_error }}
         {% endif %}
-        <div class="row">
-          <div class="col-6">
-            <p class="mb-1">
-              <span class="fw-bold">Nom :</span> {{ siret_info.name }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Adresse :</span> {{ siret_info.address.street }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Code postal :</span> {{ siret_info.address.postal_code }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Ville :</span> {{ siret_info.address.city }}
-            </p>
-          </div>
-          <div class="col-6">
-            <p class="mb-1">
-              <span class="fw-bold">SIRET actif :</span> {{ siret_info.active | format_bool_badge }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Diffusible :</span> {{ siret_info.diffusible | format_bool_badge }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Code APE :</span> {{ siret_info.ape_code }}
-            </p>
-            <p class="mb-1">
-              <span class="fw-bold">Activité principale :</span> {{ siret_info.ape_label }}
-            </p>
-          </div>
-        </div>
-      {% else %}
-        <span class="mr-2 pb-1 badge rounded-pill text-bg-warning"><i class="bi bi-exclamation-triangle"></i> Erreur</span>
-        {{ siret_error }}
-      {% endif %}
-    </div>
+      </div>
+    {% endif %}
   </div>
 </div>
 </turbo-frame>

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -49,6 +49,7 @@ from pcapi.routes.serialization import base as serialize_base
 from pcapi.routes.serialization import reimbursement_csv_serialize
 from pcapi.utils import regions as regions_utils
 from pcapi.utils.clean_accents import clean_accents
+from pcapi.utils.siren import is_valid_siret
 from pcapi.utils.string import to_camelcase
 from pcapi.workers.fully_sync_venue_job import fully_sync_venue_job
 
@@ -1057,6 +1058,9 @@ def get_entreprise_info(venue_id: int) -> utils.BackofficeResponse:
 
     if not venue.siret:
         raise NotFound()
+
+    if not is_valid_siret(venue.siret):
+        return render_template("venue/get/entreprise_info.html", is_invalid_siret=True, venue=venue)
 
     siret_info = None
     siret_error = None

--- a/api/src/pcapi/utils/siren.py
+++ b/api/src/pcapi/utils/siren.py
@@ -1,0 +1,50 @@
+SIREN_LENGTH = 9
+SIRET_LENGTH = 14
+
+
+def _compute_luhn_sum(digits: str, total_length: int) -> int:
+    """
+    Last digit in a SIREN or SIRET code is a check digit calculated using the Luhn formula:
+    https://fr.wikipedia.org/wiki/Syst%C3%A8me_d%27identification_du_r%C3%A9pertoire_des_entreprises
+    https://fr.wikipedia.org/wiki/Formule_de_Luhn
+    """
+    parity = total_length % 2
+    result = 0
+    for i, digit in enumerate(digits):
+        value = int(digit)
+        if (i + 1) % 2 == parity:
+            result += value
+        elif value > 4:
+            result += 2 * value - 9
+        else:
+            result += 2 * value
+    return result % 10
+
+
+def complete_siren_or_siret(digits: str) -> str:
+    if len(digits) not in (SIREN_LENGTH - 1, SIRET_LENGTH - 1):
+        raise ValueError("Unexpected length")
+
+    return digits + str((10 - _compute_luhn_sum(digits, len(digits) + 1)) % 10)
+
+
+def is_valid_siren(digits: str) -> bool:
+    if len(digits) != SIREN_LENGTH or not digits.isnumeric():
+        return False
+
+    return _compute_luhn_sum(digits, SIREN_LENGTH) == 0
+
+
+def is_valid_siret(digits: str) -> bool:
+    if len(digits) != SIRET_LENGTH or not digits.isnumeric():
+        return False
+
+    if _compute_luhn_sum(digits, SIRET_LENGTH) == 0:
+        return True
+
+    if digits[:9] == "356000000":
+        # La Poste, special case described here:
+        # https://fr.wikipedia.org/wiki/Syst%C3%A8me_d%27identification_du_r%C3%A9pertoire_des_%C3%A9tablissements
+        return sum(int(digit) for digit in digits) % 5 == 0
+
+    return False

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -655,22 +655,22 @@ def offerers_to_be_validated_fixture(offerer_tags):
     top_tag, collec_tag, public_tag, festival_tag = offerer_tags
 
     no_tag = offerers_factories.NotValidatedOffererFactory(
-        name="A", siren="123001001", address=None, postalCode="35000", city="Rennes"
+        name="A", siren="123001000", address=None, postalCode="35000", city="Rennes"
     )
     top = offerers_factories.NotValidatedOffererFactory(
-        name="B", siren="123002002", validationStatus=ValidationStatus.PENDING, postalCode="29000", city="Quimper"
+        name="B", siren="123002008", validationStatus=ValidationStatus.PENDING, postalCode="29000", city="Quimper"
     )
     collec = offerers_factories.NotValidatedOffererFactory(
-        name="C", siren="123003003", postalCode="50170", city="Le Mont-Saint-Michel"
+        name="C", siren="123003006", postalCode="50170", city="Le Mont-Saint-Michel"
     )
     public = offerers_factories.NotValidatedOffererFactory(
         name="D", siren="123004004", validationStatus=ValidationStatus.PENDING, postalCode="29300", city="Quimperlé"
     )
     top_collec = offerers_factories.NotValidatedOffererFactory(
-        name="E", siren="123005005", postalCode="35400", city="Saint-Malo"
+        name="E", siren="123005001", postalCode="35400", city="Saint-Malo"
     )
     top_public = offerers_factories.NotValidatedOffererFactory(
-        name="F", siren="123006006", validationStatus=ValidationStatus.PENDING, postalCode="44000", city="Nantes"
+        name="F", siren="123006009", validationStatus=ValidationStatus.PENDING, postalCode="44000", city="Nantes"
     )
 
     for offerer in (top, top_collec, top_public):

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -3533,7 +3533,7 @@ class GetEntrepriseInfoTest(GetEndpointHelper):
     expected_num_queries = 3
 
     def test_offerer_entreprise_info(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="123456789")
+        offerer = offerers_factories.OffererFactory(siren="123456782")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()
@@ -3545,7 +3545,7 @@ class GetEntrepriseInfoTest(GetEndpointHelper):
         # Values come from TestingBackend, check display
         sirene_content = html_parser.extract_cards_text(response.data)[0]
         assert "Nom : MINISTERE DE LA CULTURE" in sirene_content
-        assert "SIRET du siège social : 12345678900001" in sirene_content
+        assert "SIRET du siège social : 12345678200010" in sirene_content
         assert "Adresse : 3 RUE DE VALOIS" in sirene_content
         assert "Code postal : 75001" in sirene_content
         assert "Ville : PARIS" in sirene_content
@@ -3588,6 +3588,22 @@ class GetEntrepriseInfoTest(GetEndpointHelper):
             response = authenticated_client.get(url)
             assert response.status_code == 404
 
+    def test_offerer_with_invalid_siren(self, authenticated_client):
+        offerer = offerers_factories.OffererFactory(siren="222222222")
+        url = url_for(self.endpoint, offerer_id=offerer.id)
+
+        db.session.expire_all()
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        sirene_content = html_parser.extract_cards_text(response.data)[0]
+        assert (
+            "Erreur Le format du numéro SIREN est détecté comme invalide, nous ne pouvons pas récupérer de données sur l'entreprise."
+            in sirene_content
+        )
+
 
 class GetEntrepriseInfoRcsTest(GetEndpointHelper):
     endpoint = "backoffice_web.offerer.get_entreprise_rcs_info"
@@ -3600,7 +3616,7 @@ class GetEntrepriseInfoRcsTest(GetEndpointHelper):
     expected_num_queries = 3
 
     def test_get_rcs_info_registered(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="010000000")
+        offerer = offerers_factories.OffererFactory(siren="010000008")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()
@@ -3617,7 +3633,7 @@ class GetEntrepriseInfoRcsTest(GetEndpointHelper):
         assert "Activité du siège social : TEST" in content
 
     def test_get_rcs_info_not_registered(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="020000000")
+        offerer = offerers_factories.OffererFactory(siren="020000006")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()
@@ -3631,7 +3647,7 @@ class GetEntrepriseInfoRcsTest(GetEndpointHelper):
         assert content == "Activité commerciale : Non"
 
     def test_get_rcs_info_deregistered(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="030099000")
+        offerer = offerers_factories.OffererFactory(siren="030099006")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()
@@ -3670,7 +3686,7 @@ class GetEntrepriseInfoUrssafTest(GetEndpointHelper):
     expected_num_queries = 4
 
     def test_get_urssaf_info_ok(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="123456789")
+        offerer = offerers_factories.OffererFactory(siren="123456782")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()
@@ -3690,7 +3706,7 @@ class GetEntrepriseInfoUrssafTest(GetEndpointHelper):
         )
 
     def test_get_urssaf_info_taxes_not_paid(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="009000000")
+        offerer = offerers_factories.OffererFactory(siren="009000001")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()
@@ -3731,7 +3747,7 @@ class GetEntrepriseInfoDgfipTest(GetEndpointHelper):
     expected_num_queries = 4
 
     def test_get_dgfip_info_ok(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="123456789")
+        offerer = offerers_factories.OffererFactory(siren="123456782")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()
@@ -3750,7 +3766,7 @@ class GetEntrepriseInfoDgfipTest(GetEndpointHelper):
         )
 
     def test_get_dgfip_info_taxes_not_paid(self, authenticated_client):
-        offerer = offerers_factories.OffererFactory(siren="009000000")
+        offerer = offerers_factories.OffererFactory(siren="009000001")
         url = url_for(self.endpoint, offerer_id=offerer.id)
 
         db.session.expire_all()

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -710,7 +710,7 @@ class CreateOffererTest(PostEndpointHelper):
 
         form_data = {
             "email": user.email,
-            "siret": "90000000100001",
+            "siret": "90000000100017",
             "public_name": "Le Masque de Fer",
             "venue_type_code": offerers_models.VenueTypeCode.PERFORMING_ARTS.name,
             "web_presence": "https://www.example.com, https://offers.example.com",
@@ -769,7 +769,7 @@ class CreateOffererTest(PostEndpointHelper):
                 "ape_code": "90.01Z",
                 "ape_label": "Arts du spectacle vivant",
                 "diffusible": False,
-                "head_office_siret": "90000000100001",
+                "head_office_siret": "90000000100017",
                 "legal_category_code": "1000",
                 "name": "[ND]",
                 "siren": "900000001",

--- a/api/tests/utils/siren_test.py
+++ b/api/tests/utils/siren_test.py
@@ -1,0 +1,60 @@
+import pytest
+
+from pcapi.utils import siren as siren_utils
+
+
+@pytest.mark.parametrize(
+    "digits,expected",
+    [
+        ("73282932", "732829320"),
+        ("85331845", "853318459"),
+        ("8533184590001", "85331845900015"),
+        ("8533184590002", "85331845900023"),
+        ("8533184590003", "85331845900031"),
+        ("8533184590004", "85331845900049"),
+        ("11004601", "110046018"),
+        ("1100460180001", "11004601800013"),
+        ("12345678", "123456782"),
+    ],
+)
+def test_complete_siren_or_siret(digits, expected):
+    result = siren_utils.complete_siren_or_siret(digits)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "digits,expected",
+    [
+        ("732829320", True),
+        ("853318459", True),
+        ("85331845", False),
+        ("8533184590", False),
+        ("110046018", True),
+        ("110046019", False),
+        ("110046018 ", False),
+        ("notasiren", False),
+    ],
+)
+def test_is_valid_siren(digits, expected):
+    result = siren_utils.is_valid_siren(digits)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "digits,expected",
+    [
+        ("85331845900015", True),
+        ("853318459000155", False),
+        ("85331845900022", False),
+        ("1100460180001", False),
+        ("11004601800018", False),
+        ("11004601800013", True),
+        ("11004601800013 ", False),
+        ("invalid__siret", False),
+        ("35600000000048", True),  # La Poste
+        ("35600000009075", True),  # La Poste
+    ],
+)
+def test_is_valid_siret(digits, expected):
+    result = siren_utils.is_valid_siret(digits)
+    assert result == expected


### PR DESCRIPTION
- Backoffice: check that SIREN format is valid before calling API Entreprise (avoids error 422)
- Nightly offerer check: same check
- Generate valid SIREN/SIRET in factories according to Luhn formula (this changes SIREN/SIRET in sandbox)

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28660

![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/575fb9af-8bd7-4bdb-ac82-c2c03ef7e797)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques