### PR TITLE
(PC-29267)[API] feat: adapt acceslibre widget results

### DIFF
--- a/api/src/pcapi/connectors/acceslibre.py
+++ b/api/src/pcapi/connectors/acceslibre.py
@@ -337,11 +337,11 @@ def acceslibre_to_accessibility_infos(acceslibre_data: list[AcceslibreWidgetData
             continue
         labels_enum = []
         for label in labels:
-            if not (labels_enum_list := ExpectedFieldsEnum.find_enum_from_string(label)):
+            if label not in [item.value for item in ExpectedFieldsEnum]:
                 # If this exception is raised, you should probably set the ExpectedFieldsEnum for the given label
                 # according to acceslibre API schema, at https://github.com/MTES-MCT/acceslibre/blob/master/erp/views.py
                 raise AccesLibreApiException(f"Acceslibre API returned an unexpected value: {label} for {title}")
-            labels_enum.extend(labels_enum_list)
+            labels_enum.append(ExpectedFieldsEnum(label))
         setattr(accessibility_infos, attribute_name, labels_enum)
     return accessibility_infos
 

--- a/api/src/pcapi/connectors/serialization/acceslibre_serializers.py
+++ b/api/src/pcapi/connectors/serialization/acceslibre_serializers.py
@@ -29,12 +29,12 @@ class MotorDisabilityModel(pydantic_v1.BaseModel):
 
 
 class AudioDisabilityModel(pydantic_v1.BaseModel):
-    deafAndHardOfHearing: str = acceslibre_enum.UNKNOWN.value
+    deafAndHardOfHearing: list[str] = [acceslibre_enum.UNKNOWN.value]
 
 
 class VisualDisabilityModel(pydantic_v1.BaseModel):
     soundBeacon: str = acceslibre_enum.UNKNOWN.value
-    audioDescription: str = acceslibre_enum.UNKNOWN.value
+    audioDescription: list[str] = [acceslibre_enum.UNKNOWN.value]
 
 
 class MentalDisabilityModel(pydantic_v1.BaseModel):
@@ -81,16 +81,14 @@ class ExternalAccessibilityDataModel(pydantic_v1.BaseModel):
 
                 case "deaf_and_hard_of_hearing_amenities":
                     if value:
-                        # In acceslibre widget, deaf and hard of hearing can have several values comma separated
-                        item = ", ".join(value)
-                        accessibility_data.audioDisability.deafAndHardOfHearing = item
+                        # In acceslibre widget, deaf and hard of hearing can have several values in a list
+                        accessibility_data.audioDisability.deafAndHardOfHearing = value
                         accessibility_data.isAccessibleAudioDisability = True
 
                 case "audio_description":
                     if value:
-                        # In acceslibre widget, audiodescription can have several values comma separated
-                        item = ", ".join(value)
-                        accessibility_data.visualDisability.audioDescription = item
+                        # In acceslibre widget, audiodescription can have several values in a list
+                        accessibility_data.visualDisability.audioDescription = value
                         accessibility_data.isAccessibleVisualDisability = True
 
                 case "sound_beacon":

--- a/api/src/pcapi/core/offerers/commands.py
+++ b/api/src/pcapi/core/offerers/commands.py
@@ -152,7 +152,6 @@ def synchronize_venues_with_acceslibre(venue_ids: list[int], dry_run: bool = Tru
             logger.info("No match found at acceslibre for Venue %s ", venue_id)
             continue
 
-        offerers_api.set_accessibility_last_update_at_provider(venue)
         offerers_api.set_accessibility_infos_from_provider_id(venue)
         db.session.add(venue)
 

--- a/api/src/pcapi/sandboxes/scripts/mocks/accessibility_mocks.py
+++ b/api/src/pcapi/sandboxes/scripts/mocks/accessibility_mocks.py
@@ -24,8 +24,8 @@ ACCESSIBILITY_MOCK = [
         "access_modality": [acceslibre_enum.EXTERIOR_ACCESS_ELEVATOR.value, acceslibre_enum.ENTRANCE_ELEVATOR.value],
         "audio_description": [acceslibre_enum.AUDIODESCRIPTION_OCCASIONAL.value],
         "deaf_and_hard_of_hearing_amenities": [
-            f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value}, "
-            f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value}"
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value,
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value,
         ],
         "facilities": [acceslibre_enum.FACILITIES_UNADAPTED.value],
         "sound_beacon": [acceslibre_enum.SOUND_BEACON.value],
@@ -36,12 +36,12 @@ ACCESSIBILITY_MOCK = [
         "access_modality": [acceslibre_enum.EXTERIOR_ONE_LEVEL.value, acceslibre_enum.ENTRANCE_PRM.value],
         "audio_description": [acceslibre_enum.AUDIODESCRIPTION_PERMANENT_SMARTPHONE.value],
         "deaf_and_hard_of_hearing_amenities": [
-            f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_FIXED_INDUCTION_LOOP.value}, "
-            f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value}, "
-            f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SIGN_LANGUAGE.value}, "
-            f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_CUED_SPEECH.value}, "
-            f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value}, "
-            f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_OTHER.value}"
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_FIXED_INDUCTION_LOOP.value,
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value,
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SIGN_LANGUAGE.value,
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_CUED_SPEECH.value,
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value,
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_OTHER.value,
         ],
         "facilities": [acceslibre_enum.FACILITIES_ADAPTED.value],
         "sound_beacon": [acceslibre_enum.SOUND_BEACON.value],

--- a/api/tests/connectors/acceslibre/acceslibre_test.py
+++ b/api/tests/connectors/acceslibre/acceslibre_test.py
@@ -146,7 +146,7 @@ class AcceslibreTest:
         )
 
     def test_get_accessibility_infos_from_widget(self, requests_mock):
-        slug = "mon-super-slug"
+        slug = "mon-slug-acceslibre"
         requests_mock.get(
             f"https://acceslibre.beta.gouv.fr/api/erps/{slug}/widget/",
             json=fixtures.ACCESLIBRE_WIDGET_RESULT,
@@ -158,12 +158,11 @@ class AcceslibreTest:
             acceslibre_enum.ENTRANCE_RAMP,
         ]
         assert accessibility_infos.audio_description == [
-            acceslibre_enum.AUDIODESCRIPTION_NO_DEVICE,
             acceslibre_enum.AUDIODESCRIPTION_PERMANENT_SMARTPHONE,
+            acceslibre_enum.AUDIODESCRIPTION_OCCASIONAL,
         ]
         assert accessibility_infos.deaf_and_hard_of_hearing_amenities == [
-            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE,
-            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_CUED_SPEECH,
+            acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP,
             acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SIGN_LANGUAGE,
         ]
 

--- a/api/tests/connectors/acceslibre/acceslibre_test.py
+++ b/api/tests/connectors/acceslibre/acceslibre_test.py
@@ -86,24 +86,15 @@ class AcceslibreTest:
             acceslibre_infos["url"] == "https://acceslibre.beta.gouv.fr/app/59-lille/a/librairie/erp/belette-du-nord/"
         )
 
-    def test_check_last_update(self, requests_mock):
-        slug = "office-du-tourisme-4"
-        requests_mock.get(
-            f"https://acceslibre.beta.gouv.fr/api/erps/{slug}/",
-            json=fixtures.ACCESLIBRE_RESULTS_BY_SLUG,
-        )
-        last_update = acceslibre.get_last_update_at_provider(slug=slug)
-        assert last_update == parser.isoparse("2023-04-13T15:10:25.612731+02:00")
-
     @patch("pcapi.connectors.acceslibre.AcceslibreBackend._fetch_request")
     def test_catch_connection_error(self, requests_mock):
         slug = "office-du-tourisme-4"
         requests_mock.side_effect = [requests.exceptions.ConnectionError]
         with pytest.raises(acceslibre.AccesLibreApiException) as exception:
-            acceslibre.get_last_update_at_provider(slug=slug)
+            acceslibre.get_accessibility_infos(slug=slug)
         assert (
             str(exception.value)
-            == f"Error connecting AccesLibre API for https://acceslibre.beta.gouv.fr/api/erps/{slug}/ and query parameters: None"
+            == f"Error connecting AccesLibre API for https://acceslibre.beta.gouv.fr/api/erps/{slug}/widget/ and query parameters: None"
         )
 
     def test_get_accessibility_infos(self):
@@ -151,7 +142,8 @@ class AcceslibreTest:
             f"https://acceslibre.beta.gouv.fr/api/erps/{slug}/widget/",
             json=fixtures.ACCESLIBRE_WIDGET_RESULT,
         )
-        accessibility_infos = acceslibre.get_accessibility_infos(slug)
+        last_update, accessibility_infos = acceslibre.get_accessibility_infos(slug)
+        assert last_update == parser.isoparse("2022-12-18T16:43:16.100479+01:00")
         assert accessibility_infos.trained_personnel == [acceslibre_enum.PERSONNEL_TRAINED]
         assert accessibility_infos.access_modality == [
             acceslibre_enum.EXTERIOR_ONE_LEVEL,

--- a/api/tests/connectors/acceslibre/fixtures.py
+++ b/api/tests/connectors/acceslibre/fixtures.py
@@ -623,6 +623,8 @@ ACCESLIBRE_RESULTS_BY_SLUG = {
 
 ACCESLIBRE_WIDGET_RESULT = {
     "slug": "mon-super-slug",
+    "created_at": "2022-12-18T16:38:16.774631+01:00",
+    "updated_at": "2022-12-18T16:43:16.100479+01:00",
     "sections": [
         {
             "title": "stationnement",

--- a/api/tests/connectors/acceslibre/fixtures.py
+++ b/api/tests/connectors/acceslibre/fixtures.py
@@ -626,7 +626,7 @@ ACCESLIBRE_WIDGET_RESULT = {
     "sections": [
         {
             "title": "stationnement",
-            "labels": ["Stationnement adapté dans l'établissement"],
+            "labels": ["Stationnement adapté à proximité"],
         },
         {
             "title": "accès",
@@ -639,18 +639,17 @@ ACCESLIBRE_WIDGET_RESULT = {
         {
             "title": "audiodescription",
             "labels": [
-                "sans équipement, audiodescription audible par toute la salle (selon la programmation), avec équipement permanent nécessitant le téléchargement d'une application sur smartphone"
+                "avec équipement permanent nécessitant le téléchargement d'une application sur smartphone",
+                "avec équipement occasionnel selon la programmation",
             ],
+        },
+        {
+            "title": "équipements sourd et malentendant",
+            "labels": ["boucle à induction magnétique portative", "langue des signes française (LSF)"],
         },
         {
             "title": "sanitaire",
             "labels": ["Sanitaire adapté"],
-        },
-        {
-            "title": "équipements sourd et malentendant",
-            "labels": [
-                "sous-titrage ou transcription simultanée, langue française parlée complétée (LFPC), langue des signes française (LSF)"
-            ],
         },
     ],
 }

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -10,6 +10,7 @@ import pytest
 import time_machine
 
 from pcapi.connectors.acceslibre import AcceslibreInfos
+from pcapi.connectors.acceslibre import AccessibilityInfo
 from pcapi.connectors.acceslibre import ExpectedFieldsEnum as acceslibre_enum
 from pcapi.connectors.entreprise import models as sirene_models
 from pcapi.core import search
@@ -2716,7 +2717,7 @@ class AccessibilityProviderTest:
             city="Paris",
         )
         offerers_factories.AccessibilityProviderFactory(venue=venue)
-        offerers_api.set_accessibility_last_update_at_provider(venue)
+        offerers_api.set_accessibility_infos_from_provider_id(venue)
         assert venue.accessibilityProvider.lastUpdateAtProvider == datetime.datetime(2024, 3, 1, 0, 0)
 
     def test_set_accessibility_infos_from_provider_id(self):
@@ -2753,7 +2754,7 @@ class AccessibilityProviderTest:
         accessibility_provider = offerers_factories.AccessibilityProviderFactory(
             venue=venue, lastUpdateAtProvider=datetime.datetime(2023, 2, 1)
         )
-        # TestingBackend for acceslibre get_last_update_at_provider returns datetime(2024, 3, 1, 0, 0)
+        # TestingBackend for acceslibre get_id_at_accessibility_provider returns datetime(2024, 3, 1, 0, 0)
         accessibility_provider.externalAccessibilityData["audio_description"] = (
             acceslibre_enum.AUDIODESCRIPTION_NO_DEVICE
         )
@@ -2764,10 +2765,10 @@ class AccessibilityProviderTest:
             acceslibre_enum.AUDIODESCRIPTION_OCCASIONAL
         ]
 
-    @patch("pcapi.connectors.acceslibre.get_last_update_at_provider")
+    @patch("pcapi.connectors.acceslibre.get_accessibility_infos")
     @patch("pcapi.connectors.acceslibre.get_id_at_accessibility_provider")
     def test_synchronize_accessibility_provider_with_new_slug(
-        self, mock_get_id_at_accessibility_provider, mock_get_last_update_at_provider
+        self, mock_get_id_at_accessibility_provider, mock_get_accessibility_infos
     ):
         venue = offerers_factories.VenueFactory(
             name="Une librairie de test",
@@ -2777,11 +2778,14 @@ class AccessibilityProviderTest:
         mock_get_id_at_accessibility_provider.side_effect = [
             AcceslibreInfos(slug="nouveau-slug", url="https://nouvelle.adresse/nouveau-slug")
         ]
-        # While trying to synchronize venue with acceslibre, we receive None when fetching last update
+        # While trying to synchronize venue with acceslibre, we receive None when fetching widget data
         # This means the entry with this slug (ie. externalAccessibilityId) has been removed
         # from acceslibre database (usualy because of deduplication);
         # In that case, we try a new match and look for the new slug
-        mock_get_last_update_at_provider.side_effect = [None, datetime.datetime(2024, 3, 1, 0, 0)]
+        mock_get_accessibility_infos.side_effect = [
+            (None, None),
+            (datetime.datetime(2024, 3, 1, 0, 0), AccessibilityInfo()),
+        ]
 
         accessibility_provider = offerers_factories.AccessibilityProviderFactory(
             venue=venue, externalAccessibilityId="slug-qui-n-existe-plus"

--- a/api/tests/routes/native/openapi_test.py
+++ b/api/tests/routes/native/openapi_test.py
@@ -708,7 +708,7 @@ def test_public_api(client):
                     "properties": {
                         "audioDisability": {
                             "allOf": [{"$ref": "#/components/schemas/AudioDisabilityModel"}],
-                            "default": {"deafAndHardOfHearing": "Non renseign\u00e9"},
+                            "default": {"deafAndHardOfHearing": ["Non renseign\u00e9"]},
                             "title": "Audiodisability",
                         },
                         "isAccessibleAudioDisability": {
@@ -744,7 +744,7 @@ def test_public_api(client):
                         "visualDisability": {
                             "allOf": [{"$ref": "#/components/schemas/VisualDisabilityModel"}],
                             "default": {
-                                "audioDescription": "Non renseign\u00e9",
+                                "audioDescription": ["Non renseign\u00e9"],
                                 "soundBeacon": "Non renseign\u00e9",
                             },
                             "title": "Visualdisability",
@@ -2387,9 +2387,10 @@ def test_public_api(client):
                 "AudioDisabilityModel": {
                     "properties": {
                         "deafAndHardOfHearing": {
-                            "default": "Non renseign\u00e9",
+                            "default": ["Non renseign\u00e9"],
                             "title": "Deafandhardofhearing",
-                            "type": "string",
+                            "items": {"type": "string"},
+                            "type": "array",
                         }
                     },
                     "title": "AudioDisabilityModel",
@@ -2419,9 +2420,10 @@ def test_public_api(client):
                 "VisualDisabilityModel": {
                     "properties": {
                         "audioDescription": {
-                            "default": "Non renseign\u00e9",
+                            "default": ["Non renseign\u00e9"],
+                            "items": {"type": "string"},
                             "title": "Audiodescription",
-                            "type": "string",
+                            "type": "array",
                         },
                         "soundBeacon": {"default": "Non renseign\u00e9", "title": "Soundbeacon", "type": "string"},
                     },

--- a/api/tests/routes/native/v1/offerers_test.py
+++ b/api/tests/routes/native/v1/offerers_test.py
@@ -75,13 +75,17 @@ class VenuesTest:
                     "parking": acceslibre_enum.PARKING_NEARBY.value,
                 },
                 "audioDisability": {
-                    "deafAndHardOfHearing": f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value}, "
-                    f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value}"
+                    "deafAndHardOfHearing": [
+                        acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value,
+                        acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value,
+                    ]
                 },
                 "visualDisability": {
                     "soundBeacon": acceslibre_enum.UNKNOWN.value,
-                    "audioDescription": f"{acceslibre_enum.AUDIODESCRIPTION_NO_DEVICE.value}, "
-                    f"{acceslibre_enum.AUDIODESCRIPTION_OCCASIONAL.value}",
+                    "audioDescription": [
+                        acceslibre_enum.AUDIODESCRIPTION_NO_DEVICE.value,
+                        acceslibre_enum.AUDIODESCRIPTION_OCCASIONAL.value,
+                    ],
                 },
                 "mentalDisability": {"trainedPersonnel": acceslibre_enum.PERSONNEL_UNTRAINED.value},
             },

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -110,19 +110,25 @@ class Returns200Test:
                 "isAccessibleVisualDisability": True,
                 "isAccessibleMentalDisability": False,
                 "motorDisability": {
-                    "facilities": "Sanitaire non adapté",
-                    "exterior": "Chemin rendu accessible (ascenseur)",
-                    "entrance": "Accès à l'entrée par ascenseur",
-                    "parking": "Stationnement adapté à proximité",
+                    "facilities": acceslibre_enum.FACILITIES_UNADAPTED.value,
+                    "exterior": acceslibre_enum.EXTERIOR_ACCESS_ELEVATOR.value,
+                    "entrance": acceslibre_enum.ENTRANCE_ELEVATOR.value,
+                    "parking": acceslibre_enum.PARKING_NEARBY.value,
                 },
                 "audioDisability": {
-                    "deafAndHardOfHearing": "boucle à induction magnétique portative, sous-titrage ou transcription simultanée",
+                    "deafAndHardOfHearing": [
+                        acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value,
+                        acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value,
+                    ],
                 },
                 "visualDisability": {
-                    "soundBeacon": "Non renseigné",
-                    "audioDescription": "avec équipement occasionnel selon la programmation, avec équipement permanent nécessitant le téléchargement d'une application sur smartphone",
+                    "soundBeacon": acceslibre_enum.UNKNOWN.value,
+                    "audioDescription": [
+                        acceslibre_enum.AUDIODESCRIPTION_OCCASIONAL.value,
+                        acceslibre_enum.AUDIODESCRIPTION_PERMANENT_SMARTPHONE.value,
+                    ],
                 },
-                "mentalDisability": {"trainedPersonnel": "Personnel non formé"},
+                "mentalDisability": {"trainedPersonnel": acceslibre_enum.PERSONNEL_UNTRAINED.value},
             },
             "externalAccessibilityId": "accessibility-slug",
             "externalAccessibilityUrl": "https://site-d-accessibilite.com/erps/accessibility-slug/",
@@ -497,19 +503,19 @@ class Returns200Test:
             "isAccessibleVisualDisability": False,
             "isAccessibleMentalDisability": False,
             "motorDisability": {
-                "facilities": "Non renseigné",
-                "exterior": "Non renseigné",
-                "entrance": "Non renseigné",
-                "parking": "Non renseigné",
+                "facilities": acceslibre_enum.UNKNOWN.value,
+                "exterior": acceslibre_enum.UNKNOWN.value,
+                "entrance": acceslibre_enum.UNKNOWN.value,
+                "parking": acceslibre_enum.UNKNOWN.value,
             },
             "audioDisability": {
-                "deafAndHardOfHearing": "Non renseigné",
+                "deafAndHardOfHearing": [acceslibre_enum.UNKNOWN.value],
             },
             "visualDisability": {
-                "soundBeacon": "Non renseigné",
-                "audioDescription": "Non renseigné",
+                "soundBeacon": acceslibre_enum.UNKNOWN.value,
+                "audioDescription": [acceslibre_enum.UNKNOWN.value],
             },
-            "mentalDisability": {"trainedPersonnel": "Non renseigné"},
+            "mentalDisability": {"trainedPersonnel": acceslibre_enum.UNKNOWN.value},
         }
 
     def should_return_accessibility_data_when_venue_has_accessibility_provider(self, client):
@@ -539,19 +545,22 @@ class Returns200Test:
             "isAccessibleVisualDisability": True,
             "isAccessibleMentalDisability": False,
             "motorDisability": {
-                "facilities": "Sanitaire non adapté",
-                "exterior": "Chemin rendu accessible (ascenseur)",
-                "entrance": "Accès à l'entrée par une rampe",
-                "parking": "Pas de stationnement adapté à proximité",
+                "facilities": acceslibre_enum.FACILITIES_UNADAPTED.value,
+                "exterior": acceslibre_enum.EXTERIOR_ACCESS_ELEVATOR.value,
+                "entrance": acceslibre_enum.ENTRANCE_RAMP.value,
+                "parking": acceslibre_enum.PARKING_UNAVAILABLE.value,
             },
             "audioDisability": {
-                "deafAndHardOfHearing": "boucle à induction magnétique portative, sous-titrage ou transcription simultanée",
+                "deafAndHardOfHearing": [
+                    acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value,
+                    acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value,
+                ],
             },
             "visualDisability": {
-                "soundBeacon": "Balise sonore",
-                "audioDescription": "Non renseigné",
+                "soundBeacon": acceslibre_enum.SOUND_BEACON.value,
+                "audioDescription": [acceslibre_enum.UNKNOWN.value],
             },
-            "mentalDisability": {"trainedPersonnel": "Personnel non formé"},
+            "mentalDisability": {"trainedPersonnel": acceslibre_enum.PERSONNEL_UNTRAINED.value},
         }
 
 

--- a/api/tests/routes/pro/get_venues_test.py
+++ b/api/tests/routes/pro/get_venues_test.py
@@ -77,12 +77,14 @@ def test_response_serialization(client):
                     "parking": acceslibre_enum.PARKING_NEARBY.value,
                 },
                 "audioDisability": {
-                    "deafAndHardOfHearing": f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value}, "
-                    f"{acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value}"
+                    "deafAndHardOfHearing": [
+                        acceslibre_enum.DEAF_AND_HARD_OF_HEARING_PORTABLE_INDUCTION_LOOP.value,
+                        acceslibre_enum.DEAF_AND_HARD_OF_HEARING_SUBTITLE.value,
+                    ]
                 },
                 "visualDisability": {
                     "soundBeacon": acceslibre_enum.SOUND_BEACON.value,
-                    "audioDescription": acceslibre_enum.UNKNOWN.value,
+                    "audioDescription": [acceslibre_enum.UNKNOWN.value],
                 },
                 "mentalDisability": {"trainedPersonnel": acceslibre_enum.PERSONNEL_UNTRAINED.value},
             },

--- a/pro/src/apiClient/v1/models/AudioDisabilityModel.ts
+++ b/pro/src/apiClient/v1/models/AudioDisabilityModel.ts
@@ -3,6 +3,6 @@
 /* tslint:disable */
 /* eslint-disable */
 export type AudioDisabilityModel = {
-  deafAndHardOfHearing?: string;
+  deafAndHardOfHearing?: Array<string>;
 };
 

--- a/pro/src/apiClient/v1/models/VisualDisabilityModel.ts
+++ b/pro/src/apiClient/v1/models/VisualDisabilityModel.ts
@@ -3,7 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export type VisualDisabilityModel = {
-  audioDescription?: string;
+  audioDescription?: Array<string>;
   soundBeacon?: string;
 };
 

--- a/pro/src/pages/VenueEdition/AccesLibreSection/AccesLibreSection.module.scss
+++ b/pro/src/pages/VenueEdition/AccesLibreSection/AccesLibreSection.module.scss
@@ -44,3 +44,13 @@
     text-transform: uppercase;
   }
 }
+
+.details-list {
+  display: flex;
+  flex-direction: column;
+  gap: rem.torem(8px);
+
+  & > *::first-letter {
+    text-transform: uppercase;
+  }
+}

--- a/pro/src/pages/VenueEdition/AccesLibreSection/AccesLibreSection.tsx
+++ b/pro/src/pages/VenueEdition/AccesLibreSection/AccesLibreSection.tsx
@@ -130,7 +130,17 @@ export const AccesLibreSection = ({ venue }: AccesLibreSectionProps) => {
                 </span>
                 <span className={styles['details-item']}>
                   {venue.externalAccessibilityData.audioDisability
-                    ?.deafAndHardOfHearing ?? 'Non renseigné'}
+                    ?.deafAndHardOfHearing?.length ? (
+                    <ul className={styles['details-list']}>
+                      {venue.externalAccessibilityData.audioDisability.deafAndHardOfHearing.map(
+                        (item) => (
+                          <li key={item}>{item}</li>
+                        )
+                      )}
+                    </ul>
+                  ) : (
+                    'Non renseigné'
+                  )}
                 </span>
               </div>
             </div>
@@ -150,7 +160,17 @@ export const AccesLibreSection = ({ venue }: AccesLibreSectionProps) => {
                 </span>
                 <span className={styles['details-item']}>
                   {venue.externalAccessibilityData.visualDisability
-                    ?.audioDescription ?? 'Non renseigné'}
+                    ?.audioDescription?.length ? (
+                    <ul className={styles['details-list']}>
+                      {venue.externalAccessibilityData.visualDisability.audioDescription.map(
+                        (item) => (
+                          <li key={item}>{item}</li>
+                        )
+                      )}
+                    </ul>
+                  ) : (
+                    'Non renseigné'
+                  )}
                 </span>
               </li>
               <li>

--- a/pro/src/pages/VenueEdition/AccesLibreSection/__specs__/AccesLibreSection.spec.tsx
+++ b/pro/src/pages/VenueEdition/AccesLibreSection/__specs__/AccesLibreSection.spec.tsx
@@ -25,12 +25,13 @@ describe('AccesLibreSection', () => {
             parking: "Stationnement adapté dans l'établissement",
           },
           audioDisability: {
-            deafAndHardOfHearing: 'boucle à induction magnétique fixe',
+            deafAndHardOfHearing: ['boucle à induction magnétique fixe'],
           },
           visualDisability: {
             soundBeacon: 'Non renseigné',
-            audioDescription:
+            audioDescription: [
               'avec équipement permanent, casques et boîtiers disponibles à l’accueil',
+            ],
           },
           mentalDisability: {
             trainedPersonnel: 'Personnel non sensibilisé / formé',


### PR DESCRIPTION
## But de la pull request
1er commit: changement des champs audio description et deaf and hard of hearing pour renvoyer une liste au front
2e commit: last update est désormais renvoyé par la route widget chez acceslibre 
3e commit: disposition des champs listés sur plusieurs lignes

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29277

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques