### PR TITLE
(PC-26084)[PRO] style: Make booking tables headers responsive.

### DIFF
--- a/pro/src/components/StocksEventList/SortArrow.module.scss
+++ b/pro/src/components/StocksEventList/SortArrow.module.scss
@@ -2,7 +2,6 @@
 
 .sorting-icons {
   display: inline-block;
-  height: rem.torem(20px);
   margin-left: rem.torem(4px);
   position: relative;
   vertical-align: middle;

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/BookingsTable.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/BookingsTable.module.scss
@@ -16,11 +16,15 @@
   @include fonts.caption;
 
   color: var(--color-black);
-  line-height: rem.torem(20px);
-  min-height: rem.torem(60px);
   padding: rem.torem(14px);
-  vertical-align: middle;
-  text-align: left;
+}
+
+.table-header-cell {
+  @include fonts.caption;
+
+  color: var(--color-black);
+  padding: rem.torem(14px);
+  display: inline-block;
 }
 
 .table-body {
@@ -46,8 +50,6 @@
 
 .column-booking-id {
   width: rem.torem(110px);
-  display: flex;
-  align-items: center;
 }
 
 .column-offer-name {
@@ -59,8 +61,6 @@
 }
 
 .column-booking-duo {
-  align-items: center;
-  display: flex;
   padding: 0;
   width: rem.torem(35px);
 }

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons.module.scss
@@ -3,4 +3,5 @@
 .action-buttons {
   display: flex;
   gap: rem.torem(16px);
+  margin-top: rem.torem(32px);
 }

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveBookingDetails.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveBookingDetails.module.scss
@@ -1,9 +1,11 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/variables/_size.scss" as size;
 
 .container {
   display: flex;
   gap: rem.torem(16px);
+  flex-wrap: wrap;
 }
 
 .details-timeline {
@@ -80,5 +82,11 @@
         margin-right: 0;
       }
     }
+  }
+}
+
+@media (min-width: size.$tablet) {
+  .container {
+    flex-wrap: nowrap;
   }
 }

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveBookingsTable.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveBookingsTable.tsx
@@ -91,12 +91,12 @@ export const CollectiveBookingsTable = ({
         <caption className="visually-hidden">Liste des réservations</caption>
 
         <thead className={styles['table-header']}>
-          <tr>
+          <tr className={styles['table-header-row']}>
             <th
               scope="col"
               className={cn(
-                styles['table-header'],
-                styles['column-booking-id']
+                styles['column-booking-id'],
+                styles['table-header-cell']
               )}
             >
               Réservation
@@ -105,8 +105,8 @@ export const CollectiveBookingsTable = ({
             <th
               scope="col"
               className={cn(
-                styles['table-header'],
-                styles['column-offer-name']
+                styles['column-offer-name'],
+                styles['table-header-cell']
               )}
             >
               <span>Nom de l’offre</span>
@@ -129,8 +129,8 @@ export const CollectiveBookingsTable = ({
             <th
               scope="col"
               className={cn(
-                styles['table-header'],
-                styles['column-institution']
+                styles['column-institution'],
+                styles['table-header-cell']
               )}
             >
               <span>Établissement</span>
@@ -153,8 +153,8 @@ export const CollectiveBookingsTable = ({
             <th
               scope="col"
               className={cn(
-                styles['table-header'],
-                styles['column-price-and-price']
+                styles['column-price-and-price'],
+                styles['table-header-cell']
               )}
             >
               Places et prix
@@ -163,8 +163,8 @@ export const CollectiveBookingsTable = ({
             <th
               scope="col"
               className={cn(
-                styles['table-header'],
-                styles['column-booking-status']
+                styles['column-booking-status'],
+                styles['table-header-cell']
               )}
             >
               <FilterByBookingStatus

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/IndividualBookingsTable.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/IndividualBookingsTable.tsx
@@ -102,8 +102,8 @@ export const IndividualBookingsTable = ({
               <th
                 scope="col"
                 className={cn(
-                  styles['table-header'],
-                  styles['column-offer-name']
+                  styles['column-offer-name'],
+                  styles['table-header-cell']
                 )}
               >
                 <span>Nom de l’offre</span>
@@ -126,16 +126,16 @@ export const IndividualBookingsTable = ({
               <th
                 scope="col"
                 className={cn(
-                  styles['table-header'],
-                  styles['column-booking-duo']
+                  styles['column-booking-duo'],
+                  styles['table-header-cell']
                 )}
               />
 
               <th
                 scope="col"
                 className={cn(
-                  styles['table-header'],
-                  styles['column-beneficiary']
+                  styles['column-beneficiary'],
+                  styles['table-header-cell']
                 )}
               >
                 <span>Bénéficiaire</span>
@@ -158,8 +158,8 @@ export const IndividualBookingsTable = ({
               <th
                 scope="col"
                 className={cn(
-                  styles['table-header'],
-                  styles['column-booking-date']
+                  styles['column-booking-date'],
+                  styles['table-header-cell']
                 )}
               >
                 <span>Réservation</span>
@@ -182,8 +182,8 @@ export const IndividualBookingsTable = ({
               <th
                 scope="col"
                 className={cn(
-                  styles['table-header'],
-                  styles['column-booking-token']
+                  styles['column-booking-token'],
+                  styles['table-header-cell']
                 )}
               >
                 Contremarque
@@ -192,8 +192,8 @@ export const IndividualBookingsTable = ({
               <th
                 scope="col"
                 className={cn(
-                  styles['table-header'],
-                  styles['column-booking-status']
+                  styles['column-booking-status'],
+                  styles['table-header-cell']
                 )}
               >
                 <FilterByBookingStatus

--- a/pro/src/ui-kit/Timeline/Timeline.module.scss
+++ b/pro/src/ui-kit/Timeline/Timeline.module.scss
@@ -8,6 +8,7 @@ $time-line-width: rem.torem(2px);
 
 .container {
   display: flex;
+  gap: $margin-between-steps;
   flex-direction: column;
 
   // TODO This kind of reset should be in a global reset file
@@ -59,7 +60,6 @@ $time-line-width: rem.torem(2px);
 
 .step {
   position: relative;
-  margin-bottom: $margin-between-steps;
   margin-left: calc(
     #{$icon-size} / 2 + #{$margin-between-content-and-time-line}
   );


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-26084

**Objectif**
Rendre responsive les headers des tables de réservation collective et individuelle
<img width="566" alt="Capture d’écran 2024-05-27 à 12 28 21" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/da332736-6775-4b2a-ab5d-b5aff24b545a">

<img width="611" alt="Capture d’écran 2024-05-27 à 12 34 21" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/7f9df95b-ea36-40d6-82ab-be52b43465ee">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques