### PR TITLE
(BSR)[BO] feat: Add a note for better understanding of revenue details

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/components/revenue_details.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/revenue_details.html
@@ -20,12 +20,19 @@
         {% for year, year_stats in details | dictsort(reverse=true) %}
           <tr>
             <td class="text-start">{{ year }}</td>
-            <td class="text-end">{{ year_stats.individual | format_amount | safe }}</td>
+            <td class="text-end">{{ year_stats.individual | format_amount | safe }}</td>
             <td class="text-end">{{ year_stats.collective | format_amount | safe }}</td>
           </tr>
         {% endfor %}
       </tbody>
     </table>
+    {% if "En cours" in details %}
+      <div class="my-3 small">
+        Note : Le CA « En cours » correspond aux réservations qui n'ont pas encore été validées.
+        Ce chiffre d'affaires en cours n'est pas certain (annulations possibles), chaque réservation
+        sera comptabilisée sur l'année du jour de sa validation.
+      </div>
+    {% endif %}
   </div>
 </div>
 <div class="modal-footer">


### PR DESCRIPTION
## But de la pull request

Un message de précision dans le CA par année pour une meilleur compréhension des chargés de territoire :

![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/32f075fb-8001-4611-864b-6989213ccb92)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques