### PR TITLE
(PC-29508)[API] feat: Revert add sentry traces sampler

### DIFF
--- a/api/src/pcapi/utils/sentry.py
+++ b/api/src/pcapi/utils/sentry.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import typing
 
@@ -16,15 +15,6 @@ from pcapi.utils.health_checker import read_version_from_file
 if typing.TYPE_CHECKING:
     from sentry_sdk.types import Event
 
-logger = logging.getLogger(__name__)
-
-
-DEFAULT_SAMPLING_RATE = settings.SENTRY_TRACES_SAMPLE_RATE
-LOW_SAMPLING_RATE = DEFAULT_SAMPLING_RATE / 10
-LOWER_SAMPLING_RATE = DEFAULT_SAMPLING_RATE / 100
-LOWEST_SAMPLING_RATE = DEFAULT_SAMPLING_RATE / 1000
-NO_SAMPLING_RATE = 0.0
-
 
 def before_send(event: "Event", _hint: dict[str, typing.Any]) -> "Event | None":
     if _is_flask_shell_event():
@@ -35,66 +25,6 @@ def before_send(event: "Event", _hint: dict[str, typing.Any]) -> "Event | None":
     return event
 
 
-def traces_sampler(sampling_context: dict) -> float:
-    """
-    This sampler defines a fraction of the DEFAULT_SAMPLING_RATE according to the transaction name
-    """
-    transaction_context = sampling_context.get("transaction_context")
-    if transaction_context is None:
-        logger.info("[sentry traces_sampler] No transaction_context", extra={"sampling_context": sampling_context})
-        return NO_SAMPLING_RATE
-
-    name = transaction_context.get("name")
-    # Each Flask app Blueprint name should be in this pattern matching
-    # From lowest to standard sampling rates
-    match name:
-        # static files for BO
-        case "static":
-            return LOWEST_SAMPLING_RATE
-        # monitoring endpoints
-        case _ if name.endswith("health_api"):
-            return LOWEST_SAMPLING_RATE
-        case _ if name.endswith("health_database"):
-            return LOWEST_SAMPLING_RATE
-        # cloud tasks
-        case _ if name.startswith("Cloud task internal API"):
-            return LOWEST_SAMPLING_RATE
-        # public
-        case _ if name.startswith("public_blueprint"):
-            return LOWEST_SAMPLING_RATE
-        # public V2
-        case _ if name.startswith("pro_public_api_v2"):
-            return LOWEST_SAMPLING_RATE
-        # native routes
-        case _ if name.startswith("native"):
-            return LOWER_SAMPLING_RATE
-        # deprecated public API
-        case _ if name.startswith("Public API"):
-            return LOWER_SAMPLING_RATE
-        # adage
-        case _ if name.startswith("adage_v1"):
-            return LOW_SAMPLING_RATE
-        # SAML
-        case _ if name.startswith("saml_blueprint"):
-            return LOW_SAMPLING_RATE
-        # adage
-        case _ if name.startswith("adage_iframe"):
-            return DEFAULT_SAMPLING_RATE
-        # backoffice
-        case _ if name.startswith("backoffice_web"):
-            return DEFAULT_SAMPLING_RATE
-        # private API
-        case _ if name.startswith("Private API"):
-            return DEFAULT_SAMPLING_RATE
-        # other private API
-        case _ if name.startswith("pro_private_api"):
-            return DEFAULT_SAMPLING_RATE
-        # Unmatched or None
-        case _:
-            logger.info("[sentry traces_sampler] Could not match transaction name", extra={"transaction_name": name})
-            return LOWEST_SAMPLING_RATE
-
-
 def init_sentry_sdk() -> None:
     if settings.IS_DEV:
         return
@@ -103,7 +33,7 @@ def init_sentry_sdk() -> None:
         integrations=[FlaskIntegration(), RedisIntegration(), RqIntegration(), SqlalchemyIntegration()],
         release=read_version_from_file(),
         environment=settings.ENV,
-        traces_sampler=traces_sampler,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
         before_send=before_send,
         max_value_length=8192,
     )


### PR DESCRIPTION
This reverts commit 1a5c0ee33aa9d92963ec1cf07138a688b9ef0176.

It's the only commit i reverted after this PR, the sampling will still be reduced. 
I don't know how the code could work, i can't find what `transaction_context.get("name")` (and sentry sdk devs cannot guarantee it too see [this issue](https://github.com/getsentry/sentry-python/issues/969) and [this PR](https://github.com/getsentry/sentry-docs/pull/2882/files)). If we want to do that again we should do it from the path info `path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")` like [the example](https://github.com/PostHog/posthog/blob/efbc85b08ee5261d02585bd2908076d6a270d71c/posthog/settings/sentry.py#L75) françois gave.

This is spamming logs, i revert it until we have something working
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques