### PR TITLE
(PC-28816)[PRO] fix: Results can be null in react instantsearch.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/OffersSuggestions.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/OffersSuggestions.tsx
@@ -38,7 +38,10 @@ function getSearchIndexIdDisplayed(
 
   //  Find first index that has results
   for (const result of noResultIndexesResults) {
-    if (result.results.nbHits > 0) {
+    // react-instantsearch results mignt be null but the lib does not
+    // export a SearchResults type that we could use to make sure of that
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (result.results?.nbHits > 0) {
       return result.indexId
     }
   }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28816

**Objectif**
Considérer que les résultats de la recherche algolia peuvent être null.

`react-instantsearch` n'exporte pas de type pour SearchResults, et le type bricolé ne pense pas que `results` peut être null. J'ai ignoré l'erreur mais si vous avez une solution plus propre c'est cool 👍  

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques