### PR TITLE
(BSR)[API] chore: remove very old isEducational property

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -446,11 +446,6 @@ class CollectiveOffer(
     nationalProgram: sa_orm.Mapped["NationalProgram"] = relationship("NationalProgram", foreign_keys=nationalProgramId)
 
     @property
-    def isEducational(self) -> bool:
-        # FIXME (rpaoloni, 2022-03-7): Remove legacy support layer
-        return True
-
-    @property
     def isEditable(self) -> bool:
         return self.status not in [offer_mixin.OfferStatus.PENDING, offer_mixin.OfferStatus.REJECTED]
 
@@ -774,11 +769,6 @@ class CollectiveOfferTemplate(
         if not self.dateRange:
             return None
         return {"start": self.start, "end": self.end}
-
-    @property
-    def isEducational(self) -> bool:
-        # FIXME (rpaoloni, 2022-05-09): Remove legacy support layer
-        return True
 
     @property
     def isEditable(self) -> bool:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : les deux propriétés semblent obsolètes. Mais je fais une PR plus pour être sûr que ça casse rien, j'ai eu des résultats curieux avec mes tests

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques