### PR TITLE
PC-21409 remove route next step

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -37,6 +37,21 @@ class SubscriptionMessage(BaseModel):
         use_enum_values = True
 
 
+class SubscriptionMessageV2(BaseModel):
+    user_message: str
+    message_summary: str | None = None
+    call_to_action: CallToActionMessage | None
+    pop_over_icon: subscription_models.PopOverIcon | None
+    updated_at: datetime.datetime | None
+
+    class Config:
+        orm_mode = True
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+        json_encoders = {datetime.datetime: format_into_utc_date}
+        use_enum_values = True
+
+
 class NextSubscriptionStepResponse(BaseModel):
     next_subscription_step: subscription_models.SubscriptionStep | None
     maintenance_page_type: subscription_models.MaintenancePageType | None
@@ -68,6 +83,21 @@ class SubscriptionStepperResponse(BaseModel):
     title: str
     subtitle: str | None
     error_message: str | None
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+
+
+class SubscriptionStepperResponseV2(BaseModel):
+    subscription_steps_to_display: list[SubscriptionStepDetailsResponse]
+    allowed_identity_check_methods: list[subscription_models.IdentityCheckMethod]
+    has_identity_check_pending: bool
+    maintenance_page_type: subscription_models.MaintenancePageType | None
+    next_subscription_step: subscription_models.SubscriptionStep | None
+    title: str
+    subtitle: str | None
+    subscription_message: SubscriptionMessageV2 | None
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/serialization/decorator.py
+++ b/api/src/pcapi/serialization/decorator.py
@@ -76,6 +76,7 @@ def spectree_serialize(
     raw_response: bool = False,
     response_headers: dict[str, str] | None = None,
     resp: SpectreeResponse | None = None,
+    deprecated: bool = False,
 ) -> Callable[[Any], Any]:
     """A decorator that serialize/deserialize and validate input/output
 
@@ -127,6 +128,7 @@ def spectree_serialize(
             after=after,
             before=before,
             cookies=cookies,
+            deprecated=deprecated,
             form=form_in_kwargs,
             headers=headers,
             json=body_in_kwargs,

--- a/api/tests/routes/native/openapi_test.py
+++ b/api/tests/routes/native/openapi_test.py
@@ -580,6 +580,29 @@ def test_public_api(client):
                     "enum": ["GRANT_15_17", "GRANT_18"],
                     "title": "DepositType",
                 },
+                "SubscriptionStepperResponse": {
+                    "properties": {
+                        "allowedIdentityCheckMethods": {
+                            "items": {"$ref": "#/components/schemas/IdentityCheckMethod"},
+                            "type": "array",
+                        },
+                        "maintenancePageType": {
+                            "anyOf": [{"$ref": "#/components/schemas/MaintenancePageType"}],
+                            "nullable": True,
+                        },
+                        "errorMessage": {"nullable": True, "title": "Errormessage", "type": "string"},
+                        "subscriptionStepsToDisplay": {
+                            "items": {"$ref": "#/components/schemas/SubscriptionStepDetailsResponse"},
+                            "title": "Subscriptionstepstodisplay",
+                            "type": "array",
+                        },
+                        "subtitle": {"nullable": True, "title": "Subtitle", "type": "string"},
+                        "title": {"title": "Title", "type": "string"},
+                    },
+                    "required": ["subscriptionStepsToDisplay", "allowedIdentityCheckMethods", "title"],
+                    "title": "SubscriptionStepperResponse",
+                    "type": "object",
+                },
                 "DomainsCredit": {
                     "properties": {
                         "all": {"$ref": "#/components/schemas/Credit"},
@@ -1909,6 +1932,22 @@ def test_public_api(client):
                     "title": "SubscriptionMessage",
                     "type": "object",
                 },
+                "SubscriptionMessageV2": {
+                    "properties": {
+                        "callToAction": {
+                            "anyOf": [{"$ref": "#/components/schemas/CallToActionMessage"}],
+                            "nullable": True,
+                            "title": "CallToActionMessage",
+                        },
+                        "messageSummary": {"title": "Messagesummary", "type": "string", "nullable": True},
+                        "popOverIcon": {"anyOf": [{"$ref": "#/components/schemas/PopOverIcon"}], "nullable": True},
+                        "updatedAt": {"format": "date-time", "nullable": True, "title": "Updatedat", "type": "string"},
+                        "userMessage": {"title": "Usermessage", "type": "string"},
+                    },
+                    "required": ["userMessage"],
+                    "title": "SubscriptionMessageV2",
+                    "type": "object",
+                },
                 "SubscriptionStatus": {
                     "description": "An enumeration.",
                     "enum": ["has_to_complete_subscription", "has_subscription_pending", "has_subscription_issues"],
@@ -1947,17 +1986,26 @@ def test_public_api(client):
                     "enum": ["Numéro de téléphone", "Profil", "Identification", "Confirmation"],
                     "title": "SubscriptionStepTitle",
                 },
-                "SubscriptionStepperResponse": {
+                "SubscriptionStepperResponseV2": {
                     "properties": {
                         "allowedIdentityCheckMethods": {
                             "items": {"$ref": "#/components/schemas/IdentityCheckMethod"},
                             "type": "array",
                         },
+                        "hasIdentityCheckPending": {"title": "Hasidentitycheckpending", "type": "boolean"},
                         "maintenancePageType": {
                             "anyOf": [{"$ref": "#/components/schemas/MaintenancePageType"}],
                             "nullable": True,
                         },
-                        "errorMessage": {"nullable": True, "title": "Errormessage", "type": "string"},
+                        "nextSubscriptionStep": {
+                            "anyOf": [{"$ref": "#/components/schemas/SubscriptionStep"}],
+                            "nullable": True,
+                        },
+                        "subscriptionMessage": {
+                            "anyOf": [{"$ref": "#/components/schemas/SubscriptionMessageV2"}],
+                            "nullable": True,
+                            "title": "SubscriptionMessageV2",
+                        },
                         "subscriptionStepsToDisplay": {
                             "items": {"$ref": "#/components/schemas/SubscriptionStepDetailsResponse"},
                             "title": "Subscriptionstepstodisplay",
@@ -1966,8 +2014,13 @@ def test_public_api(client):
                         "subtitle": {"nullable": True, "title": "Subtitle", "type": "string"},
                         "title": {"title": "Title", "type": "string"},
                     },
-                    "required": ["subscriptionStepsToDisplay", "allowedIdentityCheckMethods", "title"],
-                    "title": "SubscriptionStepperResponse",
+                    "required": [
+                        "subscriptionStepsToDisplay",
+                        "allowedIdentityCheckMethods",
+                        "hasIdentityCheckPending",
+                        "title",
+                    ],
+                    "title": "SubscriptionStepperResponseV2",
                     "type": "object",
                 },
                 "SuspendAccountForSuspiciousLoginRequest": {
@@ -3904,6 +3957,7 @@ def test_public_api(client):
             },
             "/native/v1/subscription/next_step": {
                 "get": {
+                    "deprecated": True,
                     "description": "",
                     "operationId": "get__native_v1_subscription_next_step",
                     "parameters": [],
@@ -3975,6 +4029,7 @@ def test_public_api(client):
             },
             "/native/v1/subscription/stepper": {
                 "get": {
+                    "deprecated": True,
                     "description": "",
                     "operationId": "get__native_v1_subscription_stepper",
                     "parameters": [],
@@ -3996,7 +4051,7 @@ def test_public_api(client):
                         },
                     },
                     "security": [{"JWTAuth": []}],
-                    "summary": "get_subscription_stepper <GET>",
+                    "summary": "get_subscription_stepper_deprecated <GET>",
                     "tags": [],
                 }
             },
@@ -4278,6 +4333,33 @@ def test_public_api(client):
                     },
                     "security": [{"JWTAuth": []}],
                     "summary": "update_user_email <POST>",
+                    "tags": [],
+                }
+            },
+            "/native/v2/subscription/stepper": {
+                "get": {
+                    "description": "",
+                    "operationId": "get__native_v2_subscription_stepper",
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/SubscriptionStepperResponseV2"}
+                                }
+                            },
+                            "description": "OK",
+                        },
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable Entity",
+                        },
+                    },
+                    "security": [{"JWTAuth": []}],
+                    "summary": "get_subscription_stepper <GET>",
                     "tags": [],
                 }
             },


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-21409

Les routes `/next_step/` et `/stepper` étaient redondantes. On les déprécie donc au profit d'une v2 de la route `/stepper` contenant toutes les infos nécessaires à l'app dans le parcours d'activation.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques