### PR TITLE
(PC-28450)[API] fix: Add script to fix missing or wrong ban_id in permanent venues

### DIFF
--- a/api/src/pcapi/scripts/venue/fix_ban_ids.py
+++ b/api/src/pcapi/scripts/venue/fix_ban_ids.py
@@ -1,0 +1,158 @@
+from collections import namedtuple
+import json
+import logging
+
+import pydantic
+
+from pcapi.connectors.api_adresse import RELIABLE_SCORE_THRESHOLD
+from pcapi.connectors.api_adresse import ResultColumn
+from pcapi.connectors.api_adresse import format_payload
+from pcapi.connectors.api_adresse import format_q
+from pcapi.connectors.api_adresse import search_csv
+from pcapi.core.offerers.models import Venue
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+ObjVenue = namedtuple("ObjVenue", ["id", "banId", "address", "city"])
+
+
+class SearchedVenue(pydantic.BaseModel):
+    venue_id: int
+    venue_ban_id: str
+    q: str
+    latitude: float
+    longitude: float
+    result_id: str
+    result_label: str
+    result_score: float
+
+    @pydantic.field_validator("result_score", "latitude", "longitude", mode="before")
+    def to_float(cls, s: str) -> float:
+        return float(s or 0)
+
+
+def _get_permanent_venues(json_venues_path: str | None = None) -> list[ObjVenue] | list[Venue]:
+    if json_venues_path:
+        with open(json_venues_path, mode="r", encoding="utf-8") as f:
+            venues = json.load(f)
+        permanent_venues = [
+            ObjVenue(
+                id=venue["Venue ID"],
+                banId=venue["Ban ID"],
+                address=venue["Venue Address"],
+                city=venue["Venue City"],
+            )
+            for venue in venues
+            if venue["Venue Is Permanent"] and not venue["Venue Is Virtual"]
+        ]
+    else:
+        permanent_venues = Venue.query.filter(Venue.isPermanent == True, Venue.isVirtual == False).all()
+    logger.info("Permanent venues: %d", len(permanent_venues))
+    return permanent_venues
+
+
+def _search_csv_venues(venues: list[ObjVenue] | list[Venue]) -> list[SearchedVenue]:
+    headers = ["venue_id", "venue_ban_id", "q"]
+    lines = []
+    for venue in venues:
+        id_ = venue.id
+        ban_id = venue.banId or ""
+        address = venue.address or ""
+        city = venue.city or ""
+        q = format_q(address, city)
+        lines.append(
+            {
+                "venue_id": id_,
+                "venue_ban_id": ban_id,
+                "q": q,
+            }
+        )
+    payload = format_payload(headers, lines)
+    results = search_csv(
+        payload,
+        columns=["q"],
+        result_columns=[
+            ResultColumn.LATITUDE,
+            ResultColumn.LONGITUDE,
+            ResultColumn.RESULT_ID,
+            ResultColumn.RESULT_LABEL,
+            ResultColumn.RESULT_SCORE,
+        ],
+    )
+    searched_venues = [SearchedVenue(**result) for result in results]
+    logger.info("Searched venues: %d", len(searched_venues))
+    return searched_venues
+
+
+def _get_mismatched_venues(searched_venues: list[SearchedVenue]) -> list[SearchedVenue]:
+    mismatched_venues = [
+        searched_venue for searched_venue in searched_venues if searched_venue.venue_ban_id != searched_venue.result_id
+    ]
+    logger.info("Mismatched venues: %d", len(mismatched_venues))
+    return mismatched_venues
+
+
+def _split_venues_on_fixable(
+    mismatched_venues: list[SearchedVenue],
+) -> tuple[list[SearchedVenue], list[SearchedVenue]]:
+    fixable_venues = []
+    non_fixable_venues = []
+    for mismatched_venue in mismatched_venues:
+        q = mismatched_venue.q
+        result_id = mismatched_venue.result_id
+        result_score = mismatched_venue.result_score
+        is_housenumber = bool(result_id.count("_") in (2, 3))  # 3 is for bis / ter
+        is_street = bool(q and not q[0].isdigit() and result_id.count("_") == 1)
+        has_high_score = bool(result_score > RELIABLE_SCORE_THRESHOLD)
+        if (is_housenumber or is_street) and has_high_score:
+            fixable_venues.append(mismatched_venue)
+        else:
+            non_fixable_venues.append(mismatched_venue)
+    logger.info("Fixable venues: %d", len(fixable_venues))
+    logger.info("Non-fixable venues: %d", len(non_fixable_venues))
+    return fixable_venues, non_fixable_venues
+
+
+def _fix_venues(permanent_venues: list[Venue], fixable_venues: list[SearchedVenue]) -> None:
+    d_fixable_venues = {fixable_venue.venue_id: fixable_venue for fixable_venue in fixable_venues}
+    venues_to_update = []
+    for permanent_venue in permanent_venues:
+        fixable_venue = d_fixable_venues.get(permanent_venue.id)
+        if not fixable_venue:
+            continue
+        permanent_venue.banId = fixable_venue.result_id
+        permanent_venue.latitude = fixable_venue.latitude
+        permanent_venue.longitude = fixable_venue.longitude
+        venues_to_update.append(permanent_venue)
+
+    batch_size = 1000
+    batches = [venues_to_update[i : i + batch_size] for i in range(0, len(venues_to_update), batch_size)]
+    for batch in batches:
+        for venue in batch:
+            db.session.add(venue)
+        db.session.commit()
+
+
+def main(
+    json_venues_path: str | None = None,
+    dry_run: bool = True,
+) -> tuple[list[SearchedVenue], list[SearchedVenue]]:
+    # 1) Get permanent venues:
+    permanent_venues = _get_permanent_venues(json_venues_path=json_venues_path)
+
+    # 2) Search permanent venues in Base Adresse Nationale (BAN):
+    searched_venues = _search_csv_venues(permanent_venues)
+
+    # 3) Identify permanent venues with mismatched ban_id:
+    mismatched_venues = _get_mismatched_venues(searched_venues)
+
+    # 4) Split between fixable and non-fixable mismatched venues:
+    fixable_venues, non_fixable_venues = _split_venues_on_fixable(mismatched_venues)
+
+    # 5) Fix venues which are fixable:
+    if not json_venues_path and not dry_run:
+        _fix_venues(permanent_venues, fixable_venues)  # type: ignore
+
+    return fixable_venues, non_fixable_venues

--- a/api/tests/connectors/api_adresse/fixtures.py
+++ b/api/tests/connectors/api_adresse/fixtures.py
@@ -73,3 +73,71 @@ MUNICIPALITY_CENTROID_RESPONSE = {
     "filters": {"citycode": "75118", "type": "municipality"},
     "limit": 1,
 }
+
+SEARCH_CSV_HEADERS = [
+    "venue_id",
+    "venue_ban_id",
+    "q",
+    "latitude",
+    "longitude",
+    "result_id",
+    "result_label",
+    "result_score",
+]
+SEARCH_CSV_RESULTS = [
+    # Matching ban_id:
+    {
+        "venue_id": 1,
+        "venue_ban_id": "38185_1660_00033",
+        "q": "33 Boulevard Clemenceau Grenoble",
+        "latitude": 45.18403,
+        "longitude": 5.740288,
+        "result_id": "38185_1660_00033",
+        "result_label": "33 Boulevard Clemenceau 38100 Grenoble",
+        "result_score": 0.9762045454545454,
+    },
+    # Mismatching ban_id / Wrong ban_id / Housenumber / Fixable:
+    {
+        "venue_id": 2,
+        "venue_ban_id": "38185_3000_00033",
+        "q": "33 Boulevard Clemenceau Grenoble",
+        "latitude": 45.18403,
+        "longitude": 5.740288,
+        "result_id": "38185_1660_00033",
+        "result_label": "33 Boulevard Clemenceau 38100 Grenoble",
+        "result_score": 0.9762045454545454,
+    },
+    # Mismatching ban_id / Missing ban_id / Housenumber / Fixable:
+    {
+        "venue_id": 3,
+        "venue_ban_id": None,
+        "q": "33 Boulevard Clemenceau Grenoble",
+        "latitude": 45.18403,
+        "longitude": 5.740288,
+        "result_id": "38185_1660_00033",
+        "result_label": "33 Boulevard Clemenceau 38100 Grenoble",
+        "result_score": 0.9762045454545454,
+    },
+    # Mismatching ban_id / Wrong ban_id / Street / Fixable:
+    {
+        "venue_id": 4,
+        "venue_ban_id": "38185_3000_00033",
+        "q": "Boulevard Clemenceau Grenoble",
+        "latitude": 45.183808,
+        "longitude": 5.739678,
+        "result_id": "38185_1660",
+        "result_label": "Boulevard Clemenceau 38100 Grenoble",
+        "result_score": 0.9762045454545454,
+    },
+    # Mismatching ban_id / Missing ban_id / Street / Non-fixable:
+    {
+        "venue_id": 5,
+        "venue_ban_id": None,
+        "q": "This address does not exist",
+        "latitude": 48.644701,
+        "longitude": -3.898144,
+        "result_id": "29023_2455",
+        "result_label": "Rue des Hauts de Ty Nod 29660 Carantec",
+        "result_score": 0.17157103896103892,
+    },
+]

--- a/api/tests/scripts/venue/fix_ban_ids_test.py
+++ b/api/tests/scripts/venue/fix_ban_ids_test.py
@@ -1,0 +1,89 @@
+import decimal
+
+import pytest
+
+from pcapi.connectors.api_adresse import format_payload
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offerers.models as offerers_models
+from pcapi.core.testing import override_settings
+from pcapi.scripts.venue.fix_ban_ids import main
+
+from tests.connectors.api_adresse import fixtures
+
+
+@pytest.mark.usefixtures("db_session")
+class FixBanIdsTest:
+    @override_settings(ADRESSE_BACKEND="pcapi.connectors.api_adresse.ApiAdresseBackend")
+    def test_script(self, requests_mock, client, db_session):
+        text = format_payload(fixtures.SEARCH_CSV_HEADERS, fixtures.SEARCH_CSV_RESULTS)
+        requests_mock.post("https://api-adresse.data.gouv.fr/search/csv", text=text)
+
+        venue_type_code = offerers_models.VenueTypeCode.LIBRARY  # Permanent
+
+        # Matching ban_id:
+        offerers_factories.VenueFactory(
+            id=1,
+            banId="38185_1660_00033",
+            venueTypeCode=venue_type_code,
+        )
+
+        # Mismatching ban_id / Wrong ban_id / Housenumber / Fixable:
+        offerers_factories.VenueFactory(
+            id=2,
+            banId="38185_3000_00033",
+            venueTypeCode=venue_type_code,
+        )
+
+        # Mismatching ban_id / Missing ban_id / Housenumber / Fixable:
+        offerers_factories.VenueFactory(
+            id=3,
+            banId=None,
+            venueTypeCode=venue_type_code,
+        )
+
+        # Mismatching ban_id / Wrong ban_id / Street / Fixable:
+        offerers_factories.VenueFactory(
+            id=4,
+            banId="38185_3000_00033",
+            venueTypeCode=venue_type_code,
+        )
+
+        # Mismatching ban_id / Missing ban_id / Street / Non-fixable:
+        offerers_factories.VenueFactory(
+            id=5,
+            banId=None,
+            venueTypeCode=venue_type_code,
+        )
+
+        # Run fix_ban_ids script:
+        main(dry_run=False)
+
+        # Matching ban_id:
+        venue = offerers_models.Venue.query.get(1)
+        assert venue.banId == "38185_1660_00033"
+        assert venue.latitude == decimal.Decimal("48.87004")
+        assert venue.longitude == decimal.Decimal("2.37850")
+
+        # Mismatching ban_id / Wrong ban_id / Housenumber / Fixable:
+        venue = offerers_models.Venue.query.get(2)
+        assert venue.banId == "38185_1660_00033"
+        assert venue.latitude == decimal.Decimal("45.18403")
+        assert venue.longitude == decimal.Decimal("5.74029")
+
+        # Mismatching ban_id / Missing ban_id / Housenumber / Fixable:
+        venue = offerers_models.Venue.query.get(3)
+        assert venue.banId == "38185_1660_00033"
+        assert venue.latitude == decimal.Decimal("45.18403")
+        assert venue.longitude == decimal.Decimal("5.74029")
+
+        # Mismatching ban_id / Wrong ban_id / Street / Fixable:
+        venue = offerers_models.Venue.query.get(4)
+        assert venue.banId == "38185_1660"
+        assert venue.latitude == decimal.Decimal("45.18381")
+        assert venue.longitude == decimal.Decimal("5.73968")
+
+        # Mismatching ban_id / Missing ban_id / Street / Non-fixable:
+        venue = offerers_models.Venue.query.get(5)
+        assert venue.banId is None
+        assert venue.latitude == decimal.Decimal("48.87004")
+        assert venue.longitude == decimal.Decimal("2.37850")


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-28450

Cette PR ajoute un script qui permet de corriger une partie des venues permanentes avec un `banId` vide ou erroné.
Elle fait suite à 2 PR qui pourront probablement être fermées après le merge de cette PR :
 - https://github.com/pass-culture/pass-culture-main/pull/9484
 - https://github.com/pass-culture/pass-culture-main/pull/11000

Ce script se déroule en 5 étapes :

1) Récupération des venues permanentes, soit à partir d'un export JSON soit à partir de la DB.

2) Appel à l'endpoint `/search/csv` de l'API Adresse pour rechercher les venues permanentes dans la Base Adresse Nationale (BAN).
La recherche s'effectue en 1 seul appel, qui prend entre 20 et 40 secondes.
Le terme de recherche (appelé `q`) est formé à partir de l'adresse et de la ville de la venue permanente (cf. la docstring de `format_q()` pour les détails).

3) Identification des venues permanentes dont le `BanId` diffère de celui trouvé dans la Base Adresse Nationale (BAN).

4) Répartition des venues en 2 catégories : celles que l'on peut corriger automatiquement (`fixable`) et celles qui nécessitent une revue manuelle (`non_fixable`).
Une venue est considérée comme `fixable` lorsque le format du `BanId` trouvé est cohérent avec l'adresse recherchée (`housenumber` / `street`) et que le score de pertinence est élevé (> 80 %).
Pour les venues `non_fixable`, une revue manuelle est possible en comparant l'adresse recherchée (`q`) avec l'adresse retournée par la BAN (`result_label`). Si les 2 adresses ne correspondent pas, il est fort probable que l'adresse recherchée (`q`) soit erronée ou alors qu'elle n'existe pas dans la BAN.

5) Correction des venues permanentes que l'on a identifiées comme `fixable` avec la mise à jour du `BanId`, de la `latitude` et de la `longitude`.

Pour tester le script à partir d'un export JSON des venues permanentes :
```
$ cd api/src
$ python3
```

```python
>>> import logging, os, sys
>>> from dotenv import load_dotenv
>>> load_dotenv("../.env.development")
>>> os.environ["ADRESSE_BACKEND"] = "pcapi.connectors.api_adresse.ApiAdresseBackend"
>>> logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
>>> from pcapi.scripts.venue.fix_ban_ids import main
>>> json_venues_path = "~/pc_permanent_venues.json"  # TODO: update this with the path to JSON permanent venues file
>>> fixable_venues, non_fixable_venues = main(json_venues_path)  # dry_run by default (it will not fix the venues)
>>> fixable_venues[0]
>>> non_fixable_venues[0]
```

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques