### PR TITLE
(PC-29922)[API] Permettre de facilement corriger les tests portant sur le JSON Open API

### DIFF
--- a/api/src/pcapi/routes/public/documentation_constants.py
+++ b/api/src/pcapi/routes/public/documentation_constants.py
@@ -1,6 +1,19 @@
 from spectree import Tag
 
 
+# HIGH LEVEL INFORMATION
+PUBLIC_API_DESCRIPTION = """
+This the documentation of the Pass Culture public REST API.
+
+**Important notice:**
+- Since January 2023, rate limiting has been implemented on the Pass Culture API.
+  You are limited to **200 requests/minute** per API key.
+  Once this limit reached, you will received a `429 Too Many Requests` error message. You will then need to back down.
+- Dates of event offers are stored in the **UTC format** to be able to format them correctly, according to the user timezone, in our application interface.
+- Any non-blank field sent using a `PATCH` method will be considered as changed, even if the new value is equal to old value.
+  _For example, if you update the stock of an event, you **should not resend the `beginningDate`** if it has not changed because, otherwise it is going to trigger the reschedule process on our side._
+"""
+
 # BOOKING_TAGS
 BOOKING_TAG = Tag(name="Booking", description="Endpoints to manage the bookings of an offer (event and product).")
 
@@ -39,6 +52,7 @@ COLLECTIVE_EDUCATIONAL_DATA = Tag(name="Collective educational data")
 BASE_CODE_DESCRIPTIONS = {
     "HTTP_401": (None, "Authentication is necessary to use this API"),
     "HTTP_403": (None, "You do not have the necessary rights to use this API"),
+    "HTTP_429": (None, "You have made too many requests. (**rate limit: 200 requests/minute**)"),
 }
 
 OPEN_API_TAGS = [

--- a/api/src/pcapi/routes/public/spectree_schemas.py
+++ b/api/src/pcapi/routes/public/spectree_schemas.py
@@ -11,7 +11,7 @@ from . import documentation_constants
 public_api_schema = ExtendedSpecTree(
     "flask",
     title="Pass Culture REST API",
-    description="This the documentation of the Pass Culture public REST API",
+    description=documentation_constants.PUBLIC_API_DESCRIPTION,
     PATH="/",
     MODE="strict",
     version="1.0",

--- a/api/tests/routes/public/blueprint_openapi_test.py
+++ b/api/tests/routes/public/blueprint_openapi_test.py
@@ -31,6 +31,7 @@ def test_public_api_openapi_json(client):
     response = client.get("/openapi.json")
     assert response.status_code == 200
 
+    # To regenerate the expected JSON use the generate_openapi_json function
     expected = _get_expected_json()
 
     # Test paths key

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -1,11048 +1,11132 @@
 {
-  "components": {
-    "schemas": {
-      "ABO_BIBLIOTHEQUE_create": {
-        "description": "Abonnement (biblioth\u00e8ques, m\u00e9diath\u00e8ques...)", 
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_BIBLIOTHEQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "ABO_BIBLIOTHEQUE_create", 
-        "type": "object"
-      }, 
-      "ABO_BIBLIOTHEQUE_edit": {
-        "description": "Abonnement (biblioth\u00e8ques, m\u00e9diath\u00e8ques...)", 
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_BIBLIOTHEQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "ABO_BIBLIOTHEQUE_edit", 
-        "type": "object"
-      }, 
-      "ABO_BIBLIOTHEQUE_read": {
-        "description": "Abonnement (biblioth\u00e8ques, m\u00e9diath\u00e8ques...)", 
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_BIBLIOTHEQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "ABO_BIBLIOTHEQUE_read", 
-        "type": "object"
-      }, 
-      "ABO_CONCERT_create": {
-        "description": "Abonnement concert", 
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_CONCERT"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }
-        }, 
-        "required": [
-          "musicType",
-          "category"
-        ],
-        "title": "ABO_CONCERT_create",
-        "type": "object"
-      },
-      "ABO_CONCERT_edit": {
-        "description": "Abonnement concert",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_CONCERT"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_CONCERT_edit",
-        "type": "object"
-      },
-      "ABO_CONCERT_read": {
-        "description": "Abonnement concert",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_CONCERT"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_CONCERT_read",
-        "type": "object"
-      },
-      "ABO_JEU_VIDEO_read": {
-        "description": "Abonnement jeux vid\u00e9os",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_JEU_VIDEO"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_JEU_VIDEO_read",
-        "type": "object"
-      },
-      "ABO_LIVRE_NUMERIQUE_create": {
-        "description": "Abonnement livres num\u00e9riques",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_LIVRE_NUMERIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_LIVRE_NUMERIQUE_create",
-        "type": "object"
-      },
-      "ABO_LIVRE_NUMERIQUE_edit": {
-        "description": "Abonnement livres num\u00e9riques",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_LIVRE_NUMERIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_LIVRE_NUMERIQUE_edit",
-        "type": "object"
-      },
-      "ABO_LIVRE_NUMERIQUE_read": {
-        "description": "Abonnement livres num\u00e9riques",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_LIVRE_NUMERIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_LIVRE_NUMERIQUE_read",
-        "type": "object"
-      },
-      "ABO_LUDOTHEQUE_read": {
-        "description": "Abonnement ludoth\u00e8que",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_LUDOTHEQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_LUDOTHEQUE_read",
-        "type": "object"
-      },
-      "ABO_MEDIATHEQUE_create": {
-        "description": "Abonnement m\u00e9diath\u00e8que",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_MEDIATHEQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_MEDIATHEQUE_create",
-        "type": "object"
-      },
-      "ABO_MEDIATHEQUE_edit": {
-        "description": "Abonnement m\u00e9diath\u00e8que",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_MEDIATHEQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_MEDIATHEQUE_edit",
-        "type": "object"
-      },
-      "ABO_MEDIATHEQUE_read": {
-        "description": "Abonnement m\u00e9diath\u00e8que",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_MEDIATHEQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_MEDIATHEQUE_read",
-        "type": "object"
-      },
-      "ABO_PLATEFORME_MUSIQUE_create": {
-        "description": "Abonnement plateforme musicale",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PLATEFORME_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PLATEFORME_MUSIQUE_create",
-        "type": "object"
-      },
-      "ABO_PLATEFORME_MUSIQUE_edit": {
-        "description": "Abonnement plateforme musicale",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PLATEFORME_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PLATEFORME_MUSIQUE_edit",
-        "type": "object"
-      },
-      "ABO_PLATEFORME_MUSIQUE_read": {
-        "description": "Abonnement plateforme musicale",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PLATEFORME_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PLATEFORME_MUSIQUE_read",
-        "type": "object"
-      },
-      "ABO_PLATEFORME_VIDEO_create": {
-        "description": "Abonnement plateforme streaming",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PLATEFORME_VIDEO"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PLATEFORME_VIDEO_create",
-        "type": "object"
-      },
-      "ABO_PLATEFORME_VIDEO_edit": {
-        "description": "Abonnement plateforme streaming",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PLATEFORME_VIDEO"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PLATEFORME_VIDEO_edit",
-        "type": "object"
-      },
-      "ABO_PLATEFORME_VIDEO_read": {
-        "description": "Abonnement plateforme streaming",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PLATEFORME_VIDEO"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PLATEFORME_VIDEO_read",
-        "type": "object"
-      },
-      "ABO_PRATIQUE_ART_create": {
-        "description": "Abonnement pratique artistique",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PRATIQUE_ART"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PRATIQUE_ART_create",
-        "type": "object"
-      },
-      "ABO_PRATIQUE_ART_edit": {
-        "description": "Abonnement pratique artistique",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PRATIQUE_ART"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PRATIQUE_ART_edit",
-        "type": "object"
-      },
-      "ABO_PRATIQUE_ART_read": {
-        "description": "Abonnement pratique artistique",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PRATIQUE_ART"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PRATIQUE_ART_read",
-        "type": "object"
-      },
-      "ABO_PRESSE_EN_LIGNE_create": {
-        "description": "Abonnement presse en ligne",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PRESSE_EN_LIGNE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PRESSE_EN_LIGNE_create",
-        "type": "object"
-      },
-      "ABO_PRESSE_EN_LIGNE_edit": {
-        "description": "Abonnement presse en ligne",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PRESSE_EN_LIGNE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PRESSE_EN_LIGNE_edit",
-        "type": "object"
-      },
-      "ABO_PRESSE_EN_LIGNE_read": {
-        "description": "Abonnement presse en ligne",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_PRESSE_EN_LIGNE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_PRESSE_EN_LIGNE_read",
-        "type": "object"
-      },
-      "ABO_SPECTACLE_create": {
-        "description": "Abonnement spectacle",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_SPECTACLE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }
-        },
-        "required": [
-          "showType",
-          "category"
-        ],
-        "title": "ABO_SPECTACLE_create",
-        "type": "object"
-      },
-      "ABO_SPECTACLE_edit": {
-        "description": "Abonnement spectacle",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_SPECTACLE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_SPECTACLE_edit",
-        "type": "object"
-      },
-      "ABO_SPECTACLE_read": {
-        "description": "Abonnement spectacle",
-        "properties": {
-          "category": {
-            "enum": [
-              "ABO_SPECTACLE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ABO_SPECTACLE_read",
-        "type": "object"
-      },
-      "ACHAT_INSTRUMENT_create": {
-        "description": "Achat instrument",
-        "properties": {
-          "category": {
-            "enum": [
-              "ACHAT_INSTRUMENT"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "ean": {
-            "title": "Ean",
-            "type": "string"
-          }
-        },
-        "required": [
-          "ean",
-          "category"
-        ],
-        "title": "ACHAT_INSTRUMENT_create",
-        "type": "object"
-      },
-      "ACHAT_INSTRUMENT_edit": {
-        "description": "Achat instrument",
-        "properties": {
-          "category": {
-            "enum": [
-              "ACHAT_INSTRUMENT"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "ean": {
-            "title": "Ean",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ACHAT_INSTRUMENT_edit",
-        "type": "object"
-      },
-      "ACHAT_INSTRUMENT_read": {
-        "description": "Achat instrument",
-        "properties": {
-          "category": {
-            "enum": [
-              "ACHAT_INSTRUMENT"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "ean": {
-            "title": "Ean",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ACHAT_INSTRUMENT_read",
-        "type": "object"
-      },
-      "ACTIVATION_EVENT_read": {
-        "description": "Cat\u00e9gorie technique d'\u00e9v\u00e8nement d'activation ",
-        "properties": {
-          "category": {
-            "enum": [
-              "ACTIVATION_EVENT"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ACTIVATION_EVENT_read",
-        "type": "object"
-      },
-      "ACTIVATION_THING_read": {
-        "description": "Cat\u00e9gorie technique de thing d'activation",
-        "properties": {
-          "category": {
-            "enum": [
-              "ACTIVATION_THING"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ACTIVATION_THING_read",
-        "type": "object"
-      },
-      "APP_CULTURELLE_create": {
-        "description": "Application culturelle",
-        "properties": {
-          "category": {
-            "enum": [
-              "APP_CULTURELLE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "APP_CULTURELLE_create",
-        "type": "object"
-      },
-      "APP_CULTURELLE_edit": {
-        "description": "Application culturelle",
-        "properties": {
-          "category": {
-            "enum": [
-              "APP_CULTURELLE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "APP_CULTURELLE_edit",
-        "type": "object"
-      },
-      "APP_CULTURELLE_read": {
-        "description": "Application culturelle",
-        "properties": {
-          "category": {
-            "enum": [
-              "APP_CULTURELLE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "APP_CULTURELLE_read",
-        "type": "object"
-      },
-      "ATELIER_PRATIQUE_ART_create": {
-        "description": "Atelier, stage de pratique artistique",
-        "properties": {
-          "category": {
-            "enum": [
-              "ATELIER_PRATIQUE_ART"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "speaker": {
-            "title": "Speaker",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ATELIER_PRATIQUE_ART_create",
-        "type": "object"
-      },
-      "ATELIER_PRATIQUE_ART_edit": {
-        "description": "Atelier, stage de pratique artistique",
-        "properties": {
-          "category": {
-            "enum": [
-              "ATELIER_PRATIQUE_ART"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "speaker": {
-            "title": "Speaker",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ATELIER_PRATIQUE_ART_edit",
-        "type": "object"
-      },
-      "ATELIER_PRATIQUE_ART_read": {
-        "description": "Atelier, stage de pratique artistique",
-        "properties": {
-          "category": {
-            "enum": [
-              "ATELIER_PRATIQUE_ART"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "speaker": {
-            "title": "Speaker",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ATELIER_PRATIQUE_ART_read",
-        "type": "object"
-      },
-      "AUTRE_SUPPORT_NUMERIQUE_create": {
-        "description": "Autre support num\u00e9rique",
-        "properties": {
-          "category": {
-            "enum": [
-              "AUTRE_SUPPORT_NUMERIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "AUTRE_SUPPORT_NUMERIQUE_create",
-        "type": "object"
-      },
-      "AUTRE_SUPPORT_NUMERIQUE_edit": {
-        "description": "Autre support num\u00e9rique",
-        "properties": {
-          "category": {
-            "enum": [
-              "AUTRE_SUPPORT_NUMERIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "AUTRE_SUPPORT_NUMERIQUE_edit",
-        "type": "object"
-      },
-      "AUTRE_SUPPORT_NUMERIQUE_read": {
-        "description": "Autre support num\u00e9rique",
-        "properties": {
-          "category": {
-            "enum": [
-              "AUTRE_SUPPORT_NUMERIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "AUTRE_SUPPORT_NUMERIQUE_read",
-        "type": "object"
-      },
-      "Accessibility": {
-        "description": "Accessibility for people with disabilities.",
-        "properties": {
-          "audioDisabilityCompliant": {
-            "title": "Audiodisabilitycompliant",
-            "type": "boolean"
-          },
-          "mentalDisabilityCompliant": {
-            "title": "Mentaldisabilitycompliant",
-            "type": "boolean"
-          },
-          "motorDisabilityCompliant": {
-            "title": "Motordisabilitycompliant",
-            "type": "boolean"
-          },
-          "visualDisabilityCompliant": {
-            "title": "Visualdisabilitycompliant",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "audioDisabilityCompliant",
-          "mentalDisabilityCompliant",
-          "motorDisabilityCompliant",
-          "visualDisabilityCompliant"
-        ],
-        "title": "Accessibility",
-        "type": "object"
-      },
-      "AccessibilityResponse": {
-        "description": "Accessibility for people with disabilities.",
-        "properties": {
-          "audioDisabilityCompliant": {
-            "nullable": true,
-            "title": "Audiodisabilitycompliant",
-            "type": "boolean"
-          },
-          "mentalDisabilityCompliant": {
-            "nullable": true,
-            "title": "Mentaldisabilitycompliant",
-            "type": "boolean"
-          },
-          "motorDisabilityCompliant": {
-            "nullable": true,
-            "title": "Motordisabilitycompliant",
-            "type": "boolean"
-          },
-          "visualDisabilityCompliant": {
-            "nullable": true,
-            "title": "Visualdisabilitycompliant",
-            "type": "boolean"
-          }
-        },
-        "title": "AccessibilityResponse",
-        "type": "object"
-      },
-      "AuthErrorResponseModel": {
-        "properties": {
-          "errors": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "title": "Errors",
-            "type": "object"
-          }
-        },
-        "required": [
-          "errors"
-        ],
-        "title": "AuthErrorResponseModel",
-        "type": "object"
-      },
-      "BON_ACHAT_INSTRUMENT_read": {
-        "description": "Bon d'achat instrument",
-        "properties": {
-          "category": {
-            "enum": [
-              "BON_ACHAT_INSTRUMENT"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "BON_ACHAT_INSTRUMENT_read",
-        "type": "object"
-      },
-      "BookingStatus": {
-        "description": "An enumeration.",
-        "enum": [
-          "CONFIRMED",
-          "USED",
-          "CANCELLED",
-          "REIMBURSED"
-        ],
-        "title": "BookingStatus"
-      },
-      "CAPTATION_MUSIQUE_read": {
-        "description": "Captation musicale", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "CAPTATION_MUSIQUE"
-            ], 
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CAPTATION_MUSIQUE_read",
-        "type": "object"
-      },
-      "CARTE_CINE_ILLIMITE_read": {
-        "description": "Carte cin\u00e9ma illimit\u00e9",
-        "properties": {
-          "category": {
-            "enum": [
-              "CARTE_CINE_ILLIMITE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CARTE_CINE_ILLIMITE_read",
-        "type": "object"
-      },
-      "CARTE_CINE_MULTISEANCES_read": {
-        "description": "Carte cin\u00e9ma multi-s\u00e9ances",
-        "properties": {
-          "category": {
-            "enum": [
-              "CARTE_CINE_MULTISEANCES"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CARTE_CINE_MULTISEANCES_read",
-        "type": "object"
-      },
-      "CARTE_JEUNES_create": {
-        "description": "Carte jeunes",
-        "properties": {
-          "category": {
-            "enum": [
-              "CARTE_JEUNES"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CARTE_JEUNES_create",
-        "type": "object"
-      },
-      "CARTE_JEUNES_edit": {
-        "description": "Carte jeunes",
-        "properties": {
-          "category": {
-            "enum": [
-              "CARTE_JEUNES"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CARTE_JEUNES_edit",
-        "type": "object"
-      },
-      "CARTE_JEUNES_read": {
-        "description": "Carte jeunes",
-        "properties": {
-          "category": {
-            "enum": [
-              "CARTE_JEUNES"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CARTE_JEUNES_read",
-        "type": "object"
-      },
-      "CARTE_MUSEE_create": {
-        "description": "Abonnement mus\u00e9e, carte ou pass",
-        "properties": {
-          "category": {
-            "enum": [
-              "CARTE_MUSEE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CARTE_MUSEE_create",
-        "type": "object"
-      },
-      "CARTE_MUSEE_edit": {
-        "description": "Abonnement mus\u00e9e, carte ou pass",
-        "properties": {
-          "category": {
-            "enum": [
-              "CARTE_MUSEE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CARTE_MUSEE_edit",
-        "type": "object"
-      },
-      "CARTE_MUSEE_read": {
-        "description": "Abonnement mus\u00e9e, carte ou pass",
-        "properties": {
-          "category": {
-            "enum": [
-              "CARTE_MUSEE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CARTE_MUSEE_read",
-        "type": "object"
-      },
-      "CINE_PLEIN_AIR_create": {
-        "description": "Cin\u00e9ma plein air",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "CINE_PLEIN_AIR"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CINE_PLEIN_AIR_create",
-        "type": "object"
-      },
-      "CINE_PLEIN_AIR_edit": {
-        "description": "Cin\u00e9ma plein air",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "CINE_PLEIN_AIR"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CINE_PLEIN_AIR_edit",
-        "type": "object"
-      },
-      "CINE_PLEIN_AIR_read": {
-        "description": "Cin\u00e9ma plein air",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "CINE_PLEIN_AIR"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CINE_PLEIN_AIR_read",
-        "type": "object"
-      },
-      "CINE_VENTE_DISTANCE_read": {
-        "description": "Cin\u00e9ma vente \u00e0 distance",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "CINE_VENTE_DISTANCE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CINE_VENTE_DISTANCE_read",
-        "type": "object"
-      },
-      "CONCERT_create": {
-        "description": "Concert",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "CONCERT"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "musicType",
-          "category"
-        ],
-        "title": "CONCERT_create",
-        "type": "object"
-      },
-      "CONCERT_edit": {
-        "description": "Concert",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "CONCERT"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CONCERT_edit",
-        "type": "object"
-      },
-      "CONCERT_read": {
-        "description": "Concert",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "CONCERT"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CONCERT_read",
-        "type": "object"
-      },
-      "CONCOURS_create": {
-        "description": "Concours - jeux",
-        "properties": {
-          "category": {
-            "enum": [
-              "CONCOURS"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CONCOURS_create",
-        "type": "object"
-      },
-      "CONCOURS_edit": {
-        "description": "Concours - jeux",
-        "properties": {
-          "category": {
-            "enum": [
-              "CONCOURS"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CONCOURS_edit",
-        "type": "object"
-      },
-      "CONCOURS_read": {
-        "description": "Concours - jeux",
-        "properties": {
-          "category": {
-            "enum": [
-              "CONCOURS"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CONCOURS_read",
-        "type": "object"
-      },
-      "CONFERENCE_create": {
-        "description": "Conf\u00e9rence",
-        "properties": {
-          "category": {
-            "enum": [
-              "CONFERENCE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "speaker": {
-            "title": "Speaker",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CONFERENCE_create",
-        "type": "object"
-      },
-      "CONFERENCE_edit": {
-        "description": "Conf\u00e9rence",
-        "properties": {
-          "category": {
-            "enum": [
-              "CONFERENCE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "speaker": {
-            "title": "Speaker",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CONFERENCE_edit",
-        "type": "object"
-      },
-      "CONFERENCE_read": {
-        "description": "Conf\u00e9rence",
-        "properties": {
-          "category": {
-            "enum": [
-              "CONFERENCE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "speaker": {
-            "title": "Speaker",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "CONFERENCE_read",
-        "type": "object"
-      },
-      "CategoryEnum": {
-        "description": "An enumeration.",
-        "enum": [
-          "ABO_BIBLIOTHEQUE",
-          "ABO_CONCERT",
-          "ABO_LIVRE_NUMERIQUE",
-          "ABO_MEDIATHEQUE",
-          "ABO_PLATEFORME_MUSIQUE",
-          "ABO_PLATEFORME_VIDEO",
-          "ABO_PRATIQUE_ART",
-          "ABO_PRESSE_EN_LIGNE",
-          "ABO_SPECTACLE",
-          "ACHAT_INSTRUMENT",
-          "APP_CULTURELLE",
-          "AUTRE_SUPPORT_NUMERIQUE",
-          "CAPTATION_MUSIQUE",
-          "CARTE_JEUNES",
-          "CARTE_MUSEE",
-          "LIVRE_AUDIO_PHYSIQUE",
-          "LIVRE_NUMERIQUE",
-          "LOCATION_INSTRUMENT",
-          "PARTITION",
-          "PLATEFORME_PRATIQUE_ARTISTIQUE",
-          "PODCAST",
-          "PRATIQUE_ART_VENTE_DISTANCE",
-          "SPECTACLE_ENREGISTRE",
-          "SUPPORT_PHYSIQUE_FILM",
-          "TELECHARGEMENT_LIVRE_AUDIO",
-          "TELECHARGEMENT_MUSIQUE",
-          "VISITE_VIRTUELLE",
-          "VOD"
-        ],
-        "title": "CategoryEnum",
-        "type": "string"
-      },
-      "CollectiveBookingResponseModel": {
-        "properties": {
-          "cancellationLimitDate": {
-            "format": "date-time",
-            "nullable": true,
-            "title": "Cancellationlimitdate",
-            "type": "string"
-          },
-          "confirmationDate": {
-            "format": "date-time",
-            "nullable": true,
-            "title": "Confirmationdate",
-            "type": "string"
-          },
-          "dateCreated": {
-            "format": "date-time",
-            "title": "Datecreated",
-            "type": "string"
-          },
-          "dateUsed": {
-            "format": "date-time",
-            "nullable": true,
-            "title": "Dateused",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "reimbursementDate": {
-            "format": "date-time",
-            "nullable": true,
-            "title": "Reimbursementdate",
-            "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/CollectiveBookingStatus"
-          }
-        },
-        "required": [
-          "id",
-          "status",
-          "dateCreated"
-        ],
-        "title": "CollectiveBookingResponseModel",
-        "type": "object"
-      },
-      "CollectiveBookingStatus": {
-        "description": "An enumeration.",
-        "enum": [
-          "PENDING",
-          "CONFIRMED",
-          "USED",
-          "CANCELLED",
-          "REIMBURSED"
-        ],
-        "title": "CollectiveBookingStatus"
-      },
-      "CollectiveOffersCategoryResponseModel": {
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ],
-        "title": "CollectiveOffersCategoryResponseModel",
-        "type": "object"
-      },
-      "CollectiveOffersDomainResponseModel": {
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "nationalPrograms": {
-            "items": {
-              "$ref": "#/components/schemas/NationalProgramModel"
-            },
-            "title": "Nationalprograms",
-            "type": "array"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "nationalPrograms"
-        ],
-        "title": "CollectiveOffersDomainResponseModel",
-        "type": "object"
-      },
-      "CollectiveOffersEducationalInstitutionResponseModel": {
-        "properties": {
-          "city": {
-            "title": "City",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "institutionType": {
-            "title": "Institutiontype",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          },
-          "postalCode": {
-            "title": "Postalcode",
-            "type": "string"
-          },
-          "uai": {
-            "title": "Uai",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "uai",
-          "name",
-          "institutionType",
-          "city",
-          "postalCode"
-        ],
-        "title": "CollectiveOffersEducationalInstitutionResponseModel",
-        "type": "object"
-      },
-      "CollectiveOffersListCategoriesResponseModel": {
-        "items": {
-          "$ref": "#/components/schemas/CollectiveOffersCategoryResponseModel"
-        },
-        "title": "CollectiveOffersListCategoriesResponseModel",
-        "type": "array"
-      },
-      "CollectiveOffersListDomainsResponseModel": {
-        "items": {
-          "$ref": "#/components/schemas/CollectiveOffersDomainResponseModel"
-        },
-        "title": "CollectiveOffersListDomainsResponseModel",
-        "type": "array"
-      },
-      "CollectiveOffersListEducationalInstitutionResponseModel": {
-        "items": {
-          "$ref": "#/components/schemas/CollectiveOffersEducationalInstitutionResponseModel"
-        },
-        "title": "CollectiveOffersListEducationalInstitutionResponseModel",
-        "type": "array"
-      },
-      "CollectiveOffersListResponseModel": {
-        "items": {
-          "$ref": "#/components/schemas/CollectiveOffersResponseModel"
-        },
-        "title": "CollectiveOffersListResponseModel",
-        "type": "array"
-      },
-      "CollectiveOffersListStudentLevelsResponseModel": {
-        "items": {
-          "$ref": "#/components/schemas/CollectiveOffersStudentLevelResponseModel"
-        },
-        "title": "CollectiveOffersListStudentLevelsResponseModel",
-        "type": "array"
-      },
-      "CollectiveOffersListSubCategoriesResponseModel": {
-        "items": {
-          "$ref": "#/components/schemas/CollectiveOffersSubCategoryResponseModel"
-        },
-        "title": "CollectiveOffersListSubCategoriesResponseModel",
-        "type": "array"
-      },
-      "CollectiveOffersListVenuesResponseModel": {
-        "items": {
-          "$ref": "#/components/schemas/VenueResponse"
-        },
-        "title": "CollectiveOffersListVenuesResponseModel",
-        "type": "array"
-      },
-      "CollectiveOffersResponseModel": {
-        "properties": {
-          "beginningDatetime": {
-            "title": "Beginningdatetime",
-            "type": "string"
-          },
-          "bookings": {
-            "items": {
-              "$ref": "#/components/schemas/CollectiveBookingResponseModel"
-            },
-            "title": "Bookings",
-            "type": "array"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
-          },
-          "venueId": {
-            "title": "Venueid",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "beginningDatetime",
-          "status",
-          "venueId",
-          "bookings"
-        ],
-        "title": "CollectiveOffersResponseModel",
-        "type": "object"
-      },
-      "CollectiveOffersStudentLevelResponseModel": {
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ],
-        "title": "CollectiveOffersStudentLevelResponseModel",
-        "type": "object"
-      },
-      "CollectiveOffersSubCategoryResponseModel": {
-        "properties": {
-          "category": {
-            "title": "Category",
-            "type": "string"
-          },
-          "categoryId": {
-            "title": "Categoryid",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "label": {
-            "title": "Label",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "label",
-          "category",
-          "categoryId"
-        ],
-        "title": "CollectiveOffersSubCategoryResponseModel",
-        "type": "object"
-      },
-      "DECOUVERTE_METIERS_read": {
-        "description": "D\u00e9couverte des m\u00e9tiers",
-        "properties": {
-          "category": {
-            "enum": [
-              "DECOUVERTE_METIERS"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "speaker": {
-            "title": "Speaker",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "DECOUVERTE_METIERS_read",
-        "type": "object"
-      },
-      "DateCreation": {
-        "properties": {
-          "beginningDatetime": {
-            "description": "Timezone aware datetime of the event.",
-            "example": "2024-06-21T14:00:00+02:00",
-            "format": "date-time",
-            "title": "Beginningdatetime",
-            "type": "string"
-          },
-          "bookingLimitDatetime": {
-            "description": "Timezone aware datetime after which the offer can no longer be booked.",
-            "example": "2024-06-21T14:00:00+02:00",
-            "format": "date-time",
-            "title": "Bookinglimitdatetime",
-            "type": "string"
-          },
-          "priceCategoryId": {
-            "title": "Pricecategoryid",
-            "type": "integer"
-          },
-          "quantity": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "enum": [
-                  "unlimited"
+    "components": {
+        "schemas": {
+            "ABO_BIBLIOTHEQUE_create": {
+                "description": "Abonnement (biblioth\u00e8ques, m\u00e9diath\u00e8ques...)",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_BIBLIOTHEQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
                 ],
-                "type": "string"
-              }
-            ],
-            "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
-            "example": 10,
-            "title": "Quantity"
-          }
-        },
-        "required": [
-          "quantity",
-          "beginningDatetime",
-          "bookingLimitDatetime",
-          "priceCategoryId"
-        ],
-        "title": "DateCreation",
-        "type": "object"
-      },
-      "DateEdition": {
-        "additionalProperties": false,
-        "properties": {
-          "beginningDatetime": {
-            "description": "Timezone aware datetime of the event.",
-            "example": "2024-06-21T14:00:00+02:00",
-            "format": "date-time",
-            "nullable": true,
-            "title": "Beginningdatetime",
-            "type": "string"
-          },
-          "bookingLimitDatetime": {
-            "description": "Timezone aware datetime after which the offer can no longer be booked.",
-            "example": "2024-06-21T14:00:00+02:00",
-            "format": "date-time",
-            "nullable": true,
-            "title": "Bookinglimitdatetime",
-            "type": "string"
-          },
-          "priceCategoryId": {
-            "nullable": true,
-            "title": "Pricecategoryid",
-            "type": "integer"
-          },
-          "quantity": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "enum": [
-                  "unlimited"
+                "title": "ABO_BIBLIOTHEQUE_create",
+                "type": "object"
+            },
+            "ABO_BIBLIOTHEQUE_edit": {
+                "description": "Abonnement (biblioth\u00e8ques, m\u00e9diath\u00e8ques...)",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_BIBLIOTHEQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
                 ],
-                "type": "string"
-              }
-            ],
-            "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
-            "example": 10,
-            "nullable": true,
-            "title": "Quantity"
-          }
-        },
-        "title": "DateEdition",
-        "type": "object"
-      },
-      "DateResponse": {
-        "properties": {
-          "beginningDatetime": {
-            "description": "Timezone aware datetime of the event.",
-            "example": "2024-06-21T14:00:00+02:00",
-            "format": "date-time",
-            "title": "Beginningdatetime",
-            "type": "string"
-          },
-          "bookedQuantity": {
-            "description": "Number of bookings.",
-            "example": 0,
-            "title": "Bookedquantity",
-            "type": "integer"
-          },
-          "bookingLimitDatetime": {
-            "description": "Timezone aware datetime after which the offer can no longer be booked.",
-            "example": "2024-06-21T14:00:00+02:00",
-            "format": "date-time",
-            "title": "Bookinglimitdatetime",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "priceCategory": {
-            "$ref": "#/components/schemas/PriceCategoryResponse"
-          },
-          "quantity": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "enum": [
-                  "unlimited"
+                "title": "ABO_BIBLIOTHEQUE_edit",
+                "type": "object"
+            },
+            "ABO_BIBLIOTHEQUE_read": {
+                "description": "Abonnement (biblioth\u00e8ques, m\u00e9diath\u00e8ques...)",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_BIBLIOTHEQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
                 ],
-                "type": "string"
-              }
-            ],
-            "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
-            "example": 10,
-            "title": "Quantity"
-          }
-        },
-        "required": [
-          "bookingLimitDatetime",
-          "bookedQuantity",
-          "quantity",
-          "id",
-          "beginningDatetime",
-          "priceCategory"
-        ],
-        "title": "DateResponse",
-        "type": "object"
-      },
-      "DatesCreation": {
-        "additionalProperties": false,
-        "properties": {
-          "dates": {
-            "description": "Dates to add to the event. If there are different prices and quantity for the same date, you must add several date objects",
-            "items": {
-              "$ref": "#/components/schemas/DateCreation"
+                "title": "ABO_BIBLIOTHEQUE_read",
+                "type": "object"
             },
-            "title": "Dates",
-            "type": "array"
-          }
-        },
-        "required": [
-          "dates"
-        ],
-        "title": "DatesCreation",
-        "type": "object"
-      },
-      "DigitalLocation": {
-        "properties": {
-          "type": {
-            "default": "digital",
-            "enum": [
-              "digital"
-            ],
-            "title": "Type",
-            "type": "string"
-          },
-          "url": {
-            "description": "Link users will be redirected to after booking this offer. You may include '{token}', '{email}' and/or '{offerId}' in the URL, which will be replaced respectively by the booking token (use this token to confirm the offer - see API Contremarque), the email of the user who booked the offer and the created offer id",
-            "example": "https://example.com?token={token}&email={email}&offerId={offerId}",
-            "format": "uri",
-            "maxLength": 2083,
-            "minLength": 1,
-            "title": "Url",
-            "type": "string"
-          },
-          "venueId": {
-            "description": "List of venues is available at GET /offerer_venues",
-            "example": 1,
-            "title": "Venueid",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "venueId",
-          "url"
-        ],
-        "title": "DigitalLocation",
-        "type": "object"
-      },
-      "ESCAPE_GAME_read": {
-        "description": "Escape game",
-        "properties": {
-          "category": {
-            "enum": [
-              "ESCAPE_GAME"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "ESCAPE_GAME_read",
-        "type": "object"
-      },
-      "EVENEMENT_CINE_create": {
-        "description": "\u00c9v\u00e8nement cin\u00e9matographique",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "EVENEMENT_CINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_CINE_create",
-        "type": "object"
-      },
-      "EVENEMENT_CINE_edit": {
-        "description": "\u00c9v\u00e8nement cin\u00e9matographique",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "EVENEMENT_CINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_CINE_edit",
-        "type": "object"
-      },
-      "EVENEMENT_CINE_read": {
-        "description": "\u00c9v\u00e8nement cin\u00e9matographique",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "EVENEMENT_CINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_CINE_read",
-        "type": "object"
-      },
-      "EVENEMENT_JEU_create": {
-        "description": "\u00c9v\u00e8nements - jeux",
-        "properties": {
-          "category": {
-            "enum": [
-              "EVENEMENT_JEU"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_JEU_create",
-        "type": "object"
-      },
-      "EVENEMENT_JEU_edit": {
-        "description": "\u00c9v\u00e8nements - jeux",
-        "properties": {
-          "category": {
-            "enum": [
-              "EVENEMENT_JEU"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_JEU_edit",
-        "type": "object"
-      },
-      "EVENEMENT_JEU_read": {
-        "description": "\u00c9v\u00e8nements - jeux",
-        "properties": {
-          "category": {
-            "enum": [
-              "EVENEMENT_JEU"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_JEU_read",
-        "type": "object"
-      },
-      "EVENEMENT_MUSIQUE_create": {
-        "description": "Autre type d'\u00e9v\u00e8nement musical",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "EVENEMENT_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "musicType",
-          "category"
-        ],
-        "title": "EVENEMENT_MUSIQUE_create",
-        "type": "object"
-      },
-      "EVENEMENT_MUSIQUE_edit": {
-        "description": "Autre type d'\u00e9v\u00e8nement musical",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "EVENEMENT_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_MUSIQUE_edit",
-        "type": "object"
-      },
-      "EVENEMENT_MUSIQUE_read": {
-        "description": "Autre type d'\u00e9v\u00e8nement musical",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "EVENEMENT_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_MUSIQUE_read",
-        "type": "object"
-      },
-      "EVENEMENT_PATRIMOINE_create": {
-        "description": "\u00c9v\u00e8nement et atelier patrimoine",
-        "properties": {
-          "category": {
-            "enum": [
-              "EVENEMENT_PATRIMOINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_PATRIMOINE_create",
-        "type": "object"
-      },
-      "EVENEMENT_PATRIMOINE_edit": {
-        "description": "\u00c9v\u00e8nement et atelier patrimoine",
-        "properties": {
-          "category": {
-            "enum": [
-              "EVENEMENT_PATRIMOINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_PATRIMOINE_edit",
-        "type": "object"
-      },
-      "EVENEMENT_PATRIMOINE_read": {
-        "description": "\u00c9v\u00e8nement et atelier patrimoine",
-        "properties": {
-          "category": {
-            "enum": [
-              "EVENEMENT_PATRIMOINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "EVENEMENT_PATRIMOINE_read",
-        "type": "object"
-      },
-      "EacFormat": {
-        "description": "An enumeration.",
-        "enum": [
-          "Atelier de pratique",
-          "Concert",
-          "Conf\u00e9rence, rencontre",
-          "Festival, salon, congr\u00e8s",
-          "Projection audiovisuelle",
-          "Repr\u00e9sentation",
-          "Visite guid\u00e9e",
-          "Visite libre"
-        ],
-        "title": "EacFormat"
-      },
-      "ErrorResponseModel": {
-        "properties": {
-          "errors": {
-            "additionalProperties": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
+            "ABO_CONCERT_create": {
+                "description": "Abonnement concert",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_CONCERT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    }
+                },
+                "required": [
+                    "musicType",
+                    "category"
+                ],
+                "title": "ABO_CONCERT_create",
+                "type": "object"
             },
-            "title": "Errors",
-            "type": "object"
-          }
-        },
-        "required": [
-          "errors"
-        ],
-        "title": "ErrorResponseModel",
-        "type": "object"
-      },
-      "EventCategoryResponse": {
-        "properties": {
-          "conditionalFields": {
-            "additionalProperties": {
-              "type": "boolean"
+            "ABO_CONCERT_edit": {
+                "description": "Abonnement concert",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_CONCERT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_CONCERT_edit",
+                "type": "object"
             },
-            "description": "The keys are fields that should be set in the category_related_fields of an event. The values indicate whether their associated field is mandatory during event creation.",
-            "title": "Conditionalfields",
-            "type": "object"
-          },
-          "id": {
-            "$ref": "#/components/schemas/CategoryEnum"
-          }
-        },
-        "required": [
-          "id",
-          "conditionalFields"
-        ],
-        "title": "EventCategoryResponse",
-        "type": "object"
-      },
-      "EventOfferCreation": {
-        "additionalProperties": false,
-        "properties": {
-          "accessibility": {
-            "$ref": "#/components/schemas/Accessibility"
-          },
-          "bookingContact": {
-            "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
-            "format": "email",
-            "nullable": true,
-            "title": "Bookingcontact",
-            "type": "string"
-          },
-          "bookingEmail": {
-            "description": "Recipient email for notifications about bookings, cancellations, etc.",
-            "format": "email",
-            "nullable": true,
-            "title": "Bookingemail",
-            "type": "string"
-          },
-          "categoryRelatedFields": {
-            "description": "Cultural category the offer belongs to. According to the category, some fields may or must be specified.",
-            "discriminator": {
-              "mapping": {
-                "ATELIER_PRATIQUE_ART": "#/components/schemas/ATELIER_PRATIQUE_ART_create",
-                "CINE_PLEIN_AIR": "#/components/schemas/CINE_PLEIN_AIR_create",
-                "CONCERT": "#/components/schemas/CONCERT_create",
-                "CONCOURS": "#/components/schemas/CONCOURS_create",
-                "CONFERENCE": "#/components/schemas/CONFERENCE_create",
-                "EVENEMENT_CINE": "#/components/schemas/EVENEMENT_CINE_create",
-                "EVENEMENT_JEU": "#/components/schemas/EVENEMENT_JEU_create",
-                "EVENEMENT_MUSIQUE": "#/components/schemas/EVENEMENT_MUSIQUE_create",
-                "EVENEMENT_PATRIMOINE": "#/components/schemas/EVENEMENT_PATRIMOINE_create",
-                "FESTIVAL_ART_VISUEL": "#/components/schemas/FESTIVAL_ART_VISUEL_create",
-                "FESTIVAL_CINE": "#/components/schemas/FESTIVAL_CINE_create",
-                "FESTIVAL_LIVRE": "#/components/schemas/FESTIVAL_LIVRE_create",
-                "FESTIVAL_MUSIQUE": "#/components/schemas/FESTIVAL_MUSIQUE_create",
-                "FESTIVAL_SPECTACLE": "#/components/schemas/FESTIVAL_SPECTACLE_create",
-                "LIVESTREAM_EVENEMENT": "#/components/schemas/LIVESTREAM_EVENEMENT_create",
-                "LIVESTREAM_MUSIQUE": "#/components/schemas/LIVESTREAM_MUSIQUE_create",
-                "LIVESTREAM_PRATIQUE_ARTISTIQUE": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_create",
-                "RENCONTRE": "#/components/schemas/RENCONTRE_create",
-                "RENCONTRE_EN_LIGNE": "#/components/schemas/RENCONTRE_EN_LIGNE_create",
-                "RENCONTRE_JEU": "#/components/schemas/RENCONTRE_JEU_create",
-                "SALON": "#/components/schemas/SALON_create",
-                "SEANCE_CINE": "#/components/schemas/SEANCE_CINE_create",
-                "SEANCE_ESSAI_PRATIQUE_ART": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_create",
-                "SPECTACLE_REPRESENTATION": "#/components/schemas/SPECTACLE_REPRESENTATION_create",
-                "VISITE": "#/components/schemas/VISITE_create",
-                "VISITE_GUIDEE": "#/components/schemas/VISITE_GUIDEE_create"
-              },
-              "propertyName": "category"
+            "ABO_CONCERT_read": {
+                "description": "Abonnement concert",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_CONCERT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_CONCERT_read",
+                "type": "object"
             },
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ATELIER_PRATIQUE_ART_create"
-              },
-              {
-                "$ref": "#/components/schemas/CINE_PLEIN_AIR_create"
-              },
-              {
-                "$ref": "#/components/schemas/CONCERT_create"
-              },
-              {
-                "$ref": "#/components/schemas/CONCOURS_create"
-              },
-              {
-                "$ref": "#/components/schemas/CONFERENCE_create"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_CINE_create"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_JEU_create"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_MUSIQUE_create"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_PATRIMOINE_create"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_ART_VISUEL_create"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_CINE_create"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_LIVRE_create"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_MUSIQUE_create"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_SPECTACLE_create"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_EVENEMENT_create"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_MUSIQUE_create"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_create"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_EN_LIGNE_create"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_JEU_create"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_create"
-              },
-              {
-                "$ref": "#/components/schemas/SALON_create"
-              },
-              {
-                "$ref": "#/components/schemas/SEANCE_CINE_create"
-              },
-              {
-                "$ref": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_create"
-              },
-              {
-                "$ref": "#/components/schemas/SPECTACLE_REPRESENTATION_create"
-              },
-              {
-                "$ref": "#/components/schemas/VISITE_GUIDEE_create"
-              },
-              {
-                "$ref": "#/components/schemas/VISITE_create"
-              }
-            ],
-            "title": "Categoryrelatedfields"
-          },
-          "description": {
-            "description": "Offer description",
-            "example": "A great book for kids and old kids.",
-            "maxLength": 1000,
-            "nullable": true,
-            "title": "Description",
-            "type": "string"
-          },
-          "enableDoubleBookings": {
-            "default": false,
-            "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
-            "nullable": true,
-            "title": "Enabledoublebookings",
-            "type": "boolean"
-          },
-          "eventDuration": {
-            "description": "Event duration in minutes",
-            "example": 60,
-            "nullable": true,
-            "title": "Eventduration",
-            "type": "integer"
-          },
-          "externalTicketOfficeUrl": {
-            "description": "Link displayed to users wishing to book the offer but who do not have (anymore) credit.",
-            "example": "https://example.com",
-            "format": "uri",
-            "maxLength": 2083,
-            "minLength": 1,
-            "nullable": true,
-            "title": "Externalticketofficeurl",
-            "type": "string"
-          },
-          "hasTicket": {
-            "description": "Indicates whether the offer has an associated ticket. True if a ticket is available, False otherwise. To create an offer with tickets you must have developed the pass culture ticketing interface.",
-            "example": false,
-            "title": "Hasticket",
-            "type": "boolean"
-          },
-          "image": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ImageBody"
-              }
-            ],
-            "nullable": true,
-            "title": "ImageBody"
-          },
-          "itemCollectionDetails": {
-            "description": "Further information that will be provided to attendees to ease the offer collection.",
-            "example": "Opening hours, specific office, collection period, access code, email annoucement...",
-            "nullable": true,
-            "title": "Itemcollectiondetails",
-            "type": "string"
-          },
-          "location": {
-            "description": "Location where the offer will be available or will take place. The location type must be compatible with the category",
-            "discriminator": {
-              "mapping": {
-                "digital": "#/components/schemas/DigitalLocation",
-                "physical": "#/components/schemas/PhysicalLocation"
-              },
-              "propertyName": "type"
+            "ABO_JEU_VIDEO_read": {
+                "description": "Abonnement jeux vid\u00e9os",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_JEU_VIDEO"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_JEU_VIDEO_read",
+                "type": "object"
             },
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PhysicalLocation"
-              },
-              {
-                "$ref": "#/components/schemas/DigitalLocation"
-              }
-            ],
-            "title": "Location"
-          },
-          "name": {
-            "description": "Offer title",
-            "example": "Le Petit Prince",
-            "maxLength": 90,
-            "title": "Name",
-            "type": "string"
-          },
-          "priceCategories": {
-            "description": "Available price categories for dates of this offer",
-            "items": {
-              "$ref": "#/components/schemas/PriceCategoryCreation"
+            "ABO_LIVRE_NUMERIQUE_create": {
+                "description": "Abonnement livres num\u00e9riques",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_LIVRE_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_LIVRE_NUMERIQUE_create",
+                "type": "object"
             },
-            "nullable": true,
-            "title": "Pricecategories",
-            "type": "array"
-          }
-        },
-        "required": [
-          "accessibility",
-          "categoryRelatedFields",
-          "name",
-          "location",
-          "hasTicket"
-        ],
-        "title": "EventOfferCreation",
-        "type": "object"
-      },
-      "EventOfferEdition": {
-        "additionalProperties": false,
-        "properties": {
-          "accessibility": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PartialAccessibility"
-              }
-            ],
-            "description": "Accessibility to disabled people. Leave fields undefined to keep current value",
-            "nullable": true,
-            "title": "Accessibility"
-          },
-          "bookingContact": {
-            "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
-            "format": "email",
-            "nullable": true,
-            "title": "Bookingcontact",
-            "type": "string"
-          },
-          "bookingEmail": {
-            "description": "Recipient email for notifications about bookings, cancellations, etc.",
-            "format": "email",
-            "nullable": true,
-            "title": "Bookingemail",
-            "type": "string"
-          },
-          "categoryRelatedFields": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ATELIER_PRATIQUE_ART_edit"
-              },
-              {
-                "$ref": "#/components/schemas/CINE_PLEIN_AIR_edit"
-              },
-              {
-                "$ref": "#/components/schemas/CONCERT_edit"
-              },
-              {
-                "$ref": "#/components/schemas/CONCOURS_edit"
-              },
-              {
-                "$ref": "#/components/schemas/CONFERENCE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_CINE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_JEU_edit"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_MUSIQUE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_PATRIMOINE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_ART_VISUEL_edit"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_CINE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_LIVRE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_MUSIQUE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_SPECTACLE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_EVENEMENT_edit"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_MUSIQUE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_EN_LIGNE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_JEU_edit"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/SALON_edit"
-              },
-              {
-                "$ref": "#/components/schemas/SEANCE_CINE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_edit"
-              },
-              {
-                "$ref": "#/components/schemas/SPECTACLE_REPRESENTATION_edit"
-              },
-              {
-                "$ref": "#/components/schemas/VISITE_GUIDEE_edit"
-              },
-              {
-                "$ref": "#/components/schemas/VISITE_edit"
-              }
-            ],
-            "description": "To override category related fields, the category must be specified, even if it cannot be changed. Other category related fields may be left undefined to keep their current value.",
-            "nullable": true,
-            "title": "Categoryrelatedfields"
-          },
-          "description": {
-            "description": "Offer description",
-            "example": "A great book for kids and old kids.",
-            "maxLength": 1000,
-            "nullable": true,
-            "title": "Description",
-            "type": "string"
-          },
-          "enableDoubleBookings": {
-            "default": false,
-            "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
-            "nullable": true,
-            "title": "Enabledoublebookings",
-            "type": "boolean"
-          },
-          "eventDuration": {
-            "description": "Event duration in minutes",
-            "example": 60,
-            "nullable": true,
-            "title": "Eventduration",
-            "type": "integer"
-          },
-          "image": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ImageBody"
-              }
-            ],
-            "nullable": true,
-            "title": "ImageBody"
-          },
-          "isActive": {
-            "description": "Whether the offer is activated. An inactive offer cannot be booked.",
-            "nullable": true,
-            "title": "Isactive",
-            "type": "boolean"
-          },
-          "itemCollectionDetails": {
-            "description": "Further information that will be provided to attendees to ease the offer collection.",
-            "example": "Opening hours, specific office, collection period, access code, email annoucement...",
-            "nullable": true,
-            "title": "Itemcollectiondetails",
-            "type": "string"
-          }
-        },
-        "title": "EventOfferEdition",
-        "type": "object"
-      },
-      "EventOfferResponse": {
-        "properties": {
-          "accessibility": {
-            "$ref": "#/components/schemas/AccessibilityResponse"
-          },
-          "bookingContact": {
-            "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
-            "nullable": true,
-            "title": "Bookingcontact",
-            "type": "string"
-          },
-          "bookingEmail": {
-            "description": "Recipient email for notifications about bookings, cancellations, etc.",
-            "nullable": true,
-            "title": "Bookingemail",
-            "type": "string"
-          },
-          "categoryRelatedFields": {
-            "description": "Cultural category the offer belongs to. According to the category, some fields may or must be specified.",
-            "discriminator": {
-              "mapping": {
-                "ACTIVATION_EVENT": "#/components/schemas/ACTIVATION_EVENT_read",
-                "ATELIER_PRATIQUE_ART": "#/components/schemas/ATELIER_PRATIQUE_ART_read",
-                "CINE_PLEIN_AIR": "#/components/schemas/CINE_PLEIN_AIR_read",
-                "CONCERT": "#/components/schemas/CONCERT_read",
-                "CONCOURS": "#/components/schemas/CONCOURS_read",
-                "CONFERENCE": "#/components/schemas/CONFERENCE_read",
-                "DECOUVERTE_METIERS": "#/components/schemas/DECOUVERTE_METIERS_read",
-                "EVENEMENT_CINE": "#/components/schemas/EVENEMENT_CINE_read",
-                "EVENEMENT_JEU": "#/components/schemas/EVENEMENT_JEU_read",
-                "EVENEMENT_MUSIQUE": "#/components/schemas/EVENEMENT_MUSIQUE_read",
-                "EVENEMENT_PATRIMOINE": "#/components/schemas/EVENEMENT_PATRIMOINE_read",
-                "FESTIVAL_ART_VISUEL": "#/components/schemas/FESTIVAL_ART_VISUEL_read",
-                "FESTIVAL_CINE": "#/components/schemas/FESTIVAL_CINE_read",
-                "FESTIVAL_LIVRE": "#/components/schemas/FESTIVAL_LIVRE_read",
-                "FESTIVAL_MUSIQUE": "#/components/schemas/FESTIVAL_MUSIQUE_read",
-                "FESTIVAL_SPECTACLE": "#/components/schemas/FESTIVAL_SPECTACLE_read",
-                "LIVESTREAM_EVENEMENT": "#/components/schemas/LIVESTREAM_EVENEMENT_read",
-                "LIVESTREAM_MUSIQUE": "#/components/schemas/LIVESTREAM_MUSIQUE_read",
-                "LIVESTREAM_PRATIQUE_ARTISTIQUE": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_read",
-                "RENCONTRE": "#/components/schemas/RENCONTRE_read",
-                "RENCONTRE_EN_LIGNE": "#/components/schemas/RENCONTRE_EN_LIGNE_read",
-                "RENCONTRE_JEU": "#/components/schemas/RENCONTRE_JEU_read",
-                "SALON": "#/components/schemas/SALON_read",
-                "SEANCE_CINE": "#/components/schemas/SEANCE_CINE_read",
-                "SEANCE_ESSAI_PRATIQUE_ART": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_read",
-                "SPECTACLE_REPRESENTATION": "#/components/schemas/SPECTACLE_REPRESENTATION_read",
-                "VISITE": "#/components/schemas/VISITE_read",
-                "VISITE_GUIDEE": "#/components/schemas/VISITE_GUIDEE_read"
-              },
-              "propertyName": "category"
+            "ABO_LIVRE_NUMERIQUE_edit": {
+                "description": "Abonnement livres num\u00e9riques",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_LIVRE_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_LIVRE_NUMERIQUE_edit",
+                "type": "object"
             },
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ACTIVATION_EVENT_read"
-              },
-              {
-                "$ref": "#/components/schemas/ATELIER_PRATIQUE_ART_read"
-              },
-              {
-                "$ref": "#/components/schemas/CINE_PLEIN_AIR_read"
-              },
-              {
-                "$ref": "#/components/schemas/CONCERT_read"
-              },
-              {
-                "$ref": "#/components/schemas/CONCOURS_read"
-              },
-              {
-                "$ref": "#/components/schemas/CONFERENCE_read"
-              },
-              {
-                "$ref": "#/components/schemas/DECOUVERTE_METIERS_read"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_CINE_read"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_JEU_read"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_MUSIQUE_read"
-              },
-              {
-                "$ref": "#/components/schemas/EVENEMENT_PATRIMOINE_read"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_ART_VISUEL_read"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_CINE_read"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_LIVRE_read"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_MUSIQUE_read"
-              },
-              {
-                "$ref": "#/components/schemas/FESTIVAL_SPECTACLE_read"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_EVENEMENT_read"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_MUSIQUE_read"
-              },
-              {
-                "$ref": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_read"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_EN_LIGNE_read"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_JEU_read"
-              },
-              {
-                "$ref": "#/components/schemas/RENCONTRE_read"
-              },
-              {
-                "$ref": "#/components/schemas/SALON_read"
-              },
-              {
-                "$ref": "#/components/schemas/SEANCE_CINE_read"
-              },
-              {
-                "$ref": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_read"
-              },
-              {
-                "$ref": "#/components/schemas/SPECTACLE_REPRESENTATION_read"
-              },
-              {
-                "$ref": "#/components/schemas/VISITE_GUIDEE_read"
-              },
-              {
-                "$ref": "#/components/schemas/VISITE_read"
-              }
-            ],
-            "title": "Categoryrelatedfields"
-          },
-          "description": {
-            "description": "Offer description",
-            "example": "A great book for kids and old kids.",
-            "nullable": true,
-            "title": "Description",
-            "type": "string"
-          },
-          "enableDoubleBookings": {
-            "default": false,
-            "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
-            "nullable": true,
-            "title": "Enabledoublebookings",
-            "type": "boolean"
-          },
-          "eventDuration": {
-            "description": "Event duration in minutes",
-            "example": 60,
-            "nullable": true,
-            "title": "Eventduration",
-            "type": "integer"
-          },
-          "externalTicketOfficeUrl": {
-            "description": "Link displayed to users wishing to book the offer but who do not have (anymore) credit.",
-            "example": "https://example.com",
-            "nullable": true,
-            "title": "Externalticketofficeurl",
-            "type": "string"
-          },
-          "hasTicket": {
-            "description": "Indicates whether the offer has an associated ticket. True if a ticket is available, False otherwise. To create an offer with tickets you must have developed the pass culture ticketing interface.",
-            "example": false,
-            "title": "Hasticket",
-            "type": "boolean"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "image": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ImageResponse"
-              }
-            ],
-            "nullable": true,
-            "title": "ImageResponse"
-          },
-          "itemCollectionDetails": {
-            "description": "Further information that will be provided to attendees to ease the offer collection.",
-            "example": "Opening hours, specific office, collection period, access code, email annoucement...",
-            "nullable": true,
-            "title": "Itemcollectiondetails",
-            "type": "string"
-          },
-          "location": {
-            "description": "Location where the offer will be available or will take place. The location type must be compatible with the category",
-            "discriminator": {
-              "mapping": {
-                "digital": "#/components/schemas/DigitalLocation",
-                "physical": "#/components/schemas/PhysicalLocation"
-              },
-              "propertyName": "type"
+            "ABO_LIVRE_NUMERIQUE_read": {
+                "description": "Abonnement livres num\u00e9riques",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_LIVRE_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_LIVRE_NUMERIQUE_read",
+                "type": "object"
             },
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PhysicalLocation"
-              },
-              {
-                "$ref": "#/components/schemas/DigitalLocation"
-              }
-            ],
-            "title": "Location"
-          },
-          "name": {
-            "description": "Offer title",
-            "example": "Le Petit Prince",
-            "maxLength": 90,
-            "title": "Name",
-            "type": "string"
-          },
-          "priceCategories": {
-            "description": "Available price categories for dates of this offer",
-            "items": {
-              "$ref": "#/components/schemas/PriceCategoryResponse"
+            "ABO_LUDOTHEQUE_read": {
+                "description": "Abonnement ludoth\u00e8que",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_LUDOTHEQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_LUDOTHEQUE_read",
+                "type": "object"
             },
-            "title": "Pricecategories",
-            "type": "array"
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OfferStatus"
-              }
-            ],
-            "description": "ACTIVE: offer is validated and active.\n\nDRAFT: offer is still draft and not yet submitted for validation - this status is not applicable to offers created via this API.\n\nEXPIRED: offer is validated but the booking limit datetime has passed.\n\nINACTIVE: offer is not active and cannot be booked.\n\nPENDING: offer is pending for pass Culture rules compliance validation. This step may last 72 hours.\n\nREJECTED: offer validation has been rejected because it is not compliant with pass Culture rules.\n\nSOLD_OUT: offer is validated but there is no (more) stock available for booking.",
-            "example": "ACTIVE"
-          }
-        },
-        "required": [
-          "priceCategories",
-          "id",
-          "accessibility",
-          "location",
-          "name",
-          "status",
-          "categoryRelatedFields",
-          "hasTicket"
-        ],
-        "title": "EventOfferResponse",
-        "type": "object"
-      },
-      "EventOffersResponse": {
-        "properties": {
-          "events": {
-            "items": {
-              "$ref": "#/components/schemas/EventOfferResponse"
+            "ABO_MEDIATHEQUE_create": {
+                "description": "Abonnement m\u00e9diath\u00e8que",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_MEDIATHEQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_MEDIATHEQUE_create",
+                "type": "object"
             },
-            "title": "Events",
-            "type": "array"
-          }
-        },
-        "required": [
-          "events"
-        ],
-        "title": "EventOffersResponse",
-        "type": "object"
-      },
-      "FESTIVAL_ART_VISUEL_create": {
-        "description": "Festival d'arts visuels / arts num\u00e9riques",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_ART_VISUEL"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_ART_VISUEL_create",
-        "type": "object"
-      },
-      "FESTIVAL_ART_VISUEL_edit": {
-        "description": "Festival d'arts visuels / arts num\u00e9riques",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_ART_VISUEL"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_ART_VISUEL_edit",
-        "type": "object"
-      },
-      "FESTIVAL_ART_VISUEL_read": {
-        "description": "Festival d'arts visuels / arts num\u00e9riques",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_ART_VISUEL"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_ART_VISUEL_read",
-        "type": "object"
-      },
-      "FESTIVAL_CINE_create": {
-        "description": "Festival de cin\u00e9ma",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_CINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_CINE_create",
-        "type": "object"
-      },
-      "FESTIVAL_CINE_edit": {
-        "description": "Festival de cin\u00e9ma",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_CINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_CINE_edit",
-        "type": "object"
-      },
-      "FESTIVAL_CINE_read": {
-        "description": "Festival de cin\u00e9ma",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_CINE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          },
-          "visa": {
-            "title": "Visa",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_CINE_read",
-        "type": "object"
-      },
-      "FESTIVAL_LIVRE_create": {
-        "description": "Festival et salon du livre",
-        "properties": {
-          "category": {
-            "enum": [
-              "FESTIVAL_LIVRE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_LIVRE_create",
-        "type": "object"
-      },
-      "FESTIVAL_LIVRE_edit": {
-        "description": "Festival et salon du livre",
-        "properties": {
-          "category": {
-            "enum": [
-              "FESTIVAL_LIVRE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_LIVRE_edit",
-        "type": "object"
-      },
-      "FESTIVAL_LIVRE_read": {
-        "description": "Festival et salon du livre",
-        "properties": {
-          "category": {
-            "enum": [
-              "FESTIVAL_LIVRE"
-            ],
-            "title": "Category",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_LIVRE_read",
-        "type": "object"
-      },
-      "FESTIVAL_MUSIQUE_create": {
-        "description": "Festival de musique",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "musicType",
-          "category"
-        ],
-        "title": "FESTIVAL_MUSIQUE_create",
-        "type": "object"
-      },
-      "FESTIVAL_MUSIQUE_edit": {
-        "description": "Festival de musique",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_MUSIQUE_edit",
-        "type": "object"
-      },
-      "FESTIVAL_MUSIQUE_read": {
-        "description": "Festival de musique",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_MUSIQUE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              },
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ],
-            "title": "Musictype"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          }
-        },
-        "required": [
-          "category"
-        ],
-        "title": "FESTIVAL_MUSIQUE_read",
-        "type": "object"
-      },
-      "FESTIVAL_SPECTACLE_create": {
-        "description": "Festival de spectacle vivant",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_SPECTACLE"
-            ],
-            "title": "Category",
-            "type": "string"
-          },
-          "performer": {
-            "title": "Performer",
-            "type": "string"
-          },
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          },
-          "stageDirector": {
-            "title": "Stagedirector",
-            "type": "string"
-          }
-        },
-        "required": [
-          "showType",
-          "category"
-        ],
-        "title": "FESTIVAL_SPECTACLE_create",
-        "type": "object"
-      },
-      "FESTIVAL_SPECTACLE_edit": {
-        "description": "Festival de spectacle vivant",
-        "properties": {
-          "author": {
-            "title": "Author",
-            "type": "string"
-          },
-          "category": {
-            "enum": [
-              "FESTIVAL_SPECTACLE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "FESTIVAL_SPECTACLE_edit", 
-        "type": "object"
-      }, 
-      "FESTIVAL_SPECTACLE_read": {
-        "description": "Festival de spectacle vivant", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "FESTIVAL_SPECTACLE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "FESTIVAL_SPECTACLE_read", 
-        "type": "object"
-      }, 
-      "GetBookingResponse": {
-        "properties": {
-          "confirmationDate": {
-            "description": "For event offers, deadline for cancellation by the beneficiary.", 
-            "nullable": true, 
-            "title": "Confirmationdate", 
-            "type": "string"
-          }, 
-          "creationDate": {
-            "title": "Creationdate", 
-            "type": "string"
-          }, 
-          "id": {
-            "title": "Id", 
-            "type": "integer"
-          }, 
-          "offerEan": {
-            "nullable": true, 
-            "title": "Offerean", 
-            "type": "string"
-          }, 
-          "offerId": {
-            "title": "Offerid", 
-            "type": "integer"
-          }, 
-          "offerName": {
-            "title": "Offername", 
-            "type": "string"
-          }, 
-          "price": {
-            "title": "Price", 
-            "type": "integer"
-          }, 
-          "priceCategoryId": {
-            "nullable": true, 
-            "title": "Pricecategoryid", 
-            "type": "integer"
-          }, 
-          "priceCategoryLabel": {
-            "nullable": true, 
-            "title": "Pricecategorylabel", 
-            "type": "string"
-          }, 
-          "quantity": {
-            "title": "Quantity", 
-            "type": "integer"
-          }, 
-          "status": {
-            "$ref": "#/components/schemas/BookingStatus"
-          }, 
-          "stockId": {
-            "title": "Stockid", 
-            "type": "integer"
-          }, 
-          "userBirthDate": {
-            "nullable": true, 
-            "title": "Userbirthdate", 
-            "type": "string"
-          }, 
-          "userEmail": {
-            "title": "Useremail", 
-            "type": "string"
-          }, 
-          "userFirstName": {
-            "nullable": true, 
-            "title": "Userfirstname", 
-            "type": "string"
-          }, 
-          "userLastName": {
-            "nullable": true, 
-            "title": "Userlastname", 
-            "type": "string"
-          }, 
-          "userPhoneNumber": {
-            "nullable": true, 
-            "title": "Userphonenumber", 
-            "type": "string"
-          }, 
-          "userPostalCode": {
-            "nullable": true, 
-            "title": "Userpostalcode", 
-            "type": "string"
-          }, 
-          "venueAddress": {
-            "title": "Venueaddress", 
-            "type": "string"
-          }, 
-          "venueDepartementCode": {
-            "title": "Venuedepartementcode", 
-            "type": "string"
-          }, 
-          "venueId": {
-            "title": "Venueid", 
-            "type": "integer"
-          }, 
-          "venueName": {
-            "title": "Venuename", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "id", 
-          "quantity", 
-          "creationDate", 
-          "price", 
-          "status", 
-          "offerId", 
-          "stockId", 
-          "offerName", 
-          "venueId", 
-          "venueName", 
-          "venueAddress", 
-          "venueDepartementCode", 
-          "userEmail"
-        ], 
-        "title": "GetBookingResponse", 
-        "type": "object"
-      }, 
-      "GetDatesQueryParams": {
-        "properties": {
-          "firstIndex": {
-            "default": 1, 
-            "description": "Index of the first item in page.", 
-            "minimum": 1, 
-            "title": "Firstindex", 
-            "type": "integer"
-          }, 
-          "limit": {
-            "default": 50, 
-            "description": "Maximum number of items per page.", 
-            "exclusiveMinimum": 0, 
-            "maximum": 50, 
-            "title": "Limit", 
-            "type": "integer"
-          }
-        }, 
-        "title": "GetDatesQueryParams", 
-        "type": "object"
-      }, 
-      "GetDatesResponse": {
-        "properties": {
-          "dates": {
-            "items": {
-              "$ref": "#/components/schemas/DateResponse"
-            }, 
-            "title": "Dates", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "dates"
-        ], 
-        "title": "GetDatesResponse", 
-        "type": "object"
-      }, 
-      "GetEventCategoriesResponse": {
-        "items": {
-          "$ref": "#/components/schemas/EventCategoryResponse"
-        }, 
-        "title": "GetEventCategoriesResponse", 
-        "type": "array"
-      }, 
-      "GetFilteredBookingsRequest": {
-        "properties": {
-          "beginningDatetime": {
-            "description": "Timezone aware datetime of the event.", 
-            "format": "date-time", 
-            "nullable": true, 
-            "title": "Beginningdatetime", 
-            "type": "string"
-          }, 
-          "firstIndex": {
-            "default": 1, 
-            "description": "Index of the first item in page.", 
-            "minimum": 1, 
-            "title": "Firstindex", 
-            "type": "integer"
-          }, 
-          "limit": {
-            "default": 50, 
-            "description": "Maximum number of items per page.", 
-            "exclusiveMinimum": 0, 
-            "maximum": 50, 
-            "title": "Limit", 
-            "type": "integer"
-          }, 
-          "offerId": {
-            "description": "Id of the bookings' offer.", 
-            "title": "Offerid", 
-            "type": "integer"
-          }, 
-          "priceCategoryId": {
-            "description": "Price category of the bookings' stock.", 
-            "nullable": true, 
-            "title": "Pricecategoryid", 
-            "type": "integer"
-          }, 
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BookingStatus"
-              }
-            ], 
-            "description": "Booking Status.\n\n* `CONFIRMED`: The bookings is confirmed.\n* `USED`: The bookings has been used.\n* `CANCELLED`: The bookings has been cancelled.\n* `REIMBURSED` The bookings has been reimbursed.", 
-            "nullable": true
-          }, 
-          "stockId": {
-            "description": "Id of the bookings' stock.", 
-            "nullable": true, 
-            "title": "Stockid", 
-            "type": "integer"
-          }
-        }, 
-        "required": [
-          "offerId"
-        ], 
-        "title": "GetFilteredBookingsRequest", 
-        "type": "object"
-      }, 
-      "GetFilteredBookingsResponse": {
-        "properties": {
-          "bookings": {
-            "items": {
-              "$ref": "#/components/schemas/GetBookingResponse"
-            }, 
-            "title": "Bookings", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "bookings"
-        ], 
-        "title": "GetFilteredBookingsResponse", 
-        "type": "object"
-      }, 
-      "GetListEducationalInstitutionsQueryModel": {
-        "additionalProperties": false, 
-        "properties": {
-          "city": {
-            "nullable": true, 
-            "title": "City", 
-            "type": "string"
-          }, 
-          "id": {
-            "nullable": true, 
-            "title": "Id", 
-            "type": "integer"
-          }, 
-          "institutionType": {
-            "nullable": true, 
-            "title": "Institutiontype", 
-            "type": "string"
-          }, 
-          "limit": {
-            "default": 20, 
-            "title": "Limit", 
-            "type": "integer"
-          }, 
-          "name": {
-            "nullable": true, 
-            "title": "Name", 
-            "type": "string"
-          }, 
-          "postalCode": {
-            "nullable": true, 
-            "title": "Postalcode", 
-            "type": "string"
-          }, 
-          "uai": {
-            "nullable": true, 
-            "title": "Uai", 
-            "type": "string"
-          }
-        }, 
-        "title": "GetListEducationalInstitutionsQueryModel", 
-        "type": "object"
-      }, 
-      "GetMusicTypesResponse": {
-        "items": {
-          "anyOf": [
-            {
-              "$ref": "#/components/schemas/MusicTypeResponse"
-            }, 
-            {
-              "$ref": "#/components/schemas/TiteliveMusicTypeResponse"
-            }
-          ]
-        }, 
-        "title": "GetMusicTypesResponse", 
-        "type": "array"
-      }, 
-      "GetOffererVenuesResponse": {
-        "properties": {
-          "offerer": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OffererResponse"
-              }
-            ], 
-            "description": "Offerer to which the venues belong. Entity linked to the api key used.", 
-            "title": "Offerer"
-          }, 
-          "venues": {
-            "items": {
-              "$ref": "#/components/schemas/VenueResponse"
-            }, 
-            "title": "Venues", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "offerer", 
-          "venues"
-        ], 
-        "title": "GetOffererVenuesResponse", 
-        "type": "object"
-      }, 
-      "GetOfferersVenuesQuery": {
-        "properties": {
-          "siren": {
-            "example": "123456789", 
-            "nullable": true, 
-            "pattern": "^\\d{9}$", 
-            "title": "Siren", 
-            "type": "string"
-          }
-        }, 
-        "title": "GetOfferersVenuesQuery", 
-        "type": "object"
-      }, 
-      "GetOfferersVenuesResponse": {
-        "items": {
-          "$ref": "#/components/schemas/GetOffererVenuesResponse"
-        }, 
-        "title": "GetOfferersVenuesResponse", 
-        "type": "array"
-      }, 
-      "GetOffersQueryParams": {
-        "properties": {
-          "firstIndex": {
-            "default": 1, 
-            "description": "Index of the first item in page.", 
-            "minimum": 1, 
-            "title": "Firstindex", 
-            "type": "integer"
-          }, 
-          "limit": {
-            "default": 50, 
-            "description": "Maximum number of items per page.", 
-            "exclusiveMinimum": 0, 
-            "maximum": 50, 
-            "title": "Limit", 
-            "type": "integer"
-          }, 
-          "venueId": {
-            "description": "Venue id to filter offers on.", 
-            "title": "Venueid", 
-            "type": "integer"
-          }
-        }, 
-        "required": [
-          "venueId"
-        ], 
-        "title": "GetOffersQueryParams", 
-        "type": "object"
-      }, 
-      "GetProductCategoriesResponse": {
-        "items": {
-          "$ref": "#/components/schemas/ProductCategoryResponse"
-        }, 
-        "title": "GetProductCategoriesResponse", 
-        "type": "array"
-      }, 
-      "GetProductsListByEansQuery": {
-        "properties": {
-          "eans": {
-            "example": "0123456789123,0123456789124", 
-            "title": "Eans", 
-            "type": "string"
-          }, 
-          "venueId": {
-            "example": 1, 
-            "title": "Venueid", 
-            "type": "integer"
-          }
-        }, 
-        "required": [
-          "eans", 
-          "venueId"
-        ], 
-        "title": "GetProductsListByEansQuery", 
-        "type": "object"
-      }, 
-      "GetPublicCollectiveOfferResponseModel": {
-        "additionalProperties": false, 
-        "properties": {
-          "audioDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Audiodisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "beginningDatetime": {
-            "title": "Beginningdatetime", 
-            "type": "string"
-          }, 
-          "bookingEmails": {
-            "items": {
-              "type": "string"
-            }, 
-            "nullable": true, 
-            "title": "Bookingemails", 
-            "type": "array"
-          }, 
-          "bookingLimitDatetime": {
-            "title": "Bookinglimitdatetime", 
-            "type": "string"
-          }, 
-          "bookings": {
-            "items": {
-              "$ref": "#/components/schemas/CollectiveBookingResponseModel"
-            }, 
-            "title": "Bookings", 
-            "type": "array"
-          }, 
-          "contactEmail": {
-            "title": "Contactemail", 
-            "type": "string"
-          }, 
-          "contactPhone": {
-            "title": "Contactphone", 
-            "type": "string"
-          }, 
-          "dateCreated": {
-            "title": "Datecreated", 
-            "type": "string"
-          }, 
-          "description": {
-            "nullable": true, 
-            "title": "Description", 
-            "type": "string"
-          }, 
-          "domains": {
-            "items": {
-              "type": "integer"
-            }, 
-            "title": "Domains", 
-            "type": "array"
-          }, 
-          "durationMinutes": {
-            "nullable": true, 
-            "title": "Durationminutes", 
-            "type": "integer"
-          }, 
-          "educationalInstitution": {
-            "nullable": true, 
-            "title": "Educationalinstitution", 
-            "type": "string"
-          }, 
-          "educationalInstitutionId": {
-            "nullable": true, 
-            "title": "Educationalinstitutionid", 
-            "type": "integer"
-          }, 
-          "educationalPriceDetail": {
-            "nullable": true, 
-            "title": "Educationalpricedetail", 
-            "type": "string"
-          }, 
-          "formats": {
-            "items": {
-              "$ref": "#/components/schemas/EacFormat"
-            }, 
-            "nullable": true, 
-            "type": "array"
-          }, 
-          "hasBookingLimitDatetimesPassed": {
-            "title": "Hasbookinglimitdatetimespassed", 
-            "type": "boolean"
-          }, 
-          "id": {
-            "title": "Id", 
-            "type": "integer"
-          }, 
-          "imageCredit": {
-            "nullable": true, 
-            "title": "Imagecredit", 
-            "type": "string"
-          }, 
-          "imageUrl": {
-            "nullable": true, 
-            "title": "Imageurl", 
-            "type": "string"
-          }, 
-          "interventionArea": {
-            "items": {
-              "type": "string"
-            }, 
-            "title": "Interventionarea", 
-            "type": "array"
-          }, 
-          "isActive": {
-            "nullable": true, 
-            "title": "Isactive", 
-            "type": "boolean"
-          }, 
-          "isSoldOut": {
-            "title": "Issoldout", 
-            "type": "boolean"
-          }, 
-          "mentalDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Mentaldisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "motorDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Motordisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "name": {
-            "title": "Name", 
-            "type": "string"
-          }, 
-          "nationalProgram": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/NationalProgramModel"
-              }
-            ], 
-            "nullable": true, 
-            "title": "NationalProgramModel"
-          }, 
-          "numberOfTickets": {
-            "title": "Numberoftickets", 
-            "type": "integer"
-          }, 
-          "offerVenue": {
-            "$ref": "#/components/schemas/OfferVenueModel"
-          }, 
-          "status": {
-            "title": "Status", 
-            "type": "string"
-          }, 
-          "students": {
-            "items": {
-              "type": "string"
-            }, 
-            "title": "Students", 
-            "type": "array"
-          }, 
-          "subcategoryId": {
-            "nullable": true, 
-            "title": "Subcategoryid", 
-            "type": "string"
-          }, 
-          "totalPrice": {
-            "title": "Totalprice", 
-            "type": "number"
-          }, 
-          "venueId": {
-            "title": "Venueid", 
-            "type": "integer"
-          }, 
-          "visualDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Visualdisabilitycompliant", 
-            "type": "boolean"
-          }
-        }, 
-        "required": [
-          "id", 
-          "status", 
-          "name", 
-          "contactEmail", 
-          "contactPhone", 
-          "domains", 
-          "interventionArea", 
-          "students", 
-          "dateCreated", 
-          "hasBookingLimitDatetimesPassed", 
-          "isSoldOut", 
-          "venueId", 
-          "beginningDatetime", 
-          "bookingLimitDatetime", 
-          "totalPrice", 
-          "numberOfTickets", 
-          "offerVenue", 
-          "bookings"
-        ], 
-        "title": "GetPublicCollectiveOfferResponseModel", 
-        "type": "object"
-      }, 
-      "GetShowTypesResponse": {
-        "items": {
-          "$ref": "#/components/schemas/ShowTypeResponse"
-        }, 
-        "title": "GetShowTypesResponse", 
-        "type": "array"
-      }, 
-      "ImageBody": {
-        "description": "Image illustrating the offer. Offers with images are more likely to be booked.", 
-        "properties": {
-          "credit": {
-            "description": "Image owner or author.", 
-            "example": "Jane Doe", 
-            "nullable": true, 
-            "title": "Credit", 
-            "type": "string"
-          }, 
-          "file": {
-            "description": "Image file encoded in base64 string. Image format must be PNG or JPEG. Size must be between 400x600 and 800x1200 pixels. Aspect ratio must be 2:3 (portrait format).", 
-            "example": "iVBORw0KGgoAAAANSUhEUgAAAhUAAAMgCAAAAACxT88IAAABImlDQ1BJQ0MgcHJvZmlsZQAAKJGdkLFKw1AUhr+0oiKKg6IgDhlcO5pFB6tCKCjEWMHqlCYpFpMYkpTiG/gm+jAdBMFXcFdw9r/RwcEs3nD4Pw7n/P+9gZadhGk5dwBpVhWu3x1cDq7shTfa+lbZZC8Iy7zreSc0ns9XLKMvHePVPPfnmY/iMpTOVFmYFxVY+2JnWuWGVazf9v0j8YPYjtIsEj+Jd6I0Mmx2/TSZhD+e5jbLcXZxbvqqbVx6nOJhM2TCmISKjjRT5xiHXalLQcA9JaE0IVZvqpmKG1EpJ5dDUV+k2zTkbdV5nlKG8hjLyyTckcrT5GH+7/fax1m9aW3M8qAI6lZb1RqN4P0RVgaw9gxL1w1Zi7/f1jDj1DP/fOMXG7hQfuNVil0AAAAJcEhZcwAALiMAAC4jAXilP3YAAAAHdElNRQfnAwMPGDrdy1JyAAABtElEQVR42u3BAQ0AAADCoPdPbQ8HFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8GaFGgABH6N7kwAAAABJRU5ErkJggg==", 
-            "title": "File", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "file"
-        ], 
-        "title": "ImageBody", 
-        "type": "object"
-      }, 
-      "ImageResponse": {
-        "description": "Image illustrating the offer. Offers with images are more likely to be booked.", 
-        "properties": {
-          "credit": {
-            "description": "Image owner or author.", 
-            "example": "Jane Doe", 
-            "nullable": true, 
-            "title": "Credit", 
-            "type": "string"
-          }, 
-          "url": {
-            "description": "Url where the image is accessible", 
-            "example": "https://example.com/image.png", 
-            "title": "Url", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "url"
-        ], 
-        "title": "ImageResponse", 
-        "type": "object"
-      }, 
-      "ImageUploadFile": {
-        "properties": {
-          "credit": {
-            "nullable": true, 
-            "title": "Credit", 
-            "type": "string"
-          }, 
-          "file": {
-            "description": "[required] Image format must be PNG, JPEG or JPG. Size must be between 400x600 and 800x1200 pixels. Aspect ratio must be 2:3 (portrait format).", 
-            "format": "binary", 
-            "nullable": true, 
-            "title": "File", 
-            "type": "string"
-          }
-        }, 
-        "title": "ImageUploadFile", 
-        "type": "object"
-      }, 
-      "JEU_EN_LIGNE_read": {
-        "description": "Jeux en ligne", 
-        "properties": {
-          "category": {
-            "enum": [
-              "JEU_EN_LIGNE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "JEU_EN_LIGNE_read", 
-        "type": "object"
-      }, 
-      "JEU_SUPPORT_PHYSIQUE_read": {
-        "description": "Cat\u00e9gorie technique Jeu support physique", 
-        "properties": {
-          "category": {
-            "enum": [
-              "JEU_SUPPORT_PHYSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "JEU_SUPPORT_PHYSIQUE_read", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_EVENEMENT_create": {
-        "description": "Livestream d'\u00e9v\u00e8nement", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVESTREAM_EVENEMENT"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "showType", 
-          "category"
-        ], 
-        "title": "LIVESTREAM_EVENEMENT_create", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_EVENEMENT_edit": {
-        "description": "Livestream d'\u00e9v\u00e8nement", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVESTREAM_EVENEMENT"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVESTREAM_EVENEMENT_edit", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_EVENEMENT_read": {
-        "description": "Livestream d'\u00e9v\u00e8nement", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVESTREAM_EVENEMENT"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVESTREAM_EVENEMENT_read", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_MUSIQUE_create": {
-        "description": "Livestream musical", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVESTREAM_MUSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "musicType", 
-          "category"
-        ], 
-        "title": "LIVESTREAM_MUSIQUE_create", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_MUSIQUE_edit": {
-        "description": "Livestream musical", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVESTREAM_MUSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVESTREAM_MUSIQUE_edit", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_MUSIQUE_read": {
-        "description": "Livestream musical", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVESTREAM_MUSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVESTREAM_MUSIQUE_read", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_PRATIQUE_ARTISTIQUE_create": {
-        "description": "Pratique artistique - livestream", 
-        "properties": {
-          "category": {
-            "enum": [
-              "LIVESTREAM_PRATIQUE_ARTISTIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVESTREAM_PRATIQUE_ARTISTIQUE_create", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_PRATIQUE_ARTISTIQUE_edit": {
-        "description": "Pratique artistique - livestream", 
-        "properties": {
-          "category": {
-            "enum": [
-              "LIVESTREAM_PRATIQUE_ARTISTIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVESTREAM_PRATIQUE_ARTISTIQUE_edit", 
-        "type": "object"
-      }, 
-      "LIVESTREAM_PRATIQUE_ARTISTIQUE_read": {
-        "description": "Pratique artistique - livestream", 
-        "properties": {
-          "category": {
-            "enum": [
-              "LIVESTREAM_PRATIQUE_ARTISTIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVESTREAM_PRATIQUE_ARTISTIQUE_read", 
-        "type": "object"
-      }, 
-      "LIVRE_AUDIO_PHYSIQUE_create": {
-        "description": "Livre audio sur support physique", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVRE_AUDIO_PHYSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "ean", 
-          "category"
-        ], 
-        "title": "LIVRE_AUDIO_PHYSIQUE_create", 
-        "type": "object"
-      }, 
-      "LIVRE_AUDIO_PHYSIQUE_edit": {
-        "description": "Livre audio sur support physique", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVRE_AUDIO_PHYSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVRE_AUDIO_PHYSIQUE_edit", 
-        "type": "object"
-      }, 
-      "LIVRE_AUDIO_PHYSIQUE_read": {
-        "description": "Livre audio sur support physique", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVRE_AUDIO_PHYSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVRE_AUDIO_PHYSIQUE_read", 
-        "type": "object"
-      }, 
-      "LIVRE_NUMERIQUE_create": {
-        "description": "Livre num\u00e9rique, e-book", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVRE_NUMERIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVRE_NUMERIQUE_create", 
-        "type": "object"
-      }, 
-      "LIVRE_NUMERIQUE_edit": {
-        "description": "Livre num\u00e9rique, e-book", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVRE_NUMERIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVRE_NUMERIQUE_edit", 
-        "type": "object"
-      }, 
-      "LIVRE_NUMERIQUE_read": {
-        "description": "Livre num\u00e9rique, e-book", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVRE_NUMERIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVRE_NUMERIQUE_read", 
-        "type": "object"
-      }, 
-      "LIVRE_PAPIER_read": {
-        "description": "Livre papier", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "LIVRE_PAPIER"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LIVRE_PAPIER_read", 
-        "type": "object"
-      }, 
-      "LOCATION_INSTRUMENT_create": {
-        "description": "Location instrument", 
-        "properties": {
-          "category": {
-            "enum": [
-              "LOCATION_INSTRUMENT"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "ean", 
-          "category"
-        ], 
-        "title": "LOCATION_INSTRUMENT_create", 
-        "type": "object"
-      }, 
-      "LOCATION_INSTRUMENT_edit": {
-        "description": "Location instrument", 
-        "properties": {
-          "category": {
-            "enum": [
-              "LOCATION_INSTRUMENT"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LOCATION_INSTRUMENT_edit", 
-        "type": "object"
-      }, 
-      "LOCATION_INSTRUMENT_read": {
-        "description": "Location instrument", 
-        "properties": {
-          "category": {
-            "enum": [
-              "LOCATION_INSTRUMENT"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "LOCATION_INSTRUMENT_read", 
-        "type": "object"
-      }, 
-      "ListCollectiveOffersQueryModel": {
-        "additionalProperties": false, 
-        "properties": {
-          "periodBeginningDate": {
-            "nullable": true, 
-            "title": "Periodbeginningdate", 
-            "type": "string"
-          }, 
-          "periodEndingDate": {
-            "nullable": true, 
-            "title": "Periodendingdate", 
-            "type": "string"
-          }, 
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OfferStatus"
-              }
-            ], 
-            "nullable": true
-          }, 
-          "venueId": {
-            "nullable": true, 
-            "title": "Venueid", 
-            "type": "integer"
-          }
-        }, 
-        "title": "ListCollectiveOffersQueryModel", 
-        "type": "object"
-      }, 
-      "ListNationalProgramsResponseModel": {
-        "items": {
-          "$ref": "#/components/schemas/NationalProgramModel"
-        }, 
-        "title": "ListNationalProgramsResponseModel", 
-        "type": "array"
-      }, 
-      "LocationTypeEnum": {
-        "description": "An enumeration.", 
-        "enum": [
-          "DIGITAL", 
-          "PHYSICAL"
-        ], 
-        "title": "LocationTypeEnum", 
-        "type": "string"
-      }, 
-      "MATERIEL_ART_CREATIF_read": {
-        "description": "Mat\u00e9riel arts cr\u00e9atifs", 
-        "properties": {
-          "category": {
-            "enum": [
-              "MATERIEL_ART_CREATIF"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "MATERIEL_ART_CREATIF_read", 
-        "type": "object"
-      }, 
-      "MUSEE_VENTE_DISTANCE_read": {
-        "description": "Mus\u00e9e vente \u00e0 distance", 
-        "properties": {
-          "category": {
-            "enum": [
-              "MUSEE_VENTE_DISTANCE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "MUSEE_VENTE_DISTANCE_read", 
-        "type": "object"
-      }, 
-      "MusicTypeEnum": {
-        "description": "An enumeration.", 
-        "enum": [
-          "JAZZ-ACID_JAZZ", 
-          "JAZZ-AVANT_GARDE_JAZZ", 
-          "JAZZ-BEBOP", 
-          "JAZZ-BIG_BAND", 
-          "JAZZ-BLUE_NOTE", 
-          "JAZZ-COOL_JAZZ", 
-          "JAZZ-CROSSOVER_JAZZ", 
-          "JAZZ-DIXIELAND", 
-          "JAZZ-ETHIO_JAZZ", 
-          "JAZZ-FUSION", 
-          "JAZZ-JAZZ_CONTEMPORAIN", 
-          "JAZZ-JAZZ_FUNK", 
-          "JAZZ-MAINSTREAM", 
-          "JAZZ-MANOUCHE", 
-          "JAZZ-TRADITIONEL", 
-          "JAZZ-VOCAL_JAZZ", 
-          "JAZZ-RAGTIME", 
-          "JAZZ-SMOOTH", 
-          "JAZZ-OTHER", 
-          "BLUES-BLUES_ACOUSTIQUE", 
-          "BLUES-BLUES_CONTEMPORAIN", 
-          "BLUES-BLUES_ELECTRIQUE", 
-          "BLUES-BLUES_ROCK", 
-          "BLUES-CHICAGO_BLUES", 
-          "BLUES-CLASSIC_BLUES", 
-          "BLUES-COUNTRY_BLUES", 
-          "BLUES-DELTA_BLUES", 
-          "BLUES-RAGTIME", 
-          "BLUES-OTHER", 
-          "REGGAE-TWO_TONE", 
-          "REGGAE-DANCEHALL", 
-          "REGGAE-DUB", 
-          "REGGAE-ROOTS", 
-          "REGGAE-SKA", 
-          "REGGAE-ZOUK", 
-          "REGGAE-OTHER", 
-          "CLASSIQUE-AVANT_GARDE", 
-          "CLASSIQUE-BAROQUE", 
-          "CLASSIQUE-CHANT", 
-          "CLASSIQUE-CHORALE", 
-          "CLASSIQUE-CONTEMPORAIN", 
-          "CLASSIQUE-EXPRESSIONISTE", 
-          "CLASSIQUE-IMPRESSIONISTE", 
-          "CLASSIQUE-MEDIEVALE", 
-          "CLASSIQUE-MINIMALISTE", 
-          "CLASSIQUE-MODERNE", 
-          "CLASSIQUE-ORATORIO", 
-          "CLASSIQUE-OPERA", 
-          "CLASSIQUE-RENAISSANCE", 
-          "CLASSIQUE-ROMANTIQUE", 
-          "CLASSIQUE-OTHER", 
-          "MUSIQUE_DU_MONDE-AFRICAINE", 
-          "MUSIQUE_DU_MONDE-AFRO_BEAT", 
-          "MUSIQUE_DU_MONDE-AFRO_POP", 
-          "MUSIQUE_DU_MONDE-ALTERNATIVO", 
-          "MUSIQUE_DU_MONDE-AMERIQUE_DU_NORD", 
-          "MUSIQUE_DU_MONDE-AMERIQUE_DU_SUD", 
-          "MUSIQUE_DU_MONDE-ASIATIQUE", 
-          "MUSIQUE_DU_MONDE-BALADAS_Y_BOLEROS", 
-          "MUSIQUE_DU_MONDE-BOSSA_NOVA", 
-          "MUSIQUE_DU_MONDE-BRESILIENNE", 
-          "MUSIQUE_DU_MONDE-CAJUN", 
-          "MUSIQUE_DU_MONDE-CALYPSO", 
-          "MUSIQUE_DU_MONDE-CARIBEENNE", 
-          "MUSIQUE_DU_MONDE-CELTIQUE", 
-          "MUSIQUE_DU_MONDE-CUMBIA", 
-          "MUSIQUE_DU_MONDE-FLAMENCO", 
-          "MUSIQUE_DU_MONDE-GRECQUE", 
-          "MUSIQUE_DU_MONDE-INDIENNE", 
-          "MUSIQUE_DU_MONDE-LATIN_JAZZ", 
-          "MUSIQUE_DU_MONDE-MOYEN_ORIENT", 
-          "MUSIQUE_DU_MONDE-LATINE_CONTEMPORAINE", 
-          "MUSIQUE_DU_MONDE-NUEVO_FLAMENCO", 
-          "MUSIQUE_DU_MONDE-POP_LATINO", 
-          "MUSIQUE_DU_MONDE-PORTUGUESE_FADO", 
-          "MUSIQUE_DU_MONDE-RAI", 
-          "MUSIQUE_DU_MONDE-SALSA", 
-          "MUSIQUE_DU_MONDE-TANGO_ARGENTIN", 
-          "MUSIQUE_DU_MONDE-YIDDISH", 
-          "MUSIQUE_DU_MONDE-OTHER", 
-          "POP-BRITPOP", 
-          "POP-BUBBLEGUM", 
-          "POP-DANCE_POP", 
-          "POP-DREAM_POP", 
-          "POP-ELECTRO_POP", 
-          "POP-INDIE_POP", 
-          "POP-J_POP", 
-          "POP-K_POP", 
-          "POP-POP_PUNK", 
-          "POP-POP_ROCK", 
-          "POP-POWER_POP", 
-          "POP-SOFT_ROCK", 
-          "POP-SYNTHPOP", 
-          "POP-TEEN_POP", 
-          "POP-OTHER", 
-          "ROCK-ACID_ROCK", 
-          "ROCK-ARENA_ROCK", 
-          "ROCK-ART_ROCK", 
-          "ROCK-COLLEGE_ROCK", 
-          "ROCK-GLAM_ROCK", 
-          "ROCK-GRUNGE", 
-          "ROCK-HARD_ROCK", 
-          "ROCK-INDIE_ROCK", 
-          "ROCK-LO_FI", 
-          "ROCK-PROG_ROCK", 
-          "ROCK-PSYCHEDELIC", 
-          "ROCK-ROCK_N_ROLL", 
-          "ROCK-EXPERIMENTAL", 
-          "ROCK-ROCKABILLY", 
-          "ROCK-SHOEGAZE", 
-          "ROCK-ELECTRO", 
-          "ROCK-OTHER", 
-          "METAL-BLACK_METAL", 
-          "METAL-DEATH_METAL", 
-          "METAL-DOOM_METAL", 
-          "METAL-GOTHIC", 
-          "METAL-METAL_CORE", 
-          "METAL-METAL_PROGRESSIF", 
-          "METAL-TRASH_METAL", 
-          "METAL-METAL_INDUSTRIEL", 
-          "METAL-FUSION", 
-          "METAL-OTHER", 
-          "PUNK-POST_PUNK", 
-          "PUNK-HARDCORE_PUNK", 
-          "PUNK-AFRO_PUNK", 
-          "PUNK-GRINDCORE", 
-          "PUNK-NOISE_ROCK", 
-          "PUNK-OTHER", 
-          "FOLK-FOLK_CONTEMPORAINE", 
-          "FOLK-INDIE_FOLK", 
-          "FOLK-FOLK_ROCK", 
-          "FOLK-NEW_ACOUSTIC", 
-          "FOLK-FOLK_TRADITIONELLE", 
-          "FOLK-TEX_MEX", 
-          "FOLK-OTHER", 
-          "COUNTRY-COUNTRY_ALTERNATIVE", 
-          "COUNTRY-AMERICANA", 
-          "COUNTRY-BLUEGRASS", 
-          "COUNTRY-COUNTRY_CONTEMPORAINE", 
-          "COUNTRY-GOSPEL_COUNTRY", 
-          "COUNTRY-COUNTRY_POP", 
-          "COUNTRY-OTHER", 
-          "ELECTRO-BITPOP", 
-          "ELECTRO-BREAKBEAT", 
-          "ELECTRO-CHILLWAVE", 
-          "ELECTRO-DANCE", 
-          "ELECTRO-DOWNTEMPO", 
-          "ELECTRO-DRUM_AND_BASS", 
-          "ELECTRO-DUBSTEP", 
-          "ELECTRO-EXPERIMENTAL", 
-          "ELECTRO-ELECTRONICA", 
-          "ELECTRO-GARAGE", 
-          "ELECTRO-GRIME", 
-          "ELECTRO-HARD_DANCE", 
-          "ELECTRO-HARDCORE", 
-          "ELECTRO-HOUSE", 
-          "ELECTRO-INDUSTRIEL", 
-          "ELECTRO-LOUNGE", 
-          "ELECTRO-TECHNO", 
-          "ELECTRO-TRANCE", 
-          "ELECTRO-OTHER", 
-          "HIP_HOP_RAP-BOUNCE", 
-          "HIP_HOP_RAP-HIP_HOP", 
-          "HIP_HOP_RAP-RAP_ALTERNATIF", 
-          "HIP_HOP_RAP-RAP_EAST_COAST", 
-          "HIP_HOP_RAP-RAP_FRANCAIS", 
-          "HIP_HOP_RAP-RAP_GANGSTA", 
-          "HIP_HOP_RAP-RAP_HARDCORE", 
-          "HIP_HOP_RAP-RAP_LATINO", 
-          "HIP_HOP_RAP-RAP_OLD_SCHOOL", 
-          "HIP_HOP_RAP-RAP_UNDERGROUND", 
-          "HIP_HOP_RAP-RAP_WEST_COAST", 
-          "HIP_HOP_RAP-TRAP", 
-          "HIP_HOP_RAP-TRIP_HOP", 
-          "HIP_HOP_RAP-R&B_CONTEMPORAIN", 
-          "HIP_HOP_RAP-DISCO", 
-          "HIP_HOP_RAP-DOO_WOP", 
-          "HIP_HOP_RAP-FUNK", 
-          "HIP_HOP_RAP-SOUL", 
-          "HIP_HOP_RAP-MOTOWN", 
-          "HIP_HOP_RAP-NEO_SOUL", 
-          "HIP_HOP_RAP-SOUL_PSYCHEDELIQUE", 
-          "HIP_HOP_RAP-OTHER", 
-          "GOSPEL-SPIRITUAL_GOSPEL", 
-          "GOSPEL-TRADITIONAL_GOSPEL", 
-          "GOSPEL-SOUTHERN_GOSPEL", 
-          "GOSPEL-CONTEMPORARY_GOSPEL", 
-          "GOSPEL-BLUEGRASS_GOSPEL", 
-          "GOSPEL-BLUES_GOSPEL", 
-          "GOSPEL-COUNTRY_GOSPEL", 
-          "GOSPEL-HYBRID_GOSPEL", 
-          "GOSPEL-OTHER", 
-          "CHANSON_VARIETE-MUSETTE", 
-          "CHANSON_VARIETE-CHANSON_FRANCAISE", 
-          "CHANSON_VARIETE-MUSIC_HALL", 
-          "CHANSON_VARIETE-FOLKLORE_FRANCAIS", 
-          "CHANSON_VARIETE-CHANSON_\u00c0_TEXTE", 
-          "CHANSON_VARIETE-SLAM", 
-          "CHANSON_VARIETE-OTHER", 
-          "OTHER"
-        ], 
-        "title": "MusicTypeEnum", 
-        "type": "string"
-      }, 
-      "MusicTypeResponse": {
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/MusicTypeEnum"
-          }, 
-          "label": {
-            "title": "Label", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "id", 
-          "label"
-        ], 
-        "title": "MusicTypeResponse", 
-        "type": "object"
-      }, 
-      "NationalProgramModel": {
-        "properties": {
-          "id": {
-            "title": "Id", 
-            "type": "integer"
-          }, 
-          "name": {
-            "title": "Name", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "id", 
-          "name"
-        ], 
-        "title": "NationalProgramModel", 
-        "type": "object"
-      }, 
-      "OEUVRE_ART_read": {
-        "description": "Cat\u00e9gorie technique d'oeuvre d'art", 
-        "properties": {
-          "category": {
-            "enum": [
-              "OEUVRE_ART"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "OEUVRE_ART_read", 
-        "type": "object"
-      }, 
-      "OfferAddressType": {
-        "description": "An enumeration.", 
-        "enum": [
-          "offererVenue", 
-          "school", 
-          "other"
-        ], 
-        "title": "OfferAddressType"
-      }, 
-      "OfferStatus": {
-        "description": "An enumeration.", 
-        "enum": [
-          "ACTIVE", 
-          "PENDING", 
-          "EXPIRED", 
-          "REJECTED", 
-          "SOLD_OUT", 
-          "INACTIVE", 
-          "DRAFT"
-        ], 
-        "title": "OfferStatus", 
-        "type": "string"
-      }, 
-      "OfferVenueModel": {
-        "additionalProperties": false, 
-        "properties": {
-          "addressType": {
-            "$ref": "#/components/schemas/OfferAddressType"
-          }, 
-          "otherAddress": {
-            "nullable": true, 
-            "title": "Otheraddress", 
-            "type": "string"
-          }, 
-          "venueId": {
-            "nullable": true, 
-            "title": "Venueid", 
-            "type": "integer"
-          }
-        }, 
-        "required": [
-          "addressType"
-        ], 
-        "title": "OfferVenueModel", 
-        "type": "object"
-      }, 
-      "OffererResponse": {
-        "properties": {
-          "createdDatetime": {
-            "format": "date-time", 
-            "title": "Createddatetime", 
-            "type": "string"
-          }, 
-          "id": {
-            "title": "Id", 
-            "type": "integer"
-          }, 
-          "name": {
-            "example": "Structure A", 
-            "title": "Name", 
-            "type": "string"
-          }, 
-          "siren": {
-            "example": "123456789", 
-            "nullable": true, 
-            "title": "Siren", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "id", 
-          "createdDatetime", 
-          "name"
-        ], 
-        "title": "OffererResponse", 
-        "type": "object"
-      }, 
-      "PARTITION_create": {
-        "description": "Partition", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PARTITION"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "ean", 
-          "category"
-        ], 
-        "title": "PARTITION_create", 
-        "type": "object"
-      }, 
-      "PARTITION_edit": {
-        "description": "Partition", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PARTITION"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PARTITION_edit", 
-        "type": "object"
-      }, 
-      "PARTITION_read": {
-        "description": "Partition", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PARTITION"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PARTITION_read", 
-        "type": "object"
-      }, 
-      "PLATEFORME_PRATIQUE_ARTISTIQUE_create": {
-        "description": "Pratique artistique - plateforme en ligne", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PLATEFORME_PRATIQUE_ARTISTIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PLATEFORME_PRATIQUE_ARTISTIQUE_create", 
-        "type": "object"
-      }, 
-      "PLATEFORME_PRATIQUE_ARTISTIQUE_edit": {
-        "description": "Pratique artistique - plateforme en ligne", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PLATEFORME_PRATIQUE_ARTISTIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PLATEFORME_PRATIQUE_ARTISTIQUE_edit", 
-        "type": "object"
-      }, 
-      "PLATEFORME_PRATIQUE_ARTISTIQUE_read": {
-        "description": "Pratique artistique - plateforme en ligne", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PLATEFORME_PRATIQUE_ARTISTIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PLATEFORME_PRATIQUE_ARTISTIQUE_read", 
-        "type": "object"
-      }, 
-      "PODCAST_create": {
-        "description": "Podcast", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PODCAST"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PODCAST_create", 
-        "type": "object"
-      }, 
-      "PODCAST_edit": {
-        "description": "Podcast", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PODCAST"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PODCAST_edit", 
-        "type": "object"
-      }, 
-      "PODCAST_read": {
-        "description": "Podcast", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PODCAST"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PODCAST_read", 
-        "type": "object"
-      }, 
-      "PRATIQUE_ART_VENTE_DISTANCE_create": {
-        "description": "Pratique artistique - vente \u00e0 distance", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PRATIQUE_ART_VENTE_DISTANCE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PRATIQUE_ART_VENTE_DISTANCE_create", 
-        "type": "object"
-      }, 
-      "PRATIQUE_ART_VENTE_DISTANCE_edit": {
-        "description": "Pratique artistique - vente \u00e0 distance", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PRATIQUE_ART_VENTE_DISTANCE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PRATIQUE_ART_VENTE_DISTANCE_edit", 
-        "type": "object"
-      }, 
-      "PRATIQUE_ART_VENTE_DISTANCE_read": {
-        "description": "Pratique artistique - vente \u00e0 distance", 
-        "properties": {
-          "category": {
-            "enum": [
-              "PRATIQUE_ART_VENTE_DISTANCE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "PRATIQUE_ART_VENTE_DISTANCE_read", 
-        "type": "object"
-      }, 
-      "PartialAccessibility": {
-        "description": "Accessibility for people with disabilities. Fields are null for digital venues.", 
-        "properties": {
-          "audioDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Audiodisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "mentalDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Mentaldisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "motorDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Motordisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "visualDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Visualdisabilitycompliant", 
-            "type": "boolean"
-          }
-        }, 
-        "title": "PartialAccessibility", 
-        "type": "object"
-      }, 
-      "PatchCollectiveOfferBodyModel": {
-        "additionalProperties": false, 
-        "properties": {
-          "audioDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Audiodisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "beginningDatetime": {
-            "format": "date-time", 
-            "nullable": true, 
-            "title": "Beginningdatetime", 
-            "type": "string"
-          }, 
-          "bookingEmails": {
-            "items": {
-              "type": "string"
-            }, 
-            "nullable": true, 
-            "title": "Bookingemails", 
-            "type": "array"
-          }, 
-          "bookingLimitDatetime": {
-            "format": "date-time", 
-            "nullable": true, 
-            "title": "Bookinglimitdatetime", 
-            "type": "string"
-          }, 
-          "contactEmail": {
-            "nullable": true, 
-            "title": "Contactemail", 
-            "type": "string"
-          }, 
-          "contactPhone": {
-            "nullable": true, 
-            "title": "Contactphone", 
-            "type": "string"
-          }, 
-          "description": {
-            "nullable": true, 
-            "title": "Description", 
-            "type": "string"
-          }, 
-          "domains": {
-            "items": {
-              "type": "integer"
-            }, 
-            "nullable": true, 
-            "title": "Domains", 
-            "type": "array"
-          }, 
-          "durationMinutes": {
-            "nullable": true, 
-            "title": "Durationminutes", 
-            "type": "integer"
-          }, 
-          "educationalInstitution": {
-            "nullable": true, 
-            "title": "Educationalinstitution", 
-            "type": "string"
-          }, 
-          "educationalInstitutionId": {
-            "nullable": true, 
-            "title": "Educationalinstitutionid", 
-            "type": "integer"
-          }, 
-          "educationalPriceDetail": {
-            "nullable": true, 
-            "title": "Educationalpricedetail", 
-            "type": "string"
-          }, 
-          "formats": {
-            "items": {
-              "$ref": "#/components/schemas/EacFormat"
-            }, 
-            "nullable": true, 
-            "type": "array"
-          }, 
-          "imageCredit": {
-            "nullable": true, 
-            "title": "Imagecredit", 
-            "type": "string"
-          }, 
-          "imageFile": {
-            "nullable": true, 
-            "title": "Imagefile", 
-            "type": "string"
-          }, 
-          "interventionArea": {
-            "items": {
-              "type": "string"
-            }, 
-            "nullable": true, 
-            "title": "Interventionarea", 
-            "type": "array"
-          }, 
-          "isActive": {
-            "nullable": true, 
-            "title": "Isactive", 
-            "type": "boolean"
-          }, 
-          "mentalDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Mentaldisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "motorDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Motordisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "name": {
-            "nullable": true, 
-            "title": "Name", 
-            "type": "string"
-          }, 
-          "nationalProgramId": {
-            "nullable": true, 
-            "title": "Nationalprogramid", 
-            "type": "integer"
-          }, 
-          "numberOfTickets": {
-            "nullable": true, 
-            "title": "Numberoftickets", 
-            "type": "integer"
-          }, 
-          "offerVenue": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OfferVenueModel"
-              }
-            ], 
-            "nullable": true, 
-            "title": "OfferVenueModel"
-          }, 
-          "students": {
-            "items": {
-              "type": "string"
-            }, 
-            "nullable": true, 
-            "title": "Students", 
-            "type": "array"
-          }, 
-          "subcategoryId": {
-            "nullable": true, 
-            "title": "Subcategoryid", 
-            "type": "string"
-          }, 
-          "totalPrice": {
-            "nullable": true, 
-            "title": "Totalprice", 
-            "type": "number"
-          }, 
-          "venueId": {
-            "nullable": true, 
-            "title": "Venueid", 
-            "type": "integer"
-          }, 
-          "visualDisabilityCompliant": {
-            "nullable": true, 
-            "title": "Visualdisabilitycompliant", 
-            "type": "boolean"
-          }
-        }, 
-        "title": "PatchCollectiveOfferBodyModel", 
-        "type": "object"
-      }, 
-      "PhysicalLocation": {
-        "properties": {
-          "type": {
-            "default": "physical", 
-            "enum": [
-              "physical"
-            ], 
-            "title": "Type", 
-            "type": "string"
-          }, 
-          "venueId": {
-            "description": "List of venues is available at GET /offerer_venues", 
-            "example": 1, 
-            "title": "Venueid", 
-            "type": "integer"
-          }
-        }, 
-        "required": [
-          "venueId"
-        ], 
-        "title": "PhysicalLocation", 
-        "type": "object"
-      }, 
-      "PostCollectiveOfferBodyModel": {
-        "additionalProperties": false, 
-        "properties": {
-          "audioDisabilityCompliant": {
-            "default": false, 
-            "title": "Audiodisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "beginningDatetime": {
-            "format": "date-time", 
-            "title": "Beginningdatetime", 
-            "type": "string"
-          }, 
-          "bookingEmails": {
-            "items": {
-              "type": "string"
-            }, 
-            "title": "Bookingemails", 
-            "type": "array"
-          }, 
-          "bookingLimitDatetime": {
-            "format": "date-time", 
-            "title": "Bookinglimitdatetime", 
-            "type": "string"
-          }, 
-          "contactEmail": {
-            "title": "Contactemail", 
-            "type": "string"
-          }, 
-          "contactPhone": {
-            "title": "Contactphone", 
-            "type": "string"
-          }, 
-          "description": {
-            "title": "Description", 
-            "type": "string"
-          }, 
-          "domains": {
-            "items": {
-              "type": "integer"
-            }, 
-            "title": "Domains", 
-            "type": "array"
-          }, 
-          "durationMinutes": {
-            "nullable": true, 
-            "title": "Durationminutes", 
-            "type": "integer"
-          }, 
-          "educationalInstitution": {
-            "nullable": true, 
-            "title": "Educationalinstitution", 
-            "type": "string"
-          }, 
-          "educationalInstitutionId": {
-            "nullable": true, 
-            "title": "Educationalinstitutionid", 
-            "type": "integer"
-          }, 
-          "educationalPriceDetail": {
-            "nullable": true, 
-            "title": "Educationalpricedetail", 
-            "type": "string"
-          }, 
-          "formats": {
-            "items": {
-              "$ref": "#/components/schemas/EacFormat"
-            }, 
-            "nullable": true, 
-            "type": "array"
-          }, 
-          "imageCredit": {
-            "nullable": true, 
-            "title": "Imagecredit", 
-            "type": "string"
-          }, 
-          "imageFile": {
-            "nullable": true, 
-            "title": "Imagefile", 
-            "type": "string"
-          }, 
-          "isActive": {
-            "title": "Isactive", 
-            "type": "boolean"
-          }, 
-          "mentalDisabilityCompliant": {
-            "default": false, 
-            "title": "Mentaldisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "motorDisabilityCompliant": {
-            "default": false, 
-            "title": "Motordisabilitycompliant", 
-            "type": "boolean"
-          }, 
-          "name": {
-            "title": "Name", 
-            "type": "string"
-          }, 
-          "nationalProgramId": {
-            "nullable": true, 
-            "title": "Nationalprogramid", 
-            "type": "integer"
-          }, 
-          "numberOfTickets": {
-            "title": "Numberoftickets", 
-            "type": "integer"
-          }, 
-          "offerVenue": {
-            "$ref": "#/components/schemas/OfferVenueModel"
-          }, 
-          "students": {
-            "items": {
-              "type": "string"
-            }, 
-            "title": "Students", 
-            "type": "array"
-          }, 
-          "subcategoryId": {
-            "nullable": true, 
-            "title": "Subcategoryid", 
-            "type": "string"
-          }, 
-          "totalPrice": {
-            "title": "Totalprice", 
-            "type": "number"
-          }, 
-          "venueId": {
-            "title": "Venueid", 
-            "type": "integer"
-          }, 
-          "visualDisabilityCompliant": {
-            "default": false, 
-            "title": "Visualdisabilitycompliant", 
-            "type": "boolean"
-          }
-        }, 
-        "required": [
-          "venueId", 
-          "name", 
-          "description", 
-          "bookingEmails", 
-          "contactEmail", 
-          "contactPhone", 
-          "domains", 
-          "students", 
-          "offerVenue", 
-          "isActive", 
-          "beginningDatetime", 
-          "bookingLimitDatetime", 
-          "totalPrice", 
-          "numberOfTickets"
-        ], 
-        "title": "PostCollectiveOfferBodyModel", 
-        "type": "object"
-      }, 
-      "PostDatesResponse": {
-        "properties": {
-          "dates": {
-            "description": "Dates of the event.", 
-            "items": {
-              "$ref": "#/components/schemas/DateResponse"
-            }, 
-            "title": "Dates", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "dates"
-        ], 
-        "title": "PostDatesResponse", 
-        "type": "object"
-      }, 
-      "PriceCategoriesCreation": {
-        "additionalProperties": false, 
-        "properties": {
-          "priceCategories": {
-            "description": "Available price categories for dates of this offer", 
-            "items": {
-              "$ref": "#/components/schemas/PriceCategoryCreation"
-            }, 
-            "title": "Pricecategories", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "priceCategories"
-        ], 
-        "title": "PriceCategoriesCreation", 
-        "type": "object"
-      }, 
-      "PriceCategoriesResponse": {
-        "properties": {
-          "priceCategories": {
-            "description": "Available price categories for dates of this offer", 
-            "items": {
-              "$ref": "#/components/schemas/PriceCategoryResponse"
-            }, 
-            "title": "Pricecategories", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "priceCategories"
-        ], 
-        "title": "PriceCategoriesResponse", 
-        "type": "object"
-      }, 
-      "PriceCategoryCreation": {
-        "properties": {
-          "label": {
-            "description": "Price category label", 
-            "example": "Carr\u00e9 or", 
-            "maxLength": 50, 
-            "minLength": 1, 
-            "title": "Label", 
-            "type": "string"
-          }, 
-          "price": {
-            "description": "Offer price in euro cents.", 
-            "example": 1000, 
-            "maximum": 30000, 
-            "minimum": 0, 
-            "title": "Price", 
-            "type": "integer"
-          }
-        }, 
-        "required": [
-          "label", 
-          "price"
-        ], 
-        "title": "PriceCategoryCreation", 
-        "type": "object"
-      }, 
-      "PriceCategoryEdition": {
-        "additionalProperties": false, 
-        "properties": {
-          "label": {
-            "description": "Price category label", 
-            "example": "Carr\u00e9 or", 
-            "maxLength": 50, 
-            "minLength": 1, 
-            "nullable": true, 
-            "title": "Label", 
-            "type": "string"
-          }, 
-          "price": {
-            "description": "Offer price in euro cents.", 
-            "example": 1000, 
-            "maximum": 30000, 
-            "minimum": 0, 
-            "nullable": true, 
-            "title": "Price", 
-            "type": "integer"
-          }
-        }, 
-        "title": "PriceCategoryEdition", 
-        "type": "object"
-      }, 
-      "PriceCategoryResponse": {
-        "properties": {
-          "id": {
-            "title": "Id", 
-            "type": "integer"
-          }, 
-          "label": {
-            "description": "Price category label", 
-            "example": "Carr\u00e9 or", 
-            "title": "Label", 
-            "type": "string"
-          }, 
-          "price": {
-            "description": "Offer price in euro cents.", 
-            "example": 1000, 
-            "title": "Price", 
-            "type": "integer"
-          }
-        }, 
-        "required": [
-          "id", 
-          "label", 
-          "price"
-        ], 
-        "title": "PriceCategoryResponse", 
-        "type": "object"
-      }, 
-      "ProductCategoryResponse": {
-        "properties": {
-          "conditionalFields": {
-            "additionalProperties": {
-              "type": "boolean"
-            }, 
-            "description": "The keys are fields that should be set in the category_related_fields of a product. The values indicate whether their associated field is mandatory during product creation.", 
-            "title": "Conditionalfields", 
-            "type": "object"
-          }, 
-          "id": {
-            "$ref": "#/components/schemas/CategoryEnum"
-          }, 
-          "locationType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/LocationTypeEnum"
-              }
-            ], 
-            "nullable": true
-          }
-        }, 
-        "required": [
-          "id", 
-          "conditionalFields"
-        ], 
-        "title": "ProductCategoryResponse", 
-        "type": "object"
-      }, 
-      "ProductOfferByEanCreation": {
-        "additionalProperties": false, 
-        "properties": {
-          "ean": {
-            "description": "European Article Number (EAN-13)", 
-            "example": "1234567890123", 
-            "maxLength": 13, 
-            "minLength": 13, 
-            "title": "Ean", 
-            "type": "string"
-          }, 
-          "stock": {
-            "$ref": "#/components/schemas/StockCreation"
-          }
-        }, 
-        "required": [
-          "ean", 
-          "stock"
-        ], 
-        "title": "ProductOfferByEanCreation", 
-        "type": "object"
-      }, 
-      "ProductOfferCreation": {
-        "additionalProperties": false, 
-        "properties": {
-          "accessibility": {
-            "$ref": "#/components/schemas/Accessibility"
-          }, 
-          "bookingContact": {
-            "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.", 
-            "format": "email", 
-            "nullable": true, 
-            "title": "Bookingcontact", 
-            "type": "string"
-          }, 
-          "bookingEmail": {
-            "description": "Recipient email for notifications about bookings, cancellations, etc.", 
-            "format": "email", 
-            "nullable": true, 
-            "title": "Bookingemail", 
-            "type": "string"
-          }, 
-          "categoryRelatedFields": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ABO_BIBLIOTHEQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_CONCERT_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_LIVRE_NUMERIQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_MEDIATHEQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PLATEFORME_MUSIQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PLATEFORME_VIDEO_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PRATIQUE_ART_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PRESSE_EN_LIGNE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_SPECTACLE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/ACHAT_INSTRUMENT_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/APP_CULTURELLE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/AUTRE_SUPPORT_NUMERIQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/CARTE_JEUNES_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/CARTE_MUSEE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/LIVRE_AUDIO_PHYSIQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/LIVRE_NUMERIQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/LOCATION_INSTRUMENT_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/PARTITION_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/PLATEFORME_PRATIQUE_ARTISTIQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/PODCAST_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/PRATIQUE_ART_VENTE_DISTANCE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/SPECTACLE_ENREGISTRE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_FILM_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/TELECHARGEMENT_LIVRE_AUDIO_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/TELECHARGEMENT_MUSIQUE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/VISITE_VIRTUELLE_create"
-              }, 
-              {
-                "$ref": "#/components/schemas/VOD_create"
-              }
-            ], 
-            "description": "Cultural category the offer belongs to. According to the category, some fields may or must be specified.", 
-            "title": "Categoryrelatedfields"
-          }, 
-          "description": {
-            "description": "Offer description", 
-            "example": "A great book for kids and old kids.", 
-            "maxLength": 1000, 
-            "nullable": true, 
-            "title": "Description", 
-            "type": "string"
-          }, 
-          "enableDoubleBookings": {
-            "default": false, 
-            "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.", 
-            "nullable": true, 
-            "title": "Enabledoublebookings", 
-            "type": "boolean"
-          }, 
-          "externalTicketOfficeUrl": {
-            "description": "Link displayed to users wishing to book the offer but who do not have (anymore) credit.", 
-            "example": "https://example.com", 
-            "format": "uri", 
-            "maxLength": 2083, 
-            "minLength": 1, 
-            "nullable": true, 
-            "title": "Externalticketofficeurl", 
-            "type": "string"
-          }, 
-          "image": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ImageBody"
-              }
-            ], 
-            "nullable": true, 
-            "title": "ImageBody"
-          }, 
-          "itemCollectionDetails": {
-            "description": "Further information that will be provided to attendees to ease the offer collection.", 
-            "example": "Opening hours, specific office, collection period, access code, email annoucement...", 
-            "nullable": true, 
-            "title": "Itemcollectiondetails", 
-            "type": "string"
-          }, 
-          "location": {
-            "description": "Location where the offer will be available or will take place. The location type must be compatible with the category", 
-            "discriminator": {
-              "mapping": {
-                "digital": "#/components/schemas/DigitalLocation", 
-                "physical": "#/components/schemas/PhysicalLocation"
-              }, 
-              "propertyName": "type"
-            }, 
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PhysicalLocation"
-              }, 
-              {
-                "$ref": "#/components/schemas/DigitalLocation"
-              }
-            ], 
-            "title": "Location"
-          }, 
-          "name": {
-            "description": "Offer title", 
-            "example": "Le Petit Prince", 
-            "maxLength": 90, 
-            "title": "Name", 
-            "type": "string"
-          }, 
-          "stock": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/StockCreation"
-              }
-            ], 
-            "nullable": true, 
-            "title": "StockCreation"
-          }
-        }, 
-        "required": [
-          "accessibility", 
-          "categoryRelatedFields", 
-          "name", 
-          "location"
-        ], 
-        "title": "ProductOfferCreation", 
-        "type": "object"
-      }, 
-      "ProductOfferEdition": {
-        "additionalProperties": false, 
-        "properties": {
-          "accessibility": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PartialAccessibility"
-              }
-            ], 
-            "description": "Accessibility to disabled people. Leave fields undefined to keep current value", 
-            "nullable": true, 
-            "title": "Accessibility"
-          }, 
-          "bookingContact": {
-            "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.", 
-            "format": "email", 
-            "nullable": true, 
-            "title": "Bookingcontact", 
-            "type": "string"
-          }, 
-          "bookingEmail": {
-            "description": "Recipient email for notifications about bookings, cancellations, etc.", 
-            "format": "email", 
-            "nullable": true, 
-            "title": "Bookingemail", 
-            "type": "string"
-          }, 
-          "categoryRelatedFields": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ABO_BIBLIOTHEQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_CONCERT_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_LIVRE_NUMERIQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_MEDIATHEQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PLATEFORME_MUSIQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PLATEFORME_VIDEO_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PRATIQUE_ART_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PRESSE_EN_LIGNE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_SPECTACLE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/ACHAT_INSTRUMENT_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/APP_CULTURELLE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/AUTRE_SUPPORT_NUMERIQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/CARTE_JEUNES_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/CARTE_MUSEE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/LIVRE_AUDIO_PHYSIQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/LIVRE_NUMERIQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/LOCATION_INSTRUMENT_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/PARTITION_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/PLATEFORME_PRATIQUE_ARTISTIQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/PODCAST_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/PRATIQUE_ART_VENTE_DISTANCE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/SPECTACLE_ENREGISTRE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_FILM_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/TELECHARGEMENT_LIVRE_AUDIO_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/TELECHARGEMENT_MUSIQUE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/VISITE_VIRTUELLE_edit"
-              }, 
-              {
-                "$ref": "#/components/schemas/VOD_edit"
-              }
-            ], 
-            "description": "To override category related fields, the category must be specified, even if it cannot be changed. Other category related fields may be left undefined to keep their current value.", 
-            "nullable": true, 
-            "title": "Categoryrelatedfields"
-          }, 
-          "description": {
-            "description": "Offer description", 
-            "example": "A great book for kids and old kids.", 
-            "maxLength": 1000, 
-            "nullable": true, 
-            "title": "Description", 
-            "type": "string"
-          }, 
-          "enableDoubleBookings": {
-            "default": false, 
-            "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.", 
-            "nullable": true, 
-            "title": "Enabledoublebookings", 
-            "type": "boolean"
-          }, 
-          "image": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ImageBody"
-              }
-            ], 
-            "nullable": true, 
-            "title": "ImageBody"
-          }, 
-          "isActive": {
-            "description": "Whether the offer is activated. An inactive offer cannot be booked.", 
-            "nullable": true, 
-            "title": "Isactive", 
-            "type": "boolean"
-          }, 
-          "itemCollectionDetails": {
-            "description": "Further information that will be provided to attendees to ease the offer collection.", 
-            "example": "Opening hours, specific office, collection period, access code, email annoucement...", 
-            "nullable": true, 
-            "title": "Itemcollectiondetails", 
-            "type": "string"
-          }, 
-          "offerId": {
-            "title": "Offerid", 
-            "type": "integer"
-          }, 
-          "stock": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/StockEdition"
-              }
-            ], 
-            "description": "If stock is set to null, all cancellable bookings (i.e not used) will be cancelled. To prevent from further bookings, you may alternatively set stock.quantity to the bookedQuantity (but not below).", 
-            "nullable": true, 
-            "title": "Stock"
-          }
-        }, 
-        "required": [
-          "offerId"
-        ], 
-        "title": "ProductOfferEdition", 
-        "type": "object"
-      }, 
-      "ProductOfferResponse": {
-        "properties": {
-          "accessibility": {
-            "$ref": "#/components/schemas/AccessibilityResponse"
-          }, 
-          "bookingContact": {
-            "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.", 
-            "nullable": true, 
-            "title": "Bookingcontact", 
-            "type": "string"
-          }, 
-          "bookingEmail": {
-            "description": "Recipient email for notifications about bookings, cancellations, etc.", 
-            "nullable": true, 
-            "title": "Bookingemail", 
-            "type": "string"
-          }, 
-          "categoryRelatedFields": {
-            "description": "Cultural category the offer belongs to. According to the category, some fields may or must be specified.", 
-            "discriminator": {
-              "mapping": {
-                "ABO_BIBLIOTHEQUE": "#/components/schemas/ABO_BIBLIOTHEQUE_read", 
-                "ABO_CONCERT": "#/components/schemas/ABO_CONCERT_read", 
-                "ABO_JEU_VIDEO": "#/components/schemas/ABO_JEU_VIDEO_read", 
-                "ABO_LIVRE_NUMERIQUE": "#/components/schemas/ABO_LIVRE_NUMERIQUE_read", 
-                "ABO_LUDOTHEQUE": "#/components/schemas/ABO_LUDOTHEQUE_read", 
-                "ABO_MEDIATHEQUE": "#/components/schemas/ABO_MEDIATHEQUE_read", 
-                "ABO_PLATEFORME_MUSIQUE": "#/components/schemas/ABO_PLATEFORME_MUSIQUE_read", 
-                "ABO_PLATEFORME_VIDEO": "#/components/schemas/ABO_PLATEFORME_VIDEO_read", 
-                "ABO_PRATIQUE_ART": "#/components/schemas/ABO_PRATIQUE_ART_read", 
-                "ABO_PRESSE_EN_LIGNE": "#/components/schemas/ABO_PRESSE_EN_LIGNE_read", 
-                "ABO_SPECTACLE": "#/components/schemas/ABO_SPECTACLE_read", 
-                "ACHAT_INSTRUMENT": "#/components/schemas/ACHAT_INSTRUMENT_read", 
-                "ACTIVATION_THING": "#/components/schemas/ACTIVATION_THING_read", 
-                "APP_CULTURELLE": "#/components/schemas/APP_CULTURELLE_read", 
-                "AUTRE_SUPPORT_NUMERIQUE": "#/components/schemas/AUTRE_SUPPORT_NUMERIQUE_read", 
-                "BON_ACHAT_INSTRUMENT": "#/components/schemas/BON_ACHAT_INSTRUMENT_read", 
-                "CAPTATION_MUSIQUE": "#/components/schemas/CAPTATION_MUSIQUE_read", 
-                "CARTE_CINE_ILLIMITE": "#/components/schemas/CARTE_CINE_ILLIMITE_read", 
-                "CARTE_CINE_MULTISEANCES": "#/components/schemas/CARTE_CINE_MULTISEANCES_read", 
-                "CARTE_JEUNES": "#/components/schemas/CARTE_JEUNES_read", 
-                "CARTE_MUSEE": "#/components/schemas/CARTE_MUSEE_read", 
-                "CINE_VENTE_DISTANCE": "#/components/schemas/CINE_VENTE_DISTANCE_read", 
-                "ESCAPE_GAME": "#/components/schemas/ESCAPE_GAME_read", 
-                "JEU_EN_LIGNE": "#/components/schemas/JEU_EN_LIGNE_read", 
-                "JEU_SUPPORT_PHYSIQUE": "#/components/schemas/JEU_SUPPORT_PHYSIQUE_read", 
-                "LIVRE_AUDIO_PHYSIQUE": "#/components/schemas/LIVRE_AUDIO_PHYSIQUE_read", 
-                "LIVRE_NUMERIQUE": "#/components/schemas/LIVRE_NUMERIQUE_read", 
-                "LIVRE_PAPIER": "#/components/schemas/LIVRE_PAPIER_read", 
-                "LOCATION_INSTRUMENT": "#/components/schemas/LOCATION_INSTRUMENT_read", 
-                "MATERIEL_ART_CREATIF": "#/components/schemas/MATERIEL_ART_CREATIF_read", 
-                "MUSEE_VENTE_DISTANCE": "#/components/schemas/MUSEE_VENTE_DISTANCE_read", 
-                "OEUVRE_ART": "#/components/schemas/OEUVRE_ART_read", 
-                "PARTITION": "#/components/schemas/PARTITION_read", 
-                "PLATEFORME_PRATIQUE_ARTISTIQUE": "#/components/schemas/PLATEFORME_PRATIQUE_ARTISTIQUE_read", 
-                "PODCAST": "#/components/schemas/PODCAST_read", 
-                "PRATIQUE_ART_VENTE_DISTANCE": "#/components/schemas/PRATIQUE_ART_VENTE_DISTANCE_read", 
-                "SPECTACLE_ENREGISTRE": "#/components/schemas/SPECTACLE_ENREGISTRE_read", 
-                "SPECTACLE_VENTE_DISTANCE": "#/components/schemas/SPECTACLE_VENTE_DISTANCE_read", 
-                "SUPPORT_PHYSIQUE_FILM": "#/components/schemas/SUPPORT_PHYSIQUE_FILM_read", 
-                "SUPPORT_PHYSIQUE_MUSIQUE_CD": "#/components/schemas/SUPPORT_PHYSIQUE_MUSIQUE_CD_read", 
-                "SUPPORT_PHYSIQUE_MUSIQUE_VINYLE": "#/components/schemas/SUPPORT_PHYSIQUE_MUSIQUE_VINYLE_read", 
-                "TELECHARGEMENT_LIVRE_AUDIO": "#/components/schemas/TELECHARGEMENT_LIVRE_AUDIO_read", 
-                "TELECHARGEMENT_MUSIQUE": "#/components/schemas/TELECHARGEMENT_MUSIQUE_read", 
-                "VISITE_VIRTUELLE": "#/components/schemas/VISITE_VIRTUELLE_read", 
-                "VOD": "#/components/schemas/VOD_read"
-              }, 
-              "propertyName": "category"
-            }, 
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ABO_BIBLIOTHEQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_CONCERT_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_JEU_VIDEO_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_LIVRE_NUMERIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_LUDOTHEQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_MEDIATHEQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PLATEFORME_MUSIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PLATEFORME_VIDEO_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PRATIQUE_ART_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_PRESSE_EN_LIGNE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ABO_SPECTACLE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ACHAT_INSTRUMENT_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ACTIVATION_THING_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/APP_CULTURELLE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/AUTRE_SUPPORT_NUMERIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/BON_ACHAT_INSTRUMENT_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/CAPTATION_MUSIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/CARTE_CINE_ILLIMITE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/CARTE_CINE_MULTISEANCES_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/CARTE_JEUNES_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/CARTE_MUSEE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/CINE_VENTE_DISTANCE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/ESCAPE_GAME_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/JEU_EN_LIGNE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/JEU_SUPPORT_PHYSIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/LIVRE_AUDIO_PHYSIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/LIVRE_NUMERIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/LIVRE_PAPIER_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/LOCATION_INSTRUMENT_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/MATERIEL_ART_CREATIF_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/MUSEE_VENTE_DISTANCE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/OEUVRE_ART_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/PARTITION_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/PLATEFORME_PRATIQUE_ARTISTIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/PRATIQUE_ART_VENTE_DISTANCE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/PODCAST_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/SPECTACLE_ENREGISTRE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/SPECTACLE_VENTE_DISTANCE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_FILM_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_MUSIQUE_CD_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_MUSIQUE_VINYLE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/TELECHARGEMENT_LIVRE_AUDIO_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/TELECHARGEMENT_MUSIQUE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/VISITE_VIRTUELLE_read"
-              }, 
-              {
-                "$ref": "#/components/schemas/VOD_read"
-              }
-            ], 
-            "title": "Categoryrelatedfields"
-          }, 
-          "description": {
-            "description": "Offer description", 
-            "example": "A great book for kids and old kids.", 
-            "nullable": true, 
-            "title": "Description", 
-            "type": "string"
-          }, 
-          "enableDoubleBookings": {
-            "default": false, 
-            "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.", 
-            "nullable": true, 
-            "title": "Enabledoublebookings", 
-            "type": "boolean"
-          }, 
-          "externalTicketOfficeUrl": {
-            "description": "Link displayed to users wishing to book the offer but who do not have (anymore) credit.", 
-            "example": "https://example.com", 
-            "nullable": true, 
-            "title": "Externalticketofficeurl", 
-            "type": "string"
-          }, 
-          "id": {
-            "title": "Id", 
-            "type": "integer"
-          }, 
-          "image": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ImageResponse"
-              }
-            ], 
-            "nullable": true, 
-            "title": "ImageResponse"
-          }, 
-          "itemCollectionDetails": {
-            "description": "Further information that will be provided to attendees to ease the offer collection.", 
-            "example": "Opening hours, specific office, collection period, access code, email annoucement...", 
-            "nullable": true, 
-            "title": "Itemcollectiondetails", 
-            "type": "string"
-          }, 
-          "location": {
-            "description": "Location where the offer will be available or will take place. The location type must be compatible with the category", 
-            "discriminator": {
-              "mapping": {
-                "digital": "#/components/schemas/DigitalLocation", 
-                "physical": "#/components/schemas/PhysicalLocation"
-              }, 
-              "propertyName": "type"
-            }, 
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PhysicalLocation"
-              }, 
-              {
-                "$ref": "#/components/schemas/DigitalLocation"
-              }
-            ], 
-            "title": "Location"
-          }, 
-          "name": {
-            "description": "Offer title", 
-            "example": "Le Petit Prince", 
-            "maxLength": 90, 
-            "title": "Name", 
-            "type": "string"
-          }, 
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OfferStatus"
-              }
-            ], 
-            "description": "ACTIVE: offer is validated and active.\n\nDRAFT: offer is still draft and not yet submitted for validation - this status is not applicable to offers created via this API.\n\nEXPIRED: offer is validated but the booking limit datetime has passed.\n\nINACTIVE: offer is not active and cannot be booked.\n\nPENDING: offer is pending for pass Culture rules compliance validation. This step may last 72 hours.\n\nREJECTED: offer validation has been rejected because it is not compliant with pass Culture rules.\n\nSOLD_OUT: offer is validated but there is no (more) stock available for booking.", 
-            "example": "ACTIVE"
-          }, 
-          "stock": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ProductStockResponse"
-              }
-            ], 
-            "nullable": true, 
-            "title": "ProductStockResponse"
-          }
-        }, 
-        "required": [
-          "id", 
-          "accessibility", 
-          "location", 
-          "name", 
-          "status", 
-          "categoryRelatedFields"
-        ], 
-        "title": "ProductOfferResponse", 
-        "type": "object"
-      }, 
-      "ProductOffersByEanResponse": {
-        "properties": {
-          "products": {
-            "items": {
-              "$ref": "#/components/schemas/ProductOfferResponse"
-            }, 
-            "title": "Products", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "products"
-        ], 
-        "title": "ProductOffersByEanResponse", 
-        "type": "object"
-      }, 
-      "ProductOffersResponse": {
-        "properties": {
-          "products": {
-            "items": {
-              "$ref": "#/components/schemas/ProductOfferResponse"
-            }, 
-            "title": "Products", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "products"
-        ], 
-        "title": "ProductOffersResponse", 
-        "type": "object"
-      }, 
-      "ProductStockResponse": {
-        "properties": {
-          "bookedQuantity": {
-            "description": "Number of bookings.", 
-            "example": 0, 
-            "title": "Bookedquantity", 
-            "type": "integer"
-          }, 
-          "bookingLimitDatetime": {
-            "description": "Timezone aware datetime after which the offer can no longer be booked.", 
-            "example": "2024-06-21T14:00:00+02:00", 
-            "format": "date-time", 
-            "nullable": true, 
-            "title": "Bookinglimitdatetime", 
-            "type": "string"
-          }, 
-          "price": {
-            "description": "Offer price in euro cents.", 
-            "example": 1000, 
-            "title": "Price", 
-            "type": "integer"
-          }, 
-          "quantity": {
-            "anyOf": [
-              {
-                "type": "integer"
-              }, 
-              {
+            "ABO_MEDIATHEQUE_edit": {
+                "description": "Abonnement m\u00e9diath\u00e8que",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_MEDIATHEQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_MEDIATHEQUE_edit",
+                "type": "object"
+            },
+            "ABO_MEDIATHEQUE_read": {
+                "description": "Abonnement m\u00e9diath\u00e8que",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_MEDIATHEQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_MEDIATHEQUE_read",
+                "type": "object"
+            },
+            "ABO_PLATEFORME_MUSIQUE_create": {
+                "description": "Abonnement plateforme musicale",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PLATEFORME_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PLATEFORME_MUSIQUE_create",
+                "type": "object"
+            },
+            "ABO_PLATEFORME_MUSIQUE_edit": {
+                "description": "Abonnement plateforme musicale",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PLATEFORME_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PLATEFORME_MUSIQUE_edit",
+                "type": "object"
+            },
+            "ABO_PLATEFORME_MUSIQUE_read": {
+                "description": "Abonnement plateforme musicale",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PLATEFORME_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PLATEFORME_MUSIQUE_read",
+                "type": "object"
+            },
+            "ABO_PLATEFORME_VIDEO_create": {
+                "description": "Abonnement plateforme streaming",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PLATEFORME_VIDEO"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PLATEFORME_VIDEO_create",
+                "type": "object"
+            },
+            "ABO_PLATEFORME_VIDEO_edit": {
+                "description": "Abonnement plateforme streaming",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PLATEFORME_VIDEO"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PLATEFORME_VIDEO_edit",
+                "type": "object"
+            },
+            "ABO_PLATEFORME_VIDEO_read": {
+                "description": "Abonnement plateforme streaming",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PLATEFORME_VIDEO"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PLATEFORME_VIDEO_read",
+                "type": "object"
+            },
+            "ABO_PRATIQUE_ART_create": {
+                "description": "Abonnement pratique artistique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PRATIQUE_ART_create",
+                "type": "object"
+            },
+            "ABO_PRATIQUE_ART_edit": {
+                "description": "Abonnement pratique artistique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PRATIQUE_ART_edit",
+                "type": "object"
+            },
+            "ABO_PRATIQUE_ART_read": {
+                "description": "Abonnement pratique artistique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PRATIQUE_ART_read",
+                "type": "object"
+            },
+            "ABO_PRESSE_EN_LIGNE_create": {
+                "description": "Abonnement presse en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PRESSE_EN_LIGNE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PRESSE_EN_LIGNE_create",
+                "type": "object"
+            },
+            "ABO_PRESSE_EN_LIGNE_edit": {
+                "description": "Abonnement presse en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PRESSE_EN_LIGNE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PRESSE_EN_LIGNE_edit",
+                "type": "object"
+            },
+            "ABO_PRESSE_EN_LIGNE_read": {
+                "description": "Abonnement presse en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_PRESSE_EN_LIGNE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_PRESSE_EN_LIGNE_read",
+                "type": "object"
+            },
+            "ABO_SPECTACLE_create": {
+                "description": "Abonnement spectacle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_SPECTACLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    }
+                },
+                "required": [
+                    "showType",
+                    "category"
+                ],
+                "title": "ABO_SPECTACLE_create",
+                "type": "object"
+            },
+            "ABO_SPECTACLE_edit": {
+                "description": "Abonnement spectacle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_SPECTACLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_SPECTACLE_edit",
+                "type": "object"
+            },
+            "ABO_SPECTACLE_read": {
+                "description": "Abonnement spectacle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ABO_SPECTACLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ABO_SPECTACLE_read",
+                "type": "object"
+            },
+            "ACHAT_INSTRUMENT_create": {
+                "description": "Achat instrument",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ACHAT_INSTRUMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "ean",
+                    "category"
+                ],
+                "title": "ACHAT_INSTRUMENT_create",
+                "type": "object"
+            },
+            "ACHAT_INSTRUMENT_edit": {
+                "description": "Achat instrument",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ACHAT_INSTRUMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ACHAT_INSTRUMENT_edit",
+                "type": "object"
+            },
+            "ACHAT_INSTRUMENT_read": {
+                "description": "Achat instrument",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ACHAT_INSTRUMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ACHAT_INSTRUMENT_read",
+                "type": "object"
+            },
+            "ACTIVATION_EVENT_read": {
+                "description": "Cat\u00e9gorie technique d'\u00e9v\u00e8nement d'activation ",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ACTIVATION_EVENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ACTIVATION_EVENT_read",
+                "type": "object"
+            },
+            "ACTIVATION_THING_read": {
+                "description": "Cat\u00e9gorie technique de thing d'activation",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ACTIVATION_THING"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ACTIVATION_THING_read",
+                "type": "object"
+            },
+            "APP_CULTURELLE_create": {
+                "description": "Application culturelle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "APP_CULTURELLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "APP_CULTURELLE_create",
+                "type": "object"
+            },
+            "APP_CULTURELLE_edit": {
+                "description": "Application culturelle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "APP_CULTURELLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "APP_CULTURELLE_edit",
+                "type": "object"
+            },
+            "APP_CULTURELLE_read": {
+                "description": "Application culturelle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "APP_CULTURELLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "APP_CULTURELLE_read",
+                "type": "object"
+            },
+            "ATELIER_PRATIQUE_ART_create": {
+                "description": "Atelier, stage de pratique artistique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ATELIER_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ATELIER_PRATIQUE_ART_create",
+                "type": "object"
+            },
+            "ATELIER_PRATIQUE_ART_edit": {
+                "description": "Atelier, stage de pratique artistique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ATELIER_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ATELIER_PRATIQUE_ART_edit",
+                "type": "object"
+            },
+            "ATELIER_PRATIQUE_ART_read": {
+                "description": "Atelier, stage de pratique artistique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ATELIER_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ATELIER_PRATIQUE_ART_read",
+                "type": "object"
+            },
+            "AUTRE_SUPPORT_NUMERIQUE_create": {
+                "description": "Autre support num\u00e9rique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "AUTRE_SUPPORT_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "AUTRE_SUPPORT_NUMERIQUE_create",
+                "type": "object"
+            },
+            "AUTRE_SUPPORT_NUMERIQUE_edit": {
+                "description": "Autre support num\u00e9rique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "AUTRE_SUPPORT_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "AUTRE_SUPPORT_NUMERIQUE_edit",
+                "type": "object"
+            },
+            "AUTRE_SUPPORT_NUMERIQUE_read": {
+                "description": "Autre support num\u00e9rique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "AUTRE_SUPPORT_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "AUTRE_SUPPORT_NUMERIQUE_read",
+                "type": "object"
+            },
+            "Accessibility": {
+                "description": "Accessibility for people with disabilities.",
+                "properties": {
+                    "audioDisabilityCompliant": {
+                        "title": "Audiodisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "mentalDisabilityCompliant": {
+                        "title": "Mentaldisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "motorDisabilityCompliant": {
+                        "title": "Motordisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "visualDisabilityCompliant": {
+                        "title": "Visualdisabilitycompliant",
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "audioDisabilityCompliant",
+                    "mentalDisabilityCompliant",
+                    "motorDisabilityCompliant",
+                    "visualDisabilityCompliant"
+                ],
+                "title": "Accessibility",
+                "type": "object"
+            },
+            "AccessibilityResponse": {
+                "description": "Accessibility for people with disabilities.",
+                "properties": {
+                    "audioDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Audiodisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "mentalDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Mentaldisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "motorDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Motordisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "visualDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Visualdisabilitycompliant",
+                        "type": "boolean"
+                    }
+                },
+                "title": "AccessibilityResponse",
+                "type": "object"
+            },
+            "AuthErrorResponseModel": {
+                "properties": {
+                    "errors": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "title": "Errors",
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "errors"
+                ],
+                "title": "AuthErrorResponseModel",
+                "type": "object"
+            },
+            "BON_ACHAT_INSTRUMENT_read": {
+                "description": "Bon d'achat instrument",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "BON_ACHAT_INSTRUMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "BON_ACHAT_INSTRUMENT_read",
+                "type": "object"
+            },
+            "BookingStatus": {
+                "description": "An enumeration.",
                 "enum": [
-                  "unlimited"
-                ], 
-                "type": "string"
-              }
-            ], 
-            "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.", 
-            "example": 10, 
-            "title": "Quantity"
-          }
-        }, 
-        "required": [
-          "bookedQuantity", 
-          "quantity", 
-          "price"
-        ], 
-        "title": "ProductStockResponse", 
-        "type": "object"
-      }, 
-      "ProductsOfferByEanCreation": {
-        "additionalProperties": false, 
-        "properties": {
-          "location": {
-            "description": "Location where the offer will be available or will take place. The location type must be compatible with the category", 
-            "discriminator": {
-              "mapping": {
-                "digital": "#/components/schemas/DigitalLocation", 
-                "physical": "#/components/schemas/PhysicalLocation"
-              }, 
-              "propertyName": "type"
-            }, 
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PhysicalLocation"
-              }, 
-              {
-                "$ref": "#/components/schemas/DigitalLocation"
-              }
-            ], 
-            "title": "Location"
-          }, 
-          "products": {
-            "description": "List of product to create or update", 
-            "items": {
-              "$ref": "#/components/schemas/ProductOfferByEanCreation"
-            }, 
-            "maxItems": 500, 
-            "title": "Products", 
-            "type": "array"
-          }
-        }, 
-        "required": [
-          "products", 
-          "location"
-        ], 
-        "title": "ProductsOfferByEanCreation", 
-        "type": "object"
-      }, 
-      "RENCONTRE_EN_LIGNE_create": {
-        "description": "Rencontre en ligne", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE_EN_LIGNE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_EN_LIGNE_create", 
-        "type": "object"
-      }, 
-      "RENCONTRE_EN_LIGNE_edit": {
-        "description": "Rencontre en ligne", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE_EN_LIGNE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_EN_LIGNE_edit", 
-        "type": "object"
-      }, 
-      "RENCONTRE_EN_LIGNE_read": {
-        "description": "Rencontre en ligne", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE_EN_LIGNE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_EN_LIGNE_read", 
-        "type": "object"
-      }, 
-      "RENCONTRE_JEU_create": {
-        "description": "Rencontres - jeux", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE_JEU"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_JEU_create", 
-        "type": "object"
-      }, 
-      "RENCONTRE_JEU_edit": {
-        "description": "Rencontres - jeux", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE_JEU"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_JEU_edit", 
-        "type": "object"
-      }, 
-      "RENCONTRE_JEU_read": {
-        "description": "Rencontres - jeux", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE_JEU"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_JEU_read", 
-        "type": "object"
-      }, 
-      "RENCONTRE_create": {
-        "description": "Rencontre", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_create", 
-        "type": "object"
-      }, 
-      "RENCONTRE_edit": {
-        "description": "Rencontre", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_edit", 
-        "type": "object"
-      }, 
-      "RENCONTRE_read": {
-        "description": "Rencontre", 
-        "properties": {
-          "category": {
-            "enum": [
-              "RENCONTRE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "RENCONTRE_read", 
-        "type": "object"
-      }, 
-      "SALON_create": {
-        "description": "Salon, Convention", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SALON"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SALON_create", 
-        "type": "object"
-      }, 
-      "SALON_edit": {
-        "description": "Salon, Convention", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SALON"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SALON_edit", 
-        "type": "object"
-      }, 
-      "SALON_read": {
-        "description": "Salon, Convention", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SALON"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SALON_read", 
-        "type": "object"
-      }, 
-      "SEANCE_CINE_create": {
-        "description": "S\u00e9ance de cin\u00e9ma", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SEANCE_CINE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }, 
-          "visa": {
-            "title": "Visa", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SEANCE_CINE_create", 
-        "type": "object"
-      }, 
-      "SEANCE_CINE_edit": {
-        "description": "S\u00e9ance de cin\u00e9ma", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SEANCE_CINE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }, 
-          "visa": {
-            "title": "Visa", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SEANCE_CINE_edit", 
-        "type": "object"
-      }, 
-      "SEANCE_CINE_read": {
-        "description": "S\u00e9ance de cin\u00e9ma", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SEANCE_CINE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }, 
-          "visa": {
-            "title": "Visa", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SEANCE_CINE_read", 
-        "type": "object"
-      }, 
-      "SEANCE_ESSAI_PRATIQUE_ART_create": {
-        "description": "S\u00e9ance d'essai", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SEANCE_ESSAI_PRATIQUE_ART"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SEANCE_ESSAI_PRATIQUE_ART_create", 
-        "type": "object"
-      }, 
-      "SEANCE_ESSAI_PRATIQUE_ART_edit": {
-        "description": "S\u00e9ance d'essai", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SEANCE_ESSAI_PRATIQUE_ART"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SEANCE_ESSAI_PRATIQUE_ART_edit", 
-        "type": "object"
-      }, 
-      "SEANCE_ESSAI_PRATIQUE_ART_read": {
-        "description": "S\u00e9ance d'essai", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SEANCE_ESSAI_PRATIQUE_ART"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "speaker": {
-            "title": "Speaker", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SEANCE_ESSAI_PRATIQUE_ART_read", 
-        "type": "object"
-      }, 
-      "SPECTACLE_ENREGISTRE_create": {
-        "description": "Spectacle enregistr\u00e9", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SPECTACLE_ENREGISTRE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "showType", 
-          "category"
-        ], 
-        "title": "SPECTACLE_ENREGISTRE_create", 
-        "type": "object"
-      }, 
-      "SPECTACLE_ENREGISTRE_edit": {
-        "description": "Spectacle enregistr\u00e9", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SPECTACLE_ENREGISTRE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SPECTACLE_ENREGISTRE_edit", 
-        "type": "object"
-      }, 
-      "SPECTACLE_ENREGISTRE_read": {
-        "description": "Spectacle enregistr\u00e9", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SPECTACLE_ENREGISTRE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SPECTACLE_ENREGISTRE_read", 
-        "type": "object"
-      }, 
-      "SPECTACLE_REPRESENTATION_create": {
-        "description": "Spectacle, repr\u00e9sentation", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SPECTACLE_REPRESENTATION"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "showType", 
-          "category"
-        ], 
-        "title": "SPECTACLE_REPRESENTATION_create", 
-        "type": "object"
-      }, 
-      "SPECTACLE_REPRESENTATION_edit": {
-        "description": "Spectacle, repr\u00e9sentation", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SPECTACLE_REPRESENTATION"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SPECTACLE_REPRESENTATION_edit", 
-        "type": "object"
-      }, 
-      "SPECTACLE_REPRESENTATION_read": {
-        "description": "Spectacle, repr\u00e9sentation", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SPECTACLE_REPRESENTATION"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SPECTACLE_REPRESENTATION_read", 
-        "type": "object"
-      }, 
-      "SPECTACLE_VENTE_DISTANCE_read": {
-        "description": "Spectacle vivant - vente \u00e0 distance", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SPECTACLE_VENTE_DISTANCE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }, 
-          "showType": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "stageDirector": {
-            "title": "Stagedirector", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SPECTACLE_VENTE_DISTANCE_read", 
-        "type": "object"
-      }, 
-      "SUPPORT_PHYSIQUE_FILM_create": {
-        "description": "Support physique (DVD, Blu-ray...)", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SUPPORT_PHYSIQUE_FILM"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "ean", 
-          "category"
-        ], 
-        "title": "SUPPORT_PHYSIQUE_FILM_create", 
-        "type": "object"
-      }, 
-      "SUPPORT_PHYSIQUE_FILM_edit": {
-        "description": "Support physique (DVD, Blu-ray...)", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SUPPORT_PHYSIQUE_FILM"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SUPPORT_PHYSIQUE_FILM_edit", 
-        "type": "object"
-      }, 
-      "SUPPORT_PHYSIQUE_FILM_read": {
-        "description": "Support physique (DVD, Blu-ray...)", 
-        "properties": {
-          "category": {
-            "enum": [
-              "SUPPORT_PHYSIQUE_FILM"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SUPPORT_PHYSIQUE_FILM_read", 
-        "type": "object"
-      }, 
-      "SUPPORT_PHYSIQUE_MUSIQUE_CD_read": {
-        "description": "CD", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SUPPORT_PHYSIQUE_MUSIQUE_CD"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SUPPORT_PHYSIQUE_MUSIQUE_CD_read", 
-        "type": "object"
-      }, 
-      "SUPPORT_PHYSIQUE_MUSIQUE_VINYLE_read": {
-        "description": "Vinyles et autres supports", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "SUPPORT_PHYSIQUE_MUSIQUE_VINYLE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "SUPPORT_PHYSIQUE_MUSIQUE_VINYLE_read", 
-        "type": "object"
-      }, 
-      "ShowTypeEnum": {
-        "description": "An enumeration.", 
-        "enum": [
-          "ART_DE_LA_RUE-CARNAVAL", 
-          "ART_DE_LA_RUE-FANFARE", 
-          "ART_DE_LA_RUE-MIME", 
-          "ART_DE_LA_RUE-PARADE", 
-          "ART_DE_LA_RUE-THEATRE_DE_RUE", 
-          "ART_DE_LA_RUE-THEATRE_PROMENADE", 
-          "ART_DE_LA_RUE-OTHER", 
-          "CIRQUE-CIRQUE_CONTEMPORAIN", 
-          "CIRQUE-CIRQUE_HORS_LES_MURS", 
-          "CIRQUE-CIRQUE_TRADITIONNEL", 
-          "CIRQUE-CIRQUE_VOYAGEUR", 
-          "CIRQUE-CLOWN", 
-          "CIRQUE-HYPNOSE", 
-          "CIRQUE-MENTALISTE", 
-          "CIRQUE-SPECTACLE_DE_MAGIE", 
-          "CIRQUE-SPECTACLE_EQUESTRE", 
-          "CIRQUE-OTHER", 
-          "DANSE-BALLET", 
-          "DANSE-CANCAN", 
-          "DANSE-CLAQUETTE", 
-          "DANSE-CLASSIQUE", 
-          "DANSE-CONTEMPORAINE", 
-          "DANSE-DANSE_DU_MONDE", 
-          "DANSE-FLAMENCO", 
-          "DANSE-MODERNE_JAZZ", 
-          "DANSE-SALSA", 
-          "DANSE-SWING", 
-          "DANSE-TANGO", 
-          "DANSE-URBAINE", 
-          "DANSE-OTHER", 
-          "HUMOUR-CAFE_THEATRE", 
-          "HUMOUR-IMPROVISATION", 
-          "HUMOUR-SEUL_EN_SCENE", 
-          "HUMOUR-SKETCH", 
-          "HUMOUR-STAND_UP", 
-          "HUMOUR-VENTRILOQUE", 
-          "HUMOUR-OTHER", 
-          "SPECTACLE_MUSICAL-CABARET", 
-          "SPECTACLE_MUSICAL-CAFE_CONCERT", 
-          "SPECTACLE_MUSICAL-CLAQUETTE", 
-          "SPECTACLE_MUSICAL-COMEDIE_MUSICALE", 
-          "SPECTACLE_MUSICAL-OPERA_BOUFFE", 
-          "SPECTACLE_MUSICAL-OPERETTE", 
-          "SPECTACLE_MUSICAL-REVUE", 
-          "SPECTACLE_MUSICAL-BURLESQUE", 
-          "SPECTACLE_MUSICAL-COMEDIE_BALLET", 
-          "SPECTACLE_MUSICAL-OPERA_COMIQUE", 
-          "SPECTACLE_MUSICAL-OPERA_BALLET", 
-          "SPECTACLE_MUSICAL-THEATRE_MUSICAL", 
-          "SPECTACLE_MUSICAL-OTHER", 
-          "SPECTACLE_JEUNESSE-CONTE", 
-          "SPECTACLE_JEUNESSE-THEATRE_JEUNESSE", 
-          "SPECTACLE_JEUNESSE-SPECTACLE_PETITE_ENFANCE", 
-          "SPECTACLE_JEUNESSE-MAGIE_ENFANCE", 
-          "SPECTACLE_JEUNESSE-SPECTACLE_PEDAGOGIQUE", 
-          "SPECTACLE_JEUNESSE-MARIONETTES", 
-          "SPECTACLE_JEUNESSE-COMEDIE_MUSICALE_JEUNESSE", 
-          "SPECTACLE_JEUNESSE-THEATRE_D_OMBRES", 
-          "SPECTACLE_JEUNESSE-OTHER", 
-          "THEATRE-BOULEVARD", 
-          "THEATRE-CLASSIQUE", 
-          "THEATRE-COMEDIE", 
-          "THEATRE-CONTEMPORAIN", 
-          "THEATRE-LECTURE", 
-          "THEATRE-SPECTACLE_SCENOGRAPHIQUE", 
-          "THEATRE-THEATRE_EXPERIMENTAL", 
-          "THEATRE-THEATRE_D_OBJET", 
-          "THEATRE-TRAGEDIE", 
-          "THEATRE-OTHER", 
-          "PLURIDISCIPLINAIRE-PERFORMANCE", 
-          "PLURIDISCIPLINAIRE-POESIE", 
-          "PLURIDISCIPLINAIRE-OTHER", 
-          "OTHER-SON_ET_LUMIERE", 
-          "OTHER-SPECTACLE_SUR_GLACE", 
-          "OTHER-SPECTACLE_HISTORIQUE", 
-          "OTHER-SPECTACLE_AQUATIQUE", 
-          "OTHER-OTHER", 
-          "OPERA-OPERA_SERIE", 
-          "OPERA-GRAND_OPERA", 
-          "OPERA-OPERA_BOUFFE", 
-          "OPERA-OPERA_COMIQUE", 
-          "OPERA-OPERA_BALLET", 
-          "OPERA-SINGSPIEL", 
-          "OPERA-OTHER", 
-          "OTHER"
-        ], 
-        "title": "ShowTypeEnum", 
-        "type": "string"
-      }, 
-      "ShowTypeResponse": {
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ShowTypeEnum"
-          }, 
-          "label": {
-            "title": "Label", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "id", 
-          "label"
-        ], 
-        "title": "ShowTypeResponse", 
-        "type": "object"
-      }, 
-      "StockCreation": {
-        "properties": {
-          "bookingLimitDatetime": {
-            "description": "Timezone aware datetime after which the offer can no longer be booked.", 
-            "example": "2024-06-21T14:00:00+02:00", 
-            "format": "date-time", 
-            "nullable": true, 
-            "title": "Bookinglimitdatetime", 
-            "type": "string"
-          }, 
-          "price": {
-            "description": "Offer price in euro cents.", 
-            "example": 1000, 
-            "maximum": 30000, 
-            "minimum": 0, 
-            "title": "Price", 
-            "type": "integer"
-          }, 
-          "quantity": {
-            "anyOf": [
-              {
-                "type": "integer"
-              }, 
-              {
+                    "CONFIRMED",
+                    "USED",
+                    "CANCELLED",
+                    "REIMBURSED"
+                ],
+                "title": "BookingStatus"
+            },
+            "CAPTATION_MUSIQUE_read": {
+                "description": "Captation musicale",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "CAPTATION_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CAPTATION_MUSIQUE_read",
+                "type": "object"
+            },
+            "CARTE_CINE_ILLIMITE_read": {
+                "description": "Carte cin\u00e9ma illimit\u00e9",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CARTE_CINE_ILLIMITE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CARTE_CINE_ILLIMITE_read",
+                "type": "object"
+            },
+            "CARTE_CINE_MULTISEANCES_read": {
+                "description": "Carte cin\u00e9ma multi-s\u00e9ances",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CARTE_CINE_MULTISEANCES"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CARTE_CINE_MULTISEANCES_read",
+                "type": "object"
+            },
+            "CARTE_JEUNES_create": {
+                "description": "Carte jeunes",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CARTE_JEUNES"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CARTE_JEUNES_create",
+                "type": "object"
+            },
+            "CARTE_JEUNES_edit": {
+                "description": "Carte jeunes",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CARTE_JEUNES"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CARTE_JEUNES_edit",
+                "type": "object"
+            },
+            "CARTE_JEUNES_read": {
+                "description": "Carte jeunes",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CARTE_JEUNES"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CARTE_JEUNES_read",
+                "type": "object"
+            },
+            "CARTE_MUSEE_create": {
+                "description": "Abonnement mus\u00e9e, carte ou pass",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CARTE_MUSEE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CARTE_MUSEE_create",
+                "type": "object"
+            },
+            "CARTE_MUSEE_edit": {
+                "description": "Abonnement mus\u00e9e, carte ou pass",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CARTE_MUSEE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CARTE_MUSEE_edit",
+                "type": "object"
+            },
+            "CARTE_MUSEE_read": {
+                "description": "Abonnement mus\u00e9e, carte ou pass",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CARTE_MUSEE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CARTE_MUSEE_read",
+                "type": "object"
+            },
+            "CINE_PLEIN_AIR_create": {
+                "description": "Cin\u00e9ma plein air",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "CINE_PLEIN_AIR"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CINE_PLEIN_AIR_create",
+                "type": "object"
+            },
+            "CINE_PLEIN_AIR_edit": {
+                "description": "Cin\u00e9ma plein air",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "CINE_PLEIN_AIR"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CINE_PLEIN_AIR_edit",
+                "type": "object"
+            },
+            "CINE_PLEIN_AIR_read": {
+                "description": "Cin\u00e9ma plein air",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "CINE_PLEIN_AIR"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CINE_PLEIN_AIR_read",
+                "type": "object"
+            },
+            "CINE_VENTE_DISTANCE_read": {
+                "description": "Cin\u00e9ma vente \u00e0 distance",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "CINE_VENTE_DISTANCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CINE_VENTE_DISTANCE_read",
+                "type": "object"
+            },
+            "CONCERT_create": {
+                "description": "Concert",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "CONCERT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "musicType",
+                    "category"
+                ],
+                "title": "CONCERT_create",
+                "type": "object"
+            },
+            "CONCERT_edit": {
+                "description": "Concert",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "CONCERT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CONCERT_edit",
+                "type": "object"
+            },
+            "CONCERT_read": {
+                "description": "Concert",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "CONCERT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CONCERT_read",
+                "type": "object"
+            },
+            "CONCOURS_create": {
+                "description": "Concours - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CONCOURS"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CONCOURS_create",
+                "type": "object"
+            },
+            "CONCOURS_edit": {
+                "description": "Concours - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CONCOURS"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CONCOURS_edit",
+                "type": "object"
+            },
+            "CONCOURS_read": {
+                "description": "Concours - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CONCOURS"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CONCOURS_read",
+                "type": "object"
+            },
+            "CONFERENCE_create": {
+                "description": "Conf\u00e9rence",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CONFERENCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CONFERENCE_create",
+                "type": "object"
+            },
+            "CONFERENCE_edit": {
+                "description": "Conf\u00e9rence",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CONFERENCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CONFERENCE_edit",
+                "type": "object"
+            },
+            "CONFERENCE_read": {
+                "description": "Conf\u00e9rence",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "CONFERENCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "CONFERENCE_read",
+                "type": "object"
+            },
+            "CategoryEnum": {
+                "description": "An enumeration.",
                 "enum": [
-                  "unlimited"
-                ], 
+                    "ABO_BIBLIOTHEQUE",
+                    "ABO_CONCERT",
+                    "ABO_LIVRE_NUMERIQUE",
+                    "ABO_MEDIATHEQUE",
+                    "ABO_PLATEFORME_MUSIQUE",
+                    "ABO_PLATEFORME_VIDEO",
+                    "ABO_PRATIQUE_ART",
+                    "ABO_PRESSE_EN_LIGNE",
+                    "ABO_SPECTACLE",
+                    "ACHAT_INSTRUMENT",
+                    "APP_CULTURELLE",
+                    "AUTRE_SUPPORT_NUMERIQUE",
+                    "CAPTATION_MUSIQUE",
+                    "CARTE_JEUNES",
+                    "CARTE_MUSEE",
+                    "LIVRE_AUDIO_PHYSIQUE",
+                    "LIVRE_NUMERIQUE",
+                    "LOCATION_INSTRUMENT",
+                    "PARTITION",
+                    "PLATEFORME_PRATIQUE_ARTISTIQUE",
+                    "PODCAST",
+                    "PRATIQUE_ART_VENTE_DISTANCE",
+                    "SPECTACLE_ENREGISTRE",
+                    "SUPPORT_PHYSIQUE_FILM",
+                    "TELECHARGEMENT_LIVRE_AUDIO",
+                    "TELECHARGEMENT_MUSIQUE",
+                    "VISITE_VIRTUELLE",
+                    "VOD"
+                ],
+                "title": "CategoryEnum",
                 "type": "string"
-              }
-            ], 
-            "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.", 
-            "example": 10, 
-            "title": "Quantity"
-          }
-        }, 
-        "required": [
-          "quantity", 
-          "price"
-        ], 
-        "title": "StockCreation", 
-        "type": "object"
-      }, 
-      "StockEdition": {
-        "additionalProperties": false, 
-        "properties": {
-          "bookingLimitDatetime": {
-            "description": "Timezone aware datetime after which the offer can no longer be booked.", 
-            "example": "2024-06-21T14:00:00+02:00", 
-            "format": "date-time", 
-            "nullable": true, 
-            "title": "Bookinglimitdatetime", 
-            "type": "string"
-          }, 
-          "price": {
-            "description": "Offer price in euro cents.", 
-            "example": 1000, 
-            "maximum": 30000, 
-            "minimum": 0, 
-            "nullable": true, 
-            "title": "Price", 
-            "type": "integer"
-          }, 
-          "quantity": {
-            "anyOf": [
-              {
-                "type": "integer"
-              }, 
-              {
+            },
+            "CollectiveBookingResponseModel": {
+                "properties": {
+                    "cancellationLimitDate": {
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Cancellationlimitdate",
+                        "type": "string"
+                    },
+                    "confirmationDate": {
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Confirmationdate",
+                        "type": "string"
+                    },
+                    "dateCreated": {
+                        "format": "date-time",
+                        "title": "Datecreated",
+                        "type": "string"
+                    },
+                    "dateUsed": {
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Dateused",
+                        "type": "string"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "reimbursementDate": {
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Reimbursementdate",
+                        "type": "string"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/CollectiveBookingStatus"
+                    }
+                },
+                "required": [
+                    "id",
+                    "status",
+                    "dateCreated"
+                ],
+                "title": "CollectiveBookingResponseModel",
+                "type": "object"
+            },
+            "CollectiveBookingStatus": {
+                "description": "An enumeration.",
                 "enum": [
-                  "unlimited"
-                ], 
+                    "PENDING",
+                    "CONFIRMED",
+                    "USED",
+                    "CANCELLED",
+                    "REIMBURSED"
+                ],
+                "title": "CollectiveBookingStatus"
+            },
+            "CollectiveOffersCategoryResponseModel": {
+                "properties": {
+                    "id": {
+                        "title": "Id",
+                        "type": "string"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "title": "CollectiveOffersCategoryResponseModel",
+                "type": "object"
+            },
+            "CollectiveOffersDomainResponseModel": {
+                "properties": {
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "nationalPrograms": {
+                        "items": {
+                            "$ref": "#/components/schemas/NationalProgramModel"
+                        },
+                        "title": "Nationalprograms",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "nationalPrograms"
+                ],
+                "title": "CollectiveOffersDomainResponseModel",
+                "type": "object"
+            },
+            "CollectiveOffersEducationalInstitutionResponseModel": {
+                "properties": {
+                    "city": {
+                        "title": "City",
+                        "type": "string"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "institutionType": {
+                        "title": "Institutiontype",
+                        "type": "string"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "postalCode": {
+                        "title": "Postalcode",
+                        "type": "string"
+                    },
+                    "uai": {
+                        "title": "Uai",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "uai",
+                    "name",
+                    "institutionType",
+                    "city",
+                    "postalCode"
+                ],
+                "title": "CollectiveOffersEducationalInstitutionResponseModel",
+                "type": "object"
+            },
+            "CollectiveOffersListCategoriesResponseModel": {
+                "items": {
+                    "$ref": "#/components/schemas/CollectiveOffersCategoryResponseModel"
+                },
+                "title": "CollectiveOffersListCategoriesResponseModel",
+                "type": "array"
+            },
+            "CollectiveOffersListDomainsResponseModel": {
+                "items": {
+                    "$ref": "#/components/schemas/CollectiveOffersDomainResponseModel"
+                },
+                "title": "CollectiveOffersListDomainsResponseModel",
+                "type": "array"
+            },
+            "CollectiveOffersListEducationalInstitutionResponseModel": {
+                "items": {
+                    "$ref": "#/components/schemas/CollectiveOffersEducationalInstitutionResponseModel"
+                },
+                "title": "CollectiveOffersListEducationalInstitutionResponseModel",
+                "type": "array"
+            },
+            "CollectiveOffersListResponseModel": {
+                "items": {
+                    "$ref": "#/components/schemas/CollectiveOffersResponseModel"
+                },
+                "title": "CollectiveOffersListResponseModel",
+                "type": "array"
+            },
+            "CollectiveOffersListStudentLevelsResponseModel": {
+                "items": {
+                    "$ref": "#/components/schemas/CollectiveOffersStudentLevelResponseModel"
+                },
+                "title": "CollectiveOffersListStudentLevelsResponseModel",
+                "type": "array"
+            },
+            "CollectiveOffersListSubCategoriesResponseModel": {
+                "items": {
+                    "$ref": "#/components/schemas/CollectiveOffersSubCategoryResponseModel"
+                },
+                "title": "CollectiveOffersListSubCategoriesResponseModel",
+                "type": "array"
+            },
+            "CollectiveOffersListVenuesResponseModel": {
+                "items": {
+                    "$ref": "#/components/schemas/VenueResponse"
+                },
+                "title": "CollectiveOffersListVenuesResponseModel",
+                "type": "array"
+            },
+            "CollectiveOffersResponseModel": {
+                "properties": {
+                    "beginningDatetime": {
+                        "title": "Beginningdatetime",
+                        "type": "string"
+                    },
+                    "bookings": {
+                        "items": {
+                            "$ref": "#/components/schemas/CollectiveBookingResponseModel"
+                        },
+                        "title": "Bookings",
+                        "type": "array"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "status": {
+                        "title": "Status",
+                        "type": "string"
+                    },
+                    "venueId": {
+                        "title": "Venueid",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "id",
+                    "beginningDatetime",
+                    "status",
+                    "venueId",
+                    "bookings"
+                ],
+                "title": "CollectiveOffersResponseModel",
+                "type": "object"
+            },
+            "CollectiveOffersStudentLevelResponseModel": {
+                "properties": {
+                    "id": {
+                        "title": "Id",
+                        "type": "string"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "title": "CollectiveOffersStudentLevelResponseModel",
+                "type": "object"
+            },
+            "CollectiveOffersSubCategoryResponseModel": {
+                "properties": {
+                    "category": {
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "categoryId": {
+                        "title": "Categoryid",
+                        "type": "string"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "string"
+                    },
+                    "label": {
+                        "title": "Label",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "label",
+                    "category",
+                    "categoryId"
+                ],
+                "title": "CollectiveOffersSubCategoryResponseModel",
+                "type": "object"
+            },
+            "DECOUVERTE_METIERS_read": {
+                "description": "D\u00e9couverte des m\u00e9tiers",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "DECOUVERTE_METIERS"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "DECOUVERTE_METIERS_read",
+                "type": "object"
+            },
+            "DateCreation": {
+                "properties": {
+                    "beginningDatetime": {
+                        "description": "Timezone aware datetime of the event.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "title": "Beginningdatetime",
+                        "type": "string"
+                    },
+                    "bookingLimitDatetime": {
+                        "description": "Timezone aware datetime after which the offer can no longer be booked.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "priceCategoryId": {
+                        "title": "Pricecategoryid",
+                        "type": "integer"
+                    },
+                    "quantity": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "enum": [
+                                    "unlimited"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
+                        "example": 10,
+                        "title": "Quantity"
+                    }
+                },
+                "required": [
+                    "quantity",
+                    "beginningDatetime",
+                    "bookingLimitDatetime",
+                    "priceCategoryId"
+                ],
+                "title": "DateCreation",
+                "type": "object"
+            },
+            "DateEdition": {
+                "additionalProperties": false,
+                "properties": {
+                    "beginningDatetime": {
+                        "description": "Timezone aware datetime of the event.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Beginningdatetime",
+                        "type": "string"
+                    },
+                    "bookingLimitDatetime": {
+                        "description": "Timezone aware datetime after which the offer can no longer be booked.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "priceCategoryId": {
+                        "nullable": true,
+                        "title": "Pricecategoryid",
+                        "type": "integer"
+                    },
+                    "quantity": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "enum": [
+                                    "unlimited"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
+                        "example": 10,
+                        "nullable": true,
+                        "title": "Quantity"
+                    }
+                },
+                "title": "DateEdition",
+                "type": "object"
+            },
+            "DateResponse": {
+                "properties": {
+                    "beginningDatetime": {
+                        "description": "Timezone aware datetime of the event.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "title": "Beginningdatetime",
+                        "type": "string"
+                    },
+                    "bookedQuantity": {
+                        "description": "Number of bookings.",
+                        "example": 0,
+                        "title": "Bookedquantity",
+                        "type": "integer"
+                    },
+                    "bookingLimitDatetime": {
+                        "description": "Timezone aware datetime after which the offer can no longer be booked.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "priceCategory": {
+                        "$ref": "#/components/schemas/PriceCategoryResponse"
+                    },
+                    "quantity": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "enum": [
+                                    "unlimited"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
+                        "example": 10,
+                        "title": "Quantity"
+                    }
+                },
+                "required": [
+                    "bookingLimitDatetime",
+                    "bookedQuantity",
+                    "quantity",
+                    "id",
+                    "beginningDatetime",
+                    "priceCategory"
+                ],
+                "title": "DateResponse",
+                "type": "object"
+            },
+            "DatesCreation": {
+                "additionalProperties": false,
+                "properties": {
+                    "dates": {
+                        "description": "Dates to add to the event. If there are different prices and quantity for the same date, you must add several date objects",
+                        "items": {
+                            "$ref": "#/components/schemas/DateCreation"
+                        },
+                        "title": "Dates",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "dates"
+                ],
+                "title": "DatesCreation",
+                "type": "object"
+            },
+            "DigitalLocation": {
+                "properties": {
+                    "type": {
+                        "default": "digital",
+                        "enum": [
+                            "digital"
+                        ],
+                        "title": "Type",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "Link users will be redirected to after booking this offer. You may include '{token}', '{email}' and/or '{offerId}' in the URL, which will be replaced respectively by the booking token (use this token to confirm the offer - see API Contremarque), the email of the user who booked the offer and the created offer id",
+                        "example": "https://example.com?token={token}&email={email}&offerId={offerId}",
+                        "format": "uri",
+                        "maxLength": 2083,
+                        "minLength": 1,
+                        "title": "Url",
+                        "type": "string"
+                    },
+                    "venueId": {
+                        "description": "List of venues is available at GET /offerer_venues",
+                        "example": 1,
+                        "title": "Venueid",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "venueId",
+                    "url"
+                ],
+                "title": "DigitalLocation",
+                "type": "object"
+            },
+            "ESCAPE_GAME_read": {
+                "description": "Escape game",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "ESCAPE_GAME"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "ESCAPE_GAME_read",
+                "type": "object"
+            },
+            "EVENEMENT_CINE_create": {
+                "description": "\u00c9v\u00e8nement cin\u00e9matographique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_CINE_create",
+                "type": "object"
+            },
+            "EVENEMENT_CINE_edit": {
+                "description": "\u00c9v\u00e8nement cin\u00e9matographique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_CINE_edit",
+                "type": "object"
+            },
+            "EVENEMENT_CINE_read": {
+                "description": "\u00c9v\u00e8nement cin\u00e9matographique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_CINE_read",
+                "type": "object"
+            },
+            "EVENEMENT_JEU_create": {
+                "description": "\u00c9v\u00e8nements - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_JEU"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_JEU_create",
+                "type": "object"
+            },
+            "EVENEMENT_JEU_edit": {
+                "description": "\u00c9v\u00e8nements - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_JEU"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_JEU_edit",
+                "type": "object"
+            },
+            "EVENEMENT_JEU_read": {
+                "description": "\u00c9v\u00e8nements - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_JEU"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_JEU_read",
+                "type": "object"
+            },
+            "EVENEMENT_MUSIQUE_create": {
+                "description": "Autre type d'\u00e9v\u00e8nement musical",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "musicType",
+                    "category"
+                ],
+                "title": "EVENEMENT_MUSIQUE_create",
+                "type": "object"
+            },
+            "EVENEMENT_MUSIQUE_edit": {
+                "description": "Autre type d'\u00e9v\u00e8nement musical",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_MUSIQUE_edit",
+                "type": "object"
+            },
+            "EVENEMENT_MUSIQUE_read": {
+                "description": "Autre type d'\u00e9v\u00e8nement musical",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_MUSIQUE_read",
+                "type": "object"
+            },
+            "EVENEMENT_PATRIMOINE_create": {
+                "description": "\u00c9v\u00e8nement et atelier patrimoine",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_PATRIMOINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_PATRIMOINE_create",
+                "type": "object"
+            },
+            "EVENEMENT_PATRIMOINE_edit": {
+                "description": "\u00c9v\u00e8nement et atelier patrimoine",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_PATRIMOINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_PATRIMOINE_edit",
+                "type": "object"
+            },
+            "EVENEMENT_PATRIMOINE_read": {
+                "description": "\u00c9v\u00e8nement et atelier patrimoine",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "EVENEMENT_PATRIMOINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "EVENEMENT_PATRIMOINE_read",
+                "type": "object"
+            },
+            "EacFormat": {
+                "description": "An enumeration.",
+                "enum": [
+                    "Atelier de pratique",
+                    "Concert",
+                    "Conf\u00e9rence, rencontre",
+                    "Festival, salon, congr\u00e8s",
+                    "Projection audiovisuelle",
+                    "Repr\u00e9sentation",
+                    "Visite guid\u00e9e",
+                    "Visite libre"
+                ],
+                "title": "EacFormat"
+            },
+            "ErrorResponseModel": {
+                "properties": {
+                    "errors": {
+                        "additionalProperties": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "title": "Errors",
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "errors"
+                ],
+                "title": "ErrorResponseModel",
+                "type": "object"
+            },
+            "EventCategoryResponse": {
+                "properties": {
+                    "conditionalFields": {
+                        "additionalProperties": {
+                            "type": "boolean"
+                        },
+                        "description": "The keys are fields that should be set in the category_related_fields of an event. The values indicate whether their associated field is mandatory during event creation.",
+                        "title": "Conditionalfields",
+                        "type": "object"
+                    },
+                    "id": {
+                        "$ref": "#/components/schemas/CategoryEnum"
+                    }
+                },
+                "required": [
+                    "id",
+                    "conditionalFields"
+                ],
+                "title": "EventCategoryResponse",
+                "type": "object"
+            },
+            "EventOfferCreation": {
+                "additionalProperties": false,
+                "properties": {
+                    "accessibility": {
+                        "$ref": "#/components/schemas/Accessibility"
+                    },
+                    "bookingContact": {
+                        "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
+                        "format": "email",
+                        "nullable": true,
+                        "title": "Bookingcontact",
+                        "type": "string"
+                    },
+                    "bookingEmail": {
+                        "description": "Recipient email for notifications about bookings, cancellations, etc.",
+                        "format": "email",
+                        "nullable": true,
+                        "title": "Bookingemail",
+                        "type": "string"
+                    },
+                    "categoryRelatedFields": {
+                        "description": "Cultural category the offer belongs to. According to the category, some fields may or must be specified.",
+                        "discriminator": {
+                            "mapping": {
+                                "ATELIER_PRATIQUE_ART": "#/components/schemas/ATELIER_PRATIQUE_ART_create",
+                                "CINE_PLEIN_AIR": "#/components/schemas/CINE_PLEIN_AIR_create",
+                                "CONCERT": "#/components/schemas/CONCERT_create",
+                                "CONCOURS": "#/components/schemas/CONCOURS_create",
+                                "CONFERENCE": "#/components/schemas/CONFERENCE_create",
+                                "EVENEMENT_CINE": "#/components/schemas/EVENEMENT_CINE_create",
+                                "EVENEMENT_JEU": "#/components/schemas/EVENEMENT_JEU_create",
+                                "EVENEMENT_MUSIQUE": "#/components/schemas/EVENEMENT_MUSIQUE_create",
+                                "EVENEMENT_PATRIMOINE": "#/components/schemas/EVENEMENT_PATRIMOINE_create",
+                                "FESTIVAL_ART_VISUEL": "#/components/schemas/FESTIVAL_ART_VISUEL_create",
+                                "FESTIVAL_CINE": "#/components/schemas/FESTIVAL_CINE_create",
+                                "FESTIVAL_LIVRE": "#/components/schemas/FESTIVAL_LIVRE_create",
+                                "FESTIVAL_MUSIQUE": "#/components/schemas/FESTIVAL_MUSIQUE_create",
+                                "FESTIVAL_SPECTACLE": "#/components/schemas/FESTIVAL_SPECTACLE_create",
+                                "LIVESTREAM_EVENEMENT": "#/components/schemas/LIVESTREAM_EVENEMENT_create",
+                                "LIVESTREAM_MUSIQUE": "#/components/schemas/LIVESTREAM_MUSIQUE_create",
+                                "LIVESTREAM_PRATIQUE_ARTISTIQUE": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_create",
+                                "RENCONTRE": "#/components/schemas/RENCONTRE_create",
+                                "RENCONTRE_EN_LIGNE": "#/components/schemas/RENCONTRE_EN_LIGNE_create",
+                                "RENCONTRE_JEU": "#/components/schemas/RENCONTRE_JEU_create",
+                                "SALON": "#/components/schemas/SALON_create",
+                                "SEANCE_CINE": "#/components/schemas/SEANCE_CINE_create",
+                                "SEANCE_ESSAI_PRATIQUE_ART": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_create",
+                                "SPECTACLE_REPRESENTATION": "#/components/schemas/SPECTACLE_REPRESENTATION_create",
+                                "VISITE": "#/components/schemas/VISITE_create",
+                                "VISITE_GUIDEE": "#/components/schemas/VISITE_GUIDEE_create"
+                            },
+                            "propertyName": "category"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ATELIER_PRATIQUE_ART_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CINE_PLEIN_AIR_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONCERT_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONCOURS_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONFERENCE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_CINE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_JEU_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_MUSIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_PATRIMOINE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_ART_VISUEL_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_CINE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_LIVRE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_MUSIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_SPECTACLE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_EVENEMENT_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_MUSIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_EN_LIGNE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_JEU_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SALON_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SEANCE_CINE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SPECTACLE_REPRESENTATION_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_GUIDEE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_create"
+                            }
+                        ],
+                        "title": "Categoryrelatedfields"
+                    },
+                    "description": {
+                        "description": "Offer description",
+                        "example": "A great book for kids and old kids.",
+                        "maxLength": 1000,
+                        "nullable": true,
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "enableDoubleBookings": {
+                        "default": false,
+                        "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
+                        "nullable": true,
+                        "title": "Enabledoublebookings",
+                        "type": "boolean"
+                    },
+                    "eventDuration": {
+                        "description": "Event duration in minutes",
+                        "example": 60,
+                        "nullable": true,
+                        "title": "Eventduration",
+                        "type": "integer"
+                    },
+                    "externalTicketOfficeUrl": {
+                        "description": "Link displayed to users wishing to book the offer but who do not have (anymore) credit.",
+                        "example": "https://example.com",
+                        "format": "uri",
+                        "maxLength": 2083,
+                        "minLength": 1,
+                        "nullable": true,
+                        "title": "Externalticketofficeurl",
+                        "type": "string"
+                    },
+                    "hasTicket": {
+                        "description": "Indicates whether the offer has an associated ticket. True if a ticket is available, False otherwise. To create an offer with tickets you must have developed the pass culture ticketing interface.",
+                        "example": false,
+                        "title": "Hasticket",
+                        "type": "boolean"
+                    },
+                    "image": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ImageBody"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "ImageBody"
+                    },
+                    "itemCollectionDetails": {
+                        "description": "Further information that will be provided to attendees to ease the offer collection.",
+                        "example": "Opening hours, specific office, collection period, access code, email annoucement...",
+                        "nullable": true,
+                        "title": "Itemcollectiondetails",
+                        "type": "string"
+                    },
+                    "location": {
+                        "description": "Location where the offer will be available or will take place. The location type must be compatible with the category",
+                        "discriminator": {
+                            "mapping": {
+                                "digital": "#/components/schemas/DigitalLocation",
+                                "physical": "#/components/schemas/PhysicalLocation"
+                            },
+                            "propertyName": "type"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PhysicalLocation"
+                            },
+                            {
+                                "$ref": "#/components/schemas/DigitalLocation"
+                            }
+                        ],
+                        "title": "Location"
+                    },
+                    "name": {
+                        "description": "Offer title",
+                        "example": "Le Petit Prince",
+                        "maxLength": 90,
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "priceCategories": {
+                        "description": "Available price categories for dates of this offer",
+                        "items": {
+                            "$ref": "#/components/schemas/PriceCategoryCreation"
+                        },
+                        "nullable": true,
+                        "title": "Pricecategories",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "accessibility",
+                    "categoryRelatedFields",
+                    "name",
+                    "location",
+                    "hasTicket"
+                ],
+                "title": "EventOfferCreation",
+                "type": "object"
+            },
+            "EventOfferEdition": {
+                "additionalProperties": false,
+                "properties": {
+                    "accessibility": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PartialAccessibility"
+                            }
+                        ],
+                        "description": "Accessibility to disabled people. Leave fields undefined to keep current value",
+                        "nullable": true,
+                        "title": "Accessibility"
+                    },
+                    "bookingContact": {
+                        "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
+                        "format": "email",
+                        "nullable": true,
+                        "title": "Bookingcontact",
+                        "type": "string"
+                    },
+                    "bookingEmail": {
+                        "description": "Recipient email for notifications about bookings, cancellations, etc.",
+                        "format": "email",
+                        "nullable": true,
+                        "title": "Bookingemail",
+                        "type": "string"
+                    },
+                    "categoryRelatedFields": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ATELIER_PRATIQUE_ART_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CINE_PLEIN_AIR_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONCERT_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONCOURS_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONFERENCE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_CINE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_JEU_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_MUSIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_PATRIMOINE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_ART_VISUEL_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_CINE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_LIVRE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_MUSIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_SPECTACLE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_EVENEMENT_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_MUSIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_EN_LIGNE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_JEU_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SALON_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SEANCE_CINE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SPECTACLE_REPRESENTATION_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_GUIDEE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_edit"
+                            }
+                        ],
+                        "description": "To override category related fields, the category must be specified, even if it cannot be changed. Other category related fields may be left undefined to keep their current value.",
+                        "nullable": true,
+                        "title": "Categoryrelatedfields"
+                    },
+                    "description": {
+                        "description": "Offer description",
+                        "example": "A great book for kids and old kids.",
+                        "maxLength": 1000,
+                        "nullable": true,
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "enableDoubleBookings": {
+                        "default": false,
+                        "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
+                        "nullable": true,
+                        "title": "Enabledoublebookings",
+                        "type": "boolean"
+                    },
+                    "eventDuration": {
+                        "description": "Event duration in minutes",
+                        "example": 60,
+                        "nullable": true,
+                        "title": "Eventduration",
+                        "type": "integer"
+                    },
+                    "image": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ImageBody"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "ImageBody"
+                    },
+                    "isActive": {
+                        "description": "Whether the offer is activated. An inactive offer cannot be booked.",
+                        "nullable": true,
+                        "title": "Isactive",
+                        "type": "boolean"
+                    },
+                    "itemCollectionDetails": {
+                        "description": "Further information that will be provided to attendees to ease the offer collection.",
+                        "example": "Opening hours, specific office, collection period, access code, email annoucement...",
+                        "nullable": true,
+                        "title": "Itemcollectiondetails",
+                        "type": "string"
+                    }
+                },
+                "title": "EventOfferEdition",
+                "type": "object"
+            },
+            "EventOfferResponse": {
+                "properties": {
+                    "accessibility": {
+                        "$ref": "#/components/schemas/AccessibilityResponse"
+                    },
+                    "bookingContact": {
+                        "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
+                        "nullable": true,
+                        "title": "Bookingcontact",
+                        "type": "string"
+                    },
+                    "bookingEmail": {
+                        "description": "Recipient email for notifications about bookings, cancellations, etc.",
+                        "nullable": true,
+                        "title": "Bookingemail",
+                        "type": "string"
+                    },
+                    "categoryRelatedFields": {
+                        "description": "Cultural category the offer belongs to. According to the category, some fields may or must be specified.",
+                        "discriminator": {
+                            "mapping": {
+                                "ACTIVATION_EVENT": "#/components/schemas/ACTIVATION_EVENT_read",
+                                "ATELIER_PRATIQUE_ART": "#/components/schemas/ATELIER_PRATIQUE_ART_read",
+                                "CINE_PLEIN_AIR": "#/components/schemas/CINE_PLEIN_AIR_read",
+                                "CONCERT": "#/components/schemas/CONCERT_read",
+                                "CONCOURS": "#/components/schemas/CONCOURS_read",
+                                "CONFERENCE": "#/components/schemas/CONFERENCE_read",
+                                "DECOUVERTE_METIERS": "#/components/schemas/DECOUVERTE_METIERS_read",
+                                "EVENEMENT_CINE": "#/components/schemas/EVENEMENT_CINE_read",
+                                "EVENEMENT_JEU": "#/components/schemas/EVENEMENT_JEU_read",
+                                "EVENEMENT_MUSIQUE": "#/components/schemas/EVENEMENT_MUSIQUE_read",
+                                "EVENEMENT_PATRIMOINE": "#/components/schemas/EVENEMENT_PATRIMOINE_read",
+                                "FESTIVAL_ART_VISUEL": "#/components/schemas/FESTIVAL_ART_VISUEL_read",
+                                "FESTIVAL_CINE": "#/components/schemas/FESTIVAL_CINE_read",
+                                "FESTIVAL_LIVRE": "#/components/schemas/FESTIVAL_LIVRE_read",
+                                "FESTIVAL_MUSIQUE": "#/components/schemas/FESTIVAL_MUSIQUE_read",
+                                "FESTIVAL_SPECTACLE": "#/components/schemas/FESTIVAL_SPECTACLE_read",
+                                "LIVESTREAM_EVENEMENT": "#/components/schemas/LIVESTREAM_EVENEMENT_read",
+                                "LIVESTREAM_MUSIQUE": "#/components/schemas/LIVESTREAM_MUSIQUE_read",
+                                "LIVESTREAM_PRATIQUE_ARTISTIQUE": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_read",
+                                "RENCONTRE": "#/components/schemas/RENCONTRE_read",
+                                "RENCONTRE_EN_LIGNE": "#/components/schemas/RENCONTRE_EN_LIGNE_read",
+                                "RENCONTRE_JEU": "#/components/schemas/RENCONTRE_JEU_read",
+                                "SALON": "#/components/schemas/SALON_read",
+                                "SEANCE_CINE": "#/components/schemas/SEANCE_CINE_read",
+                                "SEANCE_ESSAI_PRATIQUE_ART": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_read",
+                                "SPECTACLE_REPRESENTATION": "#/components/schemas/SPECTACLE_REPRESENTATION_read",
+                                "VISITE": "#/components/schemas/VISITE_read",
+                                "VISITE_GUIDEE": "#/components/schemas/VISITE_GUIDEE_read"
+                            },
+                            "propertyName": "category"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ACTIVATION_EVENT_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ATELIER_PRATIQUE_ART_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CINE_PLEIN_AIR_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONCERT_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONCOURS_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CONFERENCE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/DECOUVERTE_METIERS_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_CINE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_JEU_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_MUSIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EVENEMENT_PATRIMOINE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_ART_VISUEL_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_CINE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_LIVRE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_MUSIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/FESTIVAL_SPECTACLE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_EVENEMENT_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_MUSIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVESTREAM_PRATIQUE_ARTISTIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_EN_LIGNE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_JEU_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RENCONTRE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SALON_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SEANCE_CINE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SEANCE_ESSAI_PRATIQUE_ART_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SPECTACLE_REPRESENTATION_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_GUIDEE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_read"
+                            }
+                        ],
+                        "title": "Categoryrelatedfields"
+                    },
+                    "description": {
+                        "description": "Offer description",
+                        "example": "A great book for kids and old kids.",
+                        "nullable": true,
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "enableDoubleBookings": {
+                        "default": false,
+                        "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
+                        "nullable": true,
+                        "title": "Enabledoublebookings",
+                        "type": "boolean"
+                    },
+                    "eventDuration": {
+                        "description": "Event duration in minutes",
+                        "example": 60,
+                        "nullable": true,
+                        "title": "Eventduration",
+                        "type": "integer"
+                    },
+                    "externalTicketOfficeUrl": {
+                        "description": "Link displayed to users wishing to book the offer but who do not have (anymore) credit.",
+                        "example": "https://example.com",
+                        "nullable": true,
+                        "title": "Externalticketofficeurl",
+                        "type": "string"
+                    },
+                    "hasTicket": {
+                        "description": "Indicates whether the offer has an associated ticket. True if a ticket is available, False otherwise. To create an offer with tickets you must have developed the pass culture ticketing interface.",
+                        "example": false,
+                        "title": "Hasticket",
+                        "type": "boolean"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "image": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ImageResponse"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "ImageResponse"
+                    },
+                    "itemCollectionDetails": {
+                        "description": "Further information that will be provided to attendees to ease the offer collection.",
+                        "example": "Opening hours, specific office, collection period, access code, email annoucement...",
+                        "nullable": true,
+                        "title": "Itemcollectiondetails",
+                        "type": "string"
+                    },
+                    "location": {
+                        "description": "Location where the offer will be available or will take place. The location type must be compatible with the category",
+                        "discriminator": {
+                            "mapping": {
+                                "digital": "#/components/schemas/DigitalLocation",
+                                "physical": "#/components/schemas/PhysicalLocation"
+                            },
+                            "propertyName": "type"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PhysicalLocation"
+                            },
+                            {
+                                "$ref": "#/components/schemas/DigitalLocation"
+                            }
+                        ],
+                        "title": "Location"
+                    },
+                    "name": {
+                        "description": "Offer title",
+                        "example": "Le Petit Prince",
+                        "maxLength": 90,
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "priceCategories": {
+                        "description": "Available price categories for dates of this offer",
+                        "items": {
+                            "$ref": "#/components/schemas/PriceCategoryResponse"
+                        },
+                        "title": "Pricecategories",
+                        "type": "array"
+                    },
+                    "status": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/OfferStatus"
+                            }
+                        ],
+                        "description": "ACTIVE: offer is validated and active.\n\nDRAFT: offer is still draft and not yet submitted for validation - this status is not applicable to offers created via this API.\n\nEXPIRED: offer is validated but the booking limit datetime has passed.\n\nINACTIVE: offer is not active and cannot be booked.\n\nPENDING: offer is pending for pass Culture rules compliance validation. This step may last 72 hours.\n\nREJECTED: offer validation has been rejected because it is not compliant with pass Culture rules.\n\nSOLD_OUT: offer is validated but there is no (more) stock available for booking.",
+                        "example": "ACTIVE"
+                    }
+                },
+                "required": [
+                    "priceCategories",
+                    "id",
+                    "accessibility",
+                    "location",
+                    "name",
+                    "status",
+                    "categoryRelatedFields",
+                    "hasTicket"
+                ],
+                "title": "EventOfferResponse",
+                "type": "object"
+            },
+            "EventOffersResponse": {
+                "properties": {
+                    "events": {
+                        "items": {
+                            "$ref": "#/components/schemas/EventOfferResponse"
+                        },
+                        "title": "Events",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "events"
+                ],
+                "title": "EventOffersResponse",
+                "type": "object"
+            },
+            "FESTIVAL_ART_VISUEL_create": {
+                "description": "Festival d'arts visuels / arts num\u00e9riques",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_ART_VISUEL"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_ART_VISUEL_create",
+                "type": "object"
+            },
+            "FESTIVAL_ART_VISUEL_edit": {
+                "description": "Festival d'arts visuels / arts num\u00e9riques",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_ART_VISUEL"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_ART_VISUEL_edit",
+                "type": "object"
+            },
+            "FESTIVAL_ART_VISUEL_read": {
+                "description": "Festival d'arts visuels / arts num\u00e9riques",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_ART_VISUEL"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_ART_VISUEL_read",
+                "type": "object"
+            },
+            "FESTIVAL_CINE_create": {
+                "description": "Festival de cin\u00e9ma",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_CINE_create",
+                "type": "object"
+            },
+            "FESTIVAL_CINE_edit": {
+                "description": "Festival de cin\u00e9ma",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_CINE_edit",
+                "type": "object"
+            },
+            "FESTIVAL_CINE_read": {
+                "description": "Festival de cin\u00e9ma",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_CINE_read",
+                "type": "object"
+            },
+            "FESTIVAL_LIVRE_create": {
+                "description": "Festival et salon du livre",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_LIVRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_LIVRE_create",
+                "type": "object"
+            },
+            "FESTIVAL_LIVRE_edit": {
+                "description": "Festival et salon du livre",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_LIVRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_LIVRE_edit",
+                "type": "object"
+            },
+            "FESTIVAL_LIVRE_read": {
+                "description": "Festival et salon du livre",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_LIVRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_LIVRE_read",
+                "type": "object"
+            },
+            "FESTIVAL_MUSIQUE_create": {
+                "description": "Festival de musique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "musicType",
+                    "category"
+                ],
+                "title": "FESTIVAL_MUSIQUE_create",
+                "type": "object"
+            },
+            "FESTIVAL_MUSIQUE_edit": {
+                "description": "Festival de musique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_MUSIQUE_edit",
+                "type": "object"
+            },
+            "FESTIVAL_MUSIQUE_read": {
+                "description": "Festival de musique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_MUSIQUE_read",
+                "type": "object"
+            },
+            "FESTIVAL_SPECTACLE_create": {
+                "description": "Festival de spectacle vivant",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_SPECTACLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "showType",
+                    "category"
+                ],
+                "title": "FESTIVAL_SPECTACLE_create",
+                "type": "object"
+            },
+            "FESTIVAL_SPECTACLE_edit": {
+                "description": "Festival de spectacle vivant",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_SPECTACLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_SPECTACLE_edit",
+                "type": "object"
+            },
+            "FESTIVAL_SPECTACLE_read": {
+                "description": "Festival de spectacle vivant",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "FESTIVAL_SPECTACLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "FESTIVAL_SPECTACLE_read",
+                "type": "object"
+            },
+            "GetBookingResponse": {
+                "properties": {
+                    "confirmationDate": {
+                        "description": "For event offers, deadline for cancellation by the beneficiary.",
+                        "nullable": true,
+                        "title": "Confirmationdate",
+                        "type": "string"
+                    },
+                    "creationDate": {
+                        "title": "Creationdate",
+                        "type": "string"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "offerEan": {
+                        "nullable": true,
+                        "title": "Offerean",
+                        "type": "string"
+                    },
+                    "offerId": {
+                        "title": "Offerid",
+                        "type": "integer"
+                    },
+                    "offerName": {
+                        "title": "Offername",
+                        "type": "string"
+                    },
+                    "price": {
+                        "title": "Price",
+                        "type": "integer"
+                    },
+                    "priceCategoryId": {
+                        "nullable": true,
+                        "title": "Pricecategoryid",
+                        "type": "integer"
+                    },
+                    "priceCategoryLabel": {
+                        "nullable": true,
+                        "title": "Pricecategorylabel",
+                        "type": "string"
+                    },
+                    "quantity": {
+                        "title": "Quantity",
+                        "type": "integer"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/BookingStatus"
+                    },
+                    "stockId": {
+                        "title": "Stockid",
+                        "type": "integer"
+                    },
+                    "userBirthDate": {
+                        "nullable": true,
+                        "title": "Userbirthdate",
+                        "type": "string"
+                    },
+                    "userEmail": {
+                        "title": "Useremail",
+                        "type": "string"
+                    },
+                    "userFirstName": {
+                        "nullable": true,
+                        "title": "Userfirstname",
+                        "type": "string"
+                    },
+                    "userLastName": {
+                        "nullable": true,
+                        "title": "Userlastname",
+                        "type": "string"
+                    },
+                    "userPhoneNumber": {
+                        "nullable": true,
+                        "title": "Userphonenumber",
+                        "type": "string"
+                    },
+                    "userPostalCode": {
+                        "nullable": true,
+                        "title": "Userpostalcode",
+                        "type": "string"
+                    },
+                    "venueAddress": {
+                        "title": "Venueaddress",
+                        "type": "string"
+                    },
+                    "venueDepartementCode": {
+                        "title": "Venuedepartementcode",
+                        "type": "string"
+                    },
+                    "venueId": {
+                        "title": "Venueid",
+                        "type": "integer"
+                    },
+                    "venueName": {
+                        "title": "Venuename",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "quantity",
+                    "creationDate",
+                    "price",
+                    "status",
+                    "offerId",
+                    "stockId",
+                    "offerName",
+                    "venueId",
+                    "venueName",
+                    "venueAddress",
+                    "venueDepartementCode",
+                    "userEmail"
+                ],
+                "title": "GetBookingResponse",
+                "type": "object"
+            },
+            "GetDatesQueryParams": {
+                "properties": {
+                    "firstIndex": {
+                        "default": 1,
+                        "description": "Index of the first item in page.",
+                        "minimum": 1,
+                        "title": "Firstindex",
+                        "type": "integer"
+                    },
+                    "limit": {
+                        "default": 50,
+                        "description": "Maximum number of items per page.",
+                        "exclusiveMinimum": 0,
+                        "maximum": 50,
+                        "title": "Limit",
+                        "type": "integer"
+                    }
+                },
+                "title": "GetDatesQueryParams",
+                "type": "object"
+            },
+            "GetDatesResponse": {
+                "properties": {
+                    "dates": {
+                        "items": {
+                            "$ref": "#/components/schemas/DateResponse"
+                        },
+                        "title": "Dates",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "dates"
+                ],
+                "title": "GetDatesResponse",
+                "type": "object"
+            },
+            "GetEventCategoriesResponse": {
+                "items": {
+                    "$ref": "#/components/schemas/EventCategoryResponse"
+                },
+                "title": "GetEventCategoriesResponse",
+                "type": "array"
+            },
+            "GetFilteredBookingsRequest": {
+                "properties": {
+                    "beginningDatetime": {
+                        "description": "Timezone aware datetime of the event.",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Beginningdatetime",
+                        "type": "string"
+                    },
+                    "firstIndex": {
+                        "default": 1,
+                        "description": "Index of the first item in page.",
+                        "minimum": 1,
+                        "title": "Firstindex",
+                        "type": "integer"
+                    },
+                    "limit": {
+                        "default": 50,
+                        "description": "Maximum number of items per page.",
+                        "exclusiveMinimum": 0,
+                        "maximum": 50,
+                        "title": "Limit",
+                        "type": "integer"
+                    },
+                    "offerId": {
+                        "description": "Id of the bookings' offer.",
+                        "title": "Offerid",
+                        "type": "integer"
+                    },
+                    "priceCategoryId": {
+                        "description": "Price category of the bookings' stock.",
+                        "nullable": true,
+                        "title": "Pricecategoryid",
+                        "type": "integer"
+                    },
+                    "status": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/BookingStatus"
+                            }
+                        ],
+                        "description": "Booking Status.\n\n* `CONFIRMED`: The bookings is confirmed.\n* `USED`: The bookings has been used.\n* `CANCELLED`: The bookings has been cancelled.\n* `REIMBURSED` The bookings has been reimbursed.",
+                        "nullable": true
+                    },
+                    "stockId": {
+                        "description": "Id of the bookings' stock.",
+                        "nullable": true,
+                        "title": "Stockid",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "offerId"
+                ],
+                "title": "GetFilteredBookingsRequest",
+                "type": "object"
+            },
+            "GetFilteredBookingsResponse": {
+                "properties": {
+                    "bookings": {
+                        "items": {
+                            "$ref": "#/components/schemas/GetBookingResponse"
+                        },
+                        "title": "Bookings",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "bookings"
+                ],
+                "title": "GetFilteredBookingsResponse",
+                "type": "object"
+            },
+            "GetListEducationalInstitutionsQueryModel": {
+                "additionalProperties": false,
+                "properties": {
+                    "city": {
+                        "nullable": true,
+                        "title": "City",
+                        "type": "string"
+                    },
+                    "id": {
+                        "nullable": true,
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "institutionType": {
+                        "nullable": true,
+                        "title": "Institutiontype",
+                        "type": "string"
+                    },
+                    "limit": {
+                        "default": 20,
+                        "title": "Limit",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "nullable": true,
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "postalCode": {
+                        "nullable": true,
+                        "title": "Postalcode",
+                        "type": "string"
+                    },
+                    "uai": {
+                        "nullable": true,
+                        "title": "Uai",
+                        "type": "string"
+                    }
+                },
+                "title": "GetListEducationalInstitutionsQueryModel",
+                "type": "object"
+            },
+            "GetMusicTypesResponse": {
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/components/schemas/MusicTypeResponse"
+                        },
+                        {
+                            "$ref": "#/components/schemas/TiteliveMusicTypeResponse"
+                        }
+                    ]
+                },
+                "title": "GetMusicTypesResponse",
+                "type": "array"
+            },
+            "GetOffererVenuesResponse": {
+                "properties": {
+                    "offerer": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/OffererResponse"
+                            }
+                        ],
+                        "description": "Offerer to which the venues belong. Entity linked to the api key used.",
+                        "title": "Offerer"
+                    },
+                    "venues": {
+                        "items": {
+                            "$ref": "#/components/schemas/VenueResponse"
+                        },
+                        "title": "Venues",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "offerer",
+                    "venues"
+                ],
+                "title": "GetOffererVenuesResponse",
+                "type": "object"
+            },
+            "GetOfferersVenuesQuery": {
+                "properties": {
+                    "siren": {
+                        "example": "123456789",
+                        "nullable": true,
+                        "pattern": "^\\d{9}$",
+                        "title": "Siren",
+                        "type": "string"
+                    }
+                },
+                "title": "GetOfferersVenuesQuery",
+                "type": "object"
+            },
+            "GetOfferersVenuesResponse": {
+                "items": {
+                    "$ref": "#/components/schemas/GetOffererVenuesResponse"
+                },
+                "title": "GetOfferersVenuesResponse",
+                "type": "array"
+            },
+            "GetOffersQueryParams": {
+                "properties": {
+                    "firstIndex": {
+                        "default": 1,
+                        "description": "Index of the first item in page.",
+                        "minimum": 1,
+                        "title": "Firstindex",
+                        "type": "integer"
+                    },
+                    "limit": {
+                        "default": 50,
+                        "description": "Maximum number of items per page.",
+                        "exclusiveMinimum": 0,
+                        "maximum": 50,
+                        "title": "Limit",
+                        "type": "integer"
+                    },
+                    "venueId": {
+                        "description": "Venue id to filter offers on.",
+                        "title": "Venueid",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "venueId"
+                ],
+                "title": "GetOffersQueryParams",
+                "type": "object"
+            },
+            "GetProductCategoriesResponse": {
+                "items": {
+                    "$ref": "#/components/schemas/ProductCategoryResponse"
+                },
+                "title": "GetProductCategoriesResponse",
+                "type": "array"
+            },
+            "GetProductsListByEansQuery": {
+                "properties": {
+                    "eans": {
+                        "example": "0123456789123,0123456789124",
+                        "title": "Eans",
+                        "type": "string"
+                    },
+                    "venueId": {
+                        "example": 1,
+                        "title": "Venueid",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "eans",
+                    "venueId"
+                ],
+                "title": "GetProductsListByEansQuery",
+                "type": "object"
+            },
+            "GetPublicCollectiveOfferResponseModel": {
+                "additionalProperties": false,
+                "properties": {
+                    "audioDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Audiodisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "beginningDatetime": {
+                        "title": "Beginningdatetime",
+                        "type": "string"
+                    },
+                    "bookingEmails": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "nullable": true,
+                        "title": "Bookingemails",
+                        "type": "array"
+                    },
+                    "bookingLimitDatetime": {
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "bookings": {
+                        "items": {
+                            "$ref": "#/components/schemas/CollectiveBookingResponseModel"
+                        },
+                        "title": "Bookings",
+                        "type": "array"
+                    },
+                    "contactEmail": {
+                        "title": "Contactemail",
+                        "type": "string"
+                    },
+                    "contactPhone": {
+                        "title": "Contactphone",
+                        "type": "string"
+                    },
+                    "dateCreated": {
+                        "title": "Datecreated",
+                        "type": "string"
+                    },
+                    "description": {
+                        "nullable": true,
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "domains": {
+                        "items": {
+                            "type": "integer"
+                        },
+                        "title": "Domains",
+                        "type": "array"
+                    },
+                    "durationMinutes": {
+                        "nullable": true,
+                        "title": "Durationminutes",
+                        "type": "integer"
+                    },
+                    "educationalInstitution": {
+                        "nullable": true,
+                        "title": "Educationalinstitution",
+                        "type": "string"
+                    },
+                    "educationalInstitutionId": {
+                        "nullable": true,
+                        "title": "Educationalinstitutionid",
+                        "type": "integer"
+                    },
+                    "educationalPriceDetail": {
+                        "nullable": true,
+                        "title": "Educationalpricedetail",
+                        "type": "string"
+                    },
+                    "formats": {
+                        "items": {
+                            "$ref": "#/components/schemas/EacFormat"
+                        },
+                        "nullable": true,
+                        "type": "array"
+                    },
+                    "hasBookingLimitDatetimesPassed": {
+                        "title": "Hasbookinglimitdatetimespassed",
+                        "type": "boolean"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "imageCredit": {
+                        "nullable": true,
+                        "title": "Imagecredit",
+                        "type": "string"
+                    },
+                    "imageUrl": {
+                        "nullable": true,
+                        "title": "Imageurl",
+                        "type": "string"
+                    },
+                    "interventionArea": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Interventionarea",
+                        "type": "array"
+                    },
+                    "isActive": {
+                        "nullable": true,
+                        "title": "Isactive",
+                        "type": "boolean"
+                    },
+                    "isSoldOut": {
+                        "title": "Issoldout",
+                        "type": "boolean"
+                    },
+                    "mentalDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Mentaldisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "motorDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Motordisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "nationalProgram": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/NationalProgramModel"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "NationalProgramModel"
+                    },
+                    "numberOfTickets": {
+                        "title": "Numberoftickets",
+                        "type": "integer"
+                    },
+                    "offerVenue": {
+                        "$ref": "#/components/schemas/OfferVenueModel"
+                    },
+                    "status": {
+                        "title": "Status",
+                        "type": "string"
+                    },
+                    "students": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Students",
+                        "type": "array"
+                    },
+                    "subcategoryId": {
+                        "nullable": true,
+                        "title": "Subcategoryid",
+                        "type": "string"
+                    },
+                    "totalPrice": {
+                        "title": "Totalprice",
+                        "type": "number"
+                    },
+                    "venueId": {
+                        "title": "Venueid",
+                        "type": "integer"
+                    },
+                    "visualDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Visualdisabilitycompliant",
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "id",
+                    "status",
+                    "name",
+                    "contactEmail",
+                    "contactPhone",
+                    "domains",
+                    "interventionArea",
+                    "students",
+                    "dateCreated",
+                    "hasBookingLimitDatetimesPassed",
+                    "isSoldOut",
+                    "venueId",
+                    "beginningDatetime",
+                    "bookingLimitDatetime",
+                    "totalPrice",
+                    "numberOfTickets",
+                    "offerVenue",
+                    "bookings"
+                ],
+                "title": "GetPublicCollectiveOfferResponseModel",
+                "type": "object"
+            },
+            "GetShowTypesResponse": {
+                "items": {
+                    "$ref": "#/components/schemas/ShowTypeResponse"
+                },
+                "title": "GetShowTypesResponse",
+                "type": "array"
+            },
+            "ImageBody": {
+                "description": "Image illustrating the offer. Offers with images are more likely to be booked.",
+                "properties": {
+                    "credit": {
+                        "description": "Image owner or author.",
+                        "example": "Jane Doe",
+                        "nullable": true,
+                        "title": "Credit",
+                        "type": "string"
+                    },
+                    "file": {
+                        "description": "Image file encoded in base64 string. Image format must be PNG or JPEG. Size must be between 400x600 and 800x1200 pixels. Aspect ratio must be 2:3 (portrait format).",
+                        "example": "iVBORw0KGgoAAAANSUhEUgAAAhUAAAMgCAAAAACxT88IAAABImlDQ1BJQ0MgcHJvZmlsZQAAKJGdkLFKw1AUhr+0oiKKg6IgDhlcO5pFB6tCKCjEWMHqlCYpFpMYkpTiG/gm+jAdBMFXcFdw9r/RwcEs3nD4Pw7n/P+9gZadhGk5dwBpVhWu3x1cDq7shTfa+lbZZC8Iy7zreSc0ns9XLKMvHePVPPfnmY/iMpTOVFmYFxVY+2JnWuWGVazf9v0j8YPYjtIsEj+Jd6I0Mmx2/TSZhD+e5jbLcXZxbvqqbVx6nOJhM2TCmISKjjRT5xiHXalLQcA9JaE0IVZvqpmKG1EpJ5dDUV+k2zTkbdV5nlKG8hjLyyTckcrT5GH+7/fax1m9aW3M8qAI6lZb1RqN4P0RVgaw9gxL1w1Zi7/f1jDj1DP/fOMXG7hQfuNVil0AAAAJcEhZcwAALiMAAC4jAXilP3YAAAAHdElNRQfnAwMPGDrdy1JyAAABtElEQVR42u3BAQ0AAADCoPdPbQ8HFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8GaFGgABH6N7kwAAAABJRU5ErkJggg==",
+                        "title": "File",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "file"
+                ],
+                "title": "ImageBody",
+                "type": "object"
+            },
+            "ImageResponse": {
+                "description": "Image illustrating the offer. Offers with images are more likely to be booked.",
+                "properties": {
+                    "credit": {
+                        "description": "Image owner or author.",
+                        "example": "Jane Doe",
+                        "nullable": true,
+                        "title": "Credit",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "Url where the image is accessible",
+                        "example": "https://example.com/image.png",
+                        "title": "Url",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "url"
+                ],
+                "title": "ImageResponse",
+                "type": "object"
+            },
+            "ImageUploadFile": {
+                "properties": {
+                    "credit": {
+                        "nullable": true,
+                        "title": "Credit",
+                        "type": "string"
+                    },
+                    "file": {
+                        "description": "[required] Image format must be PNG, JPEG or JPG. Size must be between 400x600 and 800x1200 pixels. Aspect ratio must be 2:3 (portrait format).",
+                        "format": "binary",
+                        "nullable": true,
+                        "title": "File",
+                        "type": "string"
+                    }
+                },
+                "title": "ImageUploadFile",
+                "type": "object"
+            },
+            "JEU_EN_LIGNE_read": {
+                "description": "Jeux en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "JEU_EN_LIGNE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "JEU_EN_LIGNE_read",
+                "type": "object"
+            },
+            "JEU_SUPPORT_PHYSIQUE_read": {
+                "description": "Cat\u00e9gorie technique Jeu support physique",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "JEU_SUPPORT_PHYSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "JEU_SUPPORT_PHYSIQUE_read",
+                "type": "object"
+            },
+            "LIVESTREAM_EVENEMENT_create": {
+                "description": "Livestream d'\u00e9v\u00e8nement",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_EVENEMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "showType",
+                    "category"
+                ],
+                "title": "LIVESTREAM_EVENEMENT_create",
+                "type": "object"
+            },
+            "LIVESTREAM_EVENEMENT_edit": {
+                "description": "Livestream d'\u00e9v\u00e8nement",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_EVENEMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVESTREAM_EVENEMENT_edit",
+                "type": "object"
+            },
+            "LIVESTREAM_EVENEMENT_read": {
+                "description": "Livestream d'\u00e9v\u00e8nement",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_EVENEMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVESTREAM_EVENEMENT_read",
+                "type": "object"
+            },
+            "LIVESTREAM_MUSIQUE_create": {
+                "description": "Livestream musical",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "musicType",
+                    "category"
+                ],
+                "title": "LIVESTREAM_MUSIQUE_create",
+                "type": "object"
+            },
+            "LIVESTREAM_MUSIQUE_edit": {
+                "description": "Livestream musical",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVESTREAM_MUSIQUE_edit",
+                "type": "object"
+            },
+            "LIVESTREAM_MUSIQUE_read": {
+                "description": "Livestream musical",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVESTREAM_MUSIQUE_read",
+                "type": "object"
+            },
+            "LIVESTREAM_PRATIQUE_ARTISTIQUE_create": {
+                "description": "Pratique artistique - livestream",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_PRATIQUE_ARTISTIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVESTREAM_PRATIQUE_ARTISTIQUE_create",
+                "type": "object"
+            },
+            "LIVESTREAM_PRATIQUE_ARTISTIQUE_edit": {
+                "description": "Pratique artistique - livestream",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_PRATIQUE_ARTISTIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVESTREAM_PRATIQUE_ARTISTIQUE_edit",
+                "type": "object"
+            },
+            "LIVESTREAM_PRATIQUE_ARTISTIQUE_read": {
+                "description": "Pratique artistique - livestream",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "LIVESTREAM_PRATIQUE_ARTISTIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVESTREAM_PRATIQUE_ARTISTIQUE_read",
+                "type": "object"
+            },
+            "LIVRE_AUDIO_PHYSIQUE_create": {
+                "description": "Livre audio sur support physique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVRE_AUDIO_PHYSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "ean",
+                    "category"
+                ],
+                "title": "LIVRE_AUDIO_PHYSIQUE_create",
+                "type": "object"
+            },
+            "LIVRE_AUDIO_PHYSIQUE_edit": {
+                "description": "Livre audio sur support physique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVRE_AUDIO_PHYSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVRE_AUDIO_PHYSIQUE_edit",
+                "type": "object"
+            },
+            "LIVRE_AUDIO_PHYSIQUE_read": {
+                "description": "Livre audio sur support physique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVRE_AUDIO_PHYSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVRE_AUDIO_PHYSIQUE_read",
+                "type": "object"
+            },
+            "LIVRE_NUMERIQUE_create": {
+                "description": "Livre num\u00e9rique, e-book",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVRE_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVRE_NUMERIQUE_create",
+                "type": "object"
+            },
+            "LIVRE_NUMERIQUE_edit": {
+                "description": "Livre num\u00e9rique, e-book",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVRE_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVRE_NUMERIQUE_edit",
+                "type": "object"
+            },
+            "LIVRE_NUMERIQUE_read": {
+                "description": "Livre num\u00e9rique, e-book",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVRE_NUMERIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVRE_NUMERIQUE_read",
+                "type": "object"
+            },
+            "LIVRE_PAPIER_read": {
+                "description": "Livre papier",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "LIVRE_PAPIER"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LIVRE_PAPIER_read",
+                "type": "object"
+            },
+            "LOCATION_INSTRUMENT_create": {
+                "description": "Location instrument",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "LOCATION_INSTRUMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "ean",
+                    "category"
+                ],
+                "title": "LOCATION_INSTRUMENT_create",
+                "type": "object"
+            },
+            "LOCATION_INSTRUMENT_edit": {
+                "description": "Location instrument",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "LOCATION_INSTRUMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LOCATION_INSTRUMENT_edit",
+                "type": "object"
+            },
+            "LOCATION_INSTRUMENT_read": {
+                "description": "Location instrument",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "LOCATION_INSTRUMENT"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "LOCATION_INSTRUMENT_read",
+                "type": "object"
+            },
+            "ListCollectiveOffersQueryModel": {
+                "additionalProperties": false,
+                "properties": {
+                    "periodBeginningDate": {
+                        "nullable": true,
+                        "title": "Periodbeginningdate",
+                        "type": "string"
+                    },
+                    "periodEndingDate": {
+                        "nullable": true,
+                        "title": "Periodendingdate",
+                        "type": "string"
+                    },
+                    "status": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OfferStatus"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "venueId": {
+                        "nullable": true,
+                        "title": "Venueid",
+                        "type": "integer"
+                    }
+                },
+                "title": "ListCollectiveOffersQueryModel",
+                "type": "object"
+            },
+            "ListNationalProgramsResponseModel": {
+                "items": {
+                    "$ref": "#/components/schemas/NationalProgramModel"
+                },
+                "title": "ListNationalProgramsResponseModel",
+                "type": "array"
+            },
+            "LocationTypeEnum": {
+                "description": "An enumeration.",
+                "enum": [
+                    "DIGITAL",
+                    "PHYSICAL"
+                ],
+                "title": "LocationTypeEnum",
                 "type": "string"
-              }
-            ], 
-            "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.", 
-            "example": 10, 
-            "nullable": true, 
-            "title": "Quantity"
-          }
-        }, 
-        "title": "StockEdition", 
-        "type": "object"
-      }, 
-      "TELECHARGEMENT_LIVRE_AUDIO_create": {
-        "description": "Livre audio \u00e0 t\u00e9l\u00e9charger", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "TELECHARGEMENT_LIVRE_AUDIO"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "TELECHARGEMENT_LIVRE_AUDIO_create", 
-        "type": "object"
-      }, 
-      "TELECHARGEMENT_LIVRE_AUDIO_edit": {
-        "description": "Livre audio \u00e0 t\u00e9l\u00e9charger", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "TELECHARGEMENT_LIVRE_AUDIO"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "TELECHARGEMENT_LIVRE_AUDIO_edit", 
-        "type": "object"
-      }, 
-      "TELECHARGEMENT_LIVRE_AUDIO_read": {
-        "description": "Livre audio \u00e0 t\u00e9l\u00e9charger", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "TELECHARGEMENT_LIVRE_AUDIO"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "TELECHARGEMENT_LIVRE_AUDIO_read", 
-        "type": "object"
-      }, 
-      "TELECHARGEMENT_MUSIQUE_create": {
-        "description": "T\u00e9l\u00e9chargement de musique", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "TELECHARGEMENT_MUSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "musicType", 
-          "category"
-        ], 
-        "title": "TELECHARGEMENT_MUSIQUE_create", 
-        "type": "object"
-      }, 
-      "TELECHARGEMENT_MUSIQUE_edit": {
-        "description": "T\u00e9l\u00e9chargement de musique", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "TELECHARGEMENT_MUSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "TELECHARGEMENT_MUSIQUE_edit", 
-        "type": "object"
-      }, 
-      "TELECHARGEMENT_MUSIQUE_read": {
-        "description": "T\u00e9l\u00e9chargement de musique", 
-        "properties": {
-          "author": {
-            "title": "Author", 
-            "type": "string"
-          }, 
-          "category": {
-            "enum": [
-              "TELECHARGEMENT_MUSIQUE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }, 
-          "ean": {
-            "title": "Ean", 
-            "type": "string"
-          }, 
-          "musicType": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-              }, 
-              {
-                "$ref": "#/components/schemas/MusicTypeEnum"
-              }
-            ], 
-            "title": "Musictype"
-          }, 
-          "performer": {
-            "title": "Performer", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "TELECHARGEMENT_MUSIQUE_read", 
-        "type": "object"
-      }, 
-      "TiteliveMusicTypeEnum": {
-        "description": "An enumeration.", 
-        "enum": [
-          "MUSIQUE_CLASSIQUE", 
-          "JAZZ-BLUES", 
-          "BANDES_ORIGINALES", 
-          "ELECTRO", 
-          "POP", 
-          "ROCK", 
-          "METAL", 
-          "ALTERNATIF", 
-          "VARIETES", 
-          "FUNK-SOUL-RNB-DISCO", 
-          "RAP-HIP HOP", 
-          "REGGAE-RAGGA", 
-          "MUSIQUE_DU_MONDE", 
-          "COUNTRY-FOLK", 
-          "VIDEOS_MUSICALES", 
-          "COMPILATIONS", 
-          "AMBIANCE", 
-          "ENFANTS", 
-          "AUTRES"
-        ], 
-        "title": "TiteliveMusicTypeEnum", 
-        "type": "string"
-      }, 
-      "TiteliveMusicTypeResponse": {
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
-          }, 
-          "label": {
-            "title": "Label", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "id", 
-          "label"
-        ], 
-        "title": "TiteliveMusicTypeResponse", 
-        "type": "object"
-      }, 
-      "VISITE_GUIDEE_create": {
-        "description": "Visite guid\u00e9e", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE_GUIDEE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_GUIDEE_create", 
-        "type": "object"
-      }, 
-      "VISITE_GUIDEE_edit": {
-        "description": "Visite guid\u00e9e", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE_GUIDEE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_GUIDEE_edit", 
-        "type": "object"
-      }, 
-      "VISITE_GUIDEE_read": {
-        "description": "Visite guid\u00e9e", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE_GUIDEE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_GUIDEE_read", 
-        "type": "object"
-      }, 
-      "VISITE_VIRTUELLE_create": {
-        "description": "Visite virtuelle", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE_VIRTUELLE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_VIRTUELLE_create", 
-        "type": "object"
-      }, 
-      "VISITE_VIRTUELLE_edit": {
-        "description": "Visite virtuelle", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE_VIRTUELLE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_VIRTUELLE_edit", 
-        "type": "object"
-      }, 
-      "VISITE_VIRTUELLE_read": {
-        "description": "Visite virtuelle", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE_VIRTUELLE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_VIRTUELLE_read", 
-        "type": "object"
-      }, 
-      "VISITE_create": {
-        "description": "Visite", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_create", 
-        "type": "object"
-      }, 
-      "VISITE_edit": {
-        "description": "Visite", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_edit", 
-        "type": "object"
-      }, 
-      "VISITE_read": {
-        "description": "Visite", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VISITE"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VISITE_read", 
-        "type": "object"
-      }, 
-      "VOD_create": {
-        "description": "Vid\u00e9o \u00e0 la demande", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VOD"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VOD_create", 
-        "type": "object"
-      }, 
-      "VOD_edit": {
-        "description": "Vid\u00e9o \u00e0 la demande", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VOD"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VOD_edit", 
-        "type": "object"
-      }, 
-      "VOD_read": {
-        "description": "Vid\u00e9o \u00e0 la demande", 
-        "properties": {
-          "category": {
-            "enum": [
-              "VOD"
-            ], 
-            "title": "Category", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "category"
-        ], 
-        "title": "VOD_read", 
-        "type": "object"
-      }, 
-      "ValidationError": {
-        "description": "Model of a validation error response.", 
-        "items": {
-          "$ref": "#/components/schemas/ValidationErrorElement"
-        }, 
-        "title": "ValidationError", 
-        "type": "array"
-      }, 
-      "ValidationErrorElement": {
-        "description": "Model of a validation error response element.", 
-        "properties": {
-          "ctx": {
-            "title": "Error context", 
-            "type": "object"
-          }, 
-          "loc": {
-            "items": {
-              "type": "string"
-            }, 
-            "title": "Missing field name", 
-            "type": "array"
-          }, 
-          "msg": {
-            "title": "Error message", 
-            "type": "string"
-          }, 
-          "type": {
-            "title": "Error type", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "loc", 
-          "msg", 
-          "type"
-        ], 
-        "title": "ValidationErrorElement", 
-        "type": "object"
-      }, 
-      "VenueDigitalLocation": {
-        "properties": {
-          "type": {
-            "default": "digital", 
-            "enum": [
-              "digital"
-            ], 
-            "title": "Type", 
-            "type": "string"
-          }
-        }, 
-        "title": "VenueDigitalLocation", 
-        "type": "object"
-      }, 
-      "VenuePhysicalLocation": {
-        "properties": {
-          "address": {
-            "example": "55 rue du Faubourg-Saint-Honor\u00e9", 
-            "nullable": true, 
-            "title": "Address", 
-            "type": "string"
-          }, 
-          "city": {
-            "example": "Paris", 
-            "nullable": true, 
-            "title": "City", 
-            "type": "string"
-          }, 
-          "postalCode": {
-            "example": "75008", 
-            "nullable": true, 
-            "title": "Postalcode", 
-            "type": "string"
-          }, 
-          "type": {
-            "default": "physical", 
-            "enum": [
-              "physical"
-            ], 
-            "title": "Type", 
-            "type": "string"
-          }
-        }, 
-        "title": "VenuePhysicalLocation", 
-        "type": "object"
-      }, 
-      "VenueResponse": {
-        "properties": {
-          "accessibility": {
-            "$ref": "#/components/schemas/PartialAccessibility"
-          }, 
-          "activityDomain": {
-            "$ref": "#/components/schemas/VenueTypeEnum"
-          }, 
-          "createdDatetime": {
-            "format": "date-time", 
-            "title": "Createddatetime", 
-            "type": "string"
-          }, 
-          "id": {
-            "title": "Id", 
-            "type": "integer"
-          }, 
-          "legalName": {
-            "example": "Palais de l'\u00c9lys\u00e9e", 
-            "title": "Legalname", 
-            "type": "string"
-          }, 
-          "location": {
-            "description": "Location where the offers will be available or will take place. There is exactly one digital venue per offerer, which is listed although its id is not required to create a digital offer (see DigitalLocation model).", 
-            "discriminator": {
-              "mapping": {
-                "digital": "#/components/schemas/VenueDigitalLocation", 
-                "physical": "#/components/schemas/VenuePhysicalLocation"
-              }, 
-              "propertyName": "type"
-            }, 
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/VenuePhysicalLocation"
-              }, 
-              {
-                "$ref": "#/components/schemas/VenueDigitalLocation"
-              }
-            ], 
-            "title": "Location"
-          }, 
-          "publicName": {
-            "description": "If null, legalName is used.", 
-            "example": "\u00c9lys\u00e9e", 
-            "nullable": true, 
-            "title": "Publicname", 
-            "type": "string"
-          }, 
-          "siret": {
-            "description": "Null when venue is digital or when siretComment field is not null.", 
-            "example": "12345678901234", 
-            "nullable": true, 
-            "title": "Siret", 
-            "type": "string"
-          }, 
-          "siretComment": {
-            "description": "Applicable if siret is null and venue is physical.", 
-            "example": null, 
-            "nullable": true, 
-            "title": "Siretcomment", 
-            "type": "string"
-          }
-        }, 
-        "required": [
-          "createdDatetime", 
-          "id", 
-          "location", 
-          "legalName", 
-          "publicName", 
-          "activityDomain", 
-          "accessibility"
-        ], 
-        "title": "VenueResponse", 
-        "type": "object"
-      }, 
-      "VenueTypeEnum": {
-        "description": "An enumeration.", 
-        "enum": [
-          "ADMINISTRATIVE", 
-          "ARTISTIC_COURSE", 
-          "BOOKSTORE", 
-          "CONCERT_HALL", 
-          "CREATIVE_ARTS_STORE", 
-          "CULTURAL_CENTRE", 
-          "DIGITAL", 
-          "DISTRIBUTION_STORE", 
-          "FESTIVAL", 
-          "GAMES", 
-          "LIBRARY", 
-          "MOVIE", 
-          "MUSEUM", 
-          "MUSICAL_INSTRUMENT_STORE", 
-          "OTHER", 
-          "PATRIMONY_TOURISM", 
-          "PERFORMING_ARTS", 
-          "RECORD_STORE", 
-          "SCIENTIFIC_CULTURE", 
-          "TRAVELING_CINEMA", 
-          "VISUAL_ARTS"
-        ], 
-        "title": "VenueTypeEnum", 
-        "type": "string"
-      }
-    }, 
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "description": "Api key issued by passculture", 
-        "scheme": "bearer", 
-        "type": "http"
-      }
-    }
-  }, 
-  "info": {
-    "description": "This the documentation of the Pass Culture public REST API", 
-    "title": "Pass Culture REST API", 
-    "version": "1.0"
-  }, 
-  "openapi": "3.0.3", 
-  "paths": {
-    "/public/bookings/v1/bookings": {
-      "get": {
-        "description": "Return all the bookings for a given offer. Results are paginated (by default, there are `50` bookings per page)", 
-        "operationId": "GetBookingsByOffer", 
-        "parameters": [
-          {
-            "description": "Maximum number of items per page.", 
-            "in": "query", 
-            "name": "limit", 
-            "required": false, 
-            "schema": {
-              "default": 50, 
-              "description": "Maximum number of items per page.", 
-              "exclusiveMinimum": 0, 
-              "maximum": 50, 
-              "title": "Limit", 
-              "type": "integer"
+            },
+            "MATERIEL_ART_CREATIF_read": {
+                "description": "Mat\u00e9riel arts cr\u00e9atifs",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "MATERIEL_ART_CREATIF"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "MATERIEL_ART_CREATIF_read",
+                "type": "object"
+            },
+            "MUSEE_VENTE_DISTANCE_read": {
+                "description": "Mus\u00e9e vente \u00e0 distance",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "MUSEE_VENTE_DISTANCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "MUSEE_VENTE_DISTANCE_read",
+                "type": "object"
+            },
+            "MusicTypeEnum": {
+                "description": "An enumeration.",
+                "enum": [
+                    "JAZZ-ACID_JAZZ",
+                    "JAZZ-AVANT_GARDE_JAZZ",
+                    "JAZZ-BEBOP",
+                    "JAZZ-BIG_BAND",
+                    "JAZZ-BLUE_NOTE",
+                    "JAZZ-COOL_JAZZ",
+                    "JAZZ-CROSSOVER_JAZZ",
+                    "JAZZ-DIXIELAND",
+                    "JAZZ-ETHIO_JAZZ",
+                    "JAZZ-FUSION",
+                    "JAZZ-JAZZ_CONTEMPORAIN",
+                    "JAZZ-JAZZ_FUNK",
+                    "JAZZ-MAINSTREAM",
+                    "JAZZ-MANOUCHE",
+                    "JAZZ-TRADITIONEL",
+                    "JAZZ-VOCAL_JAZZ",
+                    "JAZZ-RAGTIME",
+                    "JAZZ-SMOOTH",
+                    "JAZZ-OTHER",
+                    "BLUES-BLUES_ACOUSTIQUE",
+                    "BLUES-BLUES_CONTEMPORAIN",
+                    "BLUES-BLUES_ELECTRIQUE",
+                    "BLUES-BLUES_ROCK",
+                    "BLUES-CHICAGO_BLUES",
+                    "BLUES-CLASSIC_BLUES",
+                    "BLUES-COUNTRY_BLUES",
+                    "BLUES-DELTA_BLUES",
+                    "BLUES-RAGTIME",
+                    "BLUES-OTHER",
+                    "REGGAE-TWO_TONE",
+                    "REGGAE-DANCEHALL",
+                    "REGGAE-DUB",
+                    "REGGAE-ROOTS",
+                    "REGGAE-SKA",
+                    "REGGAE-ZOUK",
+                    "REGGAE-OTHER",
+                    "CLASSIQUE-AVANT_GARDE",
+                    "CLASSIQUE-BAROQUE",
+                    "CLASSIQUE-CHANT",
+                    "CLASSIQUE-CHORALE",
+                    "CLASSIQUE-CONTEMPORAIN",
+                    "CLASSIQUE-EXPRESSIONISTE",
+                    "CLASSIQUE-IMPRESSIONISTE",
+                    "CLASSIQUE-MEDIEVALE",
+                    "CLASSIQUE-MINIMALISTE",
+                    "CLASSIQUE-MODERNE",
+                    "CLASSIQUE-ORATORIO",
+                    "CLASSIQUE-OPERA",
+                    "CLASSIQUE-RENAISSANCE",
+                    "CLASSIQUE-ROMANTIQUE",
+                    "CLASSIQUE-OTHER",
+                    "MUSIQUE_DU_MONDE-AFRICAINE",
+                    "MUSIQUE_DU_MONDE-AFRO_BEAT",
+                    "MUSIQUE_DU_MONDE-AFRO_POP",
+                    "MUSIQUE_DU_MONDE-ALTERNATIVO",
+                    "MUSIQUE_DU_MONDE-AMERIQUE_DU_NORD",
+                    "MUSIQUE_DU_MONDE-AMERIQUE_DU_SUD",
+                    "MUSIQUE_DU_MONDE-ASIATIQUE",
+                    "MUSIQUE_DU_MONDE-BALADAS_Y_BOLEROS",
+                    "MUSIQUE_DU_MONDE-BOSSA_NOVA",
+                    "MUSIQUE_DU_MONDE-BRESILIENNE",
+                    "MUSIQUE_DU_MONDE-CAJUN",
+                    "MUSIQUE_DU_MONDE-CALYPSO",
+                    "MUSIQUE_DU_MONDE-CARIBEENNE",
+                    "MUSIQUE_DU_MONDE-CELTIQUE",
+                    "MUSIQUE_DU_MONDE-CUMBIA",
+                    "MUSIQUE_DU_MONDE-FLAMENCO",
+                    "MUSIQUE_DU_MONDE-GRECQUE",
+                    "MUSIQUE_DU_MONDE-INDIENNE",
+                    "MUSIQUE_DU_MONDE-LATIN_JAZZ",
+                    "MUSIQUE_DU_MONDE-MOYEN_ORIENT",
+                    "MUSIQUE_DU_MONDE-LATINE_CONTEMPORAINE",
+                    "MUSIQUE_DU_MONDE-NUEVO_FLAMENCO",
+                    "MUSIQUE_DU_MONDE-POP_LATINO",
+                    "MUSIQUE_DU_MONDE-PORTUGUESE_FADO",
+                    "MUSIQUE_DU_MONDE-RAI",
+                    "MUSIQUE_DU_MONDE-SALSA",
+                    "MUSIQUE_DU_MONDE-TANGO_ARGENTIN",
+                    "MUSIQUE_DU_MONDE-YIDDISH",
+                    "MUSIQUE_DU_MONDE-OTHER",
+                    "POP-BRITPOP",
+                    "POP-BUBBLEGUM",
+                    "POP-DANCE_POP",
+                    "POP-DREAM_POP",
+                    "POP-ELECTRO_POP",
+                    "POP-INDIE_POP",
+                    "POP-J_POP",
+                    "POP-K_POP",
+                    "POP-POP_PUNK",
+                    "POP-POP_ROCK",
+                    "POP-POWER_POP",
+                    "POP-SOFT_ROCK",
+                    "POP-SYNTHPOP",
+                    "POP-TEEN_POP",
+                    "POP-OTHER",
+                    "ROCK-ACID_ROCK",
+                    "ROCK-ARENA_ROCK",
+                    "ROCK-ART_ROCK",
+                    "ROCK-COLLEGE_ROCK",
+                    "ROCK-GLAM_ROCK",
+                    "ROCK-GRUNGE",
+                    "ROCK-HARD_ROCK",
+                    "ROCK-INDIE_ROCK",
+                    "ROCK-LO_FI",
+                    "ROCK-PROG_ROCK",
+                    "ROCK-PSYCHEDELIC",
+                    "ROCK-ROCK_N_ROLL",
+                    "ROCK-EXPERIMENTAL",
+                    "ROCK-ROCKABILLY",
+                    "ROCK-SHOEGAZE",
+                    "ROCK-ELECTRO",
+                    "ROCK-OTHER",
+                    "METAL-BLACK_METAL",
+                    "METAL-DEATH_METAL",
+                    "METAL-DOOM_METAL",
+                    "METAL-GOTHIC",
+                    "METAL-METAL_CORE",
+                    "METAL-METAL_PROGRESSIF",
+                    "METAL-TRASH_METAL",
+                    "METAL-METAL_INDUSTRIEL",
+                    "METAL-FUSION",
+                    "METAL-OTHER",
+                    "PUNK-POST_PUNK",
+                    "PUNK-HARDCORE_PUNK",
+                    "PUNK-AFRO_PUNK",
+                    "PUNK-GRINDCORE",
+                    "PUNK-NOISE_ROCK",
+                    "PUNK-OTHER",
+                    "FOLK-FOLK_CONTEMPORAINE",
+                    "FOLK-INDIE_FOLK",
+                    "FOLK-FOLK_ROCK",
+                    "FOLK-NEW_ACOUSTIC",
+                    "FOLK-FOLK_TRADITIONELLE",
+                    "FOLK-TEX_MEX",
+                    "FOLK-OTHER",
+                    "COUNTRY-COUNTRY_ALTERNATIVE",
+                    "COUNTRY-AMERICANA",
+                    "COUNTRY-BLUEGRASS",
+                    "COUNTRY-COUNTRY_CONTEMPORAINE",
+                    "COUNTRY-GOSPEL_COUNTRY",
+                    "COUNTRY-COUNTRY_POP",
+                    "COUNTRY-OTHER",
+                    "ELECTRO-BITPOP",
+                    "ELECTRO-BREAKBEAT",
+                    "ELECTRO-CHILLWAVE",
+                    "ELECTRO-DANCE",
+                    "ELECTRO-DOWNTEMPO",
+                    "ELECTRO-DRUM_AND_BASS",
+                    "ELECTRO-DUBSTEP",
+                    "ELECTRO-EXPERIMENTAL",
+                    "ELECTRO-ELECTRONICA",
+                    "ELECTRO-GARAGE",
+                    "ELECTRO-GRIME",
+                    "ELECTRO-HARD_DANCE",
+                    "ELECTRO-HARDCORE",
+                    "ELECTRO-HOUSE",
+                    "ELECTRO-INDUSTRIEL",
+                    "ELECTRO-LOUNGE",
+                    "ELECTRO-TECHNO",
+                    "ELECTRO-TRANCE",
+                    "ELECTRO-OTHER",
+                    "HIP_HOP_RAP-BOUNCE",
+                    "HIP_HOP_RAP-HIP_HOP",
+                    "HIP_HOP_RAP-RAP_ALTERNATIF",
+                    "HIP_HOP_RAP-RAP_EAST_COAST",
+                    "HIP_HOP_RAP-RAP_FRANCAIS",
+                    "HIP_HOP_RAP-RAP_GANGSTA",
+                    "HIP_HOP_RAP-RAP_HARDCORE",
+                    "HIP_HOP_RAP-RAP_LATINO",
+                    "HIP_HOP_RAP-RAP_OLD_SCHOOL",
+                    "HIP_HOP_RAP-RAP_UNDERGROUND",
+                    "HIP_HOP_RAP-RAP_WEST_COAST",
+                    "HIP_HOP_RAP-TRAP",
+                    "HIP_HOP_RAP-TRIP_HOP",
+                    "HIP_HOP_RAP-R&B_CONTEMPORAIN",
+                    "HIP_HOP_RAP-DISCO",
+                    "HIP_HOP_RAP-DOO_WOP",
+                    "HIP_HOP_RAP-FUNK",
+                    "HIP_HOP_RAP-SOUL",
+                    "HIP_HOP_RAP-MOTOWN",
+                    "HIP_HOP_RAP-NEO_SOUL",
+                    "HIP_HOP_RAP-SOUL_PSYCHEDELIQUE",
+                    "HIP_HOP_RAP-OTHER",
+                    "GOSPEL-SPIRITUAL_GOSPEL",
+                    "GOSPEL-TRADITIONAL_GOSPEL",
+                    "GOSPEL-SOUTHERN_GOSPEL",
+                    "GOSPEL-CONTEMPORARY_GOSPEL",
+                    "GOSPEL-BLUEGRASS_GOSPEL",
+                    "GOSPEL-BLUES_GOSPEL",
+                    "GOSPEL-COUNTRY_GOSPEL",
+                    "GOSPEL-HYBRID_GOSPEL",
+                    "GOSPEL-OTHER",
+                    "CHANSON_VARIETE-MUSETTE",
+                    "CHANSON_VARIETE-CHANSON_FRANCAISE",
+                    "CHANSON_VARIETE-MUSIC_HALL",
+                    "CHANSON_VARIETE-FOLKLORE_FRANCAIS",
+                    "CHANSON_VARIETE-CHANSON_\u00c0_TEXTE",
+                    "CHANSON_VARIETE-SLAM",
+                    "CHANSON_VARIETE-OTHER",
+                    "OTHER"
+                ],
+                "title": "MusicTypeEnum",
+                "type": "string"
+            },
+            "MusicTypeResponse": {
+                "properties": {
+                    "id": {
+                        "$ref": "#/components/schemas/MusicTypeEnum"
+                    },
+                    "label": {
+                        "title": "Label",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "label"
+                ],
+                "title": "MusicTypeResponse",
+                "type": "object"
+            },
+            "NationalProgramModel": {
+                "properties": {
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "title": "NationalProgramModel",
+                "type": "object"
+            },
+            "OEUVRE_ART_read": {
+                "description": "Cat\u00e9gorie technique d'oeuvre d'art",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "OEUVRE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "OEUVRE_ART_read",
+                "type": "object"
+            },
+            "OfferAddressType": {
+                "description": "An enumeration.",
+                "enum": [
+                    "offererVenue",
+                    "school",
+                    "other"
+                ],
+                "title": "OfferAddressType"
+            },
+            "OfferStatus": {
+                "description": "An enumeration.",
+                "enum": [
+                    "ACTIVE",
+                    "PENDING",
+                    "EXPIRED",
+                    "REJECTED",
+                    "SOLD_OUT",
+                    "INACTIVE",
+                    "DRAFT"
+                ],
+                "title": "OfferStatus",
+                "type": "string"
+            },
+            "OfferVenueModel": {
+                "additionalProperties": false,
+                "properties": {
+                    "addressType": {
+                        "$ref": "#/components/schemas/OfferAddressType"
+                    },
+                    "otherAddress": {
+                        "nullable": true,
+                        "title": "Otheraddress",
+                        "type": "string"
+                    },
+                    "venueId": {
+                        "nullable": true,
+                        "title": "Venueid",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "addressType"
+                ],
+                "title": "OfferVenueModel",
+                "type": "object"
+            },
+            "OffererResponse": {
+                "properties": {
+                    "createdDatetime": {
+                        "format": "date-time",
+                        "title": "Createddatetime",
+                        "type": "string"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "example": "Structure A",
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "siren": {
+                        "example": "123456789",
+                        "nullable": true,
+                        "title": "Siren",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "createdDatetime",
+                    "name"
+                ],
+                "title": "OffererResponse",
+                "type": "object"
+            },
+            "PARTITION_create": {
+                "description": "Partition",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PARTITION"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "ean",
+                    "category"
+                ],
+                "title": "PARTITION_create",
+                "type": "object"
+            },
+            "PARTITION_edit": {
+                "description": "Partition",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PARTITION"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PARTITION_edit",
+                "type": "object"
+            },
+            "PARTITION_read": {
+                "description": "Partition",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PARTITION"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PARTITION_read",
+                "type": "object"
+            },
+            "PLATEFORME_PRATIQUE_ARTISTIQUE_create": {
+                "description": "Pratique artistique - plateforme en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PLATEFORME_PRATIQUE_ARTISTIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PLATEFORME_PRATIQUE_ARTISTIQUE_create",
+                "type": "object"
+            },
+            "PLATEFORME_PRATIQUE_ARTISTIQUE_edit": {
+                "description": "Pratique artistique - plateforme en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PLATEFORME_PRATIQUE_ARTISTIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PLATEFORME_PRATIQUE_ARTISTIQUE_edit",
+                "type": "object"
+            },
+            "PLATEFORME_PRATIQUE_ARTISTIQUE_read": {
+                "description": "Pratique artistique - plateforme en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PLATEFORME_PRATIQUE_ARTISTIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PLATEFORME_PRATIQUE_ARTISTIQUE_read",
+                "type": "object"
+            },
+            "PODCAST_create": {
+                "description": "Podcast",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PODCAST"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PODCAST_create",
+                "type": "object"
+            },
+            "PODCAST_edit": {
+                "description": "Podcast",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PODCAST"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PODCAST_edit",
+                "type": "object"
+            },
+            "PODCAST_read": {
+                "description": "Podcast",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PODCAST"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PODCAST_read",
+                "type": "object"
+            },
+            "PRATIQUE_ART_VENTE_DISTANCE_create": {
+                "description": "Pratique artistique - vente \u00e0 distance",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PRATIQUE_ART_VENTE_DISTANCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PRATIQUE_ART_VENTE_DISTANCE_create",
+                "type": "object"
+            },
+            "PRATIQUE_ART_VENTE_DISTANCE_edit": {
+                "description": "Pratique artistique - vente \u00e0 distance",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PRATIQUE_ART_VENTE_DISTANCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PRATIQUE_ART_VENTE_DISTANCE_edit",
+                "type": "object"
+            },
+            "PRATIQUE_ART_VENTE_DISTANCE_read": {
+                "description": "Pratique artistique - vente \u00e0 distance",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "PRATIQUE_ART_VENTE_DISTANCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "PRATIQUE_ART_VENTE_DISTANCE_read",
+                "type": "object"
+            },
+            "PartialAccessibility": {
+                "description": "Accessibility for people with disabilities. Fields are null for digital venues.",
+                "properties": {
+                    "audioDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Audiodisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "mentalDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Mentaldisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "motorDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Motordisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "visualDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Visualdisabilitycompliant",
+                        "type": "boolean"
+                    }
+                },
+                "title": "PartialAccessibility",
+                "type": "object"
+            },
+            "PatchCollectiveOfferBodyModel": {
+                "additionalProperties": false,
+                "properties": {
+                    "audioDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Audiodisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "beginningDatetime": {
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Beginningdatetime",
+                        "type": "string"
+                    },
+                    "bookingEmails": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "nullable": true,
+                        "title": "Bookingemails",
+                        "type": "array"
+                    },
+                    "bookingLimitDatetime": {
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "contactEmail": {
+                        "nullable": true,
+                        "title": "Contactemail",
+                        "type": "string"
+                    },
+                    "contactPhone": {
+                        "nullable": true,
+                        "title": "Contactphone",
+                        "type": "string"
+                    },
+                    "description": {
+                        "nullable": true,
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "domains": {
+                        "items": {
+                            "type": "integer"
+                        },
+                        "nullable": true,
+                        "title": "Domains",
+                        "type": "array"
+                    },
+                    "durationMinutes": {
+                        "nullable": true,
+                        "title": "Durationminutes",
+                        "type": "integer"
+                    },
+                    "educationalInstitution": {
+                        "nullable": true,
+                        "title": "Educationalinstitution",
+                        "type": "string"
+                    },
+                    "educationalInstitutionId": {
+                        "nullable": true,
+                        "title": "Educationalinstitutionid",
+                        "type": "integer"
+                    },
+                    "educationalPriceDetail": {
+                        "nullable": true,
+                        "title": "Educationalpricedetail",
+                        "type": "string"
+                    },
+                    "formats": {
+                        "items": {
+                            "$ref": "#/components/schemas/EacFormat"
+                        },
+                        "nullable": true,
+                        "type": "array"
+                    },
+                    "imageCredit": {
+                        "nullable": true,
+                        "title": "Imagecredit",
+                        "type": "string"
+                    },
+                    "imageFile": {
+                        "nullable": true,
+                        "title": "Imagefile",
+                        "type": "string"
+                    },
+                    "interventionArea": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "nullable": true,
+                        "title": "Interventionarea",
+                        "type": "array"
+                    },
+                    "isActive": {
+                        "nullable": true,
+                        "title": "Isactive",
+                        "type": "boolean"
+                    },
+                    "mentalDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Mentaldisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "motorDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Motordisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "nullable": true,
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "nationalProgramId": {
+                        "nullable": true,
+                        "title": "Nationalprogramid",
+                        "type": "integer"
+                    },
+                    "numberOfTickets": {
+                        "nullable": true,
+                        "title": "Numberoftickets",
+                        "type": "integer"
+                    },
+                    "offerVenue": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OfferVenueModel"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "OfferVenueModel"
+                    },
+                    "students": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "nullable": true,
+                        "title": "Students",
+                        "type": "array"
+                    },
+                    "subcategoryId": {
+                        "nullable": true,
+                        "title": "Subcategoryid",
+                        "type": "string"
+                    },
+                    "totalPrice": {
+                        "nullable": true,
+                        "title": "Totalprice",
+                        "type": "number"
+                    },
+                    "venueId": {
+                        "nullable": true,
+                        "title": "Venueid",
+                        "type": "integer"
+                    },
+                    "visualDisabilityCompliant": {
+                        "nullable": true,
+                        "title": "Visualdisabilitycompliant",
+                        "type": "boolean"
+                    }
+                },
+                "title": "PatchCollectiveOfferBodyModel",
+                "type": "object"
+            },
+            "PhysicalLocation": {
+                "properties": {
+                    "type": {
+                        "default": "physical",
+                        "enum": [
+                            "physical"
+                        ],
+                        "title": "Type",
+                        "type": "string"
+                    },
+                    "venueId": {
+                        "description": "List of venues is available at GET /offerer_venues",
+                        "example": 1,
+                        "title": "Venueid",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "venueId"
+                ],
+                "title": "PhysicalLocation",
+                "type": "object"
+            },
+            "PostCollectiveOfferBodyModel": {
+                "additionalProperties": false,
+                "properties": {
+                    "audioDisabilityCompliant": {
+                        "default": false,
+                        "title": "Audiodisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "beginningDatetime": {
+                        "format": "date-time",
+                        "title": "Beginningdatetime",
+                        "type": "string"
+                    },
+                    "bookingEmails": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Bookingemails",
+                        "type": "array"
+                    },
+                    "bookingLimitDatetime": {
+                        "format": "date-time",
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "contactEmail": {
+                        "title": "Contactemail",
+                        "type": "string"
+                    },
+                    "contactPhone": {
+                        "title": "Contactphone",
+                        "type": "string"
+                    },
+                    "description": {
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "domains": {
+                        "items": {
+                            "type": "integer"
+                        },
+                        "title": "Domains",
+                        "type": "array"
+                    },
+                    "durationMinutes": {
+                        "nullable": true,
+                        "title": "Durationminutes",
+                        "type": "integer"
+                    },
+                    "educationalInstitution": {
+                        "nullable": true,
+                        "title": "Educationalinstitution",
+                        "type": "string"
+                    },
+                    "educationalInstitutionId": {
+                        "nullable": true,
+                        "title": "Educationalinstitutionid",
+                        "type": "integer"
+                    },
+                    "educationalPriceDetail": {
+                        "nullable": true,
+                        "title": "Educationalpricedetail",
+                        "type": "string"
+                    },
+                    "formats": {
+                        "items": {
+                            "$ref": "#/components/schemas/EacFormat"
+                        },
+                        "nullable": true,
+                        "type": "array"
+                    },
+                    "imageCredit": {
+                        "nullable": true,
+                        "title": "Imagecredit",
+                        "type": "string"
+                    },
+                    "imageFile": {
+                        "nullable": true,
+                        "title": "Imagefile",
+                        "type": "string"
+                    },
+                    "isActive": {
+                        "title": "Isactive",
+                        "type": "boolean"
+                    },
+                    "mentalDisabilityCompliant": {
+                        "default": false,
+                        "title": "Mentaldisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "motorDisabilityCompliant": {
+                        "default": false,
+                        "title": "Motordisabilitycompliant",
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "nationalProgramId": {
+                        "nullable": true,
+                        "title": "Nationalprogramid",
+                        "type": "integer"
+                    },
+                    "numberOfTickets": {
+                        "title": "Numberoftickets",
+                        "type": "integer"
+                    },
+                    "offerVenue": {
+                        "$ref": "#/components/schemas/OfferVenueModel"
+                    },
+                    "students": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Students",
+                        "type": "array"
+                    },
+                    "subcategoryId": {
+                        "nullable": true,
+                        "title": "Subcategoryid",
+                        "type": "string"
+                    },
+                    "totalPrice": {
+                        "title": "Totalprice",
+                        "type": "number"
+                    },
+                    "venueId": {
+                        "title": "Venueid",
+                        "type": "integer"
+                    },
+                    "visualDisabilityCompliant": {
+                        "default": false,
+                        "title": "Visualdisabilitycompliant",
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "venueId",
+                    "name",
+                    "description",
+                    "bookingEmails",
+                    "contactEmail",
+                    "contactPhone",
+                    "domains",
+                    "students",
+                    "offerVenue",
+                    "isActive",
+                    "beginningDatetime",
+                    "bookingLimitDatetime",
+                    "totalPrice",
+                    "numberOfTickets"
+                ],
+                "title": "PostCollectiveOfferBodyModel",
+                "type": "object"
+            },
+            "PostDatesResponse": {
+                "properties": {
+                    "dates": {
+                        "description": "Dates of the event.",
+                        "items": {
+                            "$ref": "#/components/schemas/DateResponse"
+                        },
+                        "title": "Dates",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "dates"
+                ],
+                "title": "PostDatesResponse",
+                "type": "object"
+            },
+            "PriceCategoriesCreation": {
+                "additionalProperties": false,
+                "properties": {
+                    "priceCategories": {
+                        "description": "Available price categories for dates of this offer",
+                        "items": {
+                            "$ref": "#/components/schemas/PriceCategoryCreation"
+                        },
+                        "title": "Pricecategories",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "priceCategories"
+                ],
+                "title": "PriceCategoriesCreation",
+                "type": "object"
+            },
+            "PriceCategoriesResponse": {
+                "properties": {
+                    "priceCategories": {
+                        "description": "Available price categories for dates of this offer",
+                        "items": {
+                            "$ref": "#/components/schemas/PriceCategoryResponse"
+                        },
+                        "title": "Pricecategories",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "priceCategories"
+                ],
+                "title": "PriceCategoriesResponse",
+                "type": "object"
+            },
+            "PriceCategoryCreation": {
+                "properties": {
+                    "label": {
+                        "description": "Price category label",
+                        "example": "Carr\u00e9 or",
+                        "maxLength": 50,
+                        "minLength": 1,
+                        "title": "Label",
+                        "type": "string"
+                    },
+                    "price": {
+                        "description": "Offer price in euro cents.",
+                        "example": 1000,
+                        "maximum": 30000,
+                        "minimum": 0,
+                        "title": "Price",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "label",
+                    "price"
+                ],
+                "title": "PriceCategoryCreation",
+                "type": "object"
+            },
+            "PriceCategoryEdition": {
+                "additionalProperties": false,
+                "properties": {
+                    "label": {
+                        "description": "Price category label",
+                        "example": "Carr\u00e9 or",
+                        "maxLength": 50,
+                        "minLength": 1,
+                        "nullable": true,
+                        "title": "Label",
+                        "type": "string"
+                    },
+                    "price": {
+                        "description": "Offer price in euro cents.",
+                        "example": 1000,
+                        "maximum": 30000,
+                        "minimum": 0,
+                        "nullable": true,
+                        "title": "Price",
+                        "type": "integer"
+                    }
+                },
+                "title": "PriceCategoryEdition",
+                "type": "object"
+            },
+            "PriceCategoryResponse": {
+                "properties": {
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "label": {
+                        "description": "Price category label",
+                        "example": "Carr\u00e9 or",
+                        "title": "Label",
+                        "type": "string"
+                    },
+                    "price": {
+                        "description": "Offer price in euro cents.",
+                        "example": 1000,
+                        "title": "Price",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "id",
+                    "label",
+                    "price"
+                ],
+                "title": "PriceCategoryResponse",
+                "type": "object"
+            },
+            "ProductCategoryResponse": {
+                "properties": {
+                    "conditionalFields": {
+                        "additionalProperties": {
+                            "type": "boolean"
+                        },
+                        "description": "The keys are fields that should be set in the category_related_fields of a product. The values indicate whether their associated field is mandatory during product creation.",
+                        "title": "Conditionalfields",
+                        "type": "object"
+                    },
+                    "id": {
+                        "$ref": "#/components/schemas/CategoryEnum"
+                    },
+                    "locationType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/LocationTypeEnum"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "id",
+                    "conditionalFields"
+                ],
+                "title": "ProductCategoryResponse",
+                "type": "object"
+            },
+            "ProductOfferByEanCreation": {
+                "additionalProperties": false,
+                "properties": {
+                    "ean": {
+                        "description": "European Article Number (EAN-13)",
+                        "example": "1234567890123",
+                        "maxLength": 13,
+                        "minLength": 13,
+                        "title": "Ean",
+                        "type": "string"
+                    },
+                    "stock": {
+                        "$ref": "#/components/schemas/StockCreation"
+                    }
+                },
+                "required": [
+                    "ean",
+                    "stock"
+                ],
+                "title": "ProductOfferByEanCreation",
+                "type": "object"
+            },
+            "ProductOfferCreation": {
+                "additionalProperties": false,
+                "properties": {
+                    "accessibility": {
+                        "$ref": "#/components/schemas/Accessibility"
+                    },
+                    "bookingContact": {
+                        "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
+                        "format": "email",
+                        "nullable": true,
+                        "title": "Bookingcontact",
+                        "type": "string"
+                    },
+                    "bookingEmail": {
+                        "description": "Recipient email for notifications about bookings, cancellations, etc.",
+                        "format": "email",
+                        "nullable": true,
+                        "title": "Bookingemail",
+                        "type": "string"
+                    },
+                    "categoryRelatedFields": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ABO_BIBLIOTHEQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_CONCERT_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_LIVRE_NUMERIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_MEDIATHEQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PLATEFORME_MUSIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PLATEFORME_VIDEO_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PRATIQUE_ART_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PRESSE_EN_LIGNE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_SPECTACLE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ACHAT_INSTRUMENT_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/APP_CULTURELLE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AUTRE_SUPPORT_NUMERIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CARTE_JEUNES_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CARTE_MUSEE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVRE_AUDIO_PHYSIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVRE_NUMERIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LOCATION_INSTRUMENT_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PARTITION_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PLATEFORME_PRATIQUE_ARTISTIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PODCAST_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PRATIQUE_ART_VENTE_DISTANCE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SPECTACLE_ENREGISTRE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_FILM_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TELECHARGEMENT_LIVRE_AUDIO_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TELECHARGEMENT_MUSIQUE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_VIRTUELLE_create"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VOD_create"
+                            }
+                        ],
+                        "description": "Cultural category the offer belongs to. According to the category, some fields may or must be specified.",
+                        "title": "Categoryrelatedfields"
+                    },
+                    "description": {
+                        "description": "Offer description",
+                        "example": "A great book for kids and old kids.",
+                        "maxLength": 1000,
+                        "nullable": true,
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "enableDoubleBookings": {
+                        "default": false,
+                        "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
+                        "nullable": true,
+                        "title": "Enabledoublebookings",
+                        "type": "boolean"
+                    },
+                    "externalTicketOfficeUrl": {
+                        "description": "Link displayed to users wishing to book the offer but who do not have (anymore) credit.",
+                        "example": "https://example.com",
+                        "format": "uri",
+                        "maxLength": 2083,
+                        "minLength": 1,
+                        "nullable": true,
+                        "title": "Externalticketofficeurl",
+                        "type": "string"
+                    },
+                    "image": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ImageBody"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "ImageBody"
+                    },
+                    "itemCollectionDetails": {
+                        "description": "Further information that will be provided to attendees to ease the offer collection.",
+                        "example": "Opening hours, specific office, collection period, access code, email annoucement...",
+                        "nullable": true,
+                        "title": "Itemcollectiondetails",
+                        "type": "string"
+                    },
+                    "location": {
+                        "description": "Location where the offer will be available or will take place. The location type must be compatible with the category",
+                        "discriminator": {
+                            "mapping": {
+                                "digital": "#/components/schemas/DigitalLocation",
+                                "physical": "#/components/schemas/PhysicalLocation"
+                            },
+                            "propertyName": "type"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PhysicalLocation"
+                            },
+                            {
+                                "$ref": "#/components/schemas/DigitalLocation"
+                            }
+                        ],
+                        "title": "Location"
+                    },
+                    "name": {
+                        "description": "Offer title",
+                        "example": "Le Petit Prince",
+                        "maxLength": 90,
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "stock": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StockCreation"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "StockCreation"
+                    }
+                },
+                "required": [
+                    "accessibility",
+                    "categoryRelatedFields",
+                    "name",
+                    "location"
+                ],
+                "title": "ProductOfferCreation",
+                "type": "object"
+            },
+            "ProductOfferEdition": {
+                "additionalProperties": false,
+                "properties": {
+                    "accessibility": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PartialAccessibility"
+                            }
+                        ],
+                        "description": "Accessibility to disabled people. Leave fields undefined to keep current value",
+                        "nullable": true,
+                        "title": "Accessibility"
+                    },
+                    "bookingContact": {
+                        "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
+                        "format": "email",
+                        "nullable": true,
+                        "title": "Bookingcontact",
+                        "type": "string"
+                    },
+                    "bookingEmail": {
+                        "description": "Recipient email for notifications about bookings, cancellations, etc.",
+                        "format": "email",
+                        "nullable": true,
+                        "title": "Bookingemail",
+                        "type": "string"
+                    },
+                    "categoryRelatedFields": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ABO_BIBLIOTHEQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_CONCERT_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_LIVRE_NUMERIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_MEDIATHEQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PLATEFORME_MUSIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PLATEFORME_VIDEO_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PRATIQUE_ART_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PRESSE_EN_LIGNE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_SPECTACLE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ACHAT_INSTRUMENT_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/APP_CULTURELLE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AUTRE_SUPPORT_NUMERIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CARTE_JEUNES_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CARTE_MUSEE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVRE_AUDIO_PHYSIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVRE_NUMERIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LOCATION_INSTRUMENT_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PARTITION_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PLATEFORME_PRATIQUE_ARTISTIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PODCAST_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PRATIQUE_ART_VENTE_DISTANCE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SPECTACLE_ENREGISTRE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_FILM_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TELECHARGEMENT_LIVRE_AUDIO_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TELECHARGEMENT_MUSIQUE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_VIRTUELLE_edit"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VOD_edit"
+                            }
+                        ],
+                        "description": "To override category related fields, the category must be specified, even if it cannot be changed. Other category related fields may be left undefined to keep their current value.",
+                        "nullable": true,
+                        "title": "Categoryrelatedfields"
+                    },
+                    "description": {
+                        "description": "Offer description",
+                        "example": "A great book for kids and old kids.",
+                        "maxLength": 1000,
+                        "nullable": true,
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "enableDoubleBookings": {
+                        "default": false,
+                        "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
+                        "nullable": true,
+                        "title": "Enabledoublebookings",
+                        "type": "boolean"
+                    },
+                    "image": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ImageBody"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "ImageBody"
+                    },
+                    "isActive": {
+                        "description": "Whether the offer is activated. An inactive offer cannot be booked.",
+                        "nullable": true,
+                        "title": "Isactive",
+                        "type": "boolean"
+                    },
+                    "itemCollectionDetails": {
+                        "description": "Further information that will be provided to attendees to ease the offer collection.",
+                        "example": "Opening hours, specific office, collection period, access code, email annoucement...",
+                        "nullable": true,
+                        "title": "Itemcollectiondetails",
+                        "type": "string"
+                    },
+                    "offerId": {
+                        "title": "Offerid",
+                        "type": "integer"
+                    },
+                    "stock": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/StockEdition"
+                            }
+                        ],
+                        "description": "If stock is set to null, all cancellable bookings (i.e not used) will be cancelled. To prevent from further bookings, you may alternatively set stock.quantity to the bookedQuantity (but not below).",
+                        "nullable": true,
+                        "title": "Stock"
+                    }
+                },
+                "required": [
+                    "offerId"
+                ],
+                "title": "ProductOfferEdition",
+                "type": "object"
+            },
+            "ProductOfferResponse": {
+                "properties": {
+                    "accessibility": {
+                        "$ref": "#/components/schemas/AccessibilityResponse"
+                    },
+                    "bookingContact": {
+                        "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
+                        "nullable": true,
+                        "title": "Bookingcontact",
+                        "type": "string"
+                    },
+                    "bookingEmail": {
+                        "description": "Recipient email for notifications about bookings, cancellations, etc.",
+                        "nullable": true,
+                        "title": "Bookingemail",
+                        "type": "string"
+                    },
+                    "categoryRelatedFields": {
+                        "description": "Cultural category the offer belongs to. According to the category, some fields may or must be specified.",
+                        "discriminator": {
+                            "mapping": {
+                                "ABO_BIBLIOTHEQUE": "#/components/schemas/ABO_BIBLIOTHEQUE_read",
+                                "ABO_CONCERT": "#/components/schemas/ABO_CONCERT_read",
+                                "ABO_JEU_VIDEO": "#/components/schemas/ABO_JEU_VIDEO_read",
+                                "ABO_LIVRE_NUMERIQUE": "#/components/schemas/ABO_LIVRE_NUMERIQUE_read",
+                                "ABO_LUDOTHEQUE": "#/components/schemas/ABO_LUDOTHEQUE_read",
+                                "ABO_MEDIATHEQUE": "#/components/schemas/ABO_MEDIATHEQUE_read",
+                                "ABO_PLATEFORME_MUSIQUE": "#/components/schemas/ABO_PLATEFORME_MUSIQUE_read",
+                                "ABO_PLATEFORME_VIDEO": "#/components/schemas/ABO_PLATEFORME_VIDEO_read",
+                                "ABO_PRATIQUE_ART": "#/components/schemas/ABO_PRATIQUE_ART_read",
+                                "ABO_PRESSE_EN_LIGNE": "#/components/schemas/ABO_PRESSE_EN_LIGNE_read",
+                                "ABO_SPECTACLE": "#/components/schemas/ABO_SPECTACLE_read",
+                                "ACHAT_INSTRUMENT": "#/components/schemas/ACHAT_INSTRUMENT_read",
+                                "ACTIVATION_THING": "#/components/schemas/ACTIVATION_THING_read",
+                                "APP_CULTURELLE": "#/components/schemas/APP_CULTURELLE_read",
+                                "AUTRE_SUPPORT_NUMERIQUE": "#/components/schemas/AUTRE_SUPPORT_NUMERIQUE_read",
+                                "BON_ACHAT_INSTRUMENT": "#/components/schemas/BON_ACHAT_INSTRUMENT_read",
+                                "CAPTATION_MUSIQUE": "#/components/schemas/CAPTATION_MUSIQUE_read",
+                                "CARTE_CINE_ILLIMITE": "#/components/schemas/CARTE_CINE_ILLIMITE_read",
+                                "CARTE_CINE_MULTISEANCES": "#/components/schemas/CARTE_CINE_MULTISEANCES_read",
+                                "CARTE_JEUNES": "#/components/schemas/CARTE_JEUNES_read",
+                                "CARTE_MUSEE": "#/components/schemas/CARTE_MUSEE_read",
+                                "CINE_VENTE_DISTANCE": "#/components/schemas/CINE_VENTE_DISTANCE_read",
+                                "ESCAPE_GAME": "#/components/schemas/ESCAPE_GAME_read",
+                                "JEU_EN_LIGNE": "#/components/schemas/JEU_EN_LIGNE_read",
+                                "JEU_SUPPORT_PHYSIQUE": "#/components/schemas/JEU_SUPPORT_PHYSIQUE_read",
+                                "LIVRE_AUDIO_PHYSIQUE": "#/components/schemas/LIVRE_AUDIO_PHYSIQUE_read",
+                                "LIVRE_NUMERIQUE": "#/components/schemas/LIVRE_NUMERIQUE_read",
+                                "LIVRE_PAPIER": "#/components/schemas/LIVRE_PAPIER_read",
+                                "LOCATION_INSTRUMENT": "#/components/schemas/LOCATION_INSTRUMENT_read",
+                                "MATERIEL_ART_CREATIF": "#/components/schemas/MATERIEL_ART_CREATIF_read",
+                                "MUSEE_VENTE_DISTANCE": "#/components/schemas/MUSEE_VENTE_DISTANCE_read",
+                                "OEUVRE_ART": "#/components/schemas/OEUVRE_ART_read",
+                                "PARTITION": "#/components/schemas/PARTITION_read",
+                                "PLATEFORME_PRATIQUE_ARTISTIQUE": "#/components/schemas/PLATEFORME_PRATIQUE_ARTISTIQUE_read",
+                                "PODCAST": "#/components/schemas/PODCAST_read",
+                                "PRATIQUE_ART_VENTE_DISTANCE": "#/components/schemas/PRATIQUE_ART_VENTE_DISTANCE_read",
+                                "SPECTACLE_ENREGISTRE": "#/components/schemas/SPECTACLE_ENREGISTRE_read",
+                                "SPECTACLE_VENTE_DISTANCE": "#/components/schemas/SPECTACLE_VENTE_DISTANCE_read",
+                                "SUPPORT_PHYSIQUE_FILM": "#/components/schemas/SUPPORT_PHYSIQUE_FILM_read",
+                                "SUPPORT_PHYSIQUE_MUSIQUE_CD": "#/components/schemas/SUPPORT_PHYSIQUE_MUSIQUE_CD_read",
+                                "SUPPORT_PHYSIQUE_MUSIQUE_VINYLE": "#/components/schemas/SUPPORT_PHYSIQUE_MUSIQUE_VINYLE_read",
+                                "TELECHARGEMENT_LIVRE_AUDIO": "#/components/schemas/TELECHARGEMENT_LIVRE_AUDIO_read",
+                                "TELECHARGEMENT_MUSIQUE": "#/components/schemas/TELECHARGEMENT_MUSIQUE_read",
+                                "VISITE_VIRTUELLE": "#/components/schemas/VISITE_VIRTUELLE_read",
+                                "VOD": "#/components/schemas/VOD_read"
+                            },
+                            "propertyName": "category"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ABO_BIBLIOTHEQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_CONCERT_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_JEU_VIDEO_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_LIVRE_NUMERIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_LUDOTHEQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_MEDIATHEQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PLATEFORME_MUSIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PLATEFORME_VIDEO_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PRATIQUE_ART_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_PRESSE_EN_LIGNE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ABO_SPECTACLE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ACHAT_INSTRUMENT_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ACTIVATION_THING_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/APP_CULTURELLE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AUTRE_SUPPORT_NUMERIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/BON_ACHAT_INSTRUMENT_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CAPTATION_MUSIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CARTE_CINE_ILLIMITE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CARTE_CINE_MULTISEANCES_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CARTE_JEUNES_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CARTE_MUSEE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/CINE_VENTE_DISTANCE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ESCAPE_GAME_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/JEU_EN_LIGNE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/JEU_SUPPORT_PHYSIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVRE_AUDIO_PHYSIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVRE_NUMERIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LIVRE_PAPIER_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/LOCATION_INSTRUMENT_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MATERIEL_ART_CREATIF_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MUSEE_VENTE_DISTANCE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OEUVRE_ART_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PARTITION_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PLATEFORME_PRATIQUE_ARTISTIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PRATIQUE_ART_VENTE_DISTANCE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/PODCAST_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SPECTACLE_ENREGISTRE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SPECTACLE_VENTE_DISTANCE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_FILM_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_MUSIQUE_CD_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SUPPORT_PHYSIQUE_MUSIQUE_VINYLE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TELECHARGEMENT_LIVRE_AUDIO_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TELECHARGEMENT_MUSIQUE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VISITE_VIRTUELLE_read"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VOD_read"
+                            }
+                        ],
+                        "title": "Categoryrelatedfields"
+                    },
+                    "description": {
+                        "description": "Offer description",
+                        "example": "A great book for kids and old kids.",
+                        "nullable": true,
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "enableDoubleBookings": {
+                        "default": false,
+                        "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
+                        "nullable": true,
+                        "title": "Enabledoublebookings",
+                        "type": "boolean"
+                    },
+                    "externalTicketOfficeUrl": {
+                        "description": "Link displayed to users wishing to book the offer but who do not have (anymore) credit.",
+                        "example": "https://example.com",
+                        "nullable": true,
+                        "title": "Externalticketofficeurl",
+                        "type": "string"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "image": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ImageResponse"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "ImageResponse"
+                    },
+                    "itemCollectionDetails": {
+                        "description": "Further information that will be provided to attendees to ease the offer collection.",
+                        "example": "Opening hours, specific office, collection period, access code, email annoucement...",
+                        "nullable": true,
+                        "title": "Itemcollectiondetails",
+                        "type": "string"
+                    },
+                    "location": {
+                        "description": "Location where the offer will be available or will take place. The location type must be compatible with the category",
+                        "discriminator": {
+                            "mapping": {
+                                "digital": "#/components/schemas/DigitalLocation",
+                                "physical": "#/components/schemas/PhysicalLocation"
+                            },
+                            "propertyName": "type"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PhysicalLocation"
+                            },
+                            {
+                                "$ref": "#/components/schemas/DigitalLocation"
+                            }
+                        ],
+                        "title": "Location"
+                    },
+                    "name": {
+                        "description": "Offer title",
+                        "example": "Le Petit Prince",
+                        "maxLength": 90,
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "status": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/OfferStatus"
+                            }
+                        ],
+                        "description": "ACTIVE: offer is validated and active.\n\nDRAFT: offer is still draft and not yet submitted for validation - this status is not applicable to offers created via this API.\n\nEXPIRED: offer is validated but the booking limit datetime has passed.\n\nINACTIVE: offer is not active and cannot be booked.\n\nPENDING: offer is pending for pass Culture rules compliance validation. This step may last 72 hours.\n\nREJECTED: offer validation has been rejected because it is not compliant with pass Culture rules.\n\nSOLD_OUT: offer is validated but there is no (more) stock available for booking.",
+                        "example": "ACTIVE"
+                    },
+                    "stock": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ProductStockResponse"
+                            }
+                        ],
+                        "nullable": true,
+                        "title": "ProductStockResponse"
+                    }
+                },
+                "required": [
+                    "id",
+                    "accessibility",
+                    "location",
+                    "name",
+                    "status",
+                    "categoryRelatedFields"
+                ],
+                "title": "ProductOfferResponse",
+                "type": "object"
+            },
+            "ProductOffersByEanResponse": {
+                "properties": {
+                    "products": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProductOfferResponse"
+                        },
+                        "title": "Products",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "products"
+                ],
+                "title": "ProductOffersByEanResponse",
+                "type": "object"
+            },
+            "ProductOffersResponse": {
+                "properties": {
+                    "products": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProductOfferResponse"
+                        },
+                        "title": "Products",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "products"
+                ],
+                "title": "ProductOffersResponse",
+                "type": "object"
+            },
+            "ProductStockResponse": {
+                "properties": {
+                    "bookedQuantity": {
+                        "description": "Number of bookings.",
+                        "example": 0,
+                        "title": "Bookedquantity",
+                        "type": "integer"
+                    },
+                    "bookingLimitDatetime": {
+                        "description": "Timezone aware datetime after which the offer can no longer be booked.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "price": {
+                        "description": "Offer price in euro cents.",
+                        "example": 1000,
+                        "title": "Price",
+                        "type": "integer"
+                    },
+                    "quantity": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "enum": [
+                                    "unlimited"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
+                        "example": 10,
+                        "title": "Quantity"
+                    }
+                },
+                "required": [
+                    "bookedQuantity",
+                    "quantity",
+                    "price"
+                ],
+                "title": "ProductStockResponse",
+                "type": "object"
+            },
+            "ProductsOfferByEanCreation": {
+                "additionalProperties": false,
+                "properties": {
+                    "location": {
+                        "description": "Location where the offer will be available or will take place. The location type must be compatible with the category",
+                        "discriminator": {
+                            "mapping": {
+                                "digital": "#/components/schemas/DigitalLocation",
+                                "physical": "#/components/schemas/PhysicalLocation"
+                            },
+                            "propertyName": "type"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PhysicalLocation"
+                            },
+                            {
+                                "$ref": "#/components/schemas/DigitalLocation"
+                            }
+                        ],
+                        "title": "Location"
+                    },
+                    "products": {
+                        "description": "List of product to create or update",
+                        "items": {
+                            "$ref": "#/components/schemas/ProductOfferByEanCreation"
+                        },
+                        "maxItems": 500,
+                        "title": "Products",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "products",
+                    "location"
+                ],
+                "title": "ProductsOfferByEanCreation",
+                "type": "object"
+            },
+            "RENCONTRE_EN_LIGNE_create": {
+                "description": "Rencontre en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE_EN_LIGNE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_EN_LIGNE_create",
+                "type": "object"
+            },
+            "RENCONTRE_EN_LIGNE_edit": {
+                "description": "Rencontre en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE_EN_LIGNE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_EN_LIGNE_edit",
+                "type": "object"
+            },
+            "RENCONTRE_EN_LIGNE_read": {
+                "description": "Rencontre en ligne",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE_EN_LIGNE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_EN_LIGNE_read",
+                "type": "object"
+            },
+            "RENCONTRE_JEU_create": {
+                "description": "Rencontres - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE_JEU"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_JEU_create",
+                "type": "object"
+            },
+            "RENCONTRE_JEU_edit": {
+                "description": "Rencontres - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE_JEU"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_JEU_edit",
+                "type": "object"
+            },
+            "RENCONTRE_JEU_read": {
+                "description": "Rencontres - jeux",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE_JEU"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_JEU_read",
+                "type": "object"
+            },
+            "RENCONTRE_create": {
+                "description": "Rencontre",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_create",
+                "type": "object"
+            },
+            "RENCONTRE_edit": {
+                "description": "Rencontre",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_edit",
+                "type": "object"
+            },
+            "RENCONTRE_read": {
+                "description": "Rencontre",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "RENCONTRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "RENCONTRE_read",
+                "type": "object"
+            },
+            "SALON_create": {
+                "description": "Salon, Convention",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SALON"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SALON_create",
+                "type": "object"
+            },
+            "SALON_edit": {
+                "description": "Salon, Convention",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SALON"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SALON_edit",
+                "type": "object"
+            },
+            "SALON_read": {
+                "description": "Salon, Convention",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SALON"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SALON_read",
+                "type": "object"
+            },
+            "SEANCE_CINE_create": {
+                "description": "S\u00e9ance de cin\u00e9ma",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SEANCE_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SEANCE_CINE_create",
+                "type": "object"
+            },
+            "SEANCE_CINE_edit": {
+                "description": "S\u00e9ance de cin\u00e9ma",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SEANCE_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SEANCE_CINE_edit",
+                "type": "object"
+            },
+            "SEANCE_CINE_read": {
+                "description": "S\u00e9ance de cin\u00e9ma",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SEANCE_CINE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    },
+                    "visa": {
+                        "title": "Visa",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SEANCE_CINE_read",
+                "type": "object"
+            },
+            "SEANCE_ESSAI_PRATIQUE_ART_create": {
+                "description": "S\u00e9ance d'essai",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SEANCE_ESSAI_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SEANCE_ESSAI_PRATIQUE_ART_create",
+                "type": "object"
+            },
+            "SEANCE_ESSAI_PRATIQUE_ART_edit": {
+                "description": "S\u00e9ance d'essai",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SEANCE_ESSAI_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SEANCE_ESSAI_PRATIQUE_ART_edit",
+                "type": "object"
+            },
+            "SEANCE_ESSAI_PRATIQUE_ART_read": {
+                "description": "S\u00e9ance d'essai",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SEANCE_ESSAI_PRATIQUE_ART"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "speaker": {
+                        "title": "Speaker",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SEANCE_ESSAI_PRATIQUE_ART_read",
+                "type": "object"
+            },
+            "SPECTACLE_ENREGISTRE_create": {
+                "description": "Spectacle enregistr\u00e9",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SPECTACLE_ENREGISTRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "showType",
+                    "category"
+                ],
+                "title": "SPECTACLE_ENREGISTRE_create",
+                "type": "object"
+            },
+            "SPECTACLE_ENREGISTRE_edit": {
+                "description": "Spectacle enregistr\u00e9",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SPECTACLE_ENREGISTRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SPECTACLE_ENREGISTRE_edit",
+                "type": "object"
+            },
+            "SPECTACLE_ENREGISTRE_read": {
+                "description": "Spectacle enregistr\u00e9",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SPECTACLE_ENREGISTRE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SPECTACLE_ENREGISTRE_read",
+                "type": "object"
+            },
+            "SPECTACLE_REPRESENTATION_create": {
+                "description": "Spectacle, repr\u00e9sentation",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SPECTACLE_REPRESENTATION"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "showType",
+                    "category"
+                ],
+                "title": "SPECTACLE_REPRESENTATION_create",
+                "type": "object"
+            },
+            "SPECTACLE_REPRESENTATION_edit": {
+                "description": "Spectacle, repr\u00e9sentation",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SPECTACLE_REPRESENTATION"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SPECTACLE_REPRESENTATION_edit",
+                "type": "object"
+            },
+            "SPECTACLE_REPRESENTATION_read": {
+                "description": "Spectacle, repr\u00e9sentation",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SPECTACLE_REPRESENTATION"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SPECTACLE_REPRESENTATION_read",
+                "type": "object"
+            },
+            "SPECTACLE_VENTE_DISTANCE_read": {
+                "description": "Spectacle vivant - vente \u00e0 distance",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SPECTACLE_VENTE_DISTANCE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    },
+                    "showType": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "stageDirector": {
+                        "title": "Stagedirector",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SPECTACLE_VENTE_DISTANCE_read",
+                "type": "object"
+            },
+            "SUPPORT_PHYSIQUE_FILM_create": {
+                "description": "Support physique (DVD, Blu-ray...)",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SUPPORT_PHYSIQUE_FILM"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "ean",
+                    "category"
+                ],
+                "title": "SUPPORT_PHYSIQUE_FILM_create",
+                "type": "object"
+            },
+            "SUPPORT_PHYSIQUE_FILM_edit": {
+                "description": "Support physique (DVD, Blu-ray...)",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SUPPORT_PHYSIQUE_FILM"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SUPPORT_PHYSIQUE_FILM_edit",
+                "type": "object"
+            },
+            "SUPPORT_PHYSIQUE_FILM_read": {
+                "description": "Support physique (DVD, Blu-ray...)",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "SUPPORT_PHYSIQUE_FILM"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SUPPORT_PHYSIQUE_FILM_read",
+                "type": "object"
+            },
+            "SUPPORT_PHYSIQUE_MUSIQUE_CD_read": {
+                "description": "CD",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SUPPORT_PHYSIQUE_MUSIQUE_CD"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SUPPORT_PHYSIQUE_MUSIQUE_CD_read",
+                "type": "object"
+            },
+            "SUPPORT_PHYSIQUE_MUSIQUE_VINYLE_read": {
+                "description": "Vinyles et autres supports",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "SUPPORT_PHYSIQUE_MUSIQUE_VINYLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "SUPPORT_PHYSIQUE_MUSIQUE_VINYLE_read",
+                "type": "object"
+            },
+            "ShowTypeEnum": {
+                "description": "An enumeration.",
+                "enum": [
+                    "ART_DE_LA_RUE-CARNAVAL",
+                    "ART_DE_LA_RUE-FANFARE",
+                    "ART_DE_LA_RUE-MIME",
+                    "ART_DE_LA_RUE-PARADE",
+                    "ART_DE_LA_RUE-THEATRE_DE_RUE",
+                    "ART_DE_LA_RUE-THEATRE_PROMENADE",
+                    "ART_DE_LA_RUE-OTHER",
+                    "CIRQUE-CIRQUE_CONTEMPORAIN",
+                    "CIRQUE-CIRQUE_HORS_LES_MURS",
+                    "CIRQUE-CIRQUE_TRADITIONNEL",
+                    "CIRQUE-CIRQUE_VOYAGEUR",
+                    "CIRQUE-CLOWN",
+                    "CIRQUE-HYPNOSE",
+                    "CIRQUE-MENTALISTE",
+                    "CIRQUE-SPECTACLE_DE_MAGIE",
+                    "CIRQUE-SPECTACLE_EQUESTRE",
+                    "CIRQUE-OTHER",
+                    "DANSE-BALLET",
+                    "DANSE-CANCAN",
+                    "DANSE-CLAQUETTE",
+                    "DANSE-CLASSIQUE",
+                    "DANSE-CONTEMPORAINE",
+                    "DANSE-DANSE_DU_MONDE",
+                    "DANSE-FLAMENCO",
+                    "DANSE-MODERNE_JAZZ",
+                    "DANSE-SALSA",
+                    "DANSE-SWING",
+                    "DANSE-TANGO",
+                    "DANSE-URBAINE",
+                    "DANSE-OTHER",
+                    "HUMOUR-CAFE_THEATRE",
+                    "HUMOUR-IMPROVISATION",
+                    "HUMOUR-SEUL_EN_SCENE",
+                    "HUMOUR-SKETCH",
+                    "HUMOUR-STAND_UP",
+                    "HUMOUR-VENTRILOQUE",
+                    "HUMOUR-OTHER",
+                    "SPECTACLE_MUSICAL-CABARET",
+                    "SPECTACLE_MUSICAL-CAFE_CONCERT",
+                    "SPECTACLE_MUSICAL-CLAQUETTE",
+                    "SPECTACLE_MUSICAL-COMEDIE_MUSICALE",
+                    "SPECTACLE_MUSICAL-OPERA_BOUFFE",
+                    "SPECTACLE_MUSICAL-OPERETTE",
+                    "SPECTACLE_MUSICAL-REVUE",
+                    "SPECTACLE_MUSICAL-BURLESQUE",
+                    "SPECTACLE_MUSICAL-COMEDIE_BALLET",
+                    "SPECTACLE_MUSICAL-OPERA_COMIQUE",
+                    "SPECTACLE_MUSICAL-OPERA_BALLET",
+                    "SPECTACLE_MUSICAL-THEATRE_MUSICAL",
+                    "SPECTACLE_MUSICAL-OTHER",
+                    "SPECTACLE_JEUNESSE-CONTE",
+                    "SPECTACLE_JEUNESSE-THEATRE_JEUNESSE",
+                    "SPECTACLE_JEUNESSE-SPECTACLE_PETITE_ENFANCE",
+                    "SPECTACLE_JEUNESSE-MAGIE_ENFANCE",
+                    "SPECTACLE_JEUNESSE-SPECTACLE_PEDAGOGIQUE",
+                    "SPECTACLE_JEUNESSE-MARIONETTES",
+                    "SPECTACLE_JEUNESSE-COMEDIE_MUSICALE_JEUNESSE",
+                    "SPECTACLE_JEUNESSE-THEATRE_D_OMBRES",
+                    "SPECTACLE_JEUNESSE-OTHER",
+                    "THEATRE-BOULEVARD",
+                    "THEATRE-CLASSIQUE",
+                    "THEATRE-COMEDIE",
+                    "THEATRE-CONTEMPORAIN",
+                    "THEATRE-LECTURE",
+                    "THEATRE-SPECTACLE_SCENOGRAPHIQUE",
+                    "THEATRE-THEATRE_EXPERIMENTAL",
+                    "THEATRE-THEATRE_D_OBJET",
+                    "THEATRE-TRAGEDIE",
+                    "THEATRE-OTHER",
+                    "PLURIDISCIPLINAIRE-PERFORMANCE",
+                    "PLURIDISCIPLINAIRE-POESIE",
+                    "PLURIDISCIPLINAIRE-OTHER",
+                    "OTHER-SON_ET_LUMIERE",
+                    "OTHER-SPECTACLE_SUR_GLACE",
+                    "OTHER-SPECTACLE_HISTORIQUE",
+                    "OTHER-SPECTACLE_AQUATIQUE",
+                    "OTHER-OTHER",
+                    "OPERA-OPERA_SERIE",
+                    "OPERA-GRAND_OPERA",
+                    "OPERA-OPERA_BOUFFE",
+                    "OPERA-OPERA_COMIQUE",
+                    "OPERA-OPERA_BALLET",
+                    "OPERA-SINGSPIEL",
+                    "OPERA-OTHER",
+                    "OTHER"
+                ],
+                "title": "ShowTypeEnum",
+                "type": "string"
+            },
+            "ShowTypeResponse": {
+                "properties": {
+                    "id": {
+                        "$ref": "#/components/schemas/ShowTypeEnum"
+                    },
+                    "label": {
+                        "title": "Label",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "label"
+                ],
+                "title": "ShowTypeResponse",
+                "type": "object"
+            },
+            "StockCreation": {
+                "properties": {
+                    "bookingLimitDatetime": {
+                        "description": "Timezone aware datetime after which the offer can no longer be booked.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "price": {
+                        "description": "Offer price in euro cents.",
+                        "example": 1000,
+                        "maximum": 30000,
+                        "minimum": 0,
+                        "title": "Price",
+                        "type": "integer"
+                    },
+                    "quantity": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "enum": [
+                                    "unlimited"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
+                        "example": 10,
+                        "title": "Quantity"
+                    }
+                },
+                "required": [
+                    "quantity",
+                    "price"
+                ],
+                "title": "StockCreation",
+                "type": "object"
+            },
+            "StockEdition": {
+                "additionalProperties": false,
+                "properties": {
+                    "bookingLimitDatetime": {
+                        "description": "Timezone aware datetime after which the offer can no longer be booked.",
+                        "example": "2024-06-23T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookinglimitdatetime",
+                        "type": "string"
+                    },
+                    "price": {
+                        "description": "Offer price in euro cents.",
+                        "example": 1000,
+                        "maximum": 30000,
+                        "minimum": 0,
+                        "nullable": true,
+                        "title": "Price",
+                        "type": "integer"
+                    },
+                    "quantity": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "enum": [
+                                    "unlimited"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "description": "Quantity of items currently available to pass Culture. Value 'unlimited' is used for infinite quantity of items.",
+                        "example": 10,
+                        "nullable": true,
+                        "title": "Quantity"
+                    }
+                },
+                "title": "StockEdition",
+                "type": "object"
+            },
+            "TELECHARGEMENT_LIVRE_AUDIO_create": {
+                "description": "Livre audio \u00e0 t\u00e9l\u00e9charger",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "TELECHARGEMENT_LIVRE_AUDIO"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "TELECHARGEMENT_LIVRE_AUDIO_create",
+                "type": "object"
+            },
+            "TELECHARGEMENT_LIVRE_AUDIO_edit": {
+                "description": "Livre audio \u00e0 t\u00e9l\u00e9charger",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "TELECHARGEMENT_LIVRE_AUDIO"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "TELECHARGEMENT_LIVRE_AUDIO_edit",
+                "type": "object"
+            },
+            "TELECHARGEMENT_LIVRE_AUDIO_read": {
+                "description": "Livre audio \u00e0 t\u00e9l\u00e9charger",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "TELECHARGEMENT_LIVRE_AUDIO"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "TELECHARGEMENT_LIVRE_AUDIO_read",
+                "type": "object"
+            },
+            "TELECHARGEMENT_MUSIQUE_create": {
+                "description": "T\u00e9l\u00e9chargement de musique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "TELECHARGEMENT_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "musicType",
+                    "category"
+                ],
+                "title": "TELECHARGEMENT_MUSIQUE_create",
+                "type": "object"
+            },
+            "TELECHARGEMENT_MUSIQUE_edit": {
+                "description": "T\u00e9l\u00e9chargement de musique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "TELECHARGEMENT_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "TELECHARGEMENT_MUSIQUE_edit",
+                "type": "object"
+            },
+            "TELECHARGEMENT_MUSIQUE_read": {
+                "description": "T\u00e9l\u00e9chargement de musique",
+                "properties": {
+                    "author": {
+                        "title": "Author",
+                        "type": "string"
+                    },
+                    "category": {
+                        "enum": [
+                            "TELECHARGEMENT_MUSIQUE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    },
+                    "ean": {
+                        "title": "Ean",
+                        "type": "string"
+                    },
+                    "musicType": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                            },
+                            {
+                                "$ref": "#/components/schemas/MusicTypeEnum"
+                            }
+                        ],
+                        "title": "Musictype"
+                    },
+                    "performer": {
+                        "title": "Performer",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "TELECHARGEMENT_MUSIQUE_read",
+                "type": "object"
+            },
+            "TiteliveMusicTypeEnum": {
+                "description": "An enumeration.",
+                "enum": [
+                    "MUSIQUE_CLASSIQUE",
+                    "JAZZ-BLUES",
+                    "BANDES_ORIGINALES",
+                    "ELECTRO",
+                    "POP",
+                    "ROCK",
+                    "METAL",
+                    "ALTERNATIF",
+                    "VARIETES",
+                    "FUNK-SOUL-RNB-DISCO",
+                    "RAP-HIP HOP",
+                    "REGGAE-RAGGA",
+                    "MUSIQUE_DU_MONDE",
+                    "COUNTRY-FOLK",
+                    "VIDEOS_MUSICALES",
+                    "COMPILATIONS",
+                    "AMBIANCE",
+                    "ENFANTS",
+                    "AUTRES"
+                ],
+                "title": "TiteliveMusicTypeEnum",
+                "type": "string"
+            },
+            "TiteliveMusicTypeResponse": {
+                "properties": {
+                    "id": {
+                        "$ref": "#/components/schemas/TiteliveMusicTypeEnum"
+                    },
+                    "label": {
+                        "title": "Label",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "label"
+                ],
+                "title": "TiteliveMusicTypeResponse",
+                "type": "object"
+            },
+            "VISITE_GUIDEE_create": {
+                "description": "Visite guid\u00e9e",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE_GUIDEE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_GUIDEE_create",
+                "type": "object"
+            },
+            "VISITE_GUIDEE_edit": {
+                "description": "Visite guid\u00e9e",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE_GUIDEE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_GUIDEE_edit",
+                "type": "object"
+            },
+            "VISITE_GUIDEE_read": {
+                "description": "Visite guid\u00e9e",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE_GUIDEE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_GUIDEE_read",
+                "type": "object"
+            },
+            "VISITE_VIRTUELLE_create": {
+                "description": "Visite virtuelle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE_VIRTUELLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_VIRTUELLE_create",
+                "type": "object"
+            },
+            "VISITE_VIRTUELLE_edit": {
+                "description": "Visite virtuelle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE_VIRTUELLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_VIRTUELLE_edit",
+                "type": "object"
+            },
+            "VISITE_VIRTUELLE_read": {
+                "description": "Visite virtuelle",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE_VIRTUELLE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_VIRTUELLE_read",
+                "type": "object"
+            },
+            "VISITE_create": {
+                "description": "Visite",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_create",
+                "type": "object"
+            },
+            "VISITE_edit": {
+                "description": "Visite",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_edit",
+                "type": "object"
+            },
+            "VISITE_read": {
+                "description": "Visite",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VISITE"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VISITE_read",
+                "type": "object"
+            },
+            "VOD_create": {
+                "description": "Vid\u00e9o \u00e0 la demande",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VOD"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VOD_create",
+                "type": "object"
+            },
+            "VOD_edit": {
+                "description": "Vid\u00e9o \u00e0 la demande",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VOD"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VOD_edit",
+                "type": "object"
+            },
+            "VOD_read": {
+                "description": "Vid\u00e9o \u00e0 la demande",
+                "properties": {
+                    "category": {
+                        "enum": [
+                            "VOD"
+                        ],
+                        "title": "Category",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "category"
+                ],
+                "title": "VOD_read",
+                "type": "object"
+            },
+            "ValidationError": {
+                "description": "Model of a validation error response.",
+                "items": {
+                    "$ref": "#/components/schemas/ValidationErrorElement"
+                },
+                "title": "ValidationError",
+                "type": "array"
+            },
+            "ValidationErrorElement": {
+                "description": "Model of a validation error response element.",
+                "properties": {
+                    "ctx": {
+                        "title": "Error context",
+                        "type": "object"
+                    },
+                    "loc": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Missing field name",
+                        "type": "array"
+                    },
+                    "msg": {
+                        "title": "Error message",
+                        "type": "string"
+                    },
+                    "type": {
+                        "title": "Error type",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "title": "ValidationErrorElement",
+                "type": "object"
+            },
+            "VenueDigitalLocation": {
+                "properties": {
+                    "type": {
+                        "default": "digital",
+                        "enum": [
+                            "digital"
+                        ],
+                        "title": "Type",
+                        "type": "string"
+                    }
+                },
+                "title": "VenueDigitalLocation",
+                "type": "object"
+            },
+            "VenuePhysicalLocation": {
+                "properties": {
+                    "address": {
+                        "example": "55 rue du Faubourg-Saint-Honor\u00e9",
+                        "nullable": true,
+                        "title": "Address",
+                        "type": "string"
+                    },
+                    "city": {
+                        "example": "Paris",
+                        "nullable": true,
+                        "title": "City",
+                        "type": "string"
+                    },
+                    "postalCode": {
+                        "example": "75008",
+                        "nullable": true,
+                        "title": "Postalcode",
+                        "type": "string"
+                    },
+                    "type": {
+                        "default": "physical",
+                        "enum": [
+                            "physical"
+                        ],
+                        "title": "Type",
+                        "type": "string"
+                    }
+                },
+                "title": "VenuePhysicalLocation",
+                "type": "object"
+            },
+            "VenueResponse": {
+                "properties": {
+                    "accessibility": {
+                        "$ref": "#/components/schemas/PartialAccessibility"
+                    },
+                    "activityDomain": {
+                        "$ref": "#/components/schemas/VenueTypeEnum"
+                    },
+                    "createdDatetime": {
+                        "format": "date-time",
+                        "title": "Createddatetime",
+                        "type": "string"
+                    },
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "legalName": {
+                        "example": "Palais de l'\u00c9lys\u00e9e",
+                        "title": "Legalname",
+                        "type": "string"
+                    },
+                    "location": {
+                        "description": "Location where the offers will be available or will take place. There is exactly one digital venue per offerer, which is listed although its id is not required to create a digital offer (see DigitalLocation model).",
+                        "discriminator": {
+                            "mapping": {
+                                "digital": "#/components/schemas/VenueDigitalLocation",
+                                "physical": "#/components/schemas/VenuePhysicalLocation"
+                            },
+                            "propertyName": "type"
+                        },
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/VenuePhysicalLocation"
+                            },
+                            {
+                                "$ref": "#/components/schemas/VenueDigitalLocation"
+                            }
+                        ],
+                        "title": "Location"
+                    },
+                    "publicName": {
+                        "description": "If null, legalName is used.",
+                        "example": "\u00c9lys\u00e9e",
+                        "nullable": true,
+                        "title": "Publicname",
+                        "type": "string"
+                    },
+                    "siret": {
+                        "description": "Null when venue is digital or when siretComment field is not null.",
+                        "example": "12345678901234",
+                        "nullable": true,
+                        "title": "Siret",
+                        "type": "string"
+                    },
+                    "siretComment": {
+                        "description": "Applicable if siret is null and venue is physical.",
+                        "example": null,
+                        "nullable": true,
+                        "title": "Siretcomment",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "createdDatetime",
+                    "id",
+                    "location",
+                    "legalName",
+                    "publicName",
+                    "activityDomain",
+                    "accessibility"
+                ],
+                "title": "VenueResponse",
+                "type": "object"
+            },
+            "VenueTypeEnum": {
+                "description": "An enumeration.",
+                "enum": [
+                    "ADMINISTRATIVE",
+                    "ARTISTIC_COURSE",
+                    "BOOKSTORE",
+                    "CONCERT_HALL",
+                    "CREATIVE_ARTS_STORE",
+                    "CULTURAL_CENTRE",
+                    "DIGITAL",
+                    "DISTRIBUTION_STORE",
+                    "FESTIVAL",
+                    "GAMES",
+                    "LIBRARY",
+                    "MOVIE",
+                    "MUSEUM",
+                    "MUSICAL_INSTRUMENT_STORE",
+                    "OTHER",
+                    "PATRIMONY_TOURISM",
+                    "PERFORMING_ARTS",
+                    "RECORD_STORE",
+                    "SCIENTIFIC_CULTURE",
+                    "TRAVELING_CINEMA",
+                    "VISUAL_ARTS"
+                ],
+                "title": "VenueTypeEnum",
+                "type": "string"
             }
-          }, 
-          {
-            "description": "Index of the first item in page.", 
-            "in": "query", 
-            "name": "firstIndex", 
-            "required": false, 
-            "schema": {
-              "default": 1, 
-              "description": "Index of the first item in page.", 
-              "minimum": 1, 
-              "title": "Firstindex", 
-              "type": "integer"
+        },
+        "securitySchemes": {
+            "ApiKeyAuth": {
+                "description": "Api key issued by passculture",
+                "scheme": "bearer",
+                "type": "http"
             }
-          }, 
-          {
-            "description": "Id of the bookings' offer.", 
-            "in": "query", 
-            "name": "offerId", 
-            "required": true, 
-            "schema": {
-              "description": "Id of the bookings' offer.", 
-              "title": "Offerid", 
-              "type": "integer"
+        }
+    },
+    "info": {
+        "description": "\nThis the documentation of the Pass Culture public REST API.\n\n**Important notice:**\n- Since January 2023, rate limiting has been implemented on the Pass Culture API.\n  You are limited to **200 requests/minute** per API key.\n  Once this limit reached, you will received a `429 Too Many Requests` error message. You will then need to back down.\n- Dates of event offers are stored in the **UTC format** to be able to format them correctly, according to the user timezone, in our application interface.\n- Any non-blank field sent using a `PATCH` method will be considered as changed, even if the new value is equal to old value.\n  _For example, if you update the stock of an event, you **should not resend the `beginningDate`** if it has not changed because, otherwise it is going to trigger the reschedule process on our side._\n",
+        "title": "Pass Culture REST API",
+        "version": "1.0"
+    },
+    "openapi": "3.0.3",
+    "paths": {
+        "/public/bookings/v1/bookings": {
+            "get": {
+                "description": "Return all the bookings for a given offer. Results are paginated (by default, there are `50` bookings per page)",
+                "operationId": "GetBookingsByOffer",
+                "parameters": [
+                    {
+                        "description": "Maximum number of items per page.",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "default": 50,
+                            "description": "Maximum number of items per page.",
+                            "exclusiveMinimum": 0,
+                            "maximum": 50,
+                            "title": "Limit",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Index of the first item in page.",
+                        "in": "query",
+                        "name": "firstIndex",
+                        "required": false,
+                        "schema": {
+                            "default": 1,
+                            "description": "Index of the first item in page.",
+                            "minimum": 1,
+                            "title": "Firstindex",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Id of the bookings' offer.",
+                        "in": "query",
+                        "name": "offerId",
+                        "required": true,
+                        "schema": {
+                            "description": "Id of the bookings' offer.",
+                            "title": "Offerid",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Price category of the bookings' stock.",
+                        "in": "query",
+                        "name": "priceCategoryId",
+                        "required": false,
+                        "schema": {
+                            "description": "Price category of the bookings' stock.",
+                            "nullable": true,
+                            "title": "Pricecategoryid",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Id of the bookings' stock.",
+                        "in": "query",
+                        "name": "stockId",
+                        "required": false,
+                        "schema": {
+                            "description": "Id of the bookings' stock.",
+                            "nullable": true,
+                            "title": "Stockid",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Booking Status.\n\n* `CONFIRMED`: The bookings is confirmed.\n* `USED`: The bookings has been used.\n* `CANCELLED`: The bookings has been cancelled.\n* `REIMBURSED` The bookings has been reimbursed.",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/BookingStatus"
+                                }
+                            ],
+                            "description": "Booking Status.\n\n* `CONFIRMED`: The bookings is confirmed.\n* `USED`: The bookings has been used.\n* `CANCELLED`: The bookings has been cancelled.\n* `REIMBURSED` The bookings has been reimbursed.",
+                            "nullable": true
+                        }
+                    },
+                    {
+                        "description": "Timezone aware datetime of the event.",
+                        "in": "query",
+                        "name": "beginningDatetime",
+                        "required": false,
+                        "schema": {
+                            "description": "Timezone aware datetime of the event.",
+                            "format": "date-time",
+                            "nullable": true,
+                            "title": "Beginningdatetime",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetFilteredBookingsResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get bookings for a given offer",
+                "tags": [
+                    "Booking"
+                ]
             }
-          }, 
-          {
-            "description": "Price category of the bookings' stock.", 
-            "in": "query", 
-            "name": "priceCategoryId", 
-            "required": false, 
-            "schema": {
-              "description": "Price category of the bookings' stock.", 
-              "nullable": true, 
-              "title": "Pricecategoryid", 
-              "type": "integer"
+        },
+        "/public/bookings/v1/cancel/token/{token}": {
+            "patch": {
+                "description": "Cancel a booking that has not been refunded. For events, the booking can be cancelled until 48 hours before the event.",
+                "operationId": "CancelBookingByToken",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "token",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "The booking has been cancelled successfully"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "This booking cannot be cancelled because you do not have the proper right or because the token has already been validated"
+                    },
+                    "404": {
+                        "description": "This booking cannot be found"
+                    },
+                    "410": {
+                        "description": "This booking has already been cancelled"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Cancel a booking",
+                "tags": [
+                    "Booking"
+                ]
             }
-          }, 
-          {
-            "description": "Id of the bookings' stock.", 
-            "in": "query", 
-            "name": "stockId", 
-            "required": false, 
-            "schema": {
-              "description": "Id of the bookings' stock.", 
-              "nullable": true, 
-              "title": "Stockid", 
-              "type": "integer"
+        },
+        "/public/bookings/v1/keep/token/{token}": {
+            "patch": {
+                "description": "Mark a booking as `unused`.",
+                "operationId": "CancelBookingValidationByToken",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "token",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "The booking's validation has been cancelled successfully"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "This booking's validation cannot be cancelled because you do not have the proper rights or because the token's status is not used"
+                    },
+                    "404": {
+                        "description": "This booking cannot be found"
+                    },
+                    "410": {
+                        "description": "This booking cannot be unvalidated because it is already cancelled"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Cancel a booking validation",
+                "tags": [
+                    "Booking"
+                ]
             }
-          }, 
-          {
-            "description": "Booking Status.\n\n* `CONFIRMED`: The bookings is confirmed.\n* `USED`: The bookings has been used.\n* `CANCELLED`: The bookings has been cancelled.\n* `REIMBURSED` The bookings has been reimbursed.", 
-            "in": "query", 
-            "name": "status", 
-            "required": false, 
-            "schema": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BookingStatus"
-                }
-              ], 
-              "description": "Booking Status.\n\n* `CONFIRMED`: The bookings is confirmed.\n* `USED`: The bookings has been used.\n* `CANCELLED`: The bookings has been cancelled.\n* `REIMBURSED` The bookings has been reimbursed.", 
-              "nullable": true
+        },
+        "/public/bookings/v1/token/{token}": {
+            "get": {
+                "description": "The countermark or token code is a character string that identifies the reservation and serves as proof of booking. This unique code is generated for each user's booking on the application and is transmitted to them on that occasion.",
+                "operationId": "GetBookingByToken",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "token",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetBookingResponse"
+                                }
+                            }
+                        },
+                        "description": "The booking has been found successfully"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "This booking cannot be found"
+                    },
+                    "410": {
+                        "description": "You do not have the proper right or the token has already been validated."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get a booking",
+                "tags": [
+                    "Booking"
+                ]
             }
-          }, 
-          {
-            "description": "Timezone aware datetime of the event.", 
-            "in": "query", 
-            "name": "beginningDatetime", 
-            "required": false, 
-            "schema": {
-              "description": "Timezone aware datetime of the event.", 
-              "format": "date-time", 
-              "nullable": true, 
-              "title": "Beginningdatetime", 
-              "type": "string"
+        },
+        "/public/bookings/v1/use/token/{token}": {
+            "patch": {
+                "description": "Confirms that the booking has been successfully used by the beneficiary.",
+                "operationId": "ValidateBookingByToken",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "token",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "This countermark has been validated successfully"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "This booking cannot be found"
+                    },
+                    "410": {
+                        "description": "You do not have the proper right or the token has already been validated."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Validate a booking",
+                "tags": [
+                    "Booking"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetFilteredBookingsResponse"
-                }
-              }
-            }, 
-            "description": "OK"
-          }, 
-          "403": {
-            "description": "Forbidden"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get bookings for a given offer", 
-        "tags": [
-          "Booking"
-        ]
-      }
-    }, 
-    "/public/bookings/v1/cancel/token/{token}": {
-      "patch": {
-        "description": "Cancel a booking that has not been refunded. For events, the booking can be cancelled until 48 hours before the event.", 
-        "operationId": "CancelBookingByToken", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "token", 
-            "required": true, 
-            "schema": {
-              "type": "string"
+        },
+        "/public/offers/v1/events": {
+            "get": {
+                "description": "Return all the events linked to given venue. Results are paginated (by default there are `50` events per page).",
+                "operationId": "GetEvents",
+                "parameters": [
+                    {
+                        "description": "Maximum number of items per page.",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "default": 50,
+                            "description": "Maximum number of items per page.",
+                            "exclusiveMinimum": 0,
+                            "maximum": 50,
+                            "title": "Limit",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Index of the first item in page.",
+                        "in": "query",
+                        "name": "firstIndex",
+                        "required": false,
+                        "schema": {
+                            "default": 1,
+                            "description": "Index of the first item in page.",
+                            "minimum": 1,
+                            "title": "Firstindex",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Venue id to filter offers on.",
+                        "in": "query",
+                        "name": "venueId",
+                        "required": true,
+                        "schema": {
+                            "description": "Venue id to filter offers on.",
+                            "title": "Venueid",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EventOffersResponse"
+                                }
+                            }
+                        },
+                        "description": "The event offers have been returned"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The venue could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get events",
+                "tags": [
+                    "Event offer"
+                ]
+            },
+            "post": {
+                "description": "",
+                "operationId": "PostEventOffer",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EventOfferCreation"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EventOfferResponse"
+                                }
+                            }
+                        },
+                        "description": "The event offer has been created successfully"
+                    },
+                    "400": {
+                        "description": "The request is invalid. The response body contains a list of errors."
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Create event offer",
+                "tags": [
+                    "Event offer"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "204": {
-            "description": "The booking has been cancelled successfully"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "This booking cannot be cancelled because you do not have the proper right or because the token has already been validated"
-          }, 
-          "404": {
-            "description": "This booking cannot be found"
-          }, 
-          "410": {
-            "description": "This booking has already been cancelled"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Cancel a booking", 
-        "tags": [
-          "Booking"
-        ]
-      }
-    }, 
-    "/public/bookings/v1/keep/token/{token}": {
-      "patch": {
-        "description": "Mark a booking as `unused`.", 
-        "operationId": "CancelBookingValidationByToken", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "token", 
-            "required": true, 
-            "schema": {
-              "type": "string"
+        },
+        "/public/offers/v1/events/categories": {
+            "get": {
+                "description": "Return all the categories available for an event, with their conditional fields, and whether they are required for event creation.",
+                "operationId": "GetEventCategories",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetEventCategoriesResponse"
+                                }
+                            }
+                        },
+                        "description": "The event categories have been returned"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get event categories",
+                "tags": [
+                    "Offer attributes"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "204": {
-            "description": "The booking's validation has been cancelled successfully"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "This booking's validation cannot be cancelled because you do not have the proper rights or because the token's status is not used"
-          }, 
-          "404": {
-            "description": "This booking cannot be found"
-          }, 
-          "410": {
-            "description": "This booking cannot be unvalidated because it is already cancelled"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Cancel a booking validation", 
-        "tags": [
-          "Booking"
-        ]
-      }
-    }, 
-    "/public/bookings/v1/token/{token}": {
-      "get": {
-        "description": "The countermark or token code is a character string that identifies the reservation and serves as proof of booking. This unique code is generated for each user's booking on the application and is transmitted to them on that occasion.", 
-        "operationId": "GetBookingByToken", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "token", 
-            "required": true, 
-            "schema": {
-              "type": "string"
+        },
+        "/public/offers/v1/events/{event_id}": {
+            "get": {
+                "description": "Return event offer by id.",
+                "operationId": "GetEvent",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "event_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EventOfferResponse"
+                                }
+                            }
+                        },
+                        "description": "The event offer has been returned"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The event offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get event offer",
+                "tags": [
+                    "Event offer"
+                ]
+            },
+            "patch": {
+                "description": "Will update only the non-blank fields. If you some fields to keep their current values, leave them `undefined`.",
+                "operationId": "EditEvent",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "event_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EventOfferEdition"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EventOfferResponse"
+                                }
+                            }
+                        },
+                        "description": "The event offer has been returned"
+                    },
+                    "400": {
+                        "description": "The request is invalid. The response body contains a list of errors."
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The event offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Update event offer",
+                "tags": [
+                    "Event offer"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetBookingResponse"
-                }
-              }
-            }, 
-            "description": "The booking has been found successfully"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "This booking cannot be found"
-          }, 
-          "410": {
-            "description": "You do not have the proper right or the token has already been validated."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get a booking", 
-        "tags": [
-          "Booking"
-        ]
-      }
-    }, 
-    "/public/bookings/v1/use/token/{token}": {
-      "patch": {
-        "description": "Confirms that the booking has been successfully used by the beneficiary.", 
-        "operationId": "ValidateBookingByToken", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "token", 
-            "required": true, 
-            "schema": {
-              "type": "string"
+        },
+        "/public/offers/v1/events/{event_id}/dates": {
+            "get": {
+                "description": "Return all the dates linked to an event. Results are paginated (by default there are `50` date per page).",
+                "operationId": "GetEventDates",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "event_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Maximum number of items per page.",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "default": 50,
+                            "description": "Maximum number of items per page.",
+                            "exclusiveMinimum": 0,
+                            "maximum": 50,
+                            "title": "Limit",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Index of the first item in page.",
+                        "in": "query",
+                        "name": "firstIndex",
+                        "required": false,
+                        "schema": {
+                            "default": 1,
+                            "description": "Index of the first item in page.",
+                            "minimum": 1,
+                            "title": "Firstindex",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetDatesResponse"
+                                }
+                            }
+                        },
+                        "description": "The event dates have been returned"
+                    },
+                    "400": {
+                        "description": "The request is invalid. The response body contains a list of errors."
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The event offer or the price category could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get event dates",
+                "tags": [
+                    "Event offer dates"
+                ]
+            },
+            "post": {
+                "description": "Add a dates to given event. Each date is attached to a price category so if there are several prices categories, several dates must be added.",
+                "operationId": "PostEventDates",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "event_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DatesCreation"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostDatesResponse"
+                                }
+                            }
+                        },
+                        "description": "The event dates have been created successfully"
+                    },
+                    "400": {
+                        "description": "The request is invalid. The response body contains a list of errors."
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The event offer or the price category could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Add dates to event",
+                "tags": [
+                    "Event offer dates"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "204": {
-            "description": "This countermark has been validated successfully"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "This booking cannot be found"
-          }, 
-          "410": {
-            "description": "You do not have the proper right or the token has already been validated."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Validate a booking", 
-        "tags": [
-          "Booking"
-        ]
-      }
-    }, 
-    "/public/offers/v1/events": {
-      "get": {
-        "description": "Return all the events linked to given venue. Results are paginated (by default there are `50` events per page).", 
-        "operationId": "GetEvents", 
-        "parameters": [
-          {
-            "description": "Maximum number of items per page.", 
-            "in": "query", 
-            "name": "limit", 
-            "required": false, 
-            "schema": {
-              "default": 50, 
-              "description": "Maximum number of items per page.", 
-              "exclusiveMinimum": 0, 
-              "maximum": 50, 
-              "title": "Limit", 
-              "type": "integer"
+        },
+        "/public/offers/v1/events/{event_id}/dates/{date_id}": {
+            "delete": {
+                "description": "When an event date is deleted, all cancellable bookings (i.e not used) are cancelled. To prevent from further bookings, you may alternatively update the date's quantity to the bookedQuantity (but not below).",
+                "operationId": "DeleteEventDate",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "event_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "date_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "The event date has been deleted successfully"
+                    },
+                    "400": {
+                        "description": "The request is invalid. The response body contains a list of errors."
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The event offer or the price category could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Delete event date",
+                "tags": [
+                    "Event offer dates"
+                ]
+            },
+            "patch": {
+                "description": "Update the price category and the beginning time of an event date.",
+                "operationId": "PatchEventDate",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "event_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "date_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DateEdition"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DateResponse"
+                                }
+                            }
+                        },
+                        "description": "The event date has been modified successfully"
+                    },
+                    "400": {
+                        "description": "The request is invalid. The response body contains a list of errors."
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The event offer or the price category could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Update event date",
+                "tags": [
+                    "Event offer dates"
+                ]
             }
-          }, 
-          {
-            "description": "Index of the first item in page.", 
-            "in": "query", 
-            "name": "firstIndex", 
-            "required": false, 
-            "schema": {
-              "default": 1, 
-              "description": "Index of the first item in page.", 
-              "minimum": 1, 
-              "title": "Firstindex", 
-              "type": "integer"
+        },
+        "/public/offers/v1/events/{event_id}/price_categories": {
+            "post": {
+                "description": "Batch create price categories for given event.",
+                "operationId": "PostEventPriceCategories",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "event_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PriceCategoriesCreation"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PriceCategoriesResponse"
+                                }
+                            }
+                        },
+                        "description": "The price category has been created successfully"
+                    },
+                    "400": {
+                        "description": "The request is invalid. The response body contains a list of errors. Or one of the price categories already exists."
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The event offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Create price categories",
+                "tags": [
+                    "Event offer prices"
+                ]
             }
-          }, 
-          {
-            "description": "Venue id to filter offers on.", 
-            "in": "query", 
-            "name": "venueId", 
-            "required": true, 
-            "schema": {
-              "description": "Venue id to filter offers on.", 
-              "title": "Venueid", 
-              "type": "integer"
+        },
+        "/public/offers/v1/events/{event_id}/price_categories/{price_category_id}": {
+            "patch": {
+                "description": "Will update only the non-blank field. If you want one of the field to remain unchanged, leave it `undefined`.",
+                "operationId": "PatchEventPriceCategories",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "event_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "price_category_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PriceCategoryEdition"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PriceCategoryResponse"
+                                }
+                            }
+                        },
+                        "description": "The price category has been modified successfully"
+                    },
+                    "400": {
+                        "description": "The request is invalid. The response body contains a list of errors."
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The event offer or the price category could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Update price category",
+                "tags": [
+                    "Event offer prices"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOffersResponse"
-                }
-              }
-            }, 
-            "description": "The event offers have been returned"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The venue could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get events", 
-        "tags": [
-          "Event offer"
-        ]
-      }, 
-      "post": {
-        "description": "", 
-        "operationId": "PostEventOffer", 
-        "parameters": [], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventOfferCreation"
-              }
+        },
+        "/public/offers/v1/music_types": {
+            "get": {
+                "deprecated": true,
+                "description": "\u26a0\ufe0f This is a DEPRACTED endpoint. It should not be used.",
+                "operationId": "GetMusicTypes",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetMusicTypesResponse"
+                                }
+                            }
+                        },
+                        "description": "The music types have been returned"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "[LEGACY] Get music types",
+                "tags": [
+                    "Offer attributes"
+                ]
             }
-          }
-        }, 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOfferResponse"
-                }
-              }
-            }, 
-            "description": "The event offer has been created successfully"
-          }, 
-          "400": {
-            "description": "The request is invalid. The response body contains a list of errors."
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Create event offer", 
-        "tags": [
-          "Event offer"
-        ]
-      }
-    }, 
-    "/public/offers/v1/events/categories": {
-      "get": {
-        "description": "Return all the categories available for an event, with their conditional fields, and whether they are required for event creation.", 
-        "operationId": "GetEventCategories", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetEventCategoriesResponse"
-                }
-              }
-            }, 
-            "description": "The event categories have been returned"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get event categories", 
-        "tags": [
-          "Offer attributes"
-        ]
-      }
-    }, 
-    "/public/offers/v1/events/{event_id}": {
-      "get": {
-        "description": "Return event offer by id.", 
-        "operationId": "GetEvent", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "event_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/public/offers/v1/music_types/all": {
+            "get": {
+                "description": "Return all the music types.",
+                "operationId": "GetAllTiteliveMusicTypes",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetMusicTypesResponse"
+                                }
+                            }
+                        },
+                        "description": "The music types have been returned"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get all music types",
+                "tags": [
+                    "Offer attributes"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOfferResponse"
-                }
-              }
-            }, 
-            "description": "The event offer has been returned"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The event offer could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get event offer", 
-        "tags": [
-          "Event offer"
-        ]
-      }, 
-      "patch": {
-        "description": "Will update only the non-blank fields. If you some fields to keep their current values, leave them `undefined`.", 
-        "operationId": "EditEvent", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "event_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/public/offers/v1/music_types/event": {
+            "get": {
+                "description": "Return all eligible music types for events.",
+                "operationId": "GetEventTiteliveMusicTypes",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetMusicTypesResponse"
+                                }
+                            }
+                        },
+                        "description": "The music types have been returned"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get events music types",
+                "tags": [
+                    "Offer attributes"
+                ]
             }
-          }
-        ], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EventOfferEdition"
-              }
+        },
+        "/public/offers/v1/offerer_venues": {
+            "get": {
+                "description": "Return all the venues attached to the API key for given offerer.",
+                "operationId": "GetOffererVenues",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "siren",
+                        "required": false,
+                        "schema": {
+                            "example": "123456789",
+                            "nullable": true,
+                            "pattern": "^\\d{9}$",
+                            "title": "Siren",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetOfferersVenuesResponse"
+                                }
+                            }
+                        },
+                        "description": "The offerer and its venues"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get offerer venues",
+                "tags": [
+                    "Offerer and Venues"
+                ]
             }
-          }
-        }, 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOfferResponse"
-                }
-              }
-            }, 
-            "description": "The event offer has been returned"
-          }, 
-          "400": {
-            "description": "The request is invalid. The response body contains a list of errors."
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The event offer could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Update event offer", 
-        "tags": [
-          "Event offer"
-        ]
-      }
-    }, 
-    "/public/offers/v1/events/{event_id}/dates": {
-      "get": {
-        "description": "Return all the dates linked to an event. Results are paginated (by default there are `50` date per page).", 
-        "operationId": "GetEventDates", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "event_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/public/offers/v1/products": {
+            "get": {
+                "description": "Return all products linked to a venue. Results are paginated (by default `50` products by page).",
+                "operationId": "GetProducts",
+                "parameters": [
+                    {
+                        "description": "Maximum number of items per page.",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "default": 50,
+                            "description": "Maximum number of items per page.",
+                            "exclusiveMinimum": 0,
+                            "maximum": 50,
+                            "title": "Limit",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Index of the first item in page.",
+                        "in": "query",
+                        "name": "firstIndex",
+                        "required": false,
+                        "schema": {
+                            "default": 1,
+                            "description": "Index of the first item in page.",
+                            "minimum": 1,
+                            "title": "Firstindex",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Venue id to filter offers on.",
+                        "in": "query",
+                        "name": "venueId",
+                        "required": true,
+                        "schema": {
+                            "description": "Venue id to filter offers on.",
+                            "title": "Venueid",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductOffersResponse"
+                                }
+                            }
+                        },
+                        "description": "The product offers"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "No venue found for the used api key"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get venue products",
+                "tags": [
+                    "Product offer"
+                ]
+            },
+            "patch": {
+                "description": "Will update only the non-blank fields. If you want to keep the current value of certains fields, leave them `undefined`.",
+                "operationId": "EditProduct",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProductOfferEdition"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductOfferResponse"
+                                }
+                            }
+                        },
+                        "description": "The product offer have been edited successfully"
+                    },
+                    "400": {
+                        "description": "The product offer could not be edited"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The product offer could not be found"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Update product offer",
+                "tags": [
+                    "Product offer"
+                ]
+            },
+            "post": {
+                "description": "Create a product in authorized categories.",
+                "operationId": "PostProductOffer",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProductOfferCreation"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductOfferResponse"
+                                }
+                            }
+                        },
+                        "description": "The product offer have been created successfully"
+                    },
+                    "400": {
+                        "description": "The product offer could not be created"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "No venue found for the used api key"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Create product",
+                "tags": [
+                    "Product offer"
+                ]
             }
-          }, 
-          {
-            "description": "Maximum number of items per page.", 
-            "in": "query", 
-            "name": "limit", 
-            "required": false, 
-            "schema": {
-              "default": 50, 
-              "description": "Maximum number of items per page.", 
-              "exclusiveMinimum": 0, 
-              "maximum": 50, 
-              "title": "Limit", 
-              "type": "integer"
+        },
+        "/public/offers/v1/products/categories": {
+            "get": {
+                "description": "Return all product categories with their conditional fields, and whether they are required for product creation.",
+                "operationId": "GetProductCategories",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetProductCategoriesResponse"
+                                }
+                            }
+                        },
+                        "description": "The product categories have been returned"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get product categories",
+                "tags": [
+                    "Product offer"
+                ]
             }
-          }, 
-          {
-            "description": "Index of the first item in page.", 
-            "in": "query", 
-            "name": "firstIndex", 
-            "required": false, 
-            "schema": {
-              "default": 1, 
-              "description": "Index of the first item in page.", 
-              "minimum": 1, 
-              "title": "Firstindex", 
-              "type": "integer"
+        },
+        "/public/offers/v1/products/ean": {
+            "get": {
+                "description": "Return all the product offers of a given venue matching given EANs (European Article Number, EAN-13).",
+                "operationId": "GetProductByEan",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "eans",
+                        "required": true,
+                        "schema": {
+                            "example": "0123456789123,0123456789124",
+                            "title": "Eans",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "venueId",
+                        "required": true,
+                        "schema": {
+                            "example": 1,
+                            "title": "Venueid",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductOffersByEanResponse"
+                                }
+                            }
+                        },
+                        "description": "The product offers"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get product offers by EAN",
+                "tags": [
+                    "Product offer bulk operations"
+                ]
+            },
+            "post": {
+                "description": "Batch create offers using products EAN. EAN is the European Article Number identifiying each product sold in the european market (EAN-13).",
+                "operationId": "PostProductOfferByEan",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProductsOfferByEanCreation"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "The product offers have been created successfully"
+                    },
+                    "400": {
+                        "description": "The product offers could not be created"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "No venue found for the used api key"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Batch create offers",
+                "tags": [
+                    "Product offer bulk operations"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetDatesResponse"
-                }
-              }
-            }, 
-            "description": "The event dates have been returned"
-          }, 
-          "400": {
-            "description": "The request is invalid. The response body contains a list of errors."
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The event offer or the price category could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get event dates", 
-        "tags": [
-          "Event offer dates"
-        ]
-      }, 
-      "post": {
-        "description": "Add a dates to given event. Each date is attached to a price category so if there are several prices categories, several dates must be added.", 
-        "operationId": "PostEventDates", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "event_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/public/offers/v1/products/{product_id}": {
+            "get": {
+                "description": "Return a product offer by id.",
+                "operationId": "GetProduct",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "product_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProductOfferResponse"
+                                }
+                            }
+                        },
+                        "description": "The product offer"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "404": {
+                        "description": "The product offer could not be found"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get product offer",
+                "tags": [
+                    "Product offer"
+                ]
             }
-          }
-        ], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DatesCreation"
-              }
+        },
+        "/public/offers/v1/show_types": {
+            "get": {
+                "description": "",
+                "operationId": "GetShowTypes",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetShowTypesResponse"
+                                }
+                            }
+                        },
+                        "description": "The show types have been returned"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get all the show types",
+                "tags": [
+                    "Offer attributes"
+                ]
             }
-          }
-        }, 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PostDatesResponse"
-                }
-              }
-            }, 
-            "description": "The event dates have been created successfully"
-          }, 
-          "400": {
-            "description": "The request is invalid. The response body contains a list of errors."
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The event offer or the price category could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Add dates to event", 
-        "tags": [
-          "Event offer dates"
-        ]
-      }
-    }, 
-    "/public/offers/v1/events/{event_id}/dates/{date_id}": {
-      "delete": {
-        "description": "When an event date is deleted, all cancellable bookings (i.e not used) are cancelled. To prevent from further bookings, you may alternatively update the date's quantity to the bookedQuantity (but not below).", 
-        "operationId": "DeleteEventDate", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "event_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/public/offers/v1/{offer_id}/image": {
+            "post": {
+                "description": "Upload an image for given offer.",
+                "operationId": "UploadImage",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "offer_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ImageUploadFile"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Image updated successfully"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API"
+                    },
+                    "403": {
+                        "description": "You do not have the necessary rights to use this API"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Upload an image",
+                "tags": [
+                    "Image"
+                ]
             }
-          }, 
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "date_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/v2/collective/bookings/{booking_id}": {
+            "patch": {
+                "description": "",
+                "operationId": "CancelCollectiveBooking",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "booking_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Annuler une r\u00e9servation collective"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Cancel collective booking",
+                "tags": [
+                    "Collective booking"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "204": {
-            "description": "The event date has been deleted successfully"
-          }, 
-          "400": {
-            "description": "The request is invalid. The response body contains a list of errors."
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The event offer or the price category could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Delete event date", 
-        "tags": [
-          "Event offer dates"
-        ]
-      }, 
-      "patch": {
-        "description": "Update the price category and the beginning time of an event date.", 
-        "operationId": "PatchEventDate", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "event_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/v2/collective/categories": {
+            "get": {
+                "description": "",
+                "operationId": "ListCategories",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectiveOffersListCategoriesResponseModel"
+                                }
+                            }
+                        },
+                        "description": "La liste des cat\u00e9gories \u00e9ligibles existantes."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cup\u00e9ration de la liste des cat\u00e9gories d'offres propos\u00e9es.",
+                "tags": [
+                    "Collective categories"
+                ]
             }
-          }, 
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "date_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/v2/collective/educational-domains": {
+            "get": {
+                "description": "",
+                "operationId": "ListEducationalDomains",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectiveOffersListDomainsResponseModel"
+                                }
+                            }
+                        },
+                        "description": "La liste des domaines d'\u00e9ducation."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cup\u00e9ration de la liste des domaines d'\u00e9ducation pouvant \u00eatre associ\u00e9s aux offres collectives.",
+                "tags": [
+                    "Collective educational data"
+                ]
             }
-          }
-        ], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DateEdition"
-              }
+        },
+        "/v2/collective/educational-institutions/": {
+            "get": {
+                "description": "",
+                "operationId": "ListEducationalInstitutions",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "id",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "Id",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "name",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "Name",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "institutionType",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "Institutiontype",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "city",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "City",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "postalCode",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "Postalcode",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "uai",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "Uai",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "default": 20,
+                            "title": "Limit",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectiveOffersListEducationalInstitutionResponseModel"
+                                }
+                            }
+                        },
+                        "description": "La liste des \u00e9tablissement scolaires \u00e9ligibles."
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Requ\u00eate malform\u00e9e"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cup\u00e9ration de la liste \u00e9tablissements scolaires.",
+                "tags": [
+                    "Collective educational data"
+                ]
             }
-          }
-        }, 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DateResponse"
-                }
-              }
-            }, 
-            "description": "The event date has been modified successfully"
-          }, 
-          "400": {
-            "description": "The request is invalid. The response body contains a list of errors."
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The event offer or the price category could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Update event date", 
-        "tags": [
-          "Event offer dates"
-        ]
-      }
-    }, 
-    "/public/offers/v1/events/{event_id}/price_categories": {
-      "post": {
-        "description": "Batch create price categories for given event.", 
-        "operationId": "PostEventPriceCategories", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "event_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/v2/collective/national-programs/": {
+            "get": {
+                "description": "",
+                "operationId": "GetNationalPrograms",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListNationalProgramsResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Il n'y a pas de dispositifs nationaux"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir ces informations"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Liste de tous les dispositifs nationaux connus",
+                "tags": [
+                    "Collective educational data"
+                ]
             }
-          }
-        ], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PriceCategoriesCreation"
-              }
+        },
+        "/v2/collective/offerer_venues": {
+            "get": {
+                "description": "Tous les lieux enregistr\u00e9s, sont list\u00e9s ici avec leurs coordonn\u00e9es.",
+                "operationId": "GetOffererVenues",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "siren",
+                        "required": false,
+                        "schema": {
+                            "example": "123456789",
+                            "nullable": true,
+                            "pattern": "^\\d{9}$",
+                            "title": "Siren",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetOfferersVenuesResponse"
+                                }
+                            }
+                        },
+                        "description": "La liste des lieux, group\u00e9s par structures"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cup\u00e9ration des lieux associ\u00e9s au fournisseur authentifi\u00e9 par le jeton d'API; group\u00e9s par structures.",
+                "tags": [
+                    "Collective venues"
+                ]
             }
-          }
-        }, 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PriceCategoriesResponse"
-                }
-              }
-            }, 
-            "description": "The price category has been created successfully"
-          }, 
-          "400": {
-            "description": "The request is invalid. The response body contains a list of errors. Or one of the price categories already exists."
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The event offer could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Create price categories", 
-        "tags": [
-          "Event offer prices"
-        ]
-      }
-    }, 
-    "/public/offers/v1/events/{event_id}/price_categories/{price_category_id}": {
-      "patch": {
-        "description": "Will update only the non-blank field. If you want one of the field to remain unchanged, leave it `undefined`.", 
-        "operationId": "PatchEventPriceCategories", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "event_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/v2/collective/offers/": {
+            "get": {
+                "description": "",
+                "operationId": "GetCollectiveOffersPublic",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/OfferStatus"
+                                }
+                            ],
+                            "nullable": true
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "venueId",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "Venueid",
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "periodBeginningDate",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "Periodbeginningdate",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "periodEndingDate",
+                        "required": false,
+                        "schema": {
+                            "nullable": true,
+                            "title": "Periodendingdate",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectiveOffersListResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'offre collective existe"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette offre collective"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'offre collective n'existe pas"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cuperation des offres collectives Cette api ignore les offre vitrines et les offres commenc\u00e9es sur l'interface web et non finalis\u00e9es.",
+                "tags": [
+                    "Collective offers"
+                ]
+            },
+            "post": {
+                "description": "",
+                "operationId": "PostCollectiveOfferPublic",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PostCollectiveOfferBodyModel"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPublicCollectiveOfferResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'offre collective \u00e0 \u00e9t\u00e9 cr\u00e9\u00e9e avec succes"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Requ\u00eate malform\u00e9e"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Non \u00e9ligible pour les offres collectives"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'une des resources pour la cr\u00e9ation de l'offre n'a pas \u00e9t\u00e9 trouv\u00e9e"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Cr\u00e9ation d'une offre collective.",
+                "tags": [
+                    "Collective offers"
+                ]
             }
-          }, 
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "price_category_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
+        },
+        "/v2/collective/offers/formats": {
+            "get": {
+                "description": "",
+                "operationId": "GetOffersFormats",
+                "parameters": [],
+                "responses": {
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette offre collective"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'offre collective n'existe pas"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Liste des formats d'offres collectives",
+                "tags": [
+                    "Collective offers"
+                ]
             }
-          }
-        ], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PriceCategoryEdition"
-              }
+        },
+        "/v2/collective/offers/{offer_id}": {
+            "get": {
+                "description": "",
+                "operationId": "GetCollectiveOfferPublic",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "offer_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPublicCollectiveOfferResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'offre collective existe"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette offre collective"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'offre collective n'existe pas"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cuperation de l'offre collective avec l'identifiant offer_id.",
+                "tags": [
+                    "Collective offers"
+                ]
+            },
+            "patch": {
+                "description": "",
+                "operationId": "PatchCollectiveOfferPublic",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "offer_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchCollectiveOfferBodyModel"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPublicCollectiveOfferResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'offre collective \u00e0 \u00e9t\u00e9 \u00e9dit\u00e9 avec succes"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Requ\u00eate malform\u00e9e"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Vous n'avez pas les droits n\u00e9cessaires pour \u00e9diter cette offre collective"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "L'une des resources pour la cr\u00e9ation de l'offre n'a pas \u00e9t\u00e9 trouv\u00e9e"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Cetains champs ne peuvent pas \u00eatre \u00e9dit\u00e9s selon l'\u00e9tat de l'offre"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "\u00c9dition d'une offre collective.",
+                "tags": [
+                    "Collective offers"
+                ]
             }
-          }
-        }, 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PriceCategoryResponse"
-                }
-              }
-            }, 
-            "description": "The price category has been modified successfully"
-          }, 
-          "400": {
-            "description": "The request is invalid. The response body contains a list of errors."
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The event offer or the price category could not be found."
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Update price category", 
-        "tags": [
-          "Event offer prices"
-        ]
-      }
-    }, 
-    "/public/offers/v1/music_types": {
-      "get": {
-        "deprecated": true, 
-        "description": "\u26a0\ufe0f This is a DEPRACTED endpoint. It should not be used.", 
-        "operationId": "GetMusicTypes", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetMusicTypesResponse"
-                }
-              }
-            }, 
-            "description": "The music types have been returned"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "[LEGACY] Get music types", 
-        "tags": [
-          "Offer attributes"
-        ]
-      }
-    }, 
-    "/public/offers/v1/music_types/all": {
-      "get": {
-        "description": "Return all the music types.", 
-        "operationId": "GetAllTiteliveMusicTypes", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetMusicTypesResponse"
-                }
-              }
-            }, 
-            "description": "The music types have been returned"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get all music types", 
-        "tags": [
-          "Offer attributes"
-        ]
-      }
-    }, 
-    "/public/offers/v1/music_types/event": {
-      "get": {
-        "description": "Return all eligible music types for events.", 
-        "operationId": "GetEventTiteliveMusicTypes", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetMusicTypesResponse"
-                }
-              }
-            }, 
-            "description": "The music types have been returned"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get events music types", 
-        "tags": [
-          "Offer attributes"
-        ]
-      }
-    }, 
-    "/public/offers/v1/offerer_venues": {
-      "get": {
-        "description": "Return all the venues attached to the API key for given offerer.", 
-        "operationId": "GetOffererVenues", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "siren", 
-            "required": false, 
-            "schema": {
-              "example": "123456789", 
-              "nullable": true, 
-              "pattern": "^\\d{9}$", 
-              "title": "Siren", 
-              "type": "string"
+        },
+        "/v2/collective/student-levels": {
+            "get": {
+                "description": "",
+                "operationId": "ListStudentsLevels",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectiveOffersListStudentLevelsResponseModel"
+                                }
+                            }
+                        },
+                        "description": "La liste des domaines d'\u00e9ducation."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cup\u00e9ration de la liste des publics cibles pour lesquelles des offres collectives peuvent \u00eatre propos\u00e9es.",
+                "tags": [
+                    "Collective educational data"
+                ]
             }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetOfferersVenuesResponse"
-                }
-              }
-            }, 
-            "description": "The offerer and its venues"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get offerer venues", 
-        "tags": [
-          "Offerer and Venues"
-        ]
-      }
-    }, 
-    "/public/offers/v1/products": {
-      "get": {
-        "description": "Return all products linked to a venue. Results are paginated (by default `50` products by page).", 
-        "operationId": "GetProducts", 
-        "parameters": [
-          {
-            "description": "Maximum number of items per page.", 
-            "in": "query", 
-            "name": "limit", 
-            "required": false, 
-            "schema": {
-              "default": 50, 
-              "description": "Maximum number of items per page.", 
-              "exclusiveMinimum": 0, 
-              "maximum": 50, 
-              "title": "Limit", 
-              "type": "integer"
+        },
+        "/v2/collective/subcategories": {
+            "get": {
+                "description": "",
+                "operationId": "ListSubcategories",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectiveOffersListSubCategoriesResponseModel"
+                                }
+                            }
+                        },
+                        "description": "La liste des sous-cat\u00e9gories \u00e9ligibles existantes."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cup\u00e9ration de la liste des sous-cat\u00e9gories d'offres propos\u00e9es a un public collectif.",
+                "tags": [
+                    "Collective categories"
+                ]
             }
-          }, 
-          {
-            "description": "Index of the first item in page.", 
-            "in": "query", 
-            "name": "firstIndex", 
-            "required": false, 
-            "schema": {
-              "default": 1, 
-              "description": "Index of the first item in page.", 
-              "minimum": 1, 
-              "title": "Firstindex", 
-              "type": "integer"
+        },
+        "/v2/collective/venues": {
+            "get": {
+                "description": "Tous les lieux enregistr\u00e9s, sont list\u00e9s ici avec leurs coordonn\u00e9es.",
+                "operationId": "ListVenues",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectiveOffersListVenuesResponseModel"
+                                }
+                            }
+                        },
+                        "description": "La liste des lieux ou vous pouvez cr\u00e9er une offre."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentification n\u00e9cessaire"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "R\u00e9cup\u00e9ration de la liste des lieux associ\u00e9s au fournisseur authentifi\u00e9e par le jeton d'API.",
+                "tags": [
+                    "Collective venues"
+                ]
             }
-          }, 
-          {
-            "description": "Venue id to filter offers on.", 
-            "in": "query", 
-            "name": "venueId", 
-            "required": true, 
-            "schema": {
-              "description": "Venue id to filter offers on.", 
-              "title": "Venueid", 
-              "type": "integer"
-            }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProductOffersResponse"
-                }
-              }
-            }, 
-            "description": "The product offers"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "No venue found for the used api key"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get venue products", 
-        "tags": [
-          "Product offer"
-        ]
-      }, 
-      "patch": {
-        "description": "Will update only the non-blank fields. If you want to keep the current value of certains fields, leave them `undefined`.", 
-        "operationId": "EditProduct", 
-        "parameters": [], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProductOfferEdition"
-              }
-            }
-          }
-        }, 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProductOfferResponse"
-                }
-              }
-            }, 
-            "description": "The product offer have been edited successfully"
-          }, 
-          "400": {
-            "description": "The product offer could not be edited"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The product offer could not be found"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Update product offer", 
-        "tags": [
-          "Product offer"
-        ]
-      }, 
-      "post": {
-        "description": "Create a product in authorized categories.", 
-        "operationId": "PostProductOffer", 
-        "parameters": [], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProductOfferCreation"
-              }
-            }
-          }
-        }, 
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProductOfferResponse"
-                }
-              }
-            }, 
-            "description": "The product offer have been created successfully"
-          }, 
-          "400": {
-            "description": "The product offer could not be created"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "No venue found for the used api key"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Create product", 
-        "tags": [
-          "Product offer"
-        ]
-      }
-    }, 
-    "/public/offers/v1/products/categories": {
-      "get": {
-        "description": "Return all product categories with their conditional fields, and whether they are required for product creation.", 
-        "operationId": "GetProductCategories", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetProductCategoriesResponse"
-                }
-              }
-            }, 
-            "description": "The product categories have been returned"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get product categories", 
-        "tags": [
-          "Product offer"
-        ]
-      }
-    }, 
-    "/public/offers/v1/products/ean": {
-      "get": {
-        "description": "Return all the product offers of a given venue matching given EANs (European Article Number, EAN-13).", 
-        "operationId": "GetProductByEan", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "eans", 
-            "required": true, 
-            "schema": {
-              "example": "0123456789123,0123456789124", 
-              "title": "Eans", 
-              "type": "string"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "venueId", 
-            "required": true, 
-            "schema": {
-              "example": 1, 
-              "title": "Venueid", 
-              "type": "integer"
-            }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProductOffersByEanResponse"
-                }
-              }
-            }, 
-            "description": "The product offers"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get product offers by EAN", 
-        "tags": [
-          "Product offer bulk operations"
-        ]
-      }, 
-      "post": {
-        "description": "Batch create offers using products EAN. EAN is the European Article Number identifiying each product sold in the european market (EAN-13).", 
-        "operationId": "PostProductOfferByEan", 
-        "parameters": [], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProductsOfferByEanCreation"
-              }
-            }
-          }
-        }, 
-        "responses": {
-          "204": {
-            "description": "The product offers have been created successfully"
-          }, 
-          "400": {
-            "description": "The product offers could not be created"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "No venue found for the used api key"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Batch create offers", 
-        "tags": [
-          "Product offer bulk operations"
-        ]
-      }
-    }, 
-    "/public/offers/v1/products/{product_id}": {
-      "get": {
-        "description": "Return a product offer by id.", 
-        "operationId": "GetProduct", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "product_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
-            }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProductOfferResponse"
-                }
-              }
-            }, 
-            "description": "The product offer"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "404": {
-            "description": "The product offer could not be found"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get product offer", 
-        "tags": [
-          "Product offer"
-        ]
-      }
-    }, 
-    "/public/offers/v1/show_types": {
-      "get": {
-        "description": "", 
-        "operationId": "GetShowTypes", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetShowTypesResponse"
-                }
-              }
-            }, 
-            "description": "The show types have been returned"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Get all the show types", 
-        "tags": [
-          "Offer attributes"
-        ]
-      }
-    }, 
-    "/public/offers/v1/{offer_id}/image": {
-      "post": {
-        "description": "Upload an image for given offer.", 
-        "operationId": "UploadImage", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "offer_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
-            }
-          }
-        ], 
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ImageUploadFile"
-              }
-            }
-          }
-        }, 
-        "responses": {
-          "204": {
-            "description": "Image updated successfully"
-          }, 
-          "401": {
-            "description": "Authentication is necessary to use this API"
-          }, 
-          "403": {
-            "description": "You do not have the necessary rights to use this API"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Upload an image", 
-        "tags": [
-          "Image"
-        ]
-      }
-    }, 
-    "/v2/collective/bookings/{booking_id}": {
-      "patch": {
-        "description": "", 
-        "operationId": "CancelCollectiveBooking", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "booking_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
-            }
-          }
-        ], 
-        "responses": {
-          "204": {
-            "description": "Annuler une r\u00e9servation collective"
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Cancel collective booking", 
-        "tags": [
-          "Collective booking"
-        ]
-      }
-    }, 
-    "/v2/collective/categories": {
-      "get": {
-        "description": "", 
-        "operationId": "ListCategories", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectiveOffersListCategoriesResponseModel"
-                }
-              }
-            }, 
-            "description": "La liste des cat\u00e9gories \u00e9ligibles existantes."
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cup\u00e9ration de la liste des cat\u00e9gories d'offres propos\u00e9es.", 
-        "tags": [
-          "Collective categories"
-        ]
-      }
-    }, 
-    "/v2/collective/educational-domains": {
-      "get": {
-        "description": "", 
-        "operationId": "ListEducationalDomains", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectiveOffersListDomainsResponseModel"
-                }
-              }
-            }, 
-            "description": "La liste des domaines d'\u00e9ducation."
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cup\u00e9ration de la liste des domaines d'\u00e9ducation pouvant \u00eatre associ\u00e9s aux offres collectives.", 
-        "tags": [
-          "Collective educational data"
-        ]
-      }
-    }, 
-    "/v2/collective/educational-institutions/": {
-      "get": {
-        "description": "", 
-        "operationId": "ListEducationalInstitutions", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "id", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "Id", 
-              "type": "integer"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "name", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "Name", 
-              "type": "string"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "institutionType", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "Institutiontype", 
-              "type": "string"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "city", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "City", 
-              "type": "string"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "postalCode", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "Postalcode", 
-              "type": "string"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "uai", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "Uai", 
-              "type": "string"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "limit", 
-            "required": false, 
-            "schema": {
-              "default": 20, 
-              "title": "Limit", 
-              "type": "integer"
-            }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectiveOffersListEducationalInstitutionResponseModel"
-                }
-              }
-            }, 
-            "description": "La liste des \u00e9tablissement scolaires \u00e9ligibles."
-          }, 
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Requ\u00eate malform\u00e9e"
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cup\u00e9ration de la liste \u00e9tablissements scolaires.", 
-        "tags": [
-          "Collective educational data"
-        ]
-      }
-    }, 
-    "/v2/collective/national-programs/": {
-      "get": {
-        "description": "", 
-        "operationId": "GetNationalPrograms", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListNationalProgramsResponseModel"
-                }
-              }
-            }, 
-            "description": "Il n'y a pas de dispositifs nationaux"
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir ces informations"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Liste de tous les dispositifs nationaux connus", 
-        "tags": [
-          "Collective educational data"
-        ]
-      }
-    }, 
-    "/v2/collective/offerer_venues": {
-      "get": {
-        "description": "Tous les lieux enregistr\u00e9s, sont list\u00e9s ici avec leurs coordonn\u00e9es.", 
-        "operationId": "GetOffererVenues", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "siren", 
-            "required": false, 
-            "schema": {
-              "example": "123456789", 
-              "nullable": true, 
-              "pattern": "^\\d{9}$", 
-              "title": "Siren", 
-              "type": "string"
-            }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetOfferersVenuesResponse"
-                }
-              }
-            }, 
-            "description": "La liste des lieux, group\u00e9s par structures"
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cup\u00e9ration des lieux associ\u00e9s au fournisseur authentifi\u00e9 par le jeton d'API; group\u00e9s par structures.", 
-        "tags": [
-          "Collective venues"
-        ]
-      }
-    }, 
-    "/v2/collective/offers/": {
-      "get": {
-        "description": "", 
-        "operationId": "GetCollectiveOffersPublic", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "status", 
-            "required": false, 
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/OfferStatus"
-                }
-              ], 
-              "nullable": true
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "venueId", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "Venueid", 
-              "type": "integer"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "periodBeginningDate", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "Periodbeginningdate", 
-              "type": "string"
-            }
-          }, 
-          {
-            "description": "", 
-            "in": "query", 
-            "name": "periodEndingDate", 
-            "required": false, 
-            "schema": {
-              "nullable": true, 
-              "title": "Periodendingdate", 
-              "type": "string"
-            }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectiveOffersListResponseModel"
-                }
-              }
-            }, 
-            "description": "L'offre collective existe"
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette offre collective"
-          }, 
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "L'offre collective n'existe pas"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cuperation des offres collectives Cette api ignore les offre vitrines et les offres commenc\u00e9es sur l'interface web et non finalis\u00e9es.", 
-        "tags": [
-          "Collective offers"
-        ]
-      }, 
-      "post": {
-        "description": "", 
-        "operationId": "PostCollectiveOfferPublic", 
-        "parameters": [], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PostCollectiveOfferBodyModel"
-              }
-            }
-          }
-        }, 
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetPublicCollectiveOfferResponseModel"
-                }
-              }
-            }, 
-            "description": "L'offre collective \u00e0 \u00e9t\u00e9 cr\u00e9\u00e9e avec succes"
-          }, 
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Requ\u00eate malform\u00e9e"
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Non \u00e9ligible pour les offres collectives"
-          }, 
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "L'une des resources pour la cr\u00e9ation de l'offre n'a pas \u00e9t\u00e9 trouv\u00e9e"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Cr\u00e9ation d'une offre collective.", 
-        "tags": [
-          "Collective offers"
-        ]
-      }
-    }, 
-    "/v2/collective/offers/formats": {
-      "get": {
-        "description": "", 
-        "operationId": "GetOffersFormats", 
-        "parameters": [], 
-        "responses": {
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette offre collective"
-          }, 
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "L'offre collective n'existe pas"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "Liste des formats d'offres collectives", 
-        "tags": [
-          "Collective offers"
-        ]
-      }
-    }, 
-    "/v2/collective/offers/{offer_id}": {
-      "get": {
-        "description": "", 
-        "operationId": "GetCollectiveOfferPublic", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "offer_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
-            }
-          }
-        ], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetPublicCollectiveOfferResponseModel"
-                }
-              }
-            }, 
-            "description": "L'offre collective existe"
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Vous n'avez pas les droits n\u00e9cessaires pour voir cette offre collective"
-          }, 
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "L'offre collective n'existe pas"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cuperation de l'offre collective avec l'identifiant offer_id.", 
-        "tags": [
-          "Collective offers"
-        ]
-      }, 
-      "patch": {
-        "description": "", 
-        "operationId": "PatchCollectiveOfferPublic", 
-        "parameters": [
-          {
-            "description": "", 
-            "in": "path", 
-            "name": "offer_id", 
-            "required": true, 
-            "schema": {
-              "format": "int32", 
-              "type": "integer"
-            }
-          }
-        ], 
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PatchCollectiveOfferBodyModel"
-              }
-            }
-          }
-        }, 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetPublicCollectiveOfferResponseModel"
-                }
-              }
-            }, 
-            "description": "L'offre collective \u00e0 \u00e9t\u00e9 \u00e9dit\u00e9 avec succes"
-          }, 
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Requ\u00eate malform\u00e9e"
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Vous n'avez pas les droits n\u00e9cessaires pour \u00e9diter cette offre collective"
-          }, 
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "L'une des resources pour la cr\u00e9ation de l'offre n'a pas \u00e9t\u00e9 trouv\u00e9e"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Cetains champs ne peuvent pas \u00eatre \u00e9dit\u00e9s selon l'\u00e9tat de l'offre"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "\u00c9dition d'une offre collective.", 
-        "tags": [
-          "Collective offers"
-        ]
-      }
-    }, 
-    "/v2/collective/student-levels": {
-      "get": {
-        "description": "", 
-        "operationId": "ListStudentsLevels", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectiveOffersListStudentLevelsResponseModel"
-                }
-              }
-            }, 
-            "description": "La liste des domaines d'\u00e9ducation."
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cup\u00e9ration de la liste des publics cibles pour lesquelles des offres collectives peuvent \u00eatre propos\u00e9es.", 
-        "tags": [
-          "Collective educational data"
-        ]
-      }
-    }, 
-    "/v2/collective/subcategories": {
-      "get": {
-        "description": "", 
-        "operationId": "ListSubcategories", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectiveOffersListSubCategoriesResponseModel"
-                }
-              }
-            }, 
-            "description": "La liste des sous-cat\u00e9gories \u00e9ligibles existantes."
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cup\u00e9ration de la liste des sous-cat\u00e9gories d'offres propos\u00e9es a un public collectif.", 
-        "tags": [
-          "Collective categories"
-        ]
-      }
-    }, 
-    "/v2/collective/venues": {
-      "get": {
-        "description": "Tous les lieux enregistr\u00e9s, sont list\u00e9s ici avec leurs coordonn\u00e9es.", 
-        "operationId": "ListVenues", 
-        "parameters": [], 
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CollectiveOffersListVenuesResponseModel"
-                }
-              }
-            }, 
-            "description": "La liste des lieux ou vous pouvez cr\u00e9er une offre."
-          }, 
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthErrorResponseModel"
-                }
-              }
-            }, 
-            "description": "Authentification n\u00e9cessaire"
-          }, 
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }, 
-            "description": "Unprocessable Entity"
-          }
-        }, 
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ], 
-        "summary": "R\u00e9cup\u00e9ration de la liste des lieux associ\u00e9s au fournisseur authentifi\u00e9e par le jeton d'API.", 
-        "tags": [
-          "Collective venues"
-        ]
-      }
-    }
-  }, 
-  "security": [], 
-  "servers": [
-    {
-      "url": "http://localhost:5001"
-    }
-  ], 
-  "tags": [
-    {
-      "description": "", 
-      "externalDocs": null, 
-      "name": "Offerer and Venues"
-    }, 
-    {
-      "description": "Endpoints to manage event offers data of a venue (except prices and dates).", 
-      "externalDocs": null, 
-      "name": "Event offer"
-    }, 
-    {
-      "description": "Endpoints to create and update price categories of an event.", 
-      "externalDocs": null, 
-      "name": "Event offer prices"
-    }, 
-    {
-      "description": "Endpoints to manager the dates of an event. The date of an event is composed of a price category and an actual date.         Hence for a given performance, you might have several dates (one per category).", 
-      "externalDocs": null, 
-      "name": "Event offer dates"
-    }, 
-    {
-      "description": "Endpoints to manage product offers of a venue.", 
-      "externalDocs": null, 
-      "name": "Product offer"
-    }, 
-    {
-      "description": "Endpoints to create and get products usings European Article Number (EAN-13).", 
-      "externalDocs": null, 
-      "name": "Product offer bulk operations"
-    }, 
-    {
-      "description": "Endpoints to manage the bookings of an offer (event and product).", 
-      "externalDocs": null, 
-      "name": "Booking"
-    }, 
-    {
-      "description": "", 
-      "externalDocs": null, 
-      "name": "Image"
-    }, 
-    {
-      "description": "", 
-      "externalDocs": null, 
-      "name": "Offer attributes"
-    }, 
-    {
-      "description": "", 
-      "externalDocs": null, 
-      "name": "Collective offers"
-    }, 
-    {
-      "description": "", 
-      "externalDocs": null, 
-      "name": "Collective booking"
-    }, 
-    {
-      "description": "", 
-      "externalDocs": null, 
-      "name": "Collective categories"
-    }, 
-    {
-      "description": "", 
-      "externalDocs": null, 
-      "name": "Collective venues"
-    }, 
-    {
-      "description": "", 
-      "externalDocs": null, 
-      "name": "Collective educational data"
-    }
-  ]
+        }
+    },
+    "security": [],
+    "servers": [
+        {
+            "url": "http://localhost:5001"
+        }
+    ],
+    "tags": [
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Offerer and Venues"
+        },
+        {
+            "description": "Endpoints to manage event offers data of a venue (except prices and dates).",
+            "externalDocs": null,
+            "name": "Event offer"
+        },
+        {
+            "description": "Endpoints to create and update price categories of an event.",
+            "externalDocs": null,
+            "name": "Event offer prices"
+        },
+        {
+            "description": "Endpoints to manager the dates of an event. The date of an event is composed of a price category and an actual date.         Hence for a given performance, you might have several dates (one per category).",
+            "externalDocs": null,
+            "name": "Event offer dates"
+        },
+        {
+            "description": "Endpoints to manage product offers of a venue.",
+            "externalDocs": null,
+            "name": "Product offer"
+        },
+        {
+            "description": "Endpoints to create and get products usings European Article Number (EAN-13).",
+            "externalDocs": null,
+            "name": "Product offer bulk operations"
+        },
+        {
+            "description": "Endpoints to manage the bookings of an offer (event and product).",
+            "externalDocs": null,
+            "name": "Booking"
+        },
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Image"
+        },
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Offer attributes"
+        },
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Collective offers"
+        },
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Collective booking"
+        },
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Collective categories"
+        },
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Collective venues"
+        },
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Collective educational data"
+        }
+    ]
 }

--- a/api/tests/routes/public/generate_expected_openapi_json.py
+++ b/api/tests/routes/public/generate_expected_openapi_json.py
@@ -1,0 +1,14 @@
+import json
+
+from pcapi.app import app
+
+
+def generate_expected_openapi_json():
+    """
+    Regenerate the expected_openapi.json used in the blueprint_openapi_test
+    """
+    client = app.test_client()
+    r = client.get("/openapi.json")
+
+    with open("tests/routes/public/expected_openapi.json", "w", encoding="UTF-8") as f:
+        json.dump(r.json, f, indent=4, sort_keys=True)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29922

### Contexte

Nous avons mis en place un test sur le JSON open API généré à partir de spectree afin de vérifier que l'on n'introduit pas de régression dans la documentation Redoc.

Le but de ce ticket est d'ajouter une fonction qui permette de régénérer facilement et proprement le JSON attendu (i.e. sans trailling whitespace et de manière ordonnée pour que le commit de modification soit lisible).

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques