### PR TITLE
(PC-29946)[PRO] feat: Fetch all adage search offers at once.

### DIFF
--- a/pro/src/config/swrQueryKeys.ts
+++ b/pro/src/config/swrQueryKeys.ts
@@ -7,6 +7,8 @@ export const GET_CLASSROOM_PLAYLIST_QUERY_KEY = 'getClassroomPlaylist'
 export const GET_COLLECTIVE_OFFER_QUERY_KEY = 'getCollectiveOffer'
 export const GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY =
   'getCollectiveOfferTemplate'
+export const GET_COLLECTIVE_OFFER_TEMPLATES_QUERY_KEY =
+  'getCollectiveOfferTemplates'
 export const GET_COLLECTIVE_OFFERS_FOR_INSTITUTION_QUERY_KEY =
   'getCollectiveOffersForMyInstitution'
 export const GET_COLLECTIVE_OFFERS_QUERY_KEY = 'getCollectiveOffers'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/utils/extractOfferIdFromObjectId.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/utils/extractOfferIdFromObjectId.ts
@@ -1,9 +1,0 @@
-export const extractOfferIdFromObjectId = (offerId: string): number => {
-  const splitResult = offerId.split('T-')
-
-  if (splitResult.length === 2) {
-    return Number(splitResult[1])
-  }
-
-  return Number(offerId)
-}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -69,6 +69,16 @@ export const OffersSearch = ({
   )?.results
   const nbHits = mainOffersSearchResults?.nbHits
 
+  useEffect(() => {
+    if (mainOffersSearchResults) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      logFiltersOnSearch(
+        mainOffersSearchResults.nbHits,
+        mainOffersSearchResults.queryID
+      )
+    }
+  }, [mainOffersSearchResults?.queryID])
+
   const isMarseilleEnabled = useActiveFeature('WIP_ENABLE_MARSEILLE')
   const isUserInMarseilleProgram = (adageUser.programs ?? []).some(
     (prog) => prog.name === MARSEILLE_EN_GRAND
@@ -138,7 +148,7 @@ export const OffersSearch = ({
     formik.handleSubmit()
   }
 
-  const logFiltersOnSearch = async (nbHits: number, queryId?: string) => {
+  async function logFiltersOnSearch(nbHits: number, queryId?: string) {
     /* istanbul ignore next: TO FIX the current structure make it hard to test, we probably should not mock Offers in OfferSearch tests */
     if (formik.submitCount > 0 || adageQueryFromSelector !== null) {
       await logTrackingFilter({
@@ -204,10 +214,9 @@ export const OffersSearch = ({
       </FormikContext.Provider>
       <div className="search-results">
         <Offers
-          logFiltersOnSearch={logFiltersOnSearch}
           submitCount={formik.submitCount}
           isBackToTopVisibile={!isOfferFiltersVisible}
-          indexId="main_offers_index"
+          indexId={MAIN_INDEX_ID}
           venue={formik.values.venue}
         />
         {nbHits === 0 && !isUserAdmin && (

--- a/pro/src/utils/adageFactories.ts
+++ b/pro/src/utils/adageFactories.ts
@@ -136,7 +136,7 @@ export const defaultUseStatsReturn = {
 }
 
 const hit = {
-  objectID: '481',
+  objectID: 'T-481',
   offer: {
     dates: [new Date('2021-09-29T13:54:30+00:00').valueOf()],
     name: 'titre',
@@ -147,7 +147,7 @@ const hit = {
     publicName: 'lieu public',
   },
   _highlightResult: {},
-  isTemplate: false,
+  isTemplate: true,
   __queryID: 'queryId',
   __position: 0,
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29946

**Objectif**
Récupérer les offres de la recherche ADAGE toutes en même temps.
Jusqu'a maintenant l'api pour récupérer plusieurs offres collectives depuis leurs ids n'existait pas, donc on envoyait une requête par offre. Mais maintenant on a `getCollectiveOfferTemplates` 🎉 

J'ai aussi simplifié le fonctionnement en utilisant swr pour avoir un cache (quand on revient sur la page recherche, on va souvent requeter les memes 8 ids d'offres), gérer le loading et éviter le useEffect. Et aussi on ne veut voir que des offres vitrine, donc plus la peine d'appeler 2 apis différentes vitrine/réservable.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques