### PR TITLE
(BSR)[BO] chore: ADAGE should be displayed uppercase

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offerers/forms.py
@@ -108,7 +108,7 @@ class OffererValidationListForm(utils.PCForm):
         endpoint="backoffice_web.autocomplete_bo_users",
     )
     dms_adage_status = fields.PCSelectMultipleField(
-        "États du dossier DMS Adage",
+        "États du dossier DMS ADAGE",
         choices=utils.choices_from_enum(GraphQLApplicationStates, filters.format_dms_application_status),
     )
     from_date = fields.PCDateField("Demande à partir du", validators=(wtforms.validators.Optional(),))

--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -129,7 +129,7 @@
 {% macro build_dms_adage_application_external_link(collective_dms_application) %}
   <a href="https://www.demarches-simplifiees.fr/procedures/{{ collective_dms_application.procedure }}/dossiers/{{ collective_dms_application.application }}"
      target="_blank"
-     title="Visualiser le dossier Démarches Simplifiées Adage"
+     title="Visualiser le dossier Démarches Simplifiées ADAGE"
      class="link-primary">{{ collective_dms_application.application }} <i class="bi bi-box-arrow-up-right"></i></a>
 {% endmacro %}
 {% macro build_safe_redirect_link(url) %}

--- a/api/src/pcapi/routes/backoffice/templates/components/offerer_validation/extra_row.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/offerer_validation/extra_row.html
@@ -19,7 +19,7 @@
                   <ul>
                     <li>Nom : {{ dms_venue.name }}</li>
                     <li>SIRET : {{ dms_venue.siret }}</li>
-                    <li>Statut du dossier DMS Adage : {{ dms_venue.state | format_dms_status }}</li>
+                    <li>Statut du dossier DMS ADAGE : {{ dms_venue.state | format_dms_status }}</li>
                   </ul>
                 {% endif %}
               {% endfor %}

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -162,7 +162,7 @@
                 <span class="fw-bold">Peut créer une offre EAC : {{ offerer.allowedOnAdage | format_bool_badge }}</span>
               </p>
               <p class="mb-1">
-                <span class="fw-bold">Lieux cartographiés sur Adage : {{ adage_information }}</span>
+                <span class="fw-bold">Lieux cartographiés sur ADAGE : {{ adage_information }}</span>
               </p>
               <p class="mb-1">
                 <span class="fw-bold">Présence CB dans les lieux :</span>
@@ -275,7 +275,7 @@
             {# tab is hidden when there is no address in database; so it does not need a FF until migration #}
             {{ build_details_tab("addresses", "Adresses", active_tab == 'addresses') }}
           {% endif %}
-          {{ build_details_tab("dms-adage", "Dossiers DMS Adage", active_tab == 'dms_adage') }}
+          {{ build_details_tab("dms-adage", "Dossiers DMS ADAGE", active_tab == 'dms_adage') }}
           {{ build_details_tab("bank-accounts", "Comptes bancaires", active_tab == 'bank_accounts') }}
         {% endcall %}
         {% call build_details_tabs_content_wrapper() %}

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/individual_subscription.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/individual_subscription.html
@@ -45,13 +45,13 @@
             {{ build_step("Certifications professionnelles", "bi-box-fill", "bi-check-circle-fill text-success" if individual_subscription.isExperienceReceived else ("bi-exclamation-circle-fill text-warning" if individual_subscription) , "step-success" if individual_subscription.isExperienceReceived) }}
             {% if has_adage_tag or adage_decision %}
               {% if adage_decision == "accepte" %}
-                {{ build_step('Référencement Adage', 'bi-briefcase-fill', 'bi-check-circle-fill text-success', 'step-success') }}
+                {{ build_step('Référencement ADAGE', 'bi-briefcase-fill', 'bi-check-circle-fill text-success', 'step-success') }}
               {% elif adage_decision == "refuse" %}
-                {{ build_step('Référencement Adage', 'bi-briefcase-fill', 'bi-x-circle-fill text-danger', 'step-error') }}
+                {{ build_step('Référencement ADAGE', 'bi-briefcase-fill', 'bi-x-circle-fill text-danger', 'step-error') }}
               {% elif adage_decision == "en_instruction" %}
-                {{ build_step("Référencement Adage", "bi-briefcase-fill", "bi-hourglass-split text-info", null) }}
+                {{ build_step("Référencement ADAGE", "bi-briefcase-fill", "bi-hourglass-split text-info", null) }}
               {% else %}
-                {{ build_step("Référencement Adage", "bi-briefcase-fill", "bi-exclamation-circle-fill text-warning" if individual_subscription, "") }}
+                {{ build_step("Référencement ADAGE", "bi-briefcase-fill", "bi-exclamation-circle-fill text-warning" if individual_subscription, "") }}
               {% endif %}
             {% endif %}
           </ol>

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -215,11 +215,11 @@
                 <span class="fw-bold">Peut créer une offre EAC : {{ venue.managingOfferer.allowedOnAdage | format_bool_badge }}</span>
               </p>
               <p class="mb-1">
-                <span class="fw-bold">Cartographié sur Adage : {{ (venue.adageId is not none) | format_bool_badge }}</span>
+                <span class="fw-bold">Cartographié sur ADAGE : {{ (venue.adageId is not none) | format_bool_badge }}</span>
               </p>
               {% if venue.adageId %}
                 <p class="mb-1">
-                  <span class="fw-bold">ID Adage :</span>
+                  <span class="fw-bold">ID ADAGE :</span>
                   {{ venue.adageId }}
                 </p>
               {% endif %}
@@ -411,7 +411,7 @@
           {% if venue.siret and has_permission("READ_PRO_ENTREPRISE_INFO") %}
             {{ build_details_tab("entreprise", "Données Entreprise", active_tab == 'entreprise') }}
           {% endif %}
-          {% if venue.siret %}{{ build_details_tab("dms-adage", "Dossiers DMS Adage", active_tab == 'dms_adage') }}{% endif %}
+          {% if venue.siret %}{{ build_details_tab("dms-adage", "Dossiers DMS ADAGE", active_tab == 'dms_adage') }}{% endif %}
         {% endcall %}
         {% call build_details_tabs_content_wrapper() %}
           {% call build_details_tab_content("history", active_tab == 'history') %}

--- a/api/tests/routes/backoffice/bank_account_test.py
+++ b/api/tests/routes/backoffice/bank_account_test.py
@@ -53,7 +53,7 @@ class GetBankAccountTest(GetEndpointHelper):
         assert f"Humanized ID : {humanize(bank_account.id)} " in response_text
         assert f"IBAN : {bank_account.iban} " in response_text
         assert f"BIC : {bank_account.bic} " in response_text
-        assert "Statut dossier DMS Adage :" not in response_text
+        assert "Statut dossier DMS ADAGE :" not in response_text
         assert "Pas de dossier DMS CB" in response_text
         assert "État du compte bancaire : Accepté" in response_text
         assert "ACCÉDER AU DOSSIER DMS CB" not in response_text

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -544,7 +544,7 @@ def top_acteur_tag_fixture():
 @pytest.fixture(name="adage_tag")
 def adage_tag_fixture():
     category = offerers_factories.OffererTagCategoryFactory(name="homologation", label="Homologation")
-    return offerers_factories.OffererTagFactory(name="adage", label="Adage", categories=[category])
+    return offerers_factories.OffererTagFactory(name="adage", label="ADAGE", categories=[category])
 
 
 @pytest.fixture(name="offerer_tags")
@@ -604,7 +604,7 @@ def offerers_to_be_validated_fixture(offerer_tags):
     offerers_factories.OffererFactory(name="G")
     offerers_factories.RejectedOffererFactory(name="H")
 
-    # DMS adage statuses
+    # DMS ADAGE statuses
     educational_factories.CollectiveDmsApplicationFactory(venue__managingOfferer=no_tag, state="accepte")
     educational_factories.CollectiveDmsApplicationFactory(venue__managingOfferer=no_tag, state="refuse")
     educational_factories.CollectiveDmsApplicationFactory(venue__managingOfferer=top, state="en_instruction")

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -228,7 +228,7 @@ class GetOffererTest(GetEndpointHelper):
 
         assert "Peut créer une offre EAC : Oui" in html_parser.content_as_text(response.data)
         # One venue with adageId out of two physical venues
-        assert "Lieux cartographiés sur Adage : 1/2" in html_parser.content_as_text(response.data)
+        assert "Lieux cartographiés sur ADAGE : 1/2" in html_parser.content_as_text(response.data)
 
     def test_offerer_with_no_adage_venue_has_adage_data(self, authenticated_client, offerer):
         offerer = offerers_factories.OffererFactory(allowedOnAdage=True)
@@ -240,7 +240,7 @@ class GetOffererTest(GetEndpointHelper):
             assert response.status_code == 200
 
         assert "Peut créer une offre EAC : Oui" in html_parser.content_as_text(response.data)
-        assert "Lieux cartographiés sur Adage : 0/1" in html_parser.content_as_text(response.data)
+        assert "Lieux cartographiés sur ADAGE : 0/1" in html_parser.content_as_text(response.data)
 
     def test_offerer_with_no_individual_subscription_tab(self, authenticated_client, offerer):
         offerer_id = offerer.id
@@ -1640,7 +1640,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
             dms_adage_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[0]
             assert f"Nom : {venue.name}" in dms_adage_data
             assert f"SIRET : {venue.siret}" in dms_adage_data
-            assert "Statut du dossier DMS Adage : Accepté" in dms_adage_data
+            assert "Statut du dossier DMS ADAGE : Accepté" in dms_adage_data
 
         @pytest.mark.parametrize(
             "total_items, pagination_config, expected_total_pages, expected_page, expected_items",
@@ -3653,7 +3653,7 @@ class GetIndividualOffererSubscriptionTest(GetEndpointHelper):
                 "Casier judiciaire": ["bi-exclamation-circle-fill", "text-warning"],
                 "Diplômes": ["bi-check-circle-fill", "text-success"],
                 "Certifications professionnelles": ["bi-exclamation-circle-fill", "text-warning"],
-                "Référencement Adage": ["bi-exclamation-circle-fill", "text-warning"],
+                "Référencement ADAGE": ["bi-exclamation-circle-fill", "text-warning"],
             },
         )
 
@@ -3688,7 +3688,7 @@ class GetIndividualOffererSubscriptionTest(GetEndpointHelper):
                 "Casier judiciaire": ["bi-check-circle-fill", "text-success"],
                 "Diplômes": ["bi-check-circle-fill", "text-success"],
                 "Certifications professionnelles": ["bi-check-circle-fill", "text-success"],
-                "Référencement Adage": expected_adage_classes,
+                "Référencement ADAGE": expected_adage_classes,
             },
         )
 

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -331,8 +331,8 @@ class GetVenueTest(GetEndpointHelper):
         assert f"Email : {venue.bookingEmail} " in response_text
         assert f"Numéro de téléphone : {venue.contact.phone_number} " in response_text
         assert "Peut créer une offre EAC : Non" in response_text
-        assert "Cartographié sur Adage : Non" in response_text
-        assert "ID Adage" not in response_text
+        assert "Cartographié sur ADAGE : Non" in response_text
+        assert "ID ADAGE" not in response_text
         assert "Site web : https://www.example.com" in response_text
         assert f"Activité principale : {venue.venueTypeCode.value}" in response_text
         assert f"Label : {venue.venueLabel.label} " in response_text
@@ -353,8 +353,8 @@ class GetVenueTest(GetEndpointHelper):
 
         response_text = html_parser.content_as_text(response.data)
         assert "Peut créer une offre EAC : Oui" in response_text
-        assert "Cartographié sur Adage : Oui" in response_text
-        assert "ID Adage : 7122022" in response_text
+        assert "Cartographié sur ADAGE : Oui" in response_text
+        assert "ID ADAGE : 7122022" in response_text
 
     def test_get_venue_with_no_contact(self, authenticated_client):
         venue = offerers_factories.VenueFactory(contact=None)
@@ -446,8 +446,8 @@ class GetVenueTest(GetEndpointHelper):
         assert f"Email : {venue.bookingEmail} " in response_text
         assert f"Numéro de téléphone : {venue.contact.phone_number} " in response_text
         assert "Peut créer une offre EAC : Oui" in response_text
-        assert "Cartographié sur Adage : Non" in response_text
-        assert "ID Adage" not in response_text
+        assert "Cartographié sur ADAGE : Non" in response_text
+        assert "ID ADAGE" not in response_text
         assert "Site web : https://my.website.com" in response_text
 
         badges = html_parser.extract(response.data, tag="span", class_="badge")


### PR DESCRIPTION
## But de la pull request

Suite à la démo, @Charlottux a fait remarquer qu'Adage devait s'écrire ADAGE. Nous corrigeons donc dans le backoffice.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques