### PR TITLE
(PC-29327)[API] fix: use getter dict instead of orm override to avoid changing the venue object

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -16,6 +16,24 @@ class VenueAccessibilityModel(BaseModel):
     visualDisability: bool | None
 
 
+class VenueResponseGetterDict(base.VenueResponseGetterDict):
+    def get(self, key: str, default: typing.Any = None) -> typing.Any:
+        if key == "venueTypeCode":
+            return self._obj.venueTypeCode.name
+
+        if key == "address":
+            return self._obj.street
+
+        if key == "accessibility":
+            return VenueAccessibilityModel(
+                audioDisability=self._obj.audioDisabilityCompliant,
+                mentalDisability=self._obj.mentalDisabilityCompliant,
+                motorDisability=self._obj.motorDisabilityCompliant,
+                visualDisability=self._obj.visualDisabilityCompliant,
+            )
+        return super().get(key, default)
+
+
 class VenueResponse(base.BaseVenueResponse):
     id: int
     address: str | None
@@ -23,14 +41,5 @@ class VenueResponse(base.BaseVenueResponse):
     venueTypeCode: offerers_models.VenueTypeCodeKey
     bannerMeta: BannerMetaModel | None
 
-    @classmethod
-    def from_orm(cls, venue: offerers_models.Venue) -> "VenueResponse":
-        venue.venueTypeCode = venue.venueTypeCode.name
-        venue.accessibility = VenueAccessibilityModel(
-            audioDisability=venue.audioDisabilityCompliant,
-            mentalDisability=venue.mentalDisabilityCompliant,
-            motorDisability=venue.motorDisabilityCompliant,
-            visualDisability=venue.visualDisabilityCompliant,
-        )
-        venue.address = venue.street
-        return super().from_orm(venue)
+    class Config:
+        getter_dict = VenueResponseGetterDict

--- a/api/tests/routes/native/v1/offerers_test.py
+++ b/api/tests/routes/native/v1/offerers_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from pcapi.connectors.acceslibre import ExpectedFieldsEnum as acceslibre_enum
 import pcapi.core.offerers.factories as offerer_factories
+from pcapi.core.offerers.models import VenueTypeCode
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -107,3 +108,9 @@ class VenuesTest:
     def test_get_non_existing_venue(self, client):
         response = client.get("/native/v1/venue/123456789")
         assert response.status_code == 404
+
+    def test_get_venue_always_has_banner_url(self, client):
+        venue = offerer_factories.VenueFactory(venueTypeCode=VenueTypeCode.BOOKSTORE)
+        response = client.get(f"/native/v1/venue/{venue.id}")
+        assert response.status_code == 200
+        assert response.json["bannerUrl"] is not None


### PR DESCRIPTION

The line `venue.venueTypeCode = venue.venueTypeCode.name` changes the value in the object and breaks any property using the venueTypeCode (i.e. bannerUrl)

using a getter dict we avoid actally changing the python object, and keep bannerUrl safe

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29327

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques