### PR TITLE
(PC-29465)[API] chore: drop unused booking reimbursement date index

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 154f5e68cb31 (pre) (head)
-c51c13995e1f (post) (head)
+ad995e8eff73 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240424T152513_ad995e8eff73_drop_ix_booking_reimbursementdate.py
+++ b/api/src/pcapi/alembic/versions/20240424T152513_ad995e8eff73_drop_ix_booking_reimbursementdate.py
@@ -1,0 +1,27 @@
+"""Drop ix_booking_reimbursementDate index
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "ad995e8eff73"
+down_revision = "c51c13995e1f"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_booking_reimbursementDate",
+            table_name="booking",
+            postgresql_using="gin",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -154,7 +154,7 @@ class Booking(PcObject, Base, Model):
 
     validationAuthorType: BookingValidationAuthorType = Column(Enum(BookingValidationAuthorType), nullable=True)
 
-    reimbursementDate = Column(DateTime, nullable=True, index=True)
+    reimbursementDate = Column(DateTime, nullable=True)
 
     depositId = Column(BigInteger, ForeignKey("deposit.id"), index=True, nullable=True)
 


### PR DESCRIPTION
## But de la pull request
This indexe is no longer used according to a query on pg_stat_user_tables

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29465

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques