### PR TITLE
(PC-28951)[PRO] fix: Submit form when clearing location or interventi…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.module.scss
@@ -9,6 +9,7 @@
   width: rem.torem(1020px);
   max-width: 100%;
   margin: rem.torem(32px) auto rem.torem(32px);
+  align-items: center;
 }
 
 .adage-tag {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.tsx
@@ -66,6 +66,7 @@ const FiltersTags = ({
     return createTag(label, () => {
       void setFieldValue('eventAddressType', OfferAddressType.OTHER)
       setLocalisationFilterState(LocalisationFilterStates.NONE)
+      handleSubmit()
     })
   }
   const getGeoLocalisationTag = () => {
@@ -77,6 +78,7 @@ const FiltersTags = ({
       () => {
         void setFieldValue('geolocRadius', 50)
         setLocalisationFilterState(LocalisationFilterStates.NONE)
+        handleSubmit()
       }
     )
   }


### PR DESCRIPTION
…on type filters by clicking the tag.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28951

**Objectif**
Corriger le fait que le clic sur un tag de filtre dans adage ne re-déclenche pas la recherche quand le tag est sur le filtre de géoloc ou le filtre de type d'intervention. 

Et au passage alignement vertical des tags et du bouton Réinitialiser les filtres (voir screen)

<img width="858" alt="Capture d’écran 2024-04-03 à 12 29 21" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/4292efef-fd3c-49de-9dd1-68402a770d37">

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques