### PR TITLE
(PC-29921)[PRO] perf: Dont load unnecessary dana when switching from …

### DIFF
--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -84,6 +84,11 @@ describe('OfferType', () => {
     })
     vi.spyOn(api, 'getCollectiveOffers').mockResolvedValue([])
 
+    vi.spyOn(api, 'getOfferer').mockResolvedValue({
+      ...defaultGetOffererResponseModel,
+      isValidated: true,
+    })
+
     vi.spyOn(useAnalytics, 'default').mockImplementation(() => ({
       logEvent: mockLogEvent,
     }))
@@ -159,14 +164,9 @@ describe('OfferType', () => {
   })
 
   it('should display non eligible banner if offerer can not create collective offer', async () => {
-    vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
-      offerersNames: [
-        getOffererNameFactory({
-          id: 1,
-          name: 'Ma super structure',
-          allowedOnAdage: false,
-        }),
-      ],
+    vi.spyOn(api, 'getOfferer').mockResolvedValue({
+      ...defaultGetOffererResponseModel,
+      allowedOnAdage: false,
     })
 
     renderOfferTypes()
@@ -182,9 +182,10 @@ describe('OfferType', () => {
     ).toBeInTheDocument()
   })
 
-  it('should display dms application banner if offerer can not create collective offer but as dms application', async () => {
+  it('should display dms application banner if offerer can not create collective offer but has a dms application', async () => {
     const offerer: GetOffererResponseModel = {
       ...defaultGetOffererResponseModel,
+      allowedOnAdage: false,
       managedVenues: [
         {
           ...defaultGetOffererVenueResponseModel,
@@ -274,21 +275,6 @@ describe('OfferType', () => {
       screen.getByRole('radio', { name: 'À un groupe scolaire' })
     )
 
-    await waitFor(() => {
-      expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'template',
-        undefined
-      )
-    })
-
     await userEvent.click(
       await screen.findByRole('radio', {
         name: 'Une offre réservable Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé.',
@@ -310,6 +296,21 @@ describe('OfferType', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Étape suivante' })
     )
+
+    await waitFor(() => {
+      expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'template',
+        undefined
+      )
+    })
 
     expect(screen.getByText('Sélection collectif')).toBeInTheDocument()
   })

--- a/pro/src/utils/getLastCollectiveDmsApplication.ts
+++ b/pro/src/utils/getLastCollectiveDmsApplication.ts
@@ -19,9 +19,12 @@ export const getLastCollectiveDmsApplication = (
 }
 
 export const getLastDmsApplicationForOfferer = (
-  venueId: string | null,
-  offerer: GetOffererResponseModel
+  venueId?: string | null,
+  offerer?: GetOffererResponseModel
 ) => {
+  if (!offerer) {
+    return
+  }
   if (venueId) {
     const venue = offerer.managedVenues?.find(
       (venue) => venue.id.toString() === venueId


### PR DESCRIPTION
…individual offers to collective in offer type form.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29921

**Objectif**
Optimiser le nombre de requêtes faites dans le carrefour au moment de passer d'une offre indiv à une offre collective. 
Actuellement 3 requêtes sont faites systématiquement : 
- L'offerer dont l'id est dans l'url
- La liste des offerers de l'utilisateur, pour qu'en cas d'absence d'id dans l'url, on prend le premier offerer de la liste
- La liste des offres vitrines de la venue dont l'id est dans l'url si il y a un id, ou de l'ensemble des venues de l'offerer si il n'y a pas d'id. Cette liste permet de savoir s'il est possible ou non de dupliquer une offre vitrine.

Améliorations :
- Utiliser SWR pour l'offerer, et comme on l'a probablement déjà chargé précédemment (par ex au moment de le choisir dans la home), il est en cache donc pas de requête faite
- Ne requêter la liste des offerers pour obtenir l'id du premier uniquement si il n'y a pas d'id d'offerer dans l'url
- Ne vérifier l'existence des offres vitrines sur les venues de l'offerer qu'au moment de cliquer sur le bouton de duplication.

Ca a permis de simplifier le composant `CollectiveOfferType.tsx` et de supprimer le useEffect.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques