### PR TITLE
(BSR)[API] fix: Work around uniqueness requirement in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,10 @@ updates:
   # We don't want to get a pull request every day for insignificant changes.
   - package-ecosystem: 'pip'
     directory: '/api'
+    # Specify a branch here (but _not_ in the block above), to work
+    # around uniqueness requirement on the directory.
+    # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140291
+    target-branch: master
     schedule:
       interval: 'weekly'
       day: 'wednesday'


### PR DESCRIPTION
The previous version of the configuration failed with the following
error:

    Update configs must have a unique combination of
    'package-ecosystem', 'directory', and 'target-branch'

To avoid that, apply the workaround that has been suggested here:
https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219