### PR TITLE
(PC-28385)[BO] feat: add acceslibre url in BO to edit venue

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -757,6 +757,18 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
 
         return opening_days
 
+    @property
+    def external_accessibility_id(self) -> str | None:
+        if not self.accessibilityProvider:
+            return None
+        return self.accessibilityProvider.externalAccessibilityId
+
+    @property
+    def external_accessibility_url(self) -> str | None:
+        if not self.accessibilityProvider:
+            return None
+        return self.accessibilityProvider.externalAccessibilityUrl
+
 
 class GooglePlacesInfo(PcObject, Base, Model):
     __tablename__ = "google_places_info"

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -664,6 +664,10 @@ def format_modified_info_name(info_name: str) -> str:
             return "Activité principale"
         case "label":
             return "Intitulé"
+        case "accessibilityProvider.externalAccessibilityId":
+            return "Id chez Acceslibre"
+        case "accessibilityProvider.externalAccessibilityUrl":
+            return "Url chez Acceslibre"
         case _:
             return info_name.replace("_", " ").capitalize()
 

--- a/api/src/pcapi/routes/backoffice/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice/forms/utils.py
@@ -1,4 +1,5 @@
 import enum
+import re
 import typing
 
 from flask_wtf import FlaskForm
@@ -23,3 +24,8 @@ def choices_from_enum(
     exclude_opts: typing.Iterable[enum.Enum] = (),
 ) -> list[tuple]:
     return [(opt.name, formatter(opt) if formatter else opt.value) for opt in enum_cls if opt not in exclude_opts]
+
+
+def is_slug(string: str) -> bool:
+    pattern = r"^[a-z0-9\-]+$"
+    return bool(re.match(pattern, string))

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -274,6 +274,20 @@
                   {{ venue.criteria | format_criteria | safe }}
                 </p>
               {% endif %}
+              {% if venue.accessibilityProvider %}
+                <p class="mb-1">
+                  <span class="fw-bold">Page Acceslibre :</span>
+                  {% if venue.accessibilityProvider.externalAccessibilityUrl %}
+                    <a href="{{ venue.accessibilityProvider.externalAccessibilityUrl | format_website }}"
+                       target="_blank"
+                       class="link-primary">{{ venue.accessibilityProvider.externalAccessibilityUrl | format_website }} <i class="bi bi-box-arrow-up-right"></i></a>
+                  {% elif venue.accessibilityProvider.externalAccessibilityId and not venue.accessibilityProvider.externalAccessibilityUrl %}
+                    Attention, l'URL pour l'identifiant Acceslibre <i>{{ venue.accessibilityProvider.externalAccessibilityId }}</i> n'est pas renseignée
+                  {% elif not venue.accessibilityProvider.externalAccessibilityId and not venue.accessibilityProvider.externalAccessibilityUrl %}
+                    Attention, l'URL et l'identifiant Acceslibre ne sont pas renseignés alors que le lieu est synchronisé
+                  {% endif %}
+                </p>
+              {% endif %}
             </div>
             <div class="col-4">
               {% for venue_provider in venue.venueProviders %}


### PR DESCRIPTION
## But de la pull request

But: ajouter un champ dans l'édition des lieux qui permette d'ajouter un URL d'acceslibre, qui peux forcer la MAJ des données d'accessibilité.

J'ai une page sur acceslibre, mais mes données n'apparaissent pas côté PC (ce qui arrive si le matching n'a pas marché). En entrant cet url, on récupère le slug et les données d'accessibilité du lieu

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28385

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques