### PR TITLE
(PC-27743)[PRO] style: Marge du titre du Callout de stock

### DIFF
--- a/pro/src/screens/IndividualOffer/StocksThing/StockThing.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksThing/StockThing.module.scss
@@ -58,7 +58,7 @@
 }
 
 .callout-area {
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .callout-area-margin {


### PR DESCRIPTION
## Ajouter margin de 8px entre title et détails, voir commentaire jira de Marion; Bien numérique

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27743

<img width="681" alt="Capture d’écran 2024-03-27 à 15 06 57" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/a90b8653-6174-4fe1-b224-7d31df067fb7">

