### PR TITLE
(PC-29577)[PRO] feat: add isImpersonated field to user model

### DIFF
--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import flask
 import pydantic.v1 as pydantic_v1
 from pydantic.v1 import EmailStr
 from pydantic.v1.class_validators import validator
@@ -188,6 +189,7 @@ class SharedCurrentUserResponseModel(BaseModel):
     roles: list[users_models.UserRole]
     navState: NavStateResponseModel | None
     hasPartnerPage: bool | None
+    isImpersonated: bool = False
 
     class Config:
         json_encoders = {datetime: format_into_utc_date}
@@ -200,6 +202,7 @@ class SharedCurrentUserResponseModel(BaseModel):
         user.hasUserOfferer = user.has_user_offerer
         user.navState = NavStateResponseModel.from_orm(user.pro_new_nav_state)
         user.hasPartnerPage = user.has_partner_page
+        user.isImpersonated = flask.session.get("internal_admin_email") is not None
         result = super().from_orm(user)
         return result
 

--- a/api/tests/routes/pro/get_user_profile_test.py
+++ b/api/tests/routes/pro/get_user_profile_test.py
@@ -1,6 +1,7 @@
 import datetime
 
 from dateutil.relativedelta import relativedelta
+import flask
 import pytest
 
 from pcapi.core.users import factories as users_factories
@@ -8,8 +9,28 @@ from pcapi.core.users import models as users_models
 from pcapi.utils.date import format_into_utc_date
 
 
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
 class Returns200Test:
-    @pytest.mark.usefixtures("db_session")
+    def test_is_impersonated(self, client):
+        user = users_factories.BaseUserFactory(
+            isEmailValidated=True,
+            roles=[users_models.UserRole.PRO],
+            hasSeenProTutorials=True,
+        )
+
+        url = flask.url_for("pro_private_api.get_profile")
+        client = client.with_session_auth(email=user.email)
+
+        with client.client.session_transaction() as session:
+            session["internal_admin_email"] = user.email
+
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.json["isImpersonated"]
+
     def when_user_is_logged_in_and_has_no_deposit(self, client):
         user = users_factories.BeneficiaryGrant18Factory(
             civility=users_models.GenderEnum.M.value,
@@ -58,11 +79,11 @@ class Returns200Test:
             "postalCode": None,
             "roles": ["BENEFICIARY"],
             "navState": {"eligibilityDate": None, "newNavDate": None},
+            "isImpersonated": False,
         }
 
 
 class Returns401Test:
-    @pytest.mark.usefixtures("db_session")
     def when_user_is_not_logged_in(self, client):
         # When
         response = client.get("/users/current")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29577

Ajout d'un champ `isImpersonated` dans la réponse des routes pro `/current` et `/signin` qui vaut `true` lorsque la session contient une adresse dans `internal_admin_email` (cela signifie que le vrai utilisateur est un compte admin qui vient du backoffice et qu'il a utilisé la fonctionnalité `connect as`).