### PR TITLE
(PC-29620)[PRO] style: Make the activuty url inptu responsive and mak…

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/EmailInputRow/EmailInputRow.module.scss
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/EmailInputRow/EmailInputRow.module.scss
@@ -5,6 +5,9 @@
 
 .notification-mail {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: rem.torem(8px);
 
   &-input {
     width: 90%;

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/EmailInputRow/EmailInputRow.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/EmailInputRow/EmailInputRow.tsx
@@ -23,7 +23,7 @@ const EmailInputRow = ({
   onDelete,
 }: EmailInputRowProps) => {
   return (
-    <FormLayout.Row inline className={styles['notification-mail']}>
+    <FormLayout.Row className={styles['notification-mail']}>
       <TextInput
         label={NOTIFICATIONS_EMAIL_LABEL}
         name={name}

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.module.scss
@@ -8,11 +8,17 @@
 }
 
 .url-input input {
-  width: size.$signup-content-width;
+  max-width: size.$signup-content-width;
 }
 
 .form-row-actions {
   margin-top: rem.torem(4px);
+}
+
+.input-gap {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: rem.torem(8px);
 }
 
 .first-row {
@@ -22,13 +28,13 @@
 }
 
 .delete-button {
-    display: flex;
-    align-content: center;
+  display: flex;
+  align-content: center;
 
-    & svg {
-        width: 24px;
-        height: 24px;
-    }
+  & svg {
+    width: 24px;
+    height: 24px;
+  }
 }
 
 .target-customer-row {

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -60,11 +60,7 @@ export const ActivityForm = ({
         render={(arrayHelpers) => (
           <FormLayout.Row>
             {values.socialUrls.map((url, index) => (
-              <FormLayout.Row
-                key={index}
-                inline
-                className={styles['input-gap']}
-              >
+              <FormLayout.Row key={index} className={styles['input-gap']}>
                 <TextInput
                   name={`socialUrls[${index}]`}
                   label="Site internet, réseau social"


### PR DESCRIPTION
…e sure the icon button stays next to the input on smaller screens.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29620

**Objectif**
Corriger le responsive de l'input de l'url et de l'icon button poubelle
<img width="385" alt="Capture d’écran 2024-05-27 à 12 22 47" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/7710b1ad-2c1d-428d-b670-3310baa4e054">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques