### PR TITLE
Pc 28978 rpa connect as part 2

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -2666,7 +2666,7 @@ def update_bank_account_venues_links(
             action_history_bulk_insert_mapping.append(
                 {
                     "actionType": history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_DEPRECATED,
-                    "authorUserId": user.id,
+                    "authorUserId": user.real_user.id,
                     "venueId": link.venueId,
                     "bankAccountId": bank_account.id,
                 }
@@ -2699,7 +2699,7 @@ def update_bank_account_venues_links(
             action_history_bulk_insert_mapping.append(
                 {
                     "actionType": history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED,
-                    "authorUserId": user.id,
+                    "authorUserId": user.real_user.id,
                     "venueId": venue_id,
                     "bankAccountId": bank_account.id,
                 }

--- a/api/src/pcapi/core/history/api.py
+++ b/api/src/pcapi/core/history/api.py
@@ -58,7 +58,7 @@ def add_action(
 
     action = models.ActionHistory(
         actionType=action_type,
-        authorUser=author,
+        authorUser=author.real_user if author else None,
         user=user,
         # FIXME remove type ignores when upgrading to sqlalchemy 2.0
         offerer=offerer,  # type: ignore [arg-type]

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -633,6 +633,18 @@ class User(PcObject, Base, Model, DeactivableMixin):
             and self.pro_new_nav_state.newNavDate <= datetime.utcnow()
         )
 
+    @property
+    def impersonator(self) -> "User | None":
+        return getattr(self, "_impersonator", None)
+
+    @impersonator.setter
+    def impersonator(self, impersonator: "User") -> None:
+        self._impersonator = impersonator
+
+    @property
+    def real_user(self) -> "User":
+        return self.impersonator or self
+
 
 User.trig_ensure_password_or_sso_exists_ddl = sa.DDL(
     """

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -260,7 +260,9 @@ def connect_as(token: str) -> Response:
             status_code=404,
         )
 
-    if not current_user.has_admin_role:
+    admin = current_user.real_user
+
+    if not admin.has_admin_role:
         raise ForbiddenError(
             errors={
                 "global": "L'utilisateur doit être connecté avec un compte admin pour pouvoir utiliser cet endpoint",
@@ -278,7 +280,7 @@ def connect_as(token: str) -> Response:
 
     token_data = ConnectAsInternalModel(**secure_token.data)
 
-    if not token_data.internal_admin_id == current_user.id:
+    if not token_data.internal_admin_id == admin.id:
         raise ForbiddenError(
             errors={
                 "global": "Le token a été généré pour un autre admin",

--- a/api/tests/core/history/test_api.py
+++ b/api/tests/core/history/test_api.py
@@ -90,6 +90,23 @@ class LogActionTest:
             )
             db.session.commit()
 
+    def test_add_action_from_impersonated_user(self):
+        admin = users_factories.AdminFactory()
+        pro = users_factories.ProFactory()
+        user_offerer = offerers_factories.UserOffererFactory()
+        pro.impersonator = admin
+
+        history_api.add_action(
+            history_models.ActionType.OFFERER_REJECTED,
+            author=pro,
+            offerer=user_offerer.offerer,
+            custom_data="Test",
+        )
+        db.session.commit()
+
+        action = history_models.ActionHistory.query.one()
+        assert action.authorUser == admin
+
 
 class ObjectUpdateSnapshotTest:
     def test_trace_update(self):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28978

Cette PR modifie le connect as pour permetre a un admin de sauter d'un utilisateur a un autre sans devoir se reconnecter a chaque fois avec un compte admin

Cette PR modifie aussi les ActionHistory pour qu'ils gerent le connect as dans pro.

## Vérifications

- [x] J'ai écrit les tests nécessaires
