### PR TITLE
(BSR)[PRO] fix: fix user selection in SignupValidation

### DIFF
--- a/pro/src/pages/Signup/SignUpValidation/SignUpValidation.tsx
+++ b/pro/src/pages/Signup/SignUpValidation/SignUpValidation.tsx
@@ -1,20 +1,21 @@
 import { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
 import { useParams, Navigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { getError, isErrorAPIError } from 'apiClient/helpers'
-import useCurrentUser from 'hooks/useCurrentUser'
+import { selectCurrentUser } from 'store/user/selectors'
 
 type Params = { token: string }
 
 const SignupValidation = (): JSX.Element | null => {
   const { token } = useParams<Params>()
-  const { currentUser } = useCurrentUser()
+  const currentUser = useSelector(selectCurrentUser)
   const [urlToRedirect, setUrlToRedirect] = useState<string>()
 
   useEffect(() => {
     const validateTokenAndRedirect = async () => {
-      if (currentUser.id) {
+      if (currentUser?.id) {
         setUrlToRedirect('/')
       } else if (token) {
         try {
@@ -36,7 +37,7 @@ const SignupValidation = (): JSX.Element | null => {
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     validateTokenAndRedirect()
-  }, [token, currentUser.id])
+  }, [token, currentUser?.id])
 
   return urlToRedirect ? <Navigate to={urlToRedirect} replace /> : null
 }

--- a/pro/src/pages/Signup/SignUpValidation/__specs__/SignupValidation.spec.tsx
+++ b/pro/src/pages/Signup/SignUpValidation/__specs__/SignupValidation.spec.tsx
@@ -9,6 +9,7 @@ import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import type { UseCurrentUserReturn } from 'hooks/useCurrentUser'
 import * as useCurrentUser from 'hooks/useCurrentUser'
 import * as useNotification from 'hooks/useNotification'
+import { RootState } from 'store/rootReducer'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import SignUpValidation from '../SignUpValidation'
@@ -17,7 +18,10 @@ vi.mock('repository/pcapi/pcapi')
 vi.mock('hooks/useCurrentUser')
 vi.mock('hooks/useNotification')
 
-const renderSignupValidation = (url: string) =>
+const renderSignupValidation = (
+  url: string,
+  storeOverrides: Partial<RootState> = {}
+) =>
   renderWithProviders(
     <Routes>
       <Route path="/validation/:token" element={<SignUpValidation />} />
@@ -25,6 +29,7 @@ const renderSignupValidation = (url: string) =>
       <Route path="/connexion" element={<div>Connexion</div>} />
     </Routes>,
     {
+      storeOverrides,
       initialRouterEntries: [url],
     }
   )
@@ -51,13 +56,22 @@ describe('src | components | pages | Signup | validation', () => {
 
   it('should redirect to home page if the user is logged in', () => {
     const validateUser = vi.spyOn(api, 'validateUser')
-    vi.spyOn(useCurrentUser, 'default').mockReturnValue({
-      currentUser: {
-        id: 123,
+    const storeOverrides = {
+      user: {
+        initialized: true,
+        currentUser: {
+          isAdmin: false,
+          dateCreated: '2001-01-01',
+          email: 'test@email.com',
+          id: 12,
+          roles: [],
+          isEmailValidated: true,
+        },
+        selectedOffererId: null,
       },
-    } as UseCurrentUserReturn)
+    }
     // when the user is logged in and lands on signup validation page
-    renderSignupValidation('/validation/AAA')
+    renderSignupValidation('/validation/AAA', storeOverrides)
 
     // then the validity of his token should not be verified
     expect(validateUser).not.toHaveBeenCalled()


### PR DESCRIPTION
## But de la pull request

Fix la récupération de l'utilisateur sur la page de validation d'email 
En lien avec [cette PR](https://github.com/pass-culture/pass-culture-main/pull/11425/commits/0efb9b4f464b2dcc2fcdca74200697cc0100ba28#diff-21922470e43db3fb9a1f832b3eb1cd16e3948f005bcba5adbde8da7c6c49fc46) 