### PR TITLE
(PC-29684)[PRO] feat: Simplify offers checkboxes and trigger notif er…

### DIFF
--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/CheckboxCell.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/CheckboxCell.tsx
@@ -10,8 +10,7 @@ interface CheckboxCellProps {
   offerId: number
   status: OfferStatus
   disabled: boolean
-  isShowcase: boolean
-  selectOffer: (offerId: number, selected: boolean, isTemplate: boolean) => void
+  selectOffer: (offerId: number, selected: boolean) => void
 }
 
 export const CheckboxCell = ({
@@ -20,11 +19,10 @@ export const CheckboxCell = ({
   offerId,
   status,
   disabled,
-  isShowcase,
   selectOffer,
 }: CheckboxCellProps) => {
   const handleOnChangeSelected = () => {
-    selectOffer(offerId, !isSelected, !!isShowcase)
+    selectOffer(offerId, !isSelected)
   }
 
   return (

--- a/pro/src/pages/Offers/Offers/OfferItem/CollectiveOfferItem.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/CollectiveOfferItem.tsx
@@ -18,7 +18,7 @@ type CollectiveOfferItemProps = {
   disabled: boolean
   isSelected: boolean
   offer: CollectiveOfferResponseModel
-  selectOffer: (offerId: number, selected: boolean, isTemplate: boolean) => void
+  selectOffer: (offerId: number, selected: boolean) => void
   editionOfferLink: string
   venue: ListOffersVenueResponseModel
   audience: Audience
@@ -42,7 +42,6 @@ export const CollectiveOfferItem = ({
         disabled={disabled}
         isSelected={isSelected}
         selectOffer={selectOffer}
-        isShowcase={Boolean(offer.isShowcase)}
       />
 
       <ThumbCell offer={offer} editionOfferLink={editionOfferLink} />

--- a/pro/src/pages/Offers/Offers/OfferItem/IndividualOfferItem.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/IndividualOfferItem.tsx
@@ -18,7 +18,7 @@ type IndividualOfferItemProps = {
   disabled: boolean
   isSelected: boolean
   offer: ListOffersOfferResponseModel
-  selectOffer: (offerId: number, selected: boolean, isTemplate: boolean) => void
+  selectOffer: (offerId: number, selected: boolean) => void
   editionOfferLink: string
   editionStockLink: string
   venue: ListOffersVenueResponseModel
@@ -44,7 +44,6 @@ export const IndividualOfferItem = ({
         disabled={disabled}
         isSelected={isSelected}
         selectOffer={selectOffer}
-        isShowcase={Boolean(offer.isShowcase)}
       />
 
       <ThumbCell offer={offer} editionOfferLink={editionOfferLink} />

--- a/pro/src/pages/Offers/Offers/OfferItem/OfferItem.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/OfferItem.tsx
@@ -22,7 +22,7 @@ export type OfferItemProps = {
   disabled?: boolean
   isSelected?: boolean
   offer: CollectiveOfferResponseModel | ListOffersOfferResponseModel
-  selectOffer: (offerId: number, selected: boolean, isTemplate: boolean) => void
+  selectOffer: (offerId: number, selected: boolean) => void
   audience: Audience
 }
 

--- a/pro/src/pages/Offers/Offers/Offers.tsx
+++ b/pro/src/pages/Offers/Offers/Offers.tsx
@@ -1,14 +1,10 @@
-import React, { useCallback } from 'react'
-
 import {
   CollectiveOfferResponseModel,
   ListOffersOfferResponseModel,
 } from 'apiClient/v1'
-import { computeURLCollectiveOfferId } from 'core/OfferEducational/utils/computeURLCollectiveOfferId'
 import { MAX_OFFERS_TO_DISPLAY } from 'core/Offers/constants'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { hasSearchFilters } from 'core/Offers/utils/hasSearchFilters'
-import { isOfferDisabled } from 'core/Offers/utils/isOfferDisabled'
 import { Audience } from 'core/shared/types'
 import { getOffersCountToDisplay } from 'pages/Offers/domain/getOffersCountToDisplay'
 import { NoResults } from 'screens/Offers/NoResults/NoResults'
@@ -40,9 +36,9 @@ type OffersProps = {
   pageCount: number
   resetFilters: () => void
   searchFilters: SearchFiltersParams
-  selectedOfferIds: string[]
+  selectedOfferIds: number[]
   setSearchFilters: React.Dispatch<React.SetStateAction<SearchFiltersParams>>
-  setSelectedOfferIds: React.Dispatch<React.SetStateAction<string[]>>
+  setSelectedOfferIds: React.Dispatch<React.SetStateAction<number[]>>
   toggleSelectAllCheckboxes: () => void
   urlSearchFilters: SearchFiltersParams
   isAtLeastOneOfferChecked: boolean
@@ -97,33 +93,17 @@ const Offers = ({
       false
     )
 
-  const selectOffer = useCallback(
-    (offerId: number, selected: boolean, isTemplate: boolean) => {
-      setSelectedOfferIds((currentSelectedIds) => {
-        const newSelectedOfferIds = [...currentSelectedIds]
-        const id = computeURLCollectiveOfferId(offerId, isTemplate)
-        if (selected) {
-          newSelectedOfferIds.push(id)
-        } else {
-          const offerIdIndex = newSelectedOfferIds.indexOf(id)
-          newSelectedOfferIds.splice(offerIdIndex, 1)
-        }
-        return newSelectedOfferIds
-      })
-    },
-    [setSelectedOfferIds]
-  )
-
-  function selectAllOffers() {
-    setSelectedOfferIds(
-      areAllOffersSelected
-        ? []
-        : currentPageOffersSubset
-            .filter((offer) => !isOfferDisabled(offer.status))
-            .map((offer) => offer.id.toString())
-    )
-
-    toggleSelectAllCheckboxes()
+  function selectOffer(offerId: number, isAlreadyChecked: boolean) {
+    setSelectedOfferIds((currentSelectedIds) => {
+      const newSelectedOfferIds = [...currentSelectedIds]
+      if (isAlreadyChecked) {
+        newSelectedOfferIds.push(offerId)
+      } else {
+        const offerIdIndex = newSelectedOfferIds.indexOf(offerId)
+        newSelectedOfferIds.splice(offerIdIndex, 1)
+      }
+      return newSelectedOfferIds
+    })
   }
 
   return (
@@ -149,12 +129,12 @@ const Offers = ({
             <>
               <div className={styles['select-all-container']}>
                 <BaseCheckbox
-                  checked={areAllOffersSelected || isAtLeastOneOfferChecked}
+                  checked={areAllOffersSelected}
                   partialCheck={
                     !areAllOffersSelected && isAtLeastOneOfferChecked
                   }
                   disabled={isAdminForbidden(searchFilters)}
-                  onChange={selectAllOffers}
+                  onChange={toggleSelectAllCheckboxes}
                   label={
                     areAllOffersSelected
                       ? 'Tout désélectionner'
@@ -169,13 +149,11 @@ const Offers = ({
                   areOffersPresent={hasOffers}
                   filters={searchFilters}
                   isAdminForbidden={isAdminForbidden}
-                  selectAllOffers={selectAllOffers}
                   updateStatusFilter={updateStatusFilter}
                   audience={audience}
                   isAtLeastOneOfferChecked={isAtLeastOneOfferChecked}
                 />
                 <OffersTableBody
-                  areAllOffersSelected={areAllOffersSelected}
                   offers={currentPageOffersSubset}
                   selectOffer={selectOffer}
                   selectedOfferIds={selectedOfferIds}

--- a/pro/src/pages/Offers/Offers/OffersTableBody/OffersTableBody.tsx
+++ b/pro/src/pages/Offers/Offers/OffersTableBody/OffersTableBody.tsx
@@ -1,50 +1,37 @@
-import React from 'react'
-
 import {
   CollectiveOfferResponseModel,
   ListOffersOfferResponseModel,
 } from 'apiClient/v1'
-import { computeURLCollectiveOfferId } from 'core/OfferEducational/utils/computeURLCollectiveOfferId'
 import { Audience } from 'core/shared/types'
 
 import OfferItem from '../OfferItem/OfferItem'
 
 type OffersTableBodyProps = {
-  areAllOffersSelected: boolean
-  offers: (CollectiveOfferResponseModel | ListOffersOfferResponseModel)[]
-  selectOffer: (
-    offerId: number,
-    isSelected: boolean,
-    isTemplate: boolean
-  ) => void
-  selectedOfferIds: string[]
+  offers: CollectiveOfferResponseModel[] | ListOffersOfferResponseModel[]
+  selectOffer: (offerId: number, isSelected: boolean) => void
+  selectedOfferIds: number[]
   audience: Audience
 }
 
 export const OffersTableBody = ({
-  areAllOffersSelected,
   offers,
   selectOffer,
   selectedOfferIds,
   audience,
-}: OffersTableBodyProps) => (
-  <tbody className="offers-list">
-    {offers.map((offer) => {
-      const offerId = computeURLCollectiveOfferId(
-        offer.id,
-        Boolean(offer.isShowcase)
-      )
-
-      return (
-        <OfferItem
-          disabled={areAllOffersSelected}
-          isSelected={selectedOfferIds.includes(offerId)}
-          key={offerId}
-          offer={offer}
-          selectOffer={selectOffer}
-          audience={audience}
-        />
-      )
-    })}
-  </tbody>
-)
+}: OffersTableBodyProps) => {
+  return (
+    <tbody className="offers-list">
+      {offers.map((offer) => {
+        return (
+          <OfferItem
+            isSelected={selectedOfferIds.includes(offer.id)}
+            key={offer.id}
+            offer={offer}
+            selectOffer={selectOffer}
+            audience={audience}
+          />
+        )
+      })}
+    </tbody>
+  )
+}

--- a/pro/src/pages/Offers/Offers/OffersTableHead/OffersTableHead.tsx
+++ b/pro/src/pages/Offers/Offers/OffersTableHead/OffersTableHead.tsx
@@ -11,7 +11,6 @@ type OffersTableHeadProps = {
   areOffersPresent: boolean
   filters: SearchFiltersParams
   isAdminForbidden: (searchFilters: SearchFiltersParams) => boolean
-  selectAllOffers: () => void
   updateStatusFilter: (status: SearchFiltersParams['status']) => void
   audience: Audience
   isAtLeastOneOfferChecked: boolean

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -92,33 +92,31 @@ export const OffersRoute = (): JSX.Element => {
   }
   delete apiFilters.page
 
-  const offersQuery = useSWR(
-    [GET_OFFERS_QUERY_KEY, apiFilters],
-    () => {
-      const {
-        nameOrIsbn,
-        offererId,
-        venueId,
-        categoryId,
-        status,
-        creationMode,
-        periodBeginningDate,
-        periodEndingDate,
-      } = serializeApiFilters(apiFilters)
+  const offersQuery = useSWR([GET_OFFERS_QUERY_KEY, apiFilters], () => {
+    const {
+      nameOrIsbn,
+      offererId,
+      venueId,
+      categoryId,
+      status,
+      creationMode,
+      periodBeginningDate,
+      periodEndingDate,
+    } = serializeApiFilters(apiFilters)
 
-      return api.listOffers(
-        nameOrIsbn,
-        offererId,
-        status,
-        venueId,
-        categoryId,
-        creationMode,
-        periodBeginningDate,
-        periodEndingDate
-      )
-    },
-    { fallbackData: [] }
-  )
+    return api.listOffers(
+      nameOrIsbn,
+      offererId,
+      status,
+      venueId,
+      categoryId,
+      creationMode,
+      periodBeginningDate,
+      periodEndingDate
+    )
+  })
+
+  const offers = offersQuery.data || []
 
   return (
     <AppLayout>
@@ -135,7 +133,7 @@ export const OffersRoute = (): JSX.Element => {
           initialSearchFilters={initialSearchFilters}
           isLoading={offersQuery.isLoading}
           offerer={offerer}
-          offers={offersQuery.data}
+          offers={offers}
           redirectWithUrlFilters={redirectWithUrlFilters}
           urlSearchFilters={urlSearchFilters}
           venues={venues}

--- a/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
@@ -180,6 +180,10 @@ describe('route Offers when user is admin', () => {
         undefined
       )
     })
+
+    const loadingMessage = screen.queryByText(/Chargement en cours/)
+    await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
+
     expect(
       screen.getByRole('button', {
         name: 'Statut Afficher ou masquer le filtre par statut',
@@ -213,6 +217,10 @@ describe('route Offers when user is admin', () => {
         undefined
       )
     })
+
+    const loadingMessage = screen.queryByText(/Chargement en cours/)
+    await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
+
     expect(
       screen.getByRole('button', {
         name: /Afficher ou masquer le filtre par statut/,


### PR DESCRIPTION
…ror when offers cannot be disabled.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29684

**Objectif**
Le but initial était de déclencher un notify d'erreur dans `ActionsBar.tsx` quand on tente de désactiver un groupe d'offre et qu'elles sont pas toutes publiées ou expirées (seulement pour le collectif). En déroulant le fil j'ai clean quelques autres trucs : 
- Correction d'un bug : quand on clic sur "Tout sélectionner" les offres des autres pages apparaissaient encore en non-cochées
- Simplification du state de `areAllOffersSelected` en une valeur calculée
- Drill down des offres sélectionnées et pas seulement des ids & utilisation des ids numériques uniquement (sinon on castait tous les ids collectifs en string, pour ajouter "T-" à l'id et identifier les offres collectives vitrines parce qu'on avait que accès à l'id)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques