### PR TITLE
(PC-29529)[PRO] fix: add missing action bar on offer edition pages

### DIFF
--- a/pro/src/components/Footer/Footer.module.scss
+++ b/pro/src/components/Footer/Footer.module.scss
@@ -10,7 +10,6 @@
   }
 
   &-layout-sticky-actions {
-    height: size.$footer-height + size.$action-bar-sticky-height;
     margin-bottom: size.$action-bar-sticky-height;
   }
 

--- a/pro/src/pages/CollectiveOfferEdition/CollectiveOfferEdition.tsx
+++ b/pro/src/pages/CollectiveOfferEdition/CollectiveOfferEdition.tsx
@@ -25,7 +25,7 @@ const CollectiveOfferEdition = ({
   const isOfferTemplate = isCollectiveOfferTemplate(offer)
 
   return (
-    <AppLayout>
+    <AppLayout layout="sticky-actions">
       {!isReady ? (
         <Spinner />
       ) : (

--- a/pro/src/pages/CollectiveOfferStockEdition/CollectiveOfferStockEdition.tsx
+++ b/pro/src/pages/CollectiveOfferStockEdition/CollectiveOfferStockEdition.tsx
@@ -80,7 +80,7 @@ const CollectiveOfferStockEdition = ({
   }
 
   return (
-    <AppLayout>
+    <AppLayout layout="sticky-actions">
       <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
         <OfferEducationalStock
           initialValues={initialValues}

--- a/pro/src/pages/IndividualOfferWizard/BookingsSummary/BookingsSummary.tsx
+++ b/pro/src/pages/IndividualOfferWizard/BookingsSummary/BookingsSummary.tsx
@@ -1,8 +1,10 @@
 /* istanbul ignore file */
 import React from 'react'
 
+import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { useIndividualOfferContext } from 'context/IndividualOfferContext'
 import useOfferWizardMode from 'hooks/useOfferWizardMode'
+import ActionBar from 'screens/IndividualOffer/ActionBar/ActionBar'
 import { BookingsSummaryScreen } from 'screens/IndividualOffer/BookingsSummary/BookingsSummary'
 import IndivualOfferLayout from 'screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout'
 import Spinner from 'ui-kit/Spinner/Spinner'
@@ -18,6 +20,7 @@ const BookingsSummary = (): JSX.Element | null => {
   return (
     <IndivualOfferLayout title="Récapitulatif" offer={offer} mode={mode}>
       <BookingsSummaryScreen offer={offer} />
+      <ActionBar step={OFFER_WIZARD_STEP_IDS.SUMMARY} isDisabled={false} />
     </IndivualOfferLayout>
   )
 }

--- a/pro/src/pages/IndividualOfferWizard/StocksSummary/StocksSummary.tsx
+++ b/pro/src/pages/IndividualOfferWizard/StocksSummary/StocksSummary.tsx
@@ -1,8 +1,10 @@
 /* istanbul ignore file: DEBT, TO FIX */
 import React from 'react'
 
+import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { useIndividualOfferContext } from 'context/IndividualOfferContext'
 import { useOfferWizardMode } from 'hooks'
+import ActionBar from 'screens/IndividualOffer/ActionBar/ActionBar'
 import IndivualOfferLayout from 'screens/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout'
 import { StocksSummaryScreen } from 'screens/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen'
 import Spinner from 'ui-kit/Spinner/Spinner'
@@ -18,6 +20,7 @@ const StocksSummary = (): JSX.Element | null => {
   return (
     <IndivualOfferLayout title="Récapitulatif" offer={offer} mode={mode}>
       <StocksSummaryScreen />
+      <ActionBar step={OFFER_WIZARD_STEP_IDS.SUMMARY} isDisabled={false} />
     </IndivualOfferLayout>
   )
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29529

Ajouter la barre d'action sur les pages d'éditions d'une offre indiv (stock/réservations)
