### PR TITLE
(PC-29353)[EAC] fix: update offer's booking's venue

### DIFF
--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -258,6 +258,7 @@ def edit_collective_offer(
 
     try:
         offers_api.update_collective_offer(offer_id=offer_id, new_values=new_values)
+        db.session.commit()
     except offers_exceptions.SubcategoryNotEligibleForEducationalOffer:
         raise ApiErrors({"subcategoryId": "this subcategory is not educational"}, 400)
     except offers_exceptions.OfferUsedOrReimbursedCantBeEdit:

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -1,16 +1,12 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from flask import url_for
 import pytest
 import time_machine
 
 from pcapi.core.categories import subcategories_v2 as subcategories
 import pcapi.core.educational.factories as educational_factories
-from pcapi.core.educational.factories import CollectiveBookingFactory
-from pcapi.core.educational.factories import CollectiveOfferFactory
-from pcapi.core.educational.factories import CollectiveOfferTemplateFactory
-from pcapi.core.educational.factories import EducationalDomainFactory
-from pcapi.core.educational.factories import UsedCollectiveBookingFactory
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.educational.models import StudentLevels
@@ -20,6 +16,7 @@ from pcapi.core.offers.models import OfferValidationStatus
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
+from pcapi.models import db
 from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingEdition
 from pcapi.routes.adage.v1.serialization.prebooking import serialize_collective_booking
 
@@ -27,12 +24,37 @@ from pcapi.routes.adage.v1.serialization.prebooking import serialize_collective_
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
+@pytest.fixture(name="venue")
+def venue_fixture():
+    return offerers_factories.CollectiveVenueFactory()
+
+
+@pytest.fixture(name="other_related_venue")
+def other_related_venue_fixture(venue):
+    return offerers_factories.CollectiveVenueFactory(managingOfferer=venue.managingOfferer)
+
+
+@pytest.fixture(name="user_offerer")
+def user_offerer_fixture(venue):
+    return offerers_factories.UserOffererFactory(
+        user__email="user@example.com",
+        offerer=venue.managingOfferer,
+    )
+
+
+@pytest.fixture(name="auth_client")
+def auth_client_fixture(client, user_offerer):
+    return client.with_session_auth(user_offerer.user.email)
+
+
 class Returns200Test:
+    endpoint = "Private API.edit_collective_offer"
+
     @time_machine.travel("2019-01-01 12:00:00")
     @override_settings(ADAGE_API_URL="https://adage_base_url")
     def test_patch_collective_offer(self, client):
         # Given
-        offer = CollectiveOfferFactory(
+        offer = educational_factories.CollectiveOfferFactory(
             mentalDisabilityCompliant=False,
             contactEmail="johndoe@yopmail.com",
             bookingEmails=["booking@youpi.com", "kingboo@piyou.com"],
@@ -42,14 +64,14 @@ class Returns200Test:
             students=[StudentLevels.CAP1],
             interventionArea=["01", "07", "08"],
         )
-        booking = CollectiveBookingFactory(
+        booking = educational_factories.CollectiveBookingFactory(
             collectiveStock__collectiveOffer=offer, collectiveStock__beginningDatetime=datetime(2020, 1, 1)
         )
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
         )
-        domain = EducationalDomainFactory(name="Architecture")
+        domain = educational_factories.EducationalDomainFactory(name="Architecture")
         national_program = educational_factories.NationalProgramFactory()
 
         # When
@@ -131,8 +153,10 @@ class Returns200Test:
         client,
     ):
         # Given
-        offer = CollectiveOfferFactory()
-        CollectiveBookingFactory(collectiveStock__collectiveOffer=offer, status=CollectiveBookingStatus.CANCELLED)
+        offer = educational_factories.CollectiveOfferFactory()
+        educational_factories.CollectiveBookingFactory(
+            collectiveStock__collectiveOffer=offer, status=CollectiveBookingStatus.CANCELLED
+        )
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -154,7 +178,7 @@ class Returns200Test:
 
     def test_patch_offer_with_empty_intervention_area_in_offerer_venue(self, client):
         # Given
-        offer = CollectiveOfferFactory(interventionArea=["01", "02"])
+        offer = educational_factories.CollectiveOfferFactory(interventionArea=["01", "02"])
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -181,13 +205,13 @@ class Returns200Test:
 
     def test_patch_collective_offer_update_legacy_template(self, client):
         # Given
-        template = CollectiveOfferTemplateFactory(domains=[], interventionArea=[])
-        offer = CollectiveOfferFactory(templateId=template.id)
+        template = educational_factories.CollectiveOfferTemplateFactory(domains=[], interventionArea=[])
+        offer = educational_factories.CollectiveOfferFactory(templateId=template.id)
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
         )
-        domain = EducationalDomainFactory(name="Architecture")
+        domain = educational_factories.EducationalDomainFactory(name="Architecture")
         data = {
             "domains": [domain.id],
             "interventionArea": ["01", "2A"],
@@ -207,7 +231,7 @@ class Returns200Test:
 
     def test_patch_collective_offer_update_student_level_college_6(self, client):
         # Given
-        offer = CollectiveOfferFactory()
+        offer = educational_factories.CollectiveOfferFactory()
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -226,10 +250,39 @@ class Returns200Test:
         assert len(offer.students) == 1
         assert offer.students[0].value == "Collège - 6e"
 
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            educational_factories.PendingCollectiveBookingFactory,
+            educational_factories.ConfirmedCollectiveBookingFactory,
+        ],
+    )
+    def test_update_venue_both_offer_and_booking(self, auth_client, venue, other_related_venue, factory):
+        offer = educational_factories.CollectiveOfferFactory(venue=other_related_venue)
+        stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer)
+
+        booking = factory(venue=other_related_venue, collectiveStock=stock)
+        cancelled_booking = educational_factories.CancelledCollectiveBookingFactory(
+            venue=other_related_venue, collectiveStock=stock
+        )
+
+        patch_path = "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer"
+        with patch(patch_path):
+            response = auth_client.patch(url_for(self.endpoint, offer_id=offer.id), json={"venueId": venue.id})
+            assert response.status_code == 200
+
+        db.session.refresh(offer)
+        db.session.refresh(booking)
+        db.session.refresh(cancelled_booking)
+
+        assert offer.venueId == venue.id
+        assert booking.venueId == venue.id
+        assert cancelled_booking.venueId == venue.id
+
 
 class Returns400Test:
     def test_patch_non_approved_offer_fails(self, app, client):
-        offer = CollectiveOfferFactory(validation=OfferValidationStatus.PENDING)
+        offer = educational_factories.CollectiveOfferFactory(validation=OfferValidationStatus.PENDING)
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -250,7 +303,7 @@ class Returns400Test:
 
     def test_patch_offer_with_empty_name(self, app, client):
         # Given
-        offer = CollectiveOfferFactory()
+        offer = educational_factories.CollectiveOfferFactory()
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -269,7 +322,7 @@ class Returns400Test:
 
     def test_patch_offer_with_null_name(self, app, client):
         # Given
-        offer = CollectiveOfferFactory()
+        offer = educational_factories.CollectiveOfferFactory()
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -284,7 +337,7 @@ class Returns400Test:
 
     def test_patch_offer_with_non_educational_subcategory(self, client):
         # Given
-        offer = CollectiveOfferFactory()
+        offer = educational_factories.CollectiveOfferFactory()
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -303,7 +356,7 @@ class Returns400Test:
 
     def test_patch_offer_with_empty_educational_domain(self, client):
         # Given
-        offer = CollectiveOfferFactory(
+        offer = educational_factories.CollectiveOfferFactory(
             educational_domains=None,
         )
         offerers_factories.UserOffererFactory(
@@ -325,7 +378,7 @@ class Returns400Test:
 
     def test_patch_offer_with_none_domain(self, app, client):
         # Given
-        offer = CollectiveOfferFactory(
+        offer = educational_factories.CollectiveOfferFactory(
             educational_domains=None,
         )
         offerers_factories.UserOffererFactory(
@@ -348,7 +401,7 @@ class Returns400Test:
 
     def test_patch_offer_with_empty_intervention_area(self, client):
         # Given
-        offer = CollectiveOfferFactory(
+        offer = educational_factories.CollectiveOfferFactory(
             educational_domains=None,
         )
         offerers_factories.UserOffererFactory(
@@ -371,7 +424,7 @@ class Returns400Test:
 
     def test_patch_offer_with_none_intervention_area(self, client):
         # Given
-        offer = CollectiveOfferFactory(
+        offer = educational_factories.CollectiveOfferFactory(
             educational_domains=None,
         )
         offerers_factories.UserOffererFactory(
@@ -394,7 +447,7 @@ class Returns400Test:
 
     def test_patch_offer_with_none_description(self, client):
         # Given
-        offer = CollectiveOfferFactory(
+        offer = educational_factories.CollectiveOfferFactory(
             educational_domains=None,
         )
         offerers_factories.UserOffererFactory(
@@ -418,7 +471,7 @@ class Returns400Test:
     @time_machine.travel("2019-01-01T12:00:00Z")
     @override_settings(ADAGE_API_URL="https://adage_base_url")
     def test_update_collective_offer_with_unknown_national_program(self, client):
-        offer = CollectiveOfferFactory(
+        offer = educational_factories.CollectiveOfferFactory(
             mentalDisabilityCompliant=False,
             contactEmail="johndoe@yopmail.com",
             bookingEmails=["booking@youpi.com", "kingboo@piyou.com"],
@@ -432,7 +485,7 @@ class Returns400Test:
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
         )
-        domain = EducationalDomainFactory(name="Architecture")
+        domain = educational_factories.EducationalDomainFactory(name="Architecture")
 
         data = {
             "name": "New name",
@@ -463,7 +516,7 @@ class Returns400Test:
 class Returns403Test:
     def when_user_is_not_attached_to_offerer(self, app, client):
         # Given
-        offer = CollectiveOfferFactory(name="Old name")
+        offer = educational_factories.CollectiveOfferFactory(name="Old name")
         offerers_factories.UserOffererFactory(user__email="user@example.com")
 
         data = {"name": "New name"}
@@ -483,8 +536,8 @@ class Returns403Test:
 
     def test_cannot_update_offer_with_used_booking(self, client):
         # Given
-        offer = CollectiveOfferFactory()
-        UsedCollectiveBookingFactory(
+        offer = educational_factories.CollectiveOfferFactory()
+        educational_factories.UsedCollectiveBookingFactory(
             collectiveStock__collectiveOffer=offer,
         )
         offerers_factories.UserOffererFactory(
@@ -509,7 +562,7 @@ class Returns403Test:
     def test_cannot_update_offer_created_by_public_api(self, client):
         # Given
         provider = providers_factories.ProviderFactory()
-        offer = CollectiveOfferFactory(provider=provider)
+        offer = educational_factories.CollectiveOfferFactory(provider=provider)
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -536,7 +589,7 @@ class Returns403Test:
             user__email="user@example.com",
             offerer=offerer,
         )
-        offer = CollectiveOfferFactory(venue__managingOfferer=offerer)
+        offer = educational_factories.CollectiveOfferFactory(venue__managingOfferer=offerer)
         data = {"venueId": 0}
 
         # WHEN
@@ -558,7 +611,7 @@ class Returns403Test:
             user__email="user@example.com",
             offerer=offerer,
         )
-        offer = CollectiveOfferFactory(venue__managingOfferer=offerer)
+        offer = educational_factories.CollectiveOfferFactory(venue__managingOfferer=offerer)
         venue2 = offerers_factories.VenueFactory(managingOfferer=offerer2)
         data = {"venueId": venue2.id}
 
@@ -575,7 +628,7 @@ class Returns403Test:
 
     def test_when_activating_all_existing_offers_active_status_when_cultural_partners_not_found(self, client):
         # Given
-        offer1 = CollectiveOfferFactory(isActive=False)
+        offer1 = educational_factories.CollectiveOfferFactory(isActive=False)
         venue = offer1.venue
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
@@ -613,7 +666,7 @@ class Returns404Test:
 
     def test_patch_offer_with_unknown_educational_domain(self, app, client):
         # Given
-        offer = CollectiveOfferFactory(
+        offer = educational_factories.CollectiveOfferFactory(
             educational_domains=None,
         )
         offerers_factories.UserOffererFactory(
@@ -638,7 +691,7 @@ class Returns404Test:
     def test_edit_collective_offer_with_offerer_unregister_in_adage(self, client):
         # GIVEN
 
-        offer = CollectiveOfferFactory()
+        offer = educational_factories.CollectiveOfferFactory()
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29353

Fix : lorsque le lieu d'une offre collective est mis à jour, celui de sa (ou ses s'il y a eu des annulations) réservation doit l'être également.