### PR TITLE
(PC-28921)[PRO] feat: Dont patch offer on publish template offer.

### DIFF
--- a/pro/src/pages/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
@@ -74,7 +74,7 @@ describe('CollectiveOfferPreviewCreation', () => {
     ).toBeInTheDocument()
   })
 
-  it('Should show the redirect modal', async () => {
+  it('should show the redirect modal', async () => {
     vi.spyOn(api, 'patchCollectiveOfferPublication').mockResolvedValue({
       ...getCollectiveOfferFactory(),
       isNonFreeOffer: true,
@@ -84,6 +84,7 @@ describe('CollectiveOfferPreviewCreation', () => {
       '/offre/A1/collectif/creation/apercu',
       {
         ...defaultProps,
+        offer: getCollectiveOfferFactory(),
         offerer: {
           ...defaultGetOffererResponseModel,
           hasNonFreeOffer: false,

--- a/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -59,6 +59,8 @@ const CollectiveOfferPreviewCreationScreen = ({
 
       setOffer(response.payload)
       navigate(confirmationUrl)
+
+      return
     }
 
     const response = await publishCollectiveOfferAdapter(offer.id)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28921

**Objectif**
A la création d'une offre vitrine, on voit une notification d'erreur au moment de cliquer sur "Publier une offre", parce qu'il manque un early return, et l'appel pour l'offre réservable se fait en arrière plan et échoue.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques