### PR TITLE
(PC-29124)[PRO] style: Enlever "A deux !" quand l’offre pas duo

### DIFF
--- a/pro/src/components/OfferAppPreview/OptionsIcons/OptionsIcons.tsx
+++ b/pro/src/components/OfferAppPreview/OptionsIcons/OptionsIcons.tsx
@@ -26,15 +26,12 @@ const OptionsIcons = ({
         <span className={style['text']}>Type</span>
       </div>
 
-      <div
-        className={cn(style['option'], {
-          [style['disabled']]: !(isEvent && isDuo),
-        })}
-      >
-        <SvgIcon src={strokeDuoIcon} alt="" className={style['icon']} />
-        <span className={style['text']}>À deux !</span>
-      </div>
-
+      {isEvent && isDuo && (
+        <div className={style['option']}>
+          <SvgIcon src={strokeDuoIcon} alt="" className={style['icon']} />
+          <span className={style['text']}>À deux !</span>
+        </div>
+      )}
       <div className={style['option']}>
         <SvgIcon src={strokePriceIcon} alt="" className={style['icon']} />
         <span className={style['text']}>- - €</span>


### PR DESCRIPTION
## Enlever mention A deux quand l’offre n’est pas duo

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29124

oui:
<img width="909" alt="Capture d’écran 2024-04-30 à 14 13 58" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/66c385ad-8d0c-4ce5-b9de-da7aac18e8de">

non:
<img width="877" alt="Capture d’écran 2024-04-30 à 14 09 59" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/6d02ace2-75a8-4597-928a-5b3fcd9751a9">
