### PR TITLE
(PC-29403)[API] test: fix regression in unit tests

### DIFF
--- a/api/tests/routes/pro/signin_test.py
+++ b/api/tests/routes/pro/signin_test.py
@@ -268,6 +268,7 @@ class Returns401Test:
         assert response.status_code == 401
         assert response.json["identifier"] == ["Ce compte n'est pas validé."]
 
+    @pytest.mark.usefixtures("db_session")
     def test_session_timeout(self, client):
         from dateutil.relativedelta import relativedelta
         import time_machine


### PR DESCRIPTION
Unit tests fail on Continuous Integration because of commit [786c6583](https://github.com/pass-culture/pass-culture-main/commit/786c65831ad076ee7733382fc59174e798ecf7c1). Objects remain in database, so there is one extra educational institution for all next tests.

## But de la pull request

Réparer les tests auto

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques