### PR TITLE
(PC-27553)[API] chore: delete products without idAtProviders nor lastProviderId

### DIFF
--- a/api/src/pcapi/scripts/delete_unused_product/main.py
+++ b/api/src/pcapi/scripts/delete_unused_product/main.py
@@ -1,0 +1,69 @@
+import logging
+import time
+from typing import Generator
+
+from sqlalchemy.orm import joinedload
+
+from pcapi.core.offers import models as offers_models
+from pcapi.models import db
+from pcapi.repository import transaction
+
+
+logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = 500
+
+
+def products_to_delete(min_id: int) -> Generator[offers_models.Product, None, None]:
+    return (
+        offers_models.Product.query.filter(
+            offers_models.Product.lastProviderId.is_(None),
+            offers_models.Product.idAtProviders.is_(None),
+            offers_models.Product.id > min_id,
+        )
+        .options(joinedload(offers_models.Product.offers))
+        .limit(CHUNK_SIZE)
+        .all()
+    )
+
+
+def delete_unused_products(min_id: int) -> None:
+    current_batch_idx = 0
+    print(f"Starting from {min_id}")
+    start_time = time.time()
+    while products := products_to_delete(min_id):
+        current_batch_idx += 1
+        print(f"Starting - batch {current_batch_idx}")
+
+        with transaction():
+            products_id_to_delete = []
+            for product in products:
+                offers = product.offers
+
+                for offer in offers:
+                    offer.productId = None
+
+                db.session.add_all(offers)
+                products_id_to_delete.append(product.id)
+
+            offers_models.Product.query.filter(offers_models.Product.id.in_(products_id_to_delete)).delete(
+                synchronize_session=False
+            )
+
+        batch_time = time.time() - start_time
+        print(f"Ending - batch {current_batch_idx} - {batch_time:.2f} s")
+        start_time = time.time()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from pcapi.flask_app import app
+
+    parser = argparse.ArgumentParser(description="""Delete products with null idAtProviders""")
+
+    parser.add_argument("--min-id", type=int, default=0, help="minimum product id")
+
+    args = parser.parse_args()
+    with app.app_context():
+        delete_unused_products(args.min_id)


### PR DESCRIPTION
Another variant of the same script. 
This time there is no image to transfer. There are 7500 products to delete and the script took 125s (worst case was 20s for a batch) on staging. 

This is the state of Product table after the script : 
```
+---------+----------------+
| count   | lastProviderId |
|---------+----------------|
| 2206017 | 9              |
| 162334  | 16             |
| 129981  | 17             |
| 565668  | 19             |
| 135013  | 20             |
| 15558   | 70             | <- still to delete
| 932872  | 1082           |
| 2293    | 1097           | 
| 9       | <null>         | <- still to delete
+---------+----------------+
```

The 9 remaining products have no lastProviderId but an IdAtProvider. It should not happend, i'll manually handle them. (some might have been created (id 124 to 126) others might come from a bug when productWhitelist was created. 
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27553

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques