### PR TITLE
(PC-28894)[PRO] fix: OpeningHoursForm show all errors

### DIFF
--- a/pro/src/pages/VenueEdition/OpeningHoursForm/HourLine.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursForm/HourLine.tsx
@@ -29,8 +29,6 @@ export function HourLine({ day }: HourLineProps) {
     await setFieldValue(`${day}.afternoonStartingHour`, '')
     await setFieldValue(`${day}.afternoonEndingHour`, '')
     await setFieldValue(`${day}.isAfternoonOpen`, false)
-    await setFieldTouched(`${day}.afternoonStartingHour`, false)
-    await setFieldTouched(`${day}.afternoonEndingHour`, false)
   }
 
   return (
@@ -85,6 +83,8 @@ export function HourLine({ day }: HourLineProps) {
               icon={fullMoreIcon}
               onClick={async () => {
                 await setFieldValue(`${day}.isAfternoonOpen`, true)
+                await setFieldTouched(`${day}.afternoonStartingHour`, false)
+                await setFieldTouched(`${day}.afternoonEndingHour`, false)
                 setIsFullLineDisplayed(true)
               }}
               hasTooltip

--- a/pro/src/pages/VenueEdition/OpeningHoursForm/__specs__/OpeningHoursForm.spec.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursForm/__specs__/OpeningHoursForm.spec.tsx
@@ -23,12 +23,10 @@ const renderOpeningHoursForm = ({
       onSubmit={onSubmit}
       validationSchema={getValidationSchema(false)}
     >
-      {({ handleSubmit }) => (
-        <Form onSubmit={handleSubmit}>
-          <OpeningHoursForm />
-          <SubmitButton isLoading={false}>Submit</SubmitButton>
-        </Form>
-      )}
+      <Form>
+        <OpeningHoursForm />
+        <SubmitButton isLoading={false}>Submit</SubmitButton>
+      </Form>
     </Formik>
   )
 }
@@ -230,5 +228,22 @@ describe('OpeningHoursForm', () => {
       'min',
       '18:00'
     )
+  })
+
+  it('should show all errors', async () => {
+    renderOpeningHoursForm({})
+
+    await userEvent.click(screen.getByLabelText('Mardi'))
+    await userEvent.click(screen.getByLabelText('Mercredi'))
+    await userEvent.click(screen.getByLabelText('Jeudi'))
+
+    await userEvent.click(screen.getByText('Submit'))
+
+    expect(
+      screen.getAllByText('Veuillez renseigner une heure de début')
+    ).toHaveLength(3)
+    expect(
+      screen.getAllByText('Veuillez renseigner une heure de fin')
+    ).toHaveLength(3)
   })
 })

--- a/pro/src/pages/VenueEdition/setInitialFormValues.ts
+++ b/pro/src/pages/VenueEdition/setInitialFormValues.ts
@@ -68,13 +68,13 @@ function buildOpeningHoursValues(
   if (!openingHours || openingHours.length === 0) {
     return {
       days: [],
-      monday: DEFAULT_INTITIAL_OPENING_HOURS,
-      tuesday: DEFAULT_INTITIAL_OPENING_HOURS,
-      wednesday: DEFAULT_INTITIAL_OPENING_HOURS,
-      thursday: DEFAULT_INTITIAL_OPENING_HOURS,
-      friday: DEFAULT_INTITIAL_OPENING_HOURS,
-      saturday: DEFAULT_INTITIAL_OPENING_HOURS,
-      sunday: DEFAULT_INTITIAL_OPENING_HOURS,
+      monday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
+      wednesday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
+      tuesday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
+      thursday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
+      friday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
+      saturday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
+      sunday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
     }
   }
   const days = filledDays.map((dateAndHour) =>
@@ -116,5 +116,5 @@ function buildHourOfDay(
           : '',
         isAfternoonOpen: Object.values(dayOpeningHour)[1] ? true : false,
       }
-    : DEFAULT_INTITIAL_OPENING_HOURS
+    : { ...DEFAULT_INTITIAL_OPENING_HOURS }
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28894

Toutes les erreurs du formulaire ne s'affichaient pas au submit, 
j'ai pas hyper bien compris pourquoi le fix fixe, le prblème venait de formik qui ne mettait pas ces champs isTouched=true

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques