### PR TITLE
(PC-28551)[PRO] fix: display new nav only if new nav date is already …

### DIFF
--- a/pro/src/hooks/__specs__/useIsNewInterfaceActive.spec.tsx
+++ b/pro/src/hooks/__specs__/useIsNewInterfaceActive.spec.tsx
@@ -93,4 +93,22 @@ describe('useIsNewInterfaceActive', () => {
     renderUseIsNewInterfaceActive(options)
     expect(screen.getByText('Inactive')).toBeInTheDocument()
   })
+
+  it('should return false if user connected but as new nav date in future', () => {
+    const options = {
+      features: ['WIP_ENABLE_PRO_SIDE_NAV'],
+      storeOverrides: {
+        user: {
+          currentUser: {
+            isAdmin: false,
+            navState: {
+              newNavDate: '2999-01-01',
+            },
+          },
+        },
+      },
+    }
+    renderUseIsNewInterfaceActive(options)
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
 })

--- a/pro/src/hooks/useIsNewInterfaceActive.tsx
+++ b/pro/src/hooks/useIsNewInterfaceActive.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux'
 
 import { selectCurrentUser } from 'store/user/selectors'
+import { formatBrowserTimezonedDateAsUTC } from 'utils/date'
 
 import useActiveFeature from './useActiveFeature'
 
@@ -8,7 +9,12 @@ const useIsNewInterfaceActive = (): boolean => {
   const currentUser = useSelector(selectCurrentUser)
   const isNewNavActive = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
 
-  return isNewNavActive && Boolean(currentUser?.navState?.newNavDate)
+  return (
+    isNewNavActive &&
+    !!currentUser?.navState?.newNavDate &&
+    new Date(currentUser.navState.newNavDate) <=
+      new Date(formatBrowserTimezonedDateAsUTC(new Date()))
+  )
 }
 
 export default useIsNewInterfaceActive


### PR DESCRIPTION
…past

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28551 

Afficher la nouvelle interface ssi la date de nouvelle interface (`newNavDate`) est inférieur ou égale à la date du jour. 
