### PR TITLE
(PC-29266)[PRO] style: Ajout padding au hover, modif, stock

### DIFF
--- a/pro/src/components/StockFormActions/StockFormActions.module.scss
+++ b/pro/src/components/StockFormActions/StockFormActions.module.scss
@@ -29,7 +29,7 @@
   border: 1px solid var(--color-grey-light);
   border-radius: rem.torem(6px);
   box-shadow: 0 3px 4px 0 var(--color-medium-shadow);
-  padding: rem.torem(16px) 0;
+  padding: rem.torem(8px) 0;
   background: var(--color-white);
 }
 
@@ -37,8 +37,8 @@
   @include fonts.button;
 
   display: flex;
-  padding: 0 16px;
   color: var(--color-black);
+  padding: rem.torem(8px);
 
   &[data-selected] {
     background: var(--color-grey-medium);


### PR DESCRIPTION
## Ajout padding, 8px

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29266

<img width="975" alt="Capture d’écran 2024-04-30 à 11 42 52" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/6032481a-6ede-4090-8362-ee2fe7f95470">
