### PR TITLE
(PC-29361)[PRO] fix: fix adage preview in pro offer log api forbidden…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.tsx
@@ -23,12 +23,16 @@ export type AdageOfferProps = {
   offer: CollectiveOfferTemplateResponseModel | CollectiveOfferResponseModel
   adageUser?: AuthenticatedResponse
   isPreview?: boolean
+  setInstitutionOfferCount?: (value: number) => void
+  institutionOfferCount?: number
 }
 
 export default function AdageOffer({
   offer,
   adageUser,
   isPreview = false,
+  setInstitutionOfferCount,
+  institutionOfferCount,
 }: AdageOfferProps) {
   const isOfferBookable = isCollectiveOfferBookable(offer)
 
@@ -102,6 +106,8 @@ export default function AdageOffer({
                 offer={offer}
                 adageUser={adageUser}
                 isPreview={isPreview}
+                setInstitutionOfferCount={setInstitutionOfferCount}
+                institutionOfferCount={institutionOfferCount}
               />
             )
           ) : (

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/AdageOfferInstitutionPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferInstitutionPanel/AdageOfferInstitutionPanel.tsx
@@ -5,7 +5,6 @@ import {
 } from 'apiClient/adage'
 import fullDeskIcon from 'icons/full-desk.svg'
 import strokeTeacherIcon from 'icons/stroke-teacher.svg'
-import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { getDateTimeToFrenchText, toDateStrippedOfTimezone } from 'utils/date'
 
@@ -18,15 +17,17 @@ export type AdageOfferInstitutionPanelProps = {
   offer: CollectiveOfferResponseModel
   adageUser?: AuthenticatedResponse
   isPreview?: boolean
+  setInstitutionOfferCount?: (value: number) => void
+  institutionOfferCount?: number
 }
 
 export default function AdageOfferInstitutionPanel({
   offer,
   adageUser,
   isPreview = false,
+  setInstitutionOfferCount,
+  institutionOfferCount,
 }: AdageOfferInstitutionPanelProps) {
-  const { setInstitutionOfferCount, institutionOfferCount } = useAdageUser()
-
   return (
     <div className={styles['institution-panel']}>
       <div className={styles['institution-panel-header']}>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -41,7 +41,8 @@ export const OfferInfos = () => {
   >(state?.offer)
   const [loading, setLoading] = useState(false)
 
-  const { adageUser } = useAdageUser()
+  const { adageUser, setInstitutionOfferCount, institutionOfferCount } =
+    useAdageUser()
 
   const isNewOfferInfoEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_ADAGE_OFFER_DESIGN'
@@ -132,7 +133,12 @@ export const OfferInfos = () => {
             />
           </div>
           {isNewOfferInfoEnabled ? (
-            <AdageOffer offer={offer} adageUser={adageUser} />
+            <AdageOffer
+              offer={offer}
+              adageUser={adageUser}
+              setInstitutionOfferCount={setInstitutionOfferCount}
+              institutionOfferCount={institutionOfferCount}
+            />
           ) : (
             <div className={styles['offer-container']}>
               <Offer offer={offer} position={0} queryId="" openDetails={true} />

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.module.scss
@@ -27,7 +27,7 @@
   padding: rem.torem(4px) rem.torem(8px);
   background: var(--color-alert-dark);
   border-radius: rem.torem(4px);
-  display: flex;
+  display: inline-flex;
   align-items: center;
 
   &-icon {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
@@ -50,7 +50,7 @@ const PrebookingButton = ({
   const notification = useNotification()
 
   const handleBookingModalButtonClick = (stockId: number) => {
-    if (LOGS_DATA) {
+    if (LOGS_DATA && !isPreview) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       apiAdage.logBookingModalButtonClick({
         iframeFrom: location.pathname,
@@ -96,6 +96,7 @@ const PrebookingButton = ({
               className="prebooking-tag-icon"
               src={strokeHourglass}
               alt=""
+              width="16"
             />
             Préréservé
           </div>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29361

Régler le problème sur la page de preview sur le portail pro 
Ne plus essayer d'appeler le tracking pour savoir si la modal a été ouverte lorsqu'on est en mode preview sur la page aperçu de l'offre
Lorsque l'on pré-réservée une offre depuis la page dédiée sur adage, le picto était trop grand, on le remet à sa taille normal

Avant :
![image](https://github.com/pass-culture/pass-culture-main/assets/119043808/0d981781-9939-4f48-abe0-687f91595fc8)

Après :
<img width="484" alt="Capture d’écran 2024-04-18 à 17 07 36" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/8147010e-9396-4c41-869d-5478f9225a0c">