### PR TITLE
(PC-28945) ci: fix return code in case of migration failure

### DIFF
--- a/.github/workflows/dev_on_workflow_deploy.yml
+++ b/.github/workflows/dev_on_workflow_deploy.yml
@@ -85,11 +85,16 @@ jobs:
           export IMAGE="${IMAGE}:${VERSION}"
           export DATE=$(date +"%Y-%m-%d--%H-%M-%S")
           envsubst < .github/workflows/templates/pre-upgrade-job.yaml | kubectl -n ${{ inputs.environment }} apply -f -
-          while true;
-          do
-          kubectl logs -n ${{ inputs.environment }} -f jobs/pre-upgrade-${DATE} && break
-          done
-          kubectl wait --for=condition=complete --timeout=10900s -n ${{ inputs.environment }} jobs/pre-upgrade-${DATE}
+          # Next lines assume that job's backoffLimit is 0
+          kubectl logs -n ${{ inputs.environment }} -f jobs/pre-upgrade-${DATE} # This commands returns after first failure in job
+          kubectl wait --for=condition=complete jobs/pre-upgrade-${DATE} || kubectl wait --for=condition=failed jobs/pre-upgrade-${DATE} # Sanity check that the job is over
+          failure=$(kubectl get -n ${{ inputs.environment }} jobs/pre-upgrade-${DATE} -o=jsonpath='{.status.conditions[?(@.type=="Failed")].status}') # Did the job fail or not so we can give correct return code
+          if [[ "$failure" == "True" ]]
+          then
+            exit 1
+          else
+            exit 0
+          fi
 
       # Get pcapi secrets from source code, to be passed later as a helmfile parameter.
       - name: "Generate pcapi secrets list"
@@ -155,11 +160,16 @@ jobs:
           export IMAGE="${IMAGE}:${VERSION}"
           export DATE=$(date +"%Y-%m-%d--%H-%M-%S")
           envsubst < .github/workflows/templates/post-upgrade-job.yaml | kubectl -n ${{ inputs.environment }} apply -f -
-          while true;
-          do
-          kubectl logs -n ${{ inputs.environment }} -f jobs/post-upgrade-${DATE} && break
-          done
-          kubectl wait --for=condition=complete --timeout=10900s -n ${{ inputs.environment }} jobs/post-upgrade-${DATE}
+          # Next lines assume that job's backoffLimit is 0
+          kubectl logs -n ${{ inputs.environment }} -f jobs/post-upgrade-${DATE} # This commands returns after first failure in job
+          kubectl wait --for=condition=complete jobs/post-upgrade-${DATE} || kubectl wait --for=condition=failed jobs/post-upgrade-${DATE} # Sanity check that the job is over
+          failure=$(kubectl get -n ${{ inputs.environment }} jobs/post-upgrade-${DATE} -o=jsonpath='{.status.conditions[?(@.type=="Failed")].status}') # Did the job fail or not so we can give correct return code
+          if [[ "$failure" == "True" ]]
+          then
+            exit 1
+          else
+            exit 0
+          fi
 
   deploy-api-doc-on-firebase:
     name: "Deploy api doc on firebase"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28945

## Vérifications

Effectivement j'avais fait une erreur dans ma première PR, merci et désolé @kopax et @francois-pass-culture
J'ai refait quelques test et là ça devrait aller. Ça me fait penser que même si j'ai testé en local j'ai pas vraiment de moyen de tester avant que ça soit mergé.
C'est peut-être contenu dans les sujets de déploiement continus mais ça serait bien de pouvoir avoir un environnement qu'on démarre (par exemple sur métier-ops) pour faire ce genre de tests.

```
on ⛵ teleport.ops.passculture.team in (test-lgd) ~ via  v18.12.1 via 🐍 v3.12.2 via 💠 default on ☁️   gcpadmin.louis.gerard@passculture.app(passculture-infra-prod)
❯ failure=$(kubectl get -n test-lgd jobs/exemple-job -o=jsonpath='{.status.conditions[?(@.type=="Failed")].status}')

on ⛵ teleport.ops.passculture.team in (test-lgd) ~ via  v18.12.1 via 🐍 v3.12.2 via 💠 default on ☁️   gcpadmin.louis.gerard@passculture.app(passculture-infra-prod)
❯ if [[ "$failure" == "True" ]]; then echo "failed"; else; echo "success";fi
failed
```