### PR TITLE
(PC-28870)[PRO] feat: Add tracking log for viewtype when clicking an …

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -14,10 +14,15 @@ import styles from './OfferCard.module.scss'
 
 export interface CardComponentProps {
   offer: CollectiveOfferTemplateResponseModel
-  handleTracking: () => void
+  onCardClicked: () => void
+  viewType?: 'grid' | 'list'
 }
 
-const OfferCardComponent = ({ offer, handleTracking }: CardComponentProps) => {
+const OfferCardComponent = ({
+  offer,
+  onCardClicked,
+  viewType,
+}: CardComponentProps) => {
   const location = useLocation()
 
   const currentPathname = location.pathname.split('/')[2]
@@ -32,9 +37,7 @@ const OfferCardComponent = ({ offer, handleTracking }: CardComponentProps) => {
         data-testid="card-offer-link"
         to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
         state={{ offer }}
-        onClick={() => {
-          handleTracking()
-        }}
+        onClick={onCardClicked}
       >
         <div className={styles['offer-image-container']}>
           {offer.imageUrl ? (
@@ -99,6 +102,7 @@ const OfferCardComponent = ({ offer, handleTracking }: CardComponentProps) => {
       <OfferFavoriteButton
         offer={{ ...offer, isTemplate: true }}
         className={styles['offer-favorite-button']}
+        viewType={viewType}
       />
     </div>
   )

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/__specs__/OfferCard.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/__specs__/OfferCard.spec.tsx
@@ -46,11 +46,11 @@ const adageUser: AuthenticatedResponse = {
 
 const renderOfferCardComponent = ({
   offer,
-  handleTracking,
+  onCardClicked,
 }: CardComponentProps) => {
   renderWithProviders(
     <AdageUserContextProvider adageUser={adageUser}>
-      <OfferCardComponent offer={offer} handleTracking={handleTracking} />
+      <OfferCardComponent offer={offer} onCardClicked={onCardClicked} />
     </AdageUserContextProvider>
   )
 }
@@ -76,7 +76,7 @@ describe('OfferCard component', () => {
         addressType: OfferAddressType.SCHOOL,
       },
     }
-    renderOfferCardComponent({ offer, handleTracking: vi.fn() })
+    renderOfferCardComponent({ offer, onCardClicked: vi.fn() })
 
     expect(
       screen.getByText(/Dans l’établissement scolaire/)
@@ -91,7 +91,7 @@ describe('OfferCard component', () => {
         addressType: OfferAddressType.OFFERER_VENUE,
       },
     }
-    renderOfferCardComponent({ offer, handleTracking: vi.fn() })
+    renderOfferCardComponent({ offer, onCardClicked: vi.fn() })
 
     expect(screen.getByText(/Sortie/)).toBeInTheDocument()
     expect(screen.getByText(/À 10 km/)).toBeInTheDocument()
@@ -105,7 +105,7 @@ describe('OfferCard component', () => {
         addressType: OfferAddressType.OTHER,
       },
     }
-    renderOfferCardComponent({ offer, handleTracking: vi.fn() })
+    renderOfferCardComponent({ offer, onCardClicked: vi.fn() })
 
     expect(screen.getByText(/Sortie/)).toBeInTheDocument()
     expect(screen.getByText(/Lieu à définir/)).toBeInTheDocument()
@@ -126,7 +126,7 @@ describe('OfferCard component', () => {
         },
       },
     }
-    renderOfferCardComponent({ offer, handleTracking: vi.fn() })
+    renderOfferCardComponent({ offer, onCardClicked: vi.fn() })
 
     expect(screen.getByText('à 1 km - Paris')).toBeInTheDocument()
   })
@@ -139,7 +139,7 @@ describe('OfferCard component', () => {
 
     renderOfferCardComponent({
       offer: mockOffer,
-      handleTracking: vi.fn(),
+      onCardClicked: vi.fn(),
     })
 
     const offerElement = screen.getByTestId('card-offer-link')
@@ -162,7 +162,7 @@ describe('OfferCard component', () => {
 
     renderOfferCardComponent({
       offer: mockOffer,
-      handleTracking: vi.fn(),
+      onCardClicked: vi.fn(),
     })
 
     const offerElement = screen.getByTestId('card-offer-link')
@@ -179,7 +179,7 @@ describe('OfferCard component', () => {
 
     renderOfferCardComponent({
       offer: mockOffer,
-      handleTracking: mockHandleTracking,
+      onCardClicked: mockHandleTracking,
     })
 
     const offerElement = screen.getByTestId('card-offer-link')

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/ClassroomPlaylist/ClassroomPlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/ClassroomPlaylist/ClassroomPlaylist.tsx
@@ -71,7 +71,7 @@ export const ClassroomPlaylist = ({
       loading={loading}
       elements={offers.map((offerElement, index) => (
         <OfferCardComponent
-          handleTracking={() =>
+          onCardClicked={() =>
             trackPlaylistElementClicked({
               playlistId: CLASSROOM_PLAYLIST,
               playlistType: AdagePlaylistType.OFFER,

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/NewOfferPlaylist/NewOfferPlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/NewOfferPlaylist/NewOfferPlaylist.tsx
@@ -71,7 +71,7 @@ export const NewOfferPlaylist = ({
       }
       elements={offers.map((offer, index) => (
         <OfferCardComponent
-          handleTracking={() =>
+          onCardClicked={() =>
             trackPlaylistElementClicked({
               playlistId: NEW_OFFER_PLAYLIST,
               playlistType: AdagePlaylistType.OFFER,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
@@ -7,7 +7,6 @@ import {
   CollectiveOfferResponseModel,
   CollectiveOfferTemplateResponseModel,
 } from 'apiClient/adage'
-import { apiAdage } from 'apiClient/api'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
 import {
@@ -15,7 +14,6 @@ import {
   isCollectiveOfferTemplate,
 } from 'pages/AdageIframe/app/types/offers'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
-import { LOGS_DATA } from 'utils/config'
 
 import OfferFavoriteButton from '../OfferFavoriteButton/OfferFavoriteButton'
 import OfferShareLink from '../OfferShareLink/OfferShareLink'
@@ -30,12 +28,16 @@ export type AdageOfferListCardProps = {
   afterFavoriteChange?: (isFavorite: boolean) => void
   isInSuggestions?: boolean
   queryId?: string
+  viewType?: 'grid' | 'list'
+  onCardClicked?: () => void
 }
 export function AdageOfferListCard({
   offer,
   afterFavoriteChange,
   isInSuggestions,
   queryId = '',
+  viewType,
+  onCardClicked,
 }: AdageOfferListCardProps) {
   const [searchParams] = useSearchParams()
   const adageAuthToken = searchParams.get('token')
@@ -50,22 +52,6 @@ export function AdageOfferListCard({
   const isOfferTemplate = isCollectiveOfferTemplate(offer)
   const canAddOfferToFavorites =
     isOfferTemplate && adageUser.role !== AdageFrontRoles.READONLY
-
-  function triggerOfferClickLog(
-    offer: CollectiveOfferResponseModel | CollectiveOfferTemplateResponseModel
-  ) {
-    if (!LOGS_DATA) {
-      return
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    apiAdage.logOfferTemplateDetailsButtonClick({
-      iframeFrom: location.pathname,
-      offerId: isCollectiveOfferTemplate(offer) ? offer.id : offer.stock.id,
-      queryId: queryId,
-      isFromNoResult: isInSuggestions,
-    })
-  }
 
   return (
     <div
@@ -131,7 +117,7 @@ export function AdageOfferListCard({
               to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
               state={{ offer }}
               className={styles['offer-card-link']}
-              onClick={() => triggerOfferClickLog(offer)}
+              onClick={onCardClicked}
             >
               <h2 className={styles['offer-title']}>{offer.name}</h2>
             </Link>
@@ -143,6 +129,7 @@ export function AdageOfferListCard({
               <OfferFavoriteButton
                 offer={offer}
                 afterFavoriteChange={afterFavoriteChange}
+                viewType={viewType}
               />
             )}
             {isOfferTemplate && <OfferShareLink offer={offer} />}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferFavoriteButton/OfferFavoriteButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferFavoriteButton/OfferFavoriteButton.tsx
@@ -18,6 +18,7 @@ export interface OfferFavoriteButtonProps {
   afterFavoriteChange?: (isFavorite: boolean) => void
   isInSuggestions?: boolean
   className?: string
+  viewType?: 'grid' | 'list'
 }
 
 const OfferFavoriteButton = ({
@@ -26,6 +27,7 @@ const OfferFavoriteButton = ({
   afterFavoriteChange,
   isInSuggestions,
   className,
+  viewType,
 }: OfferFavoriteButtonProps): JSX.Element => {
   const [isFavorite, setIsFavorite] = useState(offer.isFavorite)
   const [isLoading, setIsLoading] = useState(false)
@@ -51,6 +53,7 @@ const OfferFavoriteButton = ({
         iframeFrom: location.pathname,
         isFavorite: false,
         isFromNoResult: isInSuggestions,
+        vueType: viewType,
       })
 
       afterFavoriteChange?.(false)
@@ -79,6 +82,7 @@ const OfferFavoriteButton = ({
         iframeFrom: location.pathname,
         isFavorite: true,
         isFromNoResult: isInSuggestions,
+        vueType: viewType,
       })
 
       afterFavoriteChange?.(true)

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -20,12 +20,14 @@ import fullGoTop from 'icons/full-go-top.svg'
 import fullGrid from 'icons/full-grid.svg'
 import fullList from 'icons/full-list.svg'
 import useAdageUser from 'pages/AdageIframe/app/hooks/useAdageUser'
+import { isCollectiveOfferTemplate } from 'pages/AdageIframe/app/types/offers'
 import { setSearchView } from 'store/adageFilter/reducer'
 import { adageSearchViewSelector } from 'store/adageFilter/selectors'
 import { Button } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import Spinner from 'ui-kit/Spinner/Spinner'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+import { LOGS_DATA } from 'utils/config'
 import { sendSentryCustomError } from 'utils/sendSentryCustomError'
 
 import OfferCardComponent from '../../../AdageDiscovery/OfferCard/OfferCard'
@@ -212,6 +214,23 @@ export const Offers = ({
     })
   }
 
+  function triggerOfferClickLog(
+    offer: CollectiveOfferResponseModel | CollectiveOfferTemplateResponseModel
+  ) {
+    if (!LOGS_DATA) {
+      return
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    apiAdage.logOfferTemplateDetailsButtonClick({
+      iframeFrom: location.pathname,
+      offerId: isCollectiveOfferTemplate(offer) ? offer.id : offer.stock.id,
+      queryId: results?.queryID,
+      isFromNoResult: isInSuggestions,
+      vueType: adageViewType,
+    })
+  }
+
   return (
     <>
       <div className={styles['offers-view']}>
@@ -261,14 +280,15 @@ export const Offers = ({
                   offer={offer}
                   queryId={results.queryID ?? ''}
                   isInSuggestions={indexId?.startsWith('no_results_offers')}
+                  viewType={adageViewType}
+                  onCardClicked={() => triggerOfferClickLog(offer)}
                 />
               ) : (
                 <OfferCardComponent
-                  handleTracking={() =>
-                    console.log('call tracking quand ticket back terminé')
-                  }
+                  onCardClicked={() => triggerOfferClickLog(offer)}
                   key={offer.id}
                   offer={offer}
+                  viewType={adageViewType}
                 />
               )
             ) : (


### PR DESCRIPTION
…offer and cliking the favorite button

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28870

**FF à activer**
WIP_ENABLE_ADAGE_VISUALIZATION

**Objectif**
Ajouter le type de view dans les appels aux trackers d'ajout en favoris et de clic sur une offre (en mode grill et en mode liste, mais que pour les composants offre avec FF WIP_ENABLE_ADAGE_VISUALIZATION activé)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques