### PR TITLE
(PC-29065)[API] feat: Switch to  sha3_512 for public API Hashing

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -347,7 +347,7 @@ class ApiKeyFactory(BaseFactory):
         *args: typing.Any,
         **kwargs: typing.Any,
     ) -> models.ApiKey:
-        kwargs["secret"] = crypto.hash_password(kwargs.get("secret", DEFAULT_SECRET))
+        kwargs["secret"] = crypto.hash_public_api_key(kwargs.get("secret", DEFAULT_SECRET))
         return super()._create(model_class, *args, **kwargs)
 
 

--- a/api/src/pcapi/utils/crypto.py
+++ b/api/src/pcapi/utils/crypto.py
@@ -1,4 +1,7 @@
 from hashlib import md5
+from hashlib import sha3_512
+from secrets import compare_digest
+from secrets import token_hex
 
 import bcrypt
 from cryptography.fernet import Fernet
@@ -20,11 +23,24 @@ def _hash_password_with_md5(clear_text: str) -> bytes:
     return md5(clear_text.encode("utf-8")).hexdigest().encode("utf-8")
 
 
+def _hash_password_with_sha3_512(clear_text: str, salt: bytes = b"") -> bytes:
+    """Hash a password using SHA3-512. output format: $sha3_512$salt$hashed_password"""
+    if not salt:
+        salt = token_hex(16).encode("utf-8")
+    hashed_password = sha3_512(clear_text.encode("utf-8") + salt).hexdigest().encode("utf-8")
+    return b"$".join([b"$sha3_512", salt, hashed_password])
+
+
 def _check_password_with_md5(clear_text: str, hashed: bytes) -> bool:
     if not settings.USE_FAST_AND_INSECURE_PASSWORD_HASHING_ALGORITHM:
         raise RuntimeError("This password hasher should not be used in this environment.")
     # non constant-time comparison is fine, it's only used in tests
     return _hash_password_with_md5(clear_text) == hashed
+
+
+def _check_password_with_sha3_512(clear_text: str, hashed: bytes) -> bool:
+    salt = hashed.decode().split("$")[2].encode("utf-8")
+    return compare_digest(_hash_password_with_sha3_512(clear_text, salt), hashed)
 
 
 def hash_password(clear_text: str) -> bytes:
@@ -35,12 +51,24 @@ def hash_password(clear_text: str) -> bytes:
     return hasher(clear_text)
 
 
+def hash_public_api_key(clear_text: str) -> bytes:
+    if settings.USE_FAST_AND_INSECURE_PASSWORD_HASHING_ALGORITHM:
+        return _hash_password_with_md5(clear_text)
+    return _hash_password_with_sha3_512(clear_text)
+
+
 def check_password(clear_text: str, hashed: bytes) -> bool:
     if settings.USE_FAST_AND_INSECURE_PASSWORD_HASHING_ALGORITHM:
         checker = _check_password_with_md5
     else:
         checker = _check_password_with_bcrypt
     return checker(clear_text, hashed)
+
+
+def check_public_api_key(clear_text: str, hashed: bytes) -> bool:
+    if settings.USE_FAST_AND_INSECURE_PASSWORD_HASHING_ALGORITHM:
+        return _check_password_with_md5(clear_text, hashed)
+    return _check_password_with_sha3_512(clear_text, hashed)
 
 
 def encrypt(clear_text: str) -> str:

--- a/api/tests/utils/crypto_test.py
+++ b/api/tests/utils/crypto_test.py
@@ -12,6 +12,11 @@ class DevEnvironmentPasswordHasherTest:
         assert not crypto.check_password("wrong", hashed)
         assert crypto.check_password("secret", hashed)
 
+    def test_check_public_api_key(self):
+        hashed = crypto.hash_public_api_key("secret")
+        assert not crypto.check_public_api_key("wrong", hashed)
+        assert crypto.check_public_api_key("secret", hashed)
+
 
 @override_settings(USE_FAST_AND_INSECURE_PASSWORD_HASHING_ALGORITHM=False)
 class ProdEnvironmentPasswordHasherTest:
@@ -20,10 +25,20 @@ class ProdEnvironmentPasswordHasherTest:
         assert hashed != "secret"
         assert hashed.startswith(b"$2b$")  # bcrypt prefix
 
+    def test_hash_public_api_key_uses_sha3_512(self):
+        hashed = crypto.hash_public_api_key("secret")
+        assert hashed != "secret"
+        assert hashed.startswith(b"$sha3_512$")
+
     def test_check_password(self):
         hashed = crypto.hash_password("secret")
         assert not crypto.check_password("wrong", hashed)
         assert crypto.check_password("secret", hashed)
+
+    def test_check_public_api_key(self):
+        hashed = crypto.hash_public_api_key("secret")
+        assert not crypto.check_public_api_key("wrong", hashed)
+        assert crypto.check_public_api_key("secret", hashed)
 
 
 class EncryptDataTest:

--- a/api/tests/validation/routes/users_authentifications_test.py
+++ b/api/tests/validation/routes/users_authentifications_test.py
@@ -1,9 +1,14 @@
+from unittest.mock import patch
+
 import flask
 import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.providers.factories as providers_factories
+from pcapi.core.testing import override_settings
 from pcapi.models import api_errors
+from pcapi.utils.crypto import check_public_api_key
+from pcapi.utils.crypto import hash_password
 from pcapi.validation.routes import users_authentifications
 
 from tests.conftest import TestClient
@@ -66,3 +71,57 @@ class ApiKeyRequiredTest:
         response = client.get("/test", headers=headers)
 
         assert response.status_code == expected_response_status
+
+    @override_settings(
+        USE_FAST_AND_INSECURE_PASSWORD_HASHING_ALGORITHM=False,
+    )
+    def test_old_api_key_update(self, db_session):
+        """Test that old api key is updated to the new hashing algorithm"""
+        api_key = offerers_factories.ApiKeyFactory()
+
+        api_key.secret = hash_password("clearSecret")
+        assert api_key.secret.decode("utf-8").startswith("$2b$")
+        app = self._make_app()
+        client = TestClient(app.test_client())
+
+        headers = {"Authorization": "Bearer development_prefix_clearSecret"}
+        response = client.get("/test", headers=headers)
+        assert response.status_code == 200
+        assert api_key.secret.decode("utf-8").startswith("$sha3_512$")
+        assert check_public_api_key("clearSecret", api_key.secret)
+        db_session.flush()
+
+    @pytest.mark.parametrize("hashcode", ["$2a$12$hashed_password", "$2x$12$hashed_password", "$2y$12$hashed_password"])
+    @override_settings(
+        USE_FAST_AND_INSECURE_PASSWORD_HASHING_ALGORITHM=False,
+    )
+    @patch("pcapi.utils.crypto.check_password")
+    @patch("pcapi.utils.crypto.check_public_api_key")
+    def test_deprecated_hash(self, mock_check_public_api_key, mock_check_password, hashcode):
+        api_key = offerers_factories.ApiKeyFactory()
+        api_key.secret = f"$2a$12${hashcode}".encode("utf-8")
+        app = self._make_app()
+        client = TestClient(app.test_client())
+
+        headers = {"Authorization": "Bearer development_prefix_clearSecret"}
+        client.get("/test", headers=headers)
+
+        mock_check_password.assert_called()
+        mock_check_public_api_key.assert_not_called()
+
+    @override_settings(
+        USE_FAST_AND_INSECURE_PASSWORD_HASHING_ALGORITHM=True,
+    )
+    def test_unsecure_old_api_key_update(self, db_session):
+        """Test that old md5 api key isn't updated to the new hashing algorithm"""
+        api_key = offerers_factories.ApiKeyFactory()
+        api_key.secret = hash_password("clearSecret")
+        app = self._make_app()
+        client = TestClient(app.test_client())
+
+        headers = {"Authorization": "Bearer development_prefix_clearSecret"}
+        response = client.get("/test", headers=headers)
+        assert response.status_code == 200
+        assert not api_key.secret.decode("utf-8").startswith("$sha3_512$")
+        assert check_public_api_key("clearSecret", api_key.secret)
+        db_session.flush()


### PR DESCRIPTION

## But de la pull request
L'API publique réalise pour chaque requête une authentification impliquant un delai important du à bcrypt.
Le but de la PR est d'utiliser sha3-512 pour hasher la clé public. Les anciens hash seront converti à la première requête authentifié.
La stratégie [technique ](https://www.notion.so/passcultureapp/Acc-l-rer-le-traitement-des-requ-tes-HTTP-via-cl-d-API-en-changeant-le-stockage-des-cl-s-44071edd8138419c9fcf5816d9c0a0b0#53a1883386984328bc2c3b0ff36cd53b)

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29065

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques