### PR TITLE
(PC-29457)[API] chore: Create efficient index on "book_macro_section"…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 d1767ee2dac1 (pre) (head)
-984376b85d8e (post) (head)
+2c2ec9ce033e (post) (head)

--- a/api/src/pcapi/alembic/versions/20240424T134421_bd42360a53c6_create_efficient_index_book_macro_section.py
+++ b/api/src/pcapi/alembic/versions/20240424T134421_bd42360a53c6_create_efficient_index_book_macro_section.py
@@ -1,0 +1,26 @@
+"""Create efficient unique index on "book_macro_section"."section"
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "bd42360a53c6"
+down_revision = "984376b85d8e"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT;")
+    op.execute(
+        """ CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "book_macro_section_section_idx" ON "book_macro_section" USING btree (lower("section")) """
+    )
+    op.execute("BEGIN;")
+
+
+def downgrade() -> None:
+    op.execute("COMMIT;")
+    op.execute(""" DROP INDEX CONCURRENTLY IF EXISTS "book_macro_section_section_idx" """)
+    op.execute("BEGIN;")

--- a/api/src/pcapi/alembic/versions/20240424T140856_2c2ec9ce033e_drop_inefficient_unique_index_book_macro_section.py
+++ b/api/src/pcapi/alembic/versions/20240424T140856_2c2ec9ce033e_drop_inefficient_unique_index_book_macro_section.py
@@ -1,0 +1,25 @@
+"""Drop inefficient index on "book_macro_section"."section"
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "2c2ec9ce033e"
+down_revision = "bd42360a53c6"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(""" ALTER TABLE "book_macro_section" DROP CONSTRAINT "book_macro_section_section_key" """)
+
+
+def downgrade() -> None:
+    # We can safely ignore the ADD CONSTRAINT statement because:
+    # - we will never downgrade that migration
+    # - even if we have to, it will be really fast as the table has few lines
+    # - finally we can't mix DROP CONSTRAINT statement in the upgrade and CREATE UNIQUE INDEX in the downgrade
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.execute("""ALTER TABLE "book_macro_section" ADD CONSTRAINT book_macro_section_section_key UNIQUE ("section") """)

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -1072,7 +1072,9 @@ class BookMacroSection(PcObject, Base, Model):
     __tablename__ = "book_macro_section"
 
     macroSection: str = sa.Column(sa.Text, nullable=False)
-    section: str = sa.Column(sa.Text, nullable=False, unique=True)
+    section: str = sa.Column(sa.Text, nullable=False)
+
+    __table_args__ = (sa.Index("book_macro_section_section_idx", sa.func.lower(section), unique=True),)
 
 
 class PriceCategoryLabel(PcObject, Base, Model):


### PR DESCRIPTION
…."section"

Actually, all queries against "book_macro_section"."section" are using the lower operator in the WHERE clause. Unfortunately, with the actual definition of the index, it prevent postgres of using it (because it's defined on the "section" column, not on lower("section")).

Hence, the index is never used and ALL queries run against the table trigger sequential scans which is way more expensive.

So defining a more efficient index and then droping the unefficient one.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29457

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques