### PR TITLE
(PC-29204)[BO] fix: fraud team can now see price in collective offer price written in one line now

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
@@ -128,7 +128,9 @@
                 <td>{{ collective_offer.collectiveStock.beginningDatetime | format_date }}</td>
                 {% if has_permission("PRO_FRAUD_ACTIONS") %}
                   <td>
-                    {% if collective_offer.collectiveStock %}{{ collective_offer.collectiveStock.price | format_amount }}{% endif %}
+                    {% if collective_offer.collectiveStock %}
+                      <span class="text-nowrap">{{ collective_offer.collectiveStock.price | format_amount }}</span>
+                    {% endif %}
                   </td>
                 {% endif %}
                 <td>{{ links.build_offerer_name_to_details_link(collective_offer.venue.managingOfferer) }}</td>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29204

## Vérifications

### verification front 

<img width="1512" alt="Capture d’écran 2024-04-19 à 10 42 37" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/dde91360-b587-49fb-a24a-3a71092ab044">



### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### Verification ticket

- nom du ticket conforme -> OK
- nombre de commit -> OK
- nom du commit -> OK
- mettre le ticket en code-review -> OK 


