### PR TITLE
(PC-29984)[PRO] fix: dont get collective request when id is null

### DIFF
--- a/pro/src/pages/CollectiveOfferFromRequest/CollectiveOfferFromRequest.tsx
+++ b/pro/src/pages/CollectiveOfferFromRequest/CollectiveOfferFromRequest.tsx
@@ -34,12 +34,15 @@ export const CollectiveOfferFromRequest = (): JSX.Element => {
   }>()
 
   const { data: offerTemplate } = useSWR(
-    [GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY, offerId],
+    () => (offerId ? [GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY, offerId] : null),
     ([, offerIdParams]) => api.getCollectiveOfferTemplate(Number(offerIdParams))
   )
 
   const { isLoading, data: informations } = useSWR(
-    [GET_COLLECTIVE_REQUEST_INFORMATIONS_QUERY_KEY, requestId],
+    () =>
+      requestId
+        ? [GET_COLLECTIVE_REQUEST_INFORMATIONS_QUERY_KEY, requestId]
+        : null,
     ([, id]) => api.getCollectiveOfferRequest(Number(id))
   )
 

--- a/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -58,7 +58,10 @@ export const CollectiveOfferStockCreation = ({
   )
 
   const { data: requestInformations } = useSWR(
-    [GET_COLLECTIVE_REQUEST_INFORMATIONS_QUERY_KEY, requestId],
+    () =>
+      requestId
+        ? [GET_COLLECTIVE_REQUEST_INFORMATIONS_QUERY_KEY, requestId]
+        : null,
     ([, id]) => api.getCollectiveOfferRequest(Number(id))
   )
 

--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -116,7 +116,10 @@ export const CollectiveOfferVisibilityScreen = ({
   )
 
   const { data: requestInformations } = useSWR(
-    [GET_COLLECTIVE_REQUEST_INFORMATIONS_QUERY_KEY, requestId],
+    () =>
+      requestId
+        ? [GET_COLLECTIVE_REQUEST_INFORMATIONS_QUERY_KEY, requestId]
+        : null,
     ([, id]) => api.getCollectiveOfferRequest(Number(id))
   )
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29984

Vérifier que l'id de la request n'est pas null avant de faire l'appel API