### PR TITLE
(PC-29299)[PRO] style: Use svg instead of image for the handicap icon…

### DIFF
--- a/pro/src/ui-kit/AccessibilityLabel/AccessibilityLabel.tsx
+++ b/pro/src/ui-kit/AccessibilityLabel/AccessibilityLabel.tsx
@@ -6,6 +6,7 @@ import strokeAccessibilityBrain from 'icons/stroke-accessibility-brain.svg'
 import audioDisabilitySvg from 'icons/stroke-accessibility-ear.svg'
 import strokeAccessibilityEye from 'icons/stroke-accessibility-eye.svg'
 import strokeAccessibilityLeg from 'icons/stroke-accessibility-leg.svg'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './AccessibilityLabel.module.scss'
 
@@ -42,7 +43,14 @@ export const AccessibilityLabel = ({
 
   return (
     <div className={cn(styles['accessibility-label'], className)}>
-      {labelData.svg && <img src={labelData.svg} className={styles['icon']} />}
+      {labelData.svg && (
+        <SvgIcon
+          src={labelData.svg}
+          className={styles['icon']}
+          width="24"
+          alt=""
+        />
+      )}
       <span className={styles['text']}>{labelData.label}</span>
     </div>
   )


### PR DESCRIPTION
…s in offer recap.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29299

**Objectif**
Corriger l'affichage des icons de handicap du `<AccessibilityLabel>` dans le cas où l'utilisateur choisit des couleurs de texte par défait au niveau navigateur. Ca arrive quand on utilise un svg dans une balise img et que ce svg a "currentColor" comme fill.

![9 3_step3](https://github.com/pass-culture/pass-culture-main/assets/139768952/cbb02c39-92ab-4dbd-8556-66e92f08bcce)
Pour reproduire l'erreur : 
Sur Firefox, dans les paramètres "Couleurs", cliquer sur "gérer les couleurs", puis chosir du jaune pour le texte et outrepasser les couleurs uniquement pour les thèmes avec un contrast élevé.


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques