### PR TITLE
(PC-29008)[ADAGE] fix: randomize venue playlist for adage

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -988,6 +988,7 @@ def get_collective_offer_templates_for_playlist_query(
             innerjoin=True,
         )
         .selectinload(offerers_models.Venue.googlePlacesInfo),
+        sa.orm.joinedload(educational_models.CollectivePlaylist.venue),
     )
     return query
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2104,12 +2104,6 @@ def get_offerer_v2_stats(offerer_id: int) -> OffererV2Stats:
     )
 
 
-def get_venues_by_ids(ids: typing.Collection[int]) -> BaseQuery:
-    return offerers_models.Venue.query.filter(offerers_models.Venue.id.in_(ids)).options(
-        sa.orm.joinedload(offerers_models.Venue.googlePlacesInfo)
-    )
-
-
 def add_timespan(opening_hours: models.OpeningHours, new_timespan: NumericRange) -> None:
     existing_timespan = opening_hours.timespan
     if existing_timespan:

--- a/api/src/pcapi/routes/adage_iframe/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/playlists.py
@@ -9,7 +9,6 @@ from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository
 import pcapi.core.educational.api.favorites as favorites_api
-import pcapi.core.offerers.api as offerers_api
 from pcapi.core.offerers.repository import get_venue_by_id
 from pcapi.models import Model
 from pcapi.models.api_errors import ApiErrors
@@ -198,19 +197,16 @@ def get_local_offerers_playlist(
     )
     # TODO: add some more items if the playlist is too empty
 
-    distances = {item.venueId: item.distanceInKm for item in playlist_items}
-    venues = offerers_api.get_venues_by_ids(distances.keys())
-
     return playlists_serializers.LocalOfferersPlaylist(
         venues=[
             playlists_serializers.LocalOfferersPlaylistOffer(
-                imgUrl=venue.bannerUrl,
-                publicName=venue.publicName,
-                name=venue.name,
-                distance=format_distance(distances[venue.id]),
-                city=venue.city,
-                id=venue.id,
+                imgUrl=item.venue.bannerUrl,
+                publicName=item.venue.publicName,
+                name=item.venue.name,
+                distance=format_distance(item.distanceInKm),
+                city=item.venue.city,
+                id=item.venue.id,
             )
-            for venue in venues
+            for item in playlist_items
         ]
     )

--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -226,8 +226,7 @@ class GetLocalOfferersPlaylistTest(SharedPlaylistsErrorTests):
 
         # fetch the institution (1 query)
         # fetch playlist items (1 query)
-        # fetch venues (1 query)
-        with assert_num_queries(3):
+        with assert_num_queries(2):
             response = iframe_client.get(url_for(self.endpoint))
 
         assert response.status_code == 200
@@ -251,7 +250,7 @@ class GetLocalOfferersPlaylistTest(SharedPlaylistsErrorTests):
         assert response.status_code == 200
         assert response.json == {"venues": []}
 
-    def test_get_classroom_playlist_random_order(self, client):
+    def test_get_local_offerers_playlist_random_order(self, client):
         playlist_venues = offerers_factories.VenueFactory.create_batch(15)
         offerers_factories.VenueFactory()
 


### PR DESCRIPTION
34cc9af154e687f9db92c55f6dda1629df0e8783 missed the fact that the randomized playlist was then queried without randomize through

Strangly, the tests reported random results while "real life" showed they were not random at all - 20 requests gave the same results.

This commits ensures we properly randomize this playlist

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29008

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques