### PR TITLE
Pc 29294 fix adage filters on redirect

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.tsx
@@ -10,8 +10,9 @@ import { Button } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
+import { SearchFormValues } from '../../OffersInstantSearch'
 import { ADAGE_FILTERS_DEFAULT_VALUES } from '../../utils'
-import { LocalisationFilterStates, SearchFormValues } from '../OffersSearch'
+import { LocalisationFilterStates } from '../OffersSearch'
 
 import styles from './FiltersTags.module.scss'
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/__specs__/FiltersTags.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/__specs__/FiltersTags.spec.tsx
@@ -5,8 +5,9 @@ import { Formik } from 'formik'
 import { OfferAddressType } from 'apiClient/adage'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
+import { SearchFormValues } from '../../../OffersInstantSearch'
 import { ADAGE_FILTERS_DEFAULT_VALUES } from '../../../utils'
-import { LocalisationFilterStates, SearchFormValues } from '../../OffersSearch'
+import { LocalisationFilterStates } from '../../OffersSearch'
 import FiltersTags from '../FiltersTags'
 
 const domainsOptions = [

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -17,7 +17,8 @@ import AdageMultiselect from 'ui-kit/form/AdageMultiselect/AdageMultiselect'
 import Slider from 'ui-kit/form/Slider/Slider'
 import { sendSentryCustomError } from 'utils/sendSentryCustomError'
 
-import { LocalisationFilterStates, SearchFormValues } from '../OffersSearch'
+import { SearchFormValues } from '../../OffersInstantSearch'
+import { LocalisationFilterStates } from '../OffersSearch'
 
 import ModalFilterLayout from './ModalFilterLayout/ModalFilterLayout'
 import styles from './OfferFilters.module.scss'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -8,7 +8,8 @@ import { AdageUserContextProvider } from 'pages/AdageIframe/app/providers/AdageU
 import { defaultAdageUser } from 'utils/adageFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
-import { LocalisationFilterStates, SearchFormValues } from '../../OffersSearch'
+import { SearchFormValues } from '../../../OffersInstantSearch'
+import { LocalisationFilterStates } from '../../OffersSearch'
 import { OfferFilters } from '../OfferFilters'
 
 const handleSubmit = vi.fn()

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -4,7 +4,7 @@ import { useInstantSearch } from 'react-instantsearch'
 import { useDispatch, useSelector } from 'react-redux'
 import { useSearchParams } from 'react-router-dom'
 
-import { AdageFrontRoles, VenueResponse } from 'apiClient/adage'
+import { AdageFrontRoles } from 'apiClient/adage'
 import { api, apiAdage } from 'apiClient/api'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -12,16 +12,16 @@ import useIsElementVisible from 'hooks/useIsElementVisible'
 import useNotification from 'hooks/useNotification'
 import { MARSEILLE_EN_GRAND } from 'pages/AdageIframe/app/constants'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
-import { Facets, Option } from 'pages/AdageIframe/app/types'
+import { Option } from 'pages/AdageIframe/app/types'
 import { setAdageFilter } from 'store/adageFilter/reducer'
 import { adageQuerySelector } from 'store/adageFilter/selectors'
 
-import { DEFAULT_GEO_RADIUS, MAIN_INDEX_ID } from '../OffersInstantSearch'
 import {
-  ADAGE_FILTERS_DEFAULT_VALUES,
-  adageFiltersToFacetFilters,
-  serializeFiltersForData,
-} from '../utils'
+  DEFAULT_GEO_RADIUS,
+  MAIN_INDEX_ID,
+  SearchFormValues,
+} from '../OffersInstantSearch'
+import { ADAGE_FILTERS_DEFAULT_VALUES, serializeFiltersForData } from '../utils'
 
 import { Autocomplete } from './Autocomplete/Autocomplete'
 import FiltersTags from './FiltersTags/FiltersTags'
@@ -38,24 +38,13 @@ export enum LocalisationFilterStates {
 }
 
 export interface SearchProps {
-  setFacetFilters: Dispatch<SetStateAction<Facets | null>>
+  setFilters: Dispatch<SetStateAction<SearchFormValues>>
   initialFilters: Partial<SearchFormValues>
   setGeoRadius: (geoRadius: number) => void
 }
 
-export interface SearchFormValues {
-  domains: number[]
-  students: string[]
-  departments: string[]
-  academies: string[]
-  eventAddressType: string
-  geolocRadius: number
-  formats: string[]
-  venue: VenueResponse | null
-}
-
 export const OffersSearch = ({
-  setFacetFilters,
+  setFilters,
   setGeoRadius,
   initialFilters,
 }: SearchProps): JSX.Element => {
@@ -84,10 +73,7 @@ export const OffersSearch = ({
   )
 
   const formik = useFormik<SearchFormValues>({
-    initialValues: {
-      ...ADAGE_FILTERS_DEFAULT_VALUES,
-      ...initialFilters,
-    },
+    initialValues: { ...ADAGE_FILTERS_DEFAULT_VALUES, ...initialFilters },
     enableReinitialize: true,
     onSubmit: handleSubmit,
   })
@@ -111,11 +97,7 @@ export const OffersSearch = ({
   function handleSubmit() {
     resetUrlSearchFilterParams()
     dispatch(setAdageFilter(formik.values))
-    const updatedFilters = adageFiltersToFacetFilters({
-      ...formik.values,
-      uai: adageUser.uai ? ['all', adageUser.uai] : ['all'],
-    })
-    setFacetFilters(updatedFilters.queryFilters)
+    setFilters(formik.values)
 
     const adageUserHasValidGeoloc =
       (adageUser.lat || adageUser.lat === 0) &&

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/OffersSuggestions.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/OffersSuggestions.tsx
@@ -9,10 +9,10 @@ import { isNumber } from 'utils/types'
 import {
   algoliaSearchDefaultAttributesToRetrieve,
   DEFAULT_GEO_RADIUS,
+  SearchFormValues,
 } from '../../OffersInstantSearch'
 import { adageFiltersToFacetFilters } from '../../utils'
 import { Offers } from '../Offers/Offers'
-import { SearchFormValues } from '../OffersSearch'
 
 import styles from './OffersSuggestions.module.scss'
 import { OffersSuggestionsHeader } from './OffersSuggestionsHeader/OffersSuggestionsHeader'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -165,7 +165,7 @@ describe('offersSearch component', () => {
   beforeEach(() => {
     props = {
       setGeoRadius: setGeoRadiusMock,
-      setFacetFilters: () => {},
+      setFilters: () => {},
       initialFilters: {},
     }
     window.IntersectionObserver = vi.fn().mockImplementation(() => ({

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/utils.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/__specs__/utils.spec.ts
@@ -1,6 +1,6 @@
 import { EacFormat } from 'apiClient/adage'
 
-import { SearchFormValues } from '../OffersSearch/OffersSearch'
+import { SearchFormValues } from '../OffersInstantSearch'
 import { adageFiltersToFacetFilters, serializeFiltersForData } from '../utils'
 
 const venueFilter = {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/utils.ts
@@ -2,8 +2,8 @@ import { VenueResponse } from 'apiClient/adage'
 import { OfferAddressType } from 'apiClient/v1'
 import { Facets, Option } from 'pages/AdageIframe/app/types'
 
+import { SearchFormValues } from './OffersInstantSearch'
 import { studentsForData } from './OffersSearch/OfferFilters/studentsOptions'
-import { SearchFormValues } from './OffersSearch/OffersSearch'
 
 export const ADAGE_FILTERS_DEFAULT_VALUES: SearchFormValues = {
   domains: [],


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29294

**Objectif**
Corriger le bug suivant : Quand on filtre sur un domaine artistique dans ADAGE qui ne donne pas de résultats, qu'on navigue vers la page découverte, et qu'on clic sur une carte de lieu (qui a des offres) , on est redirigé vers la recherche mais aucun résultat ne s'affiche alors que seul le lieu apparait filtré.

-> Faire en sorte que les filtres envoyés à react-instansearch via `<Configure>` soient les mêmes que ceux passés aux Offres et aux filtres.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques