### PR TITLE
(PC-28188)[PRO] fix: fix alignment in responsive for new nav review

### DIFF
--- a/pro/src/components/NewNavReview/NewNavReview.module.scss
+++ b/pro/src/components/NewNavReview/NewNavReview.module.scss
@@ -8,13 +8,14 @@
     display: flex;
     gap: rem.torem(8px);
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     padding: rem.torem(16px) rem.torem(24px);
     border: solid rem.torem(1px) colors.$grey-medium;
     margin-top: size.$top-menu-height;
 
     @media (min-width: size.$tablet) {
       margin-left: size.$side-nav-width;
+      align-items: center;
     }
   }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28188

Ajuster l'alignement de la bannière de review de la nouvelle interface en mode responsive pour aligner l'icone avec le haut du texte

<img width="372" alt="Capture d’écran 2024-03-27 à 12 02 39" src="https://github.com/pass-culture/pass-culture-main/assets/71768799/32b7140d-700b-4ee9-9038-9cfcbbb646fc">
