### PR TITLE
(BSR)[API] fix: Invoice generation on the 16th

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/invoice_available_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/invoice_available_to_pro.py
@@ -19,6 +19,15 @@ def send_invoice_available_to_pro_email(invoice: finance_models.Invoice, batch: 
         start=datetime.datetime.combine(period_start, datetime.datetime.min.time()),
         end=datetime.datetime.combine(period_end, datetime.datetime.min.time()),
     )
+    if period_start == period_end:
+        # Usually cashflows and invoices are generated every two weeks. However, in practice nothing
+        # forbid to set a cutoff at every date. In this case, if the cashflows and the invoices where
+        # generated on the same day, a 16th of the month, this could lead to have a lower and an upper
+        # bound strictly equals due to the behavior of `get_invoice_period`, therefor we would have no interval to match on.
+        invoice_timespan = db_utils.make_timerange(
+            start=datetime.datetime.combine(period_start, datetime.datetime.min.time()), end=batch.cutoff
+        )
+
     data = models.TransactionalEmailData(
         template=TransactionalEmail.INVOICE_AVAILABLE_TO_PRO.value,
         params={


### PR DESCRIPTION
When trying to generate invoices on the 16th of the month (which happens running the sandbox today), we are facing a bug when try to send invoice notifications. `period_start` and `period_end` would be equals (both having the day part assign at 16). Moreover, when defining `invoice_timespan` with `min.time()` for both values we now have a lower bound strictly equals to the upper bound. Nothing can match, contains or even overlaps that kind of interval !

Hence the fix, we want the lower bound to be defined with `min.time()` and the upper one with the time part of the cutoff. So we have at least a few hours between each bounds.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques