### PR TITLE
(PC-29068)[API] refactor: add allocine venue provider price

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-2850f548b073 (pre) (head)
-fbb9ccd03884 (post) (head)
+0fdfda2e6800 (pre) (head)
+69f58f589e88 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240408T150954_0fdfda2e6800_add_price_to_allocine_venue_provider.py
+++ b/api/src/pcapi/alembic/versions/20240408T150954_0fdfda2e6800_add_price_to_allocine_venue_provider.py
@@ -1,0 +1,21 @@
+"""Add price column to AllocineVenueProvider (1/2)
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "0fdfda2e6800"
+down_revision = "2850f548b073"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("allocine_venue_provider", sa.Column("price", sa.Numeric(precision=10, scale=2), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("allocine_venue_provider", "price")

--- a/api/src/pcapi/alembic/versions/20240522T122540_69f58f589e88_populate_allocine_venue_provider_price.py
+++ b/api/src/pcapi/alembic/versions/20240522T122540_69f58f589e88_populate_allocine_venue_provider_price.py
@@ -1,0 +1,27 @@
+"""Populate AllocineVenueProvider.price (2/2)
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "69f58f589e88"
+down_revision = "fbb9ccd03884"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE allocine_venue_provider
+        SET price = allocine_venue_provider_price_rule.price
+        FROM allocine_venue_provider_price_rule
+        WHERE allocine_venue_provider.id = allocine_venue_provider_price_rule."allocineVenueProviderId";
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -167,6 +167,7 @@ def update_allocine_venue_provider(
         # could need to be tweaked in the future
         if price_rule.priceRule == PriceRule.default:
             price_rule.price = venue_provider_payload.price
+            allocine_venue_provider.price = venue_provider_payload.price
 
     repository.save(allocine_venue_provider, *allocine_venue_provider.priceRules)
 
@@ -221,6 +222,7 @@ def connect_venue_to_allocine(
         isDuo=payload.isDuo,
         quantity=payload.quantity,
         internalId=pivot.internalId,
+        price=payload.price,
     )
     price_rule = providers_models.AllocineVenueProviderPriceRule(
         allocineVenueProvider=venue_provider,

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -233,18 +233,15 @@ class CDSCinemaDetails(PcObject, Base, Model):
 
 class AllocineVenueProvider(VenueProvider):
     __tablename__ = "allocine_venue_provider"
+    __mapper_args__ = {"polymorphic_identity": "allocine_venue_provider"}
 
     id: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue_provider.id"), primary_key=True)
-
     isDuo: bool = sa.Column(sa.Boolean, default=True, server_default=sa.true(), nullable=False)
-
     quantity = sa.Column(sa.Integer, nullable=True)
-
     internalId: str = sa.Column(sa.Text, nullable=False, unique=True)
-
-    __mapper_args__ = {
-        "polymorphic_identity": "allocine_venue_provider",
-    }
+    price: decimal.Decimal = sa.Column(
+        sa.Numeric(10, 2), sa.CheckConstraint("price >= 0", name="check_price_is_not_negative"), nullable=True
+    )
 
 
 class AllocineVenueProviderPriceRule(PcObject, Base, Model):


### PR DESCRIPTION
To delete the AllocineVenueProviderPriceRule model, we first need to add
a new AllocineVenueProvider column in which we double write the price.

A later commit and deployment will exclusively read from the new column 
and delete the old model.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29068

La pull request #12359 fait suite à cette PR.