### PR TITLE
(PC-29135)[PRO] style: Ajout de padding, image d'accueuil

### DIFF
--- a/pro/src/components/Newsletter/Newsletter.module.scss
+++ b/pro/src/components/Newsletter/Newsletter.module.scss
@@ -36,5 +36,9 @@
     // We use "em" here because em is based on element font-size
     // and we want line-height to grow together with font-size
     line-height: 1.25em;
+
+    @media (min-width: size.$tablet) {
+      padding-right: 20%;
+    }
   }
 }


### PR DESCRIPTION
## Ajouter padding droit au link sur l'image d'accueil

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29135

<img width="795" alt="Capture d’écran 2024-05-07 à 15 18 37" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/5e30ad8a-8d55-4f55-ba5e-0b93a7e381fd">
