### PR TITLE
(BSR)[API] ci: Don't accept Dependabot pull requests every day for boto3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
       time: '03:00'
     open-pull-requests-limit: 15
     ignore:
+      # Exclude packages that have very frequent updates. They have a
+      # specific configuration, see block below.
+      - dependency-name: boto3
       # Except for critical ones where we only allow patches update
       - dependency-name: 'flask'
         update-types: ['version-update:semver-major', 'version-update:semver-minor']
@@ -28,6 +31,19 @@ updates:
       # We are not ready to handle upper version of spectree, even for patches
       - dependency-name: 'spectree'
     # Disable automatic rebasing for poetry pull requests
+    rebase-strategy: "disabled"
+
+  # Special configuration for Python packages that have very frequent updates.
+  # We don't want to get a pull request every day for insignificant changes.
+  - package-ecosystem: 'pip'
+    directory: '/api'
+    schedule:
+      interval: 'weekly'
+      day: 'wednesday'
+      time: '03:00'
+    open-pull-requests-limit: 15
+    allow:
+      - dependency-name: boto3
     rebase-strategy: "disabled"
 
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
`boto3` is a Python library that is released _very_ frequently. I have
counted 29 releases in the last 40 days. [1] Dependabot happily
creates a pull request for each release, resulting in a pull request
almost every day.

But `boto3` is a large library, from which we only use S3-related
features. Most of these release don't impact these features, which
means that most releases are insignificant to us. Still, we have to
manually check the changelog and approve the pull request. Almost
every day.

With this commit, we make Dependabot suggest an update of `boto3` once
a week at most.

[1] https://pypi.org/project/boto3/#history