### PR TITLE
(PC-29790)[BO] fix: should not try to sync wrong url with acceslibre

### DIFF
--- a/api/src/pcapi/connectors/acceslibre.py
+++ b/api/src/pcapi/connectors/acceslibre.py
@@ -220,6 +220,12 @@ def find_new_entries_by_activity(activity: AcceslibreActivity) -> list[Acceslibr
     return _get_backend().find_new_entries_by_activity(activity=activity)
 
 
+def id_exists_at_acceslibre(slug: str) -> bool:
+    """This method requests acceslibre for a given slug, and returns True if this
+    slug exists on their side."""
+    return _get_backend().id_exists_at_acceslibre(slug=slug)
+
+
 def get_id_at_accessibility_provider(
     name: str,
     public_name: str | None = None,
@@ -374,6 +380,9 @@ class BaseBackend:
     def get_accessibility_infos(self, slug: str) -> tuple[datetime | None, AccessibilityInfo | None]:
         raise NotImplementedError()
 
+    def id_exists_at_acceslibre(self, slug: str) -> bool:
+        raise NotImplementedError()
+
 
 class TestingBackend(BaseBackend):
     def find_venue_at_accessibility_provider(
@@ -457,6 +466,9 @@ class TestingBackend(BaseBackend):
         ]
         last_update = datetime(2024, 3, 1, 0, 0)
         return last_update, acceslibre_to_accessibility_infos(acceslibre_data)
+
+    def id_exists_at_acceslibre(self, slug: str) -> bool:
+        return True
 
 
 class AcceslibreBackend(BaseBackend):
@@ -642,3 +654,7 @@ class AcceslibreBackend(BaseBackend):
             accessibility_infos = acceslibre_to_accessibility_infos(acceslibre_data)
             return (last_update, accessibility_infos)
         return (None, None)
+
+    def id_exists_at_acceslibre(self, slug: str) -> bool:
+        response = self._send_request(slug=slug)
+        return bool(response and response.get("count"))

--- a/api/src/pcapi/routes/backoffice/venues/forms.py
+++ b/api/src/pcapi/routes/backoffice/venues/forms.py
@@ -5,6 +5,7 @@ import sqlalchemy as sa
 import wtforms
 from wtforms import validators
 
+from pcapi.connectors import acceslibre as acceslibre_connector
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.routes.backoffice.forms import empty as empty_forms
@@ -132,7 +133,8 @@ class EditVenueForm(EditVirtualVenueForm):
             raise validators.ValidationError(
                 "L'URL doit se terminer par /<slug-chez-acceslibre>/ (un slug n'est composé que de minuscules et de tirets du milieu)"
             )
-
+        if not acceslibre_connector.id_exists_at_acceslibre(slug=acceslibre_url.data.split("/")[-2]):
+            raise validators.ValidationError("Cette URL n'existe pas chez acceslibre")
         if self.is_permanent.data is False and acceslibre_url.data:
             if self.venue.isPermanent:
                 acceslibre_url.data = None

--- a/api/tests/connectors/acceslibre/acceslibre_test.py
+++ b/api/tests/connectors/acceslibre/acceslibre_test.py
@@ -204,3 +204,18 @@ class AcceslibreTest:
         with pytest.raises(acceslibre.AccesLibreApiException) as exception:
             acceslibre.get_id_at_accessibility_provider(name=name, public_name=public_name, ban_id=ban_id)
         assert str(exception.value) == "Acceslibre activite should be a dict, but received: Chaîne de caracteres"
+
+    def test_if_id_exists_at_acceslibre(self, requests_mock):
+        existing_slug = "bibliotheque-municipale-de-truchan-les-bains"
+        unexisting_slug = "sniab-sel-nahcurt-ed-elapicinum-euqehtoilbib"
+        requests_mock.get(
+            f"https://acceslibre.beta.gouv.fr/api/erps/{existing_slug}/",
+            json=fixtures.ACCESLIBRE_ACTIVITY_RESULT,
+        )
+        requests_mock.get(
+            f"https://acceslibre.beta.gouv.fr/api/erps/{unexisting_slug}/",
+            json=fixtures.ACCESLIBRE_RESULTS_EMPTY,
+        )
+
+        assert acceslibre.id_exists_at_acceslibre(existing_slug)
+        assert not acceslibre.id_exists_at_acceslibre(unexisting_slug)


### PR DESCRIPTION
## But de la pull request


Fix d'un bug lorsqu'on essaye de recupérer des infos d'acceslibre depuis le BO (en entrant l'url) si le lieux n'existe pas chez acceslibre

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29790

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques