### PR TITLE
(PC-28994)[PRO] fix: add missing margin between siren banner

### DIFF
--- a/pro/src/components/Banner/BannerInvisibleSiren.module.scss
+++ b/pro/src/components/Banner/BannerInvisibleSiren.module.scss
@@ -1,0 +1,5 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.banner {
+  margin-bottom: rem.torem(16px);
+}

--- a/pro/src/components/Banner/BannerInvisibleSiren.tsx
+++ b/pro/src/components/Banner/BannerInvisibleSiren.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import Callout from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
 
+import styles from './BannerInvisibleSiren.module.scss'
+
 interface BannerInvisibleSirenProps {
   isNewOnboarding?: boolean
 }
@@ -21,6 +23,7 @@ const BannerInvisibleSiren = ({
       },
     ]}
     variant={CalloutVariant.ERROR}
+    className={styles.banner}
   >
     Le {isNewOnboarding ? 'SIRET' : 'SIREN'} doit être rendu visible pour
     valider votre inscription. Vous pouvez effectuer cette démarche sur le site


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28994


Ajouter une marge en dessous de la bannière SIRET/SIREN Invisible dans le parcours d'inscription. En local, testable avec un SIRET/SIREN commencant par 9 (ex : 999 999 999 12345). En testing il faut trouver un siret non diffusible. 

Screen 

![Capture d’écran 2024-04-15 à 08 30 55](https://github.com/pass-culture/pass-culture-main/assets/71768799/a17fefda-274a-434c-8156-a65f77a82837)
