### PR TITLE
(PC-28385)[BO] refactor: move to end of modal acceslibre url and add it to virustotal

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -124,5 +124,5 @@
   <a href="{{ url_for('backoffice_web.safe_redirect', url=url) }}"
      target="_blank"
      title="Vérifier et ouvrir le site web externe"
-     class="link-primary">{{ url }}</a>
+     class="link-primary">{{ url }} <i class="bi bi-box-arrow-up-right"></i></a>
 {% endmacro %}

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -276,9 +276,7 @@
                 <p class="mb-1">
                   <span class="fw-bold">Page Acceslibre :</span>
                   {% if venue.accessibilityProvider.externalAccessibilityUrl %}
-                    <a href="{{ venue.accessibilityProvider.externalAccessibilityUrl | format_website }}"
-                       target="_blank"
-                       class="link-primary">{{ venue.accessibilityProvider.externalAccessibilityUrl | format_website }} <i class="bi bi-box-arrow-up-right"></i></a>
+                    {{ links.build_safe_redirect_link(venue.accessibilityProvider.externalAccessibilityUrl | format_website) }}
                   {% elif venue.accessibilityProvider.externalAccessibilityId and not venue.accessibilityProvider.externalAccessibilityUrl %}
                     Attention, l'URL pour l'identifiant Acceslibre <i>{{ venue.accessibilityProvider.externalAccessibilityId }}</i> n'est pas renseignée
                   {% elif not venue.accessibilityProvider.externalAccessibilityId and not venue.accessibilityProvider.externalAccessibilityUrl %}

--- a/api/src/pcapi/routes/backoffice/venues/forms.py
+++ b/api/src/pcapi/routes/backoffice/venues/forms.py
@@ -86,6 +86,7 @@ class EditVenueForm(EditVirtualVenueForm):
         self._fields.move_to_end("booking_email")
         self._fields.move_to_end("phone_number")
         self._fields.move_to_end("venue_type_code")
+        self._fields.move_to_end("acceslibre_url")
         self._fields.move_to_end("is_permanent")
 
     def filter_siret(self, raw_siret: str | None) -> str | None:


### PR DESCRIPTION
## But de la pull request

Position de l'url d'acceslibre dans la modale d'édition de lieux + ajout à virus total
Egalement un petit ajout de la `bi-box-arrow-up-right` aux liens vers les sites web vérifiés par virus total

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28385

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

![Capture d’écran 2024-04-19 à 15 32 04](https://github.com/pass-culture/pass-culture-main/assets/144006742/3b186806-c623-43b4-a03d-44a0edec1a06) 

![Capture d’écran 2024-04-19 à 15 42 58](https://github.com/pass-culture/pass-culture-main/assets/144006742/63a29c0a-b6ff-47d6-8703-08b15e0600a1)

