### PR TITLE
(PC-29456)[EAC] feat: adage iframe: add two new playlists routes

### DIFF
--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -286,6 +286,28 @@ class GetLocalOfferersPlaylistTest(SharedPlaylistsErrorTests):
         assert playlist_order_1 != playlist_order_2
 
 
+class GetAnyNewTemplateOffersTest(SharedPlaylistsErrorTests):
+    endpoint = "adage_iframe.get_any_new_template_offers_playlist"
+
+    def test_no_offers(self, client):
+        iframe_client = _get_iframe_client(client)
+        response = iframe_client.get(url_for(self.endpoint))
+
+        assert response.status_code == 200
+        assert response.json == {"collectiveOffers": []}
+
+
+class GetNewOfferersPlaylistTest(SharedPlaylistsErrorTests):
+    endpoint = "adage_iframe.get_new_offerers_playlist"
+
+    def test_no_offerers(self, client):
+        iframe_client = _get_iframe_client(client)
+        response = iframe_client.get(url_for(self.endpoint))
+
+        assert response.status_code == 200
+        assert response.json == {"venues": []}
+
+
 def _get_iframe_client(client, email=None, uai=None):
     if uai is None:
         uai = educational_factories.EducationalInstitutionFactory().institutionId

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -755,6 +755,22 @@ export class DefaultService {
     });
   }
   /**
+   * get_any_new_template_offers_playlist <GET>
+   * @returns ListCollectiveOfferTemplateResponseModel OK
+   * @throws ApiError
+   */
+  public getAnyNewTemplateOffersPlaylist(): CancelablePromise<ListCollectiveOfferTemplateResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/adage-iframe/playlists/any_new_template_offers',
+      errors: {
+        403: `Forbidden`,
+        404: `Not Found`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
    * get_classroom_playlist <GET>
    * @returns ListCollectiveOfferTemplateResponseModel OK
    * @throws ApiError
@@ -778,6 +794,21 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'GET',
       url: '/adage-iframe/playlists/local-offerers',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
+   * get_new_offerers_playlist <GET>
+   * @returns LocalOfferersPlaylist OK
+   * @throws ApiError
+   */
+  public getNewOfferersPlaylist(): CancelablePromise<LocalOfferersPlaylist> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/adage-iframe/playlists/new_offerers',
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Entity`,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29456

Ajouter des nouvelles routes qui renvoient chacune une liste vide.
Ceci permettra à l'équipe front de commencer le travail de leur côté grâce à cette interface
d'API. 

Les corps des fonctions seront remplis bientôt.