### PR TITLE
(BSR)[API] feat: Update `psql` client from version 12 to version 15

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -158,7 +158,7 @@ RUN apt-get install --no-install-recommends -y curl less gnupg2 && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && \
-    apt-get --no-install-recommends -y install postgresql-client-12 google-cloud-sdk && \
+    apt-get --no-install-recommends -y install postgresql-client-15 google-cloud-sdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists*
 


### PR DESCRIPTION
**ATTENTION :** Ne pas merger avant la migration du serveur de prod.

---

Now that we have migrated the server to PostgreSQL 15, we can update
the client, which is installed on "console" pods.