### PR TITLE
(PC-29306)[PRO] feat: Add css theme to the preview in storybook.

### DIFF
--- a/pro/.storybook/preview.tsx
+++ b/pro/.storybook/preview.tsx
@@ -1,4 +1,19 @@
 import '../src/styles/index.scss'
+import React from 'react';
+
+import { Preview } from '@storybook/react';
+
+const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <div data-theme-storybook="pink">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default preview;
 
 export const parameters = {
   backgrounds: {
@@ -19,3 +34,5 @@ export const parameters = {
     },
   },
 }
+
+

--- a/pro/src/styles/variables/_themes.scss
+++ b/pro/src/styles/variables/_themes.scss
@@ -1,4 +1,5 @@
-html[data-theme="pink"] {
+html[data-theme="pink"],
+[data-theme-storybook="pink"] {
   // GENERAL COLORS
   --color-white: #fff;
   --color-grey-light: #f1f1f4;
@@ -87,10 +88,11 @@ html[data-theme="pink"] {
   --color-adage-blue-light: #1fc5e9;
   --color-adage-blue-dark: #0e78b7;
   --color-adage-blue-external: #626fad;
-  --color-adage-salmon-light: #FAEAF1;
+  --color-adage-salmon-light: #faeaf1;
 }
 
-html[data-theme="blue"] {
+html[data-theme="blue"],
+[data-theme-storybook="blue"] {
   // GENERAL COLORS
   --color-white: #fff;
   --color-grey-light: #f1f1f4;
@@ -179,5 +181,5 @@ html[data-theme="blue"] {
   --color-adage-blue-light: #1fc5e9;
   --color-adage-blue-dark: #0e78b7;
   --color-adage-blue-external: #626fad;
-  --color-adage-salmon-light: #FAEAF1;
+  --color-adage-salmon-light: #faeaf1;
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29306

**Objectif**
Ajouter le thème dans la preview storybook.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques