### PR TITLE
(PC-28933)[PRO] fix: sentry ApiError Unauthorized and forbidden

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/security.py
+++ b/api/src/pcapi/routes/adage_iframe/security.py
@@ -30,19 +30,19 @@ def adage_jwt_required(route_function: typing.Callable) -> typing.Callable:
                 adage_jwt_decoded = user_utils.decode_jwt_token_rs256(adage_jwt)
             except InvalidSignatureError as invalid_signature_error:
                 logger.error("Signature of adage jwt cannot be verified", extra={"error": invalid_signature_error})
-                raise UnauthorizedError("Unrecognized token")
+                raise UnauthorizedError(errors={"msg": "Unrecognized token"})
             except ExpiredSignatureError as expired_signature_error:
                 logger.warning("Token has expired", extra={"error": expired_signature_error})
-                raise UnauthorizedError("Token expired")
+                raise UnauthorizedError(errors={"msg": "Token expired"})
 
             if not adage_jwt_decoded.get("exp"):
                 logger.warning("Token does not contain an expiration date")
-                raise UnauthorizedError("No expiration date provided")
+                raise UnauthorizedError(errors={"msg": "No expiration date provided"})
 
             email = adage_jwt_decoded.get("mail")
             if not email:
                 logger.warning("Token does not contain an email")
-                raise UnauthorizedError("Unrecognized token")
+                raise UnauthorizedError(errors={"Authorization": "Unrecognized token"})
 
             authenticated_information = AuthenticatedInformation(
                 civility=adage_jwt_decoded.get("civilite"),
@@ -56,6 +56,6 @@ def adage_jwt_required(route_function: typing.Callable) -> typing.Callable:
             kwargs["authenticated_information"] = authenticated_information
             return route_function(*args, **kwargs)
 
-        raise UnauthorizedError("Unrecognized token")
+        raise UnauthorizedError(errors={"msg": "Unrecognized token"})
 
     return wrapper

--- a/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -64,7 +64,7 @@ def unauthorized_error(error: UnauthorizedError) -> Response:
         headers["WWW-Authenticate"] = error.www_authenticate
         if error.realm:
             headers["WWW-Authenticate"] = '%s realm="%s"' % (headers["WWW-Authenticate"], error.realm)
-    return Response(json.dumps(error.errors), 401, headers)
+    return Response(json.dumps(error.errors), 401, headers, mimetype="application/json")
 
 
 @app.errorhandler(MethodNotAllowed)

--- a/api/tests/routes/adage_iframe/get_authenticate_test.py
+++ b/api/tests/routes/adage_iframe/get_authenticate_test.py
@@ -162,8 +162,8 @@ class AuthenticateTest:
         response = client.with_explicit_token(corrupted_token).get("/adage-iframe/authenticate")
 
         # Then
-        assert response.status_code == 403
-        assert "Unrecognized token" in response.json["Authorization"]
+        assert response.status_code == 401
+        assert "Unrecognized token" in response.json["msg"]
 
     def test_should_return_error_response_when_jwt_expired(self, client, valid_user):
         # Given
@@ -176,7 +176,7 @@ class AuthenticateTest:
         response = client.with_explicit_token(expired_token).get("/adage-iframe/authenticate")
 
         # Then
-        assert response.status_code == 422
+        assert response.status_code == 401
         assert "Token expired" in response.json["msg"]
 
     def test_should_return_error_response_when_no_expiration_date_in_token(self, client, valid_user):
@@ -187,7 +187,7 @@ class AuthenticateTest:
         response = client.with_explicit_token(no_expiration_date_token).get("/adage-iframe/authenticate")
 
         # Then
-        assert response.status_code == 422
+        assert response.status_code == 401
         assert "No expiration date provided" in response.json["msg"]
 
     def _create_adage_valid_token(self, valid_user, uai_code: str | None) -> bytes:

--- a/api/tests/routes/adage_iframe/get_features_test.py
+++ b/api/tests/routes/adage_iframe/get_features_test.py
@@ -24,4 +24,4 @@ class FeaturesTest:
         response = client.get("/adage-iframe/features")
 
         # then
-        assert response.status_code == 403
+        assert response.status_code == 401

--- a/api/tests/routes/adage_iframe/post_favorite_offer_test.py
+++ b/api/tests/routes/adage_iframe/post_favorite_offer_test.py
@@ -45,5 +45,5 @@ class FavoriteOfferTest:
             f"/adage-iframe/collective/offers/{collective_offer.id}/favorites",
         )
 
-        assert response.status_code == 403
-        assert response.json == {"Authorization": "Unrecognized token"}
+        assert response.status_code == 401
+        assert response.json == "Unrecognized token"

--- a/api/tests/routes/adage_iframe/post_favorite_offer_test.py
+++ b/api/tests/routes/adage_iframe/post_favorite_offer_test.py
@@ -46,4 +46,4 @@ class FavoriteOfferTest:
         )
 
         assert response.status_code == 401
-        assert response.json == "Unrecognized token"
+        assert response.json["msg"] == "Unrecognized token"

--- a/api/tests/routes/adage_iframe/post_favorite_template_test.py
+++ b/api/tests/routes/adage_iframe/post_favorite_template_test.py
@@ -46,5 +46,5 @@ class FavoriteTemplateTest:
             f"/adage-iframe/collective/templates/{collective_offer_template.id}/favorites",
         )
 
-        assert response.status_code == 403
-        assert response.json == {"Authorization": "Unrecognized token"}
+        assert response.status_code == 401
+        assert response.json == "Unrecognized token"

--- a/api/tests/routes/adage_iframe/post_favorite_template_test.py
+++ b/api/tests/routes/adage_iframe/post_favorite_template_test.py
@@ -47,4 +47,4 @@ class FavoriteTemplateTest:
         )
 
         assert response.status_code == 401
-        assert response.json == "Unrecognized token"
+        assert response.json["msg"] == "Unrecognized token"

--- a/pro/scripts/customRequest.ts
+++ b/pro/scripts/customRequest.ts
@@ -362,6 +362,10 @@ export const request = <T>(
       }
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
+        if(error.url.includes('/adage-iframe')) {
+          window.location.href = '/adage-iframe/erreur'
+          return
+        }
         // A call to users/current is made on all routes
         // including public routes
         // when user is not connected we always recieve a 401 error

--- a/pro/scripts/customRequest.ts
+++ b/pro/scripts/customRequest.ts
@@ -377,8 +377,8 @@ export const request = <T>(
           !error.url.includes('/users/signin')
         ) {
           window.location.href = '/connexion'
+          return
         }
-        return
       }
       reject(error)
     }

--- a/pro/scripts/customRequest.ts
+++ b/pro/scripts/customRequest.ts
@@ -374,6 +374,7 @@ export const request = <T>(
         ) {
           window.location.href = '/connexion'
         }
+        return
       }
       reject(error)
     }

--- a/pro/src/apiClient/adage/core/request.ts
+++ b/pro/src/apiClient/adage/core/request.ts
@@ -362,6 +362,10 @@ export const request = <T>(
       }
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
+        if(error.url.includes('/adage-iframe')) {
+          window.location.href = '/adage-iframe/erreur'
+          return
+        }
         // A call to users/current is made on all routes
         // including public routes
         // when user is not connected we always recieve a 401 error

--- a/pro/src/apiClient/adage/core/request.ts
+++ b/pro/src/apiClient/adage/core/request.ts
@@ -377,8 +377,8 @@ export const request = <T>(
           !error.url.includes('/users/signin')
         ) {
           window.location.href = '/connexion'
+          return
         }
-        return
       }
       reject(error)
     }

--- a/pro/src/apiClient/adage/core/request.ts
+++ b/pro/src/apiClient/adage/core/request.ts
@@ -374,6 +374,7 @@ export const request = <T>(
         ) {
           window.location.href = '/connexion'
         }
+        return
       }
       reject(error)
     }

--- a/pro/src/apiClient/v1/core/request.ts
+++ b/pro/src/apiClient/v1/core/request.ts
@@ -362,6 +362,10 @@ export const request = <T>(
       }
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
+        if(error.url.includes('/adage-iframe')) {
+          window.location.href = '/adage-iframe/erreur'
+          return
+        }
         // A call to users/current is made on all routes
         // including public routes
         // when user is not connected we always recieve a 401 error

--- a/pro/src/apiClient/v1/core/request.ts
+++ b/pro/src/apiClient/v1/core/request.ts
@@ -377,8 +377,8 @@ export const request = <T>(
           !error.url.includes('/users/signin')
         ) {
           window.location.href = '/connexion'
+          return
         }
-        return
       }
       reject(error)
     }

--- a/pro/src/apiClient/v1/core/request.ts
+++ b/pro/src/apiClient/v1/core/request.ts
@@ -374,6 +374,7 @@ export const request = <T>(
         ) {
           window.location.href = '/connexion'
         }
+        return
       }
       reject(error)
     }

--- a/pro/src/apiClient/v2/core/request.ts
+++ b/pro/src/apiClient/v2/core/request.ts
@@ -362,6 +362,10 @@ export const request = <T>(
       }
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
+        if(error.url.includes('/adage-iframe')) {
+          window.location.href = '/adage-iframe/erreur'
+          return
+        }
         // A call to users/current is made on all routes
         // including public routes
         // when user is not connected we always recieve a 401 error

--- a/pro/src/apiClient/v2/core/request.ts
+++ b/pro/src/apiClient/v2/core/request.ts
@@ -377,8 +377,8 @@ export const request = <T>(
           !error.url.includes('/users/signin')
         ) {
           window.location.href = '/connexion'
+          return
         }
-        return
       }
       reject(error)
     }

--- a/pro/src/apiClient/v2/core/request.ts
+++ b/pro/src/apiClient/v2/core/request.ts
@@ -374,6 +374,7 @@ export const request = <T>(
         ) {
           window.location.href = '/connexion'
         }
+        return
       }
       reject(error)
     }

--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -38,6 +38,15 @@ const routes: RouteConfig[] = [
     title: 'ADAGE',
   },
   {
+    lazy: () =>
+      import(
+        'pages/AdageIframe/app/components/UnauthenticatedError/UnauthenticatedError'
+      ),
+    path: '/adage-iframe/erreur',
+    meta: { public: true },
+    title: 'ADAGE',
+  },
+  {
     lazy: () => import('pages/Signup/Signup'),
     path: '/inscription',
     title: 'Créer un compte',

--- a/pro/src/pages/AdageIframe/app/App.tsx
+++ b/pro/src/pages/AdageIframe/app/App.tsx
@@ -1,5 +1,4 @@
 import { setUser as setSentryUser } from '@sentry/browser'
-import * as React from 'react'
 import { useEffect, useId, useState } from 'react'
 
 import { AdageFrontRoles, AuthenticatedResponse } from 'apiClient/adage'

--- a/pro/src/pages/AdageIframe/app/components/UnauthenticatedError/UnauthenticatedError.tsx
+++ b/pro/src/pages/AdageIframe/app/components/UnauthenticatedError/UnauthenticatedError.tsx
@@ -24,3 +24,7 @@ export default function UnauthenticatedError(): JSX.Element {
     </main>
   )
 }
+
+// Lazy-loaded by react-router-dom
+// ts-unused-exports:disable-next-line
+export const Component = UnauthenticatedError


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28933

- Gérer le cas où lorsqu'on était rediriger sur /connexion après avoir eu un Unauthorized, sentry envoyait quand même une alerte alors que c'est normal
- Sur adage, lorsque le token expire on gère la redirection sans envoyer d'alerte à sentry car c'est aussi normal 