### PR TITLE
(BSR) fix: revert unnecessary Slack notification

### DIFF
--- a/.github/workflows/dev_on_dispatch_release_deploy.yml
+++ b/.github/workflows/dev_on_dispatch_release_deploy.yml
@@ -28,30 +28,6 @@ jobs:
             echo "This workflow can only be triggered from a tag (starting with a 'v')"
             exit 1
           fi
-      - name: "Ask for deployment review on #shérif"
-        if: success()
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          channel-id: "CU0SQ8Y58"
-          payload: |
-            {
-              "attachments": [
-                  {
-                    "mrkdwn_in": ["text"],
-                    "color": "#ff4f00",
-                    "author_name": "${{github.actor}}",
-                    "author_link": "https://github.com/${{github.actor}}",
-                    "author_icon": "https://github.com/${{github.actor}}.png",
-                    "title": "Review Deployment",
-                    "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                    "text": "${{github.actor}} souhaite déployer `v${{ needs.version.outputs.APP_VERSION }}` sur `${{ github.event.inputs.target_environment }}` :raised-hand:"
-                  }
-              ],
-              "unfurl_links": false,
-              "unfurl_media": false
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
 
   version:
     name: "Version"


### PR DESCRIPTION
## But de la pull request

Le secret n'était pas récupéré, donc la notification ne pouvait être envoyée.
Au lieu de réparer, on revert cet envoi, car on ne veut pas que le reste du workflow soit bloqué par l'échec de cette notification, quelle qu'en soit la raison.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques