### PR TITLE
Pc 29434 parallel docker build

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -27,6 +27,7 @@ jobs:
       maintenance-site-changed: ${{ steps.check-maintenance-site-changes.outputs.any_modified }}
       db-migration-changed: ${{ steps.check-db-migration-changes.outputs.any_modified }}
       dependencies-changed: ${{ steps.check-dependencies-changes.outputs.any_modified }}
+      docker-image-tags: ${{ steps.define-image-tags.outputs.docker-image-tags }}
     steps:
       - uses: actions/checkout@v4.1.4
         with:
@@ -61,27 +62,65 @@ jobs:
           files: |
             api/poetry.lock
             pro/yarn.lock
+      - name: "Define docker image tags."
+        id: define-image-tags
+        run: |
+          DOCKER_REGISTRY="europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry"
+          OUTPUT="docker-image-tags="
+          if [ ${{ github.event_name == 'pull_request' }} ]; then
+            OUTPUT+="$DOCKER_REGISTRY/DOCKER_IMAGE:${{ github.event.pull_request.head.sha }}"
+          else
+            OUTPUT+="$DOCKER_REGISTRY/DOCKER_IMAGE:${{ github.sha }}"
+          fi
+          if [ ${{ github.ref }} == 'refs/heads/master' ]; then
+            OUTPUT+=",$DOCKER_REGISTRY/DOCKER_IMAGE:latest"
+          fi 
+          echo $OUTPUT >> "$GITHUB_OUTPUT"
 
-  build-api:
-    name: "Build API (backend) Docker image"
+  build-pcapi:
+    name: "[pcapi] build and push docker image."
     needs: check-folders-changes
     if: |
       needs.check-folders-changes.outputs.api-changed == 'true' ||
-      needs.check-folders-changes.outputs.pro-changed == 'true' ||
       github.ref == 'refs/heads/master' ||
       startsWith(github.ref,'refs/heads/maint/v')
     uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
     with:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      # Needed to run end-to-end tests, i.e. when "api" source code changes.
-      # If no changes are made in "pro" source code.
-      # we can pull the image from testing env (tag=latest)
-      pcapi: ${{ needs.check-folders-changes.outputs.api-changed == 'true' || github.ref == 'refs/heads/master' || startsWith(github.ref,'refs/heads/maint/v') }}
-      # Extra when tests are run on master before deployment on testing.
-      console: ${{ github.ref == 'refs/heads/master' }}
-      # Needed to run backend tests.
-      tests: ${{ needs.check-folders-changes.outputs.api-changed == 'true' || github.ref == 'refs/heads/master' || startsWith(github.ref,'refs/heads/maint/v') }}
+      image: pcapi
+      tags: (${{ needs.check-folders-changes.outputs.docker-image-tags }}
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  build-pcapi-console:
+    name: "[pcapi-console] build and push docker image."
+    needs: check-folders-changes
+    if: |
+      needs.check-folders-changes.outputs.api-changed == 'true' ||
+      needs.check-folders-changes.outputs.pro-changed == 'true' ||
+      github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+    with:
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      image: pcapi-console
+      tags: ${{ needs.check-folders-changes.outputs.docker-image-tags }}
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  build-pcapi-tests:
+    name: "[pcapi-tests] build and push docker image."
+    needs: check-folders-changes
+    if: |
+      needs.check-folders-changes.outputs.api-changed == 'true' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref,'refs/heads/maint/v')
+    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+    with:
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      image: pcapi-tests
+      tags: ${{ needs.check-folders-changes.outputs.docker-image-tags }}
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -96,7 +135,7 @@ jobs:
 
   update-api-client-template:  # for pull requests only
     name: "Update api client template"
-    needs: [check-folders-changes, build-api]
+    needs: [check-folders-changes, build-pcapi]
     uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
     if: github.base_ref == 'master'
     concurrency:
@@ -113,7 +152,7 @@ jobs:
 
   prepare-cache-master:  # on "master" branch only
     name: "Reset cache on master on dependency update"
-    needs: [check-folders-changes, build-api]
+    needs: [check-folders-changes, build-pcapi]
     uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
     if: github.ref == 'refs/heads/master'
     with:
@@ -127,7 +166,7 @@ jobs:
 
   test-api:
     name: "Test api"
-    needs: [check-folders-changes, build-api]
+    needs: [check-folders-changes, build-pcapi-tests]
     if: |
       needs.check-folders-changes.outputs.api-changed == 'true' ||
       github.ref == 'refs/heads/master' ||
@@ -161,7 +200,7 @@ jobs:
 
   test-pro-e2e:
     name: "Tests pro E2E"
-    needs: [check-folders-changes, build-api]
+    needs: [check-folders-changes, build-pcapi]
     if: |
       needs.check-folders-changes.outputs.api-changed == 'true' ||
       needs.check-folders-changes.outputs.pro-changed == 'true' ||

--- a/.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+++ b/.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
@@ -8,22 +8,13 @@ on:
         # Can be a branch name, a tag or a commit.
         required: false
         type: string
-      tag:
-        # The docker image tag
+      tags:
+        # The docker image tag(s)
         required: true
         type: string
-      pcapi:
-        required: false
-        type: boolean
-        default: false
-      console:
-        required: false
-        type: boolean
-        default: false
-      tests:
-        required: false
-        type: boolean
-        default: false
+      image:
+        required: true
+        type: string
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -32,10 +23,7 @@ on:
 
 jobs:
   build-and-push-docker-images:
-    name: 'Build and push Docker images'
     runs-on: ubuntu-latest
-    env:
-      DOCKER_REGISTRY: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry
     steps:
       - uses: actions/checkout@v4.1.4
         with:
@@ -70,46 +58,25 @@ jobs:
       - name: "Add version to api"
         working-directory: api
         run: |
-          echo "${{ inputs.tag }}" > version.txt
+          echo "${{ inputs.ref }}" > version.txt
           git add version.txt
       - name: "Install poetry"
         run: pip install poetry
       - name: "check poetry lock is up to date"
         working-directory: api
         run: poetry check
+      - name: Replace image name in tags inputs
+        id: define-docker-image-tags
+        run: |
+          echo "tags-to-push=${{ inputs.tags }}" | sed 's/DOCKER_IMAGE/${{ inputs.image }}/g' >> "$GITHUB_OUTPUT"
       - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker
-      - name: "Build and push pcapi image"
+      - name: "Build and push ${{ inputs.image }} image"
         uses: docker/build-push-action@v5
-        if: inputs.pcapi == true && github.ref != 'refs/heads/master'
         with:
           context: api
           push: true
           target: pcapi
-          tags: ${{ env.DOCKER_REGISTRY }}/pcapi:${{ inputs.tag }}
-      - name: "Build and push pcapi image and set latest"
-        uses: docker/build-push-action@v5
-        if: inputs.pcapi == true && github.ref == 'refs/heads/master'
-        with:
-          context: api
-          push: true
-          target: pcapi
-          tags: ${{ env.DOCKER_REGISTRY }}/pcapi:${{ inputs.tag }},${{ env.DOCKER_REGISTRY }}/pcapi:latest
-      - name: "Build and push pcapi-console image"
-        uses: docker/build-push-action@v5
-        if: inputs.console == true
-        with:
-          context: api
-          push: true
-          target: pcapi-console
-          tags: ${{ env.DOCKER_REGISTRY }}/pcapi-console:${{ inputs.tag }}
-      - name: "Build and push pcapi-tests image"
-        uses: docker/build-push-action@v5
-        if: inputs.tests == true
-        with:
-          context: api
-          push: true
-          target: pcapi-tests
-          tags: ${{ env.DOCKER_REGISTRY }}/pcapi-tests:${{ inputs.tag }}
+          tags: ${{ steps.define-docker-image-tags.outputs.tags-to-push }}


### PR DESCRIPTION
## But de la pull request
Paralleliser les builds d'image docker en remplacement de steps sequentielles.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29434
Situation initiale : 
- dev_on_workflow_build_and_push_docker_images.yml est appelle une fois par dev_on_push_workflow_main.yml avec en inputs pcapi/pcapi-console/pcapi-tests true/false
- Les tags sont definis dans dev_on_workflow_build_and_push_docker_images.yml dans chaque step.

Changes list: 

Le workflow dev_on_workflow_build_and_push_docker_images.yml est rendu plus generique et est desormais appelle plusieurs fois par l'ajout de jobs de build supplementaire (1 par image a builder) dans dev_on_push_workflow_main.yml avec en inputs les tags a push et l'image a builder, ce qui permet de paralleliser le call au workflow. 
Les tags sont maintenant predefinis en amont dans le job caller via une step supplementaire unique (notamment pour s'affranchir de devoir ajouter un job supplementaire pour poser le tag latest comme initialement). 
Split du job build-api en : 
 - build-pcapi
 - build-pcapi-console
 - build-pcapi-tests
 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques