### PR TITLE
(PC-29585)[PRO] fix: Add a callout to invite user to try removing the…

### DIFF
--- a/pro/src/screens/Bookings/PreFilters/PreFilters.module.scss
+++ b/pro/src/screens/Bookings/PreFilters/PreFilters.module.scss
@@ -73,3 +73,7 @@
 .show-button {
   z-index: 0;
 }
+
+.download-error-callout {
+  margin: rem.torem(16px) 0;
+}

--- a/pro/src/screens/Bookings/PreFilters/PreFilters.tsx
+++ b/pro/src/screens/Bookings/PreFilters/PreFilters.tsx
@@ -2,6 +2,8 @@ import classNames from 'classnames'
 import isEqual from 'lodash.isequal'
 import React, { useCallback, useEffect, useState } from 'react'
 
+import Callout from 'components/Callout/Callout'
+import { CalloutVariant } from 'components/Callout/types'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import MultiDownloadButtonsModal from 'components/MultiDownloadButtonsModal/MultiDownloadButtonsModal'
 import { DEFAULT_PRE_FILTERS } from 'core/Bookings/constants'
@@ -199,7 +201,6 @@ export const PreFilters = ({
             />
           </FormLayout.Row>
         </div>
-
         <div className={styles['reset-filters']}>
           <Button
             icon={fullRefreshIcon}
@@ -210,7 +211,18 @@ export const PreFilters = ({
             Réinitialiser les filtres
           </Button>
         </div>
-
+        {!isFiltersDisabled && selectedPreFilters.offerEventDate !== 'all' && (
+          // FIXME GuillaumeMgz (2024-05-03) : To be removed as soon as the download bug is fixed
+          <Callout
+            variant={CalloutVariant.WARNING}
+            className={styles['download-error-callout']}
+          >
+            Nous investiguons une erreur possible lors du téléchargement des
+            données de réservation. En attendant sa résolution et si une erreur
+            survient, veuillez réessayer en effaçant la date indiquée en date de
+            l’événement.
+          </Callout>
+        )}
         <div className="button-group">
           <div className="button-group-buttons">
             <span className="button-group-separator" />


### PR DESCRIPTION
… event date when downloading reservations.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29585

Patch temporaire pour inviter les utilisateurs à supprimer la date de l'événement avant de télécharger les données de réservations.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques