### PR TITLE
(PC-28742)[API] fix: truncate banks account label for  DS import

### DIFF
--- a/api/src/pcapi/connectors/dms/serializer.py
+++ b/api/src/pcapi/connectors/dms/serializer.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from datetime import timedelta
 import logging
 import re
+from textwrap import shorten
 from typing import Any
 from typing import Literal
 
@@ -239,6 +240,10 @@ class ApplicationDetailOldJourney(ApplicationDetail):
 class ApplicationDetailNewJourney(ApplicationDetail):
     status: finance_models.BankAccountApplicationStatus
     label: str | None = None
+
+    @validator("label")
+    def truncate_label(cls: "ApplicationDetailNewJourney", label: str) -> str:
+        return shorten(label, width=100, placeholder="...")
 
     @root_validator(pre=True)
     def to_representation(cls: "ApplicationDetailNewJourney", obj: dict) -> dict:

--- a/api/src/pcapi/core/finance/ds.py
+++ b/api/src/pcapi/core/finance/ds.py
@@ -56,7 +56,6 @@ def import_ds_bank_information_applications(procedure_number: int, ignore_previo
 
 def update_ds_applications_for_procedure(procedure_number: int, since: datetime.datetime | None) -> None:
     logger.info("[DS] Started processing Bank Account procedure %s", procedure_number)
-
     current_import = ds_models.LatestDmsImport(
         procedureId=procedure_number,
         latestImportDatetime=datetime.datetime.utcnow(),

--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from datetime import datetime
 import logging
+from textwrap import shorten
 import typing
 
 import schwifty
@@ -492,6 +493,7 @@ class ImportBankAccountMixin:
             label = self.application_details.label
             if label is None:
                 label = venue.common_name if venue is not None else self.application_details.obfuscatedIban
+                label = shorten(label, width=100, placeholder="...")
             bank_account = finance_models.BankAccount(
                 iban=self.application_details.iban,
                 bic=self.application_details.bic,

--- a/api/tests/connector_creators/demarches_simplifiees_creators.py
+++ b/api/tests/connector_creators/demarches_simplifiees_creators.py
@@ -153,6 +153,7 @@ def get_bank_info_response_procedure_v5(
     last_modification_date: str = "2023-10-26T14:51:09+02:00",
     last_pending_correction_date: str | None = None,
     siret: str = "85331845900049",
+    label: str | None = "Intitulé du compte bancaire",
 ) -> dict:
     iban = "".join(iban.split())
 
@@ -183,7 +184,7 @@ def get_bank_info_response_procedure_v5(
                                 "id": "Q2hhbXAtMzU3MzQ1Mw==",
                                 "label": "Intitulé du compte bancaire",
                                 "stringValue": "Intitulé du compte bancaire",
-                                "value": "Intitulé du compte bancaire",
+                                "value": label,
                             },
                             {
                                 "id": "Q2hhbXAtMzUyNzI3",


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28742
sentry issue : https://sentry.passculture.team/organizations/sentry/issues/1484914/?project=5&referrer=jira_integration
correction de l'erreur. Il s'agit de tronquer l'attribut label.
A noter:
-  pour la version V5 cela est réaliser dans le serialiser
- pour la version v4 je part du principe déjà implémenté que le label est reconstruit 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques