### PR TITLE
(PC-28494)[API/PRO] feat: Submit users new nav reviews

### DIFF
--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.sql.functions import func
 
 import pcapi.core.offerers.models as offerers_models
+from pcapi.models import db
 from pcapi.utils import crypto
 import pcapi.utils.email as email_utils
 
@@ -149,3 +150,13 @@ def get_single_sign_on(sso_provider: str, sso_user_id: str) -> models.SingleSign
 
 def create_single_sign_on(user: models.User, sso_provider: str, sso_user_id: str) -> models.SingleSignOn:
     return models.SingleSignOn(user=user, ssoProvider=sso_provider, ssoUserId=sso_user_id)
+
+
+def user_has_new_nav_activated(user: models.User) -> bool:
+    return db.session.query(
+        sa.select(1)
+        .select_from(models.User)
+        .join(models.User.pro_new_nav_state)
+        .filter(models.UserProNewNavState.newNavDate.is_not(None))
+        .exists()
+    ).scalar()

--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -212,3 +212,11 @@ class ChangePasswordBodyModel(BaseModel):
 
 class ProFlagsQueryModel(BaseModel):
     firebase: dict
+
+
+class SubmitReviewRequestModel(BaseModel):
+    isPleasant: bool
+    isConvenient: bool
+    comment: str
+    offererId: int
+    location: str

--- a/api/tests/routes/pro/post_user_new_pro_nav_test.py
+++ b/api/tests/routes/pro/post_user_new_pro_nav_test.py
@@ -1,8 +1,10 @@
 import datetime
+import logging
 from typing import Any
 
 import pytest
 
+from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.users import factories as users_factories
 
 
@@ -33,3 +35,78 @@ class PostUserNewProNavTest:
 
         assert response.status_code == 400
         assert not pro_new_nav_state.newNavDate
+
+    def test_user_can_successfully_submit_side_nav_review(self, client, caplog):
+        pro_new_nav_state = users_factories.UserProNewNavStateFactory(
+            eligibilityDate=None, newNavDate=datetime.datetime.utcnow()
+        )
+        user = pro_new_nav_state.user
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=user, offerer=offerer)
+
+        expected_data = {
+            "isConvenient": True,
+            "isPleasant": False,
+            "comment": "c'est quand même très blanc",
+            "offererId": offerer.id,
+            "location": f"/offerers/{id}",
+        }
+
+        client = client.with_session_auth(user.email)
+
+        with caplog.at_level(logging.INFO):
+            response = client.post("/users/log-new-nav-review", json=expected_data)
+
+        assert response.status_code == 204
+        assert "User with new nav activated submitting review" in caplog.messages
+        assert caplog.records[0].extra["user_id"] == user.id
+        assert caplog.records[0].extra["offerer_id"] == offerer.id
+        assert caplog.records[0].extra["isConvenient"] == expected_data["isConvenient"]
+        assert caplog.records[0].extra["isPleasant"] == expected_data["isPleasant"]
+        assert caplog.records[0].extra["comment"] == expected_data["comment"]
+        assert caplog.records[0].extra["source_page"] == f"/offerers/{id}"
+
+    def test_user_without_new_nav_activated_cant_submit_review(self, client, caplog):
+        pro_new_nav_state = users_factories.UserProNewNavStateFactory(newNavDate=None)
+        user = pro_new_nav_state.user
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=user, offerer=offerer)
+
+        data = {
+            "isConvenient": False,
+            "isPleasant": False,
+            "comment": "messing with statistics",
+            "offererId": offerer.id,
+            "location": f"/offerers/{id}/",
+        }
+
+        client = client.with_session_auth(user.email)
+
+        with caplog.at_level(logging.INFO):
+            response = client.post("/users/log-new-nav-review", json=data)
+
+        assert response.status_code == 403
+        assert "User with new nav activated submitting review" not in caplog.messages
+
+    def test_user_cannot_submit_review_for_foreign_offerer(self, client, caplog):
+        pro_new_nav_state = users_factories.UserProNewNavStateFactory(newNavDate=None)
+        user = pro_new_nav_state.user
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=user, offerer=offerer)
+        foreign_offerer = offerers_factories.OffererFactory()
+
+        data = {
+            "isConvenient": False,
+            "isPleasant": False,
+            "comment": "messing with statistics again è_é",
+            "offererId": foreign_offerer.id,
+            "location": f"/offerers/{id}/",
+        }
+
+        client = client.with_session_auth(user.email)
+
+        with caplog.at_level(logging.INFO):
+            response = client.post("/users/log-new-nav-review", json=data)
+
+        assert response.status_code == 403
+        assert "User with new nav activated submitting review" not in caplog.messages

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -208,6 +208,7 @@ export type { StocksUpsertBodyModel } from './models/StocksUpsertBodyModel';
 export { StudentLevels } from './models/StudentLevels';
 export { SubcategoryIdEnum } from './models/SubcategoryIdEnum';
 export type { SubcategoryResponseModel } from './models/SubcategoryResponseModel';
+export type { SubmitReviewRequestModel } from './models/SubmitReviewRequestModel';
 export { Target } from './models/Target';
 export type { TemplateDatesModel } from './models/TemplateDatesModel';
 export type { TopOffersResponseData } from './models/TopOffersResponseData';

--- a/pro/src/apiClient/v1/models/SubmitReviewRequestModel.ts
+++ b/pro/src/apiClient/v1/models/SubmitReviewRequestModel.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type SubmitReviewRequestModel = {
+  comment: string;
+  isConvenient: boolean;
+  isPleasant: boolean;
+  location: string;
+  offererId: number;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -98,6 +98,7 @@ import type { StocksOrderedBy } from '../models/StocksOrderedBy';
 import type { StocksResponseModel } from '../models/StocksResponseModel';
 import type { StockStatsResponseModel } from '../models/StockStatsResponseModel';
 import type { StocksUpsertBodyModel } from '../models/StocksUpsertBodyModel';
+import type { SubmitReviewRequestModel } from '../models/SubmitReviewRequestModel';
 import type { UserEmailValidationResponseModel } from '../models/UserEmailValidationResponseModel';
 import type { UserHasBookingResponse } from '../models/UserHasBookingResponse';
 import type { UserIdentityBodyModel } from '../models/UserIdentityBodyModel';
@@ -1922,6 +1923,26 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'PATCH',
       url: '/users/identity',
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
+   * submit_new_nav_review <POST>
+   * @param requestBody
+   * @returns void
+   * @throws ApiError
+   */
+  public submitNewNavReview(
+    requestBody?: SubmitReviewRequestModel,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/users/log-new-nav-review',
       body: requestBody,
       mediaType: 'application/json',
       errors: {

--- a/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.module.scss
+++ b/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.module.scss
@@ -55,3 +55,21 @@
 .radio-button {
   text-align: center;
 }
+
+.confirmation-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: rem.torem(24px);
+  align-items: center;
+  margin-top: rem.torem(48px);
+
+  &-title {
+    @include fonts.title3;
+  }
+
+  &-icon {
+    width: rem.torem(77px);
+    height: rem.torem(77px);
+    color: var(--color-valid);
+  }
+}

--- a/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.tsx
+++ b/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.tsx
@@ -1,14 +1,17 @@
 import { Form, FormikProvider, useFormik } from 'formik'
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import DialogBox from 'components/DialogBox'
+import useNotification from 'hooks/useNotification'
+import strokeValidIcon from 'icons/stroke-valid.svg'
 import { selectCurrentOffererId } from 'store/user/selectors'
 import { Button, RadioButton, SubmitButton, TextArea } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { BaseRadioVariant } from 'ui-kit/form/shared/BaseRadio/types'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { sendSentryCustomError } from 'utils/sendSentryCustomError'
 
 import styles from './NewNavReviewDialog.module.scss'
@@ -27,19 +30,23 @@ interface NewNavReviewDialogFormValues {
 const NewNavReviewDialog = ({
   setIsReviewDialogOpen,
 }: NewNavReviewDialogProps) => {
-  const onSubmitReview = (formValues: NewNavReviewDialogFormValues) => {
-    api
-      .submitNewNavReview({
+  const notify = useNotification()
+  const [displayConfirmation, setDisplayConfirmation] = useState<boolean>(false)
+  const onSubmitReview = async (formValues: NewNavReviewDialogFormValues) => {
+    try {
+      await api.submitNewNavReview({
         offererId: selectedOffererId!,
         location: location.pathname,
         isPleasant: formValues.isPleasant === 'true' ? true : false,
         isConvenient: formValues.isConvenient === 'true' ? true : false,
         comment: formValues.comment,
       })
-      .catch((e) => {
-        sendSentryCustomError(e)
-      })
-    setIsReviewDialogOpen(false)
+      setDisplayConfirmation(true)
+    } catch (e) {
+      sendSentryCustomError(e)
+      notify.error('Une erreur est survenue. Merci de réessayer plus tard')
+      setIsReviewDialogOpen(false)
+    }
   }
 
   const initialValues: NewNavReviewDialogFormValues = {
@@ -64,103 +71,117 @@ const NewNavReviewDialog = ({
       extraClassNames={styles.dialog}
       labelledBy="Votre avis compte"
     >
-      <FormikProvider value={formik}>
-        <Form>
-          <h1 className={styles['dialog-title']}>Votre avis compte !</h1>
-          <fieldset>
-            <legend className={styles['radio-legend']}>
-              Selon vous, cette nouvelle interface est ... ? *
-            </legend>
-            <ol>
-              <li className={styles['form-row']}>
-                <span className={styles['form-row-label']}>1.</span>
-                <div className={styles['radio-group']}>
-                  <RadioButton
-                    label={
-                      <>
-                        Moins pratique <span aria-hidden>🐢</span>
-                      </>
-                    }
-                    name="isConvenient"
-                    value="false"
-                    className={styles['radio-button']}
-                    withBorder
-                    variant={BaseRadioVariant.SECONDARY}
-                  />
-                  <RadioButton
-                    label={
-                      <>
-                        Plus pratique <span aria-hidden>🐇</span>
-                      </>
-                    }
-                    name="isConvenient"
-                    value="true"
-                    className={styles['radio-button']}
-                    withBorder
-                    variant={BaseRadioVariant.SECONDARY}
-                  />
-                </div>
-              </li>
-              <li className={styles['form-row']}>
-                <span className={styles['form-row-label']}>2.</span>
-                <div className={styles['radio-group']}>
-                  <RadioButton
-                    label={
-                      <>
-                        Moins agréable <span aria-hidden>🌧️</span>
-                      </>
-                    }
-                    name="isPleasant"
-                    value="false"
-                    className={styles['radio-button']}
-                    withBorder
-                    variant={BaseRadioVariant.SECONDARY}
-                  />
-                  <RadioButton
-                    label={
-                      <>
-                        Plus agréable <span aria-hidden>🌈</span>
-                      </>
-                    }
-                    name="isPleasant"
-                    value="true"
-                    className={styles['radio-button']}
-                    withBorder
-                    variant={BaseRadioVariant.SECONDARY}
-                  />
-                </div>
-              </li>
-            </ol>
-          </fieldset>
+      {!displayConfirmation ? (
+        <FormikProvider value={formik}>
+          <Form>
+            <h1 className={styles['dialog-title']}>Votre avis compte !</h1>
+            <fieldset>
+              <legend className={styles['radio-legend']}>
+                Selon vous, cette nouvelle interface est ... ? *
+              </legend>
+              <ol>
+                <li className={styles['form-row']}>
+                  <span className={styles['form-row-label']}>1.</span>
+                  <div className={styles['radio-group']}>
+                    <RadioButton
+                      label={
+                        <>
+                          Moins pratique <span aria-hidden>🐢</span>
+                        </>
+                      }
+                      name="isConvenient"
+                      value="false"
+                      className={styles['radio-button']}
+                      withBorder
+                      variant={BaseRadioVariant.SECONDARY}
+                    />
+                    <RadioButton
+                      label={
+                        <>
+                          Plus pratique <span aria-hidden>🐇</span>
+                        </>
+                      }
+                      name="isConvenient"
+                      value="true"
+                      className={styles['radio-button']}
+                      withBorder
+                      variant={BaseRadioVariant.SECONDARY}
+                    />
+                  </div>
+                </li>
+                <li className={styles['form-row']}>
+                  <span className={styles['form-row-label']}>2.</span>
+                  <div className={styles['radio-group']}>
+                    <RadioButton
+                      label={
+                        <>
+                          Moins agréable <span aria-hidden>🌧️</span>
+                        </>
+                      }
+                      name="isPleasant"
+                      value="false"
+                      className={styles['radio-button']}
+                      withBorder
+                      variant={BaseRadioVariant.SECONDARY}
+                    />
+                    <RadioButton
+                      label={
+                        <>
+                          Plus agréable <span aria-hidden>🌈</span>
+                        </>
+                      }
+                      name="isPleasant"
+                      value="true"
+                      className={styles['radio-button']}
+                      withBorder
+                      variant={BaseRadioVariant.SECONDARY}
+                    />
+                  </div>
+                </li>
+              </ol>
+            </fieldset>
 
-          <TextArea
-            name="comment"
-            label={
-              'Souhaitez-vous préciser ? Nous lisons tous les commentaires. 🙂'
-            }
-            maxLength={500}
-            countCharacters
-            isOptional
-          />
-
-          <div className={styles['dialog-buttons']}>
-            <Button
-              variant={ButtonVariant.SECONDARY}
-              onClick={() => setIsReviewDialogOpen(false)}
-            >
-              Annuler
-            </Button>
-            <SubmitButton
-              disabled={
-                formik.values.isPleasant === initialValues.isPleasant ||
-                formik.values.isConvenient === initialValues.isConvenient
+            <TextArea
+              name="comment"
+              label={
+                'Souhaitez-vous préciser ? Nous lisons tous les commentaires. 🙂'
               }
-            >
-              Envoyer
-            </SubmitButton>
+              maxLength={500}
+              countCharacters
+              isOptional
+            />
+
+            <div className={styles['dialog-buttons']}>
+              <Button
+                variant={ButtonVariant.SECONDARY}
+                onClick={() => setIsReviewDialogOpen(false)}
+              >
+                Annuler
+              </Button>
+              <SubmitButton
+                disabled={
+                  formik.values.isPleasant === initialValues.isPleasant ||
+                  formik.values.isConvenient === initialValues.isConvenient
+                }
+              >
+                Envoyer
+              </SubmitButton>
+            </div>
+          </Form>
+        </FormikProvider>
+      ) : (
+        <div className={styles['confirmation-dialog']}>
+          <SvgIcon
+            src={strokeValidIcon}
+            alt=""
+            className={styles['confirmation-dialog-icon']}
+          />
+          <div className={styles['confirmation-dialog-title']}>
+            Merci beaucoup de votre participation !
           </div>
-        </Form>
-      </FormikProvider>
+          <Button onClick={() => setIsReviewDialogOpen(false)}>Fermer</Button>
+        </div>
+      )}
     </DialogBox>
   )
 }

--- a/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.tsx
+++ b/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.tsx
@@ -1,10 +1,15 @@
 import { Form, FormikProvider, useFormik } from 'formik'
 import React from 'react'
+import { useSelector } from 'react-redux'
+import { useLocation } from 'react-router-dom'
 
+import { api } from 'apiClient/api'
 import DialogBox from 'components/DialogBox'
+import { selectCurrentOffererId } from 'store/user/selectors'
 import { Button, RadioButton, SubmitButton, TextArea } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { BaseRadioVariant } from 'ui-kit/form/shared/BaseRadio/types'
+import { sendSentryCustomError } from 'utils/sendSentryCustomError'
 
 import styles from './NewNavReviewDialog.module.scss'
 import { validationSchema } from './validationSchema'
@@ -22,8 +27,18 @@ interface NewNavReviewDialogFormValues {
 const NewNavReviewDialog = ({
   setIsReviewDialogOpen,
 }: NewNavReviewDialogProps) => {
-  const onSubmitReview = () => {
-    // Todo in PC-28494: send review to backend
+  const onSubmitReview = (formValues: NewNavReviewDialogFormValues) => {
+    api
+      .submitNewNavReview({
+        offererId: selectedOffererId!,
+        location: location.pathname,
+        isPleasant: formValues.isPleasant === 'true' ? true : false,
+        isConvenient: formValues.isConvenient === 'true' ? true : false,
+        comment: formValues.comment,
+      })
+      .catch((e) => {
+        sendSentryCustomError(e)
+      })
     setIsReviewDialogOpen(false)
   }
 
@@ -38,6 +53,9 @@ const NewNavReviewDialog = ({
     onSubmit: onSubmitReview,
     validationSchema: validationSchema,
   })
+
+  const selectedOffererId = useSelector(selectCurrentOffererId)
+  const location = useLocation()
 
   return (
     <DialogBox
@@ -64,7 +82,7 @@ const NewNavReviewDialog = ({
                       </>
                     }
                     name="isConvenient"
-                    value={'lessConvenient'}
+                    value="false"
                     className={styles['radio-button']}
                     withBorder
                     variant={BaseRadioVariant.SECONDARY}
@@ -76,7 +94,7 @@ const NewNavReviewDialog = ({
                       </>
                     }
                     name="isConvenient"
-                    value="moreConvenient"
+                    value="true"
                     className={styles['radio-button']}
                     withBorder
                     variant={BaseRadioVariant.SECONDARY}
@@ -93,7 +111,7 @@ const NewNavReviewDialog = ({
                       </>
                     }
                     name="isPleasant"
-                    value="lessPleasant"
+                    value="false"
                     className={styles['radio-button']}
                     withBorder
                     variant={BaseRadioVariant.SECONDARY}
@@ -105,7 +123,7 @@ const NewNavReviewDialog = ({
                       </>
                     }
                     name="isPleasant"
-                    value="morePleasant"
+                    value="true"
                     className={styles['radio-button']}
                     withBorder
                     variant={BaseRadioVariant.SECONDARY}

--- a/pro/src/components/NewNavReview/NewNavReviewDialog/__specs__/NewNavReviewDialog.spec.tsx
+++ b/pro/src/components/NewNavReview/NewNavReviewDialog/__specs__/NewNavReviewDialog.spec.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
+import { api } from 'apiClient/api'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import NewNavReviewDialog from '../NewNavReviewDialog'
@@ -8,8 +9,14 @@ import NewNavReviewDialog from '../NewNavReviewDialog'
 const mockSetIsReviewDialogOpen = vi.fn()
 
 const renderNewNavReviewDialog = () => {
+  const storeOverrides = {
+    user: {
+      selectedOffererId: 1,
+    },
+  }
   return renderWithProviders(
-    <NewNavReviewDialog setIsReviewDialogOpen={mockSetIsReviewDialogOpen} />
+    <NewNavReviewDialog setIsReviewDialogOpen={mockSetIsReviewDialogOpen} />,
+    { storeOverrides }
   )
 }
 
@@ -32,6 +39,7 @@ describe('NewNavReviewDialog', () => {
   })
 
   it('should close dialog when submit is clicked', async () => {
+    vi.spyOn(api, 'submitNewNavReview').mockResolvedValue()
     renderNewNavReviewDialog()
 
     const morePleasantRadioButton = screen.getByRole('radio', {
@@ -44,8 +52,22 @@ describe('NewNavReviewDialog', () => {
     await userEvent.click(moreConvenientRadioButton)
 
     const submitButton = screen.getByRole('button', { name: 'Envoyer' })
+    await userEvent.type(
+      screen.getByLabelText(
+        'Souhaitez-vous préciser ? Nous lisons tous les commentaires. 🙂'
+      ),
+      'Commentaire utilisateur'
+    )
+
     await userEvent.click(submitButton)
 
+    expect(api.submitNewNavReview).toHaveBeenCalledWith({
+      isPleasant: true,
+      isConvenient: true,
+      comment: 'Commentaire utilisateur',
+      location: location.pathname,
+      offererId: 1,
+    })
     expect(mockSetIsReviewDialogOpen).toHaveBeenCalledWith(false)
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28494

Logger les informations du formulaire de review de la nouvelle interface lorsque l'utilisateur clique sur `Envoyer`. 
Afficher un message de confirmation si l'envoie des données s'est bien passé
Sinon afficher un message d'erreur

## Screens 


| Formulaire |  Confirmation | 
| ---------- | ------------ |
| ![Capture d’écran 2024-04-18 à 09 30 01](https://github.com/pass-culture/pass-culture-main/assets/71768799/c0941206-5443-4047-8921-eeed15c39c3b) | ![Capture d’écran 2024-04-18 à 09 30 08](https://github.com/pass-culture/pass-culture-main/assets/71768799/4294b0f9-4512-4841-87a8-0ea766852d52) |
