### PR TITLE
(PC-29075)[PRO] feat: redirect from offer card to righ url and right …

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -1,4 +1,4 @@
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useLocation, useSearchParams } from 'react-router-dom'
 
 import { CollectiveOfferTemplateResponseModel } from 'apiClient/adage'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
@@ -21,6 +21,9 @@ const OfferCardComponent = ({
   offer,
   handlePlaylistElementTracking,
 }: CardComponentProps) => {
+  const location = useLocation()
+
+  const currentPathname = location.pathname.split('/')[2]
   const [searchParams] = useSearchParams()
   const adageAuthToken = searchParams.get('token')
   const { adageUser } = useAdageUser()
@@ -30,7 +33,7 @@ const OfferCardComponent = ({
       <Link
         className={styles['offer-link']}
         data-testid="card-offer-link"
-        to={`/adage-iframe/decouverte/offre/${offer.id}?token=${adageAuthToken}`}
+        to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
         state={{ offer }}
         onClick={() => {
           handlePlaylistElementTracking()

--- a/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AppLayout/AppLayout.tsx
@@ -79,6 +79,10 @@ export const AppLayout = (): JSX.Element => {
           <Route path="decouverte/offre/:offerId" element={<OfferInfos />} />
           <Route path="recherche/offre/:offerId" element={<OfferInfos />} />
           <Route path="mes-favoris/offre/:offerId" element={<OfferInfos />} />
+          <Route
+            path="mon-etablissement/offre/:offerId"
+            element={<OfferInfos />}
+          />
         </Routes>
       </main>
     </div>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -73,7 +73,7 @@ export const OfferInfos = () => {
       icon: strokeStarIcon,
     },
     ['mon-etablissement']: {
-      title: 'Mon établissement',
+      title: 'Pour mon établissement',
       link: {
         isExternal: false,
         to: `/adage-iframe/mon-etablissement?token=${adageAuthToken}`,

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/__specs__/OfferInfos.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/__specs__/OfferInfos.spec.tsx
@@ -115,6 +115,19 @@ describe('OfferInfos', () => {
     )
   })
 
+  it("should display the breadcrumb with a link back to my institution page if the url contains 'mon-etablissement'", () => {
+    vi.spyOn(router, 'useLocation').mockReturnValueOnce({
+      ...defaultUseLocationValue,
+      pathname: '/adage-iframe/mon-etablissement/offre/10',
+    })
+
+    renderOfferInfos()
+
+    expect(
+      screen.getByRole('link', { name: 'Pour mon établissement' })
+    ).toHaveAttribute('href', '/adage-iframe/mon-etablissement?token=null')
+  })
+
   it('should display the breadcrumb with a link back to the search page if the user is admin', () => {
     renderOfferInfos({ ...defaultAdageUser, role: AdageFrontRoles.READONLY })
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames'
 import { useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useLocation, useSearchParams } from 'react-router-dom'
 
 import {
   AdageFrontRoles,
@@ -41,6 +41,9 @@ export function AdageOfferListCard({
   const adageAuthToken = searchParams.get('token')
   const { adageUser, setInstitutionOfferCount, institutionOfferCount } =
     useAdageUser()
+  const location = useLocation()
+
+  const currentPathname = location.pathname.split('/')[2]
 
   const [offerPrebooked, setOfferPrebooked] = useState(false)
 
@@ -125,7 +128,7 @@ export function AdageOfferListCard({
           <div className={styles['offer-card-content']}>
             <AdageOfferListCardTags offer={offer} adageUser={adageUser} />
             <Link
-              to={`/adage-iframe/recherche/offre/${offer.id}?token=${adageAuthToken}`}
+              to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
               state={{ offer }}
               className={styles['offer-card-link']}
               onClick={() => triggerOfferClickLog(offer)}


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29075

A tester avec et sans ff activé : `WIP_ENABLE_ADAGE_VISUALIZATION`

## But de la pull request

On souhaite afficher le bon lien de retour + le bon texte dans le fil d'ariane qui s'affiche sur la page dédiée d'une offre que l'on vient d'ouvrir

## Vérifications

- [x] J'ai écrit les tests nécessaires