### PR TITLE
(PC-28894)[PRO] fix: reset errors in OpeningHourForm

### DIFF
--- a/pro/src/pages/VenueEdition/OpeningHoursForm/OpeningHoursForm.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursForm/OpeningHoursForm.tsx
@@ -23,6 +23,7 @@ export function OpeningHoursForm() {
   const {
     values: { days },
     setFieldValue,
+    setFieldTouched,
   } = useFormikContext<VenueEditionFormValues>()
 
   return (
@@ -47,6 +48,10 @@ export function OpeningHoursForm() {
                 await setFieldValue(`${day}.morningEndingHour`, '')
                 await setFieldValue(`${day}.afternoonStartingHour`, '')
                 await setFieldValue(`${day}.afternoonEndingHour`, '')
+                await setFieldTouched(`${day}.morningStartingHour`, false)
+                await setFieldTouched(`${day}.morningEndingHour`, false)
+                await setFieldTouched(`${day}.afternoonStartingHour`, false)
+                await setFieldTouched(`${day}.afternoonEndingHour`, false)
               }}
             />
           )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28894

on veut enlever les erreurs sur le champ quand il disparait

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques