### PR TITLE
(PC-29349)[PRO] fix: center close button in header dropdown

### DIFF
--- a/pro/src/components/Header/HeaderDropdown/HeaderDropdown.module.scss
+++ b/pro/src/components/Header/HeaderDropdown/HeaderDropdown.module.scss
@@ -45,6 +45,9 @@ $profil-button-size: rem.torem(34px);
   &-button {
     background-color: transparent;
     border: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     &:hover {
       cursor: pointer;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29349

Centrer l'icone du bouton de fermeture de la dropdown dans le header. Visible particulière en état focus 

![Capture d’écran 2024-05-17 à 08 50 27](https://github.com/pass-culture/pass-culture-main/assets/71768799/e7d7ecb6-4ee4-479e-8025-bd46ec9a7dbb)
