### PR TITLE
(PC-29981)[PRO] style: Make radio groups responsive by removing the n…

### DIFF
--- a/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
+++ b/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
@@ -11,6 +11,7 @@ interface RadioButtonProps
   value: string
   withBorder?: boolean
   hasError?: boolean
+  fullWidth?: boolean
 }
 
 export const RadioButton = ({
@@ -19,6 +20,7 @@ export const RadioButton = ({
   label,
   value,
   withBorder,
+  fullWidth,
   className,
   hasError,
   onChange,
@@ -46,6 +48,7 @@ export const RadioButton = ({
       checked={field.checked}
       hasError={hasError}
       withBorder={withBorder}
+      fullWidth={fullWidth}
       onChange={(e) => onCustomChange(e)}
     />
   )

--- a/pro/src/ui-kit/form/RadioGroup/RadioGroup.tsx
+++ b/pro/src/ui-kit/form/RadioGroup/RadioGroup.tsx
@@ -59,6 +59,7 @@ export const RadioGroup = ({
             value={item.value}
             withBorder={withBorder}
             hasError={meta.touched && !!meta.error}
+            fullWidth
           />
         </div>
       ))}

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
@@ -5,7 +5,6 @@
   display: inline-flex;
   align-items: center;
   cursor: pointer;
-  width: 100%;
 
   &-label {
     line-height: rem.torem(16px);
@@ -100,7 +99,6 @@
 
   .base-radio-label {
     padding: rem.torem(16px) rem.torem(16px) rem.torem(16px) 0;
-    white-space: nowrap;
   }
 
   &:focus-within {
@@ -136,4 +134,8 @@
       padding: rem.torem(16px) rem.torem(16px) rem.torem(16px) 0;
     }
   }
+}
+
+.full-width {
+  width: 100%;
 }

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
@@ -9,6 +9,7 @@ interface BaseRadioProps
   hasError?: boolean
   className?: string
   withBorder?: boolean
+  fullWidth?: boolean
 }
 
 export const BaseRadio = ({
@@ -16,6 +17,7 @@ export const BaseRadio = ({
   hasError,
   className,
   withBorder = false,
+  fullWidth = false,
   ...props
 }: BaseRadioProps): JSX.Element => {
   const id = useId()
@@ -27,6 +29,7 @@ export const BaseRadio = ({
         {
           [styles[`with-border`]]: withBorder,
           [styles[`is-disabled`]]: props.disabled,
+          [styles[`full-width`]]: fullWidth,
           [styles[`with-border-checked`]]:
             withBorder && props.checked && !props.disabled,
         },


### PR DESCRIPTION
…owrap style and making them automatically full width.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29981

**Objectif**
Corriger le responsive des radio buttons dans le cas du radio group (par exemple dans le formulaire de créatio d'offre collective vitrine, les radio buttons concernant la période de réservation sort de l'écran entre tablet et laptop). Pour corriger, j'ai empêché le nowrap des labels, et j'ai ajouté le width 100% optionnel sur le radio button (appliqué automatiquement dans le cas du radio group) qui si il est appliqué tout le temps sans le nowrap casse les radio buttons du dialog d'évaluation du NPP.

Tout est iso, à part le cas de la création d'offre collective qui est responsive.

Avant :
<img width="484" alt="Capture d’écran 2024-05-27 à 11 22 26" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/193396d6-caac-4e7b-907f-8cbb930cef67">

Après :
<img width="689" alt="Capture d’écran 2024-05-28 à 10 10 03" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/3dd59442-460a-47ad-b9d1-850d84f7adfa">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques