### PR TITLE
(PC-28655)[EAC] feat: sync only recent updates

### DIFF
--- a/api/src/pcapi/core/educational/adage_backends/__init__.py
+++ b/api/src/pcapi/core/educational/adage_backends/__init__.py
@@ -29,9 +29,9 @@ def notify_booking_cancellation_by_offerer(data: EducationalBookingResponse) -> 
     backend().notify_booking_cancellation_by_offerer(data=data)
 
 
-def get_cultural_partners() -> list[dict[str, str | int | float | None]]:
+def get_cultural_partners(timestamp: int | None = None) -> list[dict[str, str | int | float | None]]:
     backend = import_string(settings.ADAGE_BACKEND)
-    result = backend().get_cultural_partners()
+    result = backend().get_cultural_partners(timestamp)
     return result
 
 

--- a/api/src/pcapi/core/educational/adage_backends/adage.py
+++ b/api/src/pcapi/core/educational/adage_backends/adage.py
@@ -123,11 +123,17 @@ class AdageHttpClient(AdageClient):
                 api_response.text,
             )
 
-    def get_cultural_partners(self) -> list[dict[str, str | int | float | None]]:
+    def get_cultural_partners(self, timestamp: int | None = None) -> list[dict[str, str | int | float | None]]:
         api_url = f"{self.base_url}/v1/partenaire-culturel"
+
+        params = {}
+        if timestamp:
+            params["dateModificationMin"] = timestamp
+
         try:
             api_response = requests.get(
                 api_url,
+                params=params,
                 headers={self.header_key: self.api_key},
             )
         except ConnectionError as exp:

--- a/api/src/pcapi/core/educational/adage_backends/base.py
+++ b/api/src/pcapi/core/educational/adage_backends/base.py
@@ -21,7 +21,7 @@ class AdageClient:
     def notify_booking_cancellation_by_offerer(self, data: prebooking.EducationalBookingResponse) -> None:
         raise NotImplementedError()
 
-    def get_cultural_partners(self) -> list[dict[str, str | int | float | None]]:
+    def get_cultural_partners(self, timestamp: int | None = None) -> list[dict[str, str | int | float | None]]:
         raise NotImplementedError()
 
     def notify_institution_association(self, data: serialize.AdageCollectiveOffer) -> None:

--- a/api/src/pcapi/core/educational/adage_backends/logger.py
+++ b/api/src/pcapi/core/educational/adage_backends/logger.py
@@ -32,7 +32,7 @@ class AdageLoggerClient(AdageClient):
             "Adage has been notified at %s, with payload: %s", f"{self.base_url}/v1/prereservation-annule", data
         )
 
-    def get_cultural_partners(self) -> list[dict[str, str | int | float | None]]:
+    def get_cultural_partners(self, timestamp: int | None = None) -> list[dict[str, str | int | float | None]]:
         logger.info("Adage has been called at %s", f"{self.base_url}/v1/partenaire-culturel")
         return [
             {

--- a/api/src/pcapi/core/educational/adage_backends/testing.py
+++ b/api/src/pcapi/core/educational/adage_backends/testing.py
@@ -25,8 +25,10 @@ class AdageSpyClient(AdageClient):
     def notify_booking_cancellation_by_offerer(self, data: prebooking.EducationalBookingResponse) -> None:
         testing.adage_requests.append({"url": f"{self.base_url}/v1/prereservation-annule", "sent_data": data})
 
-    def get_cultural_partners(self) -> list[dict[str, str | int | float | None]]:
-        testing.adage_requests.append({"url": f"{self.base_url}/v1/partenaire-culturel", "sent_data": ""})
+    def get_cultural_partners(self, timestamp: int | None = None) -> list[dict[str, str | int | float | None]]:
+        testing.adage_requests.append(
+            {"url": f"{self.base_url}/v1/partenaire-culturel", "sent_data": {"dateModificationMin": timestamp}}
+        )
         return [
             {
                 "id": "128029",

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -19,6 +19,7 @@ from pcapi.core.educational.utils import create_adage_jwt_fake_valid_token
 from pcapi.repository import transaction
 from pcapi.scheduled_tasks.decorators import log_cron_with_transaction
 from pcapi.utils.blueprint import Blueprint
+import pcapi.utils.date as date_utils
 
 
 blueprint = Blueprint(__name__, __name__)
@@ -125,16 +126,19 @@ def import_deposit_csv(path: str, year: int, ministry: str, conflict: str, final
     default=False,
     help="Activate debugging (add logs)",
 )
+@click.option("--with-timestamp", type=bool, is_flag=True, default=False, help="Add timestamp (couple days ago)")
 @log_cron_with_transaction
-def synchronize_venues_from_adage_cultural_partners(debug: bool = False) -> None:
-    adage_api.synchronize_adage_ids_on_venues(debug)
+def synchronize_venues_from_adage_cultural_partners(debug: bool = False, with_timestamp: bool = False) -> None:
+    timestamp = date_utils.days_ago_timestamp(2) if with_timestamp else None
+    adage_api.synchronize_adage_ids_on_venues(debug=debug, timestamp=timestamp)
 
 
 @blueprint.cli.command("synchronize_offerers_from_adage_cultural_partners")
-@log_cron_with_transaction
-def synchronize_offerers_from_adage_cultural_partners() -> None:
+@click.option("--with-timestamp", type=bool, is_flag=True, default=False, help="Add timestamp (couple days ago)")
+def synchronize_offerers_from_adage_cultural_partners(with_timestamp: bool = False) -> None:
+    timestamp = date_utils.days_ago_timestamp(2) if with_timestamp else None
     with transaction():
-        adage_cultural_partners = adage_api.get_cultural_partners()
+        adage_cultural_partners = adage_api.get_cultural_partners(timestamp=timestamp)
         adage_api.synchronize_adage_ids_on_offerers(adage_cultural_partners.partners)
 
 

--- a/api/src/pcapi/core/educational/testing.py
+++ b/api/src/pcapi/core/educational/testing.py
@@ -3,7 +3,11 @@ from pcapi.core.educational.adage_backends.serialize import AdageCollectiveReque
 from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingResponse
 
 
-adage_requests: list[dict[str, AdageCollectiveOffer | AdageCollectiveRequest | EducationalBookingResponse | str]] = []
+AdageRequestItem = (
+    str | AdageCollectiveOffer | AdageCollectiveRequest | EducationalBookingResponse | dict[str, int | str | None]
+)
+
+adage_requests: list[dict[str, AdageRequestItem | None]] = []
 
 
 def reset_requests() -> None:

--- a/api/src/pcapi/utils/date.py
+++ b/api/src/pcapi/utils/date.py
@@ -1,6 +1,8 @@
 from datetime import date
 from datetime import datetime
 from datetime import time
+from datetime import timedelta
+from datetime import timezone as tz
 from zoneinfo import ZoneInfo
 
 from babel.dates import format_date
@@ -209,3 +211,9 @@ def numranges_to_readble_str(numranges: list[NumericRange] | None) -> str:
     if numranges is None:
         return ""
     return ", ".join(f"{int_to_time(int(numrange.lower))}-{int_to_time(int(numrange.upper))}" for numrange in numranges)
+
+
+def days_ago_timestamp(days: int) -> int:
+    """Get a timestamp from a date `days` ago"""
+    days_ago = datetime.now(tz.utc) - timedelta(days=2)  # pylint: disable=datetime-now
+    return int(days_ago.timestamp())

--- a/api/tests/core/educational/api/test_address.py
+++ b/api/tests/core/educational/api/test_address.py
@@ -14,7 +14,7 @@ class UnlinkUnknownVenueAddressesTest:
         venues = offerers_factories.CollectiveVenueFactory.create_batch(2)
 
         with atomic():
-            api.unlink_unknown_venue_addresses([])
+            api.unlink_deactivated_venue_addresses({venue.adageId: venue.id for venue in venues})
 
         venue_addresses = get_venue_addresses([venue.id for venue in venues])
         assert len(venue_addresses) == len(venues)
@@ -26,7 +26,7 @@ class UnlinkUnknownVenueAddressesTest:
         to_keep = offerers_factories.CollectiveVenueFactory.create_batch(2)
 
         with atomic():
-            api.unlink_unknown_venue_addresses([venue.adageId for venue in to_keep])
+            api.unlink_deactivated_venue_addresses({venue.adageId: venue.id for venue in to_unlink})
 
         venue_addresses = get_venue_addresses([venue.id for venue in to_unlink + to_keep])
         assert {ava.adageId for ava in venue_addresses} == {venue.adageId for venue in to_keep} | {None}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28655

### Objectif initial 

Demander la synchronisation des lieux ayant été modifiés récemment au lieu de télécharger les données de tous les lieux connus d'Adage.

### Changements lors de la mise à jour des informations adage des lieux

Avant : tous les lieux qui avaient un adageId mais qui ne faisaient pas partie des lieux actifs et synchronisés par Adage perdaient leur id Adage (dans notre base de données).

Problème : si les mises à jours deviennent partielles, on se retrouverait avec un grand nombre de lieux retirés d'Adage dans notre base de données.

Solution : ne retirer que les lieux qui sont devenus non-synchronisés par Adage, ou inactif ou dont l'id adage ne correspond plus.