### PR TITLE
(PC-30039)[PRO] style: Fix height of sidebar with NPP with new breakp…

### DIFF
--- a/pro/src/components/SideNavLinks/SideNavLinks.module.scss
+++ b/pro/src/components/SideNavLinks/SideNavLinks.module.scss
@@ -49,7 +49,7 @@
     min-height: calc(100% - #{size.$top-menu-height});
     height: auto;
 
-    @media (min-width: size.$tablet) {
+    @media (min-width: size.$laptop) {
       min-height: 100%;
       height: auto;
     }


### PR DESCRIPTION
…oints.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30039

**Objectif**
Corriger l'affichage de la height en fonction des breakpoints après le changement de breakpoint tablet -> laptop. Il reste une media query en tablet qui devrait être en laptop qui gère la hauteur de la sidebar NPP.
Avant :
<img width="333" alt="Capture d’écran 2024-05-28 à 17 06 24" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/267c3f3e-778f-4afa-8db8-254c9bab5f58">

Après :
<img width="308" alt="Capture d’écran 2024-05-28 à 17 13 28" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/3b14290b-50cc-4fbc-8449-6e4f2a7d48b4">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques