### PR TITLE
(PC-29593)[PRO] fix: Encode the email template when sharing an offer …

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferShareLink/OfferShareLink.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferShareLink/OfferShareLink.tsx
@@ -24,12 +24,7 @@ const OfferShareLink = ({
   tooltipContentClassName,
 }: OfferShareLinkProps): JSX.Element => {
   const mailBody = `
-Bonjour,
-%0D%0A%0D%0AJe partage avec vous l’offre pass Culture “${offer.name}”. 
-%0D%0A%0D%0APour accéder au descriptif complet de cette offre, veuillez d’abord vous connecter à Adage avec le profil “Rédacteur de projets” ou “Chef d’établissement”, puis cliquez sur le lien : ${document.referrer}adage/passculture/offres/offerid/${offer.id} 
-%0D%0A%0D%0AVous n'avez pas de profil rédacteur de projets dans ADAGE ? Contactez votre chef d'établissement pour obtenir les droits, cette vidéo pourra l'aider à réaliser la procédure : https://www.dailymotion.com/video/x7ypdmf
-%0D%0A%0D%0ACordialement
-  `
+Bonjour, \n\nJe partage avec vous l’offre pass Culture “${offer.name}”. \n\nPour accéder au descriptif complet de cette offre, veuillez d’abord vous connecter à Adage avec le profil “Rédacteur de projets” ou “Chef d’établissement”, puis cliquez sur le lien : ${document.referrer}adage/passculture/offres/offerid/${offer.id} \n\nVous n'avez pas de profil rédacteur de projets dans ADAGE ? Contactez votre chef d'établissement pour obtenir les droits, cette vidéo pourra l'aider à réaliser la procédure : https://www.dailymotion.com/video/x7ypdmf \n\nCordialement`
 
   function handleShareButtonClicked(event: MouseEvent) {
     if (LOGS_DATA) {
@@ -46,7 +41,7 @@ Bonjour,
   return (
     <ListIconButton
       className={className}
-      url={`mailto:?subject=Partage d’offre sur ADAGE - ${offer.name}&body=${mailBody}`}
+      url={`mailto:?subject=Partage d’offre sur ADAGE - ${encodeURIComponent(offer.name)}&body=${encodeURIComponent(mailBody)}`}
       icon={strokeShareIcon}
       onClick={handleShareButtonClicked}
       tooltipContentClassName={tooltipContentClassName}


### PR DESCRIPTION
…in adage.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29593

**Objectif**
Corriger l'affichage du template de mail ouvert lors du partage d'une offre dans ADAGE.

J'ai ajouté l'encodage d'uri pour que les "&" ne soient pas interprétés dans la syntaxe de l'url, et j'ai remplacé les retours à la ligne dans le body pour la lisibilité. 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques