### PR TITLE
(PC-29056)[API] fix: Add report to response header for csp report only.

### DIFF
--- a/api/.env.staging
+++ b/api/.env.staging
@@ -104,7 +104,6 @@ SENDINBLUE_PRO_INACTIVE_90_DAYS_ID=36
 SENDINBLUE_PRO_NO_ACTIVE_OFFERS_40_DAYS_ID=40
 SENDINBLUE_PRO_NO_BOOKINGS_40_DAYS_ID=41
 SENTRY_TRACES_SAMPLE_RATE=0.1
-SENTRY_CSP_REPORT_ONLY_URI=https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365
 SIRENE_BACKEND=pcapi.connectors.entreprise.backends.insee.InseeBackend
 SLACK_CHANGE_FEATURE_FLIP_CHANNEL=feature-flip-ehp
 SMS_NOTIFICATION_BACKEND=pcapi.notifications.sms.backends.sendinblue.ToDevSendinblueBackend

--- a/api/.env.testing
+++ b/api/.env.testing
@@ -110,7 +110,6 @@ SENDINBLUE_PRO_INACTIVE_90_DAYS_ID=35
 SENDINBLUE_PRO_NO_ACTIVE_OFFERS_40_DAYS_ID=40
 SENDINBLUE_PRO_NO_BOOKINGS_40_DAYS_ID=41
 SENTRY_TRACES_SAMPLE_RATE=0.01
-SENTRY_CSP_REPORT_ONLY_URI=https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365
 SIRENE_BACKEND=pcapi.connectors.entreprise.backends.insee.InseeBackend
 SLACK_CHANGE_FEATURE_FLIP_CHANNEL=feature-flip-ehp
 SMS_NOTIFICATION_BACKEND=pcapi.notifications.sms.backends.sendinblue.ToDevSendinblueBackend

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -115,9 +115,6 @@ def add_security_headers(response: flask.wrappers.Response) -> flask.wrappers.Re
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload"
-    response.headers["Content-Security-Policy-Report-Only"] = (
-        f"default-src 'self'; report-uri {settings.SENTRY_CSP_REPORT_ONLY_URI}; report-to {settings.SENTRY_CSP_REPORT_ONLY_URI}"
-    )
 
     return response
 

--- a/pro/firebase.json
+++ b/pro/firebase.json
@@ -1,15 +1,22 @@
 {
   "hosting": {
     "public": "build",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {
         "source": "**",
         "destination": "/index.html"
+      }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Content-Security-Policy-Report-Only",
+            "value": "style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; object-src 'none'; frame-src https://www.google.com https://data-analytics.passculture.team; script-src-elem 'self' https://www.gstatic.com https://static.hotjar.com https://app.getbeamer.com https://script.hotjar.com https://www.googletagmanager.com https://firebaseinstallations.googleapis.com https://firebaseremoteconfig.googleapis.com https://vc.hotjar.io https://www.google.com; connect-src https://firebase.googleapis.com https://firebaseinstallations.googleapis.com https://sentry.passculture.team https://backend.testing.passculture.team https://region1.google-analytics.com https://*.algolia.net https://insights.algolia.io https://vc.hotjar.io https://metrics.hotjar.io; report-uri https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365;"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29056

Ajout de CSP report-only qui vont déclencher des erreurs sur Sentry sans bloquer le contenu. L'objectif étant d'améliorer la sécurité de l'app pro en rendant plus strictes les règles des CSP. Pour chaque type de source de contenu, on définit la liste explicite des urls qui y ont droit.

Doc du report-to : https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to

Doc des CSP dans Sentry : https://sentry.passculture.team/settings/sentry/projects/pro/security-headers/csp/

Doc sur notion : https://www.notion.so/passcultureapp/Setup-des-CSP-Report-Only-Sentry-dd0912213f154c9eb39315a2924eb363?pvs=4

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques