### PR TITLE
(BSR)[API] test: fix EAC offerers/venues in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_users_and_offerers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_users_and_offerers.py
@@ -3,6 +3,8 @@ from pcapi.core.offerers import models as offerers_models
 
 
 def create_users_offerers() -> list[offerers_models.Offerer]:
+    # WARNING: please add offerers only at the end, because the order in the returned list is important to keep
+    # consistency in create_industrial_eac_data.create_venues.create_venues
     offerers = []
     user_offerer = offerers_factories.UserOffererFactory(
         user__email="eac_1_lieu@example.com",
@@ -16,14 +18,7 @@ def create_users_offerers() -> list[offerers_models.Offerer]:
         offerer__siren="444608442",
         offerer__allowedOnAdage=True,
     )
-    user_offerer_new_nav = offerers_factories.UserOffererFactory(
-        user__email="eac_2_lieu_new_nav@example.com",
-        offerer__name="eac_2_lieu [BON EAC]",
-        offerer__siren="444608443",
-        offerer__allowedOnAdage=True,
-    )
     offerers.append(user_offerer.offerer)
-    offerers.append(user_offerer_new_nav.offerer)
     user_offerer = offerers_factories.UserOffererFactory(
         user__email="squad-eac@passculture.app",
         offerer=user_offerer.offerer,
@@ -119,5 +114,13 @@ def create_users_offerers() -> list[offerers_models.Offerer]:
         offerer__siren="956513147",
     )
     offerers.append(user_offerer.offerer)
+
+    user_offerer_new_nav = offerers_factories.UserOffererFactory(
+        user__email="eac_2_lieu_new_nav@example.com",
+        offerer__name="eac_2_lieu [BON EAC]",
+        offerer__siren="444608443",
+        offerer__allowedOnAdage=True,
+    )
+    offerers.append(user_offerer_new_nav.offerer)
 
     return offerers


### PR DESCRIPTION
## But de la pull request

Corriger des incohérences dans la sandbox EAC, régression apportée par le commit https://github.com/pass-culture/pass-culture-main/commit/631304438e533f4e70ca31113a58987d63dfd61f

Avant (capture d'écran :copyright: @Vencespass )
![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/7647194a-65cd-41be-97c6-1f79c5d6bc74)

Après correction : 
![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/0cba9d9d-1fa3-426e-8d4b-1e3e4ba929c6)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques