### PR TITLE
(PC-29919)[API] feat: public api: deprecate collective endpoints

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/categories.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/categories.py
@@ -15,6 +15,7 @@ from pcapi.validation.routes.users_authentifications import api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[documentation_constants.COLLECTIVE_CATEGORIES],
+    deprecated=True,
     resp=SpectreeResponse(
         HTTP_200=(
             offers_serialization.CollectiveOffersListCategoriesResponseModel,
@@ -45,6 +46,7 @@ def list_categories() -> offers_serialization.CollectiveOffersListCategoriesResp
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[documentation_constants.COLLECTIVE_CATEGORIES],
+    deprecated=True,
     resp=SpectreeResponse(
         HTTP_200=(
             offers_serialization.CollectiveOffersListSubCategoriesResponseModel,

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -10122,6 +10122,7 @@
         },
         "/v2/collective/categories": {
             "get": {
+                "deprecated": true,
                 "description": "",
                 "operationId": "ListCategories",
                 "parameters": [],
@@ -10956,6 +10957,7 @@
         },
         "/v2/collective/subcategories": {
             "get": {
+                "deprecated": true,
                 "description": "",
                 "operationId": "ListSubcategories",
                 "parameters": [],


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29919

Marquer deux routes de l'API publique collective comme dépréciée : celles qui renvoient des informations sur les catégories et sous-catégories. Elles n'ont plus de raison d'être puisque les offres collectives fonctionnent désormais avec des formats à la place. Une correspondance permet d'utiliser des (sous)catégories mais il ne sera pas maintenu éternellement.

La version de Pydantic qui nous utilisons actuellement ne semble pas avoir la possibilité de marquer des champs comme dépréciés. Il s'agit de la seconde partie, optionnelle, du ticket.