### PR TITLE
 (PC-26152)[API] feat: return offererAddress of an offer under a FF

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -1271,6 +1271,14 @@ class OffererAddress(PcObject, Base, Model):
 
     __table_args__ = (sa.Index("ix_unique_offerer_address_per_label", "offererId", "addressId", "label", unique=True),)
 
+    @hybrid_property
+    def isEditable(self) -> bool:
+        return db.session.query(~sa.select(1).exists().where(Venue.offererAddressId == self.id)).scalar()
+
+    @isEditable.expression  # type: ignore [no-redef]
+    def isEditable(cls) -> sa.sql.elements.BooleanClauseList:  # pylint: disable=no-self-argument
+        return ~sa.select(1).where(Venue.offererAddressId == cls.id).exists()
+
 
 class OffererConfidenceLevel(enum.Enum):
     # No default value when offerer follows rules in offer_validation_rule table,

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -36,7 +36,7 @@ LIMIT_STOCKS_PER_PAGE = 20
 STOCK_LIMIT_TO_DELETE = 50
 
 OFFER_LOAD_OPTIONS = typing.Iterable[
-    typing.Literal["stock", "mediations", "product", "price_category", "venue", "bookings_count"]
+    typing.Literal["stock", "mediations", "product", "price_category", "venue", "bookings_count", "offerer_address"]
 ]
 
 
@@ -784,6 +784,10 @@ def get_offer_by_id(offer_id: int, load_options: OFFER_LOAD_OPTIONS = ()) -> mod
         if "bookings_count" in load_options:
             query = query.options(
                 sa_orm.with_expression(models.Offer.bookingsCount, get_bookings_count_subquery(offer_id))
+            )
+        if "offerer_address" in load_options:
+            query = query.options(
+                sa_orm.joinedload(models.Offer.offererAddress).joinedload(offerers_models.OffererAddress.address)
             )
 
         return query.one()

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -66,12 +66,14 @@ def list_offers(query: offers_serialize.ListOffersQueryModel) -> offers_serializ
     api=blueprint.pro_private_schema,
 )
 def get_offer(offer_id: int) -> offers_serialize.GetIndividualOfferResponseModel:
+
     load_all: offers_repository.OFFER_LOAD_OPTIONS = [
         "mediations",
         "product",
         "price_category",
         "venue",
         "bookings_count",
+        "offerer_address",
     ]
     try:
         offer = offers_repository.get_offer_by_id(offer_id, load_options=load_all)

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -369,10 +369,6 @@ class GetOffererAddressResponseModel(BaseModel):
         offerer_address.street = offerer_address.address.street
         offerer_address.postalCode = offerer_address.address.postalCode
         offerer_address.city = offerer_address.address.city
-        offerer_address.isEditable = (
-            False  # TODO (yacine) default value until the relation between Venue and OffererAddress be added
-        )
-
         return super().from_orm(offerer_address)
 
     class Config:

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -26,6 +26,8 @@ from pcapi.routes.native.v1.serialization.common_models import AccessibilityComp
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import ConfiguredBaseModel
 from pcapi.routes.serialization import base as base_serializers
+from pcapi.routes.serialization.offerers_serialize import AddressResponseModel
+from pcapi.routes.serialization.offerers_serialize import GetOffererAddressResponseModel
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
@@ -386,6 +388,28 @@ class PriceCategoryResponseModel(BaseModel):
         orm_mode = True
 
 
+class IndividualOfferResponseGetterDict(GetterDict):
+    def get(self, key: str, default: Any | None = None) -> Any:
+        if key == "address":
+            if not self._obj.offererAddress:
+                return None
+            offererAddress = GetOffererAddressResponseModel.from_orm(self._obj.offererAddress)
+            return AddressResponseIsEditableModel(
+                id=self._obj.offererAddress.addressId,
+                banId=self._obj.offererAddress.address.banId,
+                inseeCode=self._obj.offererAddress.address.inseeCode,
+                longitude=self._obj.offererAddress.address.longitude,
+                latitude=self._obj.offererAddress.address.latitude,
+                **offererAddress.dict(exclude={"id"}),
+            )
+        return super().get(key, default)
+
+
+class AddressResponseIsEditableModel(AddressResponseModel):
+    label: str
+    isEditable: bool
+
+
 class GetIndividualOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     activeMediation: GetOfferMediationResponseModel | None
     bookingContact: str | None
@@ -419,11 +443,13 @@ class GetIndividualOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     withdrawalType: offers_models.WithdrawalTypeEnum | None
     status: OfferStatus
     isNonFreeOffer: bool | None
+    address: AddressResponseIsEditableModel | None
 
     class Config:
         orm_mode = True
         json_encoders = {datetime.datetime: format_into_utc_date}
         use_enum_values = True
+        getter_dict = IndividualOfferResponseGetterDict
 
 
 class GetStocksResponseModel(ConfiguredBaseModel):

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -473,3 +473,24 @@ class OffererConfidenceRuleTest:
     def test_strategy_cannot_be_null(self):
         with pytest.raises(IntegrityError):
             factories.OffererConfidenceRuleFactory(offerer=factories.OffererFactory(), confidenceLevel=None)
+
+
+class OffererAddressTest:
+    def test_offerer_address_is_not_editable_property(self):
+        offererAddress = factories.OffererAddressFactory()
+        factories.VenueFactory(offererAddress=offererAddress)
+        assert offererAddress.isEditable is False
+
+    def test_offerers_address_is_editable_property(self):
+        offererAddress = factories.OffererAddressFactory()
+        assert offererAddress.isEditable is True
+
+    def test_offerers_address_is_editable_expression(self):
+        offererAddress = factories.OffererAddressFactory()
+        assert models.OffererAddress.query.filter_by(id=offererAddress.id).one().isEditable is True
+        assert models.OffererAddress.query.filter(models.OffererAddress.isEditable == True).one()
+
+    def test_offerers_address_is_not_editable_expression(self):
+        offererAddress = factories.OffererAddressFactory()
+        factories.VenueFactory(offererAddress=offererAddress)
+        assert models.OffererAddress.query.filter(models.OffererAddress.isEditable == False).one()

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -185,6 +185,7 @@ class Returns200Test:
             "subcategoryId": "SEANCE_CINE",
             "thumbUrl": None,
             "url": None,
+            "address": None,
             "venue": {
                 "street": "1 boulevard Poissonnière",
                 "audioDisabilityCompliant": False,
@@ -275,3 +276,29 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["bookingsCount"] == 2
         assert response.json["hasStocks"] == True
+
+    def test_return_offerer_address(self, client):
+        # Given
+        user_offerer = offerers_factories.UserOffererFactory()
+        offerer_address = offerers_factories.OffererAddressFactory(offerer=user_offerer.offerer)
+        offer = offers_factories.ThingOfferFactory(
+            venue__managingOfferer=user_offerer.offerer, offererAddress=offerer_address
+        )
+
+        # When
+        response = client.with_session_auth(email=user_offerer.user.email).get(f"/offers/{offer.id}")
+
+        # Then
+        assert response.status_code == 200
+        assert response.json["address"] == {
+            "label": offerer_address.label,
+            "id": offerer_address.address.id,
+            "banId": offerer_address.address.banId,
+            "inseeCode": offerer_address.address.inseeCode,
+            "city": offerer_address.address.city,
+            "latitude": float(offerer_address.address.latitude),
+            "longitude": float(offerer_address.address.longitude),
+            "postalCode": offerer_address.address.postalCode,
+            "street": offerer_address.address.street,
+            "isEditable": offerer_address.isEditable,
+        }

--- a/api/tests/routes/pro/get_offerer_addresses_test.py
+++ b/api/tests/routes/pro/get_offerer_addresses_test.py
@@ -40,7 +40,7 @@ def test_get_offerer_addresses_success(client):
         {
             "city": "Paris",
             "id": offerer_address_1.id,
-            "isEditable": False,
+            "isEditable": True,
             "label": "1ere adresse",
             "postalCode": "75002",
             "street": "1 boulevard Poissonnière",
@@ -48,7 +48,7 @@ def test_get_offerer_addresses_success(client):
         {
             "city": "Paris",
             "id": offerer_address_2.id,
-            "isEditable": False,
+            "isEditable": True,
             "label": "2eme adresse",
             "postalCode": "75007",
             "street": "20 Avenue de Ségur",

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -12,6 +12,7 @@ export type { OpenAPIConfig } from './core/OpenAPI';
 
 export type { AdageCulturalPartnersResponseModel } from './models/AdageCulturalPartnersResponseModel';
 export type { Address } from './models/Address';
+export type { AddressResponseIsEditableModel } from './models/AddressResponseIsEditableModel';
 export type { AddressResponseModel } from './models/AddressResponseModel';
 export type { AttachImageFormModel } from './models/AttachImageFormModel';
 export type { AttachImageResponseModel } from './models/AttachImageResponseModel';

--- a/pro/src/apiClient/v1/models/AddressResponseIsEditableModel.ts
+++ b/pro/src/apiClient/v1/models/AddressResponseIsEditableModel.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AddressResponseIsEditableModel = {
+  banId?: string | null;
+  city: string;
+  id: number;
+  inseeCode?: string | null;
+  isEditable: boolean;
+  label: string;
+  latitude: number;
+  longitude: number;
+  postalCode: string;
+  street?: string | null;
+};
+

--- a/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AddressResponseIsEditableModel } from './AddressResponseIsEditableModel';
 import type { GetOfferLastProviderResponseModel } from './GetOfferLastProviderResponseModel';
 import type { GetOfferMediationResponseModel } from './GetOfferMediationResponseModel';
 import type { GetOfferVenueResponseModel } from './GetOfferVenueResponseModel';
@@ -11,6 +12,7 @@ import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 import type { WithdrawalTypeEnum } from './WithdrawalTypeEnum';
 export type GetIndividualOfferResponseModel = {
   activeMediation?: GetOfferMediationResponseModel | null;
+  address?: AddressResponseIsEditableModel | null;
   audioDisabilityCompliant?: boolean | null;
   bookingContact?: string | null;
   bookingEmail?: string | null;


### PR DESCRIPTION

## But de la pull request
Retourner l'information de l'addresse pour la route /offers/id selon le FF  WIP_ENABLE_OFFERER_ADDRESS

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26152

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques