### PR TITLE
(PC-28358)[PRO] feat: allow venue settings edition with no accessibility

### DIFF
--- a/pro/src/pages/VenueSettings/VenueSettingsScreen.tsx
+++ b/pro/src/pages/VenueSettings/VenueSettingsScreen.tsx
@@ -94,11 +94,17 @@ export const VenueSettingsFormScreen = ({
     ) {
       return
     }
-
+    const accessibilityVenueValues = {
+      visualDisabilityCompliant: venue.visualDisabilityCompliant || false,
+      audioDisabilityCompliant: venue.audioDisabilityCompliant || false,
+      motorDisabilityCompliant: venue.motorDisabilityCompliant || false,
+      mentalDisabilityCompliant: venue.mentalDisabilityCompliant || false,
+    }
     try {
       await api.editVenue(
         venue.id,
         serializeEditVenueBodyModel(
+          accessibilityVenueValues,
           values,
           !venue.siret,
           venue.isVirtual,

--- a/pro/src/pages/VenueSettings/__specs__/VenueSettingsFormScreen.spec.tsx
+++ b/pro/src/pages/VenueSettings/__specs__/VenueSettingsFormScreen.spec.tsx
@@ -451,6 +451,47 @@ describe('VenueFormScreen', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('should let update venue settings without accessibility', async () => {
+    renderForm(formValues, {
+      ...venue,
+      audioDisabilityCompliant: null,
+      motorDisabilityCompliant: null,
+      mentalDisabilityCompliant: null,
+      visualDisabilityCompliant: null,
+    })
+
+    const editVenue = vi
+      .spyOn(api, 'editVenue')
+      .mockResolvedValue(venueResponse)
+
+    await userEvent.click(screen.getByText(/Enregistrer/))
+
+    expect(editVenue).toHaveBeenCalledWith(15, {
+      address: 'PARIS',
+      audioDisabilityCompliant: false,
+      banId: '35288_7283_00001',
+      bookingEmail: 'em@ail.fr',
+      city: 'Saint-Malo',
+      comment: '',
+      isEmailAppliedOnAllOffers: true,
+      isWithdrawalAppliedOnAllOffers: false,
+      latitude: 48.635699,
+      longitude: -2.006961,
+      mentalDisabilityCompliant: false,
+      motorDisabilityCompliant: false,
+      name: 'MINISTERE DE LA CULTURE',
+      postalCode: '35400',
+      publicName: 'Melodie Sims',
+      reimbursementPointId: 91,
+      shouldSendMail: false,
+      siret: '88145723823022',
+      venueLabelId: 13,
+      venueTypeCode: 'Jeux / Jeux vidéos',
+      visualDisabilityCompliant: false,
+      withdrawalDetails: 'withdrawal details field',
+    })
+  })
+
   describe('Displaying with new onboarding', () => {
     it('should display new onboarding wording labels', async () => {
       venue.isVirtual = false

--- a/pro/src/pages/VenueSettings/serializers.ts
+++ b/pro/src/pages/VenueSettings/serializers.ts
@@ -3,7 +3,15 @@ import { unhumanizeSiret } from 'core/Venue/utils'
 
 import { VenueSettingsFormValues } from './types'
 
+type VenueAccessibility = {
+  audioDisabilityCompliant: boolean
+  mentalDisabilityCompliant: boolean
+  motorDisabilityCompliant: boolean
+  visualDisabilityCompliant: boolean
+}
+
 export const serializeEditVenueBodyModel = (
+  venueAccessibilityValues: VenueAccessibility,
   formValues: VenueSettingsFormValues,
   hideSiret: boolean,
   isVenueVirtual: boolean,
@@ -39,6 +47,9 @@ export const serializeEditVenueBodyModel = (
     shouldSendMail: shouldSendMail,
     venueLabelId: !formValues.venueLabel ? null : Number(formValues.venueLabel),
     venueTypeCode: formValues.venueType as VenueTypeCode,
+    ...(Object.values(venueAccessibilityValues).every((value) => !value)
+      ? venueAccessibilityValues
+      : {}),
   }
 
   if (hideSiret) {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28358

Permettre de modifier les paramètres d'un lieu même si ce dernier n'a pas d'informations d'accessibilité remplies. Ce cas ne devrait pas arriver mais existe dans la réalité quand le support créer un lieu manuelle pour un acteur culturel. 

Cette solution est temporaire pour permettre de sortir la feature initiale, à savoir la modification de lieu avec SIRET non diffusible créé par le support. 

_A terme on voudra sans doute remplir ces informations d'accessibilité dans le BO ou rediriger l'acteur vers l'édition de lieu si ce dernier n'a pas encore d'informations d'accessibilité._ 

