### PR TITLE
(PC-29498)[PRO] feat: Redirect to the adage url from an offer when th…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -30,12 +30,16 @@ const OfferCardComponent = ({
   const adageAuthToken = searchParams.get('token')
   const { adageUser } = useAdageUser()
 
+  const offerLinkUrl = document.referrer
+    ? `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`
+    : `/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`
+
   return (
     <div className={styles['container']}>
       <Link
         className={styles['offer-link']}
         data-testid="card-offer-link"
-        to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
+        to={offerLinkUrl}
         state={{ offer }}
         onClick={onCardClicked}
       >

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
@@ -47,6 +47,10 @@ export function AdageOfferListCard({
 
   const currentPathname = location.pathname.split('/')[2]
 
+  const offerLinkUrl = document.referrer
+    ? `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`
+    : `/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`
+
   const [offerPrebooked, setOfferPrebooked] = useState(false)
 
   const isOfferTemplate = isCollectiveOfferTemplate(offer)
@@ -114,8 +118,7 @@ export function AdageOfferListCard({
           <div className={styles['offer-card-content']}>
             <AdageOfferListCardTags offer={offer} adageUser={adageUser} />
             <Link
-              to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
-              state={{ offer }}
+              to={offerLinkUrl}
               className={styles['offer-card-link']}
               onClick={onCardClicked}
             >


### PR DESCRIPTION
…e referrer exists.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29498

**FF à activer**
WIP_ENABLE_ADAGE_VISUALIZATION

**Objectif**
Lorsqu'on ouvre une offre ADAGE depuis les deux cartes offre, on route avec react-router vers l'url pass-culture sans changer de fenêtre, mais comme on est dans l'iframe si on ouvre volontairement dans une nouvelle fenetre, on sort d'ADAGE. Ce qui pose pb pour les liens qui se basaient sur l'url extérieurs à l'iframe (ex: Voir la page partenaire dans une page offre).

Donc si le referrer existe on indique l'url absolue dans les liens des cartes offres pour que l'ouverture dans un nouvel onglet garde la référence à ADAGE.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques