### PR TITLE
(PC-29223)[PRO] fix: fix sticky bar with side nav

### DIFF
--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -62,10 +62,21 @@
     box-shadow: 0 2px rem.torem(16px) var(--color-large-shadow);
     border-top: unset;
 
+    &-new-interface {
+      margin-left: calc(rem.torem(size.$side-nav-width));
+      justify-content: flex-start;
+      padding-left: rem.torem(32px);
+    }
+
     .actions-bar-content {
       justify-content: space-between;
       flex-flow: row wrap;
       margin-top: unset;
+
+      &-new-interface {
+        justify-content: flex-start;
+        margin: 0;
+      }
 
       .left {
         margin: 0;

--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.tsx
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.tsx
@@ -2,6 +2,7 @@ import classnames from 'classnames'
 import React, { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import { setIsStickyBarOpen } from 'store/notifications/reducer'
 
 import style from './ActionsBarSticky.module.scss'
@@ -11,11 +12,13 @@ import Right from './ActionsBarStickyRight'
 interface ActionsBarStickyProps {
   children: React.ReactNode
   className?: string
+  hasSideNav?: boolean
 }
 
 const ActionsBarSticky = ({
   children,
   className,
+  hasSideNav = true,
 }: ActionsBarStickyProps): JSX.Element => {
   const dispatch = useDispatch()
   useEffect(() => {
@@ -25,12 +28,28 @@ const ActionsBarSticky = ({
     }
   }, [dispatch])
 
+  const isNewInterfaceActive = useIsNewInterfaceActive()
+
   return (
     <div
-      className={classnames(style['actions-bar'], className)}
+      className={classnames(
+        style['actions-bar'],
+        {
+          [style['actions-bar-new-interface']]:
+            isNewInterfaceActive && hasSideNav,
+        },
+        className
+      )}
       data-testid="actions-bar"
     >
-      <div className={style['actions-bar-content']}>{children}</div>
+      <div
+        className={classnames(style['actions-bar-content'], {
+          [style['actions-bar-content-new-interface']]:
+            isNewInterfaceActive && hasSideNav,
+        })}
+      >
+        {children}
+      </div>
     </div>
   )
 }

--- a/pro/src/screens/SignupJourneyForm/ActionBar/ActionBar.tsx
+++ b/pro/src/screens/SignupJourneyForm/ActionBar/ActionBar.tsx
@@ -89,7 +89,7 @@ const ActionBar = ({
   }
 
   return (
-    <ActionsBarSticky>
+    <ActionsBarSticky hasSideNav={false}>
       <ActionsBarSticky.Left>{Left()}</ActionsBarSticky.Left>
       <ActionsBarSticky.Right>{Right()}</ActionsBarSticky.Right>
     </ActionsBarSticky>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29223 

Fix l'affichage de la sticky bar avec la nouvelle interface : 

- Alignement des boutons à gauche pour être alignés avec le contenu
- Gestion du responsive pour que la barre ne passe pas sous la sideNav 

![Capture d’écran 2024-04-12 à 15 46 13](https://github.com/pass-culture/pass-culture-main/assets/71768799/577278b9-2a81-4a07-931a-458370fa988f)
