### PR TITLE
(PC-28905)[PRO] fix: Disable firebase on adage iframe.

### DIFF
--- a/pro/src/app/App/App.tsx
+++ b/pro/src/app/App/App.tsx
@@ -57,8 +57,8 @@ const App = (): JSX.Element | null => {
         }
       })
     } else {
-      setConsentedToFirebase(true)
-      setConsentedToBeamer(true)
+      setConsentedToFirebase(false)
+      setConsentedToBeamer(false)
     }
   }, [location.pathname])
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28905

**Objectif**
Désactiver firebase et beamer par défaut sur l'iframe adage

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques