### PR TITLE
(PC-29228)[API] fix: silence error when user selects an existing mail

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -163,7 +163,7 @@ def validate_user_email(body: serializers.ChangeBeneficiaryEmailBody) -> seriali
         )
     except exceptions.EmailExistsError:
         # Returning an error message might help the end client find
-        # existing email addresses.
+        # existing email addresses through user enumeration attacks.
         token = token_utils.Token.load_without_checking(body.token)
         user = users_models.User.query.get(token.user_id)
     return serializers.ChangeBeneficiaryEmailResponse(

--- a/api/src/pcapi/routes/native/v2/account.py
+++ b/api/src/pcapi/routes/native/v2/account.py
@@ -119,3 +119,7 @@ def select_new_email(user: users_models.User, body: serializers.NewEmailSelectio
             {"code": "INVALID_TOKEN", "message": "Aucune demande de changement d'email en cours"},
             status_code=401,
         ) from e
+    except exceptions.EmailExistsError:
+        # Returning an error message might help the end client find
+        # existing email addresses through user enumeration attacks.
+        pass


### PR DESCRIPTION
Raising an error, if a user tries to change their email to an existing one, makes the app vulnerable to user enumeration attacks.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29228