### PR TITLE
(PC-28532)[PRO] feat: edition preview for bookable offer

### DIFF
--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -182,6 +182,14 @@ const routes: RouteConfig[] = [
       import(
         'pages/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation'
       ),
+    path: '/offre/:offerId/collectif/creation/apercu',
+    title: 'Aperçu - Créer une offre réservable',
+  },
+  {
+    lazy: () =>
+      import(
+        'pages/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation'
+      ),
     path: '/offre/:offerId/collectif/vitrine/creation/apercu',
     title: 'Aperçu - Créer une offre vitrine',
   },
@@ -223,8 +231,16 @@ const routes: RouteConfig[] = [
       import(
         'pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition'
       ),
-    path: '/offre/:offerId/collectif/preview',
+    path: '/offre/:offerId/collectif/vitrine/apercu',
     title: 'Aperçu - Prévisualisation d’une offre collective vitrine',
+  },
+  {
+    lazy: () =>
+      import(
+        'pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition'
+      ),
+    path: '/offre/:offerId/collectif/apercu',
+    title: 'Aperçu - Prévisualisation d’une offre collective réservable',
   },
   {
     lazy: () =>

--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -15,7 +15,6 @@ export interface CollectiveOfferLayoutProps {
   isCreation?: boolean
   isTemplate?: boolean
   isFromTemplate?: boolean
-  haveStock?: boolean
   requestId?: string | null
 }
 
@@ -23,7 +22,6 @@ const CollectiveOfferLayout = ({
   children,
   subTitle,
   isFromTemplate = false,
-  haveStock = false,
   isCreation = false,
   isTemplate = false,
   requestId = null,
@@ -86,7 +84,6 @@ const CollectiveOfferLayout = ({
             isCreatingOffer={navigationProps.isCreatingOffer}
             offerId={navigationProps.offerId}
             isTemplate={isTemplate}
-            haveStock={haveStock}
             requestId={requestId}
           />
         )

--- a/pro/src/components/CollectiveOfferNavigation/__specs__/CollectiveOfferNavigation.spec.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/__specs__/CollectiveOfferNavigation.spec.tsx
@@ -88,12 +88,13 @@ describe('CollectiveOfferNavigation', () => {
 
     const listItems = await screen.findAllByRole('listitem')
 
-    expect(listItems).toHaveLength(5)
+    expect(listItems).toHaveLength(6)
     expect(listItems[0]).toHaveTextContent('Détails de l’offre')
     expect(listItems[1]).toHaveTextContent('Date et prix')
     expect(listItems[2]).toHaveTextContent('Établissement et enseignant')
     expect(listItems[3]).toHaveTextContent('Récapitulatif')
-    expect(listItems[4]).toHaveTextContent('Confirmation')
+    expect(listItems[4]).toHaveTextContent('Aperçu')
+    expect(listItems[5]).toHaveTextContent('Confirmation')
 
     const links = screen.queryAllByRole('link')
     expect(links).toHaveLength(0)
@@ -110,7 +111,7 @@ describe('CollectiveOfferNavigation', () => {
     expect(screen.queryByText('Visibilité')).not.toBeInTheDocument()
 
     const links = screen.queryAllByRole('link')
-    expect(links).toHaveLength(3)
+    expect(links).toHaveLength(1)
     expect(links[0].getAttribute('href')).toBe(
       `/offre/collectif/vitrine/${offerId}/creation`
     )
@@ -120,7 +121,7 @@ describe('CollectiveOfferNavigation', () => {
     props.activeStep = CollectiveOfferStep.STOCKS
     renderCollectiveOfferNavigation(props)
     const links = screen.queryAllByRole('link')
-    expect(links).toHaveLength(3)
+    expect(links).toHaveLength(2)
     expect(links[0].getAttribute('href')).toBe(
       `/offre/collectif/${offerId}/creation`
     )
@@ -133,7 +134,7 @@ describe('CollectiveOfferNavigation', () => {
     props.activeStep = CollectiveOfferStep.VISIBILITY
     renderCollectiveOfferNavigation(props)
     const links = screen.queryAllByRole('link')
-    expect(links).toHaveLength(3)
+    expect(links).toHaveLength(2)
     expect(links[0].getAttribute('href')).toBe(
       `/offre/collectif/${offerId}/creation`
     )
@@ -146,7 +147,7 @@ describe('CollectiveOfferNavigation', () => {
     props.activeStep = CollectiveOfferStep.SUMMARY
     renderCollectiveOfferNavigation(props)
     const links = screen.queryAllByRole('link')
-    expect(links).toHaveLength(4)
+    expect(links).toHaveLength(3)
     expect(links[0].getAttribute('href')).toBe(
       `/offre/collectif/${offerId}/creation`
     )
@@ -158,11 +159,11 @@ describe('CollectiveOfferNavigation', () => {
     )
   })
 
-  it('should show links if summary is the active step', () => {
+  it('should show links if confirmation is the active step', () => {
     props.activeStep = CollectiveOfferStep.CONFIRMATION
     renderCollectiveOfferNavigation(props)
     const links = screen.queryAllByRole('link')
-    expect(links).toHaveLength(4)
+    expect(links).toHaveLength(5)
     expect(links[0].getAttribute('href')).toBe(
       `/offre/collectif/${offerId}/creation`
     )
@@ -175,6 +176,13 @@ describe('CollectiveOfferNavigation', () => {
     expect(links[3].getAttribute('href')).toBe(
       `/offre/${offerId}/collectif/creation/recapitulatif`
     )
+  })
+
+  it('should show links if confirmation is the active step and the offer is template', () => {
+    props.activeStep = CollectiveOfferStep.CONFIRMATION
+    renderCollectiveOfferNavigation({ ...props, isTemplate: true })
+    const links = screen.queryAllByRole('link')
+    expect(links).toHaveLength(3)
   })
 
   it('should generate link with offerId when user is editing an offer', async () => {
@@ -192,7 +200,7 @@ describe('CollectiveOfferNavigation', () => {
       `/offre/${offerId}/collectif/edition`
     )
     expect(linkItems[1].getAttribute('href')).toBe(
-      `/offre/${offerId}/collectif/preview`
+      `/offre/${offerId}/collectif/apercu`
     )
     expect(linkItems[2].getAttribute('href')).toBe(
       `/offre/${offerId}/collectif/edition`
@@ -202,24 +210,6 @@ describe('CollectiveOfferNavigation', () => {
     )
     expect(linkItems[4].getAttribute('href')).toBe(
       `/offre/${offerId}/collectif/visibilite/edition`
-    )
-  })
-
-  it('should generate link for visibility and summary if offer has a stock', async () => {
-    props.haveStock = true
-    renderCollectiveOfferNavigation(props)
-
-    const links = await screen.findAllByRole('link')
-
-    expect(links).toHaveLength(3)
-    expect(links[0].getAttribute('href')).toBe(
-      `/offre/${offerId}/collectif/stocks`
-    )
-    expect(links[1].getAttribute('href')).toBe(
-      `/offre/${offerId}/collectif/visibilite`
-    )
-    expect(links[2].getAttribute('href')).toBe(
-      `/offre/${offerId}/collectif/creation/recapitulatif`
     )
   })
 

--- a/pro/src/components/SignupJourneyStepper/__specs__/SignupJourneyStepper.trackers.spec.tsx
+++ b/pro/src/components/SignupJourneyStepper/__specs__/SignupJourneyStepper.trackers.spec.tsx
@@ -80,7 +80,7 @@ describe('test renderSignupJourneyStepper', () => {
       setOfferer: () => {},
     }
   })
-  it('Should not log current tab click and disabled ones', async () => {
+  it('should not log current tab click and disabled ones', async () => {
     const { tabAuthentication, tabActivity, tabValidation } =
       renderSignupJourneyStepper(contextValue)
 

--- a/pro/src/pages/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -12,6 +12,7 @@ export const CollectiveOfferPreviewCreation = ({
   offer,
   setOffer,
   isTemplate,
+  offerer,
 }: MandatoryCollectiveOfferFromParamsProps) => {
   return (
     <AppLayout layout={'sticky-actions'}>
@@ -19,11 +20,12 @@ export const CollectiveOfferPreviewCreation = ({
         subTitle={offer.name}
         isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
         isTemplate={isTemplate}
-        isCreation={true}
+        isCreation
       >
         <CollectiveOfferPreviewCreationScreen
           offer={offer}
           setOffer={setOffer}
+          offerer={offerer}
         />
         <RouteLeavingGuardCollectiveOfferCreation />
       </CollectiveOfferLayout>

--- a/pro/src/pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.tsx
@@ -1,6 +1,5 @@
 import { AppLayout } from 'app/AppLayout'
 import ActionsBarSticky from 'components/ActionsBarSticky'
-import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import AdagePreviewLayout from 'pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout'
 import {
   MandatoryCollectiveOfferFromParamsProps,
@@ -40,7 +39,6 @@ export const CollectiveOfferPreviewEdition = ({
           </ActionsBarSticky.Left>
         </ActionsBarSticky>
       </div>
-      <RouteLeavingGuardCollectiveOfferCreation />
     </AppLayout>
   )
 }

--- a/pro/src/pages/CollectiveOfferPreviewEdition/__specs__/CollectiveOfferPreviewEdition.spec.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewEdition/__specs__/CollectiveOfferPreviewEdition.spec.tsx
@@ -49,7 +49,7 @@ describe('CollectiveOfferPreviewCreation', () => {
 
   it('should render collective offer preview edition', async () => {
     renderCollectiveOfferPreviewCreation(
-      '/offre/T-A1/collectif/preview',
+      '/offre/T-A1/collectif/apercu',
       defaultProps
     )
 

--- a/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -12,9 +12,7 @@ import {
 
 export const CollectiveOfferSummaryCreation = ({
   offer,
-  setOffer,
   isTemplate,
-  offerer,
 }: MandatoryCollectiveOfferFromParamsProps) => {
   return (
     <AppLayout layout={'sticky-actions'}>
@@ -24,11 +22,7 @@ export const CollectiveOfferSummaryCreation = ({
         isTemplate={isTemplate}
         isCreation={true}
       >
-        <CollectiveOfferSummaryCreationScreen
-          offer={offer}
-          setOffer={setOffer}
-          offerer={offerer}
-        />
+        <CollectiveOfferSummaryCreationScreen offer={offer} />
         <RouteLeavingGuardCollectiveOfferCreation />
       </CollectiveOfferLayout>
     </AppLayout>

--- a/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
@@ -1,15 +1,8 @@
-import {
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
-import { userEvent } from '@testing-library/user-event'
-import React from 'react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 
 import { api } from 'apiClient/api'
 import { MandatoryCollectiveOfferFromParamsProps } from 'screens/OfferEducational/useCollectiveOfferFromParams'
 import { getCollectiveOfferFactory } from 'utils/collectiveApiFactories'
-import { defaultGetOffererResponseModel } from 'utils/individualApiFactories'
 import {
   RenderWithProvidersOptions,
   renderWithProviders,
@@ -83,35 +76,6 @@ describe('CollectiveOfferSummaryCreation', () => {
     const previousStepLink = screen.getByText('Étape précédente')
     expect(previousStepLink.getAttribute('href')).toBe(
       '/offre/1/collectif/visibilite?requete=1'
-    )
-  })
-
-  it('Should show the redirect modal', async () => {
-    vi.spyOn(api, 'patchCollectiveOfferPublication').mockResolvedValue({
-      ...getCollectiveOfferFactory(),
-      isNonFreeOffer: true,
-    })
-    await renderCollectiveOfferSummaryCreation(
-      '/offre/A1/collectif/creation/recapitulatif',
-      {
-        ...defaultProps,
-        offerer: {
-          ...defaultGetOffererResponseModel,
-          hasNonFreeOffer: false,
-          hasValidBankAccount: false,
-        },
-      },
-      {
-        features: ['WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY'],
-      }
-    )
-
-    await userEvent.click(screen.getByText('Publier l’offre'))
-
-    await waitFor(() =>
-      expect(
-        screen.queryByText(/Félicitations, vous avez créé votre offre !/)
-      ).toBeInTheDocument()
     )
   })
 })

--- a/pro/src/pages/Desk/__specs__/Desk.spec.tsx
+++ b/pro/src/pages/Desk/__specs__/Desk.spec.tsx
@@ -15,7 +15,7 @@ const renderDesk = () => {
 }
 
 describe('src | components | Desk', () => {
-  describe('Should validate while user is typing', () => {
+  describe('should validate while user is typing', () => {
     it('should remove QRcode prefix', async () => {
       renderDesk()
       const contremarque = screen.getByLabelText('Contremarque *')
@@ -94,7 +94,7 @@ describe('src | components | Desk', () => {
     })
   })
 
-  describe('Should validate contremarque when the user submits the form', () => {
+  describe('should validate contremarque when the user submits the form', () => {
     beforeEach(() => {
       vi.spyOn(getBookingAdapter, 'getBooking').mockResolvedValueOnce({
         booking: defaultGetBookingResponse,
@@ -128,7 +128,7 @@ describe('src | components | Desk', () => {
     })
   })
 
-  describe('Should invalidate contremarque when the user submits the form', () => {
+  describe('should invalidate contremarque when the user submits the form', () => {
     beforeEach(() => {
       vi.spyOn(getBookingAdapter, 'getBooking').mockResolvedValueOnce({
         error: {

--- a/pro/src/pages/Home/Offerers/__specs__/VenueCreationLinks.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/VenueCreationLinks.spec.tsx
@@ -21,7 +21,7 @@ describe('VenueCrationLinks', () => {
     }))
   })
 
-  it('Should not display creation links when user has no venue created', () => {
+  it('should not display creation links when user has no venue created', () => {
     const offerer = {
       ...defaultGetOffererResponseModel,
       hasDigitalVenueAtLeastOneOffer: false,
@@ -33,7 +33,7 @@ describe('VenueCrationLinks', () => {
     expect(screen.queryByText('Ajouter un lieu')).not.toBeInTheDocument()
   })
 
-  it('Should display creation links when user has a venue created', async () => {
+  it('should display creation links when user has a venue created', async () => {
     const offerer = {
       ...defaultGetOffererResponseModel,
       managedVenues: [defaultGetOffererVenueResponseModel],

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/AttachmentInvitations/__specs__/AttachmentInvitations.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/AttachmentInvitations/__specs__/AttachmentInvitations.spec.tsx
@@ -55,7 +55,7 @@ describe('AttachmentInvitations', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('Should display the invite form on click', async () => {
+  it('should display the invite form on click', async () => {
     await renderAttachmentInvitations()
 
     await userEvent.click(screen.getByText('Ajouter un collaborateur'))
@@ -70,7 +70,7 @@ describe('AttachmentInvitations', () => {
     ).toBeInTheDocument()
   })
 
-  it('Should display the form error on invalid email', async () => {
+  it('should display the form error on invalid email', async () => {
     await renderAttachmentInvitations()
 
     await userEvent.click(screen.getByText('Ajouter un collaborateur'))
@@ -81,7 +81,7 @@ describe('AttachmentInvitations', () => {
     ).toBeInTheDocument()
   })
 
-  it('Should display add the email on success and trigger buttons event', async () => {
+  it('should display add the email on success and trigger buttons event', async () => {
     await renderAttachmentInvitations()
 
     await userEvent.click(screen.getByText('Ajouter un collaborateur'))
@@ -112,7 +112,7 @@ describe('AttachmentInvitations', () => {
     expect(screen.getByText('test@test.fr')).toBeInTheDocument()
   })
 
-  it('Should display email error message if user is already invited', async () => {
+  it('should display email error message if user is already invited', async () => {
     await renderAttachmentInvitations()
 
     await userEvent.click(screen.getByText('Ajouter un collaborateur'))
@@ -144,7 +144,7 @@ describe('AttachmentInvitations', () => {
     })
   })
 
-  it('Should display default error message if error with server', async () => {
+  it('should display default error message if error with server', async () => {
     await renderAttachmentInvitations()
 
     await userEvent.click(screen.getByText('Ajouter un collaborateur'))

--- a/pro/src/pages/Reimbursements/__specs__/LinkVenuesDialog.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/LinkVenuesDialog.spec.tsx
@@ -77,7 +77,7 @@ describe('LinkVenueDialog', () => {
     }))
   })
 
-  it('Should display the dialog', () => {
+  it('should display the dialog', () => {
     renderWithProviders(<LinkVenuesDialog {...props} />, {
       storeOverrides,
     })
@@ -94,7 +94,7 @@ describe('LinkVenueDialog', () => {
     expect(screen.getByLabelText('Lieu 2')).not.toBeChecked()
   })
 
-  it('Should be able to submit the form but only close the modal if no changes were made', async () => {
+  it('should be able to submit the form but only close the modal if no changes were made', async () => {
     renderWithProviders(
       <>
         <LinkVenuesDialog {...props} />
@@ -120,7 +120,7 @@ describe('LinkVenueDialog', () => {
     expect(mockLogEvent).not.toHaveBeenCalled()
   })
 
-  it('Should be able to submit the form', async () => {
+  it('should be able to submit the form', async () => {
     renderWithProviders(
       <>
         <LinkVenuesDialog {...props} />
@@ -162,7 +162,7 @@ describe('LinkVenueDialog', () => {
     )
   })
 
-  it('Should handle update failure', async () => {
+  it('should handle update failure', async () => {
     vi.spyOn(api, 'linkVenueToBankAccount').mockRejectedValueOnce({})
 
     renderWithProviders(
@@ -194,7 +194,7 @@ describe('LinkVenueDialog', () => {
     ).toBeInTheDocument()
   })
 
-  it('Should close the dialog on cancel click', async () => {
+  it('should close the dialog on cancel click', async () => {
     renderWithProviders(<LinkVenuesDialog {...props} />, {
       storeOverrides,
     })
@@ -208,7 +208,7 @@ describe('LinkVenueDialog', () => {
     expect(mockClose).toHaveBeenCalled()
   })
 
-  it('Should show the discard dialog on cancel click', async () => {
+  it('should show the discard dialog on cancel click', async () => {
     renderWithProviders(<LinkVenuesDialog {...props} />, {
       storeOverrides,
     })

--- a/pro/src/screens/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
@@ -7,6 +7,7 @@ import {
   defaultGetVenue,
   getCollectiveOfferTemplateFactory,
 } from 'utils/collectiveApiFactories'
+import { defaultGetOffererResponseModel } from 'utils/individualApiFactories'
 import {
   RenderWithProvidersOptions,
   renderWithProviders,
@@ -34,6 +35,7 @@ const defaultProps = {
   setOffer: vi.fn(),
   reloadCollectiveOffer: vi.fn(),
   isTemplate: true,
+  offerer: defaultGetOffererResponseModel,
 }
 
 describe('CollectiveOfferConfirmation', () => {

--- a/pro/src/screens/SignupJourneyForm/ActionBar/__specs__/ActionBar.trackers.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/ActionBar/__specs__/ActionBar.trackers.spec.tsx
@@ -44,7 +44,7 @@ describe('screens:SignupJourney::ActionBar', () => {
     vi.spyOn(api, 'getVenueTypes').mockResolvedValue([])
   })
 
-  it('Should log next action', async () => {
+  it('should log next action', async () => {
     props = {
       onClickNext: () => null,
       nextStepTitle: 'NEXT',
@@ -68,7 +68,7 @@ describe('screens:SignupJourney::ActionBar', () => {
     )
   })
 
-  it('Should log next action if disabled', async () => {
+  it('should log next action if disabled', async () => {
     props = {
       onClickNext: () => null,
       nextStepTitle: 'NEXT',

--- a/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -112,7 +112,7 @@ describe('ValidationScreen', () => {
     expect(screen.getByText('Activite')).toBeInTheDocument()
   })
 
-  it('Should see the data from the previous forms for validation', async () => {
+  it('should see the data from the previous forms for validation', async () => {
     renderValidationScreen({
       ...contextValue,
       activity: {
@@ -158,7 +158,7 @@ describe('ValidationScreen', () => {
       }
     })
 
-    it('Should navigate to activity page with the previous step button', async () => {
+    it('should navigate to activity page with the previous step button', async () => {
       renderValidationScreen(contextValue)
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
@@ -166,7 +166,7 @@ describe('ValidationScreen', () => {
       expect(screen.getByText('Activite')).toBeInTheDocument()
     })
 
-    it('Should navigate to authentification page when clicking the first update button', async () => {
+    it('should navigate to authentification page when clicking the first update button', async () => {
       renderValidationScreen(contextValue)
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
       await userEvent.click(screen.getAllByText('Modifier')[0])
@@ -174,7 +174,7 @@ describe('ValidationScreen', () => {
       expect(screen.getByText('Authentification')).toBeInTheDocument()
     })
 
-    it('Should navigate to activite page when clicking the second update button', async () => {
+    it('should navigate to activite page when clicking the second update button', async () => {
       renderValidationScreen(contextValue)
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
       await userEvent.click(screen.getAllByText('Modifier')[1])
@@ -182,7 +182,7 @@ describe('ValidationScreen', () => {
       expect(screen.getByText('Activite')).toBeInTheDocument()
     })
 
-    it('Should redirect to home after submit', async () => {
+    it('should redirect to home after submit', async () => {
       vi.spyOn(api, 'saveNewOnboardingData').mockResolvedValue(
         {} as PostOffererResponseModel
       )
@@ -220,7 +220,7 @@ describe('ValidationScreen', () => {
 
     const publicNames = ['nom public', '']
     it.each(publicNames)(
-      'Should send data with name %s',
+      'should send data with name %s',
       async (publicName: string) => {
         if (contextValue.offerer) {
           contextValue.offerer.publicName = publicName
@@ -255,7 +255,7 @@ describe('ValidationScreen', () => {
       }
     )
 
-    it('Should see the data from the previous forms for validation without public name', async () => {
+    it('should see the data from the previous forms for validation without public name', async () => {
       renderValidationScreen(contextValue)
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
       expect(await screen.findByText('first venue label')).toBeInTheDocument()
@@ -283,7 +283,7 @@ describe('ValidationScreen', () => {
       }
     })
 
-    it('Should display error message on api error', async () => {
+    it('should display error message on api error', async () => {
       vi.spyOn(api, 'saveNewOnboardingData').mockRejectedValue({})
       vi.spyOn(utils, 'initReCaptchaScript').mockReturnValue({
         remove: vi.fn(),
@@ -297,7 +297,7 @@ describe('ValidationScreen', () => {
       ).toBeInTheDocument()
     })
 
-    it('Should not render on venue types api error', async () => {
+    it('should not render on venue types api error', async () => {
       vi.spyOn(api, 'getVenueTypes').mockRejectedValue({})
       renderValidationScreen(contextValue)
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28532

**Objectif**
Intégrer l'aperçu de l'offre dans le parcours de création d'une offre collective réservable. Et correction d'un bug au passage qui faisait que le step "Récapitulatif" était accessible trop tôt dans le parcours de créarion.


<img width="1123" alt="Capture d’écran 2024-03-27 à 10 48 32" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/9be3b4f0-88b3-42bf-ab1c-541216b83775">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques