### PR TITLE
Pc 29224 reduce app rerenders

### DIFF
--- a/pro/src/app/App/App.tsx
+++ b/pro/src/app/App/App.tsx
@@ -9,6 +9,7 @@ import { findCurrentRoute } from 'app/AppRouter/findCurrentRoute'
 import Notification from 'components/Notification/Notification'
 import useActiveFeature from 'hooks/useActiveFeature'
 import { useConfigureFirebase } from 'hooks/useAnalytics'
+import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import useNotification from 'hooks/useNotification'
 import { updateUser } from 'store/user/reducer'
 import { selectCurrentUser } from 'store/user/selectors'
@@ -29,6 +30,15 @@ const App = (): JSX.Element | null => {
   const [consentedToBeamer, setConsentedToBeamer] = useState(false)
   const dispatch = useDispatch()
   const notify = useNotification()
+
+  const isNewInterfaceActive = useIsNewInterfaceActive()
+
+  useEffect(() => {
+    document.documentElement.setAttribute(
+      'data-theme',
+      isNewInterfaceActive ? 'blue' : 'pink'
+    )
+  }, [isNewInterfaceActive])
 
   useEffect(() => {
     // Initialize cookie consent modal

--- a/pro/src/app/AppRouter/AppRouter.tsx
+++ b/pro/src/app/AppRouter/AppRouter.tsx
@@ -1,11 +1,9 @@
 import * as Sentry from '@sentry/react'
-import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 
 import App from 'app/App/App'
 import routes from 'app/AppRouter/routesMap'
-import useIsNewInterfaceActive from 'hooks/useIsNewInterfaceActive'
 import { selectActiveFeatures } from 'store/features/selectors'
 
 import { ErrorBoundary } from './ErrorBoundary'
@@ -15,18 +13,10 @@ const sentryCreateBrowserRouter =
 
 const AppRouter = (): JSX.Element => {
   const activeFeatures = useSelector(selectActiveFeatures)
-  const isNewInterfaceActive = useIsNewInterfaceActive()
 
   const activeRoutes = routes.filter(
     (route) => !route.featureName || activeFeatures.includes(route.featureName)
   )
-
-  useEffect(() => {
-    document.documentElement.setAttribute(
-      'data-theme',
-      isNewInterfaceActive ? 'blue' : 'pink'
-    )
-  }, [isNewInterfaceActive])
 
   const router = sentryCreateBrowserRouter([
     {

--- a/pro/src/pages/Home/__specs__/Homepage.spec.tsx
+++ b/pro/src/pages/Home/__specs__/Homepage.spec.tsx
@@ -333,7 +333,6 @@ describe('Homepage', () => {
 
       await userEvent.click(screen.getByText(/Activer dès maintenant/))
       expect(api.postNewProNav).toHaveBeenCalledTimes(1)
-      expect(reloadFn).toHaveBeenCalledTimes(1)
       expect(
         await screen.findByText(/Bienvenue sur la nouvelle interface/)
       ).toBeInTheDocument()

--- a/pro/src/pages/SignIn/SignIn.tsx
+++ b/pro/src/pages/SignIn/SignIn.tsx
@@ -1,7 +1,7 @@
 import { FormikProvider, useFormik } from 'formik'
 import React, { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
-import { useSearchParams } from 'react-router-dom'
+import { Navigate, useSearchParams } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { HTTP_STATUS, isErrorAPIError } from 'apiClient/helpers'
@@ -37,6 +37,7 @@ export const SignIn = (): JSX.Element => {
   const notify = useNotification()
   const dispatch = useDispatch()
   const [searchParams, setSearchParams] = useSearchParams()
+  const [shouldRedirect, setshouldRedirect] = React.useState(false)
   useInitReCaptcha()
 
   useEffect(() => {
@@ -64,6 +65,7 @@ export const SignIn = (): JSX.Element => {
         captchaToken,
       })
       dispatch(updateUser(user))
+      setshouldRedirect(true)
     } catch (error) {
       if (isErrorAPIError(error)) {
         updateUser(null)
@@ -93,7 +95,9 @@ export const SignIn = (): JSX.Element => {
     }
   }
 
-  return (
+  return shouldRedirect ? (
+    <Navigate to="/" replace />
+  ) : (
     <AppLayout pageName="sign-in" layout="without-nav">
       <header className={styles['logo-side']}>
         <SvgIcon


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29224

Réduire les rerenders et fix les effets "clignotement" sur le portail pro.

- Déplacement de la gestion des thèmes dans App pour éviter de recréer le router à chaque changement de thème. 
- Supprimer un window.reload pour mettre à jour l'interface de manière plus naturel et ne pas afficher la bannière de bienvenue tant que la nouvelle interface n'est pas affichée
- Redirection vers la homepage au Signin pour éviter que l'AppLayout soit rerendu : `navigate` ne fonctionne pas ici car appellé après le rerender du composant

