### PR TITLE
(PC-29711)[PRO] fix: Make sure to click on the first offer button whe…

### DIFF
--- a/pro/cypress/e2e/adageDiscovery.cy.ts
+++ b/pro/cypress/e2e/adageDiscovery.cy.ts
@@ -7,6 +7,10 @@ describe('Adage discovery', () => {
       method: 'GET',
       url: 'adage-iframe/playlists/new_template_offers',
     }).as('getNewTemplateOffersPlaylist')
+    cy.intercept({
+      method: 'GET',
+      url: 'adage-iframe/playlists/classroom',
+    }).as('getClassroomOffersPlaylist')
   })
 
   it('should redirect to adage discovery', () => {
@@ -128,9 +132,10 @@ describe('Adage discovery', () => {
 
   it('should put an offer in favorite', () => {
     const adageToken = Cypress.env('adageToken')
-    cy.visit(`/adage-iframe?token=${adageToken}`)
+    cy.visit(`/adage-iframe/decouverte?token=${adageToken}`)
 
-    cy.wait('@getNewTemplateOffersPlaylist')
+    cy.wait(['@getNewTemplateOffersPlaylist', '@getClassroomOffersPlaylist'])
+    cy.findAllByTestId('spinner').should('have.length', 0)
 
     cy.findAllByTestId('card-offer')
       .first()
@@ -144,8 +149,6 @@ describe('Adage discovery', () => {
         cy.contains(text)
 
         cy.findByRole('link', { name: 'Découvrir' }).click()
-
-        cy.reload()
 
         cy.findAllByTestId('favorite-active').first().click()
       })


### PR DESCRIPTION
…n all offers have loaded each times.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29711

**Objectif**
Le test de mise en favoris échoue de temps en temps (25% du temps environ). Ca arrive en local aussi. Le test clic sur le bouton favoris de la première offre pas encore en favoris. Mais entre le moment ou le nom de cette offre est enregistré, et le moment ou le clic se fait, si la première playlist a chargé c'est l'offre de la première playlist qui est prise en compte.

Je tente dans cette PR d'attendre que toutes les playlists aient chargé pour faire l'opération.

(question?) Il semble qu'avec le double déclenchement des effets en mode strict les waits ne suffisent pas à s'assurer de ça ? D'ou la vérification sur les spinners.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques