### PR TITLE
(PC-29640)[PRO] style: Ajout callout, détail de remboursements

### DIFF
--- a/pro/src/pages/Reimbursements/ReimbursementsDetails/DetailsFilters.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsDetails/DetailsFilters.tsx
@@ -1,5 +1,7 @@
 import React, { Dispatch, SetStateAction, useState } from 'react'
 
+import { Callout } from 'components/Callout/Callout'
+import { CalloutVariant } from 'components/Callout/types'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { SelectOption } from 'custom_types/form'
 import { Button } from 'ui-kit/Button/Button'
@@ -76,6 +78,10 @@ export const DetailsFilters = ({
 
   return (
     <>
+      <Callout variant={CalloutVariant.INFO}>
+        Nouveau ! Les détails de remboursements seront bientôt téléchargeables
+        depuis l’onglet justificatif.
+      </Callout>
       <div className={styles['header']}>
         <h2 className={styles['header-title']}>Affichage des remboursements</h2>
         <Button

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementDetails.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementDetails.spec.tsx
@@ -90,6 +90,16 @@ describe('reimbursementsWithFilters', () => {
     vi.spyOn(api, 'getInvoicesV2').mockResolvedValue(BASE_INVOICES)
   })
 
+  it('should display the reimbursement details callout message', async () => {
+    renderReimbursementsDetails()
+
+    expect(
+      await screen.findByText(
+        /Nouveau ! Les détails de remboursements seront bientôt téléchargeables depuis l’onglet justificatif./
+      )
+    ).toBeInTheDocument()
+  })
+
   it('should not disable buttons when the period dates are filled', async () => {
     renderReimbursementsDetails()
 


### PR DESCRIPTION
## Ajouter Callout bleu, détail de remboursements

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29725

<img width="931" alt="Capture d’écran 2024-05-21 à 10 32 23" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/f21a0f4d-8caf-437a-af77-edddfca5288a">
