### PR TITLE
(PC-28960)[PRO] feat: allow line break and increase line height in offer description and price info

### DIFF
--- a/pro/src/components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/components/SummaryLayout/SummaryLayout.module.scss
@@ -66,6 +66,7 @@
     &-description {
       word-break: break-word;
       white-space: pre-line;
+      line-height: rem.torem(24px);
     }
 
     &:last-child {

--- a/pro/src/components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/components/SummaryLayout/SummaryLayout.module.scss
@@ -65,6 +65,7 @@
 
     &-description {
       word-break: break-word;
+      white-space: pre-line;
     }
 
     &:last-child {

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
@@ -73,6 +73,8 @@
         color: var(--color-grey-dark);
         margin-bottom: rem.torem(8px);
       }
+
+      white-space: pre-line;
     }
 
     &-list {

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
@@ -74,7 +74,10 @@
         margin-bottom: rem.torem(8px);
       }
 
-      white-space: pre-line;
+      &-description {
+        white-space: pre-line;
+        line-height: rem.torem(24px);
+      }
     }
 
     &-list {

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferDetailsSection.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferDetailsSection.tsx
@@ -82,7 +82,7 @@ export default function AdageOfferDetailsSection({
       )}
 
       {offer.description && (
-        <div className={styles['offer-section-group-item']}>
+        <div className={styles['offer-section-group-item-description']}>
           <h3 className={styles['offer-section-group-item-subtitle']}>
             Description
           </h3>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferInfoSection.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferInfoSection.tsx
@@ -53,7 +53,7 @@ export default function AdageOfferInfoSection({
 
   return (
     <>
-      <div className={styles['offer-section-group-item']}>
+      <div className={styles['offer-section-group-item-description']}>
         <h3 className={styles['offer-section-group-item-subtitle']}>
           Lieu où se déroulera l’offre
         </h3>
@@ -93,7 +93,7 @@ export default function AdageOfferInfoSection({
         )}
 
       {(isOfferBookable || offer.educationalPriceDetail) && (
-        <div className={styles['offer-section-group-item']}>
+        <div className={styles['offer-section-group-item-description']}>
           <h3 className={styles['offer-section-group-item-subtitle']}>
             {isOfferBookable ? 'Prix' : 'Information sur le prix'}
           </h3>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.module.scss
@@ -103,6 +103,7 @@
   &-content {
     flex: 1;
     word-break: break-word;
+    overflow: hidden;
   }
 
   &-actions {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.module.scss
@@ -29,4 +29,5 @@
 
 .offer-description {
   margin-top: rem.torem(16px);
+  white-space: pre-line;
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.module.scss
@@ -31,4 +31,7 @@
   margin-top: rem.torem(16px);
   white-space: pre-line;
   line-height: rem.torem(24px);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.module.scss
@@ -30,4 +30,5 @@
 .offer-description {
   margin-top: rem.torem(16px);
   white-space: pre-line;
+  line-height: rem.torem(24px);
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.tsx
@@ -45,11 +45,7 @@ export function AdageOfferListCardContent({
       )}
       {description && (
         <p className={styles['offer-description']}>
-          {formatDescription(
-            description.length > 400
-              ? `${description.substring(0, 400)}...`
-              : description
-          )}
+          {formatDescription(description)}
         </p>
       )}
     </>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/__specs__/AdageOfferListCardContent.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/__specs__/AdageOfferListCardContent.spec.tsx
@@ -49,19 +49,4 @@ describe('AdageOfferListCardContent', () => {
 
     expect(screen.queryByRole('list')).not.toBeInTheDocument()
   })
-
-  it('should crop the description at the end if it is too long', () => {
-    const description = Array(500).fill('d').join(' ')
-    renderAdageOfferListCardContent({
-      offer: {
-        ...defaultCollectiveTemplateOffer,
-        description: description,
-      },
-    })
-
-    expect(screen.queryByText(description)).not.toBeInTheDocument()
-    expect(
-      screen.getByText(`${description.substring(0, 400)}...`)
-    ).toBeInTheDocument()
-  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28960
Permettre des sauts de ligne et augmenter les espaces entre les lignes pour améliorer la lisibilité des offres

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques