### PR TITLE
(BSR)[PRO] fix: attempt to fix flaky tests in offers

### DIFF
--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.admin.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.admin.spec.tsx
@@ -77,25 +77,26 @@ describe('route CollectiveOffers when user is admin', () => {
     )
 
     await userEvent.click(screen.getByText('Rechercher'))
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
+    await waitFor(() => {
+      expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+        undefined,
+        undefined,
+        OfferStatus.INACTIVE,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
     expect(
       screen.getByRole('button', {
         name: 'Statut Afficher ou masquer le filtre par statut',
       })
     ).toBeDisabled()
-    expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-      undefined,
-      undefined,
-      OfferStatus.INACTIVE,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined
-    )
   })
 
   it('should not reset or disable status filter when venue filter is deselected while offerer filter is applied', async () => {
@@ -112,25 +113,26 @@ describe('route CollectiveOffers when user is admin', () => {
     )
 
     await userEvent.click(screen.getByText('Rechercher'))
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
+    await waitFor(() => {
+      expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+        undefined,
+        'EF',
+        'INACTIVE',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
     expect(
       screen.getByRole('button', {
         name: /Afficher ou masquer le filtre par statut/,
       })
     ).not.toBeDisabled()
-    expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-      undefined,
-      'EF',
-      'INACTIVE',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined
-    )
   })
 
   it('should reset and disable status filter when offerer filter is removed', async () => {

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.admin.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.admin.spec.tsx
@@ -1,0 +1,227 @@
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+
+import { api } from 'apiClient/api'
+import { CollectiveOfferResponseModel, OfferStatus } from 'apiClient/v1'
+import { ALL_VENUES, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { SearchFiltersParams } from 'core/Offers/types'
+import { computeCollectiveOffersUrl } from 'core/Offers/utils'
+import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import { venueListItemFactory } from 'utils/individualApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { CollectiveOffers } from '../CollectiveOffers'
+
+const proVenues = [
+  venueListItemFactory({
+    id: 1,
+    name: 'Ma venue',
+    offererName: 'Mon offerer',
+    isVirtual: false,
+  }),
+  venueListItemFactory({
+    id: 2,
+    name: 'Ma venue virtuelle',
+    offererName: 'Mon offerer',
+    isVirtual: true,
+  }),
+]
+
+const renderOffers = async (
+  filters: Partial<SearchFiltersParams> = DEFAULT_SEARCH_FILTERS
+) => {
+  const route = computeCollectiveOffersUrl(filters)
+  const currentUser = {
+    id: 'EY',
+    isAdmin: true,
+    name: 'Current User',
+  }
+  const store = {
+    user: {
+      initialized: true,
+      currentUser,
+    },
+  }
+  renderWithProviders(<CollectiveOffers />, {
+    storeOverrides: store,
+    initialRouterEntries: [route],
+  })
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+}
+
+describe('route CollectiveOffers when user is admin', () => {
+  let offersRecap: CollectiveOfferResponseModel[]
+
+  beforeEach(() => {
+    offersRecap = [collectiveOfferFactory()]
+    vi.spyOn(api, 'getCollectiveOffers').mockResolvedValue(offersRecap)
+    vi.spyOn(api, 'listOfferersNames').mockResolvedValue({ offerersNames: [] })
+    vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: proVenues })
+  })
+
+  it('should reset and disable status filter when venue filter is deselected', async () => {
+    const { id: venueId, name: venueName } = proVenues[0]
+    const filters = {
+      venueId: venueId.toString(),
+      status: OfferStatus.INACTIVE,
+    }
+    await renderOffers(filters)
+    await userEvent.selectOptions(
+      screen.getByDisplayValue(venueName),
+      ALL_VENUES
+    )
+
+    await userEvent.click(screen.getByText('Rechercher'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Statut Afficher ou masquer le filtre par statut',
+      })
+    ).toBeDisabled()
+    expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+      undefined,
+      undefined,
+      OfferStatus.INACTIVE,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
+  })
+
+  it('should not reset or disable status filter when venue filter is deselected while offerer filter is applied', async () => {
+    const { id: venueId, name: venueName } = proVenues[0]
+    const filters = {
+      venueId: venueId.toString(),
+      status: OfferStatus.INACTIVE,
+      offererId: 'EF',
+    }
+    await renderOffers(filters)
+    await userEvent.selectOptions(
+      screen.getByDisplayValue(venueName),
+      ALL_VENUES
+    )
+
+    await userEvent.click(screen.getByText('Rechercher'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+    expect(
+      screen.getByRole('button', {
+        name: /Afficher ou masquer le filtre par statut/,
+      })
+    ).not.toBeDisabled()
+    expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+      undefined,
+      'EF',
+      'INACTIVE',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
+  })
+
+  it('should reset and disable status filter when offerer filter is removed', async () => {
+    const offerer = { name: 'La structure', id: 'EF' }
+    // @ts-expect-error FIX ME
+    vi.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
+    const filters = {
+      offererId: offerer.id,
+      status: OfferStatus.INACTIVE,
+    }
+    await renderOffers(filters)
+
+    await userEvent.click(screen.getByTestId('remove-offerer-filter'))
+
+    await waitFor(() => {
+      expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
+    expect(
+      screen.getByRole('button', {
+        name: 'Statut Afficher ou masquer le filtre par statut',
+      })
+    ).toBeDisabled()
+  })
+
+  it('should not reset or disable status filter when offerer filter is removed while venue filter is applied', async () => {
+    const { id: venueId } = proVenues[0]
+    const offerer = { name: 'La structure', id: 'EF' }
+    // @ts-expect-error FIX ME
+    vi.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
+    const filters = {
+      venueId: venueId.toString(),
+      status: OfferStatus.INACTIVE,
+      offererId: offerer.id,
+    }
+    await renderOffers(filters)
+
+    await userEvent.click(screen.getByTestId('remove-offerer-filter'))
+
+    await waitFor(() => {
+      expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+        undefined,
+        undefined,
+        'INACTIVE',
+        venueId.toString(),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
+    expect(
+      screen.getByRole('button', {
+        name: /Afficher ou masquer le filtre par statut/,
+      })
+    ).not.toBeDisabled()
+  })
+
+  it('should enable status filters when venue filter is applied', async () => {
+    const filters = { venueId: proVenues[0].id.toString() }
+
+    await renderOffers(filters)
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Statut Afficher ou masquer le filtre par statut',
+      })
+    ).not.toBeDisabled()
+  })
+
+  it('should enable status filters when offerer filter is applied', async () => {
+    const filters = { offererId: 'A4' }
+
+    await renderOffers(filters)
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Statut Afficher ou masquer le filtre par statut',
+      })
+    ).not.toBeDisabled()
+  })
+})

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -136,20 +136,20 @@ describe('route CollectiveOffers', () => {
         )
 
         await userEvent.click(screen.getByText('Rechercher'))
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-        expect(api.getCollectiveOffers).toHaveBeenCalledWith(
-          'Any word',
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.getCollectiveOffers).toHaveBeenCalledWith(
+            'Any word',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined
+          )
+        })
       })
 
       it('should store search value', async () => {
@@ -160,20 +160,20 @@ describe('route CollectiveOffers', () => {
 
         await userEvent.type(searchInput, 'search string')
         await userEvent.click(screen.getByText('Rechercher'))
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-        expect(api.getCollectiveOffers).toHaveBeenCalledWith(
-          'search string',
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.getCollectiveOffers).toHaveBeenCalledWith(
+            'search string',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined
+          )
+        })
       })
 
       it('should load offers with selected venue filter', async () => {
@@ -185,20 +185,20 @@ describe('route CollectiveOffers', () => {
         await userEvent.selectOptions(venueSelect, firstVenueOption)
 
         await userEvent.click(screen.getByText('Rechercher'))
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-        expect(api.getCollectiveOffers).toHaveBeenCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          proVenues[0].id.toString(),
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.getCollectiveOffers).toHaveBeenCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            proVenues[0].id.toString(),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined
+          )
+        })
       })
 
       it('should load offers with selected period beginning date', async () => {
@@ -210,20 +210,20 @@ describe('route CollectiveOffers', () => {
         )
 
         await userEvent.click(screen.getByText('Rechercher'))
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-        expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          '2020-12-25',
-          undefined,
-          undefined,
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            '2020-12-25',
+            undefined,
+            undefined,
+            undefined
+          )
+        })
       })
 
       it('should load offers with selected period ending date', async () => {
@@ -234,20 +234,20 @@ describe('route CollectiveOffers', () => {
         )
 
         await userEvent.click(screen.getByText('Rechercher'))
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-        expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          '2020-12-27',
-          undefined,
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            '2020-12-27',
+            undefined,
+            undefined
+          )
+        })
       })
 
       it('should load offers with selected offer type', async () => {
@@ -256,20 +256,20 @@ describe('route CollectiveOffers', () => {
         await userEvent.selectOptions(offerTypeSelect, 'template')
 
         await userEvent.click(screen.getByText('Rechercher'))
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-        expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          'template',
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'template',
+            undefined
+          )
+        })
       })
     })
   })
@@ -372,9 +372,9 @@ describe('route CollectiveOffers', () => {
       )
 
       await userEvent.click(screen.getByText('Rechercher'))
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-      expect(api.getCollectiveOffers).toHaveBeenCalledTimes(2)
+      await waitFor(() => {
+        expect(api.getCollectiveOffers).toHaveBeenCalledTimes(2)
+      })
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(
         2,
         undefined,
@@ -392,9 +392,9 @@ describe('route CollectiveOffers', () => {
       screen.getByText('Aucune offre trouvée pour votre recherche')
 
       await userEvent.click(screen.getByText('Afficher toutes les offres'))
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-      expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
+      await waitFor(() => {
+        expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
+      })
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(
         3,
         undefined,
@@ -445,8 +445,9 @@ describe('route CollectiveOffers', () => {
       )
 
       await userEvent.click(screen.getByText('Rechercher'))
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-      expect(api.getCollectiveOffers).toHaveBeenCalledTimes(2)
+      await waitFor(() => {
+        expect(api.getCollectiveOffers).toHaveBeenCalledTimes(2)
+      })
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(
         2,
         undefined,
@@ -462,9 +463,9 @@ describe('route CollectiveOffers', () => {
       )
 
       await userEvent.click(screen.getByText('Réinitialiser les filtres'))
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-      expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
+      await waitFor(() => {
+        expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
+      })
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(
         3,
         undefined,

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -102,22 +102,22 @@ describe('route CollectiveOffers', () => {
             })
           )
           await userEvent.click(screen.getByLabelText('Expirée'))
-
           await userEvent.click(screen.getByText('Appliquer'))
-          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-            undefined,
-            undefined,
-            'EXPIRED',
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined
-          )
+          await waitFor(() => {
+            expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+              undefined,
+              undefined,
+              'EXPIRED',
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined
+            )
+          })
         })
 
         it('should indicate that no offers match selected filters', async () => {
@@ -133,7 +133,6 @@ describe('route CollectiveOffers', () => {
           )
           await userEvent.click(screen.getByLabelText('Expirée'))
           await userEvent.click(screen.getByText('Appliquer'))
-          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
           await waitFor(() => {
             expect(
@@ -246,27 +245,26 @@ describe('route CollectiveOffers', () => {
             await renderOffers(store, filters)
 
             await userEvent.click(screen.getByTestId('remove-offerer-filter'))
-            await waitForElementToBeRemoved(() =>
-              screen.queryByTestId('spinner')
-            )
 
+            await waitFor(() => {
+              expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+              )
+            })
             expect(
               screen.getByRole('button', {
                 name: 'Statut Afficher ou masquer le filtre par statut',
               })
             ).toBeDisabled()
-            expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined
-            )
           })
 
           it('should not reset or disable status filter when offerer filter is removed while venue filter is applied', async () => {
@@ -282,27 +280,26 @@ describe('route CollectiveOffers', () => {
             await renderOffers(store, filters)
 
             await userEvent.click(screen.getByTestId('remove-offerer-filter'))
-            await waitForElementToBeRemoved(() =>
-              screen.queryByTestId('spinner')
-            )
 
+            await waitFor(() => {
+              expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+                undefined,
+                undefined,
+                'INACTIVE',
+                venueId.toString(),
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+              )
+            })
             expect(
               screen.getByRole('button', {
                 name: /Afficher ou masquer le filtre par statut/,
               })
             ).not.toBeDisabled()
-            expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-              undefined,
-              undefined,
-              'INACTIVE',
-              venueId.toString(),
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined
-            )
           })
 
           it('should enable status filters when venue filter is applied', async () => {

--- a/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
@@ -1,0 +1,260 @@
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { Route, Routes } from 'react-router-dom'
+
+import { api } from 'apiClient/api'
+import { ListOffersOfferResponseModel, OfferStatus } from 'apiClient/v1'
+import { ALL_VENUES, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { SearchFiltersParams } from 'core/Offers/types'
+import { computeOffersUrl } from 'core/Offers/utils'
+import { Audience } from 'core/shared'
+import {
+  defaultGetOffererResponseModel,
+  listOffersOfferFactory,
+  venueListItemFactory,
+} from 'utils/individualApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { OffersRoute } from '../../../pages/Offers/OffersRoute'
+
+const categoriesAndSubcategories = {
+  categories: [
+    { id: 'CINEMA', proLabel: 'Cinéma', isSelectable: true },
+    { id: 'JEU', proLabel: 'Jeux', isSelectable: true },
+    { id: 'TECHNIQUE', proLabel: 'Technique', isSelectable: false },
+  ],
+  subcategories: [],
+}
+
+const proVenues = [
+  venueListItemFactory({
+    id: 1,
+    name: 'Ma venue',
+    offererName: 'Mon offerer',
+    publicName: undefined,
+    isVirtual: false,
+  }),
+  venueListItemFactory({
+    id: 2,
+    name: 'Ma venue virtuelle',
+    offererName: 'Mon offerer',
+    isVirtual: true,
+  }),
+]
+
+const renderOffers = async (
+  filters: Partial<SearchFiltersParams> & {
+    page?: number
+    audience?: Audience
+  } = DEFAULT_SEARCH_FILTERS
+) => {
+  const route = computeOffersUrl(filters)
+  const currentUser = {
+    id: 'EY',
+    isAdmin: true,
+    name: 'Admin User',
+  }
+  const store = {
+    user: {
+      initialized: true,
+      currentUser,
+    },
+  }
+  renderWithProviders(
+    <Routes>
+      <Route path="/offres" element={<OffersRoute />} />
+      <Route
+        path="/offres/collectives"
+        element={<div>Offres collectives</div>}
+      />
+    </Routes>,
+    {
+      storeOverrides: store,
+      initialRouterEntries: [route],
+    }
+  )
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+}
+
+describe('route Offers when user is admin', () => {
+  let offersRecap: ListOffersOfferResponseModel[]
+
+  beforeEach(() => {
+    offersRecap = [listOffersOfferFactory({ venue: proVenues[0] })]
+    vi.spyOn(api, 'listOffers').mockResolvedValue(offersRecap)
+    vi.spyOn(api, 'getCategories').mockResolvedValueOnce(
+      categoriesAndSubcategories
+    )
+    vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
+      offerersNames: [],
+    })
+    vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: proVenues })
+  })
+
+  // status filter can only be used with an offerer or a venue filter for performance reasons
+  it('should reset and disable status filter when venue filter is deselected', async () => {
+    const { id: venueId, name: venueName } = proVenues[0]
+    const filters = {
+      venueId: venueId.toString(),
+      status: OfferStatus.INACTIVE,
+    }
+    await renderOffers(filters)
+
+    await userEvent.selectOptions(
+      screen.getByDisplayValue(venueName),
+      ALL_VENUES
+    )
+
+    await userEvent.click(screen.getByText('Rechercher'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Statut Afficher ou masquer le filtre par statut',
+      })
+    ).toBeDisabled()
+    expect(api.listOffers).toHaveBeenLastCalledWith(
+      undefined,
+      undefined,
+      OfferStatus.INACTIVE,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
+  })
+
+  it('should not reset or disable status filter when venue filter is deselected while offerer filter is applied', async () => {
+    const { id: venueId, name: venueName } = proVenues[0]
+    const filters = {
+      venueId: venueId.toString(),
+      status: OfferStatus.INACTIVE,
+      offererId: 'EF',
+    }
+    await renderOffers(filters)
+    await userEvent.selectOptions(
+      screen.getByDisplayValue(venueName),
+      ALL_VENUES
+    )
+
+    await userEvent.click(screen.getByText('Rechercher'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+    expect(
+      screen.getByRole('button', {
+        name: /Afficher ou masquer le filtre par statut/,
+      })
+    ).not.toBeDisabled()
+    expect(api.listOffers).toHaveBeenLastCalledWith(
+      undefined,
+      'EF',
+      'INACTIVE',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
+  })
+
+  it('should reset and disable status filter when offerer filter is removed', async () => {
+    const offerer = {
+      ...defaultGetOffererResponseModel,
+      name: 'La structure',
+      id: 25,
+    }
+
+    vi.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
+    const filters = {
+      offererId: offerer.id.toString(),
+      status: OfferStatus.INACTIVE,
+    }
+    await renderOffers(filters)
+
+    await userEvent.click(screen.getByTestId('remove-offerer-filter'))
+
+    await waitFor(() => {
+      expect(api.listOffers).toHaveBeenLastCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
+    expect(
+      screen.getByRole('button', {
+        name: 'Statut Afficher ou masquer le filtre par statut',
+      })
+    ).toBeDisabled()
+  })
+
+  it('should not reset or disable status filter when offerer filter is removed while venue filter is applied', async () => {
+    const { id: venueId } = proVenues[0]
+    const offerer = {
+      ...defaultGetOffererResponseModel,
+      name: 'La structure',
+      id: 65,
+    }
+
+    vi.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
+    const filters = {
+      venueId: venueId.toString(),
+      status: OfferStatus.INACTIVE,
+      offererId: offerer.id.toString(),
+    }
+    await renderOffers(filters)
+
+    await userEvent.click(screen.getByTestId('remove-offerer-filter'))
+    await waitFor(() => {
+      expect(api.listOffers).toHaveBeenLastCalledWith(
+        undefined,
+        undefined,
+        'INACTIVE',
+        venueId.toString(),
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
+    expect(
+      screen.getByRole('button', {
+        name: /Afficher ou masquer le filtre par statut/,
+      })
+    ).not.toBeDisabled()
+  })
+
+  it('should enable status filters when venue filter is applied', async () => {
+    const filters = { venueId: 'IJ' }
+
+    await renderOffers(filters)
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Statut Afficher ou masquer le filtre par statut',
+      })
+    ).not.toBeDisabled()
+  })
+
+  it('should enable status filters when offerer filter is applied', async () => {
+    const filters = { offererId: 'A4' }
+
+    await renderOffers(filters)
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Statut Afficher ou masquer le filtre par statut',
+      })
+    ).not.toBeDisabled()
+  })
+})

--- a/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
@@ -111,23 +111,24 @@ describe('route Offers when user is admin', () => {
     )
 
     await userEvent.click(screen.getByText('Rechercher'))
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
+    await waitFor(() => {
+      expect(api.listOffers).toHaveBeenLastCalledWith(
+        undefined,
+        undefined,
+        OfferStatus.INACTIVE,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
     expect(
       screen.getByRole('button', {
         name: 'Statut Afficher ou masquer le filtre par statut',
       })
     ).toBeDisabled()
-    expect(api.listOffers).toHaveBeenLastCalledWith(
-      undefined,
-      undefined,
-      OfferStatus.INACTIVE,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined
-    )
   })
 
   it('should not reset or disable status filter when venue filter is deselected while offerer filter is applied', async () => {
@@ -144,23 +145,24 @@ describe('route Offers when user is admin', () => {
     )
 
     await userEvent.click(screen.getByText('Rechercher'))
-    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
+    await waitFor(() => {
+      expect(api.listOffers).toHaveBeenLastCalledWith(
+        undefined,
+        'EF',
+        'INACTIVE',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
     expect(
       screen.getByRole('button', {
         name: /Afficher ou masquer le filtre par statut/,
       })
     ).not.toBeDisabled()
-    expect(api.listOffers).toHaveBeenLastCalledWith(
-      undefined,
-      'EF',
-      'INACTIVE',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined
-    )
   })
 
   it('should reset and disable status filter when offerer filter is removed', async () => {

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -319,25 +319,24 @@ describe('route Offers', () => {
             await renderOffers(store, filters)
 
             await userEvent.click(screen.getByTestId('remove-offerer-filter'))
-            await waitForElementToBeRemoved(() =>
-              screen.queryByTestId('spinner')
-            )
 
+            await waitFor(() => {
+              expect(api.listOffers).toHaveBeenLastCalledWith(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+              )
+            })
             expect(
               screen.getByRole('button', {
                 name: 'Statut Afficher ou masquer le filtre par statut',
               })
             ).toBeDisabled()
-            expect(api.listOffers).toHaveBeenLastCalledWith(
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined
-            )
           })
 
           it('should not reset or disable status filter when offerer filter is removed while venue filter is applied', async () => {
@@ -357,25 +356,23 @@ describe('route Offers', () => {
             await renderOffers(store, filters)
 
             await userEvent.click(screen.getByTestId('remove-offerer-filter'))
-            await waitForElementToBeRemoved(() =>
-              screen.queryByTestId('spinner')
-            )
-
+            await waitFor(() => {
+              expect(api.listOffers).toHaveBeenLastCalledWith(
+                undefined,
+                undefined,
+                'INACTIVE',
+                venueId.toString(),
+                undefined,
+                undefined,
+                undefined,
+                undefined
+              )
+            })
             expect(
               screen.getByRole('button', {
                 name: /Afficher ou masquer le filtre par statut/,
               })
             ).not.toBeDisabled()
-            expect(api.listOffers).toHaveBeenLastCalledWith(
-              undefined,
-              undefined,
-              'INACTIVE',
-              venueId.toString(),
-              undefined,
-              undefined,
-              undefined,
-              undefined
-            )
           })
 
           it('should enable status filters when venue filter is applied', async () => {
@@ -680,17 +677,18 @@ describe('route Offers', () => {
       await userEvent.click(screen.getByLabelText('Épuisée'))
       await userEvent.click(screen.getByText('Appliquer'))
 
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-      expect(api.listOffers).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        'SOLD_OUT',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledWith(
+          undefined,
+          undefined,
+          'SOLD_OUT',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        )
+      })
     })
 
     it('should have status value be removed when user ask for all status', async () => {
@@ -895,25 +893,27 @@ describe('route Offers', () => {
       await userEvent.selectOptions(venueSelect, firstVenueOption)
       await userEvent.click(screen.getByText('Rechercher'))
 
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-      expect(api.listOffers).toHaveBeenNthCalledWith(
-        2,
-        undefined,
-        undefined,
-        undefined,
-        proVenues[0].id.toString(),
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenNthCalledWith(
+          2,
+          undefined,
+          undefined,
+          undefined,
+          proVenues[0].id.toString(),
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        )
+      })
 
       screen.getByText('Aucune offre trouvée pour votre recherche')
 
       await userEvent.click(screen.getByText('Afficher toutes les offres'))
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-      expect(api.listOffers).toHaveBeenCalledTimes(3)
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledTimes(3)
+      })
       expect(api.listOffers).toHaveBeenNthCalledWith(
         3,
         undefined,

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -11,7 +11,6 @@ import { ListOffersOfferResponseModel, OfferStatus } from 'apiClient/v1'
 import {
   ALL_CATEGORIES_OPTION,
   ALL_CREATION_MODES,
-  ALL_VENUES,
   ALL_VENUES_OPTION,
   CREATION_MODES_OPTIONS,
   DEFAULT_SEARCH_FILTERS,
@@ -54,13 +53,23 @@ const proVenues = [
 ]
 
 const renderOffers = async (
-  storeOverrides: any,
   filters: Partial<SearchFiltersParams> & {
     page?: number
     audience?: Audience
   } = DEFAULT_SEARCH_FILTERS
 ) => {
   const route = computeOffersUrl(filters)
+  const currentUser = {
+    id: 'EY',
+    isAdmin: false,
+    name: 'Current User',
+  }
+  const store = {
+    user: {
+      initialized: true,
+      currentUser,
+    },
+  }
   renderWithProviders(
     <Routes>
       <Route path="/offres" element={<OffersRoute />} />
@@ -70,7 +79,7 @@ const renderOffers = async (
       />
     </Routes>,
     {
-      storeOverrides,
+      storeOverrides: store,
       initialRouterEntries: [route],
     }
   )
@@ -78,36 +87,10 @@ const renderOffers = async (
   await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 }
 
-vi.mock('repository/venuesService', async () => ({
-  ...(await vi.importActual('repository/venuesService')),
-}))
-
-vi.mock('utils/date', async () => ({
-  ...(await vi.importActual('utils/date')),
-  getToday: vi.fn(() => new Date('2020-12-15T12:00:00Z')),
-}))
-
 describe('route Offers', () => {
-  let currentUser: {
-    id: string
-    isAdmin: boolean
-    name: string
-  }
-  let store: any
   let offersRecap: ListOffersOfferResponseModel[]
 
   beforeEach(() => {
-    currentUser = {
-      id: 'EY',
-      isAdmin: false,
-      name: 'Current User',
-    }
-    store = {
-      user: {
-        initialized: true,
-        currentUser,
-      },
-    }
     offersRecap = [listOffersOfferFactory({ venue: proVenues[0] })]
     vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offersRecap)
     vi.spyOn(api, 'getCategories').mockResolvedValueOnce(
@@ -119,305 +102,40 @@ describe('route Offers', () => {
     vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: proVenues })
   })
 
-  describe('render', () => {
-    describe('filters', () => {
-      it('should display only selectable categories on filters', async () => {
-        await renderOffers(store)
+  describe('filters', () => {
+    it('should display only selectable categories on filters', async () => {
+      await renderOffers()
 
-        expect(
-          screen.getByRole('option', { name: 'Cinéma' })
-        ).toBeInTheDocument()
-        expect(screen.getByRole('option', { name: 'Jeux' })).toBeInTheDocument()
-        expect(
-          screen.queryByRole('option', { name: 'Technique' })
-        ).not.toBeInTheDocument()
-      })
+      expect(screen.getByRole('option', { name: 'Cinéma' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Jeux' })).toBeInTheDocument()
+      expect(
+        screen.queryByRole('option', { name: 'Technique' })
+      ).not.toBeInTheDocument()
+    })
 
-      describe('status filters', () => {
-        it('should filter offers given status filter when clicking on "Appliquer"', async () => {
-          await renderOffers(store)
+    describe('status filters', () => {
+      it('should filter offers given status filter when clicking on "Appliquer"', async () => {
+        await renderOffers()
 
-          const statusFiltersButton = screen.getByRole('button', {
-            name: /Afficher ou masquer le filtre par statut/,
-          })
-          expect(statusFiltersButton).toHaveAttribute(
-            'aria-controls',
-            'offer-status-filters-modal'
-          )
-          expect(statusFiltersButton).toHaveAttribute('aria-expanded', 'false')
-          await userEvent.click(statusFiltersButton)
-          expect(statusFiltersButton).toHaveAttribute('aria-expanded', 'true')
-
-          await userEvent.click(screen.getByLabelText('Expirée'))
-          await userEvent.click(screen.getByText('Appliquer'))
-
-          await waitFor(() => {
-            expect(api.listOffers).toHaveBeenLastCalledWith(
-              undefined,
-              undefined,
-              'EXPIRED',
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined
-            )
-          })
+        const statusFiltersButton = screen.getByRole('button', {
+          name: /Afficher ou masquer le filtre par statut/,
         })
+        expect(statusFiltersButton).toHaveAttribute(
+          'aria-controls',
+          'offer-status-filters-modal'
+        )
+        expect(statusFiltersButton).toHaveAttribute('aria-expanded', 'false')
+        await userEvent.click(statusFiltersButton)
+        expect(statusFiltersButton).toHaveAttribute('aria-expanded', 'true')
 
-        it('should filter draft offers given status filter when clicking on "Appliquer"', async () => {
-          await renderOffers(store)
+        await userEvent.click(screen.getByLabelText('Expirée'))
+        await userEvent.click(screen.getByText('Appliquer'))
 
-          await userEvent.click(
-            screen.getByRole('button', {
-              name: 'Statut Afficher ou masquer le filtre par statut',
-            })
-          )
-          await userEvent.click(screen.getByLabelText('Brouillon'))
-
-          await userEvent.click(screen.getByText('Appliquer'))
-
-          await waitFor(() => {
-            expect(api.listOffers).toHaveBeenLastCalledWith(
-              undefined,
-              undefined,
-              'DRAFT',
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined
-            )
-          })
-        })
-
-        it('should indicate that no offers match selected filters', async () => {
-          vi.spyOn(api, 'listOffers')
-            .mockResolvedValueOnce(offersRecap)
-            .mockResolvedValueOnce([])
-          await renderOffers(store)
-
-          await userEvent.click(
-            screen.getByRole('button', {
-              name: 'Statut Afficher ou masquer le filtre par statut',
-            })
-          )
-          await userEvent.click(screen.getByLabelText('Expirée'))
-          await userEvent.click(screen.getByText('Appliquer'))
-          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-          const noOffersForSearchFiltersText = screen.getByText(
-            'Aucune offre trouvée pour votre recherche'
-          )
-          expect(noOffersForSearchFiltersText).toBeInTheDocument()
-        })
-
-        it('should not display column titles when no offers are returned', async () => {
-          vi.spyOn(api, 'listOffers').mockResolvedValueOnce([])
-
-          await renderOffers(store)
-
-          expect(screen.queryByText('Lieu', { selector: 'th' })).toBeNull()
-          expect(screen.queryByText('Stock', { selector: 'th' })).toBeNull()
-        })
-      })
-
-      describe('when user is admin', () => {
-        beforeEach(() => {
-          vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offersRecap)
-          store = {
-            user: {
-              initialized: true,
-              currentUser: { ...currentUser, isAdmin: true },
-            },
-          }
-        })
-
-        describe('status filter can only be used with an offerer or a venue filter for performance reasons', () => {
-          it('should reset and disable status filter when venue filter is deselected', async () => {
-            const { id: venueId, name: venueName } = proVenues[0]
-            const filters = {
-              venueId: venueId.toString(),
-              status: OfferStatus.INACTIVE,
-            }
-            await renderOffers(store, filters)
-
-            await userEvent.selectOptions(
-              screen.getByDisplayValue(venueName),
-              ALL_VENUES
-            )
-
-            await userEvent.click(screen.getByText('Rechercher'))
-            await waitForElementToBeRemoved(() =>
-              screen.queryByTestId('spinner')
-            )
-
-            expect(
-              screen.getByRole('button', {
-                name: 'Statut Afficher ou masquer le filtre par statut',
-              })
-            ).toBeDisabled()
-            expect(api.listOffers).toHaveBeenLastCalledWith(
-              undefined,
-              undefined,
-              OfferStatus.INACTIVE,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined
-            )
-          })
-
-          it('should not reset or disable status filter when venue filter is deselected while offerer filter is applied', async () => {
-            const { id: venueId, name: venueName } = proVenues[0]
-            const filters = {
-              venueId: venueId.toString(),
-              status: OfferStatus.INACTIVE,
-              offererId: 'EF',
-            }
-            await renderOffers(store, filters)
-            await userEvent.selectOptions(
-              screen.getByDisplayValue(venueName),
-              ALL_VENUES
-            )
-
-            await userEvent.click(screen.getByText('Rechercher'))
-            await waitForElementToBeRemoved(() =>
-              screen.queryByTestId('spinner')
-            )
-
-            expect(
-              screen.getByRole('button', {
-                name: /Afficher ou masquer le filtre par statut/,
-              })
-            ).not.toBeDisabled()
-            expect(api.listOffers).toHaveBeenLastCalledWith(
-              undefined,
-              'EF',
-              'INACTIVE',
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              undefined
-            )
-          })
-
-          it('should reset and disable status filter when offerer filter is removed', async () => {
-            const offerer = {
-              ...defaultGetOffererResponseModel,
-              name: 'La structure',
-              id: 25,
-            }
-
-            vi.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
-            const filters = {
-              offererId: offerer.id.toString(),
-              status: OfferStatus.INACTIVE,
-            }
-            await renderOffers(store, filters)
-
-            await userEvent.click(screen.getByTestId('remove-offerer-filter'))
-
-            await waitFor(() => {
-              expect(api.listOffers).toHaveBeenLastCalledWith(
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-              )
-            })
-            expect(
-              screen.getByRole('button', {
-                name: 'Statut Afficher ou masquer le filtre par statut',
-              })
-            ).toBeDisabled()
-          })
-
-          it('should not reset or disable status filter when offerer filter is removed while venue filter is applied', async () => {
-            const { id: venueId } = proVenues[0]
-            const offerer = {
-              ...defaultGetOffererResponseModel,
-              name: 'La structure',
-              id: 65,
-            }
-
-            vi.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
-            const filters = {
-              venueId: venueId.toString(),
-              status: OfferStatus.INACTIVE,
-              offererId: offerer.id.toString(),
-            }
-            await renderOffers(store, filters)
-
-            await userEvent.click(screen.getByTestId('remove-offerer-filter'))
-            await waitFor(() => {
-              expect(api.listOffers).toHaveBeenLastCalledWith(
-                undefined,
-                undefined,
-                'INACTIVE',
-                venueId.toString(),
-                undefined,
-                undefined,
-                undefined,
-                undefined
-              )
-            })
-            expect(
-              screen.getByRole('button', {
-                name: /Afficher ou masquer le filtre par statut/,
-              })
-            ).not.toBeDisabled()
-          })
-
-          it('should enable status filters when venue filter is applied', async () => {
-            const filters = { venueId: 'IJ' }
-
-            await renderOffers(store, filters)
-
-            expect(
-              screen.getByRole('button', {
-                name: 'Statut Afficher ou masquer le filtre par statut',
-              })
-            ).not.toBeDisabled()
-          })
-
-          it('should enable status filters when offerer filter is applied', async () => {
-            const filters = { offererId: 'A4' }
-
-            await renderOffers(store, filters)
-
-            expect(
-              screen.getByRole('button', {
-                name: 'Statut Afficher ou masquer le filtre par statut',
-              })
-            ).not.toBeDisabled()
-          })
-        })
-      })
-
-      describe('on click on search button', () => {
-        it('should load offers with written offer name filter', async () => {
-          await renderOffers(store)
-          await userEvent.type(
-            screen.getByPlaceholderText(
-              'Rechercher par nom d’offre ou par EAN-13'
-            ),
-            'Any word'
-          )
-
-          await userEvent.click(screen.getByText('Rechercher'))
-
-          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-          expect(api.listOffers).toHaveBeenCalledWith(
-            'Any word',
+        await waitFor(() => {
+          expect(api.listOffers).toHaveBeenLastCalledWith(
             undefined,
             undefined,
+            'EXPIRED',
             undefined,
             undefined,
             undefined,
@@ -425,124 +143,204 @@ describe('route Offers', () => {
             undefined
           )
         })
+      })
 
-        it('should load offers with selected venue filter', async () => {
-          await renderOffers(store)
-          const firstVenueOption = screen.getByRole('option', {
-            name: proVenues[0].name,
+      it('should filter draft offers given status filter when clicking on "Appliquer"', async () => {
+        await renderOffers()
+
+        await userEvent.click(
+          screen.getByRole('button', {
+            name: 'Statut Afficher ou masquer le filtre par statut',
           })
-          const venueSelect = screen.getByLabelText('Lieu')
-          await userEvent.selectOptions(venueSelect, firstVenueOption)
+        )
+        await userEvent.click(screen.getByLabelText('Brouillon'))
 
-          await userEvent.click(screen.getByText('Rechercher'))
+        await userEvent.click(screen.getByText('Appliquer'))
 
-          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-          expect(api.listOffers).toHaveBeenCalledWith(
+        await waitFor(() => {
+          expect(api.listOffers).toHaveBeenLastCalledWith(
             undefined,
             undefined,
+            'DRAFT',
             undefined,
-            proVenues[0].id.toString(),
             undefined,
             undefined,
             undefined,
             undefined
           )
         })
+      })
 
-        it('should load offers with selected type filter', async () => {
-          await renderOffers(store)
-          const firstTypeOption = screen.getByRole('option', {
-            name: 'Cinéma',
+      it('should indicate that no offers match selected filters', async () => {
+        vi.spyOn(api, 'listOffers')
+          .mockResolvedValueOnce(offersRecap)
+          .mockResolvedValueOnce([])
+        await renderOffers()
+
+        await userEvent.click(
+          screen.getByRole('button', {
+            name: 'Statut Afficher ou masquer le filtre par statut',
           })
-          const typeSelect = screen.getByDisplayValue(
-            ALL_CATEGORIES_OPTION.label
-          )
-          await userEvent.selectOptions(typeSelect, firstTypeOption)
+        )
+        await userEvent.click(screen.getByLabelText('Expirée'))
+        await userEvent.click(screen.getByText('Appliquer'))
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          await userEvent.click(screen.getByText('Rechercher'))
+        const noOffersForSearchFiltersText = screen.getByText(
+          'Aucune offre trouvée pour votre recherche'
+        )
+        expect(noOffersForSearchFiltersText).toBeInTheDocument()
+      })
 
-          await waitFor(() => {
-            expect(api.listOffers).toHaveBeenLastCalledWith(
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              'CINEMA',
-              undefined,
-              undefined,
-              undefined
-            )
-          })
+      it('should not display column titles when no offers are returned', async () => {
+        vi.spyOn(api, 'listOffers').mockResolvedValueOnce([])
+
+        await renderOffers()
+
+        expect(screen.queryByText('Lieu', { selector: 'th' })).toBeNull()
+        expect(screen.queryByText('Stock', { selector: 'th' })).toBeNull()
+      })
+    })
+
+    describe('on click on search button', () => {
+      it('should load offers with written offer name filter', async () => {
+        await renderOffers()
+        await userEvent.type(
+          screen.getByPlaceholderText(
+            'Rechercher par nom d’offre ou par EAN-13'
+          ),
+          'Any word'
+        )
+
+        await userEvent.click(screen.getByText('Rechercher'))
+
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+        expect(api.listOffers).toHaveBeenCalledWith(
+          'Any word',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        )
+      })
+
+      it('should load offers with selected venue filter', async () => {
+        await renderOffers()
+        const firstVenueOption = screen.getByRole('option', {
+          name: proVenues[0].name,
         })
+        const venueSelect = screen.getByLabelText('Lieu')
+        await userEvent.selectOptions(venueSelect, firstVenueOption)
 
-        it('should load offers with selected creation mode filter', async () => {
-          await renderOffers(store)
-          const creationModeSelect = screen.getByDisplayValue('Tous')
-          const importedCreationMode = CREATION_MODES_OPTIONS[2].value
-          await userEvent.selectOptions(
-            creationModeSelect,
-            String(importedCreationMode)
-          )
+        await userEvent.click(screen.getByText('Rechercher'))
 
-          await userEvent.click(screen.getByText('Rechercher'))
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+        expect(api.listOffers).toHaveBeenCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          proVenues[0].id.toString(),
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        )
+      })
 
-          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+      it('should load offers with selected type filter', async () => {
+        await renderOffers()
+        const firstTypeOption = screen.getByRole('option', {
+          name: 'Cinéma',
+        })
+        const typeSelect = screen.getByDisplayValue(ALL_CATEGORIES_OPTION.label)
+        await userEvent.selectOptions(typeSelect, firstTypeOption)
+
+        await userEvent.click(screen.getByText('Rechercher'))
+
+        await waitFor(() => {
           expect(api.listOffers).toHaveBeenLastCalledWith(
             undefined,
             undefined,
             undefined,
             undefined,
+            'CINEMA',
             undefined,
-            'imported',
             undefined,
             undefined
           )
         })
+      })
 
-        it('should load offers with selected period beginning date', async () => {
-          await renderOffers(store)
+      it('should load offers with selected creation mode filter', async () => {
+        await renderOffers()
+        const creationModeSelect = screen.getByDisplayValue('Tous')
+        const importedCreationMode = CREATION_MODES_OPTIONS[2].value
+        await userEvent.selectOptions(
+          creationModeSelect,
+          String(importedCreationMode)
+        )
 
-          await userEvent.type(
-            screen.getByLabelText('Début de la période'),
-            '2020-12-25'
-          )
+        await userEvent.click(screen.getByText('Rechercher'))
 
-          await userEvent.click(screen.getByText('Rechercher'))
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+        expect(api.listOffers).toHaveBeenLastCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'imported',
+          undefined,
+          undefined
+        )
+      })
 
-          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-          expect(api.listOffers).toHaveBeenLastCalledWith(
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            '2020-12-25',
-            undefined
-          )
-        })
+      it('should load offers with selected period beginning date', async () => {
+        await renderOffers()
 
-        it('should load offers with selected period ending date', async () => {
-          await renderOffers(store)
+        await userEvent.type(
+          screen.getByLabelText('Début de la période'),
+          '2020-12-25'
+        )
 
-          await userEvent.type(
-            screen.getByLabelText('Fin de la période'),
-            '2020-12-27'
-          )
-          await userEvent.click(screen.getByText('Rechercher'))
+        await userEvent.click(screen.getByText('Rechercher'))
 
-          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-          expect(api.listOffers).toHaveBeenLastCalledWith(
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            '2020-12-27'
-          )
-        })
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+        expect(api.listOffers).toHaveBeenLastCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          '2020-12-25',
+          undefined
+        )
+      })
+
+      it('should load offers with selected period ending date', async () => {
+        await renderOffers()
+
+        await userEvent.type(
+          screen.getByLabelText('Fin de la période'),
+          '2020-12-27'
+        )
+        await userEvent.click(screen.getByText('Rechercher'))
+
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+        expect(api.listOffers).toHaveBeenLastCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          '2020-12-27'
+        )
       })
     })
   })
@@ -553,7 +351,7 @@ describe('route Offers', () => {
         listOffersOfferFactory()
       )
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offersRecap)
-      await renderOffers(store)
+      await renderOffers()
       const nextPageIcon = screen.getByRole('button', { name: 'Page suivante' })
 
       await userEvent.click(nextPageIcon)
@@ -562,7 +360,7 @@ describe('route Offers', () => {
     })
 
     it('should store search value', async () => {
-      await renderOffers(store)
+      await renderOffers()
       const searchInput = screen.getByPlaceholderText(
         'Rechercher par nom d’offre ou par EAN-13'
       )
@@ -584,7 +382,7 @@ describe('route Offers', () => {
     })
 
     it('should have offer name value be removed when name search value is an empty string', async () => {
-      await renderOffers(store)
+      await renderOffers()
 
       await userEvent.clear(
         screen.getByPlaceholderText('Rechercher par nom d’offre ou par EAN-13')
@@ -604,7 +402,7 @@ describe('route Offers', () => {
     })
 
     it('should have venue value when user filters by venue', async () => {
-      await renderOffers(store)
+      await renderOffers()
       const firstVenueOption = screen.getByRole('option', {
         name: proVenues[0].name,
       })
@@ -638,7 +436,7 @@ describe('route Offers', () => {
         ],
         subcategories: [],
       })
-      await renderOffers(store)
+      await renderOffers()
       const firstTypeOption = screen.getByRole('option', {
         name: 'My test value',
       })
@@ -668,7 +466,7 @@ describe('route Offers', () => {
         }),
       ])
 
-      await renderOffers(store)
+      await renderOffers()
       await userEvent.click(
         screen.getByRole('button', {
           name: 'Statut Afficher ou masquer le filtre par statut',
@@ -698,7 +496,7 @@ describe('route Offers', () => {
           stocks: [],
         }),
       ])
-      await renderOffers(store)
+      await renderOffers()
       await userEvent.click(
         screen.getByRole('button', {
           name: 'Statut Afficher ou masquer le filtre par statut',
@@ -729,7 +527,7 @@ describe('route Offers', () => {
       })
       const filters = { offererId: id.toString() }
 
-      await renderOffers(store, filters)
+      await renderOffers(filters)
 
       const offererFilter = screen.getByText('La structure')
       expect(offererFilter).toBeInTheDocument()
@@ -743,7 +541,7 @@ describe('route Offers', () => {
         id,
       })
       const filters = { offererId: id.toString() }
-      await renderOffers(store, filters)
+      await renderOffers(filters)
 
       await userEvent.click(screen.getByTestId('remove-offerer-filter'))
 
@@ -751,7 +549,7 @@ describe('route Offers', () => {
     })
 
     it('should have creation mode value when user filters by creation mode', async () => {
-      await renderOffers(store)
+      await renderOffers()
 
       await userEvent.selectOptions(screen.getByDisplayValue('Tous'), 'manual')
       await userEvent.click(screen.getByText('Rechercher'))
@@ -770,7 +568,7 @@ describe('route Offers', () => {
     })
 
     it('should have creation mode value be removed when user ask for all creation modes', async () => {
-      await renderOffers(store)
+      await renderOffers()
       const searchButton = screen.getByText('Rechercher')
       await userEvent.selectOptions(screen.getByDisplayValue('Tous'), 'manual')
       await userEvent.click(searchButton)
@@ -798,7 +596,7 @@ describe('route Offers', () => {
   describe('page navigation', () => {
     it('should redirect to collective offers when user click on collective offer link', async () => {
       vi.spyOn(api, 'listOffers').mockResolvedValue(offersRecap)
-      await renderOffers(store)
+      await renderOffers()
       screen.getByText('Rechercher')
       const collectiveAudienceLink = screen.getByText('Offres collectives', {
         selector: 'span',
@@ -812,7 +610,7 @@ describe('route Offers', () => {
     it('should display next page when clicking on right arrow', async () => {
       const offers = Array.from({ length: 11 }, () => listOffersOfferFactory())
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offers)
-      await renderOffers(store)
+      await renderOffers()
       const nextIcon = screen.getByRole('button', { name: 'Page suivante' })
 
       await userEvent.click(nextIcon)
@@ -825,7 +623,7 @@ describe('route Offers', () => {
       const offers = Array.from({ length: 11 }, () => listOffersOfferFactory())
 
       vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offers)
-      await renderOffers(store)
+      await renderOffers()
       const nextIcon = screen.getByRole('button', { name: 'Page suivante' })
       const previousIcon = screen.getByRole('button', {
         name: 'Page précédente',
@@ -848,14 +646,14 @@ describe('route Offers', () => {
       it('should have max number page of 50', async () => {
         vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offersRecap)
 
-        await renderOffers(store)
+        await renderOffers()
 
         expect(screen.getByText('Page 1/50')).toBeInTheDocument()
       })
 
       it('should not display the 501st offer', async () => {
         vi.spyOn(api, 'listOffers').mockResolvedValueOnce(offersRecap)
-        await renderOffers(store)
+        await renderOffers()
         const nextIcon = screen.getByRole('button', { name: 'Page suivante' })
 
         for (let i = 1; i < 51; i++) {
@@ -882,7 +680,7 @@ describe('route Offers', () => {
         venueId: '666',
       }
 
-      await renderOffers(store, filters)
+      await renderOffers(filters)
 
       const firstVenueOption = screen.getByRole('option', {
         name: proVenues[0].name,
@@ -936,7 +734,7 @@ describe('route Offers', () => {
       const filters = {
         venueId: '666',
       }
-      await renderOffers(store, filters)
+      await renderOffers(filters)
 
       const venueOptionToSelect = screen.getByRole('option', {
         name: proVenues[0].name,

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -184,12 +184,12 @@ describe('route Offers', () => {
         )
         await userEvent.click(screen.getByLabelText('Expirée'))
         await userEvent.click(screen.getByText('Appliquer'))
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-        const noOffersForSearchFiltersText = screen.getByText(
-          'Aucune offre trouvée pour votre recherche'
-        )
-        expect(noOffersForSearchFiltersText).toBeInTheDocument()
+        await waitFor(() => {
+          expect(
+            screen.getByText('Aucune offre trouvée pour votre recherche')
+          ).toBeInTheDocument()
+        })
       })
 
       it('should not display column titles when no offers are returned', async () => {
@@ -214,17 +214,18 @@ describe('route Offers', () => {
 
         await userEvent.click(screen.getByText('Rechercher'))
 
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-        expect(api.listOffers).toHaveBeenCalledWith(
-          'Any word',
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.listOffers).toHaveBeenCalledWith(
+            'Any word',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined
+          )
+        })
       })
 
       it('should load offers with selected venue filter', async () => {
@@ -237,17 +238,18 @@ describe('route Offers', () => {
 
         await userEvent.click(screen.getByText('Rechercher'))
 
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-        expect(api.listOffers).toHaveBeenCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          proVenues[0].id.toString(),
-          undefined,
-          undefined,
-          undefined,
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.listOffers).toHaveBeenCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            proVenues[0].id.toString(),
+            undefined,
+            undefined,
+            undefined,
+            undefined
+          )
+        })
       })
 
       it('should load offers with selected type filter', async () => {
@@ -285,17 +287,18 @@ describe('route Offers', () => {
 
         await userEvent.click(screen.getByText('Rechercher'))
 
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-        expect(api.listOffers).toHaveBeenLastCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          'imported',
-          undefined,
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.listOffers).toHaveBeenLastCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'imported',
+            undefined,
+            undefined
+          )
+        })
       })
 
       it('should load offers with selected period beginning date', async () => {
@@ -308,17 +311,18 @@ describe('route Offers', () => {
 
         await userEvent.click(screen.getByText('Rechercher'))
 
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-        expect(api.listOffers).toHaveBeenLastCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          '2020-12-25',
-          undefined
-        )
+        await waitFor(() => {
+          expect(api.listOffers).toHaveBeenLastCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            '2020-12-25',
+            undefined
+          )
+        })
       })
 
       it('should load offers with selected period ending date', async () => {
@@ -330,17 +334,18 @@ describe('route Offers', () => {
         )
         await userEvent.click(screen.getByText('Rechercher'))
 
-        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-        expect(api.listOffers).toHaveBeenLastCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          '2020-12-27'
-        )
+        await waitFor(() => {
+          expect(api.listOffers).toHaveBeenLastCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            '2020-12-27'
+          )
+        })
       })
     })
   })
@@ -368,17 +373,18 @@ describe('route Offers', () => {
       await userEvent.type(searchInput, 'search string')
       await userEvent.click(screen.getByText('Rechercher'))
 
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-      expect(api.listOffers).toHaveBeenCalledWith(
-        'search string',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledWith(
+          'search string',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        )
+      })
     })
 
     it('should have offer name value be removed when name search value is an empty string', async () => {
@@ -388,17 +394,18 @@ describe('route Offers', () => {
         screen.getByPlaceholderText('Rechercher par nom d’offre ou par EAN-13')
       )
       await userEvent.click(screen.getByText('Rechercher'))
-
-      expect(api.listOffers).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        )
+      })
     })
 
     it('should have venue value when user filters by venue', async () => {
@@ -411,17 +418,18 @@ describe('route Offers', () => {
       await userEvent.selectOptions(venueSelect, firstVenueOption)
       await userEvent.click(screen.getByText('Rechercher'))
 
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-      expect(api.listOffers).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        proVenues[0].id.toString(),
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          proVenues[0].id.toString(),
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        )
+      })
     })
 
     it('should have venue value be removed when user asks for all venues', async () => {
@@ -445,17 +453,18 @@ describe('route Offers', () => {
       await userEvent.selectOptions(typeSelect, firstTypeOption)
       await userEvent.click(screen.getByText('Rechercher'))
 
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-      expect(api.listOffers).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'test_id_1',
-        undefined,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'test_id_1',
+          undefined,
+          undefined,
+          undefined
+        )
+      })
     })
 
     it('should have status value when user filters by status', async () => {
@@ -505,17 +514,18 @@ describe('route Offers', () => {
       await userEvent.click(screen.getByLabelText('Toutes'))
 
       await userEvent.click(screen.getByText('Appliquer'))
-
-      expect(api.listOffers).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        )
+      })
     })
 
     it('should have offerer filter when user filters by offerer', async () => {
@@ -554,17 +564,18 @@ describe('route Offers', () => {
       await userEvent.selectOptions(screen.getByDisplayValue('Tous'), 'manual')
       await userEvent.click(screen.getByText('Rechercher'))
 
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-      expect(api.listOffers).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'manual',
-        undefined,
-        undefined
-      )
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledWith(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'manual',
+          undefined,
+          undefined
+        )
+      })
     })
 
     it('should have creation mode value be removed when user ask for all creation modes', async () => {
@@ -745,8 +756,9 @@ describe('route Offers', () => {
       await userEvent.selectOptions(venueSelect, venueOptionToSelect)
       await userEvent.click(screen.getByText('Rechercher'))
 
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-      expect(api.listOffers).toHaveBeenCalledTimes(2)
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledTimes(2)
+      })
       expect(api.listOffers).toHaveBeenNthCalledWith(
         2,
         undefined,
@@ -760,9 +772,10 @@ describe('route Offers', () => {
       )
 
       await userEvent.click(screen.getByText('Réinitialiser les filtres'))
-      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-      expect(api.listOffers).toHaveBeenCalledTimes(3)
+      await waitFor(() => {
+        expect(api.listOffers).toHaveBeenCalledTimes(3)
+      })
       expect(api.listOffers).toHaveBeenNthCalledWith(
         3,
         undefined,


### PR DESCRIPTION
## But de la pull request

BSR

bon j'ai pas trop trouvé la raison donc : 


- split des tests pour isoler les tests admin
- comme ça semble plus concerner les waitForElementToBeRemoved je les ai remplécé par des waitFor

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques