### PR TITLE
(PC-29664)[PRO] fix: Dont fetch offer 0 when opening the create colle…

### DIFF
--- a/pro/src/core/OfferEducational/utils/extractOfferIdAndOfferTypeFromRouteParams.ts
+++ b/pro/src/core/OfferEducational/utils/extractOfferIdAndOfferTypeFromRouteParams.ts
@@ -1,12 +1,14 @@
 export const extractOfferIdAndOfferTypeFromRouteParams = (
-  offerIdFromParams: string
-): { offerId: number; isTemplateId: boolean } => {
-  const splitResult = offerIdFromParams.split('T-')
-  if (splitResult.length === 2) {
+  offerIdFromParams?: string
+): { offerId?: number; isTemplateId: boolean } => {
+  const splitResult = offerIdFromParams?.split('T-')
+  if (splitResult?.length === 2) {
     return { offerId: Number(splitResult[1]), isTemplateId: true }
   }
   return {
-    offerId: Number(offerIdFromParams),
+    offerId: isNaN(Number(offerIdFromParams))
+      ? undefined
+      : Number(offerIdFromParams),
     isTemplateId: false,
   }
 }

--- a/pro/src/screens/OfferEducational/__specs__/useCollectiveOfferFromParams.spec.ts
+++ b/pro/src/screens/OfferEducational/__specs__/useCollectiveOfferFromParams.spec.ts
@@ -81,4 +81,12 @@ describe('useCollectiveOfferFromParams', () => {
 
     expect(result.current.offer).toEqual(undefined)
   })
+
+  it('should return undefined when the offerId in the params is an invalid number', () => {
+    const { result } = renderHook(() =>
+      useCollectiveOfferFromParams(false, 'abcd')
+    )
+
+    expect(result.current.offer).toEqual(undefined)
+  })
 })

--- a/pro/src/screens/OfferEducational/useCollectiveOfferFromParams.tsx
+++ b/pro/src/screens/OfferEducational/useCollectiveOfferFromParams.tsx
@@ -37,19 +37,20 @@ export const useCollectiveOfferFromParams = (
   const location = useLocation()
   const pathNameIncludesTemplate = location.pathname.includes('vitrine')
 
-  const { offerId, isTemplateId } = extractOfferIdAndOfferTypeFromRouteParams(
-    offerIdFromParams || ''
-  )
+  const { offerId, isTemplateId } =
+    extractOfferIdAndOfferTypeFromRouteParams(offerIdFromParams)
 
   const isTemplate = isTemplateId || pathNameIncludesTemplate
 
   const { data: offer } = useSWR(
-    [
-      isTemplate
-        ? GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY
-        : GET_COLLECTIVE_OFFER_QUERY_KEY,
-      offerId,
-    ],
+    offerId !== undefined
+      ? [
+          isTemplate
+            ? GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY
+            : GET_COLLECTIVE_OFFER_QUERY_KEY,
+          offerId,
+        ]
+      : null,
     ([, offerIdParams]) =>
       isTemplate
         ? api.getCollectiveOfferTemplate(offerIdParams)


### PR DESCRIPTION
…ctive offer form

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29664

**Objectif**
Ne pas faire de requête sur offer-template/[offerId] lorsque l'on ouvre le formulaire de création d'un offre collecive.
Actuellement on requête l'offre 0 quand le queryParam de l'offerId est `undefined`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques