### PR TITLE
(PC-29713)[PRO] fix: Use the same model for swr response when the key…

### DIFF
--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -49,14 +49,12 @@ export const OffersRoute = (): JSX.Element => {
 
   const categoriesQuery = useSWR(
     [GET_CATEGORIES_QUERY_KEY],
-    async () => {
-      const response = await api.getCategories()
-      return response.categories
-    },
-    { fallbackData: [] }
+    () => api.getCategories(),
+    { fallbackData: { categories: [], subcategories: [] } }
   )
+
   const categoriesOptions = sortByLabel(
-    categoriesQuery.data
+    categoriesQuery.data.categories
       .filter((category) => category.isSelectable)
       .map((category) => ({
         value: category.id,


### PR DESCRIPTION
… is the same.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29713

**Objectif**
Correction des tests E2E qui fail systématiquement sur le test "Create an individual offer" au moment de la redirection vers la liste des offres. 
On utilise 2 fois la même clé dans SWR mais avec un formatage de réponse différent pour l'api getCategories entre le contexte de création d'offre indiv et la page de la liste des offres. Comme la clé est la même, quand on navigue entre ces pages SWR récupère la valeur en cache avec le format précédent.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques