### PR TITLE
(PC-29171)[API] fix: Fix name of Prometheus metric

### DIFF
--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -42,7 +42,7 @@ def post_fork(server, worker):
     """Called when a Gunicorn worker is started."""
     if ENABLE_FLASK_PROMETHEUS_EXPORTER:
         registry = prometheus_client.registry.CollectorRegistry()
-        metric_name = f"gunicorn_available_threads_{KUBERNETES_DEPLOYMENT}"
+        metric_name = "gunicorn_available_threads_" + KUBERNETES_DEPLOYMENT.replace("-", "_")
         worker.available_threads = prometheus_client.Gauge(
             metric_name,
             "number of available Gunicorn threads",


### PR DESCRIPTION
Some of our Kubernetes deployments contain "-" characters, which
cannot appear in the name of a Prometheus metric. (It's even a bit
more strict [1], but our deployments generally conform, except for the
"-".)

[1] https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels