### PR TITLE
(PC-29217)[API] feat: handle missing price category and more

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -329,9 +329,16 @@ class VenueContactFactory(BaseFactory):
     social_medias = {"instagram": "http://instagram.com/@venue"}
 
 
+def build_clear_api_key(prefix: str | None = None, secret: str | None = None) -> str:
+    prefix = prefix if prefix else DEFAULT_PREFIX
+    secret = secret if secret else DEFAULT_SECRET
+
+    return f"{prefix}_{secret}"
+
+
 DEFAULT_PREFIX = "development_prefix"
 DEFAULT_SECRET = "clearSecret"
-DEFAULT_CLEAR_API_KEY = f"{DEFAULT_PREFIX}_{DEFAULT_SECRET}"
+DEFAULT_CLEAR_API_KEY = build_clear_api_key()
 
 
 class ApiKeyFactory(BaseFactory):

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -13,12 +13,12 @@ import pcapi.core.categories.subcategories_v2 as subcategories
 from pcapi.core.categories.subcategories_v2 import EacFormat
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import models as offerers_models
-from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.native.v1.serialization import common_models
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization.collective_offers_serialize import validate_venue_id
 from pcapi.routes.serialization.national_programs import NationalProgramModel
 from pcapi.routes.shared import validation
+from pcapi.routes.shared.price import convert_to_cent
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
 

--- a/api/src/pcapi/routes/institutional/serializers.py
+++ b/api/src/pcapi/routes/institutional/serializers.py
@@ -3,8 +3,8 @@ from typing import Any
 from pydantic.v1.class_validators import validator
 from pydantic.v1.utils import GetterDict
 
-from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.serialization import ConfiguredBaseModel
+from pcapi.routes.shared.price import convert_to_cent
 
 
 class OfferImageResponse(ConfiguredBaseModel):

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -20,9 +20,9 @@ from pcapi.core.users import young_status
 import pcapi.core.users.models as users_models
 from pcapi.core.users.utils import decode_jwt_token
 from pcapi.models.feature import FeatureToggle
-from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.native.v1.serialization import subscription as subscription_serialization
 from pcapi.routes.serialization import BaseModel
+from pcapi.routes.shared.price import convert_to_cent
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.email import sanitize_email

--- a/api/src/pcapi/routes/native/v1/serialization/bookings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/bookings.py
@@ -8,10 +8,10 @@ from pcapi.core.categories.subcategories_v2 import SubcategoryIdEnum
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Stock
 from pcapi.core.offers.models import WithdrawalTypeEnum
-from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.native.v1.serialization.common_models import Coordinates
 from pcapi.routes.native.v1.serialization.offers import OfferImageResponse
 from pcapi.routes.serialization import BaseModel
+from pcapi.routes.shared.price import convert_to_cent
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
 

--- a/api/src/pcapi/routes/native/v1/serialization/favorites.py
+++ b/api/src/pcapi/routes/native/v1/serialization/favorites.py
@@ -7,8 +7,8 @@ from pcapi.core.categories.subcategories_v2 import SubcategoryIdEnum
 from pcapi.core.offers.api import get_expense_domains
 from pcapi.core.offers.models import Offer
 from pcapi.core.users.models import ExpenseDomain
-from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.serialization import BaseModel
+from pcapi.routes.shared.price import convert_to_cent
 from pcapi.utils.date import format_into_utc_date
 
 

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -25,9 +25,9 @@ from pcapi.domain.music_types import MUSIC_SUB_TYPES_LABEL_BY_CODE
 from pcapi.domain.music_types import MUSIC_TYPES_LABEL_BY_CODE
 from pcapi.domain.show_types import SHOW_SUB_TYPES_LABEL_BY_CODE
 from pcapi.domain.show_types import SHOW_TYPES_LABEL_BY_CODE
-from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.native.v1.serialization.common_models import Coordinates
 from pcapi.routes.serialization import BaseModel
+from pcapi.routes.shared.price import convert_to_cent
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
 

--- a/api/src/pcapi/routes/native/v1/serialization/settings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/settings.py
@@ -1,6 +1,6 @@
 import pcapi.core.finance.conf as finance_conf
-from pcapi.routes.native.utils import convert_to_cent
 from pcapi.routes.serialization import BaseModel
+from pcapi.routes.shared.price import convert_to_cent
 from pcapi.serialization.utils import to_camel
 
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -322,24 +322,11 @@ def patch_event_price_categories(
     """
     Patch price categories.
     """
-    event_offer = (
-        utils.retrieve_offer_query(event_id)
-        .filter(offers_models.Offer.isEvent)
-        .outerjoin(offers_models.Offer.stocks.and_(sqla.not_(offers_models.Stock.isEventExpired)))
-        .options(sqla.orm.contains_eager(offers_models.Offer.stocks))
-        .options(
-            sqla.orm.joinedload(offers_models.Offer.priceCategories).joinedload(
-                offers_models.PriceCategory.priceCategoryLabel
-            )
-        )
-        .one_or_none()
-    )
+    event_offer = utils.get_event_with_details(event_id)
     if not event_offer:
         raise api_errors.ApiErrors({"event_id": ["The event could not be found"]}, status_code=404)
 
-    price_category_to_edit = next(
-        (price_category for price_category in event_offer.priceCategories if price_category.id == price_category_id)
-    )
+    price_category_to_edit = utils.get_price_category_from_event(event_offer, price_category_id)
     if not price_category_to_edit:
         raise api_errors.ApiErrors({"price_category_id": ["No price category could be found"]}, status_code=404)
 

--- a/api/src/pcapi/routes/shared/price.py
+++ b/api/src/pcapi/routes/shared/price.py
@@ -1,0 +1,7 @@
+from decimal import Decimal
+
+
+def convert_to_cent(amount: Decimal | None) -> int | None:
+    if amount is None:
+        return None
+    return int(amount * 100)

--- a/api/tests/routes/institutional/playlist_test.py
+++ b/api/tests/routes/institutional/playlist_test.py
@@ -2,12 +2,11 @@ import datetime
 
 import pytest
 
-from pcapi import settings
 from pcapi.core.criteria import factories as criteria_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.testing import assert_num_queries
-from pcapi.routes.native.utils import convert_to_cent
+from pcapi.routes.shared.price import convert_to_cent
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/public/individual_offers/conftest.py
+++ b/api/tests/routes/public/individual_offers/conftest.py
@@ -1,0 +1,128 @@
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
+import pcapi.core.providers.factories as providers_factories
+
+
+SECRET = "secret"
+OTHER_SECRET = "other-secret"
+
+
+@pytest.fixture(name="provider")
+def provider_fixture():
+    return providers_factories.ProviderFactory(
+        name="Technical provider",
+        localClass=None,
+        isActive=True,
+        enabledForPro=True,
+        bookingExternalUrl=None,
+        cancelExternalUrl=None,
+    )
+
+
+@pytest.fixture(name="offerer")
+def offerer_fixture():
+    return offerers_factories.OffererFactory(name="Technical provider")
+
+
+@pytest.fixture(name="offerer_provider")
+def offerer_provider_fixture(offerer, provider):
+    return providers_factories.OffererProviderFactory(
+        offerer=offerer,
+        provider=provider,
+    )
+
+
+@pytest.fixture(name="venue")
+def venue_fixture(provider):
+    return providers_factories.VenueProviderFactory(
+        provider=provider, venueIdAtOfferProvider="Test", isActive=True
+    ).venue
+
+
+@pytest.fixture(name="api_key")
+def api_key_fixture(offerer_provider):
+    return offerers_factories.ApiKeyFactory(
+        offerer=offerer_provider.offerer,
+        provider=offerer_provider.provider,
+        secret=SECRET,
+        prefix=f"{offerers_factories.DEFAULT_PREFIX}{offerer_provider.offerer.id}",
+    )
+
+
+@pytest.fixture(name="token")
+def token_fixture(api_key):
+    return offerers_factories.build_clear_api_key(api_key.prefix, SECRET)
+
+
+@pytest.fixture(name="auth_client")
+def auth_client(token, client):
+    return client.with_explicit_token(token)
+
+
+@pytest.fixture(name="event")
+def event_fixture(venue, api_key):
+    return offers_factories.EventOfferFactory(venue=venue, lastProvider=api_key.provider)
+
+
+@pytest.fixture(name="stock")
+def stock_fixture(event, price_category):
+    return offers_factories.StockFactory(offer=event, priceCategory=price_category)
+
+
+@pytest.fixture(name="price_category")
+def price_category_fixture(event):
+    return offers_factories.PriceCategoryFactory(offer=event)
+
+
+@pytest.fixture(name="other_provider")
+def other_provider_fixture():
+    return providers_factories.ProviderFactory(
+        name="Other technical provider",
+        localClass=None,
+        isActive=True,
+        enabledForPro=True,
+        bookingExternalUrl=None,
+        cancelExternalUrl=None,
+    )
+
+
+@pytest.fixture(name="other_offerer")
+def other_offerer_fixture():
+    return offerers_factories.OffererFactory(name="Other technical provider")
+
+
+@pytest.fixture(name="other_offerer_provider")
+def other_offerer_provider_fixture(other_offerer, other_provider):
+    return providers_factories.OffererProviderFactory(
+        offerer=other_offerer,
+        provider=other_provider,
+    )
+
+
+@pytest.fixture(name="other_venue")
+def other_venue_fixture(other_provider):
+    return providers_factories.VenueProviderFactory(
+        provider=other_provider, venueIdAtOfferProvider="Other test", isActive=True
+    ).venue
+
+
+@pytest.fixture(name="other_api_key")
+def other_api_key_fixture(other_offerer_provider):
+    return offerers_factories.ApiKeyFactory(
+        offerer=other_offerer_provider.offerer,
+        provider=other_offerer_provider.provider,
+        prefix=f"{offerers_factories.DEFAULT_PREFIX}{other_offerer_provider.offerer.id}",
+        secret=OTHER_SECRET,
+    )
+
+
+@pytest.fixture(name="other_token")
+def other_token_fixture(other_api_key):
+    return offerers_factories.build_clear_api_key(other_api_key.prefix, OTHER_SECRET)
+
+
+@pytest.fixture(name="other_auth_client")
+def other_auth_client(other_token, client):
+    return client.with_explicit_token(other_token)

--- a/api/tests/routes/public/individual_offers/v1/patch_price_category_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_price_category_test.py
@@ -1,15 +1,103 @@
+import collections
+import contextlib
 import datetime
 import decimal
 
+from flask import url_for
 import pytest
 
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
+from pcapi.models import db
+from pcapi.routes.shared.price import convert_to_cent
 
 from . import utils
 
 
-@pytest.mark.usefixtures("db_session")
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+EmptyGenerator = collections.abc.Generator[None, None, None]
+
+
+@contextlib.contextmanager
+def assert_event_and_price_category_did_not_change(event, price_category) -> EmptyGenerator:
+    old_price = price_category.price
+    old_label = price_category.priceCategoryLabel
+    old_event_prices = {stock.id: (stock.price, stock.priceCategoryId) for stock in event.stocks}
+
+    yield
+
+    db.session.refresh(price_category)
+    db.session.refresh(event)
+
+    new_price = price_category.price
+    new_label = price_category.priceCategoryLabel
+    new_event_prices = {stock.id: (stock.price, stock.priceCategoryId) for stock in event.stocks}
+
+    assert new_price == old_price
+    assert new_label == old_label
+    assert new_event_prices == old_event_prices
+
+
+@pytest.fixture(name="event_with_stock")
+def event_with_stock_fixture(stock):
+    return stock.offer
+
+
+class PatchPriceCategoryErrorsTest:
+    endpoint = "public_blueprint.individual_offers_blueprint.v1_blueprint.patch_event_price_categories"
+
+    def test_cannot_access_resource_from_other_api_key(self, other_auth_client, event_with_stock, price_category):
+        kwargs = {"event_id": event_with_stock.id, "price_category_id": price_category.id}
+        json_data = {"price": convert_to_cent(price_category.price * 3)}
+
+        with assert_event_and_price_category_did_not_change(event_with_stock, price_category):
+            assert other_auth_client.patch(url_for(self.endpoint, **kwargs), json=json_data).status_code == 404
+
+    def test_unauthenticated(self, client, event_with_stock, price_category):
+        kwargs = {"event_id": event_with_stock.id, "price_category_id": price_category.id}
+        json_data = {"price": convert_to_cent(price_category.price * 3)}
+
+        with assert_event_and_price_category_did_not_change(event_with_stock, price_category):
+            assert client.patch(url_for(self.endpoint, **kwargs), json=json_data).status_code == 401
+
+    def test_unknown_event(self, auth_client, event_with_stock, price_category):
+        kwargs = {"event_id": event_with_stock.id * 16, "price_category_id": price_category.id}
+        json_data = {"price": convert_to_cent(price_category.price * 3)}
+
+        with assert_event_and_price_category_did_not_change(event_with_stock, price_category):
+            assert auth_client.patch(url_for(self.endpoint, **kwargs), json=json_data).status_code == 404
+
+    def test_unknown_price_category(self, auth_client, event_with_stock, price_category):
+        kwargs = {"event_id": event_with_stock.id, "price_category_id": price_category.id * 16}
+        json_data = {"price": convert_to_cent(price_category.price * 3)}
+
+        with assert_event_and_price_category_did_not_change(event_with_stock, price_category):
+            assert auth_client.patch(url_for(self.endpoint, **kwargs), json=json_data).status_code == 404
+
+    def test_both_event_and_price_category_unknown(self, auth_client, event_with_stock, price_category):
+        kwargs = {"event_id": event_with_stock.id * 16, "price_category_id": price_category.id * 16}
+        json_data = {"price": convert_to_cent(price_category.price * 3)}
+
+        with assert_event_and_price_category_did_not_change(event_with_stock, price_category):
+            assert auth_client.patch(url_for(self.endpoint, **kwargs), json=json_data).status_code == 404
+
+    def test_negative_price(self, auth_client, event_with_stock, price_category):
+        kwargs = {"event_id": event_with_stock.id, "price_category_id": price_category.id}
+        json_data = {"price": -1}
+
+        with assert_event_and_price_category_did_not_change(event_with_stock, price_category):
+            assert auth_client.patch(url_for(self.endpoint, **kwargs), json=json_data).status_code == 400
+
+    def test_price_too_high(self, auth_client, event_with_stock, price_category):
+        kwargs = {"event_id": event_with_stock.id, "price_category_id": price_category.id}
+        json_data = {"price": convert_to_cent(301)}
+
+        with assert_event_and_price_category_did_not_change(event_with_stock, price_category):
+            assert auth_client.patch(url_for(self.endpoint, **kwargs), json=json_data).status_code == 400
+
+
 class PatchPriceCategoryTest:
     def test_update_price_category(self, client):
         venue, api_key = utils.create_offerer_provider_linked_to_venue()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29217

Gérer le cas où une catégorie de prix n'existe pas, ou que l'événement en question n'est pas lié à celle-là.

### Au passage

Ajout de tests avec quelques modifications
1. ajout de _fixtures_ dans un nouveau module `conftest` dédié aux routes de l'api individuelle ;
2. ajout de tests qui vérifient principalement des cas d'erreur, dont celui remonté ;
3. permettre de générer des jetons d'authentification plus facilement dans les tests.