### PR TITLE
PC 29159 bug eac improve venue sync

### DIFF
--- a/api/src/pcapi/core/educational/api/adage.py
+++ b/api/src/pcapi/core/educational/api/adage.py
@@ -15,6 +15,7 @@ from pcapi.core.mails.transactional import send_eac_offerer_activation_email
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import repository as offerers_repository
 from pcapi.core.offerers.repository import get_emails_by_venue
+from pcapi.models import db
 from pcapi.repository import atomic
 from pcapi.routes.serialization import venues_serialize
 from pcapi.utils.cache import get_from_cache
@@ -162,6 +163,7 @@ def synchronize_adage_ids_on_venues(debug: bool = False) -> None:
     with atomic():
         for venue in deactivated_venues:
             _remove_venue_from_eac(venue)
+            db.session.add(venue)
 
         for venue in venues:
             if not venue.adageId:
@@ -179,6 +181,7 @@ def synchronize_adage_ids_on_venues(debug: bool = False) -> None:
                 adage_id_updates[venue.id] = adage_id
 
             venue.adageId = adage_id
+            db.session.add(venue)
 
         # filter adage_ids_venues rows that are linked to an unexisting
         # venue. This can happen since the base data comes from an

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -118,9 +118,16 @@ def import_deposit_csv(path: str, year: int, ministry: str, conflict: str, final
 
 
 @blueprint.cli.command("synchronize_venues_from_adage_cultural_partners")
+@click.option(
+    "--debug",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Activate debugging (add logs)",
+)
 @log_cron_with_transaction
-def synchronize_venues_from_adage_cultural_partners() -> None:
-    adage_api.synchronize_adage_ids_on_venues()
+def synchronize_venues_from_adage_cultural_partners(debug: bool = False) -> None:
+    adage_api.synchronize_adage_ids_on_venues(debug)
 
 
 @blueprint.cli.command("synchronize_offerers_from_adage_cultural_partners")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29159 

Des lieux ne semblent pas être mis à jour lors de la synchronisation. Cette PR propose deux choses : ajouter les lieux à la session en cours et ajouter des logs de debug (affichés en fonction d'une variable).

⚠️ Je n'ai aucune garantie que cela corrigera le bug. Si le problème persiste, nous aurons alors des outils à disposition pour essayer d'y voir plus claire - et exclu la piste des objets en dehors de la session SQLA.

## Au passage

La liste des lieux à mettre à jour est récupérée en dehors du bloc `atomic()`. Cela ne devrait rien changer mais on ne sait jamais, autant ajouter chacun explicitement.