### PR TITLE
(PC-29171)[API] feat: Export new Gunicorn metrics to Prometheus

### DIFF
--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -2,12 +2,17 @@ import logging
 import os
 import pathlib
 
+import prometheus_client
+import prometheus_client.registry
 from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
+
+from pcapi.utils import kubernetes as kubernetes_utils
 
 
 FLASK_PROMETHEUS_EXPORTER_PORT = int(os.environ.get("FLASK_PROMETHEUS_EXPORTER_PORT", "5002"))
 ENABLE_FLASK_PROMETHEUS_EXPORTER = int(os.environ.get("ENABLE_FLASK_PROMETHEUS_EXPORTER", "0"))
 FLASK_PROMETHEUS_EXPORTER_METRICS_DIR = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+KUBERNETES_DEPLOYMENT = kubernetes_utils.get_deployment()
 
 logger = logging.getLogger(__name__)
 
@@ -31,3 +36,27 @@ def _clean_up_prometheus_metrics_directory(worker):
     directory = pathlib.Path(FLASK_PROMETHEUS_EXPORTER_METRICS_DIR)
     for path in directory.glob(f"*_{worker.pid}.db"):
         path.unlink(missing_ok=True)
+
+
+def post_fork(server, worker):
+    """Called when a Gunicorn worker is started."""
+    if ENABLE_FLASK_PROMETHEUS_EXPORTER:
+        registry = prometheus_client.registry.CollectorRegistry()
+        metric_name = f"gunicorn_available_threads_{KUBERNETES_DEPLOYMENT}"
+        worker.available_threads = prometheus_client.Gauge(
+            metric_name,
+            "number of available Gunicorn threads",
+            registry=registry,
+            multiprocess_mode="sum",
+        )
+        worker.available_threads.set(worker.cfg.settings["threads"].value)
+
+
+def pre_request(worker, req):
+    if ENABLE_FLASK_PROMETHEUS_EXPORTER:
+        worker.available_threads.dec()
+
+
+def post_request(worker, req, environ, resp):
+    if ENABLE_FLASK_PROMETHEUS_EXPORTER:
+        worker.available_threads.inc()

--- a/api/src/pcapi/utils/kubernetes.py
+++ b/api/src/pcapi/utils/kubernetes.py
@@ -1,0 +1,16 @@
+import socket
+
+
+def get_deployment():
+    """Return the name of the Kubernetes deployment, based on the
+    hostname of the pod.
+
+    Outside a Kubernetes pod, return the hostname (or a part of it).
+    """
+    # pod names look like "{env}-pcapi-{pod-kind}-{id1}-{id2}",
+    # where `{pod-kind}` may contain dashes.
+    name = socket.gethostname()
+    try:
+        return name.split("-", 2)[-1].rsplit("-", 2)[0]
+    except IndexError:  # not a pod, return full name
+        return name

--- a/api/tests/utils/kubernetes_test.py
+++ b/api/tests/utils/kubernetes_test.py
@@ -1,0 +1,20 @@
+from unittest import mock
+
+import pytest
+
+from pcapi.utils import kubernetes
+
+
+@pytest.mark.parametrize(
+    "hostname,expected_deployment",
+    [
+        ("staging-pcapi-api-1a23bc45d6-fghi7", "api"),
+        ("staging-pcapi-api-v1-1a23bc45d6-fghi7", "api-v1"),
+        ("staging-pcapi-a-really-long-name-1a23bc45d6-fghi7", "a-really-long-name"),
+        ("mylocalhost", "mylocalhost"),
+        ("my-local-host", "host"),  # it's as good as anything else
+    ],
+)
+def test_get_deployment(hostname, expected_deployment):
+    with mock.patch("socket.gethostname", lambda: hostname):
+        assert kubernetes.get_deployment() == expected_deployment


### PR DESCRIPTION
Ticket : https://passculture.atlassian.net/browse/PC-29171

Seul le dernier commit est à relire. Les 2 commits m'ont servi à tester et ne seront pas mergés.

Démo (où j'ai ajouté une route `/slow?{x}` qui attend x secondes avant de rendre la main, et où la fenêtre de droite montre la valeur des métriques en temps (presque) réel. Et machine s'appelle "labit", d'où le nom de la métrique) :

[Capture vidéo du 2024-04-11 10-01-56.webm](https://github.com/pass-culture/pass-culture-main/assets/471321/ebcc63dc-99b0-4ba5-aadd-f2153eda0698)
