### PR TITLE
(BSR)[API] chore: remove type: ignore [attr-defined] on boolean hybrid properties

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -1004,7 +1004,7 @@ def archive_old_bookings() -> None:
         Booking.query.join(Booking.stock, Stock.offer, Booking.activationCode)
         .filter(date_condition)
         .filter(
-            offers_models.Offer.isDigital.is_(True),  # type: ignore [attr-defined]
+            offers_models.Offer.isDigital,
             offers_models.ActivationCode.id.is_not(None),
         )
         .with_entities(Booking.id)

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -26,6 +26,7 @@ import sqlalchemy.exc as sa_exc
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.elements import BooleanClauseList
 from sqlalchemy.sql.elements import Label
 
@@ -242,7 +243,7 @@ class Booking(PcObject, Base, Model):
         return self.status in [BookingStatus.USED, BookingStatus.REIMBURSED]
 
     @is_used_or_reimbursed.expression  # type: ignore [no-redef]
-    def is_used_or_reimbursed(cls) -> bool:  # pylint: disable=no-self-argument
+    def is_used_or_reimbursed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status.in_([BookingStatus.USED, BookingStatus.REIMBURSED])
 
     @hybrid_property
@@ -250,7 +251,7 @@ class Booking(PcObject, Base, Model):
         return self.status == BookingStatus.REIMBURSED
 
     @isReimbursed.expression  # type: ignore [no-redef]
-    def isReimbursed(cls) -> bool:  # pylint: disable=no-self-argument
+    def isReimbursed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status == BookingStatus.REIMBURSED
 
     @hybrid_property
@@ -258,7 +259,7 @@ class Booking(PcObject, Base, Model):
         return self.status == BookingStatus.CANCELLED
 
     @isCancelled.expression  # type: ignore [no-redef]
-    def isCancelled(cls) -> bool:  # pylint: disable=no-self-argument
+    def isCancelled(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status == BookingStatus.CANCELLED
 
     @property

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import declared_attr
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.elements import False_
+from sqlalchemy.sql.elements import UnaryExpression
 from sqlalchemy.sql.functions import func
 from sqlalchemy.sql.schema import Index
 from sqlalchemy.sql.selectable import Exists
@@ -167,7 +168,7 @@ class HasImageMixin:
         return self.imageId is not None
 
     @hasImage.expression  # type: ignore[no-redef]
-    def hasImage(cls) -> bool:  # pylint: disable=no-self-argument
+    def hasImage(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.imageId is not None
 
     def _get_image_storage_id(self, original: bool = False) -> str:
@@ -573,7 +574,7 @@ class CollectiveOffer(
         return self.subcategory.is_event
 
     @isEvent.expression  # type: ignore [no-redef]
-    def isEvent(cls) -> bool:  # pylint: disable=no-self-argument
+    def isEvent(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES)
 
     @property
@@ -606,7 +607,7 @@ class CollectiveOffer(
         return self.hasBeginningDatetimePassed
 
     @is_expired.expression  # type: ignore [no-redef]
-    def is_expired(cls) -> bool:  # pylint: disable=no-self-argument
+    def is_expired(cls) -> UnaryExpression:  # pylint: disable=no-self-argument
         return cls.hasBeginningDatetimePassed
 
 
@@ -863,7 +864,7 @@ class CollectiveOfferTemplate(
         return self.subcategory.is_event
 
     @isEvent.expression  # type: ignore [no-redef]
-    def isEvent(cls) -> bool:  # pylint: disable=no-self-argument
+    def isEvent(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES)
 
     @property
@@ -912,7 +913,7 @@ class CollectiveOfferTemplate(
         return self.hasBeginningDatetimePassed
 
     @is_expired.expression  # type: ignore [no-redef]
-    def is_expired(cls) -> bool:  # pylint: disable=no-self-argument
+    def is_expired(cls) -> UnaryExpression:  # pylint: disable=no-self-argument
         return cls.hasBeginningDatetimePassed
 
 
@@ -1283,7 +1284,7 @@ class CollectiveBooking(PcObject, Base, Model):
         return self.cancellationLimitDate <= datetime.utcnow()
 
     @isConfirmed.expression  # type: ignore[no-redef]
-    def isConfirmed(cls) -> bool:  # pylint: disable=no-self-argument
+    def isConfirmed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.cancellationLimitDate <= datetime.utcnow()
 
     @hybrid_property
@@ -1291,7 +1292,7 @@ class CollectiveBooking(PcObject, Base, Model):
         return self.status in [CollectiveBookingStatus.USED, CollectiveBookingStatus.REIMBURSED]
 
     @is_used_or_reimbursed.expression  # type: ignore[no-redef]
-    def is_used_or_reimbursed(cls) -> bool:  # pylint: disable=no-self-argument
+    def is_used_or_reimbursed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status.in_([CollectiveBookingStatus.USED, CollectiveBookingStatus.REIMBURSED])
 
     @hybrid_property
@@ -1299,7 +1300,7 @@ class CollectiveBooking(PcObject, Base, Model):
         return self.status == CollectiveBookingStatus.REIMBURSED
 
     @isReimbursed.expression  # type: ignore [no-redef]
-    def isReimbursed(cls) -> bool:  # pylint: disable=no-self-argument
+    def isReimbursed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status == CollectiveBookingStatus.REIMBURSED
 
     @hybrid_property
@@ -1307,7 +1308,7 @@ class CollectiveBooking(PcObject, Base, Model):
         return self.status == CollectiveBookingStatus.CANCELLED
 
     @isCancelled.expression  # type: ignore [no-redef]
-    def isCancelled(cls) -> bool:  # pylint: disable=no-self-argument
+    def isCancelled(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status == CollectiveBookingStatus.CANCELLED
 
     @property

--- a/api/src/pcapi/core/external/commands/update_sendinblue_batch_attributes.py
+++ b/api/src/pcapi/core/external/commands/update_sendinblue_batch_attributes.py
@@ -6,6 +6,7 @@ fix this issue.
 
 import time
 
+import sqlalchemy as sa
 import urllib3.exceptions
 
 from pcapi.core.external import batch
@@ -50,8 +51,8 @@ def _run_iteration(min_user_id: int, max_user_id: int, synchronize_batch: bool, 
         User.query.filter(User.id.in_(user_ids))
         .filter(
             User.isActive.is_(True),
-            User.has_pro_role.is_(False),  # type: ignore [attr-defined]
-            User.has_admin_role.is_(False),  # type: ignore [attr-defined]
+            sa.not_(User.has_pro_role),
+            sa.not_(User.has_admin_role),
         )
         .all()
     )

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -19,6 +19,7 @@ import sqlalchemy.dialects.postgresql as sqla_psql
 from sqlalchemy.ext.hybrid import hybrid_property
 import sqlalchemy.ext.mutable as sqla_mutable
 import sqlalchemy.orm as sqla_orm
+from sqlalchemy.sql.selectable import Exists
 
 from pcapi import settings
 from pcapi.models import Base
@@ -1033,7 +1034,7 @@ class FinanceIncident(Base, Model):
         )
 
     @isClosed.expression  # type: ignore [no-redef]
-    def isClosed(cls) -> bool:  # pylint: disable=no-self-argument
+    def isClosed(cls) -> Exists:  # pylint: disable=no-self-argument
         return (
             sqla.exists()
             .where(BookingFinanceIncident.incidentId == cls.id)

--- a/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
+++ b/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
@@ -87,8 +87,8 @@ def _get_online_bookings_happening_soon() -> sa.orm.query.Query:
             booking_models.Booking.status == booking_models.BookingStatus.CONFIRMED,
             Stock.beginningDatetime >= in_30_minutes,
             Stock.beginningDatetime < in_1_hour,
-            Offer.isEvent.is_(True),  # type: ignore [attr-defined]
-            Offer.isDigital.is_(True),  # type: ignore [attr-defined]
+            Offer.isEvent,
+            Offer.isDigital,
         )
     )
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1556,7 +1556,7 @@ def get_offerer_offers_stats(offerer_id: int, max_offer_count: int = 0) -> dict:
         return sa.select(sa.func.jsonb_object_agg(sa.text("status"), sa.text("number"))).select_from(
             sa.select(
                 sa.case(
-                    (sa.and_(offer_class.isActive.is_(True), offer_class.is_expired.is_(False)), "active"),  # type: ignore [attr-defined]
+                    (sa.and_(offer_class.isActive, sa.not_(offer_class.is_expired)), "active"),  # type: ignore [type-var]
                     else_="inactive",
                 ).label("status"),
                 sa.func.count(offer_class.id).label("number"),
@@ -1568,11 +1568,11 @@ def get_offerer_offers_stats(offerer_id: int, max_offer_count: int = 0) -> dict:
                 # TODO: remove filter on isActive when all DRAFT and PENDING collective_offers are effectively at isActive = False
                 sa.or_(
                     sa.and_(
-                        offer_class.isActive.is_(True),  # type: ignore [attr-defined]
+                        offer_class.isActive,
                         offer_class.validation == offers_models.OfferValidationStatus.APPROVED.value,
                     ),
                     sa.and_(
-                        offer_class.isActive.is_(False),  # type: ignore [attr-defined]
+                        sa.not_(offer_class.isActive),
                         offer_class.validation.in_(  # type: ignore [attr-defined]
                             [
                                 offers_models.OfferValidationStatus.APPROVED.value,
@@ -1652,8 +1652,8 @@ def get_venue_offers_stats(venue_id: int, max_offer_count: int = 0) -> dict:
         return sa.select(sa.func.jsonb_object_agg(sa.text("status"), sa.text("number"))).select_from(
             sa.select(
                 sa.case(
-                    (offer_class.isActive.is_(True), "active"),  # type: ignore [attr-defined]
-                    (offer_class.isActive.is_(False), "inactive"),  # type: ignore [attr-defined]
+                    (offer_class.isActive, "active"),
+                    else_="inactive",
                 ).label("status"),
                 sa.func.count(offer_class.id).label("number"),
             )
@@ -1663,12 +1663,12 @@ def get_venue_offers_stats(venue_id: int, max_offer_count: int = 0) -> dict:
                 # TODO: remove filter on isActive when all DRAFT and PENDING collective_offers are effectively at isActive = False
                 sa.or_(
                     sa.and_(
-                        offer_class.isActive.is_(True),  # type: ignore [attr-defined]
+                        offer_class.isActive,
                         offer_class.venueId == venue_id,
                         offer_class.validation == offers_models.OfferValidationStatus.APPROVED.value,
                     ),
                     sa.and_(
-                        offer_class.isActive.is_(False),  # type: ignore [attr-defined]
+                        sa.not_(offer_class.isActive),
                         offer_class.venueId == venue_id,
                         offer_class.validation.in_(  # type: ignore [attr-defined]
                             [

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict
 import sqlalchemy.orm as sa_orm
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.elements import BooleanClauseList
 from sqlalchemy.sql.elements import Case
 from sqlalchemy.sql.elements import UnaryExpression
@@ -531,7 +532,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return self.subcategoryId in subcategories_v2.EXPIRABLE_SUBCATEGORIES
 
     @canExpire.expression  # type: ignore [no-redef]
-    def canExpire(cls) -> bool:  # pylint: disable=no-self-argument
+    def canExpire(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories_v2.EXPIRABLE_SUBCATEGORIES)
 
     @property
@@ -544,7 +545,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return self.isActive and self.validation == OfferValidationStatus.APPROVED
 
     @_released.expression  # type: ignore [no-redef]
-    def _released(cls) -> bool:  # pylint: disable=no-self-argument
+    def _released(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(cls.isActive, cls.validation == OfferValidationStatus.APPROVED)
 
     @hybrid_property
@@ -552,7 +553,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return self.subcategoryId in subcategories_v2.PERMANENT_SUBCATEGORIES
 
     @isPermanent.expression  # type: ignore [no-redef]
-    def isPermanent(cls) -> bool:  # pylint: disable=no-self-argument
+    def isPermanent(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories_v2.PERMANENT_SUBCATEGORIES)
 
     @hybrid_property
@@ -560,7 +561,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return self.subcategory.is_event
 
     @isEvent.expression  # type: ignore [no-redef]
-    def isEvent(cls) -> bool:  # pylint: disable=no-self-argument
+    def isEvent(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories_v2.EVENT_SUBCATEGORIES)
 
     @property
@@ -572,7 +573,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return self.url is not None and self.url != ""
 
     @isDigital.expression  # type: ignore [no-redef]
-    def isDigital(cls) -> bool:  # pylint: disable=no-self-argument
+    def isDigital(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(cls.url.is_not(None), cls.url != "")
 
     @property
@@ -734,7 +735,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return self.hasBookingLimitDatetimesPassed
 
     @is_expired.expression  # type: ignore [no-redef]
-    def is_expired(cls) -> bool:  # pylint: disable=no-self-argument
+    def is_expired(cls) -> UnaryExpression:  # pylint: disable=no-self-argument
         return cls.hasBookingLimitDatetimesPassed
 
     @hybrid_property

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -103,7 +103,7 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
         return self.isActive and self.apiUrl != None and "praxiel" not in self.name.lower()
 
     @allow_bo_sync.expression  # type: ignore [no-redef]
-    def allow_bo_sync(cls) -> bool:  # pylint: disable=no-self-argument
+    def allow_bo_sync(cls) -> sa_sql.elements.BooleanClauseList:  # pylint: disable=no-self-argument
         # Praxiel API is very slow (with response times up to 30 seconds) and unstable (with frequent 50x
         # error responses). Full synchronization very rarely succeeds, don't bother trying.
         return sa.and_(cls.isActive.is_(True), cls.apiUrl.is_not(None), cls.name.not_ilike("%praxiel%"))

--- a/api/src/pcapi/core/search/staging_indexation.py
+++ b/api/src/pcapi/core/search/staging_indexation.py
@@ -21,7 +21,7 @@ def get_offers_for_each_subcategory(size_per_subcategory: int) -> set[int]:
             .join(offerer_models.Venue)
             .join(offerer_models.Offerer)
             .filter(
-                offers_models.Offer.is_eligible_for_search.is_(True),  # type: ignore [attr-defined]
+                offers_models.Offer.is_eligible_for_search,
                 offers_models.Offer.subcategoryId == subcategory.id,
             )
             .with_entities(offers_models.Offer.id)
@@ -35,7 +35,7 @@ def get_offers_with_gtl(size: int) -> set[int]:
         offers_models.Offer.query.join(offers_models.Stock)
         .filter(
             offers_models.Offer.extraData["gtl_id"].is_not(None),
-            offers_models.Offer.is_eligible_for_search.is_(True),  # type: ignore [attr-defined]
+            offers_models.Offer.is_eligible_for_search,
         )
         .with_entities(offers_models.Offer.id)
         .limit(size)
@@ -50,7 +50,7 @@ def get_offers_for_each_gtl_level_1(size_per_gtl: int) -> set[int]:
             offers_models.Offer.query.join(offers_models.Stock)
             .filter(
                 offers_models.Offer.extraData["gtl_id"].astext.startswith(str(i).zfill(2)),
-                offers_models.Offer.is_eligible_for_search.is_(True),  # type: ignore [attr-defined]
+                offers_models.Offer.is_eligible_for_search,
             )
             .with_entities(offers_models.Offer.id)
             .limit(size_per_gtl)
@@ -63,7 +63,7 @@ def get_offers_with_visa_number(size: int) -> set[int]:
         offers_models.Offer.query.join(offers_models.Stock)
         .filter(
             offers_models.Offer.extraData["visa_number"].is_not(None),
-            offers_models.Offer.is_eligible_for_search.is_(True),  # type: ignore [attr-defined]
+            offers_models.Offer.is_eligible_for_search,
         )
         .with_entities(offers_models.Offer.id)
         .limit(size)
@@ -75,7 +75,7 @@ def get_random_offers(size: int, excluded_offer_ids: set[int]) -> set[int]:
     query = (
         offers_models.Offer.query.join(offers_models.Stock)
         .filter(
-            offers_models.Offer.is_eligible_for_search.is_(True),  # type: ignore [attr-defined]
+            offers_models.Offer.is_eligible_for_search,
             offers_models.Offer.id.not_in(excluded_offer_ids),
         )
         .with_entities(offers_models.Offer.id)

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -567,7 +567,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return self.phoneValidationStatus == PhoneValidationStatusType.SKIPPED_BY_SUPPORT
 
     @is_phone_validation_skipped.expression  # type: ignore [no-redef]
-    def is_phone_validation_skipped(cls):  # pylint: disable=no-self-argument
+    def is_phone_validation_skipped(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.phoneValidationStatus == PhoneValidationStatusType.SKIPPED_BY_SUPPORT
 
     @hybrid_property
@@ -575,7 +575,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.ADMIN in self.roles
 
     @has_admin_role.expression  # type: ignore [no-redef]
-    def has_admin_role(cls) -> bool:  # pylint: disable=no-self-argument
+    def has_admin_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.ADMIN])
 
     @hybrid_property
@@ -583,7 +583,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.BENEFICIARY in self.roles
 
     @has_beneficiary_role.expression  # type: ignore [no-redef]
-    def has_beneficiary_role(cls) -> bool:  # pylint: disable=no-self-argument
+    def has_beneficiary_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.BENEFICIARY])
 
     @hybrid_property
@@ -591,7 +591,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.PRO in self.roles
 
     @has_pro_role.expression  # type: ignore [no-redef]
-    def has_pro_role(cls) -> bool:  # pylint: disable=no-self-argument
+    def has_pro_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.PRO])
 
     @hybrid_property
@@ -599,7 +599,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.NON_ATTACHED_PRO in self.roles
 
     @has_non_attached_pro_role.expression  # type: ignore [no-redef]
-    def has_non_attached_pro_role(cls) -> bool:  # pylint: disable=no-self-argument
+    def has_non_attached_pro_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.NON_ATTACHED_PRO])
 
     @hybrid_property
@@ -607,7 +607,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.UNDERAGE_BENEFICIARY in self.roles
 
     @has_underage_beneficiary_role.expression  # type: ignore [no-redef]
-    def has_underage_beneficiary_role(cls) -> bool:  # pylint: disable=no-self-argument
+    def has_underage_beneficiary_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
 
     @hybrid_property
@@ -615,7 +615,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.TEST in self.roles
 
     @has_test_role.expression  # type: ignore [no-redef]
-    def has_test_role(cls) -> bool:  # pylint: disable=no-self-argument
+    def has_test_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.TEST])
 
     @hybrid_property
@@ -623,7 +623,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return UserRole.ANONYMIZED in self.roles
 
     @has_anonymized_role.expression  # type: ignore [no-redef]
-    def has_anonymized_role(cls) -> bool:  # pylint: disable=no-self-argument
+    def has_anonymized_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.ANONYMIZED])
 
     @property

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -70,11 +70,11 @@ def find_user_by_email(email: str) -> models.User | None:
 
 
 def find_pro_user_by_email_query(email: str) -> BaseQuery:
-    return _find_user_by_email_query(email).filter(models.User.has_pro_role.is_(True))  # type: ignore [attr-defined]
+    return _find_user_by_email_query(email).filter(models.User.has_pro_role)
 
 
 def find_pro_or_non_attached_pro_user_by_email_query(email: str) -> BaseQuery:
-    return _find_user_by_email_query(email).filter(sa.or_(models.User.has_pro_role.is_(True), models.User.has_non_attached_pro_role.is_(True)))  # type: ignore [attr-defined]
+    return _find_user_by_email_query(email).filter(sa.or_(models.User.has_pro_role, models.User.has_non_attached_pro_role))  # type: ignore [type-var]
 
 
 def get_newly_eligible_age_18_users(since: date) -> list[models.User]:

--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -77,12 +77,12 @@ def _join_suspension_history(query: BaseQuery) -> BaseQuery:
 
 
 def _apply_search_filters(query: BaseQuery, search_filters: list[str]) -> BaseQuery:
-    or_filters: list[sa.sql.elements.ClauseElement] = []
+    or_filters: list = []
 
     if account_forms.AccountSearchFilter.UNDERAGE.name in search_filters:
         or_filters.append(
             sa.and_(
-                users_models.User.has_underage_beneficiary_role.is_(True),  # type: ignore [attr-defined]
+                users_models.User.has_underage_beneficiary_role,
                 users_models.User.isActive.is_(True),
             )
         )
@@ -90,7 +90,7 @@ def _apply_search_filters(query: BaseQuery, search_filters: list[str]) -> BaseQu
     if account_forms.AccountSearchFilter.BENEFICIARY.name in search_filters:
         or_filters.append(
             sa.and_(
-                users_models.User.has_beneficiary_role.is_(True),  # type: ignore [attr-defined]
+                users_models.User.has_beneficiary_role,
                 users_models.User.isActive.is_(True),
             )
         )
@@ -98,7 +98,7 @@ def _apply_search_filters(query: BaseQuery, search_filters: list[str]) -> BaseQu
     if account_forms.AccountSearchFilter.PUBLIC.name in search_filters:
         or_filters.append(
             sa.and_(
-                users_models.User.is_beneficiary.is_(False),  # type: ignore [attr-defined]
+                sa.not_(users_models.User.is_beneficiary),
                 users_models.User.isActive.is_(True),
             )
         )

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -631,7 +631,7 @@ def fully_sync_venue(venue_id: int) -> utils.BackofficeResponse:
     venue_exists = db.session.query(
         offerers_models.Venue.query.join(providers_models.VenueProvider)
         .join(providers_models.Provider)
-        .filter(providers_models.Provider.allow_bo_sync.is_(True))  # type: ignore[attr-defined]
+        .filter(providers_models.Provider.allow_bo_sync)
         .filter(offerers_models.Venue.id == venue_id)
         .filter(providers_models.VenueProvider.isActive.is_(True))
         .exists()

--- a/api/src/pcapi/routes/institutional/playlist.py
+++ b/api/src/pcapi/routes/institutional/playlist.py
@@ -20,7 +20,7 @@ def get_offers_by_tag(tag_name: str) -> serializers.OffersResponse:
         .join(offers_models.Offer.stocks)
         .filter(
             criteria_models.Criterion.name == tag_name,
-            offers_models.Offer.is_eligible_for_search.is_(True),  # type: ignore [attr-defined]
+            offers_models.Offer.is_eligible_for_search,
         )
         .options(
             sqla_orm.joinedload(offers_models.Offer.stocks),

--- a/api/src/pcapi/scripts/external_users/sendinblue_batch_update_user_attributes.py
+++ b/api/src/pcapi/scripts/external_users/sendinblue_batch_update_user_attributes.py
@@ -6,6 +6,8 @@ fix this issue.
 
 import sys
 
+import sqlalchemy as sa
+
 from pcapi.core.external import batch
 from pcapi.core.external import sendinblue
 from pcapi.core.external.attributes.api import get_user_attributes
@@ -53,8 +55,10 @@ def run(
     print("%s started" % message)
     chunk = (
         User.query.filter(User.id.in_(user_ids))
-        .filter(User.has_pro_role.is_(False))  # type: ignore [attr-defined]
-        .filter(User.has_admin_role.is_(False))  # type: ignore [attr-defined]
+        .filter(
+            sa.not_(User.has_pro_role),
+            sa.not_(User.has_admin_role),
+        )
         .all()
     )
     if synchronize_batch:

--- a/api/src/pcapi/scripts/fix_pro_roles.py
+++ b/api/src/pcapi/scripts/fix_pro_roles.py
@@ -22,7 +22,7 @@ def fix_users_who_should_be_pro(do_update: bool = False) -> None:
         users_models.User.query.join(offerers_models.UserOfferer)
         .join(offerers_models.Offerer)
         .filter(
-            users_models.User.has_pro_role.is_(False),  # type: ignore [attr-defined]
+            sa.not_(users_models.User.has_pro_role),
             offerers_models.UserOfferer.isValidated,
             offerers_models.Offerer.isValidated,
         )
@@ -41,7 +41,7 @@ def fix_users_who_should_not_be_pro(do_update: bool = False) -> None:
     Users who have PRO roles but do not have any attachment (any status)
     """
     users = users_models.User.query.outerjoin(offerers_models.UserOfferer).filter(
-        users_models.User.has_pro_role.is_(True),  # type: ignore [attr-defined]
+        users_models.User.has_pro_role,
         offerers_models.UserOfferer.id.is_(None),
     )
 
@@ -60,7 +60,7 @@ def fix_users_who_should_be_non_attached_pro(do_update: bool = False) -> None:
         users_models.User.query.join(offerers_models.UserOfferer)
         .join(offerers_models.Offerer)
         .filter(
-            users_models.User.has_non_attached_pro_role.is_(False),  # type: ignore [attr-defined]
+            sa.not_(users_models.User.has_non_attached_pro_role),
             sa.or_(
                 sa.not_(offerers_models.UserOfferer.isValidated),
                 sa.not_(offerers_models.Offerer.isValidated),


### PR DESCRIPTION
## But de la pull request

Un petit pas de plus sur les `type: ignore` autour des propriétés hybrides sqlalchemy.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques