### PR TITLE
(BSR)[API] fix: throw 424 if download invoice pdf fails

### DIFF
--- a/api/src/pcapi/routes/pro/finance.py
+++ b/api/src/pcapi/routes/pro/finance.py
@@ -74,7 +74,11 @@ def get_combined_invoices(query: finance_serialize.CombinedInvoiceListModel) -> 
     tmp = BytesIO()
 
     for invoice_pdf_url in invoice_pdf_urls:
-        invoice_pdf = PdfReader(BytesIO(requests.get(invoice_pdf_url).content))
+        try:
+            invoice_pdf = PdfReader(BytesIO(requests.get(invoice_pdf_url).content))
+        except Exception:
+            merger.close()
+            raise ApiErrors({"invoice": f"Failed to fetch invoice PDF from url: {invoice_pdf_url}"}, status_code=424)
         merger.append(invoice_pdf)
 
     merger.write(tmp)

--- a/api/tests/routes/pro/get_combined_invoices_pdf.py
+++ b/api/tests/routes/pro/get_combined_invoices_pdf.py
@@ -5,6 +5,7 @@ import pytest
 
 from pcapi.core.finance import factories
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import requests
 
 from tests.utils.pdf_creation_test import TEST_FILES_PATH
 
@@ -81,3 +82,16 @@ def test_get_combined_invoices_pdf_no_invoice_references(client):
 
     assert response.status_code == 400
     assert response.json == {"invoiceReferences": ["Ce champ est obligatoire"]}
+
+
+def test_get_combined_invoices_pdf_failed_http_request(client, requests_mock):
+    invoice = factories.InvoiceFactory(reference="F240000187")
+
+    requests_mock.side_effect = [requests.exceptions.ConnectionError]
+
+    pro = users_factories.ProFactory()
+    client = client.with_session_auth(pro.email)
+
+    response = client.get("/finance/combined-invoices?invoiceReferences=F240000187")
+    assert response.status_code == 424
+    assert response.json == {"invoice": f"Failed to fetch invoice PDF from url: {invoice.url}"}


### PR DESCRIPTION
Fix de l'erreur sentry: https://sentry.passculture.team/organizations/sentry/issues/1610680/?project=5&referrer=slack

## Vérifications

- [X] J'ai écrit les tests nécessaires
