### PR TITLE
(PC-28998)[PRO] feat: display csv table in new tab when ff is active

### DIFF
--- a/pro/src/pages/CsvTable/CsvTable.tsx
+++ b/pro/src/pages/CsvTable/CsvTable.tsx
@@ -1,16 +1,20 @@
 import React from 'react'
 
 import Header from 'components/Header/Header'
+import useActiveFeature from 'hooks/useActiveFeature'
 import { CsvTableScreen } from 'screens/CsvTable'
 
 import { getCsvData } from './adapters/getCsvData'
 
-const CsvTable = (): JSX.Element => (
-  <>
-    <Header />
-    <CsvTableScreen getCsvData={getCsvData} />
-  </>
-)
+const CsvTable = (): JSX.Element => {
+  const isFFnewInterfaceActive = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
+  return (
+    <>
+      {!isFFnewInterfaceActive && <Header />}
+      <CsvTableScreen getCsvData={getCsvData} />
+    </>
+  )
+}
 
 // Lazy-loaded by react-router-dom
 // ts-unused-exports:disable-next-line

--- a/pro/src/pages/Reimbursements/ReimbursementsDetails/ReimbursementsDetails.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsDetails/ReimbursementsDetails.tsx
@@ -6,7 +6,9 @@ import { VenueListItemResponseModel } from 'apiClient/v1'
 import ButtonDownloadCSV from 'components/ButtonDownloadCSV'
 import getVenuesForOffererAdapter from 'core/Venue/adapters/getVenuesForOffererAdapter'
 import { SelectOption } from 'custom_types/form'
+import useActiveFeature from 'hooks/useActiveFeature'
 import useCurrentUser from 'hooks/useCurrentUser'
+import fullLinkIcon from 'icons/full-link.svg'
 import strokeNoBookingIcon from 'icons/stroke-no-booking.svg'
 import { ReimbursementsContextProps } from 'pages/Reimbursements/Reimbursements'
 import { ButtonLink } from 'ui-kit/Button'
@@ -50,6 +52,7 @@ const ReimbursementsDetails = (): JSX.Element => {
     !isPeriodFilterSelected || requireVenueFilterForAdmin
 
   const { selectedOfferer }: ReimbursementsContextProps = useOutletContext()
+  const isFFnewInterfaceActive = useActiveFeature('WIP_ENABLE_PRO_SIDE_NAV')
 
   const buildAndSortVenueFilterOptions = (
     venues: VenueListItemResponseModel[]
@@ -137,9 +140,11 @@ const ReimbursementsDetails = (): JSX.Element => {
           isDisabled={shouldDisableButtons}
           link={{
             to: `/remboursements-details?${csvQueryParams}`,
+            target: isFFnewInterfaceActive ? '_blank' : undefined,
             isExternal: false,
           }}
           variant={ButtonVariant.SECONDARY}
+          icon={isFFnewInterfaceActive ? fullLinkIcon : undefined}
         >
           Afficher
         </ButtonLink>

--- a/pro/src/ui-kit/Button/ButtonLink.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.tsx
@@ -111,6 +111,7 @@ const ButtonLink = ({
       to={absoluteUrl}
       aria-label={linkProps['aria-label']}
       aria-current={linkProps['aria-current'] ?? false}
+      target={linkProps.target}
     >
       {body}
       {disabled}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28998

Afficher les détails de remboursements dans un nouvel onglet sans le header quand le FF WIP_ENABLE_PRO_SIDE_NAV est activé 


![Capture d’écran 2024-04-12 à 08 23 22](https://github.com/pass-culture/pass-culture-main/assets/71768799/f2cf0734-150c-44e5-8726-ca56de46922c)
