### PR TITLE
(BSR) feat: add gtl and facets to algolia config

### DIFF
--- a/api/src/pcapi/algolia_settings_offers.json
+++ b/api/src/pcapi/algolia_settings_offers.json
@@ -53,6 +53,10 @@
         "offer.gtl_level2",
         "offer.gtl_level3",
         "offer.gtl_level4",
+        "offer.gtlCodeLevel1",
+        "offer.gtlCodeLevel2",
+        "offer.gtlCodeLevel3",
+        "offer.gtlCodeLevel4",
         "offer.nativeCategoryId",
         "filterOnly(offer.prices)",
         "filterOnly(offer.searchGroupName)",
@@ -63,7 +67,11 @@
         "searchable(offer.tags)",
         "filterOnly(offer.times)",
         "filterOnly(venue.departmentCode)",
-        "filterOnly(venue.id)"
+        "filterOnly(venue.id)",
+        "venue.isAudioDisabilityCompliant",
+        "venue.isMentalDisabilityCompliant",
+        "venue.isMotorDisabilityCompliant",
+        "venue.isVisualDisabilityCompliant"
     ],
     "attributesToSnippet": null,
     "attributesToHighlight": null,


### PR DESCRIPTION
## But de la pull request

Ajout des labels GTL et des critères d'accessibilité des lieux en tant que `facet` dans la config Algolia

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques