### PR TITLE
(PC-29016)[PRO] feat: Fix adage card offer responsive and fix in-sear…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/DiffuseHelp/DiffuseHelp.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/DiffuseHelp/DiffuseHelp.module.scss
@@ -65,7 +65,15 @@
   }
 
   &-close {
-    width: rem.torem(32px);
+    background-color: transparent;
+    border: none;
+    width: rem.torem(24px);
+    height: rem.torem(24px);
     cursor: pointer;
+
+    &:focus-visible {
+      outline: rem.torem(1px) solid var(--color-input-text-color);
+      outline-offset: rem.torem(2px);
+    }
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/DiffuseHelp/DiffuseHelp.tsx
+++ b/pro/src/pages/AdageIframe/app/components/DiffuseHelp/DiffuseHelp.tsx
@@ -1,8 +1,8 @@
 import cn from 'classnames'
 import React, { useState } from 'react'
 
-import fullClear from 'icons/full-clear.svg'
 import helpIcon from 'icons/shadow-tips-help.svg'
+import strokeCloseIcon from 'icons/stroke-close.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { localStorageAvailable } from 'utils/localStorageAvailable'
 
@@ -34,20 +34,18 @@ export const DiffuseHelp = ({
       <div className={styles['diffuse-help-infos']}>
         <div className={styles['diffuse-help-container']}>
           <div className={styles['diffuse-help-header']}>
-            <SvgIcon src={helpIcon} alt="help" width="32" />
+            <SvgIcon src={helpIcon} alt="" width="32" />
             <div className={styles['diffuse-help-title']}>Le saviez-vous ?</div>
           </div>
-          <div
-            className={styles['diffuse-help-close']}
+          <button
             onClick={onCloseDiffuseHelp}
+            title="Masquer le bandeau"
+            type="button"
+            className={styles['diffuse-help-close']}
             data-testid="close-diffuse-help"
           >
-            <SvgIcon
-              src={fullClear}
-              alt=""
-              className={styles['diffuse-help-close-icon']}
-            />{' '}
-          </div>
+            <SvgIcon src={strokeCloseIcon} alt="" width="24" />
+          </button>
         </div>
         <div className={styles['diffuse-help-description']}>{description}</div>
       </div>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.module.scss
@@ -53,7 +53,8 @@
 
   &-container {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
+    align-items: center;
     width: 100%;
     gap: rem.torem(16px);
   }
@@ -134,7 +135,7 @@
 
   &-text {
     display: flex;
-    flex-direction: column
+    flex-direction: column;
   }
 
   .intended-for {
@@ -151,7 +152,6 @@
     display: flex;
     flex-direction: column;
   }
-
 }
 
 .offer-prebooking-button {
@@ -162,6 +162,11 @@
   .offer-card {
     flex-direction: column;
     align-items: flex-start;
+
+    &-container {
+      flex-direction: row;
+      align-items: unset;
+    }
 
     &-right {
       flex-direction: row;

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.module.scss
@@ -8,12 +8,18 @@
   background-repeat: no-repeat;
   background-size: cover;
   border-radius: rem.torem(8px);
+  padding: rem.torem(32px) rem.torem(24px);
 
   &-infos {
     display: flex;
     flex-direction: column;
     gap: rem.torem(16px);
-    padding: 0 rem.torem(32px) rem.torem(24px);
+
+    &-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
   }
 }
 
@@ -30,8 +36,6 @@
 .survey-button {
   background-color: var(--color-secondary-light);
   border-color: var(--color-secondary-light);
-  width: rem.torem(196px);
-  margin-left: rem.torem(16px);
 
   &:hover,
   &:focus {
@@ -57,15 +61,22 @@
   }
 }
 
-.survey-close {
-  display: inline-flex;
-  width: 100%;
-  justify-content: flex-end;
-  padding: rem.torem(8px);
+.survey-actions {
+  display: flex;
+  align-items: center;
+  gap: rem.torem(16px);
+  flex-wrap: wrap;
+}
 
-  &-button {
-    background-color: transparent;
-    border: none;
-    width: rem.torem(24px);
+.survey-close {
+  background-color: transparent;
+  border: none;
+  width: rem.torem(24px);
+  height: rem.torem(24px);
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: rem.torem(1px) solid var(--color-input-text-color);
+    outline-offset: rem.torem(2px);
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
@@ -1,8 +1,9 @@
 import cn from 'classnames'
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { apiAdage } from 'apiClient/api'
 import useNotification from 'hooks/useNotification'
+import fullLinkIcon from 'icons/full-link.svg'
 import strokeCloseIcon from 'icons/stroke-close.svg'
 import { Button, ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -47,30 +48,25 @@ export const SurveySatisfaction = ({
         [styles['survey-satisfaction-closed']]: shouldHideSurveySatisfaction,
       })}
     >
-      <div className={styles['survey-close']}>
-        <button
-          onClick={onCloseSurvey}
-          title="Masquer le bandeau"
-          type="button"
-          className={styles['survey-close-button']}
-        >
-          <SvgIcon
-            src={strokeCloseIcon}
-            alt=""
-            className={styles['survey-close-icon']}
-          />
-        </button>
-      </div>
-
       <div className={styles['survey-satisfaction-infos']}>
-        <div className={styles['survey-title']}>Enquête de satisfaction</div>
+        <div className={styles['survey-satisfaction-infos-head']}>
+          <div className={styles['survey-title']}>Enquête de satisfaction</div>
+          <button
+            onClick={onCloseSurvey}
+            title="Masquer le bandeau"
+            type="button"
+            className={styles['survey-close']}
+          >
+            <SvgIcon src={strokeCloseIcon} alt="" width="24" />
+          </button>
+        </div>
         <div className={styles['survey-description']}>
           Le pass Culture souhaite recueillir votre avis sur cette page web :
           Les offres pass Culture.
           <br /> Cela ne vous prendra que 2 minutes.
         </div>
 
-        <div>
+        <div className={styles['survey-actions']}>
           <Button
             className={styles['survey-button-secondary']}
             onClick={onCloseSurvey}
@@ -85,6 +81,8 @@ export const SurveySatisfaction = ({
               isExternal: true,
               target: '_blank',
             }}
+            icon={fullLinkIcon}
+            svgAlt="Nouvelle fenêtre"
             className={styles['survey-button']}
             onClick={logOpenSatisfactionSurvey}
           >

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/__specs__/SurveySatisfaction.spec.tsx
@@ -64,7 +64,9 @@ describe('SurveySatisfaction', () => {
   it('should log info when opening sastisfaction survey', async () => {
     renderWithProviders(<SurveySatisfaction {...defaultProps} />)
 
-    const openButton = screen.getByRole('link', { name: 'Je donne mon avis' })
+    const openButton = screen.getByRole('link', {
+      name: 'Nouvelle fenêtre Je donne mon avis',
+    })
 
     await userEvent.click(openButton)
 


### PR DESCRIPTION
…ch banners accessibility.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29016

**Objectif**
Aligner le design et corriger l'accessibilité des bannières de la recherche ADAGE enquête de satisfaction et aide diffuse (voir ticket pour le détail des améliorations).

Pour reproduire : ouvrir la recherche adage en ayant jamais fermé les bannières, sinon vous ne les verrez pas. Les bannières apparaissent parmi les premières offres (en mode liste seulement si vous avez activé le FF Visualization)

<img width="516" alt="Capture d’écran 2024-04-23 à 16 39 34" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/a57c8403-3374-4315-89a7-b143e36bbc57">
<img width="516" alt="Capture d’écran 2024-04-23 à 16 39 28" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/e3601cac-6629-4f1c-86d6-aa068d50a48f">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques