### PR TITLE
(PC-29229)[EAC] fix: coll. api: national program should not be mandatory

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -634,7 +634,7 @@ class MissingDomains(OfferValidationError):
 def validate_national_program(
     nationalProgramId: int | None, domains: typing.Sequence[educational_models.EducationalDomain] | None
 ) -> None:
-    if not domains and not nationalProgramId:
+    if not nationalProgramId:
         return
 
     if not domains:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29229

Bug : l'api collective n'autorisait pas la création d'offre collective s'il n'y avait pas de dispositif national... alors que cette information devrait être optionnelle. Pour être exact, le code aujourd'hui permet de se passer du dispositif national, à condition de renseigner une liste de domaines éducatifs inconnus.

Fix : autoriser l'absence de dispositif national dans la fonction de validation

### Au passage

Ajout de quelques tests (avec un petit peu de nettoyage) afin de s'assurer qu'il est toujours possible de créer une offre collective avec le minimum d'information possible.