### PR TITLE
(PC-29511)[PRO] fix: reduce number of lines when fetching venue

### DIFF
--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -34,9 +34,11 @@ def get_venue(venue_id: int) -> venues_serialize.GetVenueResponseModel:
         .options(sqla_orm.joinedload(models.Venue.bankInformation))
         .options(sqla_orm.joinedload(models.Venue.managingOfferer).joinedload(models.Offerer.bankInformation))
         .options(
-            sqla_orm.joinedload(models.Venue.pricing_point_links).joinedload(models.VenuePricingPointLink.pricingPoint)
+            sqla_orm.selectinload(models.Venue.pricing_point_links).joinedload(
+                models.VenuePricingPointLink.pricingPoint
+            )
         )
-        .options(sqla_orm.joinedload(models.Venue.reimbursement_point_links))
+        .options(sqla_orm.selectinload(models.Venue.reimbursement_point_links))
         .options(sqla_orm.joinedload(models.Venue.collectiveDomains))
         .options(sqla_orm.joinedload(models.Venue.collectiveDmsApplications))
         .options(sqla_orm.joinedload(models.Venue.bankAccountLinks).joinedload(models.VenueBankAccountLink.bankAccount))


### PR DESCRIPTION
joinedload on a reversed FK are not a good idea.
We faced one cas where the offerer had:

 - 1500+ pricing_point_links
 - 1500+ reimbursement_point_links
 
Overall, the number of lines returned was 2_427_364 (1500+ * 1500+). Exploses any hope to get a response.
Using selectinload adds two more requests but avoids the combination between the two huge sets.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29511

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques