### PR TITLE
(PC-29458)[API] chore: drop deprecated indexes without unaccent

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 154f5e68cb31 (pre) (head)
-2c2ec9ce033e (post) (head)
+348fd34d687b (post) (head)

--- a/api/src/pcapi/alembic/versions/20240424T133200_833b6aed7272_drop_idx_venue_trgm_name.py
+++ b/api/src/pcapi/alembic/versions/20240424T133200_833b6aed7272_drop_idx_venue_trgm_name.py
@@ -1,0 +1,28 @@
+"""Drop deprecated index: idx_venue_trgm_name
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "833b6aed7272"
+down_revision = "2c2ec9ce033e"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "idx_venue_trgm_name",
+            table_name="venue",
+            postgresql_using="gin",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def downgrade() -> None:
+    # Index was no longer used since unaccented index has been created, we will never rollback 6 iterations in the past
+    pass

--- a/api/src/pcapi/alembic/versions/20240424T133641_0e5b68c5865d_drop_idx_venue_trgm_public_name.py
+++ b/api/src/pcapi/alembic/versions/20240424T133641_0e5b68c5865d_drop_idx_venue_trgm_public_name.py
@@ -1,0 +1,28 @@
+"""Drop deprecated index: idx_venue_trgm_public_name
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "0e5b68c5865d"
+down_revision = "833b6aed7272"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "idx_venue_trgm_public_name",
+            table_name="venue",
+            postgresql_using="gin",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def downgrade() -> None:
+    # Index was no longer used since unaccented index has been created, we will never rollback 6 iterations in the past
+    pass

--- a/api/src/pcapi/alembic/versions/20240424T133809_348fd34d687b_drop_idx_offerer_trgm_name.py
+++ b/api/src/pcapi/alembic/versions/20240424T133809_348fd34d687b_drop_idx_offerer_trgm_name.py
@@ -1,0 +1,28 @@
+"""Drop deprecated index: idx_offerer_trgm_name
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "348fd34d687b"
+down_revision = "0e5b68c5865d"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "idx_offerer_trgm_name",
+            table_name="offerer",
+            postgresql_using="gin",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def downgrade() -> None:
+    # Index was no longer used since unaccented index has been created, we will never rollback 6 iterations in the past
+    pass

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -259,8 +259,6 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     __tablename__ = "venue"
 
     name: str = Column(String(140), nullable=False)
-    # Keep both indexes until we are sure that first one is no longer used (pg_stat_user_indexes shows few uses)
-    sa.Index("idx_venue_trgm_name", name, postgresql_using="gin")
     sa.Index("ix_venue_trgm_unaccent_name", sa.func.immutable_unaccent("name"), postgresql_using="gin")
 
     siret = Column(String(14), nullable=True, unique=True)
@@ -298,8 +296,6 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     timezone = Column(String(50), nullable=False, default=METROPOLE_TIMEZONE, server_default=METROPOLE_TIMEZONE)
 
     publicName = Column(String(255), nullable=True)
-    # Keep both indexes until we are sure that first one is no longer used (pg_stat_user_indexes shows few uses)
-    sa.Index("idx_venue_trgm_public_name", publicName, postgresql_using="gin")
     sa.Index("ix_venue_trgm_unaccent_public_name", sa.func.immutable_unaccent("name"), postgresql_using="gin")
 
     isVisibleInApp = Column(Boolean, nullable=False, default=True, server_default=sa.sql.expression.true())
@@ -998,8 +994,6 @@ class Offerer(
     dateCreated: datetime = Column(DateTime, nullable=False, default=datetime.utcnow)
 
     name: str = Column(String(140), nullable=False)
-    # Keep both because pg_stat_user_indexes reports idx_offerer_trgm_name has been used (but still used?)
-    sa.Index("idx_offerer_trgm_name", name, postgresql_using="gin")
     sa.Index("ix_offerer_trgm_unaccent_name", sa.func.immutable_unaccent("name"), postgresql_using="gin")
 
     sa.Index("ix_offerer_trgm_unaccent_city", sa.func.immutable_unaccent("city"), postgresql_using="gin")


### PR DESCRIPTION
These indexes are no longer used according to a query on pg_stat_user_tables. Indexes using unaccent are used in every filter.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-29458

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques