### PR TITLE
(PC-28963)[PRO] fix: Dont transform adage template offer card dates i…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
@@ -10,13 +10,10 @@ import strokeEuroIcon from 'icons/stroke-euro.svg'
 import strokeLocationIcon from 'icons/stroke-location.svg'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
+import { getFormattedDatesForTemplateOffer } from 'pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferDates'
 import { isCollectiveOfferTemplate } from 'pages/AdageIframe/app/types/offers'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
-import { getRangeToFrenchText } from 'utils/date'
-import {
-  formatLocalTimeDateString,
-  getLocalDepartementDateTimeFromUtc,
-} from 'utils/timezone'
+import { formatLocalTimeDateString } from 'utils/timezone'
 
 import styles from './OfferSummary.module.scss'
 
@@ -38,20 +35,7 @@ const OfferSummary = ({ offer }: OfferSummaryProps): JSX.Element => {
   let offerVenueLabel = `${venue.postalCode}, ${venue.city}`
 
   const formattedDates =
-    isCollectiveOfferTemplate(offer) &&
-    ((offer.dates?.start &&
-      offer.dates.end &&
-      getRangeToFrenchText(
-        getLocalDepartementDateTimeFromUtc(
-          offer.dates.start,
-          venue.departmentCode
-        ),
-        getLocalDepartementDateTimeFromUtc(
-          offer.dates.end,
-          venue.departmentCode
-        )
-      )) ||
-      'Tout au long de l’année scolaire (l’offre est permanente)')
+    isOfferTemplate && getFormattedDatesForTemplateOffer(offer)
 
   if (offerVenue) {
     if (offerVenue.addressType === OfferAddressType.OTHER) {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/__specs__/OfferSummary.spec.tsx
@@ -21,11 +21,11 @@ describe('offer summary', () => {
   it('should show the dates range of a template offers', () => {
     const offer: CollectiveOfferTemplateResponseModel = {
       ...defaultCollectiveTemplateOffer,
-      dates: { start: '2023-10-23T22:00:00Z', end: '2023-10-24T21:59:00Z' },
+      dates: { start: '2023-10-24T00:00:00Z', end: '2023-10-24T23:59:00Z' },
       isTemplate: true,
     }
     renderOfferSummary({ offer })
-    expect(screen.queryByText('Le mardi 24 octobre 2023')).toBeInTheDocument()
+    expect(screen.getByText('Le mardi 24 octobre 2023')).toBeInTheDocument()
   })
 
   it('should not show the dates range on template offers if the dates are not defined', () => {


### PR DESCRIPTION
…nto local tz.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28963

**Objectif**
Les dates des offres vitrine dans la recherche sur adage sont transformées dans la tz de la venue alors qu'on doit les afficher telles quelles (comme dans la page offre). Il suffit donc de réutiliser la fonction de formattage de dates utilisée dans la page offre.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques