### PR TITLE
(BSR)[API] feat: make allocine movie lists and production year nullable

### DIFF
--- a/api/src/pcapi/connectors/serialization/allocine_serializers.py
+++ b/api/src/pcapi/connectors/serialization/allocine_serializers.py
@@ -209,7 +209,7 @@ class AllocineBacklink(pydantic.BaseModel):
 
 class AllocineMovieData(pydantic.BaseModel):
     eidr: str | None
-    productionYear: int
+    productionYear: int | None
 
 
 class AllocineMoviePoster(pydantic.BaseModel):
@@ -318,6 +318,10 @@ class AllocineMovie(pydantic.BaseModel):
 
         hours, minutes = map(int, match.groups())
         return hours * 60 + minutes
+
+    @pydantic.field_validator("releases", "countries", "genres", "companies", mode="before")
+    def convert_none_to_empty_list(cls, nullable_field: list | None) -> list:
+        return [] if not nullable_field else nullable_field
 
 
 class AllocinePageInfo(pydantic.BaseModel):

--- a/api/tests/domain/allocine_test.py
+++ b/api/tests/domain/allocine_test.py
@@ -25,11 +25,12 @@ class GetMovieListFromAllocineTest:
     def test_get_all_pages(self, requests_mock):
         self._configure_api_responses(requests_mock)
         movies = get_movie_list()
-        assert len(movies) == 4
+        assert len(movies) == 5
         assert movies[0].internalId == 131136
         assert movies[1].internalId == 41324
         assert movies[2].internalId == 2161
         assert movies[3].internalId == 4076
+        assert movies[4].internalId == 325691
 
     @patch("pcapi.connectors.api_allocine.get_movie_list_page")
     def test_handles_api_exception(self, mock_get_movie_list_page, caplog):

--- a/api/tests/domain/fixtures.py
+++ b/api/tests/domain/fixtures.py
@@ -3,7 +3,7 @@ import copy
 
 ALLOCINE_MOVIE_LIST_PAGE_1 = {
     "movieList": {
-        "totalCount": 4,
+        "totalCount": 5,
         "pageInfo": {"hasNextPage": True, "endCursor": "YXJyYXljb25uZWN0aW9uOjQ5"},
         "edges": [
             {
@@ -143,7 +143,7 @@ ALLOCINE_MOVIE_LIST_PAGE_1_UPDATED["movieList"]["edges"][0]["node"]["title"] = "
 
 ALLOCINE_MOVIE_LIST_PAGE_2 = {
     "movieList": {
-        "totalCount": 4,
+        "totalCount": 5,
         "pageInfo": {"hasNextPage": False, "endCursor": "YXJyYXljb25uZWN0aW9uOjQ6"},
         "edges": [
             {
@@ -284,6 +284,66 @@ ALLOCINE_MOVIE_LIST_PAGE_2 = {
                         {"activity": "Distribution", "company": {"name": "Les Acacias"}},
                         {"activity": "Production", "company": {"name": "Cineas"}},
                     ],
+                }
+            },
+            {
+                "node": {
+                    "id": "TW92aWU6MzI1Njkx",
+                    "internalId": 325691,
+                    "backlink": {
+                        "url": "https://www.allocine.fr/film/fichefilm_gen_cfilm=325691.html",
+                        "label": "Tous les détails du film sur AlloCiné",
+                    },
+                    "data": {"eidr": None, "productionYear": None},
+                    "title": "Moon le panda with null fields",
+                    "originalTitle": "Moon le panda",
+                    "type": "FEATURE_FILM",
+                    "runtime": None,
+                    "poster": None,
+                    "synopsis": "L'amitié entre un petit chinois et un panda.",
+                    "releases": None,
+                    "credits": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "person": {
+                                        "firstName": "Gilles",
+                                        "lastName": "de Maistre",
+                                    },
+                                    "position": {"name": "DIRECTOR"},
+                                }
+                            }
+                        ]
+                    },
+                    "cast": {
+                        "backlink": {
+                            "url": "https://www.allocine.fr/film/fichefilm-325691/casting/",
+                            "label": "Casting complet du film sur AlloCiné",
+                        },
+                        "edges": [
+                            {
+                                "node": {
+                                    "actor": {"firstName": "Liu", "lastName": "Ye"},
+                                    "role": None,
+                                }
+                            },
+                            {
+                                "node": {
+                                    "actor": {"firstName": "Noé", "lastName": "Yé"},
+                                    "role": None,
+                                }
+                            },
+                            {
+                                "node": {
+                                    "actor": {"firstName": "Nina", "lastName": "Ye"},
+                                    "role": None,
+                                }
+                            },
+                        ],
+                    },
+                    "countries": None,
+                    "genres": None,
+                    "companies": None,
                 }
             },
         ],

--- a/api/tests/providers/allocine_movie_list_test.py
+++ b/api/tests/providers/allocine_movie_list_test.py
@@ -28,7 +28,7 @@ class AllocineMovieListTest:
 
         # Then
         catalogue = Product.query.order_by(Product.id).all()
-        assert len(catalogue) == 4
+        assert len(catalogue) == 5
 
         allocine_products_provider = Provider.query.filter(
             Provider.name == providers_constants.ALLOCINE_PRODUCTS_PROVIDER_NAME


### PR DESCRIPTION
## But de la pull request

Des erreurs Sentry nous remontent que certains champs ne sont parfois pas renseignés dans les informations que nous envoie Allociné. On préfère enregistrer des données moins complètes que de faire crasher la synchro. On rend donc le typage plus permissifs.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques