### PR TITLE
(PC-29205)[PRO] fix: fix padding for old interface in stock edition

### DIFF
--- a/pro/src/app/AppLayout.module.scss
+++ b/pro/src/app/AppLayout.module.scss
@@ -37,7 +37,11 @@
   }
 
   &-sticky-actions {
-    padding-bottom: rem.torem(32px);
+    padding-bottom: calc(rem.torem(32px) + size.$action-bar-sticky-height);
+
+    &-new-interface {
+      padding-bottom: rem.torem(32px);
+    }
   }
 }
 

--- a/pro/src/app/AppLayout.tsx
+++ b/pro/src/app/AppLayout.tsx
@@ -172,6 +172,8 @@ export const AppLayout = ({
                   layout === 'basic' || layout === 'sticky-actions',
                 [styles['container-sticky-actions']]:
                   layout === 'sticky-actions',
+                [styles['container-sticky-actions-new-interface']]:
+                  isNewSideBarNavigation && layout === 'sticky-actions',
                 [styles['container-without-nav']]: layout === 'without-nav',
                 [styles[`content-layout`]]: isNewSideBarNavigation,
                 [styles[`content-layout-${layout}`]]: isNewSideBarNavigation,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29205

Fix l'espace en dessous du contenu quand la sticky bar est affichée mais que la nouvelle interface n'est pas active 

![Capture d’écran 2024-04-12 à 16 01 45](https://github.com/pass-culture/pass-culture-main/assets/71768799/3519bc78-561d-40b1-91ce-3962ef08f98f)