### PR TITLE
(PC-28786)[BO] feat: finance - reintroduce commercial gesture creation

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -40,7 +40,6 @@ import zipfile
 from dateutil.relativedelta import relativedelta
 from flask import current_app as app
 from flask import render_template
-from flask_login import current_user
 from flask_sqlalchemy import BaseQuery
 import pytz
 import sqlalchemy as sqla
@@ -2062,6 +2061,7 @@ def get_reimbursements_by_venue(
             models.BookingFinanceIncident.id,
             bookings_models.Booking.id,
         )
+        .order_by(offerers_models.Venue.id, offerers_models.Venue.common_name)
     )
     collective_query = (
         pricing_query.with_entities(
@@ -2093,6 +2093,7 @@ def get_reimbursements_by_venue(
             models.BookingFinanceIncident.id,
             educational_models.CollectiveStock.id,
         )
+        .order_by(offerers_models.Venue.id, offerers_models.Venue.common_name)
     )
 
     reimbursements_by_venue = {}
@@ -2720,9 +2721,10 @@ def update_bank_account_venues_links(
 
 
 def create_overpayment_finance_incident(
-    bookings: list[bookings_models.Booking | educational_models.CollectiveBooking],
-    amount: float | None = None,
-    origin: str | None = None,
+    bookings: list[bookings_models.Booking],
+    author: users_models.User,
+    origin: str,
+    amount: decimal.Decimal | None = None,
 ) -> models.FinanceIncident:
     incident = models.FinanceIncident(
         kind=models.IncidentType.OVERPAYMENT,
@@ -2730,7 +2732,7 @@ def create_overpayment_finance_incident(
         venueId=bookings[0].venueId,
         details={
             "origin": origin,
-            "author": current_user.full_name,
+            "authorId": author.id,
             "createdAt": datetime.datetime.utcnow().isoformat(),
         },
     )
@@ -2738,41 +2740,153 @@ def create_overpayment_finance_incident(
     db.session.flush()
 
     booking_finance_incidents_to_create = []
-    if isinstance(bookings[0], educational_models.CollectiveBooking):
-        collective_booking = bookings[0]
+    if len(bookings) == 1:
+        booking = bookings[0]
+        new_total_amount = decimal.Decimal(0) if amount is None else booking.total_amount - decimal.Decimal(amount)
         booking_finance_incidents_to_create.append(
             models.BookingFinanceIncident(
-                collectiveBookingId=collective_booking.id,
+                bookingId=booking.id,
                 incidentId=incident.id,
-                newTotalAmount=0,
+                beneficiaryId=booking.userId,
+                newTotalAmount=utils.to_eurocents(new_total_amount),
             )
         )
     else:
         for booking in bookings:
-            new_total_amount = decimal.Decimal(0)
-            # Only total overpayment if multiple bookings are selected
-            if amount and len(bookings) == 1:
-                new_total_amount = booking.total_amount - decimal.Decimal(amount)
-
             booking_finance_incidents_to_create.append(
                 models.BookingFinanceIncident(
                     bookingId=booking.id,
                     incidentId=incident.id,
                     beneficiaryId=booking.userId,
-                    newTotalAmount=utils.to_eurocents(new_total_amount),
+                    # Only total overpayment if multiple bookings are selected
+                    newTotalAmount=utils.to_eurocents(decimal.Decimal(0)),
                 )
             )
     db.session.add_all(booking_finance_incidents_to_create)
 
     history_api.add_action(
         history_models.ActionType.FINANCE_INCIDENT_CREATED,
-        author=current_user,
+        author=author,
         finance_incident=incident,
         comment=origin,
     )
 
     db.session.commit()
 
+    return incident
+
+
+def create_overpayment_finance_incident_collective_booking(
+    booking: educational_models.CollectiveBooking,
+    author: users_models.User,
+    origin: str,
+) -> models.FinanceIncident:
+    incident = models.FinanceIncident(
+        kind=models.IncidentType.OVERPAYMENT,
+        status=models.IncidentStatus.CREATED,
+        venueId=booking.venueId,
+        details={
+            "origin": origin,
+            "authorId": author.id,
+            "createdAt": datetime.datetime.utcnow().isoformat(),
+        },
+    )
+    db.session.add(incident)
+    db.session.flush()
+
+    booking_finance_incident = models.BookingFinanceIncident(
+        collectiveBookingId=booking.id,
+        incidentId=incident.id,
+        newTotalAmount=0,
+    )
+    db.session.add(booking_finance_incident)
+
+    history_api.add_action(
+        history_models.ActionType.FINANCE_INCIDENT_CREATED,
+        author=author,
+        finance_incident=incident,
+        comment=origin,
+    )
+
+    db.session.commit()
+
+    return incident
+
+
+def create_finance_commercial_gesture(
+    bookings: list[bookings_models.Booking],
+    amount: decimal.Decimal,
+    author: users_models.User,
+    origin: str,
+) -> models.FinanceIncident:
+    incident = models.FinanceIncident(
+        kind=models.IncidentType.COMMERCIAL_GESTURE,
+        status=models.IncidentStatus.CREATED,
+        venueId=bookings[0].venueId,
+        details={
+            "origin": origin,
+            "authorId": author.id,
+            "createdAt": datetime.datetime.utcnow().isoformat(),
+        },
+    )
+    db.session.add(incident)
+    db.session.flush()
+
+    booking_finance_incidents_to_create = []
+    total_bookings_quantity = sum(booking.quantity for booking in bookings)
+    for booking in bookings:
+        # all bookings in a commercial gesture must be from the same stock → they all have the same amount
+        new_total_amount = (amount / total_bookings_quantity) * booking.quantity
+        booking_finance_incidents_to_create.append(
+            models.BookingFinanceIncident(
+                bookingId=booking.id,
+                incidentId=incident.id,
+                beneficiaryId=booking.userId,
+                newTotalAmount=utils.to_eurocents(new_total_amount),
+            )
+        )
+
+    db.session.add_all(booking_finance_incidents_to_create)
+    history_api.add_action(
+        history_models.ActionType.FINANCE_INCIDENT_CREATED,
+        author=author,
+        finance_incident=incident,
+        comment=origin,
+    )
+    db.session.commit()
+    return incident
+
+
+def create_finance_commercial_gesture_collective_booking(
+    booking: educational_models.CollectiveBooking,
+    author: users_models.User,
+    origin: str,
+) -> models.FinanceIncident:
+    incident = models.FinanceIncident(
+        kind=models.IncidentType.COMMERCIAL_GESTURE,
+        status=models.IncidentStatus.CREATED,
+        venueId=booking.venueId,
+        details={
+            "origin": origin,
+            "authorId": author.id,
+            "createdAt": datetime.datetime.utcnow().isoformat(),
+        },
+    )
+    db.session.add(incident)
+    db.session.flush()
+    booking_finance_incident = models.BookingFinanceIncident(
+        collectiveBookingId=booking.id,
+        incidentId=incident.id,
+        newTotalAmount=0,
+    )
+    db.session.add(booking_finance_incident)
+    history_api.add_action(
+        history_models.ActionType.FINANCE_INCIDENT_CREATED,
+        author=author,
+        finance_incident=incident,
+        comment=origin,
+    )
+    db.session.commit()
     return incident
 
 
@@ -2816,7 +2930,11 @@ def _create_finance_events_from_incident(
     return finance_events
 
 
-def validate_finance_incident(finance_incident: models.FinanceIncident, force_debit_note: bool) -> None:
+def validate_finance_incident(
+    finance_incident: models.FinanceIncident,
+    force_debit_note: bool,
+    author: users_models.User,
+) -> None:
     incident_validation_date = datetime.datetime.utcnow()
     finance_events = []
     for booking_incident in finance_incident.booking_finance_incidents:
@@ -2842,7 +2960,7 @@ def validate_finance_incident(finance_incident: models.FinanceIncident, force_de
         for beneficiary in beneficiaries:
             history_api.add_action(
                 history_models.ActionType.FINANCE_INCIDENT_USER_RECREDIT,
-                author=current_user,
+                author=author,
                 user=beneficiary,
                 linked_incident_id=finance_incident.id,
             )
@@ -2853,7 +2971,7 @@ def validate_finance_incident(finance_incident: models.FinanceIncident, force_de
 
     history_api.add_action(
         history_models.ActionType.FINANCE_INCIDENT_VALIDATED,
-        author=current_user,
+        author=author,
         venue=finance_incident.venue,
         finance_incident=finance_incident,
         comment=(
@@ -2883,7 +3001,11 @@ def validate_finance_incident(finance_incident: models.FinanceIncident, force_de
             send_commercial_gesture_email(finance_incident)
 
 
-def cancel_finance_incident(incident: models.FinanceIncident, comment: str) -> None:
+def cancel_finance_incident(
+    incident: models.FinanceIncident,
+    comment: str,
+    author: users_models.User,
+) -> None:
     if incident.status == models.IncidentStatus.CANCELLED:
         raise exceptions.FinanceIncidentAlreadyCancelled
     if incident.status == models.IncidentStatus.VALIDATED:
@@ -2894,7 +3016,7 @@ def cancel_finance_incident(incident: models.FinanceIncident, comment: str) -> N
 
     history_api.add_action(
         history_models.ActionType.FINANCE_INCIDENT_CANCELLED,
-        author=current_user,
+        author=author,
         finance_incident=incident,
         comment=comment,
     )

--- a/api/src/pcapi/routes/backoffice/finance/forms.py
+++ b/api/src/pcapi/routes/backoffice/finance/forms.py
@@ -28,6 +28,19 @@ class BaseIncidentCreationForm(FlaskForm):
     origin = fields.PCStringField("Origine de la demande")
 
 
+class CommercialGestureCreationForm(empty_forms.BatchForm, BaseIncidentCreationForm):
+    class Meta:
+        locales = ["fr_FR", "fr"]
+
+    total_amount = fields.PCDecimalField(
+        "Montant total dû à l'acteur culturel (sans le calcul de barème)", use_locale=True, validators=[Optional()]
+    )
+
+
+class CollectiveCommercialGestureCreationForm(BaseIncidentCreationForm):
+    pass
+
+
 class CollectiveOverPaymentIncidentCreationForm(BaseIncidentCreationForm):
     pass
 

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -88,6 +88,13 @@
                                  data-bs-toggle="modal"
                                  data-bs-target=".pc-validate-booking-modal-{{ collective_booking.id }}">Valider la réservation</a>
                             </li>
+                            {% if has_permission('MANAGE_INCIDENTS') and is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") %}
+                              <li class="dropdown-item p-0">
+                                <a class="btn btn-sm d-block w-100 text-start px-3"
+                                   data-bs-toggle="modal"
+                                   data-bs-target="#commercial-gesture-creation-modal-{{ collective_booking.id }}">Créer un geste commercial</a>
+                              </li>
+                            {% endif %}
                           {% elif not collective_booking.isReimbursed %}
                             <li class="dropdown-item p-0">
                               <a class="btn btn-sm d-block w-100 text-start px-3"
@@ -98,7 +105,7 @@
                             <li class="dropdown-item p-0">
                               <a class="btn btn-sm d-block w-100 text-start px-3"
                                  data-bs-toggle="modal"
-                                 data-bs-target="#incident-creation-modal-{{ collective_booking.id }}">Créer un incident</a>
+                                 data-bs-target="#overpayment-creation-modal-{{ collective_booking.id }}">Créer un incident</a>
                             </li>
                           {% endif %}
                         </ul>
@@ -196,7 +203,12 @@
         {% if is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") and has_permission("MANAGE_INCIDENTS") %}
           {% for collective_booking in rows %}
             {% if collective_booking.isReimbursed %}
-              {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_collective_booking_incident_creation_form", collective_booking_id=collective_booking.id) , "incident-creation-modal-" + collective_booking.id|string) }}
+              {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_collective_booking_overpayment_creation_form", collective_booking_id=collective_booking.id) , "overpayment-creation-modal-" + collective_booking.id|string) }}
+            {% endif %}
+          {% endfor %}
+          {% for collective_booking in rows %}
+            {% if collective_booking.isCancelled %}
+              {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_collective_booking_commercial_gesture_creation_form", collective_booking_id=collective_booking.id) , "commercial-gesture-creation-modal-" + collective_booking.id|string) }}
             {% endif %}
           {% endfor %}
         {% endif %}

--- a/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
@@ -60,10 +60,17 @@
               <button disabled
                       type="button"
                       class="btn btn-outline-primary"
-                      data-modal-selector="#incident-creation-modal"
+                      data-modal-selector="#overpayment-creation-modal"
                       data-mode="fetch"
-                      data-fetch-url="{{ url_for("backoffice_web.finance_incidents.get_incident_creation_form") }}"
+                      data-fetch-url="{{ url_for("backoffice_web.finance_incidents.get_individual_bookings_overpayment_creation_form") }}"
                       data-use-confirmation-modal="true">Créer un incident</button>
+              <button disabled
+                      type="button"
+                      class="btn btn-outline-primary"
+                      data-modal-selector="#commercial-gesture-creation-modal"
+                      data-mode="fetch"
+                      data-fetch-url="{{ url_for("backoffice_web.finance_incidents.get_individual_bookings_commercial_gesture_creation_form") }}"
+                      data-use-confirmation-modal="true">Créer un geste commercial</button>
             </div>
           {% endif %}
         </div>
@@ -229,7 +236,8 @@
         {{ build_lazy_modal(url_for("backoffice_web.individual_bookings.get_batch_validate_individual_bookings_form") , "batch-validate-booking-modal", "eager") }}
         {{ build_lazy_modal(url_for("backoffice_web.individual_bookings.get_batch_cancel_individual_bookings_form") , "batch-cancel-booking-modal", "eager") }}
         {% if is_feature_active("WIP_ENABLE_FINANCE_INCIDENT") and has_permission("MANAGE_INCIDENTS") %}
-          {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_incident_creation_form") , "incident-creation-modal", "eager") }}
+          {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_individual_bookings_overpayment_creation_form") , "overpayment-creation-modal", "eager") }}
+          {{ build_lazy_modal(url_for("backoffice_web.finance_incidents.get_individual_bookings_commercial_gesture_creation_form") , "commercial-gesture-creation-modal", "eager") }}
         {% endif %}
       {% endif %}
     </div>

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -296,7 +296,8 @@ class PriceEventTest:
             newTotalAmount=0, incident__venue=venue, booking=booking
         )
 
-        api.validate_finance_incident(total_booking_incident.incident, force_debit_note=False)
+        author = users_factories.UserFactory()
+        api.validate_finance_incident(total_booking_incident.incident, force_debit_note=False, author=author)
 
         assert total_booking_incident.booking.status == bookings_models.BookingStatus.CANCELLED
 
@@ -3591,7 +3592,10 @@ class ValidateFinanceIncidentTest:
                 booking.educationalInstitution.id, booking.educationalYearId, Decimal(7800.00), deposit
             )
 
-        api.validate_finance_incident(collective_booking_finance_incident.incident, force_debit_note=False)
+        author = users_factories.UserFactory()
+        api.validate_finance_incident(
+            collective_booking_finance_incident.incident, force_debit_note=False, author=author
+        )
 
         assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
 

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -518,7 +518,8 @@ class SQLFunctionsTest:
             booking=booking_reimbursed_2, incident=incident, newTotalAmount=3000
         )  # +10 on user's wallet
 
-        finance_api.validate_finance_incident(incident, force_debit_note=False)
+        author = users_factories.UserFactory()
+        finance_api.validate_finance_incident(incident, force_debit_note=False, author=author)
 
         assert incident.status == finance_models.IncidentStatus.VALIDATED
 
@@ -543,7 +544,8 @@ class SQLFunctionsTest:
         bookings_factories.ReimbursedBookingFactory(deposit=deposit, amount=30)
 
         # When
-        finance_api.validate_finance_incident(incident, force_debit_note=False)
+        author = users_factories.UserFactory()
+        finance_api.validate_finance_incident(incident, force_debit_note=False, author=author)
 
         # Then
         assert incident.status == finance_models.IncidentStatus.VALIDATED
@@ -563,7 +565,10 @@ class SQLFunctionsTest:
             booking=booking_reimbursed_2, incident=incident, newTotalAmount=3000
         )  # +10 on user's wallet
 
-        finance_api.cancel_finance_incident(incident=incident, comment="Cancellation for the purpose of this test")
+        author = users_factories.UserFactory()
+        finance_api.cancel_finance_incident(
+            incident=incident, comment="Cancellation for the purpose of this test", author=author
+        )
 
         assert incident.status == finance_models.IncidentStatus.CANCELLED
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28786

Prise en charge de la création de gestes commerciaux sur le BO

<img width="800" alt="Capture d’écran 2024-04-09 à 17 50 58" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/0af4f54b-dcc0-4744-ac99-e1bee7725c9d">

<img width="1193" alt="Capture d’écran 2024-04-09 à 17 51 19" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/0b470793-adba-477a-8eeb-8ff5f2cb786e">

 - Réservations collectives :

<img width="692" alt="Capture d’écran 2024-04-09 à 17 50 05" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/aa5474bf-8990-40cb-83cf-44b065e2ba72">

 - Réservations individuelles :

<img width="1329" alt="Capture d’écran 2024-04-09 à 17 50 37" src="https://github.com/pass-culture/pass-culture-main/assets/155538488/9190d1f7-acfc-4e7d-8e08-8591de404d50">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques