### PR TITLE
(PC-29154)[PRO] feat: adapt search vue to implement grid vue

### DIFF
--- a/pro/cypress/e2e/adageSaveFilter.cy.ts
+++ b/pro/cypress/e2e/adageSaveFilter.cy.ts
@@ -24,4 +24,20 @@ describe('save filters so that you can retrieve them when you return to the sear
     cy.findByLabelText('Arts numériques').should('be.checked')
     cy.findByText('Nous n’avons trouvé aucune offre publiée')
   })
+
+  it.only('should save view type in search page', () => {
+    const adageToken = Cypress.env('adageToken')
+    cy.setFeatureFlags([
+      { name: 'WIP_ENABLE_ADAGE_VISUALIZATION', isActive: true },
+    ])
+    cy.visit(`/adage-iframe/recherche?token=${adageToken}`)
+
+    cy.findAllByTestId('offer-description')
+
+    cy.findAllByTestId('toggle-button').click()
+    cy.findAllByTestId('offer-description').should('not.exist')
+    cy.contains('Mes Favoris').click()
+    cy.contains('Rechercher').click()
+    cy.findAllByTestId('offer-description').should('not.exist')
+  })
 })

--- a/pro/src/hooks/useMediaQuery.tsx
+++ b/pro/src/hooks/useMediaQuery.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface UseMediaQueryOptions {
+  getInitialValueInEffect: boolean
+}
+
+type MediaQueryCallback = (event: { matches: boolean; media: string }) => void
+
+/**
+ * Older versions of Safari (shipped withCatalina and before) do not support addEventListener on matchMedia
+ * https://stackoverflow.com/questions/56466261/matchmedia-addlistener-marked-as-deprecated-addeventlistener-equivalent
+ * */
+function attachMediaListener(
+  query: MediaQueryList,
+  callback: MediaQueryCallback
+) {
+  try {
+    query.addEventListener('change', callback)
+    return () => query.removeEventListener('change', callback)
+  } catch (e) {
+    query.addListener(callback)
+    return () => query.removeListener(callback)
+  }
+}
+
+function getInitialValue(query: string, initialValue?: boolean) {
+  if (typeof initialValue === 'boolean') {
+    return initialValue
+  }
+
+  if (typeof window !== 'undefined' && 'matchMedia' in window) {
+    return window.matchMedia(query).matches
+  }
+
+  return false
+}
+
+export function useMediaQuery(
+  query: string,
+  initialValue?: boolean,
+  { getInitialValueInEffect }: UseMediaQueryOptions = {
+    getInitialValueInEffect: true,
+  }
+) {
+  const [matches, setMatches] = useState(
+    getInitialValueInEffect ? initialValue : getInitialValue(query)
+  )
+  const queryRef = useRef<MediaQueryList>()
+
+  useEffect(() => {
+    if ('matchMedia' in window) {
+      queryRef.current = window.matchMedia(query)
+      setMatches(queryRef.current.matches)
+      return attachMediaListener(queryRef.current, (event) =>
+        setMatches(event.matches)
+      )
+    }
+
+    return undefined
+  }, [query])
+
+  return matches
+}

--- a/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
@@ -101,6 +101,15 @@ vi.mock('@algolia/autocomplete-plugin-query-suggestions', () => {
   }
 })
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: () => ({
+    matches: false,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  }),
+})
+
 const renderApp = (options?: RenderWithProvidersOptions) => {
   renderWithProviders(
     <>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
@@ -10,6 +10,7 @@ $offer-image-width: rem.torem(216px);
   flex-direction: column;
   width: $offer-image-width;
   gap: rem.torem(16px);
+  z-index: 0;
 }
 
 .offer-link {

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -14,13 +14,10 @@ import styles from './OfferCard.module.scss'
 
 export interface CardComponentProps {
   offer: CollectiveOfferTemplateResponseModel
-  handlePlaylistElementTracking: () => void
+  handleTracking: () => void
 }
 
-const OfferCardComponent = ({
-  offer,
-  handlePlaylistElementTracking,
-}: CardComponentProps) => {
+const OfferCardComponent = ({ offer, handleTracking }: CardComponentProps) => {
   const location = useLocation()
 
   const currentPathname = location.pathname.split('/')[2]
@@ -36,7 +33,7 @@ const OfferCardComponent = ({
         to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
         state={{ offer }}
         onClick={() => {
-          handlePlaylistElementTracking()
+          handleTracking()
         }}
       >
         <div className={styles['offer-image-container']}>

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/__specs__/OfferCard.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/__specs__/OfferCard.spec.tsx
@@ -46,14 +46,11 @@ const adageUser: AuthenticatedResponse = {
 
 const renderOfferCardComponent = ({
   offer,
-  handlePlaylistElementTracking,
+  handleTracking,
 }: CardComponentProps) => {
   renderWithProviders(
     <AdageUserContextProvider adageUser={adageUser}>
-      <OfferCardComponent
-        offer={offer}
-        handlePlaylistElementTracking={handlePlaylistElementTracking}
-      />
+      <OfferCardComponent offer={offer} handleTracking={handleTracking} />
     </AdageUserContextProvider>
   )
 }
@@ -79,7 +76,7 @@ describe('OfferCard component', () => {
         addressType: OfferAddressType.SCHOOL,
       },
     }
-    renderOfferCardComponent({ offer, handlePlaylistElementTracking: vi.fn() })
+    renderOfferCardComponent({ offer, handleTracking: vi.fn() })
 
     expect(
       screen.getByText(/Dans l’établissement scolaire/)
@@ -94,7 +91,7 @@ describe('OfferCard component', () => {
         addressType: OfferAddressType.OFFERER_VENUE,
       },
     }
-    renderOfferCardComponent({ offer, handlePlaylistElementTracking: vi.fn() })
+    renderOfferCardComponent({ offer, handleTracking: vi.fn() })
 
     expect(screen.getByText(/Sortie/)).toBeInTheDocument()
     expect(screen.getByText(/À 10 km/)).toBeInTheDocument()
@@ -108,7 +105,7 @@ describe('OfferCard component', () => {
         addressType: OfferAddressType.OTHER,
       },
     }
-    renderOfferCardComponent({ offer, handlePlaylistElementTracking: vi.fn() })
+    renderOfferCardComponent({ offer, handleTracking: vi.fn() })
 
     expect(screen.getByText(/Sortie/)).toBeInTheDocument()
     expect(screen.getByText(/Lieu à définir/)).toBeInTheDocument()
@@ -129,7 +126,7 @@ describe('OfferCard component', () => {
         },
       },
     }
-    renderOfferCardComponent({ offer, handlePlaylistElementTracking: vi.fn() })
+    renderOfferCardComponent({ offer, handleTracking: vi.fn() })
 
     expect(screen.getByText('à 1 km - Paris')).toBeInTheDocument()
   })
@@ -142,7 +139,7 @@ describe('OfferCard component', () => {
 
     renderOfferCardComponent({
       offer: mockOffer,
-      handlePlaylistElementTracking: vi.fn(),
+      handleTracking: vi.fn(),
     })
 
     const offerElement = screen.getByTestId('card-offer-link')
@@ -165,7 +162,7 @@ describe('OfferCard component', () => {
 
     renderOfferCardComponent({
       offer: mockOffer,
-      handlePlaylistElementTracking: vi.fn(),
+      handleTracking: vi.fn(),
     })
 
     const offerElement = screen.getByTestId('card-offer-link')
@@ -177,12 +174,12 @@ describe('OfferCard component', () => {
   })
 
   it('should call tracking route on click in offer card', async () => {
-    const mockhandlePlaylistElementTracking = vi.fn()
+    const mockHandleTracking = vi.fn()
     vi.spyOn(apiAdage, 'logConsultPlaylistElement')
 
     renderOfferCardComponent({
       offer: mockOffer,
-      handlePlaylistElementTracking: mockhandlePlaylistElementTracking,
+      handleTracking: mockHandleTracking,
     })
 
     const offerElement = screen.getByTestId('card-offer-link')
@@ -191,6 +188,6 @@ describe('OfferCard component', () => {
 
     await userEvent.click(offerElement)
 
-    expect(mockhandlePlaylistElementTracking).toHaveBeenCalledTimes(1)
+    expect(mockHandleTracking).toHaveBeenCalledTimes(1)
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/ClassroomPlaylist/ClassroomPlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/ClassroomPlaylist/ClassroomPlaylist.tsx
@@ -71,7 +71,7 @@ export const ClassroomPlaylist = ({
       loading={loading}
       elements={offers.map((offerElement, index) => (
         <OfferCardComponent
-          handlePlaylistElementTracking={() =>
+          handleTracking={() =>
             trackPlaylistElementClicked({
               playlistId: CLASSROOM_PLAYLIST,
               playlistType: AdagePlaylistType.OFFER,

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/NewOfferPlaylist/NewOfferPlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/NewOfferPlaylist/NewOfferPlaylist.tsx
@@ -71,7 +71,7 @@ export const NewOfferPlaylist = ({
       }
       elements={offers.map((offer, index) => (
         <OfferCardComponent
-          handlePlaylistElementTracking={() =>
+          handleTracking={() =>
             trackPlaylistElementClicked({
               playlistId: NEW_OFFER_PLAYLIST,
               playlistType: AdagePlaylistType.OFFER,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCardContent/AdageOfferListCardContent.tsx
@@ -44,7 +44,10 @@ export function AdageOfferListCardContent({
         </div>
       )}
       {description && (
-        <p className={styles['offer-description']}>
+        <p
+          className={styles['offer-description']}
+          data-testid="offer-description"
+        >
           {formatDescription(description)}
         </p>
       )}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
@@ -1,9 +1,22 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/variables/_size.scss" as size;
+
+.offers-view {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: rem.torem(24px);
+}
 
 .offers-stats {
+  @include fonts.body-important;
+
   margin-top: rem.torem(24px);
   font-size: rem.torem(12px);
+
+  &-grid {
+    margin-left: rem.torem(16px);
+  }
 }
 
 .offers-list {
@@ -11,6 +24,24 @@
   grid-gap: rem.torem(16px);
   padding: 0;
   margin: rem.torem(8px) 0 rem.torem(24px) 0;
+}
+
+.offers-grid {
+  display: grid;
+  grid-gap: rem.torem(48px) rem.torem(16px);
+  padding: 0;
+  margin: rem.torem(8px) 0 rem.torem(24px) 0;
+  grid-template-columns: repeat(auto-fill, minmax(216px, 0fr));
+  justify-content: space-around;
+}
+
+.offers-banner {
+  display: grid;
+  grid-column: 1 / 5;
+}
+
+.offers-banner-none {
+  display: none;
 }
 
 .offers-loader {
@@ -75,5 +106,12 @@
     text-decoration: underline;
     outline: none;
     box-shadow: 0 3px 4px 0 var(--color-medium-shadow);
+  }
+}
+
+
+@media (max-width: size.$mobile) {
+  .offer-type-vue {
+    display: none;
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
@@ -47,6 +47,15 @@ vi.mock('apiClient/api', () => ({
   },
 }))
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: () => ({
+    matches: false,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  }),
+})
+
 const searchFakeResults = [
   {
     objectID: '479',
@@ -782,5 +791,50 @@ describe('offers', () => {
     expect(
       screen.getByRole('link', { name: offerInCayenne.name })
     ).toBeInTheDocument()
+  })
+
+  it('should enable grid vue on toggle click', async () => {
+    vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(offerInParis)
+    vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(
+      offerInCayenne
+    )
+    renderOffers({ ...offersProps, isBackToTopVisibile: true }, adageUser, {
+      features: ['WIP_ENABLE_ADAGE_VISUALIZATION'],
+    })
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getByText('Une offre vraiment chouette')).toBeInTheDocument()
+
+    const gridVue = screen.getByTestId('toggle-button')
+
+    await userEvent.click(gridVue)
+
+    expect(
+      screen.queryByText('Une offre vraiment chouette')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should change to grid vue when breakpoint active', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: () => ({
+        matches: true,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      }),
+    })
+
+    vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(offerInParis)
+    vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(
+      offerInCayenne
+    )
+    renderOffers({ ...offersProps, isBackToTopVisibile: true }, adageUser, {
+      features: ['WIP_ENABLE_ADAGE_VISUALIZATION'],
+    })
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(
+      screen.queryByText('Une offre vraiment chouette')
+    ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/__specs__/OffersSuggestions.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/__specs__/OffersSuggestions.spec.tsx
@@ -39,6 +39,15 @@ vi.mock('apiClient/api', () => ({
   },
 }))
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: () => ({
+    matches: false,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  }),
+})
+
 const renderOffersSuggestionsComponent = (
   props: OffersSuggestionsProps,
   user: AuthenticatedResponse,

--- a/pro/src/pages/AdageIframe/app/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/pro/src/pages/AdageIframe/app/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import { MouseEvent } from 'react'
 
 import styles from './ToggleButtonGroup.module.scss'
@@ -15,18 +16,20 @@ type ToggleButtonGroupProps = {
   groupLabel: string
   buttons: ToggleButton[]
   activeButton: string
+  className?: string
 }
 
 export default function ToggleButtonGroup({
   groupLabel,
   buttons,
   activeButton,
+  className,
 }: ToggleButtonGroupProps) {
   return (
     <div
       role="group"
       aria-label={groupLabel}
-      className={styles['button-group']}
+      className={cn(styles['button-group'], className)}
     >
       {buttons.map((button) => (
         <ToggleButtonGroupButton

--- a/pro/src/pages/AdageIframe/app/components/ToggleButtonGroup/ToggleButtonGroupButton/ToggleButtonGroupButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/ToggleButtonGroup/ToggleButtonGroupButton/ToggleButtonGroupButton.tsx
@@ -37,6 +37,7 @@ export default function ToggleButtonGroupButton({
           disabled={button.disabled}
           onClick={(e) => button.onClick(button, e)}
           type="button"
+          data-testid={`toggle-button${isActive ? '-active' : ''}`}
         >
           {isActive && <SvgIcon alt="" src={fullCheck} width="20" />}
           {button.content}

--- a/pro/src/store/adageFilter/reducer.ts
+++ b/pro/src/store/adageFilter/reducer.ts
@@ -17,6 +17,7 @@ interface SearchFormValuesWithQuery {
 interface AdageFilterState {
   adageFilter: SearchFormValuesWithQuery
   adageQuery: string | null
+  searchView: 'grid' | 'list'
 }
 
 const initialState: AdageFilterState = {
@@ -24,6 +25,7 @@ const initialState: AdageFilterState = {
     ...ADAGE_FILTERS_DEFAULT_VALUES,
   },
   adageQuery: null,
+  searchView: 'list',
 }
 
 const adageFilterSlice = createSlice({
@@ -36,9 +38,13 @@ const adageFilterSlice = createSlice({
     setAdageQuery(state, action: PayloadAction<string>) {
       state.adageQuery = action.payload
     },
+    setSearchView(state, action: PayloadAction<'grid' | 'list'>) {
+      state.searchView = action.payload
+    },
   },
 })
 
-export const { setAdageFilter, setAdageQuery } = adageFilterSlice.actions
+export const { setAdageFilter, setAdageQuery, setSearchView } =
+  adageFilterSlice.actions
 
 export const adageFilterReducer = adageFilterSlice.reducer

--- a/pro/src/store/adageFilter/selectors.ts
+++ b/pro/src/store/adageFilter/selectors.ts
@@ -5,3 +5,6 @@ export const adageFilterSelector = (state: RootState) =>
 
 export const adageQuerySelector = (state: RootState) =>
   state.adageFilter.adageQuery
+
+export const adageSearchViewSelector = (state: RootState) =>
+  state.adageFilter.searchView


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29154

Si le FF est activé : WIP_ENABLE_ADAGE_VISUALIZATION

On a un bouton pour trigger le mode de vue
Ajout d'un mode vue en grille, on veut afficher un nombre x d'offre en fonction de la taille d'écran de l'utilisateur
Changement de liste à vue automatiquement lorsque l'écran est petit

<img width="468" alt="Capture d’écran 2024-04-17 à 18 07 30" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/f3630cb3-7cc8-418f-bbb1-c34a647b31e1">
<img width="468" alt="Capture d’écran 2024-04-17 à 18 07 42" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/9adf4741-62c6-429d-bf23-55329e6b93c2">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques