### PR TITLE
(PC-29256)[PRO] fix: Filter venue is not applied to results, and when…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -98,8 +98,9 @@ export const OffersInstantSearch = (): JSX.Element | null => {
             : filterOnMarseilleStudents
               ? DEFAULT_MARSEILLE_STUDENTS
               : [],
-        venue: venue ?? null,
+        venue: venue ?? adageFilterFromSelector.venue,
       }
+
       setFacetFilters(
         adageFiltersToFacetFilters({
           ...adageFilterFromSelector,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -2,6 +2,7 @@ import { FormikContext, useFormik } from 'formik'
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react'
 import { useInstantSearch } from 'react-instantsearch'
 import { useDispatch, useSelector } from 'react-redux'
+import { useSearchParams } from 'react-router-dom'
 
 import { AdageFrontRoles, VenueResponse } from 'apiClient/adage'
 import { api, apiAdage } from 'apiClient/api'
@@ -60,6 +61,8 @@ export const OffersSearch = ({
 }: SearchProps): JSX.Element => {
   const dispatch = useDispatch()
 
+  const [searchParams, setSearchParams] = useSearchParams()
+
   const { adageUser } = useAdageUser()
   const isUserAdmin = adageUser.role === AdageFrontRoles.READONLY
 
@@ -106,6 +109,7 @@ export const OffersSearch = ({
   }, [notification])
 
   function handleSubmit() {
+    resetUrlSearchFilterParams()
     dispatch(setAdageFilter(formik.values))
     const updatedFilters = adageFiltersToFacetFilters({
       ...formik.values,
@@ -123,6 +127,15 @@ export const OffersSearch = ({
           : DEFAULT_GEO_RADIUS
       )
     }
+  }
+
+  function resetUrlSearchFilterParams() {
+    searchParams.delete('domain')
+    searchParams.delete('venue')
+    searchParams.delete('siret')
+    searchParams.delete('program')
+    searchParams.delete('all')
+    setSearchParams(searchParams)
   }
 
   const resetForm = async () => {


### PR DESCRIPTION
… set from url, cannot be removed.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29256

**Objectif**
Corriger les 2 bugs suivant dans ADAGE :
- Aller sur la recherche, taper un mot clé, cliquer sur une des suggestions de lieu, le badge du filtre s’applique mais les résultats ne sont pas mis à jour.
- Aller sur la page découverte, cliquer sur une carte lieu, on est redirigé vers la recherche. Cliquer sur le badge du lieu ne supprime pas le filtre. -> A défaut d'avoir une solution plus clean, on supprime les filtres de l'url quand on fait une recherche pour éviter qu'ils ne se ré-appliquent au re-render de la page recherche.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques