### PR TITLE
(PC-29988)[PRO] style: Use laptop breakpoint for npp layout.

### DIFF
--- a/pro/src/app/App/layout/LateralPanel/LateralPanel.module.scss
+++ b/pro/src/app/App/layout/LateralPanel/LateralPanel.module.scss
@@ -66,7 +66,7 @@
   }
 }
 
-@media (min-width: size.$tablet) {
+@media (min-width: size.$laptop) {
   .lateral-panel {
     &-wrapper {
       z-index: zIndex.$lateral-menu-z-index;

--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -48,10 +48,13 @@
 .content {
   background-color: var(--color-white);
   padding: size.$main-content-padding;
-  border-radius: rem.torem(10px);
   max-width: rem.torem(size.$main-content-width);
-  margin: rem.torem(32px);
-  border: rem.torem(1px) solid var(--color-grey-medium);
+
+  @media (min-width: size.$mobile) {
+    border: rem.torem(1px) solid var(--color-grey-medium);
+    margin: rem.torem(32px);
+    border-radius: rem.torem(10px);
+  }
 }
 
 .connect-as {

--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -56,6 +56,12 @@
   }
 }
 
+@media (min-width: size.$laptop) {
+  .actions-bar-new-interface {
+    padding-left: calc(rem.torem(size.$side-nav-width) + rem.torem(32px));
+  }
+}
+
 @media (min-width: size.$tablet) {
   .actions-bar {
     position: fixed;
@@ -63,7 +69,6 @@
     border-top: unset;
 
     &-new-interface {
-      padding-left: calc(rem.torem(size.$side-nav-width) + rem.torem(32px));
       justify-content: flex-start;
       max-width: size.$desktop;
 

--- a/pro/src/components/Header/Header.module.scss
+++ b/pro/src/components/Header/Header.module.scss
@@ -41,7 +41,7 @@
     }
   }
 
-  @media (min-width: size.$tablet) {
+  @media (min-width: size.$laptop) {
     .burger-icon {
       display: none;
     }
@@ -65,7 +65,7 @@
 
     color: var(--color-input-text-color);
 
-    @media (min-width: size.$tablet) {
+    @media (min-width: size.$laptop) {
       margin-left: rem.torem(16px);
     }
 

--- a/pro/src/styles/variables/_size.scss
+++ b/pro/src/styles/variables/_size.scss
@@ -3,6 +3,7 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 
 $desktop: rem.torem(1440px);
+$laptop: rem.torem(1024px);
 $tablet: rem.torem(744px);
 $mobile: rem.torem(380px);
 $main-content-width: rem.torem(874px);


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29988

**Objectif**
Corriger le responsive des pages du NPP en remplaçant le breakpoint tablet par laptop dans les media queries liées au layout NPP.

Changements : 
- Affichage de la sidebar à partir du breakpoint laptop à la place de tablet
- Affichage du burger menu à partir du breakpoint laptop
- Ajout d'un padding left au actions bar sticky à partir du breakpoint laptop
- Retrait de la marge autour du contenu du layout en dessous du breakpoint mobile

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques