### PR TITLE
Pc 29550 adage pagination

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -394,12 +394,7 @@ def log_search_show_more(
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)
     educational_utils.log_information_for_data_purpose(
         event_name="SearchShowMore",
-        extra_data={
-            "source": body.source,
-            "from": body.iframeFrom,
-            "queryId": body.queryId,
-            "type": body.type
-        },
+        extra_data={"source": body.source, "from": body.iframeFrom, "queryId": body.queryId, "type": body.type},
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,
         user_email=authenticated_information.email,

--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -398,6 +398,7 @@ def log_search_show_more(
             "source": body.source,
             "from": body.iframeFrom,
             "queryId": body.queryId,
+            "type": body.type
         },
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -83,6 +83,9 @@ class SuggestionType(enum.Enum):
     OFFER_BY_CATEGORY = "offer category"
     OFFER = "offer"
 
+class PaginationType(enum.Enum):
+    NEXT = "next"
+    PREVIOUS = "previous"
 
 class TrackingAutocompleteSuggestionBody(AdageBaseModel):
     suggestionType: SuggestionType
@@ -91,6 +94,7 @@ class TrackingAutocompleteSuggestionBody(AdageBaseModel):
 
 class TrackingShowMoreBody(AdageBaseModel):
     source: str
+    type: PaginationType
 
 
 class TrackingCTAShareBody(AdageBaseModel, VueTypeMixin):

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -83,9 +83,11 @@ class SuggestionType(enum.Enum):
     OFFER_BY_CATEGORY = "offer category"
     OFFER = "offer"
 
+
 class PaginationType(enum.Enum):
     NEXT = "next"
     PREVIOUS = "previous"
+
 
 class TrackingAutocompleteSuggestionBody(AdageBaseModel):
     suggestionType: SuggestionType

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -6,6 +6,7 @@ import pytest
 from pcapi.core.educational import utils
 from pcapi.core.educational.utils import get_hashed_user_id
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AdageFrontRoles
+from pcapi.routes.adage_iframe.serialization.logs import PaginationType
 
 
 EMAIL = "test@mail.com"
@@ -448,11 +449,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = test_client.post(
                 url_for("adage_iframe.log_search_show_more"),
-                json={
-                    "iframeFrom": "for_my_institution",
-                    "queryId": "1234a",
-                    "source": "partnersMap",
-                },
+                json={"iframeFrom": "for_my_institution", "queryId": "1234a", "source": "partnersMap", "type": "next"},
             )
 
         assert response.status_code == 204
@@ -461,6 +458,7 @@ class LogsTest:
             "analyticsSource": "adage",
             "source": "partnersMap",
             "queryId": "1234a",
+            "type": PaginationType.NEXT,
             "from": "for_my_institution",
             "uai": UAI,
             "user_role": AdageFrontRoles.READONLY,

--- a/pro/src/apiClient/adage/index.ts
+++ b/pro/src/apiClient/adage/index.ts
@@ -54,6 +54,7 @@ export type { OfferListSwitch } from './models/OfferListSwitch';
 export type { OfferManagingOffererResponse } from './models/OfferManagingOffererResponse';
 export type { OfferStockResponse } from './models/OfferStockResponse';
 export type { OfferVenueResponse } from './models/OfferVenueResponse';
+export { PaginationType } from './models/PaginationType';
 export type { PlaylistBody } from './models/PlaylistBody';
 export type { PostCollectiveRequestBodyModel } from './models/PostCollectiveRequestBodyModel';
 export type { RedactorPreferences } from './models/RedactorPreferences';

--- a/pro/src/apiClient/adage/models/PaginationType.ts
+++ b/pro/src/apiClient/adage/models/PaginationType.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * An enumeration.
+ */
+export enum PaginationType {
+  NEXT = 'next',
+  PREVIOUS = 'previous',
+}

--- a/pro/src/apiClient/adage/models/TrackingShowMoreBody.ts
+++ b/pro/src/apiClient/adage/models/TrackingShowMoreBody.ts
@@ -2,10 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { PaginationType } from './PaginationType';
 export type TrackingShowMoreBody = {
   iframeFrom: string;
   isFromNoResult?: boolean | null;
   queryId?: string | null;
   source: string;
+  type: PaginationType;
 };
 

--- a/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
@@ -42,7 +42,7 @@ vi.mock('react-instantsearch', async () => {
     useStats: () => ({ nbHits: 1 }),
     useSearchBox: () => ({ refine: vi.fn() }),
     useInfiniteHits: () => ({
-      hits: [],
+      currentPageHits: [],
     }),
     useInstantSearch: () => ({ scopedResults: [] }),
     Index: vi.fn(({ children }) => children),

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
@@ -109,10 +109,8 @@
   }
 }
 
-.offers-pagination {
-  .root {
-    background-color: black;
-  }
+.pagination {
+  margin: rem.torem(24px) 0;
 }
 
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
@@ -109,6 +109,12 @@
   }
 }
 
+.offers-pagination {
+  .root {
+    background-color: black;
+  }
+}
+
 
 @media (max-width: size.$mobile) {
   .offer-type-vue {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -100,6 +100,8 @@ export const Offers = ({
     !adageUser.preferences?.feedback_form_closed &&
     adageUser.role !== AdageFrontRoles.READONLY
 
+  console.log('ici', hits)
+
   useEffect(() => {
     setQueriesAreLoading(true)
     if (logFiltersOnSearch) {
@@ -299,7 +301,9 @@ export const Offers = ({
           </li>
         ))}
       </ul>
-      <CustomPagination queryId={results.queryID} />
+      {!isInSuggestions && hits.length > 0 && (
+        <CustomPagination queryId={results.queryID} />
+      )}
       {isBackToTopVisibile && (
         <a href="#root" className={styles['back-to-top-button']}>
           <SvgIcon

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -100,8 +100,6 @@ export const Offers = ({
     !adageUser.preferences?.feedback_form_closed &&
     adageUser.role !== AdageFrontRoles.READONLY
 
-  console.log('ici', hits)
-
   useEffect(() => {
     setQueriesAreLoading(true)
     if (logFiltersOnSearch) {
@@ -302,7 +300,9 @@ export const Offers = ({
         ))}
       </ul>
       {!isInSuggestions && hits.length > 0 && (
-        <CustomPagination queryId={results.queryID} />
+        <div className={styles['pagination']}>
+          <CustomPagination queryId={results.queryID} />
+        </div>
       )}
       {isBackToTopVisibile && (
         <a href="#root" className={styles['back-to-top-button']}>

--- a/pro/src/pages/AdageIframe/app/components/Pagination/Pagination.tsx
+++ b/pro/src/pages/AdageIframe/app/components/Pagination/Pagination.tsx
@@ -16,8 +16,6 @@ export const CustomPagination = ({ queryId }: CustomPaginationProps) => {
     venueId: string
   }>()
 
-  console.log('lalala ?')
-
   const logPagination = async (type: PaginationType) => {
     await apiAdage.logSearchShowMore({
       iframeFrom: location.pathname,

--- a/pro/src/pages/AdageIframe/app/components/Pagination/Pagination.tsx
+++ b/pro/src/pages/AdageIframe/app/components/Pagination/Pagination.tsx
@@ -16,6 +16,8 @@ export const CustomPagination = ({ queryId }: CustomPaginationProps) => {
     venueId: string
   }>()
 
+  console.log('lalala ?')
+
   const logPagination = async (type: PaginationType) => {
     await apiAdage.logSearchShowMore({
       iframeFrom: location.pathname,

--- a/pro/src/pages/AdageIframe/app/components/Pagination/Pagination.tsx
+++ b/pro/src/pages/AdageIframe/app/components/Pagination/Pagination.tsx
@@ -1,0 +1,44 @@
+import { usePagination } from 'react-instantsearch'
+import { useParams } from 'react-router-dom'
+
+import { PaginationType } from 'apiClient/adage'
+import { apiAdage } from 'apiClient/api'
+import { Pagination } from 'ui-kit/Pagination/Pagination'
+
+interface CustomPaginationProps {
+  queryId?: string
+}
+
+export const CustomPagination = ({ queryId }: CustomPaginationProps) => {
+  const { currentRefinement, nbPages, refine } = usePagination()
+  const { siret, venueId } = useParams<{
+    siret: string
+    venueId: string
+  }>()
+
+  const logPagination = async (type: PaginationType) => {
+    await apiAdage.logSearchShowMore({
+      iframeFrom: location.pathname,
+      source: siret || venueId ? 'partnersMap' : 'homepage',
+      queryId: queryId,
+      type,
+    })
+  }
+
+  return (
+    <Pagination
+      currentPage={currentRefinement + 1}
+      onNextPageClick={() => {
+        refine(currentRefinement + 1)
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        logPagination(PaginationType.NEXT)
+      }}
+      onPreviousPageClick={() => {
+        refine(currentRefinement - 1)
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        logPagination(PaginationType.PREVIOUS)
+      }}
+      pageCount={nbPages}
+    />
+  )
+}

--- a/pro/src/pages/AdageIframe/app/components/Pagination/__specs__/Pagination.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/Pagination/__specs__/Pagination.spec.tsx
@@ -1,0 +1,74 @@
+import { screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import * as instantSearch from 'react-instantsearch'
+
+import { apiAdage } from 'apiClient/api'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { CustomPagination } from '../Pagination'
+
+const mockRefinePagination = vi.fn()
+
+vi.mock('apiClient/api', () => ({
+  apiAdage: {
+    logSearchShowMore: vi.fn(),
+  },
+}))
+
+vi.mock('react-instantsearch', async () => {
+  return {
+    ...(await vi.importActual('react-instantsearch')),
+    usePagination: () => ({
+      currentRefinement: 0,
+      nbPages: 3,
+      refine: mockRefinePagination,
+    }),
+  }
+})
+
+describe('AdagePagination', () => {
+  const defaultProps = {
+    queryId: '123',
+  }
+  it('should go to next page', async () => {
+    renderWithProviders(<CustomPagination {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Page suivante' }))
+
+    expect(mockRefinePagination).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not refine on click previous page button', async () => {
+    renderWithProviders(<CustomPagination {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Page suivante' }))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Page précédente' })
+    )
+
+    expect(mockRefinePagination).toHaveBeenCalledTimes(1)
+  })
+
+  it('should log on click next page and previous page', async () => {
+    vi.spyOn(instantSearch, 'usePagination').mockImplementation(() => ({
+      createURL: jest.fn((page) => `/page=${page}`),
+      refine: jest.fn(),
+      canRefine: true,
+      currentRefinement: 1,
+      nbHits: 10,
+      nbPages: 5,
+      pages: [0, 1, 2, 3, 4],
+      isFirstPage: true,
+      isLastPage: false,
+    }))
+
+    renderWithProviders(<CustomPagination {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Page suivante' }))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Page précédente' })
+    )
+
+    expect(apiAdage.logSearchShowMore).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29550

Ajouter une pagination sur adage avec un tracker qui envoie si le bouton suivant ou le bouton précédent a été cliqué

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques