### PR TITLE
(PC-29825)[PRO] fix: Re-fetch booking when the status changes and clo…

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons.tsx
@@ -34,6 +34,7 @@ export const CollectiveActionButtons = ({
   const offerEditionUrl = useOfferEditionURL(true, nonHumanizedOfferId, false)
 
   const cancelBooking = async () => {
+    setIsModalOpen(false)
     if (!offerId) {
       notify.error('L’identifiant de l’offre n’est pas valide.')
       return

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTableRow.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTableRow.tsx
@@ -47,11 +47,11 @@ export const CollectiveTableRow = ({
       setIsLoading(false)
     }
 
-    if (isExpanded && bookingDetails === null) {
+    if (isExpanded) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       fetchBookingDetails()
     }
-  }, [isExpanded])
+  }, [isExpanded, booking.bookingId, booking.bookingStatus])
 
   const onRowClick = () => {
     logEvent(CollectiveBookingsEvents.CLICKED_EXPAND_COLLECTIVE_BOOKING_DETAILS)

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/__specs__/CollectiveActionButtons.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/__specs__/CollectiveActionButtons.spec.tsx
@@ -153,6 +153,10 @@ describe('collectiveActionButton api call', () => {
       'La réservation sur cette offre a été annulée avec succès, votre offre sera à nouveau visible sur ADAGE.',
       { duration: NOTIFICATION_LONG_SHOW_DURATION }
     )
+
+    expect(
+      screen.queryByRole('button', { name: 'Confirmer' })
+    ).not.toBeInTheDocument()
   })
 
   it('should return an error when booking cancellation failed', async () => {


### PR DESCRIPTION
…se the modal.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29825

**Objectif**
Quand on annule une réservation collective, il y a potentiellement deux bugs : la modal de confirmation ne se ferme pas, et le bouton d'annulation est toujours présent dans le détail.
Les row de la table ont une `key` de l'id du booking, donc les lignes ne sont pas re-render quand le status change. Or au moment de l'annulation, on re-requete via un mutate toute la liste des réservations (et on se retrouve sur la page 1). Donc si avant/après l'annulation, la réservation est toujours dans la liste, le détail du booking n'est pas mis à jour.

La modal se ferme la plupart du temps parce que re-render un row équivaut à remettre le contexte d'ouverture de la modal à la valeur initiale `false`.

Pour corriger, je propsoe de fermer explicitement la modal au moment de la confirmation d'annulation. Et de re-requeter systématiquement le booking quand le status de la réservation change.

Quand l'adapter `getCollectiveBookingAdapter` sera supprimé, on ne requêtera plus le booking à chaque expand du détail, mais ça me paraît hors scope pour ce HF.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques