### PR TITLE
(PC-29379)[BO] feat: add VALIDATE_COMMERCIAL_GESTURE permission

### DIFF
--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -374,6 +374,32 @@ class FinanceIncidentFactory(BaseFactory):
     }
 
 
+class FinanceCommercialGestureFactory(BaseFactory):
+    class Meta:
+        model = models.FinanceIncident
+
+    venue = factory.SubFactory(offerers_factories.VenueFactory)
+    kind = models.IncidentType.COMMERCIAL_GESTURE
+    status = models.IncidentStatus.CREATED
+    details = {
+        "origin": "Demande e-mail",
+        "createdAt": datetime.datetime.utcnow().isoformat(),
+        "authorId": 1,
+        "validator": "",
+        "validatedAt": "",
+    }
+
+
+class IndividualBookingFinanceCommercialGestureFactory(BaseFactory):
+    class Meta:
+        model = models.BookingFinanceIncident
+
+    booking = factory.SubFactory(bookings_factories.CancelledBookingFactory)
+    incident = factory.SubFactory(FinanceCommercialGestureFactory)
+    beneficiary = factory.SelfAttribute("booking.user")
+    newTotalAmount = factory.LazyAttribute(lambda x: x.booking.total_amount - 100)
+
+
 class IndividualBookingFinanceIncidentFactory(BaseFactory):
     class Meta:
         model = models.BookingFinanceIncident

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -1084,6 +1084,13 @@ class BookingFinanceIncident(Base, Model):
     )
 
     @property
+    def commercial_gesture_amount(self) -> int | None:  # in cents
+        # Evaluates to None if the incident is not a commercial gesture
+        if self.incident.kind == IncidentType.COMMERCIAL_GESTURE:
+            return ((self.booking or self.collectiveBooking).total_amount * 100) - self.newTotalAmount
+        return None
+
+    @property
     def is_partial(self) -> bool:
         """
         Returns True if the booking new amount is not 0. That means the incident is not total.

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -67,6 +67,7 @@ class Permissions(enum.Enum):
 
     READ_INCIDENTS = "visualiser les incidents"
     MANAGE_INCIDENTS = "gérer les incidents"
+    VALIDATE_COMMERCIAL_GESTURE = "valider les gestes commerciaux"
 
     GENERATE_INVOICES = "générer les justificatifs de remboursement"
 

--- a/api/src/pcapi/routes/backoffice/finance/finance_incidents_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/finance/finance_incidents_blueprint.py
@@ -775,14 +775,17 @@ def get_finance_incident_validation_form(finance_incident_id: int) -> utils.Back
 
     incident_total_amount_euros = finance_utils.to_euros(finance_incident.due_amount_by_offerer)
     bank_account_link = finance_incident.venue.current_bank_account_link
-    bank_account_details_str = f"{'du lieu' if not bank_account_link else bank_account_link.bankAccount.label}"
+    bank_account_details_str = "du lieu" if not bank_account_link else bank_account_link.bankAccount.label
+    validation_url = (
+        "backoffice_web.finance_incidents.validate_finance_commercial_gesture"
+        if finance_incident.kind == finance_models.IncidentType.COMMERCIAL_GESTURE
+        else "backoffice_web.finance_incidents.validate_finance_overpayment_incident"
+    )
 
     return render_template(
         "components/turbo/modal_form.html",
         form=forms.IncidentValidationForm(),
-        dst=url_for(
-            "backoffice_web.finance_incidents.validate_finance_incident", finance_incident_id=finance_incident_id
-        ),
+        dst=url_for(validation_url, finance_incident_id=finance_incident_id),
         div_id=f"finance-incident-validation-modal-{finance_incident_id}",
         title="Valider l'incident",
         button_text="Confirmer",
@@ -796,10 +799,10 @@ def get_finance_incident_validation_form(finance_incident_id: int) -> utils.Back
     )
 
 
-@finance_incidents_blueprint.route("/<int:finance_incident_id>/validate", methods=["POST"])
+@finance_incidents_blueprint.route("/overpayment/<int:finance_incident_id>/validate", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_INCIDENTS)
-def validate_finance_incident(finance_incident_id: int) -> utils.BackofficeResponse:
-    finance_incident = _get_incident(finance_incident_id)
+def validate_finance_overpayment_incident(finance_incident_id: int) -> utils.BackofficeResponse:
+    finance_incident = _get_incident(finance_incident_id, kind=finance_models.IncidentType.OVERPAYMENT)
     form = forms.IncidentValidationForm()
 
     if not form.validate():
@@ -807,12 +810,35 @@ def validate_finance_incident(finance_incident_id: int) -> utils.BackofficeRespo
     elif finance_incident.status != finance_models.IncidentStatus.CREATED:
         flash("L'incident ne peut être validé que s'il est au statut 'créé'.", "warning")
     else:
-        finance_api.validate_finance_incident(
+        finance_api.validate_finance_overpayment_incident(
             finance_incident=finance_incident,
             force_debit_note=form.compensation_mode.data == forms.IncidentCompensationModes.FORCE_DEBIT_NOTE.name,
             author=current_user,
         )
-        flash("L'incident a été validé", "success")
+        flash("L'incident a été validé.", "success")
+
+    return redirect(
+        url_for("backoffice_web.finance_incidents.get_incident", finance_incident_id=finance_incident_id), 303
+    )
+
+
+@finance_incidents_blueprint.route("/commercial-gesture/<int:finance_incident_id>/validate", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.VALIDATE_COMMERCIAL_GESTURE)
+def validate_finance_commercial_gesture(finance_incident_id: int) -> utils.BackofficeResponse:
+    finance_incident = _get_incident(finance_incident_id, kind=finance_models.IncidentType.COMMERCIAL_GESTURE)
+    form = forms.IncidentValidationForm()
+
+    if not form.validate():
+        flash(utils.build_form_error_msg(form), "warning")
+    elif finance_incident.status != finance_models.IncidentStatus.CREATED:
+        flash("Le geste commercial ne peut être validé que s'il est au statut 'créé'.", "warning")
+    else:
+        finance_api.validate_finance_commercial_gesture(
+            finance_incident=finance_incident,
+            force_debit_note=form.compensation_mode.data == forms.IncidentCompensationModes.FORCE_DEBIT_NOTE.name,
+            author=current_user,
+        )
+        flash("Le geste commercial a été validé.", "success")
 
     return redirect(
         url_for("backoffice_web.finance_incidents.get_incident", finance_incident_id=finance_incident.id), 303
@@ -921,9 +947,9 @@ def cancel_debit_note(finance_incident_id: int) -> utils.BackofficeResponse:
     )
 
 
-def _get_incident(finance_incident_id: int) -> finance_models.FinanceIncident:
+def _get_incident(finance_incident_id: int, **args: typing.Any) -> finance_models.FinanceIncident:
     incident = (
-        finance_models.FinanceIncident.query.filter_by(id=finance_incident_id)
+        finance_models.FinanceIncident.query.filter_by(id=finance_incident_id, **args)
         .join(finance_models.FinanceIncident.venue)
         .outerjoin(
             offerer_models.VenueBankAccountLink,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -16,6 +16,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "codir_admin": [
         perm_models.Permissions.READ_INCIDENTS,
         perm_models.Permissions.MANAGE_INCIDENTS,
+        perm_models.Permissions.VALIDATE_COMMERCIAL_GESTURE,
     ],
     "support_n1": [
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -294,7 +294,9 @@ class PriceEventTest:
         )
 
         author = users_factories.UserFactory()
-        api.validate_finance_incident(total_booking_incident.incident, force_debit_note=False, author=author)
+        api.validate_finance_overpayment_incident(
+            total_booking_incident.incident, force_debit_note=False, author=author
+        )
 
         assert total_booking_incident.booking.status == bookings_models.BookingStatus.CANCELLED
 
@@ -3619,7 +3621,7 @@ class ValidateFinanceIncidentTest:
             )
 
         author = users_factories.UserFactory()
-        api.validate_finance_incident(
+        api.validate_finance_overpayment_incident(
             collective_booking_finance_incident.incident, force_debit_note=False, author=author
         )
 

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -540,7 +540,7 @@ class SQLFunctionsTest:
         )  # +10 on user's wallet
 
         author = users_factories.UserFactory()
-        finance_api.validate_finance_incident(incident, force_debit_note=False, author=author)
+        finance_api.validate_finance_overpayment_incident(incident, force_debit_note=False, author=author)
 
         assert incident.status == finance_models.IncidentStatus.VALIDATED
 
@@ -566,7 +566,7 @@ class SQLFunctionsTest:
 
         # When
         author = users_factories.UserFactory()
-        finance_api.validate_finance_incident(incident, force_debit_note=False, author=author)
+        finance_api.validate_finance_overpayment_incident(incident, force_debit_note=False, author=author)
 
         # Then
         assert incident.status == finance_models.IncidentStatus.VALIDATED

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -172,6 +172,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "codir_admin": [
         perm_models.Permissions.READ_INCIDENTS,
         perm_models.Permissions.MANAGE_INCIDENTS,
+        perm_models.Permissions.VALIDATE_COMMERCIAL_GESTURE,
     ],
     "gestionnaire_des_droits": [
         perm_models.Permissions.MANAGE_PERMISSIONS,
@@ -237,6 +238,14 @@ def support_pro_n2_fixture(roles_with_permissions: None) -> users_models.User:
 def pro_fraud_admin_fixture(roles_with_permissions: None) -> users_models.User:
     user = users_factories.UserFactory(roles=["ADMIN"])
     backoffice_api.upsert_roles(user, {perm_models.Roles.FRAUDE_CONFORMITE})
+    db.session.flush()
+    return user
+
+
+@pytest.fixture
+def codir_admin(roles_with_permissions):
+    user = users_factories.UserFactory(roles=["ADMIN"])
+    backoffice_api.upsert_roles(user, {perm_models.Roles.CODIR_ADMIN})
     db.session.flush()
     return user
 


### PR DESCRIPTION
## But de la pull request

Ajout d'une nouvelle permission `VALIDATE_COMMERCIAL_GESTURE` qui autorise exclusivement le role `codir_admin` à valider les gestes commerciaux 

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29379

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques