### PR TITLE
(PC-28871)[EAC] feat: adage iframe: tracking: add vueType

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -64,7 +64,7 @@ def log_offer_details_button_click(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)
     educational_utils.log_information_for_data_purpose(
         event_name="OfferDetailButtonClick",
-        extra_data={"stockId": body.stockId, "from": body.iframeFrom, "queryId": body.queryId},
+        extra_data={"stockId": body.stockId, "from": body.iframeFrom, "queryId": body.queryId, "vueType": body.vueType},
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -82,7 +82,7 @@ def log_offer_template_details_button_click(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)
     educational_utils.log_information_for_data_purpose(
         event_name="TemplateOfferDetailButtonClick",
-        extra_data={"offerId": body.offerId, "from": body.iframeFrom, "queryId": body.queryId},
+        extra_data={"offerId": body.offerId, "from": body.iframeFrom, "queryId": body.queryId, "vueType": body.vueType},
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
@@ -177,6 +177,7 @@ def log_fav_offer_button_click(
             "queryId": body.queryId,
             "isFavorite": body.isFavorite,
             "isFromNoResult": body.isFromNoResult,
+            "vueType": body.vueType,
         },
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -9,6 +9,10 @@ class AdageBaseModel(BaseModel):
     isFromNoResult: bool | None
 
 
+class VueTypeMixin(BaseModel):
+    vueType: str | None
+
+
 class AdagePlaylistType(enum.Enum):
     OFFER = "offer"
     VENUE = "venue"
@@ -19,15 +23,15 @@ class CatalogViewBody(AdageBaseModel):
     source: str
 
 
-class StockIdBody(AdageBaseModel):
+class StockIdBody(AdageBaseModel, VueTypeMixin):
     stockId: int
 
 
-class OfferIdBody(AdageBaseModel):
+class OfferIdBody(AdageBaseModel, VueTypeMixin):
     offerId: int
 
 
-class OfferFavoriteBody(AdageBaseModel):
+class OfferFavoriteBody(AdageBaseModel, VueTypeMixin):
     offerId: int
     isFavorite: bool
 
@@ -85,6 +89,6 @@ class TrackingShowMoreBody(AdageBaseModel):
     source: str
 
 
-class TrackingCTAShareBody(AdageBaseModel):
+class TrackingCTAShareBody(AdageBaseModel, VueTypeMixin):
     source: str
     offerId: int

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -140,6 +140,7 @@ class LogsTest:
                     "stockId": 1,
                     "iframeFrom": "for_my_institution",
                     "queryId": "1234a",
+                    "vueType": "vt",
                 },
             )
 
@@ -153,13 +154,14 @@ class LogsTest:
             "userId": get_hashed_user_id(EMAIL),
             "uai": UAI,
             "user_role": AdageFrontRoles.READONLY,
+            "vueType": "vt",
         }
 
     def test_log_offer_template_details_button_click(self, test_client, caplog):
         with caplog.at_level(logging.INFO):
             response = test_client.post(
                 url_for("adage_iframe.log_offer_template_details_button_click"),
-                json={"offerId": 1, "iframeFrom": "for_my_institution"},
+                json={"offerId": 1, "iframeFrom": "for_my_institution", "vueType": "vt"},
             )
 
         assert response.status_code == 204
@@ -172,6 +174,7 @@ class LogsTest:
             "userId": get_hashed_user_id(EMAIL),
             "uai": UAI,
             "user_role": AdageFrontRoles.READONLY,
+            "vueType": "vt",
         }
 
     def test_log_booking_modal_button_click(self, test_client, caplog):
@@ -221,7 +224,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = test_client.post(
                 url_for("adage_iframe.log_fav_offer_button_click"),
-                json={"offerId": 1, "iframeFrom": "for_my_institution", "isFavorite": True},
+                json={"offerId": 1, "iframeFrom": "for_my_institution", "isFavorite": True, "vueType": "vt"},
             )
 
         assert response.status_code == 204
@@ -236,6 +239,7 @@ class LogsTest:
             "uai": UAI,
             "user_role": AdageFrontRoles.READONLY,
             "isFromNoResult": None,
+            "vueType": "vt",
         }
 
     def test_log_header_link_click(self, test_client, caplog):
@@ -451,6 +455,7 @@ class LogsTest:
             "source": "source",
             "offerId": 1,
             "iframeFrom": "some_iframe",
+            "vueType": "vt",
         }
 
         with caplog.at_level(logging.INFO):
@@ -473,6 +478,7 @@ class LogsTest:
             "uai": UAI,
             "userId": utils.get_hashed_user_id(EMAIL),
             "analyticsSource": "adage",
+            "vueType": "vt",
         }
 
     def test_log_contact_url_button_click(self, test_client, caplog):

--- a/pro/src/apiClient/adage/models/OfferFavoriteBody.ts
+++ b/pro/src/apiClient/adage/models/OfferFavoriteBody.ts
@@ -8,5 +8,6 @@ export type OfferFavoriteBody = {
   isFromNoResult?: boolean | null;
   offerId: number;
   queryId?: string | null;
+  vueType?: string | null;
 };
 

--- a/pro/src/apiClient/adage/models/OfferIdBody.ts
+++ b/pro/src/apiClient/adage/models/OfferIdBody.ts
@@ -7,5 +7,6 @@ export type OfferIdBody = {
   isFromNoResult?: boolean | null;
   offerId: number;
   queryId?: string | null;
+  vueType?: string | null;
 };
 

--- a/pro/src/apiClient/adage/models/StockIdBody.ts
+++ b/pro/src/apiClient/adage/models/StockIdBody.ts
@@ -7,5 +7,6 @@ export type StockIdBody = {
   isFromNoResult?: boolean | null;
   queryId?: string | null;
   stockId: number;
+  vueType?: string | null;
 };
 

--- a/pro/src/apiClient/adage/models/TrackingCTAShareBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingCTAShareBody.ts
@@ -8,5 +8,6 @@ export type TrackingCTAShareBody = {
   offerId: number;
   queryId?: string | null;
   source: string;
+  vueType?: string | null;
 };
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28871

Ajout d'un champ optionnel `vueType` pour certaines routes de _tracking_ de l'iframe adage : détail d'une offre, mise en favori et partage.