### PR TITLE
(PC-29728)[PRO] fix: add break-word for email in profile dropdown

### DIFF
--- a/pro/src/components/Header/HeaderDropdown/HeaderDropdown.module.scss
+++ b/pro/src/components/Header/HeaderDropdown/HeaderDropdown.module.scss
@@ -71,6 +71,11 @@ $profil-button-size: rem.torem(34px);
     border: solid rem.torem(1px) var(--color-grey-medium);
   }
 
+  &-email {
+    max-width: 100%;
+    overflow-wrap: break-word;
+  }
+
   &-title {
     @include fonts.caption;
 

--- a/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
+++ b/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
@@ -30,7 +30,7 @@ const HeaderDropdown = () => {
             <DropdownMenu.Label className={styles['menu-title']}>
               Profil
             </DropdownMenu.Label>
-            <div>{currentUser?.email}</div>
+            <div className={styles['menu-email']}>{currentUser?.email}</div>
             <DropdownMenu.Item className={styles['close-item']}>
               <button className={styles['close-button']}>
                 <SvgIcon


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29728

Retour à la ligne pour l'adresse mail de la pop-in profile du header dans le cas ou l'email est trop long. 

## Screen

![Capture d’écran 2024-05-28 à 10 02 00](https://github.com/pass-culture/pass-culture-main/assets/71768799/7d98f058-4235-4593-bb2b-ab90e7747077)
