### PR TITLE
(PC-28842)[PRO] feat: save filter in adage

### DIFF
--- a/pro/cypress/e2e/adageSaveFilter.cy.ts
+++ b/pro/cypress/e2e/adageSaveFilter.cy.ts
@@ -1,0 +1,27 @@
+describe('save filters so that you can retrieve them when you return to the search page', () => {
+  beforeEach(() => {
+    cy.visit('/connexion')
+    cy.getFakeAdageToken()
+  })
+
+  it('should save filter when page changing', () => {
+    const adageToken = Cypress.env('adageToken')
+    cy.visit(`/adage-iframe/recherche?token=${adageToken}`)
+
+    cy.findByRole('button', { name: 'Format' }).click()
+    cy.findByLabelText('Atelier de pratique').click()
+    cy.findAllByRole('button', { name: 'Rechercher' }).eq(1).click()
+    cy.findByRole('button', { name: 'Domaine artistique' }).click()
+    cy.findByLabelText('Arts numériques').click()
+    cy.findAllByRole('button', { name: 'Rechercher' }).eq(1).click()
+    cy.findByText('Nous n’avons trouvé aucune offre publiée')
+
+    cy.contains('Mes Favoris').click()
+    cy.contains('Rechercher').click()
+    cy.findByRole('button', { name: 'Format (1)' }).click()
+    cy.findByLabelText('Atelier de pratique').should('be.checked')
+    cy.findByRole('button', { name: 'Domaine artistique (1)' }).click()
+    cy.findByLabelText('Arts numériques').should('be.checked')
+    cy.findByText('Nous n’avons trouvé aucune offre publiée')
+  })
+})

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -16,10 +16,9 @@ import React, {
   useEffect,
   useRef,
   useContext,
-  Dispatch,
-  SetStateAction,
 } from 'react'
 import { useSearchBox } from 'react-instantsearch'
+import { useDispatch } from 'react-redux'
 
 import { SuggestionType } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
@@ -28,6 +27,7 @@ import strokeBuildingIcon from 'icons/stroke-building.svg'
 import strokeClockIcon from 'icons/stroke-clock.svg'
 import strokeSearchIcon from 'icons/stroke-search.svg'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
+import { setAdageQuery } from 'store/adageFilter/reducer'
 import { Button, SubmitButton } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -45,7 +45,6 @@ import { Highlight } from './Highlight'
 type AutocompleteProps = {
   initialQuery: string
   placeholder: string
-  setCurrentSearch: Dispatch<SetStateAction<string | null>>
 }
 
 export type SuggestionItem = AutocompleteQuerySuggestionsHit & {
@@ -87,8 +86,9 @@ const addSuggestionToHistory = (suggestion: string) => {
 export const Autocomplete = ({
   initialQuery,
   placeholder,
-  setCurrentSearch,
 }: AutocompleteProps) => {
+  const dispatch = useDispatch()
+
   const { refine } = useSearchBox()
   const [instantSearchUiState, setInstantSearchUiState] = useState<
     AutocompleteState<SuggestionItem>
@@ -178,7 +178,7 @@ export const Autocomplete = ({
           const venueDisplayName = item.venue.publicName || item.venue.name
           autocomplete.setQuery('')
           refine('')
-          setCurrentSearch('')
+          dispatch(setAdageQuery(''))
           await formik.setFieldValue('venue', { ...item.venue, relative: [] })
           await formik.submitForm()
 
@@ -275,7 +275,7 @@ export const Autocomplete = ({
         },
         onSubmit: ({ state }) => {
           refine(state.query)
-          setCurrentSearch(state.query)
+          dispatch(setAdageQuery(state.query))
         },
         placeholder,
         plugins: [

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
@@ -125,7 +125,6 @@ const renderAutocomplete = (
             placeholder={
               'Rechercher par mot-clé, par partenaire culturel, par nom d’offre...'
             }
-            setCurrentSearch={vi.fn()}
           />
           <a href="#">Second element</a>
         </div>

--- a/pro/src/store/adageFilter/reducer.ts
+++ b/pro/src/store/adageFilter/reducer.ts
@@ -1,0 +1,44 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+import { VenueResponse } from 'apiClient/adage'
+import { ADAGE_FILTERS_DEFAULT_VALUES } from 'pages/AdageIframe/app/components/OffersInstantSearch/utils'
+
+interface SearchFormValuesWithQuery {
+  domains: number[]
+  students: string[]
+  departments: string[]
+  academies: string[]
+  eventAddressType: string
+  geolocRadius: number
+  formats: string[]
+  venue: VenueResponse | null
+}
+
+interface AdageFilterState {
+  adageFilter: SearchFormValuesWithQuery
+  adageQuery: string | null
+}
+
+const initialState: AdageFilterState = {
+  adageFilter: {
+    ...ADAGE_FILTERS_DEFAULT_VALUES,
+  },
+  adageQuery: null,
+}
+
+const adageFilterSlice = createSlice({
+  name: 'adageFilter',
+  initialState,
+  reducers: {
+    setAdageFilter(state, action: PayloadAction<SearchFormValuesWithQuery>) {
+      state.adageFilter = action.payload
+    },
+    setAdageQuery(state, action: PayloadAction<string>) {
+      state.adageQuery = action.payload
+    },
+  },
+})
+
+export const { setAdageFilter, setAdageQuery } = adageFilterSlice.actions
+
+export const adageFilterReducer = adageFilterSlice.reducer

--- a/pro/src/store/adageFilter/selectors.ts
+++ b/pro/src/store/adageFilter/selectors.ts
@@ -1,0 +1,7 @@
+import { RootState } from 'store/rootReducer'
+
+export const adageFilterSelector = (state: RootState) =>
+  state.adageFilter.adageFilter
+
+export const adageQuerySelector = (state: RootState) =>
+  state.adageFilter.adageQuery

--- a/pro/src/store/rootReducer.ts
+++ b/pro/src/store/rootReducer.ts
@@ -4,6 +4,7 @@ import { featuresReducer } from 'store/features/reducer'
 import { notificationsReducer } from 'store/notifications/reducer'
 import { userReducer } from 'store/user/reducer'
 
+import { adageFilterReducer } from './adageFilter/reducer'
 import { navReducer } from './nav/reducer'
 
 const rootReducer = combineReducers({
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   notification: notificationsReducer,
   user: userReducer,
   nav: navReducer,
+  adageFilter: adageFilterReducer,
 })
 
 export default rootReducer


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28842

Lorsque l'on met des filtres et que l'on change de page, on souhaite garder les filtres en mémoire et les réafficher dès que l'on revient sur la page

## Vérifications

- [x] J'ai écrit les tests nécessaires