### PR TITLE
(PC-29134)[PRO] fix: show marseille levels in venue edition

### DIFF
--- a/pro/src/components/AccessibilitySummarySection/AccessibilitySummarySection.tsx
+++ b/pro/src/components/AccessibilitySummarySection/AccessibilitySummarySection.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react'
 
 import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
 import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 import { AccessibilityLabel } from 'ui-kit/AccessibilityLabel'
 
 import styles from './AccessibilitySummarySection.module.scss'
@@ -41,28 +41,28 @@ export const AccessibilitySummarySection = ({
     {accessibleItem.visualDisabilityCompliant && (
       <AccessibilityLabel
         className={styles['accessibility-row']}
-        name={AccessiblityEnum.VISUAL}
+        name={AccessibilityEnum.VISUAL}
       />
     )}
 
     {accessibleItem.mentalDisabilityCompliant && (
       <AccessibilityLabel
         className={styles['accessibility-row']}
-        name={AccessiblityEnum.MENTAL}
+        name={AccessibilityEnum.MENTAL}
       />
     )}
 
     {accessibleItem.motorDisabilityCompliant && (
       <AccessibilityLabel
         className={styles['accessibility-row']}
-        name={AccessiblityEnum.MOTOR}
+        name={AccessibilityEnum.MOTOR}
       />
     )}
 
     {accessibleItem.audioDisabilityCompliant && (
       <AccessibilityLabel
         className={styles['accessibility-row']}
-        name={AccessiblityEnum.AUDIO}
+        name={AccessibilityEnum.AUDIO}
       />
     )}
   </SummarySubSection>

--- a/pro/src/components/IndividualOfferForm/Accessibility/__specs__/Accessibility.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/Accessibility/__specs__/Accessibility.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import * as yup from 'yup'
 
 import { IndividualOfferFormValues } from 'components/IndividualOfferForm'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 import { SubmitButton } from 'ui-kit'
 
 import { Accessibility, validationSchema } from '..'
@@ -42,11 +42,11 @@ describe('Accessibility', () => {
       subcategoryId: '',
       withdrawalDetails: '',
       accessibility: {
-        [AccessiblityEnum.VISUAL]: false,
-        [AccessiblityEnum.MENTAL]: false,
-        [AccessiblityEnum.AUDIO]: false,
-        [AccessiblityEnum.MOTOR]: false,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.VISUAL]: false,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: false,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: false,
       },
     }
   })
@@ -55,11 +55,11 @@ describe('Accessibility', () => {
     initialValues = {
       ...initialValues,
       accessibility: {
-        [AccessiblityEnum.VISUAL]: false,
-        [AccessiblityEnum.MENTAL]: false,
-        [AccessiblityEnum.AUDIO]: false,
-        [AccessiblityEnum.MOTOR]: false,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.VISUAL]: false,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: false,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: false,
       },
     }
     renderAccessibility({ initialValues, onSubmit })
@@ -113,11 +113,11 @@ describe('Accessibility', () => {
     initialValues = {
       ...initialValues,
       accessibility: {
-        [AccessiblityEnum.VISUAL]: false,
-        [AccessiblityEnum.MENTAL]: false,
-        [AccessiblityEnum.AUDIO]: false,
-        [AccessiblityEnum.MOTOR]: false,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.VISUAL]: false,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: false,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: false,
       },
     }
     renderAccessibility({ initialValues, onSubmit })
@@ -165,11 +165,11 @@ describe('Accessibility', () => {
     initialValues = {
       ...initialValues,
       accessibility: {
-        [AccessiblityEnum.VISUAL]: false,
-        [AccessiblityEnum.MENTAL]: false,
-        [AccessiblityEnum.AUDIO]: false,
-        [AccessiblityEnum.MOTOR]: false,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.VISUAL]: false,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: false,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: false,
       },
     }
     renderAccessibility({ initialValues, onSubmit })

--- a/pro/src/components/IndividualOfferForm/Accessibility/constants.ts
+++ b/pro/src/components/IndividualOfferForm/Accessibility/constants.ts
@@ -1,11 +1,11 @@
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 
 export const ACCESSIBILITY_DEFAULT_VALUES = {
   accessibility: {
-    [AccessiblityEnum.VISUAL]: false,
-    [AccessiblityEnum.MENTAL]: false,
-    [AccessiblityEnum.AUDIO]: false,
-    [AccessiblityEnum.MOTOR]: false,
-    [AccessiblityEnum.NONE]: false,
+    [AccessibilityEnum.VISUAL]: false,
+    [AccessibilityEnum.MENTAL]: false,
+    [AccessibilityEnum.AUDIO]: false,
+    [AccessibilityEnum.MOTOR]: false,
+    [AccessibilityEnum.NONE]: false,
   },
 }

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/Venue/__specs__/VenueAccessibilityUpdates.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/Venue/__specs__/VenueAccessibilityUpdates.spec.tsx
@@ -9,7 +9,7 @@ import {
   VenueListItemResponseModel,
 } from 'apiClient/v1'
 import { Accessibility } from 'components/IndividualOfferForm/Accessibility'
-import { AccessiblityEnum, AccessibiltyFormValues } from 'core/shared'
+import { AccessibilityEnum, AccessibilityFormValues } from 'core/shared'
 import {
   getOffererNameFactory,
   venueListItemFactory,
@@ -21,7 +21,7 @@ import { VenueProps } from '../Venue'
 interface InitialValues {
   offererId: string
   venueId: string
-  accessibility: AccessibiltyFormValues
+  accessibility: AccessibilityFormValues
 }
 
 const renderVenue = ({
@@ -104,11 +104,11 @@ describe('IndividualOffer section: venue', () => {
       offererId: '1',
       venueId: '',
       accessibility: {
-        [AccessiblityEnum.VISUAL]: false,
-        [AccessiblityEnum.MENTAL]: false,
-        [AccessiblityEnum.AUDIO]: false,
-        [AccessiblityEnum.MOTOR]: false,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.VISUAL]: false,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: false,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: false,
       },
     }
     venueProps = {

--- a/pro/src/components/IndividualOfferForm/types.ts
+++ b/pro/src/components/IndividualOfferForm/types.ts
@@ -1,7 +1,7 @@
 import type { FormikProps } from 'formik'
 
 import { WithdrawalTypeEnum } from 'apiClient/v1'
-import { AccessibiltyFormValues } from 'core/shared'
+import { AccessibilityFormValues } from 'core/shared'
 
 export interface IndividualOfferFormValues {
   isEvent?: boolean
@@ -21,7 +21,7 @@ export interface IndividualOfferFormValues {
   gtl_id?: string
   withdrawalDelay?: number | null
   withdrawalType?: WithdrawalTypeEnum | null
-  accessibility: AccessibiltyFormValues
+  accessibility: AccessibilityFormValues
   author?: string
   performer?: string
   ean?: string

--- a/pro/src/components/IndividualOfferForm/utils/__specs__/setInitialFormValues.spec.ts
+++ b/pro/src/components/IndividualOfferForm/utils/__specs__/setInitialFormValues.spec.ts
@@ -4,7 +4,7 @@ import {
   SubcategoryResponseModel,
   WithdrawalTypeEnum,
 } from 'apiClient/v1'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 import {
   getOfferVenueFactory,
   getOfferManagingOffererFactory,
@@ -71,11 +71,11 @@ describe('setFormReadOnlyFields', () => {
   it('should fill initial form values from offer', () => {
     const expectedResult = {
       accessibility: {
-        [AccessiblityEnum.AUDIO]: true,
-        [AccessiblityEnum.MENTAL]: true,
-        [AccessiblityEnum.MOTOR]: true,
-        [AccessiblityEnum.VISUAL]: true,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.AUDIO]: true,
+        [AccessibilityEnum.MENTAL]: true,
+        [AccessibilityEnum.MOTOR]: true,
+        [AccessibilityEnum.VISUAL]: true,
+        [AccessibilityEnum.NONE]: false,
       },
       bookingEmail: 'booking@email.com',
       bookingContact: 'roberto@example.com',

--- a/pro/src/components/IndividualOfferForm/utils/setInitialFormValues.ts
+++ b/pro/src/components/IndividualOfferForm/utils/setInitialFormValues.ts
@@ -6,7 +6,7 @@ import {
   FORM_DEFAULT_VALUES,
   IndividualOfferFormValues,
 } from 'components/IndividualOfferForm'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 
 import buildSubcategoryFields from './buildSubCategoryFields'
 
@@ -35,10 +35,10 @@ const setInitialFormValues = (
   )
 
   const baseAccessibility = {
-    [AccessiblityEnum.VISUAL]: offer.visualDisabilityCompliant || false,
-    [AccessiblityEnum.MENTAL]: offer.mentalDisabilityCompliant || false,
-    [AccessiblityEnum.AUDIO]: offer.audioDisabilityCompliant || false,
-    [AccessiblityEnum.MOTOR]: offer.motorDisabilityCompliant || false,
+    [AccessibilityEnum.VISUAL]: offer.visualDisabilityCompliant || false,
+    [AccessibilityEnum.MENTAL]: offer.mentalDisabilityCompliant || false,
+    [AccessibilityEnum.AUDIO]: offer.audioDisabilityCompliant || false,
+    [AccessibilityEnum.MOTOR]: offer.motorDisabilityCompliant || false,
   }
 
   return {
@@ -66,7 +66,8 @@ const setInitialFormValues = (
     withdrawalType: offer.withdrawalType || undefined,
     accessibility: {
       ...baseAccessibility,
-      [AccessiblityEnum.NONE]: !Object.values(baseAccessibility).includes(true),
+      [AccessibilityEnum.NONE]:
+        !Object.values(baseAccessibility).includes(true),
     },
     bookingEmail: offer.bookingEmail || '',
     bookingContact: offer.bookingContact || undefined,

--- a/pro/src/core/OfferEducational/types.ts
+++ b/pro/src/core/OfferEducational/types.ts
@@ -9,7 +9,7 @@ import {
   CollectiveOfferResponseModel,
   ListOffersOfferResponseModel,
 } from 'apiClient/v1'
-import { AccessibiltyFormValues } from 'core/shared'
+import { AccessibilityFormValues } from 'core/shared'
 import { hasProperty } from 'utils/types'
 
 export type OfferDatesType = 'permanent' | 'specific_dates'
@@ -27,7 +27,7 @@ export type OfferEducationalFormValues = {
   }
   interventionArea: string[]
   participants: Record<StudentLevels | 'all', boolean>
-  accessibility: AccessibiltyFormValues
+  accessibility: AccessibilityFormValues
   phone: string
   email: string
   contactFormType?: 'form' | 'url'

--- a/pro/src/core/OfferEducational/utils/buildStudentLevelsMapWithDefaultValue.ts
+++ b/pro/src/core/OfferEducational/utils/buildStudentLevelsMapWithDefaultValue.ts
@@ -1,4 +1,5 @@
 import { StudentLevels } from 'apiClient/v1'
+import { DEFAULT_MARSEILLE_STUDENTS } from 'core/shared/constants'
 
 export const buildStudentLevelsMapWithDefaultValue = (
   value: boolean | ((studentKey: StudentLevels) => boolean),
@@ -7,14 +8,7 @@ export const buildStudentLevelsMapWithDefaultValue = (
   const mappedLavels = {} as Record<StudentLevels, boolean>
 
   for (const level of Object.values(StudentLevels)) {
-    if (
-      !isMarseilleEnabled &&
-      [
-        StudentLevels._COLES_MARSEILLE_MATERNELLE,
-        StudentLevels._COLES_MARSEILLE_CP_CE1_CE2,
-        StudentLevels._COLES_MARSEILLE_CM1_CM2,
-      ].includes(level)
-    ) {
+    if (!isMarseilleEnabled && DEFAULT_MARSEILLE_STUDENTS.includes(level)) {
       continue
     }
 

--- a/pro/src/core/Offers/adapters/createIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/createIndividualOffer/serializers.ts
@@ -2,7 +2,7 @@
 import { PostOfferBodyModel } from 'apiClient/v1'
 import { IndividualOfferFormValues } from 'components/IndividualOfferForm'
 import { OfferExtraData } from 'core/Offers/types'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 
 /* istanbul ignore next: DEBT, TO FIX */
 const serializeExtraData = (
@@ -65,7 +65,7 @@ export const serializePostOffer = (
   formValues: IndividualOfferFormValues
 ): PostOfferBodyModel => {
   return {
-    audioDisabilityCompliant: formValues.accessibility[AccessiblityEnum.AUDIO],
+    audioDisabilityCompliant: formValues.accessibility[AccessibilityEnum.AUDIO],
     bookingContact: formValues.bookingContact || null,
     bookingEmail: formValues.bookingEmail || null,
     description: formValues.description || null,
@@ -73,14 +73,14 @@ export const serializePostOffer = (
     isNational: formValues.isNational,
     isDuo: formValues.isDuo,
     mentalDisabilityCompliant:
-      formValues.accessibility[AccessiblityEnum.MENTAL],
-    motorDisabilityCompliant: formValues.accessibility[AccessiblityEnum.MOTOR],
+      formValues.accessibility[AccessibilityEnum.MENTAL],
+    motorDisabilityCompliant: formValues.accessibility[AccessibilityEnum.MOTOR],
     name: formValues.name,
     subcategoryId: formValues.subcategoryId,
     // FIXME mageoffray (2023-04-03) : This is a dirty fix until GET /venues route returns dehumanized Id
     venueId: Number(formValues.venueId),
     visualDisabilityCompliant:
-      formValues.accessibility[AccessiblityEnum.VISUAL],
+      formValues.accessibility[AccessibilityEnum.VISUAL],
     withdrawalDelay:
       formValues.withdrawalDelay === undefined
         ? null

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
@@ -2,7 +2,7 @@
 import { PatchOfferBodyModel } from 'apiClient/v1'
 import { IndividualOfferFormValues } from 'components/IndividualOfferForm'
 import { OfferExtraData } from 'core/Offers/types'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 import { getIndividualOfferFactory } from 'utils/individualApiFactories'
 
 import {
@@ -98,11 +98,11 @@ describe('test updateIndividualOffer::serializers', () => {
         withdrawalDelay: undefined,
         withdrawalType: undefined,
         accessibility: {
-          [AccessiblityEnum.AUDIO]: true,
-          [AccessiblityEnum.MENTAL]: true,
-          [AccessiblityEnum.MOTOR]: true,
-          [AccessiblityEnum.VISUAL]: true,
-          [AccessiblityEnum.NONE]: false,
+          [AccessibilityEnum.AUDIO]: true,
+          [AccessibilityEnum.MENTAL]: true,
+          [AccessibilityEnum.MOTOR]: true,
+          [AccessibilityEnum.VISUAL]: true,
+          [AccessibilityEnum.NONE]: false,
         },
         author: 'test author',
         ean: 'test ean',

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
@@ -7,7 +7,7 @@ import {
   WithdrawalTypeEnum,
 } from 'apiClient/v1'
 import { IndividualOfferFormValues } from 'components/IndividualOfferForm'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 
 import { updateIndividualOffer } from '..'
 import { serializePatchOffer } from '../serializers'
@@ -18,11 +18,11 @@ describe('updateIndividualOffer', () => {
       name: 'Test offer',
       description: 'Description for testing offer',
       accessibility: {
-        [AccessiblityEnum.AUDIO]: true,
-        [AccessiblityEnum.MENTAL]: true,
-        [AccessiblityEnum.MOTOR]: true,
-        [AccessiblityEnum.VISUAL]: true,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.AUDIO]: true,
+        [AccessibilityEnum.MENTAL]: true,
+        [AccessibilityEnum.MOTOR]: true,
+        [AccessibilityEnum.VISUAL]: true,
+        [AccessibilityEnum.NONE]: false,
       },
       isNational: true,
       isDuo: true,
@@ -109,11 +109,11 @@ describe('updateIndividualOffer', () => {
       name: 'Test offer',
       description: 'Description for testing offer',
       accessibility: {
-        [AccessiblityEnum.AUDIO]: true,
-        [AccessiblityEnum.MENTAL]: true,
-        [AccessiblityEnum.MOTOR]: true,
-        [AccessiblityEnum.VISUAL]: true,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.AUDIO]: true,
+        [AccessibilityEnum.MENTAL]: true,
+        [AccessibilityEnum.MOTOR]: true,
+        [AccessibilityEnum.VISUAL]: true,
+        [AccessibilityEnum.NONE]: false,
       },
       isNational: true,
       isDuo: true,

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -7,7 +7,7 @@ import { IndividualOfferFormValues } from 'components/IndividualOfferForm'
 import { SYNCHRONIZED_OFFER_EDITABLE_FIELDS } from 'core/Offers/constants'
 import { OfferExtraData } from 'core/Offers/types'
 import { isAllocineOffer } from 'core/Providers/utils/localProvider'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 
 export const serializeExtraData = (
   formValues: Partial<IndividualOfferFormValues>,
@@ -83,17 +83,17 @@ export const serializePatchOffer = ({
   return {
     audioDisabilityCompliant:
       sentValues.accessibility &&
-      sentValues.accessibility[AccessiblityEnum.AUDIO],
+      sentValues.accessibility[AccessibilityEnum.AUDIO],
     description: sentValues.description,
     extraData: serializeExtraData(sentValues, isTiteliveMusicGenreEnabled),
     isNational: sentValues.isNational,
     isDuo: sentValues.isDuo,
     mentalDisabilityCompliant:
       sentValues.accessibility &&
-      sentValues.accessibility[AccessiblityEnum.MENTAL],
+      sentValues.accessibility[AccessibilityEnum.MENTAL],
     motorDisabilityCompliant:
       sentValues.accessibility &&
-      sentValues.accessibility[AccessiblityEnum.MOTOR],
+      sentValues.accessibility[AccessibilityEnum.MOTOR],
     name: sentValues.name,
     withdrawalDelay:
       sentValues.withdrawalDelay === undefined
@@ -104,7 +104,7 @@ export const serializePatchOffer = ({
     withdrawalDetails: sentValues.withdrawalDetails ?? undefined,
     visualDisabilityCompliant:
       sentValues.accessibility &&
-      sentValues.accessibility[AccessiblityEnum.VISUAL],
+      sentValues.accessibility[AccessibilityEnum.VISUAL],
     withdrawalType: sentValues.withdrawalType,
     durationMinutes: serializeDurationMinutes(sentValues.durationMinutes || ''),
     bookingEmail:

--- a/pro/src/core/shared/constants.ts
+++ b/pro/src/core/shared/constants.ts
@@ -1,3 +1,5 @@
+import { StudentLevels } from 'apiClient/v1'
+
 export const urlRegex = new RegExp(
   // eslint-disable-next-line no-useless-escape
   /^(?:http(s)?:\/\/)?[\w.-\.-\.@]+(?:\.[\w\.-\.@]+)+[\w\-\._~:\/?#[\]@%!\$&'\(\)\*\+,;=.]+$/,
@@ -22,3 +24,9 @@ export const FORM_ERROR_MESSAGE =
 export const NBSP = '\u00a0'
 
 export const SAVED_OFFERER_ID_KEY = 'homepageSelectedOffererId'
+
+export const DEFAULT_MARSEILLE_STUDENTS = [
+  StudentLevels._COLES_MARSEILLE_MATERNELLE,
+  StudentLevels._COLES_MARSEILLE_CP_CE1_CE2,
+  StudentLevels._COLES_MARSEILLE_CM1_CM2,
+]

--- a/pro/src/core/shared/types.ts
+++ b/pro/src/core/shared/types.ts
@@ -3,7 +3,7 @@ export enum Audience {
   COLLECTIVE = 'collective',
 }
 
-export enum AccessiblityEnum {
+export enum AccessibilityEnum {
   VISUAL = 'visual',
   MENTAL = 'mental',
   AUDIO = 'audio',
@@ -11,7 +11,7 @@ export enum AccessiblityEnum {
   NONE = 'none',
 }
 
-export interface AccessibiltyFormValues {
+export interface AccessibilityFormValues {
   visual: boolean
   audio: boolean
   motor: boolean

--- a/pro/src/hooks/useAccessibilityOptions.tsx
+++ b/pro/src/hooks/useAccessibilityOptions.tsx
@@ -1,4 +1,4 @@
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 import strokeAccessibilityBrain from 'icons/stroke-accessibility-brain.svg'
 import audioDisabilitySvg from 'icons/stroke-accessibility-ear.svg'
 import strokeAccessibilityEye from 'icons/stroke-accessibility-eye.svg'
@@ -32,31 +32,31 @@ const useAccessibilityOptions = (
   return [
     {
       label: 'Visuel',
-      name: `accessibility.${AccessiblityEnum.VISUAL}`,
+      name: `accessibility.${AccessibilityEnum.VISUAL}`,
       icon: strokeAccessibilityEye,
       onChange: onNormalOptionChange,
     },
     {
       label: 'Psychique ou cognitif',
-      name: `accessibility.${AccessiblityEnum.MENTAL}`,
+      name: `accessibility.${AccessibilityEnum.MENTAL}`,
       icon: strokeAccessibilityBrain,
       onChange: onNormalOptionChange,
     },
     {
       label: 'Moteur',
-      name: `accessibility.${AccessiblityEnum.MOTOR}`,
+      name: `accessibility.${AccessibilityEnum.MOTOR}`,
       icon: strokeAccessibilityLeg,
       onChange: onNormalOptionChange,
     },
     {
       label: 'Auditif',
-      name: `accessibility.${AccessiblityEnum.AUDIO}`,
+      name: `accessibility.${AccessibilityEnum.AUDIO}`,
       icon: audioDisabilitySvg,
       onChange: onNormalOptionChange,
     },
     {
       label: 'Non accessible',
-      name: `accessibility.${AccessiblityEnum.NONE}`,
+      name: `accessibility.${AccessibilityEnum.NONE}`,
       onChange: onNoneOptionChange,
     },
   ]

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux'
 
 import { VenueResponse } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
-import { StudentLevels } from 'apiClient/v1'
+import { DEFAULT_MARSEILLE_STUDENTS } from 'core/shared'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useNotification from 'hooks/useNotification'
 import { adageFilterSelector } from 'store/adageFilter/selectors'
@@ -43,12 +43,6 @@ export const algoliaSearchDefaultAttributesToRetrieve = [
 ]
 
 export const DEFAULT_GEO_RADIUS = 30000000 // 30 000 km ensure we get all results in the world
-
-const DEFAULT_MARSEILLE_STUDENTS = [
-  StudentLevels._COLES_MARSEILLE_MATERNELLE,
-  StudentLevels._COLES_MARSEILLE_CP_CE1_CE2,
-  StudentLevels._COLES_MARSEILLE_CM1_CM2,
-]
 
 export interface SearchFormValues {
   domains: number[]

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
@@ -9,6 +9,7 @@ import { GET_VENUE_QUERY_KEY } from 'config/swrQueryKeys'
 import { handleAllFranceDepartmentOptions } from 'core/shared'
 import { venueInterventionOptions } from 'core/shared/interventionOptions'
 import { SelectOption } from 'custom_types/form'
+import useActiveFeature from 'hooks/useActiveFeature'
 import useNotification from 'hooks/useNotification'
 import { RouteLeavingGuardVenueEdition } from 'pages/VenueEdition/RouteLeavingGuardVenueEdition'
 import { ButtonLink, Select, SubmitButton, TextArea, TextInput } from 'ui-kit'
@@ -23,25 +24,17 @@ import { CollectiveDataFormValues } from './type'
 import { extractInitialValuesFromVenue } from './utils/extractInitialValuesFromVenue'
 import { validationSchema } from './validationSchema'
 
-const studentOptions = [
-  { value: StudentLevels.COLL_GE_4E, label: StudentLevels.COLL_GE_4E },
-  { value: StudentLevels.COLL_GE_3E, label: StudentLevels.COLL_GE_3E },
-  { value: StudentLevels.CAP_1RE_ANN_E, label: StudentLevels.CAP_1RE_ANN_E },
-  { value: StudentLevels.CAP_2E_ANN_E, label: StudentLevels.CAP_2E_ANN_E },
-  { value: StudentLevels.LYC_E_SECONDE, label: StudentLevels.LYC_E_SECONDE },
-  { value: StudentLevels.LYC_E_PREMI_RE, label: StudentLevels.LYC_E_PREMI_RE },
-  {
-    value: StudentLevels.LYC_E_TERMINALE,
-    label: StudentLevels.LYC_E_TERMINALE,
-  },
-]
-
 type CollectiveDataFormProps = {
   statuses: SelectOption[]
   domains: SelectOption[]
   culturalPartners: SelectOption[]
   venue: GetVenueResponseModel
 }
+
+const studentLevels = Object.entries(StudentLevels).map(([value, label]) => ({
+  value,
+  label,
+}))
 
 export const CollectiveDataForm = ({
   statuses,
@@ -58,6 +51,11 @@ export const CollectiveDataForm = ({
     string[] | null
   >(null)
   const initialValues = extractInitialValuesFromVenue(venue)
+
+  const isMarseilleEnabled = useActiveFeature('WIP_ENABLE_MARSEILLE')
+  const studentOptions = isMarseilleEnabled
+    ? studentLevels
+    : studentLevels.filter((level) => !level.label.includes('Marseille'))
 
   const onSubmit = async (values: CollectiveDataFormValues) => {
     const response = await editVenueCollectiveDataAdapter({

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
@@ -6,7 +6,10 @@ import { useSWRConfig } from 'swr'
 import { GetVenueResponseModel, StudentLevels } from 'apiClient/v1'
 import FormLayout from 'components/FormLayout'
 import { GET_VENUE_QUERY_KEY } from 'config/swrQueryKeys'
-import { handleAllFranceDepartmentOptions } from 'core/shared'
+import {
+  DEFAULT_MARSEILLE_STUDENTS,
+  handleAllFranceDepartmentOptions,
+} from 'core/shared'
 import { venueInterventionOptions } from 'core/shared/interventionOptions'
 import { SelectOption } from 'custom_types/form'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -55,7 +58,9 @@ export const CollectiveDataForm = ({
   const isMarseilleEnabled = useActiveFeature('WIP_ENABLE_MARSEILLE')
   const studentOptions = isMarseilleEnabled
     ? studentLevels
-    : studentLevels.filter((level) => !level.label.includes('Marseille'))
+    : studentLevels.filter(
+        (level) => !DEFAULT_MARSEILLE_STUDENTS.includes(level.label)
+      )
 
   const onSubmit = async (values: CollectiveDataFormValues) => {
     const response = await editVenueCollectiveDataAdapter({

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataForm.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataForm.spec.tsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+
+import { defaultGetVenue } from 'utils/collectiveApiFactories'
+import {
+  RenderWithProvidersOptions,
+  renderWithProviders,
+} from 'utils/renderWithProviders'
+
+import { CollectiveDataForm } from '../CollectiveDataForm/CollectiveDataForm'
+
+describe('CollectiveDataForm', () => {
+  it('should show all student levels when WIP_ENABLE_MARSEILLE is on', async () => {
+    const featureOverrides = {
+      features: ['WIP_ENABLE_MARSEILLE'],
+    }
+    renderCollectiveDataForm(featureOverrides)
+    await userEvent.click(
+      screen.getByPlaceholderText('Sélectionner un public cible')
+    )
+    expect(
+      screen.getByText('Écoles Marseille - Maternelle')
+    ).toBeInTheDocument()
+  })
+
+  it('should show student levels without Marseille options when WIP_ENABLE_MARSEILLE is off', async () => {
+    renderCollectiveDataForm()
+    await userEvent.click(
+      screen.getByPlaceholderText('Sélectionner un public cible')
+    )
+    expect(
+      screen.queryByText('Écoles Marseille - Maternelle')
+    ).not.toBeInTheDocument()
+  })
+})
+
+function renderCollectiveDataForm(options?: RenderWithProvidersOptions) {
+  return renderWithProviders(
+    <CollectiveDataForm
+      statuses={[
+        {
+          value: 1,
+          label: 'statut 1',
+        },
+        {
+          value: 2,
+          label: 'statut 2',
+        },
+      ]}
+      domains={[
+        { value: 1, label: 'domain 1' },
+        { value: 2, label: 'domain 2' },
+      ]}
+      culturalPartners={[
+        {
+          value: 'culturalPartner',
+          label: 'Dans mon lieu',
+        },
+      ]}
+      venue={defaultGetVenue}
+    />,
+    options
+  )
+}

--- a/pro/src/pages/VenueCreation/Accessibility/__specs__/Accessibility.spec.tsx
+++ b/pro/src/pages/VenueCreation/Accessibility/__specs__/Accessibility.spec.tsx
@@ -3,7 +3,7 @@ import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 import { VenueCreationFormValues } from 'pages/VenueCreation/types'
 import { SubmitButton } from 'ui-kit'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -37,11 +37,11 @@ describe('Accessibility', () => {
   beforeEach(() => {
     initialValues = {
       accessibility: {
-        [AccessiblityEnum.VISUAL]: false,
-        [AccessiblityEnum.MENTAL]: false,
-        [AccessiblityEnum.AUDIO]: false,
-        [AccessiblityEnum.MOTOR]: false,
-        [AccessiblityEnum.NONE]: false,
+        [AccessibilityEnum.VISUAL]: false,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: false,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: false,
       },
     }
     isCreatingVenue = true
@@ -136,11 +136,11 @@ describe('Accessibility', () => {
     isCreatingVenue = false
     initialValues = {
       accessibility: {
-        [AccessiblityEnum.VISUAL]: false,
-        [AccessiblityEnum.MENTAL]: false,
-        [AccessiblityEnum.AUDIO]: false,
-        [AccessiblityEnum.MOTOR]: false,
-        [AccessiblityEnum.NONE]: true,
+        [AccessibilityEnum.VISUAL]: false,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: false,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: true,
       },
     }
     renderAccessibility({ initialValues, isCreatingVenue, onSubmit })

--- a/pro/src/pages/VenueCreation/constants.ts
+++ b/pro/src/pages/VenueCreation/constants.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_ADDRESS_FORM_VALUES } from 'components/Address/constants'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 
 import { VenueCreationFormValues } from './types'
 
@@ -14,11 +14,11 @@ export const DEFAULT_INTITIAL_OPENING_HOURS = {
 export const DEFAULT_FORM_VALUES: VenueCreationFormValues = {
   ...DEFAULT_ADDRESS_FORM_VALUES,
   accessibility: {
-    [AccessiblityEnum.VISUAL]: false,
-    [AccessiblityEnum.MENTAL]: false,
-    [AccessiblityEnum.AUDIO]: false,
-    [AccessiblityEnum.MOTOR]: false,
-    [AccessiblityEnum.NONE]: false,
+    [AccessibilityEnum.VISUAL]: false,
+    [AccessibilityEnum.MENTAL]: false,
+    [AccessibilityEnum.AUDIO]: false,
+    [AccessibilityEnum.MOTOR]: false,
+    [AccessibilityEnum.NONE]: false,
   },
   bannerMeta: undefined,
   bannerUrl: '',

--- a/pro/src/pages/VenueCreation/types.ts
+++ b/pro/src/pages/VenueCreation/types.ts
@@ -1,8 +1,8 @@
 import { BannerMetaModel } from 'apiClient/v1'
-import { AccessibiltyFormValues } from 'core/shared'
+import { AccessibilityFormValues } from 'core/shared'
 
 export interface VenueCreationFormValues {
-  accessibility: AccessibiltyFormValues
+  accessibility: AccessibilityFormValues
   addressAutocomplete: string
   bannerMeta?: BannerMetaModel | null
   bannerUrl: string | undefined

--- a/pro/src/pages/VenueEdition/__specs__/setInitialFormValues.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/setInitialFormValues.spec.tsx
@@ -1,4 +1,4 @@
-import { AccessiblityEnum } from 'core/shared/types'
+import { AccessibilityEnum } from 'core/shared/types'
 import { defaultGetVenue } from 'utils/collectiveApiFactories'
 
 import { buildAccessibilityFormValues } from '../setInitialFormValues'
@@ -15,11 +15,11 @@ describe('buildAccessibilityFormValues', () => {
         externalAccessibilityData: null,
       })
     ).toEqual({
-      [AccessiblityEnum.AUDIO]: false,
-      [AccessiblityEnum.MENTAL]: false,
-      [AccessiblityEnum.MOTOR]: false,
-      [AccessiblityEnum.VISUAL]: false,
-      [AccessiblityEnum.NONE]: false,
+      [AccessibilityEnum.AUDIO]: false,
+      [AccessibilityEnum.MENTAL]: false,
+      [AccessibilityEnum.MOTOR]: false,
+      [AccessibilityEnum.VISUAL]: false,
+      [AccessibilityEnum.NONE]: false,
     })
   })
 
@@ -34,11 +34,11 @@ describe('buildAccessibilityFormValues', () => {
         externalAccessibilityData: null,
       })
     ).toEqual({
-      [AccessiblityEnum.AUDIO]: true,
-      [AccessiblityEnum.MENTAL]: true,
-      [AccessiblityEnum.MOTOR]: true,
-      [AccessiblityEnum.VISUAL]: true,
-      [AccessiblityEnum.NONE]: false,
+      [AccessibilityEnum.AUDIO]: true,
+      [AccessibilityEnum.MENTAL]: true,
+      [AccessibilityEnum.MOTOR]: true,
+      [AccessibilityEnum.VISUAL]: true,
+      [AccessibilityEnum.NONE]: false,
     })
   })
 
@@ -58,11 +58,11 @@ describe('buildAccessibilityFormValues', () => {
         },
       })
     ).toEqual({
-      [AccessiblityEnum.AUDIO]: true,
-      [AccessiblityEnum.MENTAL]: true,
-      [AccessiblityEnum.MOTOR]: true,
-      [AccessiblityEnum.VISUAL]: true,
-      [AccessiblityEnum.NONE]: false,
+      [AccessibilityEnum.AUDIO]: true,
+      [AccessibilityEnum.MENTAL]: true,
+      [AccessibilityEnum.MOTOR]: true,
+      [AccessibilityEnum.VISUAL]: true,
+      [AccessibilityEnum.NONE]: false,
     })
   })
 
@@ -82,11 +82,11 @@ describe('buildAccessibilityFormValues', () => {
         },
       })
     ).toEqual({
-      [AccessiblityEnum.AUDIO]: false,
-      [AccessiblityEnum.MENTAL]: false,
-      [AccessiblityEnum.MOTOR]: false,
-      [AccessiblityEnum.VISUAL]: false,
-      [AccessiblityEnum.NONE]: true,
+      [AccessibilityEnum.AUDIO]: false,
+      [AccessibilityEnum.MENTAL]: false,
+      [AccessibilityEnum.MOTOR]: false,
+      [AccessibilityEnum.VISUAL]: false,
+      [AccessibilityEnum.NONE]: true,
     })
   })
 })

--- a/pro/src/pages/VenueEdition/setInitialFormValues.ts
+++ b/pro/src/pages/VenueEdition/setInitialFormValues.ts
@@ -1,5 +1,5 @@
 import { GetVenueResponseModel, VenueListItemResponseModel } from 'apiClient/v1'
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 import { DEFAULT_INTITIAL_OPENING_HOURS } from 'pages/VenueCreation/constants'
 
 import { DayValues, VenueEditionFormValues, Day } from './types'
@@ -9,19 +9,19 @@ export const buildAccessibilityFormValues = (
 ) => {
   if (venue.externalAccessibilityData) {
     return {
-      [AccessiblityEnum.VISUAL]: Boolean(
+      [AccessibilityEnum.VISUAL]: Boolean(
         venue.externalAccessibilityData.isAccessibleVisualDisability
       ),
-      [AccessiblityEnum.MENTAL]: Boolean(
+      [AccessibilityEnum.MENTAL]: Boolean(
         venue.externalAccessibilityData.isAccessibleMentalDisability
       ),
-      [AccessiblityEnum.AUDIO]: Boolean(
+      [AccessibilityEnum.AUDIO]: Boolean(
         venue.externalAccessibilityData.isAccessibleAudioDisability
       ),
-      [AccessiblityEnum.MOTOR]: Boolean(
+      [AccessibilityEnum.MOTOR]: Boolean(
         venue.externalAccessibilityData.isAccessibleMotorDisability
       ),
-      [AccessiblityEnum.NONE]: [
+      [AccessibilityEnum.NONE]: [
         venue.externalAccessibilityData.isAccessibleVisualDisability,
         venue.externalAccessibilityData.isAccessibleMentalDisability,
         venue.externalAccessibilityData.isAccessibleAudioDisability,
@@ -31,11 +31,11 @@ export const buildAccessibilityFormValues = (
   }
 
   return {
-    [AccessiblityEnum.VISUAL]: venue.visualDisabilityCompliant || false,
-    [AccessiblityEnum.MENTAL]: venue.mentalDisabilityCompliant || false,
-    [AccessiblityEnum.AUDIO]: venue.audioDisabilityCompliant || false,
-    [AccessiblityEnum.MOTOR]: venue.motorDisabilityCompliant || false,
-    [AccessiblityEnum.NONE]: [
+    [AccessibilityEnum.VISUAL]: venue.visualDisabilityCompliant || false,
+    [AccessibilityEnum.MENTAL]: venue.mentalDisabilityCompliant || false,
+    [AccessibilityEnum.AUDIO]: venue.audioDisabilityCompliant || false,
+    [AccessibilityEnum.MOTOR]: venue.motorDisabilityCompliant || false,
+    [AccessibilityEnum.NONE]: [
       venue.visualDisabilityCompliant,
       venue.mentalDisabilityCompliant,
       venue.audioDisabilityCompliant,

--- a/pro/src/pages/VenueEdition/types.ts
+++ b/pro/src/pages/VenueEdition/types.ts
@@ -1,4 +1,4 @@
-import { AccessibiltyFormValues } from 'core/shared'
+import { AccessibilityFormValues } from 'core/shared'
 
 export type DayValues = {
   morningStartingHour: string
@@ -9,7 +9,7 @@ export type DayValues = {
 }
 
 export interface VenueEditionFormValues {
-  accessibility: AccessibiltyFormValues
+  accessibility: AccessibilityFormValues
   description: string
   email: string | null
   isAccessibilityAppliedOnAllOffers: boolean

--- a/pro/src/ui-kit/AccessibilityLabel/AccessibilityLabel.tsx
+++ b/pro/src/ui-kit/AccessibilityLabel/AccessibilityLabel.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames'
 import React from 'react'
 
-import { AccessiblityEnum } from 'core/shared'
+import { AccessibilityEnum } from 'core/shared'
 import strokeAccessibilityBrain from 'icons/stroke-accessibility-brain.svg'
 import audioDisabilitySvg from 'icons/stroke-accessibility-ear.svg'
 import strokeAccessibilityEye from 'icons/stroke-accessibility-eye.svg'
@@ -11,7 +11,7 @@ import styles from './AccessibilityLabel.module.scss'
 
 interface AccessibilityLabelProps {
   className?: string
-  name: AccessiblityEnum
+  name: AccessibilityEnum
 }
 
 const AccessibilityLabel = ({
@@ -19,23 +19,23 @@ const AccessibilityLabel = ({
   name,
 }: AccessibilityLabelProps): JSX.Element => {
   const labelData = {
-    [AccessiblityEnum.AUDIO]: {
+    [AccessibilityEnum.AUDIO]: {
       label: 'Auditif',
       svg: audioDisabilitySvg,
     },
-    [AccessiblityEnum.MENTAL]: {
+    [AccessibilityEnum.MENTAL]: {
       label: 'Psychique ou cognitif',
       svg: strokeAccessibilityBrain,
     },
-    [AccessiblityEnum.MOTOR]: {
+    [AccessibilityEnum.MOTOR]: {
       label: 'Moteur',
       svg: strokeAccessibilityLeg,
     },
-    [AccessiblityEnum.VISUAL]: {
+    [AccessibilityEnum.VISUAL]: {
       label: 'Visuel',
       svg: strokeAccessibilityEye,
     },
-    [AccessiblityEnum.NONE]: {
+    [AccessibilityEnum.NONE]: {
       label: 'Non accessible',
     },
   }[name]


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29134

Afficher les options des écoles à Marseille dans la liste "Public cible" sur la page partenaire quand le FF WIP_ENABLE_MARSEILLE est activé.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques