### PR TITLE
(PC-29615)[PRO] fix: Make back to top button in adage search sticky i…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
@@ -73,10 +73,12 @@
 .back-to-top-button {
   @include fonts.button;
 
-  position: fixed;
+  display: flex;
+  width: fit-content;
+  margin-left: auto;
+  position: sticky;
   right: rem.torem(16px);
   bottom: rem.torem(16px);
-  display: flex;
   align-items: center;
   gap: rem.torem(8px);
   background-color: var(--color-grey-light);
@@ -102,17 +104,15 @@
   }
 
   &:focus-visible {
-    border: solid rem.torem(2px) var(--color-black);
+    outline: solid rem.torem(2px) var(--color-black);
+    outline-offset: rem.torem(2px);
     text-decoration: underline;
-    outline: none;
-    box-shadow: 0 3px 4px 0 var(--color-medium-shadow);
   }
 }
 
 .pagination {
   margin: rem.torem(24px) 0;
 }
-
 
 @media (max-width: size.$mobile) {
   .offer-type-vue {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.module.scss
@@ -11,4 +11,5 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
 }


### PR DESCRIPTION
…nstead of fixed.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29615

**Objectif**
Corriger l'affichage du bouton "Retour en haut" de la recherche sur ADAGE qui reste en bas de la page et ne suit plus le scroll.
En ayant ajouté les container queries précédemment, avoir ajouté la propriété `container-type` a changé le "containing block" sur lequel se base la `position: fixed` du bouton. Avec quelques ajustements j'ai changé le positionnement du bouton en `position: sticky`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques