### PR TITLE
(PC-29310)[ADAGE] fix: set allowedOnAdage even if the siret does not …

### DIFF
--- a/api/src/pcapi/core/educational/api/adage.py
+++ b/api/src/pcapi/core/educational/api/adage.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from functools import partial
 import json
+import logging
 import typing
 
 from pydantic.v1 import parse_obj_as
@@ -18,6 +19,9 @@ from pcapi.repository import atomic
 from pcapi.routes.serialization import venues_serialize
 from pcapi.utils.cache import get_from_cache
 from pcapi.utils.clean_accents import clean_accents
+
+
+logger = logging.getLogger(__name__)
 
 
 def find_collective_bookings_for_adage(
@@ -100,6 +104,29 @@ def synchronize_adage_ids_on_offerers(partners_from_adage: list[venues_serialize
 
     sirens_to_add = adage_sirens - existing_adage_sirens
     sirens_to_delete = existing_adage_sirens - adage_sirens
+
+    # Tricky part here and hopefully this will be removed at some point.
+    # We have some weird cases where the SIRET from Adage does not match the SIRET from
+    # our linked venue.
+
+    logger.info("SIRENs to add from SIRET: %s", sirens_to_add)
+    logger.info("SIRENs to delete from SIRET: %s", sirens_to_delete)
+
+    # check we don't remove offerers that do have valid venues
+    existing_sirens_from_synchronized_venues: dict[str, bool] = dict(
+        offerers_models.Offerer.query.join(offerers_models.Venue)
+        .filter(
+            offerers_models.Offerer.siren != None,
+            offerers_models.Venue.adageId.is_not(None),
+        )
+        .with_entities(offerers_models.Offerer.siren, offerers_models.Offerer.allowedOnAdage)
+    )
+    sirens_to_delete = sirens_to_delete - set(existing_sirens_from_synchronized_venues)
+    sirens_to_add = sirens_to_add | {k for k, v in existing_sirens_from_synchronized_venues.items() if not v}
+
+    logger.info("SIRENs to add: %s", sirens_to_add)
+    logger.info("SIRENs to delete: %s", sirens_to_delete)
+    logger.info("existing SIRENs from synchronized venues: %s", existing_sirens_from_synchronized_venues)
 
     offerers_models.Offerer.query.filter(offerers_models.Offerer.siren.in_(list(sirens_to_add))).update(
         {offerers_models.Offerer.allowedOnAdage: True}, synchronize_session=False

--- a/api/tests/core/educational/api/test_synchronize_adage_ids_on_venues.py
+++ b/api/tests/core/educational/api/test_synchronize_adage_ids_on_venues.py
@@ -68,6 +68,7 @@ def test_synchronize_adage_ids_on_venues(db_session):
     venue5_data = {**BASE_DATA, "id": adage_id4, "venueId": venue5.id, "synchroPass": 1, "actif": None}
     venue6_data = {**BASE_DATA, "id": adage_id3, "venueId": venue6.id, "synchroPass": 0, "actif": None}
 
+    email1 = get_emails_by_venue(venue1)
     email2 = get_emails_by_venue(venue2)
 
     with requests_mock.Mocker() as request_mock:
@@ -129,8 +130,8 @@ def test_synchronize_adage_ids_on_venues(db_session):
     assert {ava.adageId for ava in venue6.adage_addresses} == {None}
     assert {ava.adageInscriptionDate for ava in venue6.adage_addresses} == {None}
 
-    assert mock_activation_mail.call_args.args[0] == venue2
-    assert set(mock_activation_mail.call_args.args[1]) == set(email2)
+    assert set(i.args[0] for i in mock_activation_mail.call_args_list) == {venue1, venue2}
+    assert set(str(i.args[1]) for i in mock_activation_mail.call_args_list) == {str(list(email1)), str(list(email2))}
 
 
 @override_settings(
@@ -180,17 +181,31 @@ def test_synchronize_adage_ids_on_venues_with_unknon_venue(db_session):
     ADAGE_BACKEND="pcapi.core.educational.adage_backends.adage.AdageHttpClient",
 )
 def test_synchronize_adage_ids_on_offerers(db_session):
-    venue1 = offerers_factories.VenueFactory()
-    venue2 = offerers_factories.VenueFactory()
-    venue3 = offerers_factories.VenueFactory()
-    venue4 = offerers_factories.VenueFactory()
-    venue5 = offerers_factories.VenueFactory(adageId="11", adageInscriptionDate=datetime.utcnow())
-    venue6 = offerers_factories.VenueFactory(adageId="1252", adageInscriptionDate=datetime.utcnow())
+    # venue1's offerer should be allowed because its venue siret matches the venue1_data
+    # venue2's offerer should be allowed because its venue siret matches the venue2_data
+    # venue3's offerer should be allowed because its venue siret matches the venue3_data though not synchronized with Pass
+    # venue4's offerer should be allowed because its venue siret matches the venue4_data though not matching venueId
+    # venue5's offerer should be allowed because its venue has an adageId (despite not being active)
+    # venue6's offerer should be allowed because its venue has an adageId (despite not being active)
+    # venue7's offerer should not be allowed because it is not active and has no adageId
+    # venue8's offerer should not be allowed because it is not active and has no adageId
+    venue1 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
+    venue2 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
+    venue3 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
+    venue4 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
+    venue5 = offerers_factories.VenueFactory(
+        managingOfferer__allowedOnAdage=False, adageId="11", adageInscriptionDate=datetime.utcnow()
+    )
+    venue6 = offerers_factories.VenueFactory(
+        managingOfferer__allowedOnAdage=False, adageId="1252", adageInscriptionDate=datetime.utcnow()
+    )
+    venue7 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
+    venue8 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
 
     venue1_data = {**BASE_DATA, "id": 128028, "siret": venue1.siret, "venueId": venue1.id}
     venue2_data = {**BASE_DATA, "id": 128029, "siret": venue2.siret, "venueId": venue2.id}
     venue3_data = {**BASE_DATA, "id": 128030, "siret": venue3.siret, "venueId": venue3.id, "synchroPass": 0}
-    venue4_data = {**BASE_DATA, "id": 128031, "siret": venue4.siret, "venueId": None}
+    venue4_data = {**BASE_DATA, "id": 128031, "siret": venue4.siret, "venueId": None, "synchroPass": 0}
     venue5_data = {
         **BASE_DATA,
         "id": 128030,
@@ -207,18 +222,92 @@ def test_synchronize_adage_ids_on_offerers(db_session):
         "synchroPass": 0,
         "actif": None,
     }
+    venue7_data = {
+        **BASE_DATA,
+        "id": 128030,
+        "siret": venue7.siret,
+        "venueId": venue7.id,
+        "synchroPass": 1,
+        "actif": None,
+    }
+    venue8_data = {
+        **BASE_DATA,
+        "id": 128030,
+        "siret": venue8.siret,
+        "venueId": venue8.id,
+        "synchroPass": 0,
+        "actif": None,
+    }
+
+    assert not venue1.managingOfferer.allowedOnAdage
+    assert not venue2.managingOfferer.allowedOnAdage
+    assert not venue3.managingOfferer.allowedOnAdage
+    assert not venue4.managingOfferer.allowedOnAdage
+    assert not venue5.managingOfferer.allowedOnAdage
+    assert not venue6.managingOfferer.allowedOnAdage
+    assert not venue7.managingOfferer.allowedOnAdage
+    assert not venue8.managingOfferer.allowedOnAdage
 
     partners = parse_obj_as(
         venues_serialize.AdageCulturalPartners,
-        {"partners": [venue1_data, venue2_data, venue3_data, venue4_data, venue5_data, venue6_data]},
+        {
+            "partners": [
+                venue1_data,
+                venue2_data,
+                venue3_data,
+                venue4_data,
+                venue5_data,
+                venue6_data,
+                venue7_data,
+                venue8_data,
+            ]
+        },
     ).partners
 
     educational_api_adage.synchronize_adage_ids_on_offerers(partners)
     db.session.commit()
 
     assert venue1.managingOfferer.allowedOnAdage
-    assert venue1.managingOfferer.allowedOnAdage
+    assert venue2.managingOfferer.allowedOnAdage
     assert venue3.managingOfferer.allowedOnAdage
     assert venue4.managingOfferer.allowedOnAdage
-    assert not venue5.managingOfferer.allowedOnAdage
-    assert not venue6.managingOfferer.allowedOnAdage
+    assert venue5.managingOfferer.allowedOnAdage
+    assert venue6.managingOfferer.allowedOnAdage
+    assert not venue7.managingOfferer.allowedOnAdage
+    assert not venue8.managingOfferer.allowedOnAdage
+
+
+@override_settings(
+    ADAGE_API_URL="https://adage-api-url",
+    ADAGE_API_KEY="adage-api-key",
+    ADAGE_BACKEND="pcapi.core.educational.adage_backends.adage.AdageHttpClient",
+)
+def test_synchronize_adage_ids_on_offerers_for_tricky_case(db_session):
+    # Let's say we have a venue that has a SIRET and is synchronized with Adage
+    # but Adage has another SIRET for it.
+    # The synchronize_adage_ids_on_venues should fill the Venue with an AdageId
+    # and it should be set on the offerer despite the difference in SIRET
+
+    ADAGE_ID = 128028
+    venue1 = offerers_factories.VenueFactory(
+        siret="24567870500000", adageId=ADAGE_ID, managingOfferer__allowedOnAdage=False
+    )
+
+    venue1_data = {**BASE_DATA, "id": ADAGE_ID, "siret": "35678980500000", "venueId": venue1.id}
+
+    assert not venue1.managingOfferer.allowedOnAdage
+
+    partners = parse_obj_as(
+        venues_serialize.AdageCulturalPartners,
+        {"partners": [venue1_data]},
+    ).partners
+
+    educational_api_adage.synchronize_adage_ids_on_offerers(partners)
+    db.session.commit()
+
+    assert venue1.managingOfferer.allowedOnAdage
+
+    educational_api_adage.synchronize_adage_ids_on_offerers(partners)
+    db.session.commit()
+
+    assert venue1.managingOfferer.allowedOnAdage


### PR DESCRIPTION
…match

We do have some cases where the venue is synchronized but the SIRET does not match.
allowedOnAdage is now True if a SIREN matches OR if one of the venue is synchronized.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29310

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques