### PR TITLE
(PC-29516)[PRO] fix: do not overwrite price when priceCategory deletion

### DIFF
--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.tsx
@@ -19,7 +19,6 @@ import { BaseCheckbox } from 'ui-kit/form/shared/BaseCheckbox/BaseCheckbox'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 
-import { computeInitialValues } from './form/computeInitialValues'
 import {
   INITIAL_PRICE_CATEGORY,
   PRICE_CATEGORY_LABEL_MAX_LENGTH,
@@ -43,7 +42,7 @@ export const PriceCategoriesForm = ({
   isDisabled,
   canBeDuo,
 }: PriceCategoriesFormProps): JSX.Element => {
-  const { setFieldValue, setValues, values } =
+  const { setFieldValue, values } =
     useFormikContext<PriceCategoriesFormValues>()
 
   const notify = useNotification()
@@ -103,11 +102,6 @@ export const PriceCategoriesForm = ({
           )
         }
       }
-      const updatedOffer = await api.getOffer(offer.id)
-      await setValues({
-        ...values,
-        priceCategories: computeInitialValues(updatedOffer).priceCategories,
-      })
     }
   }
 

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategoriesForm.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategoriesForm.spec.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
-import React from 'react'
 
 import { api } from 'apiClient/api'
 import { GetIndividualOfferResponseModel } from 'apiClient/v1'
@@ -217,11 +216,15 @@ describe('PriceCategories', () => {
     // one price category line : label is default and field is disable
     expect(screen.getByTestId('delete-button')).toBeDisabled()
     expect(screen.getByDisplayValue('Tarif unique')).toBeDisabled()
+    const nameFields = screen.getAllByLabelText('Intitulé du tarif *')
+    const priceFields = screen.getAllByLabelText('Prix par personne *')
+    await userEvent.type(priceFields[0], '66.7')
 
     // I add a price category line
     await userEvent.click(screen.getByText('Ajouter un tarif'))
-    const nameFields = screen.getAllByLabelText('Intitulé du tarif *')
+
     expect(nameFields[0]).toHaveValue('')
+    expect(priceFields[0]).toHaveValue(66.7)
     expect(nameFields[0]).not.toBeDisabled()
 
     // I change the label and remove last line, label is default and field disable
@@ -229,6 +232,8 @@ describe('PriceCategories', () => {
     await userEvent.click(
       screen.getAllByRole('button', { name: 'Supprimer le tarif' })[1]
     )
+    // it keep the input price
+    expect(priceFields[0]).toHaveValue(66.7)
 
     expect(nameFields[0]).toBeDisabled()
   })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29516

Le setValues semblait ne servir à rien et écrasait la valeur rentrée dans le prix

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques