### PR TITLE
(PC-29546)[API] refactor: move acceslibre commands to offerers/api

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2291,9 +2291,9 @@ def synchronize_accessibility_provider(venue: models.Venue, force_sync: bool = F
                 db.session.add(venue.accessibilityProvider)
         else:
             logger.info(
-                "Slug %s has not been found at acceslibre. Removing AccessibilityProvider %d",
+                "Slug %s has not been found at acceslibre. Removing AccessibilityProvider for venue %d",
                 slug,
-                venue.accessibilityProvider.id,
+                venue.id,
             )
             db.session.delete(venue.accessibilityProvider)
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2341,6 +2341,8 @@ def match_venue_with_new_entries(
             venue_name=venue.name,
             venue_public_name=venue.publicName,
             venue_address=venue.street,
+            venue_city=venue.city,
+            venue_postal_code=venue.postalCode,
             venue_ban_id=venue.banId,
             venue_siret=venue.siret,
         ):

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import decimal
 import itertools
 import logging
+from math import ceil
 import re
 import secrets
 import time
@@ -2323,6 +2324,41 @@ def match_venue_with_new_entries(
                 externalAccessibilityUrl=matching_venue.web_url,
             )
             db.session.add(venue.accessibilityProvider)
+
+
+def acceslibre_matching(batch_size: int, dry_run: bool, start_from_batch: int) -> None:
+    """
+    For all permanent venues, we are looking for a match at acceslibre
+
+    If we use the --start-from-batch option, it will start synchronization from the given batch number
+    Use case: synchronization has failed with message "Could not update batch <n>"
+    """
+    venues_list = get_permanent_venues_without_accessibility_provider()
+    num_batches = ceil(len(venues_list) / batch_size)
+    if start_from_batch > num_batches:
+        logger.info("Start from batch must be less than %d", num_batches)
+        return
+
+    results_list = []
+
+    for activity in accessibility_provider.AcceslibreActivity:
+        if results_by_activity := accessibility_provider.find_new_entries_by_activity(activity):
+            results_list.extend(results_by_activity)
+
+    start_batch_index = start_from_batch - 1
+    for i in range(start_batch_index, num_batches):
+        batch_start = i * batch_size
+        batch_end = (i + 1) * batch_size
+        match_venue_with_new_entries(venues_list[batch_start:batch_end], results_list)
+
+        if not dry_run:
+            try:
+                db.session.commit()
+            except sa.exc.SQLAlchemyError:
+                logger.exception("Could not update batch %d", i + 1)
+                db.session.rollback()
+        else:
+            db.session.rollback()
 
 
 def update_offerer_address_label(offerer_address_id: int, new_label: str) -> None:

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2306,6 +2306,31 @@ def synchronize_accessibility_provider(venue: models.Venue, force_sync: bool = F
         )
 
 
+def synchronize_venues_with_acceslibre(venue_ids: list[int], dry_run: bool) -> None:
+    for venue_id in venue_ids:
+        venue = offerers_models.Venue.query.filter_by(id=venue_id).one_or_none()
+        if venue is None:
+            logger.warning("Venue with id %s not found", venue_id)
+            continue
+
+        set_accessibility_provider_id(venue)
+        if not venue.accessibilityProvider:
+            logger.info("No match found at acceslibre for Venue %s ", venue_id)
+            continue
+
+        set_accessibility_infos_from_provider_id(venue)
+        db.session.add(venue)
+
+    if not dry_run:
+        try:
+            db.session.commit()
+        except sa.exc.SQLAlchemyError:
+            logger.exception("Could not update venues %s", venue_ids)
+            db.session.rollback()
+    else:
+        db.session.rollback()
+
+
 def match_venue_with_new_entries(
     venues_list: list[models.Venue],
     results: list[accessibility_provider.AcceslibreResult],

--- a/api/src/pcapi/core/offerers/commands.py
+++ b/api/src/pcapi/core/offerers/commands.py
@@ -138,28 +138,7 @@ def synchronize_accessibility_with_acceslibre(
 @click.argument("venue_ids", type=int, nargs=-1, required=True)
 @click.option("--dry-run", type=bool, default=True)
 def synchronize_venues_with_acceslibre(venue_ids: list[int], dry_run: bool = True) -> None:
-    for venue_id in venue_ids:
-        venue = offerers_models.Venue.query.filter_by(id=venue_id).one_or_none()
-        if venue is None:
-            logger.warning("Venue with id %s not found", venue_id)
-            continue
-
-        offerers_api.set_accessibility_provider_id(venue)
-        if not venue.accessibilityProvider:
-            logger.info("No match found at acceslibre for Venue %s ", venue_id)
-            continue
-
-        offerers_api.set_accessibility_infos_from_provider_id(venue)
-        db.session.add(venue)
-
-    if not dry_run:
-        try:
-            db.session.commit()
-        except sa.exc.SQLAlchemyError:
-            logger.exception("Could not update venues %s", venue_ids)
-            db.session.rollback()
-    else:
-        db.session.rollback()
+    offerers_api.synchronize_venues_with_acceslibre(venue_ids, dry_run)
 
 
 @blueprint.cli.command("acceslibre_matching")

--- a/api/tests/connectors/acceslibre/acceslibre_test.py
+++ b/api/tests/connectors/acceslibre/acceslibre_test.py
@@ -181,6 +181,28 @@ class AcceslibreTest:
             == "https://acceslibre.info/app/11-tuchan/a/bibliotheque-mediatheque/erp/bibliotheque-municipale-de-truchan-les-bains/"
         )
 
+    def test_should_not_match_wrong_city(self, requests_mock):
+        activity = AcceslibreActivity.BIBLIOTHEQUE
+        requests_mock.get(
+            "https://acceslibre.beta.gouv.fr/api/erps/?activite=bibliotheque-mediatheque&created_or_updated_in_last_days=7&page_size=50&page=1",
+            json=fixtures.ACCESLIBRE_ACTIVITY_RESULT,
+        )
+        requests_mock.get(
+            "https://acceslibre.beta.gouv.fr/api/erps/?activite=bibliotheque-mediatheque&created_or_updated_in_last_days=7&page_size=1",
+            json=fixtures.ACCESLIBRE_ACTIVITY_RESULT,
+        )
+
+        activity_results = acceslibre.find_new_entries_by_activity(activity)
+        assert activity_results
+        matching_venue = acceslibre.match_venue_with_acceslibre(
+            acceslibre_results=activity_results,
+            venue_address="2 Place des Thermes",
+            venue_name="Bibliothèque Municipale de Truchan-les-Bains",
+            venue_city="Paris",
+            venue_postal_code="75001",
+        )
+        assert not matching_venue
+
     def test_should_raise_error_when_slug_is_none(self, requests_mock):
         name = "Le Livre Bateau"
         public_name = ""

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -2868,6 +2868,26 @@ class AccessibilityProviderTest:
         assert venue.external_accessibility_url == "https://une-fausse-url.com"
         assert venue.external_accessibility_id == "mon-lieu-chez-acceslibre"
 
+    def test_acceslibre_matching(self):
+        venues_list = [offerers_factories.VenueFactory(isPermanent=True, isVirtual=False)]
+        venue = offerers_factories.VenueFactory(
+            isPermanent=True,
+            isVirtual=False,
+            name="Un lieu",
+            postalCode="75001",
+            city="Paris",
+            street="3 Rue de Valois",
+        )
+        venues_list.append(venue)
+
+        # match result is given by find_new_entries_by_activity in TestingBackend class in acceslibre connector
+        offerers_api.acceslibre_matching(batch_size=1000, dry_run=False, start_from_batch=1)
+
+        assert (
+            venue.external_accessibility_url == "https://acceslibre.beta.gouv.fr/app/activite/mon-lieu-chez-acceslibre/"
+        )
+        assert venue.external_accessibility_id == "mon-lieu-chez-acceslibre"
+
 
 class GetOffererConfidenceLevelTest:
     def test_no_rule(self):

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -2888,6 +2888,24 @@ class AccessibilityProviderTest:
         )
         assert venue.external_accessibility_id == "mon-lieu-chez-acceslibre"
 
+    @patch("pcapi.connectors.acceslibre.get_id_at_accessibility_provider")
+    def test_synchronize_venues_with_acceslibre(self, mock_get_id_at_accessibility_provider):
+        mock_get_id_at_accessibility_provider.side_effect = [
+            None,
+            acceslibre_connector.AcceslibreInfos(slug="mon-slug", url="https://mon.adresse/mon-slug"),
+        ]
+
+        venue_1 = offerers_factories.VenueFactory(isPermanent=True, isVirtual=False)
+        venue_2 = offerers_factories.VenueFactory(isPermanent=True, isVirtual=False)
+        venue_ids = [venue_1.id, venue_2.id]
+
+        # match result is given by find_new_entries_by_activity in TestingBackend class in acceslibre connector
+        offerers_api.synchronize_venues_with_acceslibre(venue_ids, dry_run=False)
+
+        assert not venue_1.accessibilityProvider
+        assert venue_2.external_accessibility_url == "https://mon.adresse/mon-slug"
+        assert venue_2.external_accessibility_id == "mon-slug"
+
 
 class GetOffererConfidenceLevelTest:
     def test_no_rule(self):


### PR DESCRIPTION
## But de la pull request

Contrairement à ce qu'indique le nom de la branche, il s'agit de migrer le contenu des commandes liées à acceslibre vers `offerers/api.py`

Au passage, correction du matching, qui ne prenait pas en compte les villes (ce qui ne sert à rien dans les autres appels au match car l'appel API se faisait alors par ville)

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29546

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques