### PR TITLE
(PC-29313)[API] feat: Add new `flask check_secrets` command

### DIFF
--- a/api/src/pcapi/utils/secrets.py
+++ b/api/src/pcapi/utils/secrets.py
@@ -51,3 +51,15 @@ def print_secret_keys() -> None:
     This output is used in deployment steps.
     """
     print(dump_secret_keys(), file=sys.stdout)
+
+
+@blueprint.cli.command("check_secrets")
+def check_secrets() -> None:
+    """Make sure that all secrets are defined and non-empty."""
+    missing = set()
+    for secret in SECRET_KEYS:
+        if not os.environ.get(secret):
+            missing.add(secret)
+
+    if missing:
+        sys.exit(f"The following secrets are missing: {', '.join(sorted(missing))}")

--- a/api/src/pcapi/utils/secrets.py
+++ b/api/src/pcapi/utils/secrets.py
@@ -44,18 +44,27 @@ def dump_secret_keys() -> str:
     return yaml.dump(yaml_content)
 
 
+def _check_secret_list_has_been_initialized() -> None:
+    if not SECRET_KEYS:
+        raise ValueError("The list of secrets has not been initialized.")
+
+
 @blueprint.cli.command("print_secret_keys")
 def print_secret_keys() -> None:
     """
     Prints secret's keys list in yaml format.
     This output is used in deployment steps.
     """
+    _check_secret_list_has_been_initialized()
+
     print(dump_secret_keys())
 
 
 @blueprint.cli.command("check_secrets")
 def check_secrets() -> None:
     """Make sure that all secrets are defined and non-empty."""
+    _check_secret_list_has_been_initialized()
+
     missing = set()
     for secret in SECRET_KEYS:
         if not os.environ.get(secret):

--- a/api/src/pcapi/utils/secrets.py
+++ b/api/src/pcapi/utils/secrets.py
@@ -50,7 +50,7 @@ def print_secret_keys() -> None:
     Prints secret's keys list in yaml format.
     This output is used in deployment steps.
     """
-    print(dump_secret_keys(), file=sys.stdout)
+    print(dump_secret_keys())
 
 
 @blueprint.cli.command("check_secrets")


### PR DESCRIPTION
It will be used as a Kubernetes init container to block the
initialization of a pod if a secret is missing.

---

Tickets : [PC-29313](https://passculture.atlassian.net/browse/PC-29313) pour cette commande, [PC-28437](https://passculture.atlassian.net/browse/PC-28437) pour le fonctionnement général.

[PC-29313]: https://passculture.atlassian.net/browse/PC-29313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PC-28437]: https://passculture.atlassian.net/browse/PC-28437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ