### PR TITLE
(PC-28946)[PRO] feat: Remove aria-current attribute from logout links.

### DIFF
--- a/pro/src/components/Header/Header.tsx
+++ b/pro/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames'
 import { ForwardedRef, forwardRef } from 'react'
-import { NavLink, useLocation } from 'react-router-dom'
+import { Link, NavLink, useLocation } from 'react-router-dom'
 
 import { Events } from 'core/FirebaseEvents/constants'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -65,7 +65,7 @@ const Header = forwardRef(
           <div className={styles['nav-brand']}>
             <NavLink
               className={styles['logo']}
-              to={'/accueil'}
+              to="/accueil"
               onClick={() => {
                 logEvent?.(Events.CLICKED_PRO, { from: location.pathname })
               }}
@@ -83,7 +83,7 @@ const Header = forwardRef(
             The first one is displayed only on tablet and smaller to get rid of the right margin (and has an alt)
             The second one is displayed on larger screen sizes
         */}
-          <NavLink
+          <Link
             onClick={() =>
               logEvent?.(Events.CLICKED_LOGOUT, { from: location.pathname })
             }
@@ -96,8 +96,8 @@ const Header = forwardRef(
               alt="Se déconnecter"
               width="24"
             />
-          </NavLink>
-          <NavLink
+          </Link>
+          <Link
             onClick={() =>
               logEvent?.(Events.CLICKED_LOGOUT, { from: location.pathname })
             }
@@ -111,7 +111,7 @@ const Header = forwardRef(
               width="20"
             />
             Se déconnecter
-          </NavLink>
+          </Link>
         </header>
       )
     }
@@ -122,7 +122,7 @@ const Header = forwardRef(
           <div className={styles['nav-brand']}>
             <NavLink
               className={cn('logo', 'nav-item')}
-              to={'/accueil'}
+              to="/accueil"
               onClick={() => {
                 logEvent?.(Events.CLICKED_PRO, { from: location.pathname })
               }}
@@ -274,7 +274,7 @@ const Header = forwardRef(
             <li>
               <div className={styles['separator']} />
 
-              <NavLink
+              <Link
                 className={cn(styles['nav-item'], styles['icon-only'])}
                 onClick={() =>
                   logEvent?.(Events.CLICKED_LOGOUT, { from: location.pathname })
@@ -292,7 +292,7 @@ const Header = forwardRef(
                   )}
                   width={NAV_ITEM_ICON_SIZE}
                 />
-              </NavLink>
+              </Link>
             </li>
           </ul>
         </nav>

--- a/pro/src/components/SideNavLinks/SideNavLinks.tsx
+++ b/pro/src/components/SideNavLinks/SideNavLinks.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavLink, useLocation } from 'react-router-dom'
 
@@ -75,7 +75,7 @@ const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
         </li>
         <li>
           <NavLink
-            to={'/accueil'}
+            to="/accueil"
             className={({ isActive }) =>
               classnames(styles['nav-links-item'], {
                 [styles['nav-links-item-active']]: isActive,

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import { NavLink } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 import styles from './DomainsCard.module.scss'
 
@@ -19,7 +19,7 @@ const DomainsCard = ({
   handlePlaylistElementTracking,
 }: DomainsCardProps) => {
   return (
-    <NavLink
+    <Link
       data-testid="card-domain-link"
       className={cn(styles['container'], styles[`container-${color}`])}
       to={href}
@@ -27,7 +27,7 @@ const DomainsCard = ({
     >
       <img src={src} alt="" className={styles['container-img']} />
       <div className={styles['container-title']}>{title}</div>
-    </NavLink>
+    </Link>
   )
 }
 

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { NavLink, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 
 import { CollectiveOfferTemplateResponseModel } from 'apiClient/adage'
 import { OfferAddressType } from 'apiClient/v1'
@@ -50,7 +49,7 @@ const OfferCardComponent = ({
 
   return (
     <div className={styles['container']}>
-      <NavLink
+      <Link
         className={styles['offer-link']}
         data-testid="card-offer-link"
         to={`/adage-iframe/decouverte/offre/${offer.id}?token=${adageAuthToken}`}
@@ -127,7 +126,7 @@ const OfferCardComponent = ({
               )} - ${offer.venue.city}`}</div>
             )}
         </div>
-      </NavLink>
+      </Link>
       <OfferFavoriteButton
         offer={{ ...offer, isTemplate: true }}
         className={styles['offer-favorite-button']}

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { NavLink, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 
 import { LocalOfferersPlaylistOffer } from 'apiClient/adage'
 import strokeInstitutionIcon from 'icons/stroke-institution.svg'
@@ -20,7 +19,7 @@ const VenueCard = ({
   const adageAuthToken = searchParams.get('token')
 
   return (
-    <NavLink
+    <Link
       data-testid="card-venue-link"
       className={styles.container}
       to={`/adage-iframe/recherche?token=${adageAuthToken}&venue=${venue.id}`}
@@ -48,7 +47,7 @@ const VenueCard = ({
           className={styles['venue-infos-distance']}
         >{`à ${venue.distance} km - ${venue.city}`}</div>
       </div>
-    </NavLink>
+    </Link>
   )
 }
 

--- a/pro/src/pages/SignupJourneyRoutes/SignupJourneyRoutes.tsx
+++ b/pro/src/pages/SignupJourneyRoutes/SignupJourneyRoutes.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react'
-import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { useEffect } from 'react'
+import { Link, Outlet, useLocation } from 'react-router-dom'
 
 import { AppLayout } from 'app/AppLayout'
 import { SignupJourneyFormLayout } from 'components/SignupJourneyFormLayout'
@@ -43,7 +43,7 @@ export const SignupJourneyRoutes = () => {
               src={logoPassCultureProIcon}
               viewBox="0 0 119 40"
             />
-            <NavLink
+            <Link
               onClick={() =>
                 logEvent?.(Events.CLICKED_LOGOUT, { from: location.pathname })
               }
@@ -57,7 +57,7 @@ export const SignupJourneyRoutes = () => {
                 width="20"
               />
               Se déconnecter
-            </NavLink>
+            </Link>
           </div>
         </header>
         <SignupJourneyContextProvider>

--- a/pro/src/pages/Sitemap/Sitemap.tsx
+++ b/pro/src/pages/Sitemap/Sitemap.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
 import { useSelector } from 'react-redux'
-import { NavLink } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 import { AppLayout } from 'app/AppLayout'
 import { selectCurrentOffererId } from 'store/user/selectors'
@@ -15,54 +14,51 @@ export const Sitemap = () => {
       <h1>Plan du site</h1>
       <ul className={styles['sitemap-list']}>
         <li className={styles['sitemap-list-item']}>
-          <NavLink to="/accueil" className={styles['sitemap-link']}>
+          <Link to="/accueil" className={styles['sitemap-link']}>
             Accueil
-          </NavLink>
+          </Link>
           <ul className={styles['sitemap-sub-list']}>
             <li className={styles['sitemap-list-item']}>
-              <NavLink
+              <Link
                 to={`/structures/${selectedOffererId}`}
                 className={styles['sitemap-link']}
               >
                 Structure
-              </NavLink>
+              </Link>
             </li>
             <li className={styles['sitemap-list-item']}>
-              <NavLink
+              <Link
                 to={`/offre/creation?structure=${selectedOffererId}`}
                 className={styles['sitemap-link']}
               >
                 Créer une offre
-              </NavLink>
+              </Link>
             </li>
             <li className={styles['sitemap-list-item']}>
-              <NavLink to="/profil" className={styles['sitemap-link']}>
+              <Link to="/profil" className={styles['sitemap-link']}>
                 Profil
-              </NavLink>
+              </Link>
             </li>
           </ul>
         </li>
         <li className={styles['sitemap-list-item']}>
-          <NavLink to="/guichet" className={styles['sitemap-link']}>
+          <Link to="/guichet" className={styles['sitemap-link']}>
             Guichet
-          </NavLink>
+          </Link>
         </li>
 
         <li className={styles['sitemap-list-item']}>
           <span className={styles['sitemap-list-title']}>Offres</span>
           <ul className={styles['sitemap-sub-list']}>
             <li className={styles['sitemap-list-item']}>
-              <NavLink to="/offres" className={styles['sitemap-link']}>
+              <Link to="/offres" className={styles['sitemap-link']}>
                 Offres individuelles
-              </NavLink>
+              </Link>
             </li>
             <li className={styles['sitemap-list-item']}>
-              <NavLink
-                to="/offres/collectives"
-                className={styles['sitemap-link']}
-              >
+              <Link to="/offres/collectives" className={styles['sitemap-link']}>
                 Offres collectives
-              </NavLink>
+              </Link>
             </li>
           </ul>
         </li>
@@ -70,17 +66,17 @@ export const Sitemap = () => {
           <span className={styles['sitemap-list-title']}>Réservations</span>
           <ul className={styles['sitemap-sub-list']}>
             <li className={styles['sitemap-list-item']}>
-              <NavLink to="/reservations" className={styles['sitemap-link']}>
+              <Link to="/reservations" className={styles['sitemap-link']}>
                 Réservations individuelles
-              </NavLink>
+              </Link>
             </li>
             <li className={styles['sitemap-list-item']}>
-              <NavLink
+              <Link
                 to="/reservations/collectives"
                 className={styles['sitemap-link']}
               >
                 Réservations collectives
-              </NavLink>
+              </Link>
             </li>
           </ul>
         </li>
@@ -90,32 +86,32 @@ export const Sitemap = () => {
           </span>
           <ul className={styles['sitemap-sub-list']}>
             <li className={styles['sitemap-list-item']}>
-              <NavLink to="/remboursements" className={styles['sitemap-link']}>
+              <Link to="/remboursements" className={styles['sitemap-link']}>
                 Justificatifs
-              </NavLink>
+              </Link>
             </li>
             <li className={styles['sitemap-list-item']}>
-              <NavLink
+              <Link
                 to="/remboursements/details"
                 className={styles['sitemap-link']}
               >
                 Détails
-              </NavLink>
+              </Link>
             </li>
             <li className={styles['sitemap-list-item']}>
-              <NavLink
+              <Link
                 to="/remboursements/informations-bancaires"
                 className={styles['sitemap-link']}
               >
                 Informations bancaires
-              </NavLink>
+              </Link>
             </li>
           </ul>
         </li>
         <li className={styles['sitemap-list-item']}>
-          <NavLink to="/statistiques" className={styles['sitemap-link']}>
+          <Link to="/statistiques" className={styles['sitemap-link']}>
             Statistiques
-          </NavLink>
+          </Link>
         </li>
       </ul>
     </AppLayout>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28946

**Objectif**
Ne pas laisser les `NavLink` `react-router` ajouter de `aria-current="page"` sur les liens qui ne correspondent pas à la page actuelle (ex: liens de déconnexion) parce que c'est mal interprété par les lecteurs d'écrans.
Ca n'arrive pas sur les `<Link>` (la seule différence avec le NavLink étant le isActive dispo dans les class). J'ai donc remplacé les NavLink par des Link partout où les isActive n'est pas utile, et où le `aria-current="page"` est inadapté.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques