### PR TITLE
(PC-29190)[PRO] fix: Colors using rgb() or rgba() with css variable a…

### DIFF
--- a/pro/src/app/AppLayout.module.scss
+++ b/pro/src/app/AppLayout.module.scss
@@ -83,7 +83,11 @@
       display: block;
       position: fixed;
       inset: 0;
-      background: rgb(var(--color-input-text-color) 0.48);
+      background: color-mix(
+        in srgb,
+        var(--color-input-text-color) 48%,
+        transparent
+      );
     }
 
     &-open {

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageEdit.module.scss
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageEdit.module.scss
@@ -11,7 +11,7 @@
   background-color: var(--color-grey-light);
   color: var(--color-black);
   box-shadow: 0 rem.torem(1px) rem.torem(8px)
-    rgb(var(--color-large-shadow) 0.15);
+    color-mix(in srgb, var(--color-large-shadow) 15%, transparent);
   border-radius: rem.torem(4px);
   cursor: pointer;
 
@@ -32,7 +32,7 @@
 
   &:hover {
     box-shadow: 0 rem.torem(1px) rem.torem(8px)
-      rgb(var(--color-large-shadow) 0.3);
+      color-mix(in srgb, var(--color-large-shadow) 30%, transparent);
 
     .image-upload-button-label {
       text-decoration: underline;

--- a/pro/src/components/ImageUploader/ImageUploader.module.scss
+++ b/pro/src/components/ImageUploader/ImageUploader.module.scss
@@ -30,7 +30,7 @@
   border: rem.torem(1px) solid var(--color-grey-medium);
   border-radius: rem.torem(4px);
   box-shadow: 0 rem.torem(1px) rem.torem(8px)
-    rgb(var(--color-large-shadow) 0.15);
+    color-mix(in srgb, var(--color-large-shadow) 15%, transparent);
 
   &.preview-venue {
     width: 100%;

--- a/pro/src/components/SoftDeletedOffererWarning/SoftDeletedOffererWarning.module.scss
+++ b/pro/src/components/SoftDeletedOffererWarning/SoftDeletedOffererWarning.module.scss
@@ -4,8 +4,8 @@
 .soft-deleted-offerer-warning {
   border: rem.torem(1px) solid var(--color-grey-medium);
   border-radius: rem.torem(8px);
-  /* stylelint-disable-next-line color-function-notation */
-  box-shadow: 0 rem.torem(2px) rem.torem(6px) 0 rgba(var(--color-black), 0.15);
+  box-shadow: 0 rem.torem(2px) rem.torem(6px) 0
+    color-mix(in srgb, var(--color-black) 15%, transparent);
   overflow: hidden;
   margin-top: rem.torem(16px);
 

--- a/pro/src/components/Tutorial/Tutorial.module.scss
+++ b/pro/src/components/Tutorial/Tutorial.module.scss
@@ -82,8 +82,8 @@
   &.nav-step-active {
     background: var(--color-primary);
     border-radius: 50%;
-    /* stylelint-disable-next-line color-function-notation */
-    box-shadow: 0 0 rem.torem(3px) 0 rgba(var(--color-secondary), 0.21);
+    box-shadow: 0 0 rem.torem(3px) 0
+      color-mix(in srgb, var(--color-secondary) 21%, transparent);
     height: rem.torem(16px);
     width: rem.torem(16px);
   }

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscoveryBanner/AdageDiscoveryBanner.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscoveryBanner/AdageDiscoveryBanner.module.scss
@@ -46,12 +46,9 @@
       fill: var(--color-secondary-light);
     }
 
-    .discovery-banner-svg-cross {
-      fill: rgb(var(--color-grey-light) 0.4);
-    }
-
+    .discovery-banner-svg-cross,
     .discovery-banner-svg-circle {
-      fill: rgb(var(--color-grey-light) 0.3);
+      fill: color-mix(in srgb, var(--color-grey-light) 40%, transparent);
     }
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -42,10 +42,10 @@ export const AppLayout = (): JSX.Element => {
     redirectToMarseilleSearch ||
     adageUser.role === AdageFrontRoles.READONLY
   return (
-    <div>
+    <div className={styles['app-layout']}>
       <AdageHeader />
       <main
-        className={classNames(styles['app-layout'], {
+        className={classNames({
           [styles['app-layout-content']]: !isFullWidthPage,
         })}
         id="content"

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
@@ -136,7 +136,11 @@
   z-index: 1;
   position: fixed;
   inset: 0;
-  background-color: rgb(var(--color-input-text-color) 0.16);
+  background-color: color-mix(
+    in srgb,
+    var(--color-input-text-color) 16%,
+    transparent
+  );
 }
 
 .panel-footer {

--- a/pro/src/pages/Home/Card.module.scss
+++ b/pro/src/pages/Home/Card.module.scss
@@ -4,6 +4,7 @@
 .container {
   border: rem.torem(1px) solid var(--color-grey-medium);
   border-radius: rem.torem(8px);
-  box-shadow: 0 rem.torem(2px) rem.torem(6px) 0 rgb(var(--color-black) 0.15);
+  box-shadow: 0 rem.torem(2px) rem.torem(6px) 0
+    color-mix(in srgb, var(--color-black) 15%, transparent);
   padding: rem.torem(16px);
 }

--- a/pro/src/pages/Offers/Offers/OfferItem/OfferItem.module.scss
+++ b/pro/src/pages/Offers/Offers/OfferItem/OfferItem.module.scss
@@ -121,7 +121,8 @@
   .sold-out-dates {
     background-color: var(--color-white);
     border-radius: rem.torem(4px);
-    box-shadow: 0 rem.torem(2px) rem.torem(10px) 0 rgb(var(--color-black) 0.3);
+    box-shadow: 0 rem.torem(2px) rem.torem(10px) 0
+      color-mix(in srgb, var(--color-black) 30%, transparent);
     display: none;
     margin-left: rem.torem(8px);
     padding: rem.torem(8px);

--- a/pro/src/pages/Offers/Offers/OffersStatusFiltersModal/OffersStatusFiltersModal.module.scss
+++ b/pro/src/pages/Offers/Offers/OffersStatusFiltersModal/OffersStatusFiltersModal.module.scss
@@ -4,8 +4,8 @@
 .offers-status-filters {
   background: var(--color-white);
   border-radius: rem.torem(4px);
-  /* stylelint-disable-next-line color-function-notation */
-  box-shadow: 0 rem.torem(2px) rem.torem(10px) 0 rgba(var(--color-black), 0.3);
+  box-shadow: 0 rem.torem(2px) rem.torem(10px) 0
+    color-mix(in srgb, var(--color-black) 30%, transparent);
   display: flex;
   flex-direction: column;
   padding: rem.torem(16px);

--- a/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
+++ b/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
@@ -54,7 +54,7 @@
 .variant-primary {
   width: rem.torem(40px);
   height: rem.torem(40px);
-  background-color: rgba(var(--color-primary) 0.05);
+  background-color: color-mix(in srgb, var(--color-primary) 5%, transparent);
   color: var(--color-primary);
 
   &:hover:not(:disabled),


### PR DESCRIPTION
…re not visible anymore.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29190

**Objectif**
Remplacer les utilisations de `rgb()` et `rgba()` qui ne fonctionnent plus avec les variables css pas `color-mix`.

Au passage correction du container query pour l'affichage de l'overlay de l'autocomplete.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques