### PR TITLE
(PC-29385)[BO] fix: fix batch_validate_individual_bookings when deposit is past

### DIFF
--- a/api/src/pcapi/core/bookings/exceptions.py
+++ b/api/src/pcapi/core/bookings/exceptions.py
@@ -127,3 +127,7 @@ class ConfirmationLimitDateHasPassed(Exception):
 
 class BookingIsExpired(Exception):
     pass
+
+
+class BookingDepositCreditExpired(Exception):
+    pass

--- a/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
@@ -231,6 +231,11 @@ def mark_booking_as_used(booking_id: int) -> utils.BackofficeResponse:
 
     try:
         bookings_api.mark_as_used_with_uncancelling(booking, bookings_models.BookingValidationAuthorType.BACKOFFICE)
+    except bookings_exceptions.BookingDepositCreditExpired:
+        flash(
+            f"La réservation <b>{booking.token}</b> ne peut être validée, car le crédit associé est expiré.",
+            "warning",
+        )
     except Exception as exc:  # pylint: disable=broad-except
         flash(Markup("Une erreur s'est produite : {message}").format(message=str(exc)), "warning")
     else:
@@ -351,10 +356,12 @@ def _batch_individual_bookings_action(
     form: empty_forms.BatchForm, booking_callback: typing.Callable, success_message: str
 ) -> utils.BackofficeResponse:
     bookings = bookings_models.Booking.query.filter(bookings_models.Booking.id.in_(form.object_ids_list)).all()
+    one_or_more_booking_passed = False
 
     for booking in bookings:
         try:
             booking_callback(booking)
+            one_or_more_booking_passed = True
         except bookings_exceptions.BookingIsAlreadyCancelled:
             flash("Au moins une des réservations a déjà été annulée", "warning")
             return _redirect_after_individual_booking_action()
@@ -364,7 +371,15 @@ def _batch_individual_bookings_action(
         except bookings_exceptions.BookingIsAlreadyRefunded:
             flash("Au moins une des réservations a déjà été remboursée", "warning")
             return _redirect_after_individual_booking_action()
+        except bookings_exceptions.BookingDepositCreditExpired:
+            flash(
+                f"La réservation <b>{booking.token}</b> ne peut être validée, car le crédit associé est expiré.",
+                "warning",
+            )
+            if not one_or_more_booking_passed:
+                return _redirect_after_individual_booking_action()
 
-    flash(success_message, "success")
+    if one_or_more_booking_passed:
+        flash(success_message, "success")
 
     return _redirect_after_individual_booking_action()


### PR DESCRIPTION
…eposit is past

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29385

## Vérifications

### verification front 

le problème se reproduit lorsqu'un booking est expiré et possède un deposit avec une expirationDate passé par exemple ce booking et deposit qui sont lié, le booking est canceled et le deposit a une expirationDate passé :
<img width="993" alt="Capture d’écran 2024-04-26 à 10 49 07" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/530d0676-30eb-4300-9d98-a52e5eeb6c5f">
<img width="960" alt="Capture d’écran 2024-04-26 à 10 49 45" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/14f8698f-5341-409b-9a83-6f97fd2eedea">

Lorsque l'on selectionne ce booking avec ou sans les autres  et que l'on clique sur le bouton pour valider:
<img width="1163" alt="Capture d’écran 2024-04-26 à 10 50 46" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/1e3fa206-8a97-43ad-93f3-194ded93b5dd">

il retourne a présent une erreur 400 BadRequest()
<img width="584" alt="Capture d’écran 2024-04-26 à 15 23 21" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/56cf9a54-e384-4887-9c33-87cab7906b2d">


### verification back

- CI - rouge mais cela n'est pas lié a mes modifications le reste est vert 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 

ajout d'un cas de test retournant une erreur 404 not found si le booking est cancelled avec deposit possedant une expirationDate passé

### Verification ticket

- nom du ticket conforme -> OK
- nombre de commit -> OK
- nom du commit -> OK 
- mettre le ticket en code-review -> OK 

### Tache restante si WIP + AUTRE

- refresh de la page github -> OK
