### PR TITLE
(BSR)[API] feat: keep offer validation rule history in staging

### DIFF
--- a/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
+++ b/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
@@ -165,8 +165,10 @@ SET
     "newDomainEmail" = 'anonymized.email'
 ;
 
+-- Keep those which doesn't contain personal data
 UPDATE action_history
 SET "jsonData" = '{}'
+WHERE "ruleId" is null and "financeIncidentId" is null
 ;
 
 -- FIXME (dbaty, 2023-05-04): we should anonymize `offer.bookingEmail`


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : C'est de l'historique sans données à anonymiser, et sinon ça fait crasher la page des règles de fraude en staging

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques