### PR TITLE
(PC-29253)[API] fix: Wait a little longer than the value sent to CGR

### DIFF
--- a/api/src/pcapi/connectors/cgr/cgr.py
+++ b/api/src/pcapi/connectors/cgr/cgr.py
@@ -52,6 +52,12 @@ def reservation_pass_culture(
     password = decrypt(cinema_details.password)
     cinema_url = cinema_details.cinemaUrl
     service = get_cgr_service_proxy(cinema_url)
+    # We need to wait a little longer than the value we send them
+    # Otherwise, for attempts very (very) close to the value of `CGR_TIMEOUT`
+    # they might consider the booking as valid on their side
+    # while on ours, the duration of the attempt + delay of the HTTP request + delay of HTTP response
+    # could exceed the `CGR_TIMEOUT` value
+    timeout = CGR_TIMEOUT - 2
     params = {
         "User": user,
         "mdp": password,
@@ -64,7 +70,7 @@ def reservation_pass_culture(
         "pEmail": body.pEmail,
         "pToken": body.pToken,
         "pDateLimiteAnnul": body.pDateLimiteAnnul,
-        "pTimeoutReservation": CGR_TIMEOUT,
+        "pTimeoutReservation": timeout,
     }
 
     response = service.ReservationPassCulture(**params)


### PR DESCRIPTION
We need to wait a little longer than the value we send them Otherwise, for attempts very (very) close to the value of `CGR_TIMEOUT` they might consider the booking as valid on their side while on ours, the duration of the attempt + delay of the HTTP request + delay of HTTP response could exceed the `CGR_TIMEOUT` value

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29253

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques