### PR TITLE
(PC-29816)[PRO] feat: dont display create offer button when offerer n…

### DIFF
--- a/pro/src/components/SideNavLinks/SideNavLinks.tsx
+++ b/pro/src/components/SideNavLinks/SideNavLinks.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavLink, useLocation } from 'react-router-dom'
 import useSWR from 'swr'
@@ -49,11 +49,19 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
   const isIndividualSectionOpen = useSelector(selectIsIndividualSectionOpen)
   const isCollectiveSectionOpen = useSelector(selectIsCollectiveSectionOpen)
   const selectedOffererId = useSelector(selectCurrentOffererId)
+  const [isUserOffererValidated, setIsUserOffererValidated] = useState(false)
 
   const selectedOffererQuery = useSWR(
     [GET_OFFERER_QUERY_KEY, selectedOffererId],
     async ([, offererId]) => {
-      return await api.getOfferer(Number(offererId))
+      try {
+        const response = await api.getOfferer(Number(offererId))
+        setIsUserOffererValidated(true)
+        return response
+      } catch (error) {
+        setIsUserOffererValidated(false)
+        return null
+      }
     }
   )
 
@@ -85,14 +93,16 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
       })}
     >
       <div className={styles['nav-links-first-group']}>
-        <li className={styles['nav-links-create-offer-wrapper']}>
-          <ButtonLink
-            variant={ButtonVariant.PRIMARY}
-            link={{ isExternal: false, to: createOfferPageUrl }}
-          >
-            Créer une offre
-          </ButtonLink>
-        </li>
+        {!selectedOffererQuery.isLoading && isUserOffererValidated && (
+          <li className={styles['nav-links-create-offer-wrapper']}>
+            <ButtonLink
+              variant={ButtonVariant.PRIMARY}
+              link={{ isExternal: false, to: createOfferPageUrl }}
+            >
+              Créer une offre
+            </ButtonLink>
+          </li>
+        )}
         <li>
           <NavLink
             to="/accueil"

--- a/pro/src/components/SideNavLinks/__specs__/SideNavLinks.spec.tsx
+++ b/pro/src/components/SideNavLinks/__specs__/SideNavLinks.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { api } from 'apiClient/api'
@@ -70,5 +70,21 @@ describe('SideNavLinks', () => {
     })
 
     expect(screen.queryByText('Page sur l’application')).not.toBeInTheDocument()
+  })
+
+  it('should not display create offre button if offerer is not validated', async () => {
+    vi.spyOn(api, 'getOfferer').mockRejectedValueOnce({})
+
+    renderSideNavLinks({
+      user: sharedCurrentUserFactory({ hasPartnerPage: false }),
+    })
+
+    await waitFor(() => {
+      expect(api.getOfferer).toHaveBeenCalled()
+    })
+
+    expect(
+      screen.queryByRole('link', { name: 'Créer une offre' })
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
…ot validated

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29816

Ne pas afficher le bouton de création d'offre dans la barre de nav quand l'utilisateur est en cours de rattachement à la structure sélectionnée est en cours de rattachement 

## Screen

![Capture d’écran 2024-05-28 à 09 32 30](https://github.com/pass-culture/pass-culture-main/assets/71768799/796cd14b-c116-4e82-8b7e-280c7f7bff26)
