### PR TITLE
(PC-27999)[API] feat: Cancel failing EMS external bookings

### DIFF
--- a/api/src/pcapi/connectors/ems.py
+++ b/api/src/pcapi/connectors/ems.py
@@ -90,6 +90,7 @@ class EMSSitesConnector(AbstractEMSConnector):
 
 class EMSBookingConnector:
     digest_mode = "sha512"
+    get_ticket_endpoint = "STATUT"
     booking_endpoint = "VENTE"
     shows_availability_endpoint = "SEANCE"
     cancelation_endpoint = "ANNULATION"

--- a/api/src/pcapi/connectors/serialization/ems_serializers.py
+++ b/api/src/pcapi/connectors/serialization/ems_serializers.py
@@ -72,6 +72,12 @@ class ReservationPassCultureRequest(BaseModel):
     total_price: float
     email: str
     num_pass_culture: str  # User.id
+    num_cmde: str | None
+
+
+class GetTicketRequest(BaseModel):
+    num_cine: str
+    num_cmde: str
 
 
 class AnnulationPassCultureRequest(BaseModel):

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -1,12 +1,15 @@
 import datetime
+import json
 import logging
 import typing
 
+from flask import current_app
 import sentry_sdk
 import sqlalchemy as sa
 from sqlalchemy.orm import joinedload
 
 from pcapi.analytics.amplitude import events as amplitude_events
+from pcapi.connectors.ems import EMSAPIException
 from pcapi.core import search
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
@@ -21,6 +24,8 @@ from pcapi.core.external.attributes.api import update_external_pro
 from pcapi.core.external.attributes.api import update_external_user
 import pcapi.core.external_bookings.api as external_bookings_api
 from pcapi.core.external_bookings.boost.client import get_boost_external_booking_barcode
+from pcapi.core.external_bookings.ems import constants as ems_constants
+from pcapi.core.external_bookings.ems.client import EMSClientAPI
 import pcapi.core.external_bookings.exceptions as external_bookings_exceptions
 import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.exceptions as finance_exceptions
@@ -1085,3 +1090,34 @@ def cancel_unstored_external_bookings() -> None:
                     int(external_booking_info["venue_id"]),
                     [external_booking_info["barcode"]],
                 )
+
+
+def cancel_ems_external_bookings() -> None:
+    EMS_DEADLINE_BEFORE_CANCELLING = 90
+    redis_client = current_app.redis_client
+    ems_queue = ems_constants.EMS_EXTERNAL_BOOKINGS_TO_CANCEL
+
+    while redis_client.llen(ems_queue) > 0:
+        booking_to_cancel = json.loads(redis_client.rpop(ems_queue))
+        cinema_id, token, timestamp = (
+            booking_to_cancel["cinema_id"],
+            booking_to_cancel["token"],
+            booking_to_cancel["timestamp"],
+        )
+
+        if timestamp + EMS_DEADLINE_BEFORE_CANCELLING > datetime.datetime.utcnow().timestamp():
+            # This is the oldest booking to cancel we have in the queue and its too recent.
+            redis_client.rpush(ems_queue, json.dumps(booking_to_cancel))
+            return
+
+        client = EMSClientAPI(cinema_id=cinema_id)
+        try:
+            tickets = client.get_ticket(token)
+        except EMSAPIException as exc:
+            logger.info(
+                "Fail to fetch the external booking informations with exception: %s",
+                str(exc),
+                extra={"token": token, "cinema_id": cinema_id},
+            )
+            continue
+        client.cancel_booking_with_tickets(tickets)

--- a/api/src/pcapi/core/external_bookings/ems/client.py
+++ b/api/src/pcapi/core/external_bookings/ems/client.py
@@ -1,5 +1,8 @@
+import datetime
 import json
 import logging
+
+from flask import current_app
 
 from pcapi.connectors.ems import EMSBookingConnector
 from pcapi.connectors.serialization import ems_serializers
@@ -8,6 +11,8 @@ from pcapi.core.bookings import repository as bookings_repository
 from pcapi.core.external_bookings import models as external_bookings_models
 from pcapi.core.external_bookings.exceptions import ExternalBookingSoldOutError
 from pcapi.core.users import models as users_models
+from pcapi.models.feature import FeatureToggle
+from pcapi.utils.requests import exceptions as requests_exception
 
 from . import constants
 
@@ -22,6 +27,25 @@ class EMSClientAPI(external_bookings_models.ExternalBookingsClientAPI):
         super().__init__(cinema_id=cinema_id)
         self.connector = EMSBookingConnector()
 
+    def get_ticket(self, token: str) -> list[external_bookings_models.Ticket]:
+        payload = ems_serializers.GetTicketRequest(num_cine=self.cinema_id, num_cmde=token)
+        response = self.connector.do_request(self.connector.get_ticket_endpoint, payload=payload.dict())
+        self.connector.raise_for_status(response)
+        content = ems_serializers.ReservationPassCultureResponse(**response.json())
+        return [
+            external_bookings_models.Ticket(
+                barcode=ticket.code_barre,
+                seat_number=ticket.num_place,
+                additional_information={
+                    "num_cine": content.num_cine,
+                    "num_caisse": ticket.num_caisse,
+                    "num_trans": ticket.num_trans,
+                    "num_ope": ticket.num_ope,
+                },
+            )
+            for ticket in content.billets
+        ]
+
     def book_ticket(
         self, show_id: int, booking: booking_models.Booking, beneficiary: users_models.User
     ) -> list[external_bookings_models.Ticket]:
@@ -33,8 +57,23 @@ class EMSClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             total_price=float(booking.total_amount),
             email=beneficiary.email,
             num_pass_culture=str(beneficiary.id),
+            num_cmde=booking.token,
         )
-        response = self.connector.do_request(self.connector.booking_endpoint, payload=payload.dict())
+        try:
+            response = self.connector.do_request(self.connector.booking_endpoint, payload=payload.dict())
+        except (requests_exception.ReadTimeout, requests_exception.Timeout):
+            if FeatureToggle.EMS_CANCEL_PENDING_EXTERNAL_BOOKING.is_active():
+                booking_to_cancel = json.dumps(
+                    {
+                        "cinema_id": self.cinema_id,
+                        "token": booking.token,
+                        "timestamp": datetime.datetime.utcnow().timestamp(),
+                    }
+                )
+
+                current_app.redis_client.lpush(constants.EMS_EXTERNAL_BOOKINGS_TO_CANCEL, booking_to_cancel)
+            raise
+
         self.connector.raise_for_status(response)
 
         content = ems_serializers.ReservationPassCultureResponse(**response.json())
@@ -72,6 +111,24 @@ class EMSClientAPI(external_bookings_models.ExternalBookingsClientAPI):
         logger.info(
             "Successfully canceled an EMS external bookings",
             extra={"barcodes": [external_booking.barcode for external_booking in external_bookings]},
+        )
+
+    def cancel_booking_with_tickets(self, tickets: list[external_bookings_models.Ticket]) -> None:
+        # There's no partial cancelling and only one ticket is enough to cancel a duo booking
+        ticket = tickets[0]
+        assert ticket.additional_information  # helps mypy, additional_information shouldn't be None at this point
+        payload = ems_serializers.AnnulationPassCultureRequest(
+            num_cine=self.cinema_id,
+            num_caisse=ticket.additional_information["num_caisse"],
+            num_trans=ticket.additional_information["num_trans"],
+            num_ope=ticket.additional_information["num_ope"],
+        )
+        response = self.connector.do_request(self.connector.cancelation_endpoint, payload=payload.dict())
+        self.connector.raise_for_status(response)
+
+        logger.info(
+            "Successfully canceled an EMS external bookings after failing booking",
+            extra={"barcodes": [ticket.barcode for ticket in tickets]},
         )
 
     def get_shows_remaining_places(self, shows_id: list[int]) -> dict[str, int]:

--- a/api/src/pcapi/core/external_bookings/ems/constants.py
+++ b/api/src/pcapi/core/external_bookings/ems/constants.py
@@ -1,2 +1,3 @@
 EMS_SHOWTIMES_STOCKS_CACHE_KEY = "api:cinema_provider:ems:stocks:%s:%s"
 EMS_SHOWTIMES_STOCKS_CACHE_TIMEOUT = 60
+EMS_EXTERNAL_BOOKINGS_TO_CANCEL = "api:cinema_provider:ems:cancel_external_bookings"

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -37,6 +37,7 @@ class FeatureToggle(enum.Enum):
     DISABLE_CGR_EXTERNAL_BOOKINGS = "Désactiver les réservations externes CGR"
     DISABLE_EMS_EXTERNAL_BOOKINGS = "Désactiver les réservations externes EMS"
     DISPLAY_DMS_REDIRECTION = "Affiche une redirection vers DMS si ID Check est KO"
+    EMS_CANCEL_PENDING_EXTERNAL_BOOKING = "Annuler les réservations externes EMS qui ont échouées"
     ENABLE_AUTO_VALIDATION_FOR_EXTERNAL_BOOKING = (
         "Valide automatiquement après 48h les offres issues de l'api billeterie cinéma"
     )
@@ -157,6 +158,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.DISABLE_EMS_EXTERNAL_BOOKINGS,
     FeatureToggle.DISABLE_ENTERPRISE_API,
     FeatureToggle.DISPLAY_DMS_REDIRECTION,
+    FeatureToggle.EMS_CANCEL_PENDING_EXTERNAL_BOOKING,
     FeatureToggle.ENABLE_AUTO_VALIDATION_FOR_EXTERNAL_BOOKING,
     FeatureToggle.ENABLE_BEAMER,
     FeatureToggle.ENABLE_CODIR_OFFERERS_REPORT,  # only for production

--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -121,6 +121,13 @@ def cancel_unstored_external_bookings() -> None:
     bookings_api.cancel_unstored_external_bookings()
 
 
+@blueprint.cli.command("cancel_ems_external_bookings")
+@log_cron_with_transaction
+@cron_require_feature(FeatureToggle.EMS_CANCEL_PENDING_EXTERNAL_BOOKING)
+def cancel_ems_external_bookings() -> None:
+    bookings_api.cancel_ems_external_bookings()
+
+
 @blueprint.cli.command("archive_already_processed_dms_applications")
 @log_cron_with_transaction
 def archive_already_processed_dms_applications() -> None:

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1,6 +1,7 @@
 import dataclasses
 from datetime import datetime
 from datetime import timedelta
+import json
 import logging
 import re
 from unittest import mock
@@ -13,6 +14,7 @@ from sqlalchemy.sql import text
 
 from pcapi.analytics.amplitude.backends.amplitude_connector import AmplitudeEventType
 import pcapi.analytics.amplitude.testing as amplitude_testing
+from pcapi.connectors.ems import EMSBookingConnector
 from pcapi.core import search
 from pcapi.core.bookings import api
 from pcapi.core.bookings import exceptions
@@ -29,6 +31,7 @@ from pcapi.core.educational.models import CollectiveBooking
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.external.batch import BATCH_DATETIME_FORMAT
 from pcapi.core.external_bookings import factories as external_bookings_factories
+from pcapi.core.external_bookings.ems import constants
 import pcapi.core.external_bookings.exceptions as external_bookings_exceptions
 from pcapi.core.external_bookings.factories import ExternalBookingFactory
 from pcapi.core.external_bookings.models import Ticket
@@ -51,6 +54,7 @@ from pcapi.models import feature
 import pcapi.notifications.push.testing as push_testing
 from pcapi.tasks.serialization.external_api_booking_notification_tasks import BookingAction
 from pcapi.utils import queue
+from pcapi.utils.requests import exceptions as requests_exception
 
 from tests.conftest import clean_database
 
@@ -532,6 +536,263 @@ class BookOfferTest:
                 "num_trans": 1258,
                 "num_ope": 147150,
             }
+
+        @patch("flask.current_app.redis_client.llen")
+        @patch("pcapi.core.external_bookings.ems.client.current_app.redis_client.lpush")
+        @patch("pcapi.core.external_bookings.ems.client.current_app.redis_client.rpop")
+        @patch("pcapi.core.bookings.api.generate_booking_token")
+        @patch("pcapi.core.external_bookings.ems.client.EMSClientAPI.cancel_booking_with_tickets")
+        @override_features(ENABLE_EMS_INTEGRATION=True, EMS_CANCEL_PENDING_EXTERNAL_BOOKING=True)
+        @pytest.mark.parametrize("exception", [requests_exception.Timeout, requests_exception.ReadTimeout])
+        def test_timeout_during_ems_external_booking_trigger_a_cancel_call(
+            self,
+            mock_cancel_booking,
+            mock_generate_booking_token,
+            mock_rpop,
+            mock_lpush,
+            mock_llen,
+            exception,
+            requests_mock,
+        ):
+            token = "AAAAAA"
+            mock_generate_booking_token.return_value = token
+
+            beneficiary = users_factories.BeneficiaryGrant18Factory()
+            ems_provider = get_provider_by_local_class("EMSStocks")
+            venue_provider = providers_factories.VenueProviderFactory(
+                provider=ems_provider, venueIdAtOfferProvider="9997"
+            )
+            cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(venue=venue_provider.venue)
+            offer = offers_factories.EventOfferFactory(
+                name="Film",
+                venue=venue_provider.venue,
+                subcategoryId=subcategories.SEANCE_CINE.id,
+                lastProviderId=cinema_provider_pivot.provider.id,
+            )
+            stock = offers_factories.EventStockFactory(offer=offer, idAtProviders="1111%2222%EMS#3333")
+
+            payload = {
+                "num_cine": venue_provider.venueIdAtOfferProvider,
+                "id_seance": stock.idAtProviders.split("#")[-1],
+                "qte_place": 1,
+                "pass_culture_price": float(stock.price),
+                "total_price": float(stock.price),
+                "email": beneficiary.email,
+                "num_pass_culture": str(beneficiary.id),
+                "num_cmde": token,
+            }
+            url = EMSBookingConnector()._build_url("VENTE", payload)
+            booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
+
+            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+                api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
+
+            assert not Booking.query.all()
+            assert booking_adapter.call_count == 1
+            assert mock_lpush.call_count == 1
+            assert mock_lpush.mock_calls[0].args[0] == constants.EMS_EXTERNAL_BOOKINGS_TO_CANCEL
+            booking_queued = json.loads(mock_lpush.mock_calls[0].args[1])
+            assert booking_queued["cinema_id"] == venue_provider.venueIdAtOfferProvider
+            assert booking_queued["token"] == token
+            timestamp = booking_queued["timestamp"]
+            assert timestamp == pytest.approx(datetime.utcnow().timestamp())
+
+            mock_llen.side_effect = [1, 0]
+            mock_rpop.return_value = json.dumps(
+                {
+                    "cinema_id": venue_provider.venueIdAtOfferProvider,
+                    "token": token,
+                    # Mocking an older booking, otherwise tests runs too fast
+                    "timestamp": (datetime.utcnow() - timedelta(seconds=180)).timestamp(),
+                }
+            )
+
+            # Few minutes later, a cron trigger our task
+            # First we should check that the external booking has been successfully created
+            # Otherwise, there's nothing to cancel
+            payload = {"num_cine": venue_provider.venueIdAtOfferProvider, "num_cmde": token}
+            url = EMSBookingConnector()._build_url("STATUT", payload)
+            get_tickets_adapter = requests_mock.post(
+                url=re.compile(rf"{url}"),
+                json={
+                    "statut": 1,
+                    "num_cine": "9997",
+                    "id_seance": "999700078774",
+                    "qte_place": 1,
+                    "pass_culture_price": 5.15,
+                    "total_price": 5.15,
+                    "email": "email@email.fr",
+                    "num_pass_culture": "",
+                    "num_cmde": "",
+                    "billets": [
+                        {
+                            "num_caisse": "255",
+                            "code_barre": "000000139863",
+                            "num_trans": 475,
+                            "num_ope": 139863,
+                            "code_tarif": "0RG",
+                            "num_serie": 5,
+                            "montant": 5.15,
+                            "num_place": "",
+                        }
+                    ],
+                },
+            )
+
+            api.cancel_ems_external_bookings()
+
+            assert get_tickets_adapter.call_count == 1
+            assert mock_rpop.call_count == 1
+            assert mock_cancel_booking.call_count == 1
+            assert not Booking.query.all()
+
+        @patch("flask.current_app.redis_client.llen")
+        @patch("flask.current_app.redis_client.rpush")
+        @patch("flask.current_app.redis_client.lpush")
+        @patch("pcapi.core.external_bookings.ems.client.current_app.redis_client.rpop")
+        @patch("pcapi.core.bookings.api.generate_booking_token")
+        @patch("pcapi.core.external_bookings.ems.client.EMSClientAPI.cancel_booking_with_tickets")
+        @override_features(ENABLE_EMS_INTEGRATION=True, EMS_CANCEL_PENDING_EXTERNAL_BOOKING=True)
+        @pytest.mark.parametrize("exception", [requests_exception.Timeout, requests_exception.ReadTimeout])
+        def test_we_dont_cancel_too_early_failing_booking(
+            self,
+            mock_cancel_booking,
+            mock_generate_booking_token,
+            mock_rpop,
+            mock_lpush,
+            mock_rpush,
+            mock_llen,
+            exception,
+            requests_mock,
+        ):
+            token = "AAAAAA"
+            mock_generate_booking_token.return_value = token
+
+            beneficiary = users_factories.BeneficiaryGrant18Factory()
+            ems_provider = get_provider_by_local_class("EMSStocks")
+            venue_provider = providers_factories.VenueProviderFactory(
+                provider=ems_provider, venueIdAtOfferProvider="9997"
+            )
+            cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(venue=venue_provider.venue)
+            offer = offers_factories.EventOfferFactory(
+                name="Film",
+                venue=venue_provider.venue,
+                subcategoryId=subcategories.SEANCE_CINE.id,
+                lastProviderId=cinema_provider_pivot.provider.id,
+            )
+            stock = offers_factories.EventStockFactory(offer=offer, idAtProviders="1111%2222%EMS#3333")
+
+            payload = {
+                "num_cine": venue_provider.venueIdAtOfferProvider,
+                "id_seance": stock.idAtProviders.split("#")[-1],
+                "qte_place": 1,
+                "pass_culture_price": float(stock.price),
+                "total_price": float(stock.price),
+                "email": beneficiary.email,
+                "num_pass_culture": str(beneficiary.id),
+                "num_cmde": token,
+            }
+            url = EMSBookingConnector()._build_url("VENTE", payload)
+            booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
+
+            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+                api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
+
+            assert not Booking.query.all()
+            assert booking_adapter.call_count == 1
+            assert mock_lpush.call_count == 1
+            assert mock_lpush.mock_calls[0].args[0] == constants.EMS_EXTERNAL_BOOKINGS_TO_CANCEL
+            booking_queued = json.loads(mock_lpush.mock_calls[0].args[1])
+            assert booking_queued["cinema_id"] == venue_provider.venueIdAtOfferProvider
+            assert booking_queued["token"] == token
+            timestamp = booking_queued["timestamp"]
+            assert timestamp == pytest.approx(datetime.utcnow().timestamp())
+
+            mock_llen.side_effect = [1, 0]
+            mock_rpop.return_value = json.dumps(
+                {
+                    "cinema_id": venue_provider.venueIdAtOfferProvider,
+                    "token": token,
+                    "timestamp": timestamp,
+                }
+            )
+
+            get_tickets_adapter = requests_mock.post(
+                url=re.compile(r"https://fake_url.com/STATUT/*"),
+            )
+
+            api.cancel_ems_external_bookings()
+
+            assert mock_rpop.call_count == 1
+            assert mock_rpush.call_count == 1
+            assert get_tickets_adapter.call_count == 0
+            assert mock_cancel_booking.call_count == 0
+            assert not Booking.query.all()
+
+        @patch("flask.current_app.redis_client.llen")
+        @patch("pcapi.core.external_bookings.ems.client.current_app.redis_client.lpush")
+        @patch("pcapi.core.external_bookings.ems.client.current_app.redis_client.rpop")
+        @patch("pcapi.core.bookings.api.generate_booking_token")
+        @patch("pcapi.core.external_bookings.ems.client.EMSClientAPI.cancel_booking_with_tickets")
+        @override_features(ENABLE_EMS_INTEGRATION=True, EMS_CANCEL_PENDING_EXTERNAL_BOOKING=False)
+        @pytest.mark.parametrize("exception", [requests_exception.Timeout, requests_exception.ReadTimeout])
+        def test_timeout_during_ems_external_booking_dont_do_anything_if_ff_deactivated(
+            self,
+            mock_cancel_booking,
+            mock_generate_booking_token,
+            mock_rpop,
+            mock_lpush,
+            mock_llen,
+            exception,
+            requests_mock,
+        ):
+            token = "AAAAAA"
+            mock_generate_booking_token.return_value = token
+
+            beneficiary = users_factories.BeneficiaryGrant18Factory()
+            ems_provider = get_provider_by_local_class("EMSStocks")
+            venue_provider = providers_factories.VenueProviderFactory(
+                provider=ems_provider, venueIdAtOfferProvider="9997"
+            )
+            cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(venue=venue_provider.venue)
+            offer = offers_factories.EventOfferFactory(
+                name="Film",
+                venue=venue_provider.venue,
+                subcategoryId=subcategories.SEANCE_CINE.id,
+                lastProviderId=cinema_provider_pivot.provider.id,
+            )
+            stock = offers_factories.EventStockFactory(offer=offer, idAtProviders="1111%2222%EMS#3333")
+
+            payload = {
+                "num_cine": venue_provider.venueIdAtOfferProvider,
+                "id_seance": stock.idAtProviders.split("#")[-1],
+                "qte_place": 1,
+                "pass_culture_price": float(stock.price),
+                "total_price": float(stock.price),
+                "email": beneficiary.email,
+                "num_pass_culture": str(beneficiary.id),
+                "num_cmde": token,
+            }
+            url = EMSBookingConnector()._build_url("VENTE", payload)
+            booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
+
+            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+                api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
+
+            assert not Booking.query.all()
+            assert booking_adapter.call_count == 1
+            assert mock_lpush.call_count == 0
+
+            mock_llen.return_value = 0
+
+            # Few minutes later, a cron trigger our task
+            # First we should check that the external booking has been successfully created
+            # Otherwise, there's nothing to cancel
+            api.cancel_ems_external_bookings()
+
+            assert mock_rpop.call_count == 0
+            assert mock_cancel_booking.call_count == 0
+            assert not Booking.query.all()
 
         @patch("pcapi.core.bookings.api.external_bookings_api.book_cinema_ticket")
         @override_features(ENABLE_CDS_IMPLEMENTATION=True)

--- a/api/tests/core/external_bookings/ems/test_client.py
+++ b/api/tests/core/external_bookings/ems/test_client.py
@@ -25,9 +25,12 @@ class EMSBookTicketTest:
         return urljoin(base_url, digest)
 
     def test_we_can_book_one_ticket(self, requests_mock):
+        token = "AAAAAA"
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="beneficiary@example.com")
         showtime_stock = offers_factories.EventStockFactory()
-        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=1, amount=7.15, stock=showtime_stock)
+        booking = bookings_factories.BookingFactory(
+            user=beneficiary, quantity=1, amount=7.15, stock=showtime_stock, token="AAAAAA"
+        )
         cinema_pivot = providers_factories.EMSCinemaProviderPivotFactory(idAtProvider="9997")
         cinema_details = providers_factories.EMSCinemaDetailsFactory(cinemaProviderPivot=cinema_pivot)
         cinema_id = cinema_details.cinemaProviderPivot.idAtProvider
@@ -40,6 +43,7 @@ class EMSBookTicketTest:
             "total_price": 7.15,
             "email": beneficiary.email,
             "num_pass_culture": str(beneficiary.id),
+            "num_cmde": token,
         }
         url = self._build_url("VENTE/", payload_reservation)
 
@@ -52,6 +56,7 @@ class EMSBookTicketTest:
             "total_price": 7.15,
             "email": beneficiary.email,
             "num_pass_culture": beneficiary.id,
+            "num_cmde": token,
             "billets": [
                 {
                     "num_caisse": "255",
@@ -77,9 +82,12 @@ class EMSBookTicketTest:
         assert ticket.seat_number == ""
 
     def test_we_can_book_two_tickets_at_once(self, requests_mock):
+        token = "AAAAAA"
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="beneficiary@example.com")
         showtime_stock = offers_factories.EventStockFactory()
-        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=2, amount=7.15, stock=showtime_stock)
+        booking = bookings_factories.BookingFactory(
+            user=beneficiary, quantity=2, amount=7.15, stock=showtime_stock, token=token
+        )
         cinema_pivot = providers_factories.EMSCinemaProviderPivotFactory(idAtProvider="9997")
         cinema_details = providers_factories.EMSCinemaDetailsFactory(cinemaProviderPivot=cinema_pivot)
         cinema_id = cinema_details.cinemaProviderPivot.idAtProvider
@@ -92,6 +100,7 @@ class EMSBookTicketTest:
             "total_price": 14.30,
             "email": beneficiary.email,
             "num_pass_culture": str(beneficiary.id),
+            "num_cmde": token,
         }
         url = self._build_url("VENTE/", payload_reservation)
 
@@ -104,6 +113,7 @@ class EMSBookTicketTest:
             "total_price": 14.30,
             "email": beneficiary.email,
             "num_pass_culture": beneficiary.id,
+            "num_cmde": token,
             "billets": [
                 {
                     "num_caisse": "255",
@@ -140,9 +150,12 @@ class EMSBookTicketTest:
         assert tickets[1].seat_number == ""
 
     def test_we_handle_no_session_left_case(self, requests_mock):
+        token = "AAAAAA"
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="beneficiary@example.com")
         showtime_stock = offers_factories.EventStockFactory()
-        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=1, amount=7.15, stock=showtime_stock)
+        booking = bookings_factories.BookingFactory(
+            user=beneficiary, quantity=1, amount=7.15, stock=showtime_stock, token=token
+        )
         cinema_pivot = providers_factories.EMSCinemaProviderPivotFactory(idAtProvider="9997")
         cinema_details = providers_factories.EMSCinemaDetailsFactory(cinemaProviderPivot=cinema_pivot)
         cinema_id = cinema_details.cinemaProviderPivot.idAtProvider
@@ -155,6 +168,7 @@ class EMSBookTicketTest:
             "total_price": 7.15,
             "email": beneficiary.email,
             "num_pass_culture": str(beneficiary.id),
+            "num_cmde": token,
         }
         url = self._build_url("VENTE/", payload_reservation)
 


### PR DESCRIPTION
Revert "Revert "(PC-27999)[API] feat: Cancel failing EMS external bookings"" 
This reverts commit aa06d4bd565c98d17e303124cfb3d5f48af9ebad.
and add a FF over the all feature

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27999

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques