### PR TITLE
(PC-29404)[BO] feat: feature flag are now visible in read only for authenticate user without permission

### DIFF
--- a/api/src/pcapi/routes/backoffice/admin/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/blueprint.py
@@ -89,7 +89,7 @@ def update_role(role_id: int) -> utils.BackofficeResponse:
 
 
 @blueprint.backoffice_web.route("/admin/feature-flipping", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FEATURE_FLIPPING)
+@utils.custom_login_required(redirect_to=".home")
 def list_feature_flags() -> utils.BackofficeResponse:
     feature_flags = feature_models.Feature.query.order_by(feature_models.Feature.name).all()
     form = empty_forms.EmptyForm()

--- a/api/src/pcapi/routes/backoffice/templates/admin/feature_flipping.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/feature_flipping.html
@@ -41,41 +41,47 @@
             <tr class="pc-filter-dataset">
               <td>
                 {% set feature_flag_checked = feature_flag.isActive %}
-                <div class="form-check form-switch">
-                  <input class="form-check-input" type="checkbox" role="switch" data-bs-toggle="modal" data-bs-target=".pc-toggle-feature-flag-modal-{{ feature_flag.id }}" name="is_feature_flag_active" id="feature-flag-switch-{{ feature_flag.id }}" aria-label="{{ feature_flag_checked | format_bool }}" {{ "checked" if feature_flag_checked else "" }} data-description="{{ feature_flag.description }}" data-name="{{ feature_flag.name }}" data-confirm-modal=".pc-toggle-feature-flag-modal-{{ feature_flag.id }}" />
-                </div>
-                <div class="modal modal-lg fade pc-toggle-feature-flag-modal-{{ feature_flag.id }}"
-                     tabindex="-1"
-                     aria-labelledby="{{ toggle_feature_flag_modal_label_id }}"
-                     aria-hidden="true">
-                  <div class="modal-dialog modal-dialog-centered">
-                    <div class="modal-content">
-                      <form action="{{ url_for(".disable_feature_flag", feature_flag_id=feature_flag.id) if feature_flag.isActive else url_for(".enable_feature_flag", feature_flag_id=feature_flag.id) }}"
-                            name="{{ url_for(".disable_feature_flag", feature_flag_id=feature_flag.id) if feature_flag.isActive else url_for(".enable_feature_flag", feature_flag_id=feature_flag.id) | action_to_name }}"
-                            method="post"
-                            data-turbo="false">
-                        {{ csrf_token }}
-                        <div class="modal-header"
-                             id="{{ toggle_feature_flag_modal_label_id }}">
-                          <h5 class="modal-title">{{ "Désactiver" if feature_flag.isActive else "Activer" }} le feature flag {{ feature_flag.name }}</h5>
-                        </div>
-                        <div class="modal-body row">
-                          <p>
-                            Vous allez {{ "désactiver" if feature_flag.isActive else "activer" }} le feature flag {{ feature_flag.name }} dans l'environnement <strong>{{ env | upper }}</strong>. Veuillez confirmer ce choix.
-                          </p>
-                          {{ build_form_fields_group(toggle_feature_flag_form) }}
-                        </div>
-                        <div class="modal-footer">
-                          <button type="button"
-                                  class="btn btn-outline-primary"
-                                  data-bs-dismiss="modal">Annuler</button>
-                          <button type="submit"
-                                  class="btn btn-primary">Confirmer</button>
-                        </div>
-                      </form>
+                {% if has_permission("FEATURE_FLIPPING") %}
+                  <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" role="switch" data-bs-toggle="modal" data-bs-target=".pc-toggle-feature-flag-modal-{{ feature_flag.id }}" name="is_feature_flag_active" id="feature-flag-switch-{{ feature_flag.id }}" aria-label="{{ feature_flag_checked | format_bool }}" {{ "checked" if feature_flag_checked else "" }} data-description="{{ feature_flag.description }}" data-name="{{ feature_flag.name }}" data-confirm-modal=".pc-toggle-feature-flag-modal-{{ feature_flag.id }}" />
+                  </div>
+                  <div class="modal modal-lg fade pc-toggle-feature-flag-modal-{{ feature_flag.id }}"
+                       tabindex="-1"
+                       aria-labelledby="{{ toggle_feature_flag_modal_label_id }}"
+                       aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                        <form action="{{ url_for(".disable_feature_flag", feature_flag_id=feature_flag.id) if feature_flag.isActive else url_for(".enable_feature_flag", feature_flag_id=feature_flag.id) }}"
+                              name="{{ url_for(".disable_feature_flag", feature_flag_id=feature_flag.id) if feature_flag.isActive else url_for(".enable_feature_flag", feature_flag_id=feature_flag.id) | action_to_name }}"
+                              method="post"
+                              data-turbo="false">
+                          {{ csrf_token }}
+                          <div class="modal-header"
+                               id="{{ toggle_feature_flag_modal_label_id }}">
+                            <h5 class="modal-title">{{ "Désactiver" if feature_flag.isActive else "Activer" }} le feature flag {{ feature_flag.name }}</h5>
+                          </div>
+                          <div class="modal-body row">
+                            <p>
+                              Vous allez {{ "désactiver" if feature_flag.isActive else "activer" }} le feature flag {{ feature_flag.name }} dans l'environnement <strong>{{ env | upper }}</strong>. Veuillez confirmer ce choix.
+                            </p>
+                            {{ build_form_fields_group(toggle_feature_flag_form) }}
+                          </div>
+                          <div class="modal-footer">
+                            <button type="button"
+                                    class="btn btn-outline-primary"
+                                    data-bs-dismiss="modal">Annuler</button>
+                            <button type="submit"
+                                    class="btn btn-primary">Confirmer</button>
+                          </div>
+                        </form>
+                      </div>
                     </div>
                   </div>
-                </div>
+                {% else %}
+                  <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" role="switch" {{ "checked" if feature_flag_checked else "" }} disabled />
+                  </div>
+                {% endif %}
               </td>
               <td>{{ feature_flag.name }}</td>
               <td>{{ feature_flag.description }}</td>

--- a/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
@@ -150,7 +150,7 @@
                   {% if has_permission("READ_ADMIN_ACCOUNTS") %}
                     {{ menu_section_item('Utilisateurs BackOffice', 'backoffice_web.bo_users.search_bo_users') }}
                   {% endif %}
-                  {% if has_permission("FEATURE_FLIPPING") %}{{ menu_section_item('Feature flipping', 'backoffice_web.list_feature_flags') }}{% endif %}
+                  {{ menu_section_item('Feature flipping', 'backoffice_web.list_feature_flags') }}
                   {{ menu_section_item('Liste des sous-catégories', 'backoffice_web.get_subcategories') }}
                   {% if get_setting("ENABLE_TEST_USER_GENERATION") %}
                     {{ menu_section_item("Générateur d'utilisateurs de test", 'backoffice_web.generate_user') }}

--- a/api/tests/routes/backoffice/helpers/get.py
+++ b/api/tests/routes/backoffice/helpers/get.py
@@ -2,7 +2,19 @@ from flask import url_for
 
 from pcapi.core.users import factories as users_factories
 
+from .unauthorized import AuthenticatedHelperBase
 from .unauthorized import UnauthorizedHelperBase
+
+
+class GetEndpointWithoutPermissionHelper(AuthenticatedHelperBase):
+    @property
+    def method(self) -> str:
+        return "get"
+
+    def test_not_logged_in(self, client):
+        response = getattr(client, self.http_method)(self.path)
+        assert response.status_code in (302, 303)
+        assert response.location == url_for("backoffice_web.home", _external=True)
 
 
 class GetEndpointHelper(UnauthorizedHelperBase):

--- a/api/tests/routes/backoffice/helpers/unauthorized.py
+++ b/api/tests/routes/backoffice/helpers/unauthorized.py
@@ -19,7 +19,13 @@ pytestmark = [
 ]
 
 
-class UnauthorizedHelperBase(base.BaseHelper, metaclass=abc.ABCMeta):
+class AuthenticatedHelperBase(base.BaseHelper, metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def test_not_logged_in(self, client):
+        pass
+
+
+class UnauthorizedHelperBase(AuthenticatedHelperBase):
     @property
     @abc.abstractmethod
     def needed_permission(self) -> perm_models.Permissions | typing.Iterable[perm_models.Permissions]:
@@ -31,10 +37,6 @@ class UnauthorizedHelperBase(base.BaseHelper, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def test_no_backoffice_profile(self, client):
-        pass
-
-    @abc.abstractmethod
-    def test_not_logged_in(self, client):
         pass
 
     def setup_user(self) -> users_models.User:

--- a/api/tests/routes/backoffice/user_generation_test.py
+++ b/api/tests/routes/backoffice/user_generation_test.py
@@ -10,6 +10,7 @@ from pcapi.core.users import models as users_models
 
 from tests.routes.backoffice.helpers import html_parser
 from tests.routes.backoffice.helpers import post as post_endpoint_helper
+from tests.routes.backoffice.helpers.get import GetEndpointWithoutPermissionHelper
 
 
 pytestmark = [
@@ -18,7 +19,7 @@ pytestmark = [
 ]
 
 
-class UserGenerationGetRouteTest:
+class UserGenerationGetRouteTest(GetEndpointWithoutPermissionHelper):
     endpoint = "backoffice_web.get_generated_user"
     needed_permission = None
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29404

## Vérifications

### verification front 

cas 1 : l'utilisateur possède les droits de gestion de role.
<img width="1512" alt="Capture d’écran 2024-05-03 à 10 33 17" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/d70b4e0c-404b-4fcd-9473-9444866c3059">

cas 2 : l'utilisateur ne possède pas les droits de gestion de role:
<img width="1512" alt="Capture d’écran 2024-05-03 à 10 35 36" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/a2258074-a699-4704-886e-0c1239046d63">


### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 

- lire uniquement les feature flag
- ne peut pas activer un feature flag
- ne peut pas désactiver un feature flag

### Verification ticket

- nom du ticket conforme -> OK
- auteur du ticket -> OK
- nombre de commit -> OK 
- nom du commit -> OK
- mettre le ticket en code-review -> OK 

### Tache restante si WIP + AUTRE

- refresh de la page github -> 
- vérifier la sécurité afin que seul un utilisateur ayant les droit BO puisse entrer cela meme sans les permissions



