### PR TITLE
(PC-29991)[PRO] style: Make the dates & capacity tables responsive.

### DIFF
--- a/pro/src/components/StocksEventList/StocksEventList.module.scss
+++ b/pro/src/components/StocksEventList/StocksEventList.module.scss
@@ -2,6 +2,10 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_z-index.scss" as zIndex;
 
+.stock-event-table-container {
+  overflow-x: scroll;
+}
+
 .stock-event-table {
   width: 100%;
   table-layout: fixed;
@@ -65,6 +69,10 @@ $icon-size: rem.torem(20px);
 
 .date-column {
   width: rem.torem(192px);
+}
+
+.price-column {
+  width: rem.torem(174px);
 }
 
 .filter-input {

--- a/pro/src/components/StocksEventList/StocksEventList.tsx
+++ b/pro/src/components/StocksEventList/StocksEventList.tsx
@@ -367,288 +367,302 @@ export const StocksEventList = ({
             </div>
           </div>
 
-          <table className={styles['stock-event-table']}>
-            <caption className="visually-hidden">
-              Liste des dates et capacités
-            </caption>
+          <div className={styles['stock-event-table-container']}>
+            <table className={styles['stock-event-table']}>
+              <caption className="visually-hidden">
+                Liste des dates et capacités
+              </caption>
 
-            <thead>
-              <tr>
-                <th
-                  scope="col"
-                  className={cn(styles['date-column'], styles['header'])}
-                >
-                  <span className={styles['header-name']}>Date</span>
-
-                  <SortArrow
-                    onClick={() => onColumnHeaderClick(StocksOrderedBy.DATE)}
-                    sortingMode={
-                      currentSortingColumn === StocksOrderedBy.DATE
-                        ? currentSortingMode
-                        : SortingMode.NONE
-                    }
-                  />
-
-                  <div className={cn(styles['filter-input'])}>
-                    <BaseDatePicker
-                      onChange={(event) => {
-                        setDateFilter(event.target.value)
-                        onFilterChange()
-                      }}
-                      value={dateFilter ?? ''}
-                      filterVariant
-                      aria-label="Filtrer par date"
-                    />
-                  </div>
-                </th>
-
-                <th
-                  scope="col"
-                  className={cn(styles['time-column'], styles['header'])}
-                >
-                  <span className={styles['header-name']}>Horaire</span>
-
-                  <SortArrow
-                    onClick={() => onColumnHeaderClick(StocksOrderedBy.TIME)}
-                    sortingMode={
-                      currentSortingColumn === StocksOrderedBy.TIME
-                        ? currentSortingMode
-                        : SortingMode.NONE
-                    }
-                  />
-                  <div className={cn(styles['filter-input'])}>
-                    <BaseTimePicker
-                      onChange={(event) => {
-                        setTimeFilter(event.target.value)
-                        onFilterChange()
-                      }}
-                      value={timeFilter ?? ''}
-                      filterVariant
-                      aria-label="Filtrer par horaire"
-                    />
-                  </div>
-                </th>
-
-                <th scope="col" className={styles['header']}>
-                  <span className={styles['header-name']}>Tarif</span>
-
-                  <SortArrow
-                    onClick={() =>
-                      onColumnHeaderClick(StocksOrderedBy.PRICE_CATEGORY_ID)
-                    }
-                    sortingMode={
-                      currentSortingColumn === StocksOrderedBy.PRICE_CATEGORY_ID
-                        ? currentSortingMode
-                        : SortingMode.NONE
-                    }
-                  />
-                  <div className={cn(styles['filter-input'])}>
-                    <SelectInput
-                      name="priceCategoryFilter"
-                      defaultOption={{ label: '', value: '' }}
-                      options={priceCategoryOptions}
-                      value={priceCategoryIdFilter ?? ''}
-                      onChange={(event) => {
-                        setPriceCategoryIdFilter(event.target.value)
-                        onFilterChange()
-                      }}
-                      filterVariant
-                      aria-label="Filtrer par tarif"
-                    />
-                  </div>
-                </th>
-
-                <th
-                  scope="col"
-                  className={cn(
-                    styles['booking-limit-date-column'],
-                    styles['header']
-                  )}
-                >
-                  <span className={styles['header-name']}>
-                    Date limite
-                    <br />
-                    de réservation
-                  </span>
-
-                  <SortArrow
-                    onClick={() =>
-                      onColumnHeaderClick(
-                        StocksOrderedBy.BOOKING_LIMIT_DATETIME
-                      )
-                    }
-                    sortingMode={
-                      currentSortingColumn ===
-                      StocksOrderedBy.BOOKING_LIMIT_DATETIME
-                        ? currentSortingMode
-                        : SortingMode.NONE
-                    }
-                  />
-                  <div className={cn(styles['filter-input'])}>&nbsp;</div>
-                </th>
-
-                <th
-                  scope="col"
-                  className={cn(styles['quantity-column'], styles['header'])}
-                >
-                  <span className={styles['header-name']}>Places</span>
-
-                  <SortArrow
-                    onClick={() =>
-                      onColumnHeaderClick(StocksOrderedBy.REMAINING_QUANTITY)
-                    }
-                    sortingMode={
-                      currentSortingColumn ===
-                      StocksOrderedBy.REMAINING_QUANTITY
-                        ? currentSortingMode
-                        : SortingMode.NONE
-                    }
-                  />
-                  <div className={cn(styles['filter-input'])}>&nbsp;</div>
-                </th>
-
-                {readonly ? (
+              <thead>
+                <tr>
                   <th
-                    className={cn(
-                      styles['bookings-quantity-column'],
-                      styles['header']
-                    )}
+                    scope="col"
+                    className={cn(styles['date-column'], styles['header'])}
                   >
-                    <span className={styles['header-name']}>Réservations</span>
+                    <span className={styles['header-name']}>Date</span>
+
+                    <SortArrow
+                      onClick={() => onColumnHeaderClick(StocksOrderedBy.DATE)}
+                      sortingMode={
+                        currentSortingColumn === StocksOrderedBy.DATE
+                          ? currentSortingMode
+                          : SortingMode.NONE
+                      }
+                    />
+
+                    <div className={cn(styles['filter-input'])}>
+                      <BaseDatePicker
+                        onChange={(event) => {
+                          setDateFilter(event.target.value)
+                          onFilterChange()
+                        }}
+                        value={dateFilter ?? ''}
+                        filterVariant
+                        aria-label="Filtrer par date"
+                      />
+                    </div>
+                  </th>
+
+                  <th
+                    scope="col"
+                    className={cn(styles['time-column'], styles['header'])}
+                  >
+                    <span className={styles['header-name']}>Horaire</span>
+
+                    <SortArrow
+                      onClick={() => onColumnHeaderClick(StocksOrderedBy.TIME)}
+                      sortingMode={
+                        currentSortingColumn === StocksOrderedBy.TIME
+                          ? currentSortingMode
+                          : SortingMode.NONE
+                      }
+                    />
+                    <div className={cn(styles['filter-input'])}>
+                      <BaseTimePicker
+                        onChange={(event) => {
+                          setTimeFilter(event.target.value)
+                          onFilterChange()
+                        }}
+                        value={timeFilter ?? ''}
+                        filterVariant
+                        aria-label="Filtrer par horaire"
+                      />
+                    </div>
+                  </th>
+
+                  <th
+                    scope="col"
+                    className={cn(styles['price-column'], styles['header'])}
+                  >
+                    <span className={styles['header-name']}>Tarif</span>
 
                     <SortArrow
                       onClick={() =>
-                        onColumnHeaderClick(StocksOrderedBy.DN_BOOKED_QUANTITY)
+                        onColumnHeaderClick(StocksOrderedBy.PRICE_CATEGORY_ID)
                       }
                       sortingMode={
                         currentSortingColumn ===
-                        StocksOrderedBy.DN_BOOKED_QUANTITY
+                        StocksOrderedBy.PRICE_CATEGORY_ID
+                          ? currentSortingMode
+                          : SortingMode.NONE
+                      }
+                    />
+                    <div className={cn(styles['filter-input'])}>
+                      <SelectInput
+                        name="priceCategoryFilter"
+                        defaultOption={{ label: '', value: '' }}
+                        options={priceCategoryOptions}
+                        value={priceCategoryIdFilter ?? ''}
+                        onChange={(event) => {
+                          setPriceCategoryIdFilter(event.target.value)
+                          onFilterChange()
+                        }}
+                        filterVariant
+                        aria-label="Filtrer par tarif"
+                      />
+                    </div>
+                  </th>
+
+                  <th
+                    scope="col"
+                    className={cn(
+                      styles['booking-limit-date-column'],
+                      styles['header']
+                    )}
+                  >
+                    <span className={styles['header-name']}>
+                      Date limite
+                      <br />
+                      de réservation
+                    </span>
+
+                    <SortArrow
+                      onClick={() =>
+                        onColumnHeaderClick(
+                          StocksOrderedBy.BOOKING_LIMIT_DATETIME
+                        )
+                      }
+                      sortingMode={
+                        currentSortingColumn ===
+                        StocksOrderedBy.BOOKING_LIMIT_DATETIME
                           ? currentSortingMode
                           : SortingMode.NONE
                       }
                     />
                     <div className={cn(styles['filter-input'])}>&nbsp;</div>
                   </th>
-                ) : (
+
                   <th
-                    className={cn(styles['actions-column'], styles['header'])}
+                    scope="col"
+                    className={cn(styles['quantity-column'], styles['header'])}
+                  >
+                    <span className={styles['header-name']}>Places</span>
+
+                    <SortArrow
+                      onClick={() =>
+                        onColumnHeaderClick(StocksOrderedBy.REMAINING_QUANTITY)
+                      }
+                      sortingMode={
+                        currentSortingColumn ===
+                        StocksOrderedBy.REMAINING_QUANTITY
+                          ? currentSortingMode
+                          : SortingMode.NONE
+                      }
+                    />
+                    <div className={cn(styles['filter-input'])}>&nbsp;</div>
+                  </th>
+
+                  {readonly ? (
+                    <th
+                      className={cn(
+                        styles['bookings-quantity-column'],
+                        styles['header']
+                      )}
+                    >
+                      <span className={styles['header-name']}>
+                        Réservations
+                      </span>
+
+                      <SortArrow
+                        onClick={() =>
+                          onColumnHeaderClick(
+                            StocksOrderedBy.DN_BOOKED_QUANTITY
+                          )
+                        }
+                        sortingMode={
+                          currentSortingColumn ===
+                          StocksOrderedBy.DN_BOOKED_QUANTITY
+                            ? currentSortingMode
+                            : SortingMode.NONE
+                        }
+                      />
+                      <div className={cn(styles['filter-input'])}>&nbsp;</div>
+                    </th>
+                  ) : (
+                    <th
+                      className={cn(styles['actions-column'], styles['header'])}
+                    />
+                  )}
+                </tr>
+              </thead>
+
+              <tbody>
+                {areFiltersActive && (
+                  <FilterResultsRow
+                    colSpan={6}
+                    onFiltersReset={() => {
+                      setDateFilter('')
+                      setTimeFilter('')
+                      setPriceCategoryIdFilter('')
+                      onFilterChange()
+                    }}
                   />
                 )}
-              </tr>
-            </thead>
 
-            <tbody>
-              {areFiltersActive && (
-                <FilterResultsRow
-                  colSpan={6}
-                  onFiltersReset={() => {
-                    setDateFilter('')
-                    setTimeFilter('')
-                    setPriceCategoryIdFilter('')
-                    onFilterChange()
-                  }}
-                />
-              )}
+                {stocks.map((stock) => {
+                  const beginningDay = formatLocalTimeDateString(
+                    stock.beginningDatetime,
+                    departmentCode,
+                    'eee'
+                  ).replace('.', '')
 
-              {stocks.map((stock) => {
-                const beginningDay = formatLocalTimeDateString(
-                  stock.beginningDatetime,
-                  departmentCode,
-                  'eee'
-                ).replace('.', '')
+                  const beginningDate = formatLocalTimeDateString(
+                    stock.beginningDatetime,
+                    departmentCode,
+                    'dd/MM/yyyy'
+                  )
 
-                const beginningDate = formatLocalTimeDateString(
-                  stock.beginningDatetime,
-                  departmentCode,
-                  'dd/MM/yyyy'
-                )
+                  const beginningHour = formatLocalTimeDateString(
+                    stock.beginningDatetime,
+                    departmentCode,
+                    'HH:mm'
+                  )
+                  const bookingLimitDate = formatLocalTimeDateString(
+                    stock.bookingLimitDatetime,
+                    departmentCode,
+                    'dd/MM/yyyy'
+                  )
+                  const priceCategory = priceCategories.find(
+                    (pC) => pC.id === stock.priceCategoryId
+                  )
 
-                const beginningHour = formatLocalTimeDateString(
-                  stock.beginningDatetime,
-                  departmentCode,
-                  'HH:mm'
-                )
-                const bookingLimitDate = formatLocalTimeDateString(
-                  stock.bookingLimitDatetime,
-                  departmentCode,
-                  'dd/MM/yyyy'
-                )
-                const priceCategory = priceCategories.find(
-                  (pC) => pC.id === stock.priceCategoryId
-                )
+                  let price = ''
+                  /* istanbul ignore next priceCategory would never be null */
+                  if (priceCategory) {
+                    price = `${formatPrice(
+                      priceCategory.price
+                    )} - ${priceCategory.label}`
+                  }
 
-                let price = ''
-                /* istanbul ignore next priceCategory would never be null */
-                if (priceCategory) {
-                  price = `${formatPrice(
-                    priceCategory.price
-                  )} - ${priceCategory.label}`
-                }
-
-                const stockIndex = stocks.findIndex((s) => s.id === stock.id)
-                return (
-                  <tr key={stock.id} className={styles['row']}>
-                    <td className={styles['data']}>
-                      <div
-                        className={cn(
-                          styles['date-cell-wrapper'],
-                          styles['capitalize']
-                        )}
-                      >
-                        {!readonly && (
-                          <BaseCheckbox
-                            checked={checkedStocks[stockIndex]}
-                            onChange={() => onStockCheckChange(stockIndex)}
-                            label=""
-                          />
-                        )}
-
-                        <div className={styles['day']}>
-                          <strong>{beginningDay}</strong>
-                        </div>
-                        <div>{beginningDate}</div>
-                      </div>
-                    </td>
-
-                    <td className={styles['data']}>{beginningHour}</td>
-
-                    <td className={styles['data']}>{price}</td>
-
-                    <td className={styles['data']}>{bookingLimitDate}</td>
-
-                    <td className={styles['data']}>
-                      {stock.quantity === null
-                        ? 'Illimité'
-                        : new Intl.NumberFormat('fr-FR').format(stock.quantity)}
-                    </td>
-
-                    {readonly ? (
+                  const stockIndex = stocks.findIndex((s) => s.id === stock.id)
+                  return (
+                    <tr key={stock.id} className={styles['row']}>
                       <td className={styles['data']}>
-                        {stock.bookingsQuantity}
-                      </td>
-                    ) : (
-                      <td className={cn(styles['data'], styles['clear-icon'])}>
-                        <Button
-                          variant={ButtonVariant.TERNARY}
-                          onClick={async () => {
-                            if (stock.id.toString()) {
-                              await onDeleteStock(stockIndex, stock.id)
-                            }
-                          }}
-                          icon={fullTrashIcon}
-                          hasTooltip
+                        <div
+                          className={cn(
+                            styles['date-cell-wrapper'],
+                            styles['capitalize']
+                          )}
                         >
-                          Supprimer
-                        </Button>
-                      </td>
-                    )}
-                  </tr>
-                )
-              })}
+                          {!readonly && (
+                            <BaseCheckbox
+                              checked={checkedStocks[stockIndex]}
+                              onChange={() => onStockCheckChange(stockIndex)}
+                              label=""
+                            />
+                          )}
 
-              {stocks.length === 0 && <NoResultsRow colSpan={6} />}
-            </tbody>
-          </table>
+                          <div className={styles['day']}>
+                            <strong>{beginningDay}</strong>
+                          </div>
+                          <div>{beginningDate}</div>
+                        </div>
+                      </td>
+
+                      <td className={styles['data']}>{beginningHour}</td>
+
+                      <td className={styles['data']}>{price}</td>
+
+                      <td className={styles['data']}>{bookingLimitDate}</td>
+
+                      <td className={styles['data']}>
+                        {stock.quantity === null
+                          ? 'Illimité'
+                          : new Intl.NumberFormat('fr-FR').format(
+                              stock.quantity
+                            )}
+                      </td>
+
+                      {readonly ? (
+                        <td className={styles['data']}>
+                          {stock.bookingsQuantity}
+                        </td>
+                      ) : (
+                        <td
+                          className={cn(styles['data'], styles['clear-icon'])}
+                        >
+                          <Button
+                            variant={ButtonVariant.TERNARY}
+                            onClick={async () => {
+                              if (stock.id.toString()) {
+                                await onDeleteStock(stockIndex, stock.id)
+                              }
+                            }}
+                            icon={fullTrashIcon}
+                            hasTooltip
+                          >
+                            Supprimer
+                          </Button>
+                        </td>
+                      )}
+                    </tr>
+                  )
+                })}
+
+                {stocks.length === 0 && <NoResultsRow colSpan={6} />}
+              </tbody>
+            </table>
+          </div>
 
           <Pagination
             currentPage={page}

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.module.scss
@@ -7,6 +7,10 @@
   margin-bottom: rem.torem(32px);
 }
 
+.stock-table-container {
+  overflow-x: scroll;
+}
+
 .stock-table {
   margin-top: rem.torem(16px);
   table-layout: fixed;
@@ -53,6 +57,10 @@
 
 .head-time {
   width: rem.torem(105px);
+}
+
+.head-price {
+  width: rem.torem(171px);
 }
 
 .head-booking-limit-datetime {

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -470,7 +470,7 @@ const StocksEventEdition = ({
             <FieldArray
               name="stocks"
               render={() => (
-                <>
+                <div className={styles['stock-table-container']}>
                   <table className={styles['stock-table']}>
                     <caption className="visually-hidden">
                       Tableau d’édition des stocks
@@ -855,7 +855,7 @@ const StocksEventEdition = ({
                       onCancel={() => setStockToDeleteWithConfirmation(null)}
                     />
                   )}
-                </>
+                </div>
               )}
             />
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29991

**Objectif**
Rendre la page des dates et capacités d'une offre indiv responsive. On a rendu la table scrollable horizontalement. Reste à voir avec Julie si c'est conforme au RGAA, et idéalement il faudrait un nouveau design pour le responsive des tables comme celle-ci.

<img width="351" alt="Capture d’écran 2024-05-27 à 15 12 21" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/f48394cf-c831-4e07-bdbe-6acb067077cd">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques