### PR TITLE
(PC-28869)[PRO] feat: add tracker for switch vue button

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -205,6 +205,11 @@ export const Offers = ({
   function toggleButtonClicked(button: ToggleButton) {
     const viewType = button.id === 'list' ? 'list' : 'grid'
     dispatch(setSearchView(viewType))
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    apiAdage.logOfferListViewSwitch({
+      iframeFrom: location.pathname,
+      source: viewType,
+    })
   }
 
   return (

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
@@ -44,6 +44,7 @@ vi.mock('apiClient/api', () => ({
     logSearchButtonClick: vi.fn(),
     logTrackingFilter: vi.fn(),
     logSearchShowMore: vi.fn(),
+    logOfferListViewSwitch: vi.fn(),
   },
 }))
 
@@ -836,5 +837,24 @@ describe('offers', () => {
     expect(
       screen.queryByText('Une offre vraiment chouette')
     ).not.toBeInTheDocument()
+  })
+
+  it('should call tracker when clicking on toggle button view', async () => {
+    vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(offerInParis)
+    vi.spyOn(apiAdage, 'getCollectiveOffer').mockResolvedValueOnce(
+      offerInCayenne
+    )
+    renderOffers({ ...offersProps, isBackToTopVisibile: true }, adageUser, {
+      features: ['WIP_ENABLE_ADAGE_VISUALIZATION'],
+    })
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    const toggleButtonView = screen.getByTestId('toggle-button')
+
+    await userEvent.click(toggleButtonView)
+
+    expect(apiAdage.logOfferListViewSwitch).toHaveBeenCalledWith(
+      expect.objectContaining({ iframeFrom: '/', source: 'list' })
+    )
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28869

Ajouter un tracker pour savoir si on a cliqué sur le bouton pour switch de vue sur la page de recherche adage

## Vérifications

- [x] J'ai écrit les tests nécessaires