### PR TITLE
WIP (PC-29348)[API] fix: opening hours weekday wrong serialization

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -56,6 +56,7 @@ from pcapi.routes.serialization.offerers_serialize import OffererMemberStatus
 from pcapi.utils import crypto
 from pcapi.utils import human_ids
 from pcapi.utils import image_conversion
+import pcapi.utils.date as date_utils
 import pcapi.utils.db as db_utils
 import pcapi.utils.email as email_utils
 
@@ -115,10 +116,15 @@ def update_venue(
 
     if opening_days:
         for opening_hours_data in opening_days:
-            weekday = models.Weekday(opening_hours_data.weekday.upper())
+            weekday = models.Weekday(opening_hours_data.weekday)
             target = get_venue_opening_hours_by_weekday(venue, weekday)
+            target.timespan = date_utils.numranges_to_readble_str(target.timespan)
+            opening_hours_readable = {
+                "weekday": opening_hours_data.weekday,
+                "timespan": date_utils.numranges_to_readble_str(opening_hours_data.timespan),
+            }
             venue_snapshot.trace_update(
-                opening_hours_data.dict(),
+                opening_hours_readable,
                 target=target,
                 field_name_template=f"openingHours.{opening_hours_data.weekday}.{{}}",
             )
@@ -257,7 +263,7 @@ def upsert_venue_opening_hours(
     Create and attach OpeningHours for a given weekday to a Venue if it has none.
     Update (replace) an existing OpeningHours list otherwise.
     """
-    weekday = models.Weekday(opening_hours_data.weekday.upper())
+    weekday = models.Weekday(opening_hours_data.weekday)
     venue_opening_hours = get_venue_opening_hours_by_weekday(venue, weekday)
 
     modifications = {

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -611,6 +611,22 @@ def format_show_subtype(show_subtype_id: int | str) -> str:
         return f"Autre[{show_subtype_id}]"
 
 
+def match_opening_hours(info_name: str) -> str | None:
+    day_mapping = {
+        "MONDAY": "lundi",
+        "TUESDAY": "mardi",
+        "WEDNESDAY": "mercredi",
+        "THURSDAY": "jeudi",
+        "FRIDAY": "vendredi",
+        "SATURDAY": "samedi",
+        "SUNDAY": "dimanche",
+    }
+    if match := re.compile(r"^openingHours\.(\w+)\.timespan$").match(info_name):
+        day = match.group(1)
+        return day_mapping.get(day, day)
+    return None
+
+
 def format_modified_info_name(info_name: str) -> str:
     match info_name:
         case "force_debit_note":
@@ -675,8 +691,11 @@ def format_modified_info_name(info_name: str) -> str:
             return "Id chez Acceslibre"
         case "accessibilityProvider.externalAccessibilityUrl":
             return "Url chez Acceslibre"
-        case _:
-            return info_name.replace("_", " ").capitalize()
+
+    if day := match_opening_hours(info_name):
+        return f"Horaires du {day}"
+
+    return info_name.replace("_", " ").capitalize()
 
 
 def format_permission_name(permission_name: str) -> str:

--- a/api/src/pcapi/routes/serialization/base.py
+++ b/api/src/pcapi/routes/serialization/base.py
@@ -175,3 +175,7 @@ class OpeningHoursModel(BaseModel):
     def convert_to_numeric_ranges(cls, timespan: list[str]) -> NumericRange:
         start, end = timespan
         return NumericRange(time_to_int(start), time_to_int(end), "[]")
+
+    @validator("weekday", each_item=True)
+    def return_weekday_upper(cls, weekday: str) -> str:
+        return weekday.upper()

--- a/api/src/pcapi/utils/date.py
+++ b/api/src/pcapi/utils/date.py
@@ -200,3 +200,12 @@ def numranges_to_timespan_str(numranges: list[NumericRange]) -> list[tuple[str, 
     Convert a list of NumericRange to a list of tuples (start, end) in the format [("HH:MM", "HH:MM"), ...]
     """
     return [(int_to_time(int(numrange.lower)), int_to_time(int(numrange.upper))) for numrange in numranges]
+
+
+def numranges_to_readble_str(numranges: list[NumericRange] | None) -> str:
+    """
+    Convert a list of NumericRange to a list of tuples (start, end) in a str ("HH:MM", "HH:MM")]
+    """
+    if numranges is None:
+        return ""
+    return ", ".join(f"{int_to_time(int(numrange.lower))}-{int_to_time(int(numrange.upper))}" for numrange in numranges)

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -1520,6 +1520,14 @@ class GetVenueHistoryTest(GetEndpointHelper):
                     "withdrawalDetails": {"new_info": "Come here!", "old_info": None},
                     "contact.website": {"new_info": None, "old_info": "https://old.website.com"},
                     "visualDisabilityCompliant": {"new_info": True, "old_info": False},
+                    "openingHours.MONDAY.timespan": {
+                        "old_info": "14:00-19:30",
+                        "new_info": "10:00-13:00, 14:00-19:30",
+                    },
+                    "openingHours.TUESDAY.timespan": {
+                        "old_info": "14:00-19:30",
+                        "new_info": None,
+                    },
                 }
             },
         )
@@ -1546,6 +1554,8 @@ class GetVenueHistoryTest(GetEndpointHelper):
         assert "Site internet de contact : suppression de : https://old.website.com " in rows[0]["Commentaire"]
         assert "Conditions de retrait : ajout de : Come here!" in rows[0]["Commentaire"]
         assert "Accessibilité handicap visuel : Non => Oui" in rows[0]["Commentaire"]
+        assert "Horaires du lundi : 14:00-19:30 => 10:00-13:00, 14:00-19:30" in rows[0]["Commentaire"]
+        assert "Horaires du mardi : suppression de : 14:00-19:30" in rows[0]["Commentaire"]
         assert rows[0]["Auteur"] == legit_user.full_name
         assert rows[1]["Type"] == "Commentaire interne"
         assert rows[1]["Commentaire"] == comment

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -7,6 +7,7 @@ from pcapi.core.history import models as history_models
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.users import testing as external_testing
+from pcapi.utils.date import timespan_str_to_numrange
 
 from tests.routes.pro.post_venue_test import venue_malformed_test_data
 
@@ -343,9 +344,10 @@ class Returns200Test:
         venue_data = populate_missing_data_from_venue(
             {
                 "openingHours": [
-                    # We are only changing MONDAY opening Hours, TUESDAY is already like following
+                    # We are only changing MONDAY and FRIDAY opening Hours, TUESDAY is already like following
                     {"weekday": "MONDAY", "timespan": [["10:00", "13:00"], ["14:00", "19:30"]]},
                     {"weekday": "TUESDAY", "timespan": [["10:00", "13:00"], ["14:00", "19:30"]]},
+                    {"weekday": "FRIDAY", "timespan": None},
                 ],
                 "contact": None,
             },
@@ -364,8 +366,12 @@ class Returns200Test:
         assert venue.action_history[0].extraData == {
             "modified_info": {
                 "openingHours.MONDAY.timespan": {
-                    "old_info": ["[840, 1170]"],
-                    "new_info": ["[600, 780]", "[840, 1170]"],
+                    "old_info": "14:00-19:30",
+                    "new_info": "10:00-13:00, 14:00-19:30",
+                },
+                "openingHours.FRIDAY.timespan": {
+                    "old_info": "10:00-13:00, 14:00-19:30",
+                    "new_info": None,
                 },
             }
         }
@@ -383,6 +389,40 @@ class Returns200Test:
         response = auth_request.patch("/venues/%s" % venue.id, json=venue_data)
         assert response.status_code == 200
         assert len(venue.action_history) == 0
+
+    def test_should_not_update_opening_hours_with_lower_case_weekday(self, client):
+        user_offerer = offerers_factories.UserOffererFactory(
+            user__email="user.pro@test.com",
+        )
+        venue = offerers_factories.VenueFactory(
+            managingOfferer=user_offerer.offerer,
+            contact=None,
+        )
+        offerers_factories.OpeningHoursFactory(
+            venue=venue,
+            weekday=offerers_models.Weekday("TUESDAY"),
+            timespan=timespan_str_to_numrange([("10:00", "13:00")]),
+        )
+        venue_data = populate_missing_data_from_venue(
+            {
+                "contact": {"website": "https://www.venue.com"},
+                # Even if weekday is in lower case, it doesn't modify opening hours and must
+                # not appear in history
+                "weekday": "tuesday",
+                "timespan": [["10:00", "13:00"]],
+            },
+            venue,
+        )
+
+        auth_request = client.with_session_auth(email=user_offerer.user.email)
+        response = auth_request.patch("/venues/%s" % venue.id, json=venue_data)
+        assert response.status_code == 200
+
+        assert venue.action_history[0].extraData == {
+            "modified_info": {
+                "contact.website": {"new_info": venue.contact.website, "old_info": None},
+            }
+        }
 
 
 class Returns400Test:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29348

Pour la relecture: le type ignore est dû au validateur `convert_to_numeric_ranges` de `OpeningHoursModel` 

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques