### PR TITLE
(BSR)[API] fix: repair broken migration

### DIFF
--- a/api/src/pcapi/alembic/versions/20240411T121621_ed9648801317_add_validationauthor_column_for_booking_table.py
+++ b/api/src/pcapi/alembic/versions/20240411T121621_ed9648801317_add_validationauthor_column_for_booking_table.py
@@ -20,7 +20,7 @@ depends_on: list[str] | None = None
 def upgrade() -> None:
     booking_author_type = postgresql.ENUM(BookingValidationAuthorType, name="validationAuthorType")
     booking_author_type.create(op.get_bind(), checkfirst=True)
-    op.add_column("booking", sa.Column("validationAuthorType", booking_author_type, nullable=True, if_not_exists=True))
+    op.add_column("booking", sa.Column("validationAuthorType", booking_author_type, nullable=True))
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## But de la pull request

BSR 
fix broken migration on "add validationAuthor column for Booking table"
remove if_not_exists argument
