### PR TITLE
(PC-29204)[BO] feat: fraud team can now see price in collective offerlist

### DIFF
--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -244,6 +244,7 @@ def _get_collective_offers(form: forms.InternalSearchForm) -> list[educational_m
             ),
             sa.orm.joinedload(educational_models.CollectiveOffer.collectiveStock).load_only(
                 educational_models.CollectiveStock.beginningDatetime,
+                educational_models.CollectiveStock.price,
             ),
             sa.orm.joinedload(educational_models.CollectiveOffer.venue, innerjoin=True).load_only(
                 offerers_models.Venue.managingOffererId,

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
@@ -74,6 +74,7 @@
                 {% endif %}
               </th>
               <th scope="col">Date de l'évènement</th>
+              {% if has_permission("PRO_FRAUD_ACTIONS") %}<th scope="col">Tarif</th>{% endif %}
               <th scope="col">Structure</th>
               <th scope="col">Lieu</th>
               <th scope="col">{# icon #}</th>
@@ -125,6 +126,11 @@
                 <td>{{ links.build_pro_user_name_to_details_link(collective_offer.authorId, collective_offer.author.full_name) }}</td>
                 <td>{{ collective_offer.dateCreated | format_date }}</td>
                 <td>{{ collective_offer.collectiveStock.beginningDatetime | format_date }}</td>
+                {% if has_permission("PRO_FRAUD_ACTIONS") %}
+                  <td>
+                    {% if collective_offer.collectiveStock %}{{ collective_offer.collectiveStock.price | format_amount }}{% endif %}
+                  </td>
+                {% endif %}
                 <td>{{ links.build_offerer_name_to_details_link(collective_offer.venue.managingOfferer) }}</td>
                 <td>{{ links.build_venue_name_to_details_link(collective_offer.venue) }}</td>
                 <td>{{ links.build_venue_offers_icon_link(".list_collective_offers", "Offres collectives", collective_offer.venue) }}</td>


### PR DESCRIPTION
### verification front 

<img width="1512" alt="Capture d’écran 2024-04-12 à 14 29 13" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/18b34ddf-42df-4b1a-9fd1-c01c59a4dd2f">

### verification back

- CI - verte 
- faute d'orthographe - OK

cas de test détecté: 
cas visible -> si authentification avec utilisateur fraud
cas invisible -> si authentification avec utilisateur non fraud

### Verification ticket

- nom du ticket conforme -> OK
- nombre de commit -> OK
- nom du commit -> OK

### Tache restante si WIP

- Rien de visible
