### PR TITLE
(PC-28894)[PRO] feat: reset errors in Hour for OpeningHours

### DIFF
--- a/pro/src/pages/VenueEdition/OpeningHoursForm/HourLine.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursForm/HourLine.tsx
@@ -17,7 +17,8 @@ type HourLineProps = {
 }
 
 export function HourLine({ day }: HourLineProps) {
-  const { setFieldValue, values } = useFormikContext<VenueEditionFormValues>()
+  const { setFieldValue, values, setFieldTouched } =
+    useFormikContext<VenueEditionFormValues>()
   const [isFullLineDisplayed, setIsFullLineDisplayed] = useState(
     Boolean(values[day].afternoonStartingHour)
   )
@@ -28,6 +29,8 @@ export function HourLine({ day }: HourLineProps) {
     await setFieldValue(`${day}.afternoonStartingHour`, '')
     await setFieldValue(`${day}.afternoonEndingHour`, '')
     await setFieldValue(`${day}.isAfternoonOpen`, false)
+    await setFieldTouched(`${day}.afternoonStartingHour`, false)
+    await setFieldTouched(`${day}.afternoonEndingHour`, false)
   }
 
   return (


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28894

on reset les erreurs des deux champs heures avant de les afficher (pour qu'elles n'apparaissent pas)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques