### PR TITLE
(BSR)[API] chore: start flask with backoffice

### DIFF
--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -68,9 +68,7 @@ services:
       - db_nw
       - web_nw
     depends_on:
-      - postgres
-      - redis
-      - postgres-test
+      - flask
     ports:
       - 5002:5001
       - 10004:10003 # debugger port


### PR DESCRIPTION
## But de la pull request
Lorsqu'on lance backoffice, le serveur attend que l'api soit up