### PR TITLE
(BSR)[API] docs: do not add blank line to alembic version conflict de…

### DIFF
--- a/api/src/pcapi/alembic/CONTRIBUTING.md
+++ b/api/src/pcapi/alembic/CONTRIBUTING.md
@@ -121,6 +121,9 @@ def upgrade() -> None:
 
 Note : le `select 1` permet d'éviter une requête vide, ce que SQLAlchemy n'apprécie pas du tout.
 
+Attention : Ne pas ajouter de lignes vides à la fin du fichier alembic_version_conflict_detection.txt. L'ajout entraînera l'échec de l'étape de lint dans la CI sur la branche master une fois la pull request mergée.
+Si une ligne vide est ajoutée par erreur, il est nécessaire de merger une correction sur master, même si la CI échoue pour la pull request concernée.
+
 # Squasher les migrations
 
 ## Objectif


### PR DESCRIPTION
…tection

## But de la pull request

Ticket Jira (ou description si BSR) : modification de la documentation warning ajout de ligne vie à la fin d' alembic_version_conflict_detection

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques