### PR TITLE
(PC-29485)[API] feat: adage iframe: fill two new playlists' code

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/__init__.py
+++ b/api/src/pcapi/connectors/big_query/queries/__init__.py
@@ -1,6 +1,7 @@
 from .adage_playlists import ClassroomPlaylistQuery  # noqa: F401
 from .adage_playlists import InstitutionRuralLevelQuery  # noqa: F401
 from .adage_playlists import LocalOfferersQuery  # noqa: F401
+from .adage_playlists import NewOffererQuery  # noqa: F401
 from .adage_playlists import NewTemplateOffersPlaylistQuery  # noqa: F401
 from .favorites_not_booked import FavoritesNotBooked  # noqa: F401
 from .favorites_not_booked import FavoritesNotBookedModel  # noqa: F401

--- a/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
+++ b/api/src/pcapi/connectors/big_query/queries/adage_playlists.py
@@ -94,3 +94,22 @@ class InstitutionRuralLevelQuery(BaseQuery):
     """
 
     model = InstitutionRuralLevelModel
+
+
+class NewOffererQuery(BaseQuery):
+    raw_query = f"""
+        SELECT
+            institution_id,
+            venue_id,
+            MIN(distance_in_km) as distance_in_km
+        FROM
+            `{settings.BIG_QUERY_TABLE_BASENAME}.adage_home_playlist_new_venues`
+        WHERE
+            distance_in_km <= 60
+        GROUP BY
+            institution_id, venue_id
+        ORDER BY
+            institution_id, venue_id
+    """
+
+    model = LocalOfferersModel

--- a/api/src/pcapi/core/educational/api/playlists.py
+++ b/api/src/pcapi/core/educational/api/playlists.py
@@ -40,6 +40,9 @@ QUERY_DESC = {
     educational_models.PlaylistType.LOCAL_OFFERER: QueryCtx(
         query=big_query.LocalOfferersQuery, bq_attr_name="venue_id", local_attr_name="venueId"
     ),
+    educational_models.PlaylistType.NEW_OFFERER: QueryCtx(
+        query=big_query.NewOffererQuery, bq_attr_name="venue_id", local_attr_name="venueId"
+    ),
 }
 
 

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -244,3 +244,9 @@ def synchronise_collective_new_offer_playlist() -> None:
 @log_cron_with_transaction
 def synchronise_collective_local_offerer_playlist() -> None:
     playlists_api.synchronize_collective_playlist(educational_models.PlaylistType.LOCAL_OFFERER)
+
+
+@blueprint.cli.command("synchronise_collective_new_offerers_playlist")
+@log_cron_with_transaction
+def synchronise_collective_new_offerers_playlist() -> None:
+    playlists_api.synchronize_collective_playlist(educational_models.PlaylistType.NEW_OFFERER)

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -149,6 +149,7 @@ class PlaylistType(enum.Enum):
     CLASSROOM = "Dans votre classe"
     LOCAL_OFFERER = "À proximité de l'établissement"
     NEW_OFFER = "Nouvelles offres"
+    NEW_OFFERER = "Nouveaux partenaires culturels"
 
 
 @sa.orm.declarative_mixin

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/fill.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/fill.py
@@ -39,5 +39,15 @@ def fill_adage_playlists() -> None:
             for offer in collective_offer_templates[:10]
         ]
         db.session.bulk_insert_mappings(educational_models.CollectivePlaylist, playlist_items_to_add)
+        playlist_items_to_add = [
+            {
+                "type": educational_models.PlaylistType.NEW_OFFERER,
+                "institutionId": institution.id,
+                "distanceInKm": 5.0,
+                "venueId": venue.id,
+            }
+            for venue in venues
+        ]
+        db.session.bulk_insert_mappings(educational_models.CollectivePlaylist, playlist_items_to_add)
 
     db.session.commit()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29485

Ajout du code (complet) pour les deux nouvelles routes d'API (iframe adage).
Pour rappel : une précédente PR avait ajouté ces fonctions dans le seul but d'exposer rapidement une interface API.