### PR TITLE
(PC-28557)[PRO] fix: When comming back to colelctive offer creation f…

### DIFF
--- a/pro/src/core/OfferEducational/utils/__specs__/applyVenueDefaultsToFormValues.spec.ts
+++ b/pro/src/core/OfferEducational/utils/__specs__/applyVenueDefaultsToFormValues.spec.ts
@@ -1,0 +1,149 @@
+import { DEFAULT_EAC_FORM_VALUES } from 'core/OfferEducational/constants'
+
+import { applyVenueDefaultsToFormValues } from '../applyVenueDefaultsToFormValues'
+
+describe('applyVenueDefaultsToFormValues', () => {
+  it('should return the initial values if the venue cant be found', () => {
+    const formValues = { ...DEFAULT_EAC_FORM_VALUES, venueId: '2' }
+    const newFormValues = applyVenueDefaultsToFormValues(
+      formValues,
+      [
+        {
+          id: 1,
+          managedVenues: [],
+          name: 'test',
+          allowedOnAdage: true,
+        },
+      ],
+      false
+    )
+
+    expect(newFormValues).toEqual(formValues)
+  })
+
+  it('should return the accessibility values from the venue', () => {
+    const newFormValues = applyVenueDefaultsToFormValues(
+      { ...DEFAULT_EAC_FORM_VALUES, venueId: '2', offererId: '1' },
+      [
+        {
+          id: 1,
+          managedVenues: [
+            {
+              id: 2,
+              isVirtual: true,
+              name: 'test',
+              audioDisabilityCompliant: true,
+              mentalDisabilityCompliant: true,
+            },
+          ],
+          name: 'test',
+          allowedOnAdage: true,
+        },
+      ],
+      false
+    )
+
+    expect(newFormValues).toEqual(
+      expect.objectContaining({
+        accessibility: {
+          audio: true,
+          mental: true,
+          motor: false,
+          none: false,
+          visual: false,
+        },
+      })
+    )
+  })
+
+  it('should set disability compliance to none if no accessibility value is checked on the venue', () => {
+    const newFormValues = applyVenueDefaultsToFormValues(
+      { ...DEFAULT_EAC_FORM_VALUES, venueId: '2', offererId: '1' },
+      [
+        {
+          id: 1,
+          managedVenues: [
+            {
+              id: 2,
+              isVirtual: true,
+              name: 'test',
+            },
+          ],
+          name: 'test',
+          allowedOnAdage: true,
+        },
+      ],
+      false
+    )
+
+    expect(newFormValues).toEqual(
+      expect.objectContaining({
+        accessibility: {
+          audio: false,
+          mental: false,
+          motor: false,
+          none: true,
+          visual: false,
+        },
+      })
+    )
+  })
+
+  it('should prefill the form values with the venue email and phone if the venue has them', () => {
+    const newFormValues = applyVenueDefaultsToFormValues(
+      { ...DEFAULT_EAC_FORM_VALUES, offererId: '1', venueId: '2' },
+      [
+        {
+          id: 1,
+          managedVenues: [
+            {
+              id: 2,
+              isVirtual: true,
+              name: 'test',
+              collectiveEmail: 'test@email.co',
+              collectivePhone: '00000000',
+            },
+          ],
+          name: 'test',
+          allowedOnAdage: true,
+        },
+      ],
+      true
+    )
+
+    expect(newFormValues.email).toEqual('test@email.co')
+    expect(newFormValues.phone).toEqual('00000000')
+  })
+
+  it('should not prefill the form values with the venue email and phone if they already exist on in the form', () => {
+    const newFormValues = applyVenueDefaultsToFormValues(
+      {
+        ...DEFAULT_EAC_FORM_VALUES,
+        offererId: '1',
+        venueId: '2',
+        email: 'test2@email.co',
+        phone: '11111111',
+      },
+      [
+        {
+          id: 1,
+          managedVenues: [
+            {
+              id: 2,
+              isVirtual: true,
+              name: 'test',
+              collectiveEmail: 'test@email.co',
+              collectivePhone: '00000000',
+            },
+          ],
+          name: 'test',
+          allowedOnAdage: true,
+        },
+      ],
+      true
+    )
+
+    expect(newFormValues.email).toEqual('test2@email.co')
+    expect(newFormValues.phone).toEqual('11111111')
+  })
+})

--- a/pro/src/core/OfferEducational/utils/applyVenueDefaultsToFormValues.ts
+++ b/pro/src/core/OfferEducational/utils/applyVenueDefaultsToFormValues.ts
@@ -12,8 +12,24 @@ export const applyVenueDefaultsToFormValues = (
     .find(({ id }) => id.toString() === values.offererId)
     ?.managedVenues.find(({ id }) => id.toString() === values.venueId)
 
-  if (isOfferCreated || venue === undefined) {
-    return { ...values }
+  if (!venue) {
+    return values
+  }
+
+  if (isOfferCreated) {
+    //  In this case we are re-opening the first step during creation
+    //  If there are venue email and phone and no form email and phone yet, we pre-fill the form inputs
+    return {
+      ...values,
+      email:
+        venue.collectiveEmail && !values.email
+          ? venue.collectiveEmail
+          : values.email,
+      phone:
+        venue.collectivePhone && !values.phone
+          ? venue.collectivePhone
+          : values.phone,
+    }
   }
 
   const valuesWithNewVenueFields = {


### PR DESCRIPTION
…irst step, prefill the venue email and phone again.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28557

**Objectif**
Quand on crée une offre collective vitrine, qu'on passe la première étape et qu'on revient en arrière, si on n'a pas encore rempli les email et phone du formulaire, et que la venue a des valeurs par défaut, on doit à nouveau pré-remplir ces valeurs du formulaire.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques