### PR TITLE
(BSR)[PRO] fix: remove cache warning in test

### DIFF
--- a/pro/vite.config.ts
+++ b/pro/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig(({ mode }) => {
       setupFiles: './vitest.setup.ts',
       clearMocks: true,
       restoreMocks: true,
-      cache: { dir: '../.vitest_cache' },
+      cacheDir: '../.vitest_cache',
       css: { modules: { classNameStrategy: 'non-scoped' } },
       coverage: {
         reportsDirectory: '../coverage',


### PR DESCRIPTION
## But de la pull request

BSR

enlever ce warning 

```
cache.dir" is deprecated, use Vite's "cacheDir" instead if you want to change the cache director. Note caches will be written to "cacheDir/vitest"

```

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques