### PR TITLE
(PC-28935)[PRO] feat: remove add venue card in homepage

### DIFF
--- a/pro/src/pages/Home/Offerers/VenueCreationLinks.tsx
+++ b/pro/src/pages/Home/Offerers/VenueCreationLinks.tsx
@@ -9,7 +9,6 @@ import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { UNAVAILABLE_ERROR_PAGE } from 'utils/routes'
 
-import { Card } from '../Card'
 import {
   getVirtualVenueFromOfferer,
   getPhysicalVenuesFromOfferer,
@@ -39,11 +38,11 @@ export const VenueCreationLinks = ({ offerer }: VenueCreationLinksProps) => {
     ? `/structures/${offerer?.id}/lieux/creation`
     : UNAVAILABLE_ERROR_PAGE
 
-  const renderLinks = (insideCard: boolean) => {
-    return (
+  return (
+    <div className={styles['container']}>
       <div className={styles['add-venue-button']}>
         <ButtonLink
-          variant={insideCard ? ButtonVariant.PRIMARY : ButtonVariant.SECONDARY}
+          variant={ButtonVariant.SECONDARY}
           link={{
             to: venueCreationUrl,
             isExternal: false,
@@ -58,25 +57,6 @@ export const VenueCreationLinks = ({ offerer }: VenueCreationLinksProps) => {
           Ajouter un lieu
         </ButtonLink>
       </div>
-    )
-  }
-
-  const renderCard = () => (
-    <Card data-testid="offerers-creation-links-card">
-      <h3 className={styles['title']}>Lieux</h3>
-
-      <div className={styles['content']}>
-        <p>
-          Avant de créer votre première offre physique vous devez avoir un lieu
-        </p>
-        {renderLinks(true)}
-      </div>
-    </Card>
-  )
-
-  return (
-    <div className={styles['container']}>
-      {!hasVirtualOffers ? renderCard() : renderLinks(false)}
     </div>
   )
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28935

Supprimer le bloc 'Ajouter un lieu' qui ne devrait plus être utilisé maintenant qu'on a les prochaines étapes directement dans les cartes lieux, et qu'un lieu est automatiquement créé à la création d'une structure. 
| Avant | Après | 
| ------ | ------ |
| ![Capture d’écran 2024-04-12 à 08 57 18](https://github.com/pass-culture/pass-culture-main/assets/71768799/3b03d8a3-b61f-4694-9b86-fdd67fb0407e) | ![Capture d’écran 2024-04-12 à 08 58 09](https://github.com/pass-culture/pass-culture-main/assets/71768799/d864969b-773b-4e02-9626-3bc3b2210064) |
