### PR TITLE
(PC-28915)[API] chore: delete 3 unused feature flag

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 1c0c3459615b (pre) (head)
-01b735d5e27f (post) (head)
+f77615489a01 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240411T075644_f77615489a01_delete_public_api_ffs.py
+++ b/api/src/pcapi/alembic/versions/20240411T075644_f77615489a01_delete_public_api_ffs.py
@@ -1,0 +1,42 @@
+"""Delete unused FFs for public Apis."""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "f77615489a01"
+down_revision = "01b735d5e27f"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def get_features():  # type: ignore [no-untyped-def]
+    from pcapi.models import feature
+
+    return [
+        feature.Feature(
+            name="ENABLE_CHARLIE_BOOKINGS_API", isActive=True, description="Active la réservation via l'API Charlie"
+        ),
+        feature.Feature(
+            name="WIP_ENABLE_OFFER_CREATION_API_V1",
+            isActive=True,
+            description="Active la création d'offres via l'API v1",
+        ),
+        feature.Feature(
+            name="WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API",
+            isActive=True,
+            description="Activer la création d'évènements avec tickets dans l'API publique",
+        ),
+    ]
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    for feature_flag in get_features():
+        feature.remove_feature_from_database(feature_flag)
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    for feature_flag in get_features():
+        feature.add_feature_to_database(feature_flag)

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -433,9 +433,6 @@ def _book_cinema_external_ticket(booking: Booking, stock: Stock, beneficiary: Us
 
 
 def _book_event_external_ticket(booking: Booking, stock: Stock, beneficiary: User) -> int | None:
-    if not FeatureToggle.ENABLE_CHARLIE_BOOKINGS_API.is_active():
-        raise feature.DisabledFeatureError("ENABLE_CHARLIE_BOOKINGS_API is inactive")
-
     provider = providers_repository.get_provider_enabled_for_pro_by_id(stock.offer.lastProviderId)
     if not provider:
         raise providers_exceptions.InactiveProvider()

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -43,7 +43,6 @@ class FeatureToggle(enum.Enum):
     )
     ENABLE_BEAMER = "Active Beamer, le système de notifs du portail pro"
     ENABLE_CDS_IMPLEMENTATION = "Permet la réservation de place de cinéma avec l'API CDS"
-    ENABLE_CHARLIE_BOOKINGS_API = "Active la réservation via l'API Charlie"
     ENABLE_CODIR_OFFERERS_REPORT = "Active le rapport sur les structures actives pour le CODIR (tourne la nuit)"
     ENABLE_CRON_TO_UPDATE_OFFERER_STATS = "Active la mise à jour des statistiques des offrers avec un cron"
     ENABLE_CULTURAL_SURVEY = "Activer l'affichage du questionnaire des pratiques initiales pour les bénéficiaires"
@@ -97,13 +96,11 @@ class FeatureToggle(enum.Enum):
     ENABLE_SWITCH_ALLOCINE_SYNC_TO_EMS_SYNC = "Activer le passage automatique des synchronisations Allociné à EMS"
     LOG_EMS_CINEMAS_AVAILABLE_FOR_SYNC = "Stocker dans Google Drive les cinémas EMS activables"
     # For features under construction, a temporary feature flag must be named with the `WIP_` prefix
-    WIP_ENABLE_OFFER_CREATION_API_V1 = "Active la création d'offres via l'API v1"
     WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY = "Changer le template d'email de confirmation de réservation"
     WIP_ENABLE_TRUSTED_DEVICE = "Active la fonctionnalité d'appareil de confiance"
     WIP_ENABLE_SUSPICIOUS_EMAIL_SEND = "Active l'envoie d'email lors de la détection d'une connexion suspicieuse"
     WIP_MANDATORY_BOOKING_CONTACT = "Rend obligatoire offer.bookingContact pour les offres retirables"
     WIP_ENABLE_BOOST_PREFIXED_EXTERNAL_BOOKING = "Active les réservations externes boost avec préfixe"
-    WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API = "Activer la création d'évènements avec tickets dans l'API publique"
     WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY = "Activer le nouveau parcours de dépôt de coordonnées bancaires"
     WIP_ENABLE_MOCK_UBBLE = "Utiliser le mock Ubble à la place du vrai Ubble"
     WIP_ENABLE_OFFER_PRICE_LIMITATION = "Activer les règles de limitation de modification de prix des offres"

--- a/api/src/pcapi/routes/public/individual_offers/v1/blueprint.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/blueprint.py
@@ -5,7 +5,6 @@ from spectree import SecurityScheme
 from werkzeug.exceptions import BadRequest
 
 from pcapi.models import api_errors
-from pcapi.models import feature
 from pcapi.serialization.spec_tree import ExtendedSpecTree
 from pcapi.serialization.utils import public_api_before_handler
 from pcapi.validation.routes import users_authentifications
@@ -18,8 +17,6 @@ def check_api_is_enabled_and_json_valid() -> None:
         _ = request.get_json()
     except BadRequest as e:
         raise api_errors.ApiErrors({"global": [e.description]}, status_code=400)
-    if not feature.FeatureToggle.WIP_ENABLE_OFFER_CREATION_API_V1.is_active():
-        raise api_errors.ApiErrors({"global": ["This API is not enabled"]}, status_code=400)
 
 
 class IndividualApiSpectree(ExtendedSpecTree):

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -12,7 +12,6 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.offers.validation import check_for_duplicated_price_categories
 from pcapi.models import api_errors
 from pcapi.models import db
-from pcapi.models import feature
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.validation.routes.users_authentifications import api_key_required
@@ -32,11 +31,6 @@ def _deserialize_has_ticket(
         if subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id].can_be_withdrawable:
             return offers_models.WithdrawalTypeEnum.NO_TICKET
         return None
-
-    if not feature.FeatureToggle.WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API.is_active():
-        raise api_errors.ApiErrors(
-            {"global": "During this API Beta, it is only possible to create events without tickets."}, status_code=400
-        )
 
     if not (current_api_key.provider.hasProviderEnableCharlie):
         raise api_errors.ApiErrors(

--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -36,8 +36,7 @@ class GetEventTest:
         )
         event_offer_id = event_offer.id
 
-        num_query = 1  # feature flag WIP_ENABLE_OFFER_CREATION_API_V1
-        num_query += 1  # retrieve API key
+        num_query = 1  # retrieve API key
         num_query += 1  # retrieve offer
 
         with testing.assert_num_queries(num_query):

--- a/api/tests/routes/public/individual_offers/v1/get_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_test.py
@@ -95,8 +95,7 @@ class GetProductTest:
         mediation = offers_factories.MediationFactory(offer=product_offer, credit="Ph. Oto")
         product_offer_id = product_offer.id
 
-        num_query = 1  # feature flag WIP_ENABLE_OFFER_CREATION_API_V1
-        num_query += 1  # retrieve API key
+        num_query = 1  # retrieve API key
         num_query += 1  # retrieve offer
 
         with testing.assert_num_queries(num_query):

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -4,7 +4,6 @@ from pcapi import settings
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
-from pcapi.core.testing import override_features
 from pcapi.utils import human_ids
 
 from tests.routes import image_data
@@ -160,36 +159,6 @@ class PatchEventTest:
             event_offer.image.url
             == f"{settings.OBJECT_STORAGE_URL}/thumbs/mediations/{human_ids.humanize(event_offer.activeMediation.id)}"
         )
-
-    @override_features(WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API=False)
-    def test_cannot_edit_event_with_ticket_if_FF_not_active(self, client):
-        # This test can be deleted with FF WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API
-        venue, api_key = utils.create_offerer_provider_linked_to_venue()
-        event_offer = offers_factories.EventOfferFactory(
-            venue=venue,
-            bookingContact="contact@example.com",
-            bookingEmail="notify@passq.com",
-            subcategoryId="CONCERT",
-            durationMinutes=20,
-            isDuo=False,
-            lastProvider=api_key.provider,
-            withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
-            withdrawalDelay=86400,
-            withdrawalDetails="Around there",
-        )
-
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
-            f"/public/offers/v1/events/{event_offer.id}",
-            json={
-                "bookingContact": "test@myemail.com",
-                "bookingEmail": "test@myemail.com",
-                "eventDuration": 40,
-                "enableDoubleBookings": "true",
-                "itemCollectionDetails": "Here !",
-                "hasTicket": True,
-            },
-        )
-        assert response.status_code == 400
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/public/individual_offers/v1/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_event_test.py
@@ -367,28 +367,6 @@ class PostEventTest:
         assert response.status_code == 400
         assert response.json == {"priceCategories": ["Price categories must be unique"]}
 
-    @override_features(WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API=False)
-    def test_cannot_create_event_with_ticket_if_FF_not_active(self, client):
-        # This test can be deleted with FF WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API
-        venue, _ = utils.create_offerer_provider_linked_to_venue()
-
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).post(
-            "/public/offers/v1/events",
-            json={
-                "categoryRelatedFields": {"category": "FESTIVAL_ART_VISUEL"},
-                "accessibility": utils.ACCESSIBILITY_FIELDS,
-                "location": {"type": "physical", "venueId": venue.id},
-                "name": "Le champ des possibles",
-                "hasTicket": True,
-            },
-        )
-
-        assert response.status_code == 400
-        assert offers_models.Offer.query.count() == 0
-        assert response.json == {
-            "global": "During this API Beta, it is only possible to create events without tickets."
-        }
-
     def test_returns_404_for_inactive_venue_provider(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue(is_venue_provider_active=False)
 

--- a/api/tests/routes/public/individual_offers/v1/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_test.py
@@ -7,7 +7,6 @@ from unittest import mock
 import pytest
 
 from pcapi import settings
-from pcapi.core import testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.models import offer_mixin
@@ -308,25 +307,6 @@ class PostProductTest:
         assert response.status_code == 400
         assert offers_models.Offer.query.one_or_none() is None
         assert response.json == {"enableDoubleBookings": ["the category chosen does not allow double bookings"]}
-
-    @pytest.mark.usefixtures("db_session")
-    @testing.override_features(WIP_ENABLE_OFFER_CREATION_API_V1=False)
-    def test_api_disabled(self, client):
-        venue, _ = utils.create_offerer_provider_linked_to_venue()
-
-        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).post(
-            "/public/offers/v1/products",
-            json={
-                "location": {"type": "physical", "venueId": venue.id},
-                "categoryRelatedFields": {"category": "SPECTACLE_ENREGISTRE"},
-                "accessibility": utils.ACCESSIBILITY_FIELDS,
-                "name": "Le champ des possibles",
-            },
-        )
-
-        assert response.status_code == 400
-        assert offers_models.Offer.query.first() is None
-        assert response.json == {"global": ["This API is not enabled"]}
 
     @pytest.mark.usefixtures("db_session")
     def test_extra_data_deserialization(self, client):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28915

Delete these FFs : 
WIP_ENABLE_EVENTS_WITH_TICKETS_FOR_PUBLIC_API
WIP_ENABLE_OFFER_CREATION_API_V1 
ENABLE_CHARLIE_BOOKINGS_API

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques