### PR TITLE
(PC-29582)[PRO] feat: Save adage filters in sessionstorage to avoid l…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -1,4 +1,9 @@
-import { Link, useLocation, useSearchParams } from 'react-router-dom'
+import {
+  Link,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from 'react-router-dom'
 
 import { CollectiveOfferTemplateResponseModel } from 'apiClient/adage'
 import strokeOfferIcon from 'icons/stroke-offer.svg'
@@ -29,20 +34,30 @@ const OfferCardComponent = ({
   const [searchParams] = useSearchParams()
   const adageAuthToken = searchParams.get('token')
   const { adageUser } = useAdageUser()
+  const navigate = useNavigate()
 
-  const offerLinkUrl = document.referrer
-    ? `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`
-    : `/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`
+  const offerLinkUrl =
+    document.referrer && !document.referrer.includes('adage-iframe')
+      ? `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`
+      : `/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`
 
   return (
     <div className={styles['container']}>
       <Link
+        onClick={(e) => {
+          onCardClicked()
+          if (!e.metaKey) {
+            e.preventDefault()
+            navigate(`offre/${offer.id}?token=${adageAuthToken}`, {
+              state: { offer },
+            })
+          }
+        }}
         className={styles['offer-link']}
         data-testid="card-offer-link"
         to={offerLinkUrl}
         target="_parent"
         state={{ offer }}
-        onClick={onCardClicked}
       >
         <div className={styles['offer-image-container']}>
           {offer.imageUrl ? (

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/AdageOfferListCard/AdageOfferListCard.tsx
@@ -1,6 +1,11 @@
 import cn from 'classnames'
 import { useState } from 'react'
-import { Link, useLocation, useSearchParams } from 'react-router-dom'
+import {
+  Link,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from 'react-router-dom'
 
 import {
   AdageFrontRoles,
@@ -44,7 +49,7 @@ export function AdageOfferListCard({
   const { adageUser, setInstitutionOfferCount, institutionOfferCount } =
     useAdageUser()
   const location = useLocation()
-
+  const navigate = useNavigate()
   const currentPathname = location.pathname.split('/')[2]
 
   const [offerPrebooked, setOfferPrebooked] = useState(false)
@@ -53,9 +58,10 @@ export function AdageOfferListCard({
   const canAddOfferToFavorites =
     isOfferTemplate && adageUser.role !== AdageFrontRoles.READONLY
 
-  const offerLinkUrl = document.referrer
-    ? `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`
-    : `/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`
+  const offerLinkUrl =
+    document.referrer && !document.referrer.includes('adage-iframe')
+      ? `${document.referrer}adage/passculture/offres/offerid/${offer.isTemplate ? '' : 'B-'}${offer.id}`
+      : `/adage-iframe/${currentPathname}/offre/${offer.id}?token=${adageAuthToken}`
 
   return (
     <div
@@ -118,11 +124,19 @@ export function AdageOfferListCard({
           <div className={styles['offer-card-content']}>
             <AdageOfferListCardTags offer={offer} adageUser={adageUser} />
             <Link
+              onClick={(e) => {
+                onCardClicked?.()
+                if (!e.metaKey) {
+                  e.preventDefault()
+                  navigate(`offre/${offer.id}?token=${adageAuthToken}`, {
+                    state: { offer },
+                  })
+                }
+              }}
               to={offerLinkUrl}
               target="_parent"
               state={{ offer }}
               className={styles['offer-card-link']}
-              onClick={onCardClicked}
             >
               <h2 className={styles['offer-title']}>{offer.name}</h2>
             </Link>


### PR DESCRIPTION
…ost of context when redirecting to an offer.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29582

**Objectif**
Avoir un href vers adage sur les liens des cartes offre, mais si on clic sans avoir cmd/ctrl enclenché (metaKey) rediriger immédiatement en interne de l'app.
Et si on clic droit -> ouvrir dans un nouvel onglet c'est donc le lien du href qui s'ouvre (adage).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques