### PR TITLE
(BSR) ci: update Jira issue SafeToDeploy value

### DIFF
--- a/.github/update-jira-issues.sh
+++ b/.github/update-jira-issues.sh
@@ -73,14 +73,14 @@ Get_jira_previous_commit_number()
 
 Mark_issue_as_not_deployable()
 {
-  echo 'je m''apprete à update la jira avec jira edit --query=''"Numéro de commit[Number]" > '$1''' --override customfield_10044=true --noedit'
+  echo 'je m''apprete à update la jira avec jira edit --query=''"Numéro de commit[Number]" > '$1''' --override customfield_10044=true --override customfield_10086=false --noedit'
   $JIRA_BINARY edit --query='"Numéro de commit[Number]" > '$1'' --override customfield_10044=true --noedit
 
 }
 
 Push_commit_number_and_commit_hash_to_jira_issue()
 {
-  echo 'je m''apprete à update la jira avec jira edit '$1' --override customfield_10044=false --override customfield_10059='$2' --override customfield_10060='$3' --noedit'
+  echo 'je m''apprete à update la jira avec jira edit '$1' --override customfield_10044=false --override customfield_10059='$2' --override customfield_10060='$3' --override customfield_10086=true --noedit'
   $JIRA_BINARY edit $1 --override customfield_10044=false --override customfield_10059=$2 --override customfield_10060=$3 --noedit
 }
 

--- a/.github/workflows/dev_on_workflow_update_jira_issues.yml
+++ b/.github/workflows/dev_on_workflow_update_jira_issues.yml
@@ -113,19 +113,24 @@ jobs:
         if: ${{ steps.get_previous_commit_number.outputs.value != null && steps.get_previous_commit_number.outputs.value != '<no value>' }}
         # If previous_commit_number is not null, it means this push-to-master is a fix.
         # All commits with number between previous_commit_number and this commit number are therefore not safe to deploy.
-        # So mark them as "impropre: true".
+        # (deprecated) So mark them as "impropre: true" (customfield_10044)
+        # (new) So mark them as "SafeToDeploy: false" (customfield_10086)
 
         # The echo command is to clear jira config.yml file set in get jira issue step
         # The jira edit command uses .jira.d/templates/edit template by default
         run: |
           echo "issue:" >> $HOME/.jira.d/config.yml
-          jira edit --query='"Numéro de commit[Number]" > ${{ steps.get_previous_commit_number.outputs.value }}' --override customfield_10044=true --noedit
+          jira edit --query='"Numéro de commit[Number]" > ${{ steps.get_previous_commit_number.outputs.value }}' \
+            --override customfield_10044=true \
+            --override customfield_10086=false \
+            --noedit
       - name: "Push commit number and commit hash to jira issue"
         env:
           JIRA_API_TOKEN: ${{ steps.secrets.outputs.JIRA_API_TOKEN }}
         run: |
           jira edit ${{ needs.issue-number.outputs.status }} \
             --override customfield_10044=false \
+            --override customfield_10086=true \
             --override customfield_10059=${{ needs.issue-number.outputs.commit-number }} \
             --override customfield_10060=${{ needs.issue-number.outputs.commit-hash }} \
             --noedit

--- a/.github/workflows/dev_on_workflow_update_jira_issues.yml
+++ b/.github/workflows/dev_on_workflow_update_jira_issues.yml
@@ -8,6 +8,13 @@ on:
       GCP_EHP_SERVICE_ACCOUNT:
         required: true
 
+env:
+  IMPROPRE_FIELD: customfield_10044
+  SAFE_TO_DEPLOY_FIELD: customfield_10086
+  COMMIT_NUMBER_FIELD: customfield_10059
+  COMMIT_HASH_FIELD: customfield_10060
+
+
 jobs:
   issue-number:
     outputs:
@@ -113,24 +120,24 @@ jobs:
         if: ${{ steps.get_previous_commit_number.outputs.value != null && steps.get_previous_commit_number.outputs.value != '<no value>' }}
         # If previous_commit_number is not null, it means this push-to-master is a fix.
         # All commits with number between previous_commit_number and this commit number are therefore not safe to deploy.
-        # (deprecated) So mark them as "impropre: true" (customfield_10044)
-        # (new) So mark them as "SafeToDeploy: false" (customfield_10086)
+        # (deprecated) So mark them as "impropre: true"
+        # (new) So mark them as "SafeToDeploy: false"
 
         # The echo command is to clear jira config.yml file set in get jira issue step
         # The jira edit command uses .jira.d/templates/edit template by default
         run: |
           echo "issue:" >> $HOME/.jira.d/config.yml
           jira edit --query='"Numéro de commit[Number]" > ${{ steps.get_previous_commit_number.outputs.value }}' \
-            --override customfield_10044=true \
-            --override customfield_10086=false \
+            --override $IMPROPRE_FIELD=true \
+            --override $SAFE_TO_DEPLOY_FIELD=false \
             --noedit
       - name: "Push commit number and commit hash to jira issue"
         env:
           JIRA_API_TOKEN: ${{ steps.secrets.outputs.JIRA_API_TOKEN }}
         run: |
           jira edit ${{ needs.issue-number.outputs.status }} \
-            --override customfield_10044=false \
-            --override customfield_10086=true \
-            --override customfield_10059=${{ needs.issue-number.outputs.commit-number }} \
-            --override customfield_10060=${{ needs.issue-number.outputs.commit-hash }} \
+            --override $IMPROPRE_FIELD=false \
+            --override $SAFE_TO_DEPLOY_FIELD=true \
+            --override $COMMIT_NUMBER_FIELD=${{ needs.issue-number.outputs.commit-number }} \
+            --override $COMMIT_HASH_FIELD=${{ needs.issue-number.outputs.commit-hash }} \
             --noedit

--- a/.jira.d/templates/edit
+++ b/.jira.d/templates/edit
@@ -12,5 +12,8 @@ update:
   customfield_10060: # commit hash
     - set: "{{ .overrides.customfield_10060 }}"
   {{- end -}}
-
+  {{if .overrides.customfield_10086 }}
+  customfield_10086: # 'SafeToDeploy' flag
+    - set: "{{ .overrides.customfield_10086 }}"
+  {{- end -}}
 


### PR DESCRIPTION
## But de la pull request

Utiliser le label `SafeToDeploy` pour choisir le commit _release candidate_, comme dans le repo `pass-culture-app-native`
Si un commit est mergé alors qu'il est rattaché à un ticket Jira ayant un autre commit sur master, on édite alors les champs suivant du ticket:
- `Impropre=true`
- `SafeToDeploy=false`

signifiant que ce ticket ne peut être release candidate — on ne doit pas poser un tag sur son commit le plus élevé dans l'historique.

A l'inverse, si ce n'est pas le cas, on édite ainsi les champs :
- `Impropre=false`
- `SafeToDeploy=true`

Dans quelques jours, on supprimera l'utilisation du champ `Impropre`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques