### PR TITLE
(BSR) ci: use a more robust condition for a slack notification step

### DIFF
--- a/.github/workflows/dev_on_dispatch_release_deploy.yml
+++ b/.github/workflows/dev_on_dispatch_release_deploy.yml
@@ -167,7 +167,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
       - name: "Post success on #shérif"
-        if: success()
+        if: env.WORKFLOW_CONCLUSION == 'success'
         uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: "CU0SQ8Y58"


### PR DESCRIPTION
## But de la pull request

Pour une raison qui m'échappe, le workflow de déploiement n'est pas en échec [quand le 1er step est en échec](https://github.com/pass-culture/pass-culture-main/actions/runs/8664779128/job/23761986240#step:6:17), et l'utilisation de `if: success()` conduit à un résultat inattendu car la condition est évaluée à `true`.

<img width="758" alt="Capture d’écran 2024-04-15 à 10 41 28" src="https://github.com/pass-culture/pass-culture-main/assets/162352622/cf0159dd-98be-4607-99f0-2bb014688a19">

On utilise grâce à ce changement la variable d'environnement du workflow `WORKFLOW_CONCLUSION`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques