### PR TITLE
(PC-28826)[API] perf: create index on action_history."actionType"

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 4ff6cb80daee (pre) (head)
-0403f97207ba (post) (head)
+c7d04bd67054 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240328T101616_c7d04bd67054_create_index_on_action_type.py
+++ b/api/src/pcapi/alembic/versions/20240328T101616_c7d04bd67054_create_index_on_action_type.py
@@ -1,0 +1,38 @@
+"""Create index on action_history."actionType"
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "c7d04bd67054"
+down_revision = "0403f97207ba"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.create_index(
+            "ix_action_history_actionType",
+            "action_history",
+            ["actionType"],
+            unique=False,
+            postgresql_using="hash",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_action_history_actionType",
+            table_name="action_history",
+            postgresql_using="hash",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -101,6 +101,7 @@ class ActionHistory(PcObject, Base, Model):
     __tablename__ = "action_history"
 
     actionType: ActionType = sa.Column(sa.Enum(ActionType, create_constraint=False), nullable=False)
+    sa.Index("ix_action_history_actionType", actionType, postgresql_using="hash")
 
     # nullable because of old suspensions without date migrated here; but mandatory for new actions
     actionDate = sa.Column(sa.DateTime, nullable=True, server_default=sa.func.now())


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28826

L'index sert à fortement accélérer la requête sur l'historique de modifications des rôles (voir ticket), identifiée dans les requêtes lentes par Sentry. Mais il apportera potentiellement un gain sur toutes les requêtes qui filtrent en fonction du type d'action (règles de fraude, sous-requêtes pour l'homologation, etc.).

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques