### PR TITLE
(BSR)[API] fix: serialize bookingStatus in get bookings pro with the right status for booked things

### DIFF
--- a/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
+++ b/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
@@ -161,7 +161,7 @@ def serialize_bookings(booking: Booking) -> BookingRecapResponseModel:
         bookingDate=isoformat(
             typing.cast(datetime, convert_booking_dates_utc_to_venue_timezone(booking.bookedAt, booking))
         ),
-        bookingStatus=build_booking_status(booking.status),
+        bookingStatus=build_booking_status(booking),
         bookingIsDuo=booking.quantity == 2,
         bookingAmount=booking.bookingAmount,
         bookingPriceCategoryLabel=booking.priceCategoryLabel,
@@ -216,13 +216,13 @@ class ListBookingsQueryModel(BaseModel):
         return values
 
 
-def build_booking_status(booking_status: BookingStatus) -> BookingRecapStatus:
-    if booking_status == BookingStatus.REIMBURSED:
+def build_booking_status(booking: Booking) -> BookingRecapStatus:
+    if booking.status == BookingStatus.REIMBURSED:
         return BookingRecapStatus.reimbursed
-    if booking_status == BookingStatus.CANCELLED:
+    if booking.status == BookingStatus.CANCELLED:
         return BookingRecapStatus.cancelled
-    if booking_status == BookingStatus.USED:
+    if booking.status == BookingStatus.USED:
         return BookingRecapStatus.validated
-    if booking_status == BookingStatus.CONFIRMED:
+    if booking.isConfirmed:
         return BookingRecapStatus.confirmed
     return BookingRecapStatus.booked


### PR DESCRIPTION
## But de la pull request
Fixing the bug introduced during the refactoring of the serialization of the `get_bookings_pro` #11055 which was returning a "confirmed" status for all non-cancelled and unreimbursed bookings. The "confirmed" status should only apply to event offers that can still be canceled. "booked" is the correct status for physical offers."


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques