### PR TITLE
(PC-29677)[PRO] fix: dont display offerer banner before loading data

### DIFF
--- a/pro/src/pages/Home/Homepage.tsx
+++ b/pro/src/pages/Home/Homepage.tsx
@@ -202,10 +202,12 @@ export const Homepage = (): JSX.Element => {
         <BankAccountHasPendingCorrectionCallout offerer={selectedOfferer} />
       </div>
 
-      <OffererBanners
-        isUserOffererValidated={isUserOffererValidated}
-        offerer={selectedOfferer}
-      />
+      {!selectedOffererQuery.isLoading && (
+        <OffererBanners
+          isUserOffererValidated={isUserOffererValidated}
+          offerer={selectedOfferer}
+        />
+      )}
 
       {selectedOfferer?.isValidated && selectedOfferer.isActive && (
         <section className={styles['section']}>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29677


Ne pas afficher les bannières liées à la structure (en cours de rattachement, en cours de validation, etc ...) avant d'avoir chargé les données. Cela créait un effet de clignotement car on affichait la bannière avant de vérifier les conditions d'affichage. 