### PR TITLE
(PC-29198)[PRO] fix: Dont use color-mix and use rgb instead.

### DIFF
--- a/pro/src/app/AppLayout.module.scss
+++ b/pro/src/app/AppLayout.module.scss
@@ -83,11 +83,7 @@
       display: block;
       position: fixed;
       inset: 0;
-      background: color-mix(
-        in srgb,
-        var(--color-input-text-color) 48%,
-        transparent
-      );
+      background: rgb(from var(--color-input-text-color) r g b / 48%);
     }
 
     &-open {

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageEdit.module.scss
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageEdit.module.scss
@@ -11,7 +11,7 @@
   background-color: var(--color-grey-light);
   color: var(--color-black);
   box-shadow: 0 rem.torem(1px) rem.torem(8px)
-    color-mix(in srgb, var(--color-large-shadow) 15%, transparent);
+    rgb(from var(--color-large-shadow) r g b / 15%);
   border-radius: rem.torem(4px);
   cursor: pointer;
 
@@ -32,7 +32,7 @@
 
   &:hover {
     box-shadow: 0 rem.torem(1px) rem.torem(8px)
-      color-mix(in srgb, var(--color-large-shadow) 30%, transparent);
+      rgb(from var(--color-large-shadow) r g b / 30%);
 
     .image-upload-button-label {
       text-decoration: underline;

--- a/pro/src/components/ImageUploader/ImageUploader.module.scss
+++ b/pro/src/components/ImageUploader/ImageUploader.module.scss
@@ -30,7 +30,7 @@
   border: rem.torem(1px) solid var(--color-grey-medium);
   border-radius: rem.torem(4px);
   box-shadow: 0 rem.torem(1px) rem.torem(8px)
-    color-mix(in srgb, var(--color-large-shadow) 15%, transparent);
+    rgb(from var(--color-large-shadow) r g b / 15%);
 
   &.preview-venue {
     width: 100%;

--- a/pro/src/components/SoftDeletedOffererWarning/SoftDeletedOffererWarning.module.scss
+++ b/pro/src/components/SoftDeletedOffererWarning/SoftDeletedOffererWarning.module.scss
@@ -5,7 +5,7 @@
   border: rem.torem(1px) solid var(--color-grey-medium);
   border-radius: rem.torem(8px);
   box-shadow: 0 rem.torem(2px) rem.torem(6px) 0
-    color-mix(in srgb, var(--color-black) 15%, transparent);
+    rgb(from var(--color-black) r g b / 15%);
   overflow: hidden;
   margin-top: rem.torem(16px);
 

--- a/pro/src/components/Tutorial/Tutorial.module.scss
+++ b/pro/src/components/Tutorial/Tutorial.module.scss
@@ -83,7 +83,7 @@
     background: var(--color-primary);
     border-radius: 50%;
     box-shadow: 0 0 rem.torem(3px) 0
-      color-mix(in srgb, var(--color-secondary) 21%, transparent);
+      rgb(from var(--color-secondary) r g b / 21%);
     height: rem.torem(16px);
     width: rem.torem(16px);
   }

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscoveryBanner/AdageDiscoveryBanner.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscoveryBanner/AdageDiscoveryBanner.module.scss
@@ -48,7 +48,7 @@
 
     .discovery-banner-svg-cross,
     .discovery-banner-svg-circle {
-      fill: color-mix(in srgb, var(--color-grey-light) 40%, transparent);
+      fill: rgb(from var(--color-grey-light) r g b / 40%);
     }
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
@@ -136,11 +136,7 @@
   z-index: 1;
   position: fixed;
   inset: 0;
-  background-color: color-mix(
-    in srgb,
-    var(--color-input-text-color) 16%,
-    transparent
-  );
+  background-color: rgb(from var(--color-input-text-color) r g b / 16%);
 }
 
 .panel-footer {

--- a/pro/src/pages/Home/Card.module.scss
+++ b/pro/src/pages/Home/Card.module.scss
@@ -5,6 +5,6 @@
   border: rem.torem(1px) solid var(--color-grey-medium);
   border-radius: rem.torem(8px);
   box-shadow: 0 rem.torem(2px) rem.torem(6px) 0
-    color-mix(in srgb, var(--color-black) 15%, transparent);
+    rgb(from var(--color-black) r g b / 15%);
   padding: rem.torem(16px);
 }

--- a/pro/src/pages/Offers/Offers/OfferItem/OfferItem.module.scss
+++ b/pro/src/pages/Offers/Offers/OfferItem/OfferItem.module.scss
@@ -122,7 +122,7 @@
     background-color: var(--color-white);
     border-radius: rem.torem(4px);
     box-shadow: 0 rem.torem(2px) rem.torem(10px) 0
-      color-mix(in srgb, var(--color-black) 30%, transparent);
+      rgb(from var(--color-black) r g b / 30%);
     display: none;
     margin-left: rem.torem(8px);
     padding: rem.torem(8px);

--- a/pro/src/pages/Offers/Offers/OffersStatusFiltersModal/OffersStatusFiltersModal.module.scss
+++ b/pro/src/pages/Offers/Offers/OffersStatusFiltersModal/OffersStatusFiltersModal.module.scss
@@ -5,7 +5,7 @@
   background: var(--color-white);
   border-radius: rem.torem(4px);
   box-shadow: 0 rem.torem(2px) rem.torem(10px) 0
-    color-mix(in srgb, var(--color-black) 30%, transparent);
+    rgb(from var(--color-black) r g b / 30%);
   display: flex;
   flex-direction: column;
   padding: rem.torem(16px);

--- a/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
+++ b/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
@@ -54,7 +54,7 @@
 .variant-primary {
   width: rem.torem(40px);
   height: rem.torem(40px);
-  background-color: color-mix(in srgb, var(--color-primary) 5%, transparent);
+  background-color: rgb(from var(--color-primary) r g b / 5%);
   color: var(--color-primary);
 
   &:hover:not(:disabled),


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29198

**Objectif**
La fonction css `color-mix` étant pas encore super bien supportée, j'ai trouvé une autre solution en utilisant `rgb`. L'idée est que `rgb` ne fonctionne pas avec les variables de couleur css lorsque celles-ci sont en hexa, mais fonctionne si elles sont en rgb. 

❌ `rgb(var(--color-input-text-color), 48%);`
✅ `rgb(from var(--color-input-text-color) r g b / 48%);`


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques