### PR TITLE
PC-29315 add credits to google images

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1173,7 +1173,7 @@ def rm_previous_venue_thumbs(venue: models.Venue) -> None:
         storage.remove_thumb(venue, storage_id_suffix=original_image_timestamp)
 
     venue.bannerUrl = None  # type: ignore [method-assign]
-    venue.bannerMeta = None
+    venue.bannerMeta = None  # type: ignore [method-assign]
     venue.thumbCount = 1
 
 
@@ -1212,7 +1212,7 @@ def save_venue_banner(
     )
 
     venue.bannerUrl = f"{venue.thumbUrl}_{banner_timestamp}"  # type: ignore [method-assign]
-    venue.bannerMeta = {
+    venue.bannerMeta = {  # type: ignore [method-assign]
         "image_credit": image_credit,
         "author_id": user.id,
         "original_image_url": f"{venue.thumbUrl}_{original_image_timestamp}",

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -57,6 +57,7 @@ from pcapi.models.has_address_mixin import HasAddressMixin
 from pcapi.models.has_thumb_mixin import HasThumbMixin
 from pcapi.models.pc_object import PcObject
 from pcapi.models.validation_status_mixin import ValidationStatusMixin
+from pcapi.routes.native.v1.serialization.offerers import VenueTypeCode
 from pcapi.utils import crypto
 from pcapi.utils.date import METROPOLE_TIMEZONE
 from pcapi.utils.date import get_department_timezone
@@ -101,46 +102,6 @@ CONSTRAINT_CHECK_HAS_SIRET_XOR_HAS_COMMENT_XOR_IS_VIRTUAL = """
     OR (siret IS NULL AND comment IS NOT NULL AND "isVirtual" IS FALSE)
     OR (siret IS NOT NULL AND "isVirtual" IS FALSE)
 """
-
-
-class VenueTypeCode(enum.Enum):
-    ADMINISTRATIVE = "Lieu administratif"
-    ARTISTIC_COURSE = "Cours et pratique artistiques"
-    BOOKSTORE = "Librairie"
-    CONCERT_HALL = "Musique - Salle de concerts"
-    CREATIVE_ARTS_STORE = "Magasin arts créatifs"
-    CULTURAL_CENTRE = "Centre culturel"
-    DIGITAL = "Offre numérique"
-    DISTRIBUTION_STORE = "Magasin de distribution de produits culturels"
-    FESTIVAL = "Festival"
-    GAMES = "Jeux / Jeux vidéos"
-    LIBRARY = "Bibliothèque ou médiathèque"
-    MOVIE = "Cinéma - Salle de projections"
-    MUSEUM = "Musée"
-    MUSICAL_INSTRUMENT_STORE = "Musique - Magasin d’instruments"
-    OTHER = "Autre"
-    PATRIMONY_TOURISM = "Patrimoine et tourisme"
-    PERFORMING_ARTS = "Spectacle vivant"
-    RECORD_STORE = "Musique - Disquaire"
-    SCIENTIFIC_CULTURE = "Culture scientifique"
-    TRAVELING_CINEMA = "Cinéma itinérant"
-    VISUAL_ARTS = "Arts visuels, arts plastiques et galeries"
-
-    # These methods are used by pydantic in order to return the enum name and validate the value
-    # instead of returning the enum directly.
-    @classmethod
-    def __get_validators__(cls) -> typing.Iterator[typing.Callable]:
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, value: str | enum.Enum) -> str:
-        if isinstance(value, enum.Enum):
-            value = value.name
-
-        if not hasattr(cls, value):
-            raise ValueError(f"{value}: invalide")
-
-        return value
 
 
 PERMENANT_VENUE_TYPES = [
@@ -227,11 +188,6 @@ VENUE_TYPE_DEFAULT_BANNERS: dict[VenueTypeCode, tuple[str, ...]] = {
         "darya-tryfanava-UCNaGWn4EfU-unsplash.jpg",
     ),
 }
-
-VenueTypeCodeKey = enum.Enum(  # type: ignore [misc]
-    "VenueTypeCodeKey",
-    {code.name: code.name for code in VenueTypeCode},
-)
 
 
 class Target(enum.Enum):

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -75,10 +75,7 @@ def reset_recredit_amount_to_show(user: users_models.User) -> serializers.UserPr
 
 @blueprint.native_route("/profile/update_email", methods=["POST"])
 @blueprint.api.validate(deprecated=True)
-@spectree_serialize(
-    on_success_status=204,
-    api=blueprint.api,
-)
+@spectree_serialize(on_success_status=204, api=blueprint.api)
 @authenticated_and_active_user_required
 def update_user_email(user: users_models.User, body: serializers.UserProfileEmailUpdate) -> None:
     try:

--- a/api/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -53,6 +53,8 @@ VenueTypeCodeKey = enum.Enum(  # type: ignore [misc]
 
 class BannerMetaModel(typing.TypedDict, total=False):
     image_credit: base.VenueImageCredit | None
+    image_credit_url: str | None
+    is_from_google: bool
 
 
 class VenueAccessibilityModel(BaseModel):

--- a/api/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -1,8 +1,54 @@
+import enum
 import typing
 
-from pcapi.core.offerers import models as offerers_models
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import base
+
+
+class VenueTypeCode(enum.Enum):
+    ADMINISTRATIVE = "Lieu administratif"
+    ARTISTIC_COURSE = "Cours et pratique artistiques"
+    BOOKSTORE = "Librairie"
+    CONCERT_HALL = "Musique - Salle de concerts"
+    CREATIVE_ARTS_STORE = "Magasin arts créatifs"
+    CULTURAL_CENTRE = "Centre culturel"
+    DIGITAL = "Offre numérique"
+    DISTRIBUTION_STORE = "Magasin de distribution de produits culturels"
+    FESTIVAL = "Festival"
+    GAMES = "Jeux / Jeux vidéos"
+    LIBRARY = "Bibliothèque ou médiathèque"
+    MOVIE = "Cinéma - Salle de projections"
+    MUSEUM = "Musée"
+    MUSICAL_INSTRUMENT_STORE = "Musique - Magasin d’instruments"
+    OTHER = "Autre"
+    PATRIMONY_TOURISM = "Patrimoine et tourisme"
+    PERFORMING_ARTS = "Spectacle vivant"
+    RECORD_STORE = "Musique - Disquaire"
+    SCIENTIFIC_CULTURE = "Culture scientifique"
+    TRAVELING_CINEMA = "Cinéma itinérant"
+    VISUAL_ARTS = "Arts visuels, arts plastiques et galeries"
+
+    # These methods are used by pydantic in order to return the enum name and validate the value
+    # instead of returning the enum directly.
+    @classmethod
+    def __get_validators__(cls) -> typing.Iterator[typing.Callable]:
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: str | enum.Enum) -> str:
+        if isinstance(value, enum.Enum):
+            value = value.name
+
+        if not hasattr(cls, value):
+            raise ValueError(f"{value}: invalide")
+
+        return value
+
+
+VenueTypeCodeKey = enum.Enum(  # type: ignore [misc]
+    "VenueTypeCodeKey",
+    {code.name: code.name for code in VenueTypeCode},
+)
 
 
 class BannerMetaModel(typing.TypedDict, total=False):
@@ -38,7 +84,7 @@ class VenueResponse(base.BaseVenueResponse):
     id: int
     address: str | None
     accessibility: VenueAccessibilityModel
-    venueTypeCode: offerers_models.VenueTypeCodeKey
+    venueTypeCode: VenueTypeCodeKey
     bannerMeta: BannerMetaModel | None
 
     class Config:

--- a/api/tests/routes/native/openapi_test.py
+++ b/api/tests/routes/native/openapi_test.py
@@ -113,7 +113,9 @@ def test_public_api(client):
                             "nullable": True,
                             "title": "Image Credit",
                             "type": "string",
-                        }
+                        },
+                        "image_credit_url": {"nullable": True, "title": "Image Credit Url", "type": "string"},
+                        "is_from_google": {"nullable": True, "title": "Is From Google", "type": "boolean"},
                     },
                     "title": "BannerMetaModel",
                     "type": "object",

--- a/api/tests/routes/native/v1/offerers_test.py
+++ b/api/tests/routes/native/v1/offerers_test.py
@@ -104,6 +104,51 @@ class VenuesTest:
             "openingHours": venue.opening_days,
         }
 
+    def test_get_venue_google_banner_meta(self, client):
+        venue = offerer_factories.VenueFactory(isPermanent=True)
+        offerer_factories.GooglePlacesInfoFactory(
+            venue=venue,
+            bannerMeta={"html_attributions": ['<a href="http://python.org">Henri</a>']},
+        )
+        response = client.get(f"/native/v1/venue/{venue.id}")
+
+        assert response.status_code == 200
+        assert response.json["bannerUrl"] == venue.bannerUrl
+        assert response.json["bannerMeta"] == {
+            "image_credit": "Henri",
+            "image_credit_url": "http://python.org",
+            "is_from_google": True,
+        }
+
+    def test_get_venue_google_banner_meta_multiple_attributions(self, client):
+        venue = offerer_factories.VenueFactory(isPermanent=True)
+        offerer_factories.GooglePlacesInfoFactory(
+            venue=venue,
+            bannerMeta={
+                "html_attributions": [
+                    '<a href="http://python.org">Henri</a>',
+                    '<a href="http://leblogdufun.fr">Kelly</a>',
+                ]
+            },
+        )
+        response = client.get(f"/native/v1/venue/{venue.id}")
+
+        assert response.status_code == 200
+        assert response.json["bannerUrl"] == venue.bannerUrl
+        assert response.json["bannerMeta"] == {
+            "image_credit": "Henri",
+            "image_credit_url": "http://python.org",
+            "is_from_google": True,
+        }
+
+    def test_get_venue_google_banner_meta_not_from_google(self, client):
+        venue = offerer_factories.VenueFactory(isPermanent=True, _bannerMeta={"image_credit": "Henri"})
+        response = client.get(f"/native/v1/venue/{venue.id}")
+
+        assert response.status_code == 200
+        assert response.json["bannerUrl"] == venue.bannerUrl
+        assert response.json["bannerMeta"] == {"image_credit": "Henri"}
+
     def test_get_non_permanent_venue(self, client):
         venue = offerer_factories.VenueFactory(isPermanent=False)
         response = client.get(f"/native/v1/venue/{venue.id}")

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -344,6 +344,7 @@ class Returns200Test:
                     "width_crop_percent": 0.42,
                 },
                 "image_credit": "test 2",
+                "image_credit_url": "test 2",
             },
         )
 


### PR DESCRIPTION
## But de la pull request

Cette PR remonte le minimum: le premier utilisateur à créditer pour les photos de maps.
Dans l'écrasante majorité des cas, on en aura qu'un, mais la possibilité de crédit multiple existe (maps envoie une liste)

Dans un soucis de simplicité, on propose cette solution qui reste très proche de l'existant, et on se donne du temps pour voir comment on veut intégrer la potentielle liste d'attributions, sans faire de breaking change compliqué.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29315

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques