### PR TITLE
(PC-29064)[PRO] fix: Dont set the hover index to 0 when there is no o…

### DIFF
--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
@@ -139,7 +139,9 @@ export const SelectAutocomplete = ({
         break
       case 'ArrowDown':
         if (hoveredOptionIndex === null) {
-          setHoveredOptionIndex(0)
+          if (filteredOptions.length > 0) {
+            setHoveredOptionIndex(0)
+          }
         } else if (hoveredOptionIndex >= filteredOptions.length - 1) {
           setHoveredOptionIndex(filteredOptions.length - 1)
         } else {


### PR DESCRIPTION
…ptions to be hovered.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29064

**Objectif**
Corriger une erreur Sentry qui apparait dans le `SelectAutocomplete` quand on bidouille avec le clavier. Quand on presse flèche du bas, on set l'index de hover sur le premier élément des options, mais on ne vérifie pas que ces options existent

**Reproduction**
Créer une offre collective réservable, à l'étape "Établissement et enseignant", choisissez un établissement, cliquez dans le champ Enseignants, pressez flèche du bas, puis ENTER et l'erreur apparait dans la console

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques