### PR TITLE
(PC-29417)[PRO] feat: connect as

### DIFF
--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -53,3 +53,21 @@
   margin: rem.torem(32px);
   border: rem.torem(1px) solid var(--color-grey-medium);
 }
+
+.connect-as {
+  background-color: var(--color-grey-light);
+  display: flex;
+  padding: 16px;
+  min-width: 100%;
+
+  &-icon {
+    color: var(--color-grey-dark);
+  }
+
+  &-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -6,7 +6,9 @@ import Footer from 'components/Footer/Footer'
 import Header from 'components/Header/Header'
 import NewNavReview from 'components/NewNavReview/NewNavReview'
 import SkipLinks from 'components/SkipLinks'
+import fullInfoIcon from 'icons/full-info.svg'
 import { selectCurrentUser } from 'store/user/selectors'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import LateralPanel from './LateralPanel/LateralPanel'
 import styles from './Layout.module.scss'
@@ -42,6 +44,22 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
         }}
       >
         <SkipLinks />
+        {currentUser?.isImpersonated && (
+          <aside className={styles['connect-as']}>
+            <SvgIcon
+              src={fullInfoIcon}
+              alt="Information"
+              width="20"
+              className={styles['connect-as-icon']}
+            />
+            <div className={styles['connect-as-text']}>
+              Vous êtes connecté en tant que :&nbsp;
+              <strong>
+                {currentUser.firstName} {currentUser.lastName}
+              </strong>
+            </div>
+          </aside>
+        )}
         {(layout === 'basic' || layout === 'sticky-actions') && (
           <Header
             lateralPanelOpen={lateralPanelOpen}

--- a/pro/src/app/App/layout/OldLayout.module.scss
+++ b/pro/src/app/App/layout/OldLayout.module.scss
@@ -37,3 +37,21 @@
     position: relative;
   }
 }
+
+.connect-as {
+  background-color: var(--color-grey-light);
+  display: flex;
+  padding: 16px;
+  min-width: 100%;
+
+  &-icon {
+    color: var(--color-grey-dark);
+  }
+
+  &-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/pro/src/app/App/layout/OldLayout.tsx
+++ b/pro/src/app/App/layout/OldLayout.tsx
@@ -1,9 +1,13 @@
 import classnames from 'classnames'
 import React from 'react'
+import { useSelector } from 'react-redux'
 
 import Footer from 'components/Footer/Footer'
 import OldHeader from 'components/Header/OldHeader'
 import SkipLinks from 'components/SkipLinks'
+import fullInfoIcon from 'icons/full-info.svg'
+import { selectCurrentUser } from 'store/user/selectors'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './OldLayout.module.scss'
 
@@ -13,9 +17,27 @@ interface OldLayoutProps {
 }
 
 export const OldLayout = ({ children, layout = 'basic' }: OldLayoutProps) => {
+  const currentUser = useSelector(selectCurrentUser)
+
   return (
     <>
       <SkipLinks />
+      {currentUser?.isImpersonated && (
+        <aside className={styles['connect-as']}>
+          <SvgIcon
+            src={fullInfoIcon}
+            alt="Information"
+            width="20"
+            className={styles['connect-as-icon']}
+          />
+          <div className={styles['connect-as-text']}>
+            Vous êtes connecté en tant que :&nbsp;
+            <strong>
+              {currentUser.firstName} {currentUser.lastName}
+            </strong>
+          </div>
+        </aside>
+      )}
       {(layout === 'basic' || layout === 'sticky-actions') && <OldHeader />}
 
       <main

--- a/pro/src/app/App/layout/__specs__/Layout.spec.tsx
+++ b/pro/src/app/App/layout/__specs__/Layout.spec.tsx
@@ -1,0 +1,24 @@
+import { screen } from '@testing-library/react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+import { sharedCurrentUserFactory } from 'utils/storeFactories'
+
+import { Layout } from '../Layout'
+
+const renderLayout = (isImpersonated = false) => {
+  renderWithProviders(<Layout />, {
+    user: sharedCurrentUserFactory({
+      isImpersonated,
+    }),
+  })
+}
+
+describe('App', () => {
+  it('should render connect as banner if user has isImpersonated value is true', () => {
+    renderLayout(true)
+
+    expect(
+      screen.getByText('Vous êtes connecté en tant que :')
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/app/App/layout/__specs__/OldLayout.spec.tsx
+++ b/pro/src/app/App/layout/__specs__/OldLayout.spec.tsx
@@ -1,0 +1,24 @@
+import { screen } from '@testing-library/react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+import { sharedCurrentUserFactory } from 'utils/storeFactories'
+
+import { OldLayout } from '../OldLayout'
+
+const renderOldLayout = (isImpersonated = false) => {
+  renderWithProviders(<OldLayout />, {
+    user: sharedCurrentUserFactory({
+      isImpersonated,
+    }),
+  })
+}
+
+describe('App', () => {
+  it('should render connect as banner if user has isImpersonated value is true', () => {
+    renderOldLayout(true)
+
+    expect(
+      screen.getByText('Vous êtes connecté en tant que :')
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/utils/storeFactories.ts
+++ b/pro/src/utils/storeFactories.ts
@@ -9,6 +9,7 @@ export const sharedCurrentUserFactory = (
   email: 'john@do.net',
   isAdmin: false,
   isEmailValidated: true,
+  isImpersonated: false,
   roles: [],
   ...customSharedCurrentUser,
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29417

Ajout d'une bannière afin de savoir sur quel compte on est connecté via le connect-as

<img width="1508" alt="Capture d’écran 2024-05-15 à 17 22 15" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/39155585-a78c-4fb5-9c16-c2c9c1b032fa">

<img width="1508" alt="Capture d’écran 2024-05-15 à 17 22 44" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/dee1ffdc-46cc-44b7-a3fe-80e0686b07e4">

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques