### PR TITLE
Revert "(PC-29498)[PRO] feat: Use absolute urls in ADAGE offer links."

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -30,16 +30,12 @@ const OfferCardComponent = ({
   const adageAuthToken = searchParams.get('token')
   const { adageUser } = useAdageUser()
 
-  const offerLinkUrl = document.referrer
-    ? `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`
-    : `/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`
-
   return (
     <div className={styles['container']}>
       <Link
         className={styles['offer-link']}
         data-testid="card-offer-link"
-        to={offerLinkUrl}
+        to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
         state={{ offer }}
         onClick={onCardClicked}
       >

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
@@ -47,10 +47,6 @@ export function AdageOfferListCard({
 
   const currentPathname = location.pathname.split('/')[2]
 
-  const offerLinkUrl = document.referrer
-    ? `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`
-    : `/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`
-
   const [offerPrebooked, setOfferPrebooked] = useState(false)
 
   const isOfferTemplate = isCollectiveOfferTemplate(offer)
@@ -118,7 +114,8 @@ export function AdageOfferListCard({
           <div className={styles['offer-card-content']}>
             <AdageOfferListCardTags offer={offer} adageUser={adageUser} />
             <Link
-              to={offerLinkUrl}
+              to={`/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`}
+              state={{ offer }}
               className={styles['offer-card-link']}
               onClick={onCardClicked}
             >


### PR DESCRIPTION
This reverts commit cf29626c9ddcff201107ee5ecdc92d4193501e15.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29498

**Objectif**
Revert les changements d'avoir des urls absolues pour les liens vers les offres dans ADAGE.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques