### PR TITLE
(PC-29710)[PRO] fix: fix creation offer button display condition

### DIFF
--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
 
 import {
   CollectiveOfferResponseModel,
@@ -29,6 +30,7 @@ import strokeLibraryIcon from 'icons/stroke-library.svg'
 import strokeUserIcon from 'icons/stroke-user.svg'
 import { ActionsBar } from 'pages/Offers/Offers/ActionsBar/ActionsBar'
 import OffersContainer from 'pages/Offers/Offers/Offers'
+import { selectCurrentOffererId } from 'store/user/selectors'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { Tabs } from 'ui-kit/Tabs/Tabs'
@@ -77,6 +79,7 @@ export const Offers = ({
   const [areAllOffersSelected, setAreAllOffersSelected] = useState(false)
   const [selectedOfferIds, setSelectedOfferIds] = useState<string[]>([])
   const isNewSideBarNavigation = useIsNewInterfaceActive()
+  const selectedOffererId = useSelector(selectCurrentOffererId)
 
   const { isAdmin } = currentUser
   const currentPageOffersSubset = offers.slice(
@@ -95,7 +98,10 @@ export const Offers = ({
   useEffect(() => {
     const loadValidatedUserOfferers = async () => {
       const validatedUserOfferers = await getUserValidatedOfferersNamesAdapter()
-      if (validatedUserOfferers.isOk && validatedUserOfferers.payload.length) {
+      const isCurrentOffererValidated = validatedUserOfferers.payload.some(
+        (validatedOfferer) => validatedOfferer.id === selectedOffererId
+      )
+      if (isCurrentOffererValidated) {
         setIsOffererValidated(true)
       } else {
         setIsOffererValidated(false)
@@ -111,7 +117,10 @@ export const Offers = ({
   const actionLink = displayCreateOfferButton ? (
     <ButtonLink
       variant={ButtonVariant.PRIMARY}
-      link={{ isExternal: false, to: '/offre/creation' }}
+      link={{
+        isExternal: false,
+        to: `/offre/creation${selectedOffererId ? `?structure=${selectedOffererId}` : ''}`,
+      }}
       icon={fullPlusIcon}
     >
       Créer une offre

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -18,6 +18,7 @@ import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
 import {
   defaultGetOffererResponseModel,
   getOffererNameFactory,
+  getOfferManagingOffererFactory,
   listOffersOfferFactory,
 } from 'utils/individualApiFactories'
 import {
@@ -34,12 +35,17 @@ const renderOffers = (
   hasNewNav: boolean = false
 ) => {
   renderWithProviders(<Offers {...props} />, {
-    user: sharedCurrentUserFactory({
-      isAdmin: false,
-      navState: {
-        newNavDate: hasNewNav ? '2021-01-01' : null,
+    storeOverrides: {
+      user: {
+        currentUser: sharedCurrentUserFactory({
+          isAdmin: false,
+          navState: {
+            newNavDate: hasNewNav ? '2021-01-01' : null,
+          },
+        }),
+        selectedOffererId: 1,
       },
-    }),
+    },
     ...options,
   })
 }
@@ -650,7 +656,7 @@ describe('screen Offers', () => {
 
   it('should display the create offer button by default for non admins with validated offerers', async () => {
     vi.spyOn(api, 'listOfferersNames').mockResolvedValueOnce({
-      offerersNames: [getOffererNameFactory()],
+      offerersNames: [{ ...getOfferManagingOffererFactory(), id: 1 }],
     })
 
     renderOffers(props)

--- a/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
@@ -11,11 +11,19 @@ import {
   getOffererNameFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
+import { sharedCurrentUserFactory } from 'utils/storeFactories'
 
 import { Offers, OffersProps } from '../Offers'
 
 const renderOffers = (props: OffersProps) =>
-  renderWithProviders(<Offers {...props} />)
+  renderWithProviders(<Offers {...props} />, {
+    storeOverrides: {
+      user: {
+        selectedOffererId: defaultGetOffererResponseModel.id,
+        currentUser: sharedCurrentUserFactory(),
+      },
+    },
+  })
 
 vi.mock('apiClient/api', () => ({
   api: {
@@ -49,7 +57,9 @@ describe('tracker screen Offers', () => {
 
     const individualOffererNames = getOfferManagingOffererFactory()
     vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
-      offerersNames: [getOffererNameFactory(individualOffererNames)],
+      offerersNames: [
+        getOffererNameFactory({ ...individualOffererNames, id: 1 }),
+      ],
     })
 
     renderOffers(props)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29710

Ne pas afficher le bouton de création d'offre depuis la liste des offres si la structure sélectionnée n'est pas encore validé pour l'utilisateur courant (ex: rattachement non validé pour l'utilisateur)

