### PR TITLE
(PC-27765)[PRO] fix: improve signup spacings

### DIFF
--- a/pro/src/pages/Signup/SignupContainer/SignupContainer.module.scss
+++ b/pro/src/pages/Signup/SignupContainer/SignupContainer.module.scss
@@ -7,6 +7,10 @@
 .content {
   @include layout.full-content-side;
 
+  @media (min-width: size.$tablet) {
+    margin-top: size.$top-menu-height;
+  }
+
   margin-bottom: size.$footer-height;
 
   .siren-field {
@@ -14,15 +18,19 @@
   }
 
   .sign-up-infos-before-signup {
-    margin-top: rem.torem(40px);
+    margin-top: rem.torem(32px);
+  }
+
+  .checkbox-contact {
+    margin-top: rem.torem(16px);
   }
 
   .buttons-field {
     display: flex;
     flex-direction: column-reverse;
     gap: rem.torem(24px);
-    margin-top: rem.torem(16px);
-    margin-bottom: rem.torem(32px);
+    margin-top: rem.torem(40px);
+    margin-bottom: rem.torem(48px);
 
     @media (min-width: size.$tablet) {
       flex-direction: row;

--- a/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
@@ -68,6 +68,7 @@ const SignupForm = (): JSX.Element => {
         </FormLayout.Row>
         <FormLayout.Row>
           <Checkbox
+            className={styles['checkbox-contact']}
             hideFooter
             label="J’accepte d’être contacté par email pour recevoir les
                       nouveautés du pass Culture et contribuer à son

--- a/pro/src/ui-kit/form/PasswordInput/PasswordInput.module.scss
+++ b/pro/src/ui-kit/form/PasswordInput/PasswordInput.module.scss
@@ -6,5 +6,8 @@
   justify-content: space-between;
   flex-direction: column;
   position: relative;
-  margin-bottom: rem.torem(8px);
+
+  &-error {
+    margin-bottom: rem.torem(8px);
+  }
 }

--- a/pro/src/ui-kit/form/PasswordInput/PasswordInput.tsx
+++ b/pro/src/ui-kit/form/PasswordInput/PasswordInput.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import { useField } from 'formik'
 import React, { useState } from 'react'
 
@@ -28,8 +29,9 @@ export const PasswordInput = ({
   ...props
 }: PasswordInputProps): JSX.Element => {
   const [isPasswordHidden, setPasswordHidden] = useState(true)
-  const [field] = useField({ name })
+  const [field, meta] = useField({ name })
   const displayLocalErrors = withErrorPreview && field.value.length > 0
+  const errorShown = (meta.touched && !!meta.error) || displayLocalErrors
 
   const handleToggleHidden = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault()
@@ -37,7 +39,11 @@ export const PasswordInput = ({
   }
 
   return (
-    <div className={styles['password-input-wrapper']}>
+    <div
+      className={cn([styles['password-input-wrapper']], {
+        [styles['password-input-wrapper-error']]: errorShown,
+      })}
+    >
       <TextInput
         className={styles['password-input']}
         label={label}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27765
Amélioration des spacings sur la page d'inscription.

Before
<img width="1728" alt="before" src="https://github.com/pass-culture/pass-culture-main/assets/167757543/611150de-9a18-4c41-8d52-cfdbbd6734b4">

After
<img width="1728" alt="Capture d’écran 2024-04-26 à 15 00 08" src="https://github.com/pass-culture/pass-culture-main/assets/167757543/6a4c8574-2aeb-4091-a06e-bef9121a30d3">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques