### PR TITLE
(BSR) fix: empty string subcategories to None

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -46,6 +46,28 @@ def validate_venue_id(venue_id: int | str | None) -> int | None:
     return int(venue_id)  # should not be needed but it makes mypy happy
 
 
+def strip_string(s: str | None) -> str | None:
+    if not s:
+        return s
+    return s.strip()
+
+
+def empty_to_null(s: str | None) -> str | None:
+    if not s:
+        return None
+    return s
+
+
+class EmptyAsNullString(str):
+    @classmethod
+    def __get_validators__(cls) -> typing.Generator[typing.Callable, None, None]:
+        yield strip_string
+        yield empty_to_null
+
+
+EmptyStringToNone = EmptyAsNullString | None
+
+
 class ListCollectiveOffersQueryModel(BaseModel):
     nameOrIsbn: str | None
     offerer_id: int | None
@@ -101,7 +123,7 @@ class CollectiveOfferResponseModel(BaseModel):
     name: str
     stocks: list[CollectiveOffersStockResponseModel]
     booking: CollectiveOffersBookingResponseModel | None
-    subcategoryId: SubcategoryIdEnum | None
+    subcategoryId: SubcategoryIdEnum | EmptyStringToNone
     isShowcase: bool
     venue: base_serializers.ListOffersVenueResponseModel
     status: OfferStatus
@@ -294,7 +316,7 @@ class GetCollectiveOfferBaseResponseModel(BaseModel, AccessibilityComplianceMixi
     isEditable: bool
     id: int
     name: str
-    subcategoryId: SubcategoryIdEnum | None
+    subcategoryId: SubcategoryIdEnum | EmptyStringToNone
     venue: GetCollectiveOfferVenueResponseModel
     status: OfferStatus
     domains: list[OfferDomain]
@@ -613,7 +635,7 @@ class PatchCollectiveOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     contactEmail: EmailStr | None
     contactPhone: str | None
     durationMinutes: int | None
-    subcategoryId: SubcategoryIdEnum | None
+    subcategoryId: SubcategoryIdEnum | EmptyStringToNone
     domains: list[int] | None
     interventionArea: list[str] | None
     venueId: int | None

--- a/api/tests/routes/pro/get_all_collective_offers_test.py
+++ b/api/tests/routes/pro/get_all_collective_offers_test.py
@@ -344,6 +344,26 @@ class Returns200Test:
         assert len(response_json[0]["stocks"]) == 1
         assert response_json[0]["isShowcase"] is True
 
+    def test_offers_with_empty_string_subcategory_instead_of_none(self, client):
+        """Test that a list of offers can contain one that has a legal
+        but unexpected subcategory (empty string instead if none).
+        """
+        user = users_factories.UserFactory()
+        offerer = offerer_factories.OffererFactory()
+        offerer_factories.UserOffererFactory(user=user, offerer=offerer)
+
+        venue = offerer_factories.VenueFactory(managingOfferer=offerer)
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, subcategoryId="")
+        educational_factories.CollectiveStockFactory(collectiveOffer=offer)
+
+        response = client.with_session_auth(user.email).get("/collective/offers")
+        response_json = response.json
+
+        assert response.status_code == 200
+        assert isinstance(response_json, list)
+        assert len(response_json) == 1
+        assert response_json[0]["subcategoryId"] is None
+
 
 @pytest.mark.usefixtures("db_session")
 class Return400Test:

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -211,6 +211,24 @@ class Returns200Test:
             "otherAddress": "some address",
         }
 
+    def test_offer_with_empty_string_subcategory_instead_of_none(self, client):
+        """Test that an offer with a legal but unexpected subcategory
+        (empty string instead if none) can be serialized.
+        """
+        user = users_factories.UserFactory()
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=user, offerer=offerer)
+
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, subcategoryId="")
+        educational_factories.CollectiveStockFactory(collectiveOffer=offer)
+
+        dst = url_for("Private API.get_collective_offer", offer_id=offer.id)
+        response = client.with_session_auth(user.email).get(dst)
+
+        assert response.status_code == 200
+        assert response.json["subcategoryId"] is None
+
 
 @pytest.mark.usefixtures("db_session")
 class Returns403Test:


### PR DESCRIPTION
## But de la pull request

Bug : certaines offres collectives ont pour sous-catégorie '' (texte vide) ce qui cause des problèmes à la sérialisation.
Fix : transformer les `''` en `None`.