### PR TITLE
(BSR)[BO] fix: '1234+ résultats' displayed when 1234 more than 100 rows are returned

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
@@ -25,7 +25,7 @@
       {% if rows %}
         <div class="d-flex justify-content-between">
           <p class="lead num-results">
-            {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
+            {{ rows | length }}
             résultat{{ "s" if rows | length > 1 else "" }}
           </p>
           <div class="btn-group btn-group-sm"

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
@@ -10,7 +10,7 @@
       {% if rows %}
         <div class="d-flex justify-content-between">
           <p class="lead num-results">
-            {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
+            {{ rows | length }}
             résultat{{ "s" if rows | length > 1 else "" }}
           </p>
           <div class="btn-group btn-group-sm"

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/list.html
@@ -10,7 +10,7 @@
       {% if rows %}
         <div class="d-flex flex-column">
           <p class="lead num-results">
-            {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
+            {{ rows | length }}
             résultat{{ "s" if rows | length > 1 else "" }}
           </p>
           <table class="table mb-4"

--- a/api/src/pcapi/routes/backoffice/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/list.html
@@ -25,7 +25,7 @@
       {% if rows %}
         <div class="d-flex justify-content-between">
           <p class="lead num-results">
-            {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
+            {{ rows | length }}
             résultat{{ "s" if rows | length > 1 else "" }}
           </p>
           {% if has_permission("PRO_FRAUD_ACTIONS") %}

--- a/api/src/pcapi/routes/backoffice/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/list.html
@@ -11,7 +11,7 @@
       {% if rows %}
         <div class="d-flex justify-content-between">
           <p class="lead num-results">
-            {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
+            {{ rows | length }}
             résultat{{ "s" if rows | length > 1 else "" }}
           </p>
           {% if can_edit %}


### PR DESCRIPTION
- Requested limit is not always 100
- utils.limit_rows already shows a flash message to notify users that results are truncated

## But de la pull request

Clarifier l'affichage du nombre de résultats dans le BO

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques