### PR TITLE
(PC-28857)[PRO] fix: Multiply the fake offer preview price to simulat…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout.tsx
@@ -86,7 +86,10 @@ export default function AdagePreviewLayout({ offer }: AdagePreviewLayoutProps) {
       },
       stock: {
         ...offer.collectiveStock,
-        price: Number(offer.collectiveStock?.price),
+        //  The price is mutliplied by 100 in the back when the offer is sent
+        //  through the passculture ADAGE api.
+        //  Thus we need to send a x100 prixe in the fake ADAGE component
+        price: Number(offer.collectiveStock?.price) * 100,
         id: Number(offer.collectiveStock?.id),
         isBookable: offer.isBookable,
       },


### PR DESCRIPTION
…e a price received from the back.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28857

**Objectif**
Corriger l'affichage du prix dans la page Aperçu des offres réservabe. Puisque le back transform les prix en faisant x100 quand l'offre est reçue dans ADAGE (mais pas quand elle est recue dans pro), on les divise par 100 à l'affichage sur ADAGE. 

Pour simuler un prix reçu du back sur ADAGE on le multiplie donc par 100 quand on crée l'offre pour l'aperçu.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques