### PR TITLE
(PC-29265)[PRO] fix: Stock button appears at right first

### DIFF
--- a/pro/src/components/StockFormActions/StockFormActions.module.scss
+++ b/pro/src/components/StockFormActions/StockFormActions.module.scss
@@ -31,6 +31,12 @@
   box-shadow: 0 3px 4px 0 var(--color-medium-shadow);
   padding: rem.torem(16px) 0;
   background: var(--color-white);
+  transition: opacity 0.1s;
+  opacity: 0;
+
+  &-visible {
+    opacity: 1;
+  }
 }
 
 .menu-item[data-reach-menu-item] {

--- a/pro/src/components/StockFormActions/StockFormActions.tsx
+++ b/pro/src/components/StockFormActions/StockFormActions.tsx
@@ -1,7 +1,7 @@
 import { Menu, MenuButton, MenuItem, MenuPopover } from '@reach/menu-button'
 import { positionRight } from '@reach/popover'
 import cn from 'classnames'
-import React from 'react'
+import React, { useState } from 'react'
 
 import fullOtherIcon from 'icons/full-other.svg'
 import '@reach/menu-button/styles.css'
@@ -17,10 +17,12 @@ const StockFormActions = ({
   disabled = false,
   actions,
 }: StockFormActionsProps): JSX.Element => {
+  const [isPopoverReady, setPopoverReady] = useState(false)
   return (
     <div className={styles['stock-form-actions']}>
       <Menu>
         <MenuButton
+          onClick={() => setPopoverReady(true)}
           className={styles['menu-button']}
           disabled={disabled}
           title="Opérations sur le stock"
@@ -34,7 +36,12 @@ const StockFormActions = ({
           />
         </MenuButton>
 
-        <MenuPopover position={positionRight} className={styles['menu-list']}>
+        <MenuPopover
+          position={positionRight}
+          className={cn(styles['menu-list'], {
+            [styles['menu-list-visible']]: isPopoverReady,
+          })}
+        >
           {actions.map((action, i) => (
             <MenuItem
               key={`action-${i}`}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29265

Correction de l'apparition du bouton "Supprimer le stock" qui apparait d'abord à droite avant de se placer à sa position à gauche (lors de la première ouverture). C'est un peu un "hack" mais je pense que le problème vient de la librairie et elle est plus maintenue depuis 2 ans.
Si vous avez une meilleure idée je suis preneur ;).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques