### PR TITLE
(PC-29558)[PRO] fix: remove useless asterisk in npp review dialog

### DIFF
--- a/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.tsx
+++ b/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.tsx
@@ -79,7 +79,7 @@ const NewNavReviewDialog = ({
             <h1 className={styles['dialog-title']}>Votre avis compte !</h1>
             <fieldset>
               <legend className={styles['radio-legend']}>
-                Selon vous, cette nouvelle interface est ... ? *
+                Selon vous, cette nouvelle interface est… ?
               </legend>
               <ol>
                 <li className={styles['form-row']}>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29558

Enlever l'asterisk dans le dialogue permettant à l'utilisateur de laisser un avis sur la nouvelle interface. Elle n'est pas utile pour l'accessibilité. 

![Capture d’écran 2024-05-14 à 08 41 35](https://github.com/pass-culture/pass-culture-main/assets/71768799/58746894-9e1a-4aca-bc20-08b72b3c40c7)
 

