### PR TITLE
Pc 29728 api fix offer serialisation when oa has no label

### DIFF
--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -358,7 +358,7 @@ class GetOffererV2StatsResponseModel(BaseModel):
 
 class GetOffererAddressResponseModel(BaseModel):
     id: int
-    label: str
+    label: str | None
     street: str
     postalCode: str
     city: str

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -394,6 +394,7 @@ class IndividualOfferResponseGetterDict(GetterDict):
             if not self._obj.offererAddress:
                 return None
             offererAddress = GetOffererAddressResponseModel.from_orm(self._obj.offererAddress)
+            offererAddress.label = offererAddress.label or self._obj.venue.common_name
             return AddressResponseIsEditableModel(
                 id=self._obj.offererAddress.addressId,
                 banId=self._obj.offererAddress.address.banId,

--- a/pro/src/apiClient/v1/models/GetOffererAddressResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererAddressResponseModel.ts
@@ -6,7 +6,7 @@ export type GetOffererAddressResponseModel = {
   city: string;
   id: number;
   isEditable: boolean;
-  label: string;
+  label?: string | null;
   postalCode: string;
   street: string;
 };

--- a/pro/src/apiClient/v1/models/OffererAddressResponseModel.ts
+++ b/pro/src/apiClient/v1/models/OffererAddressResponseModel.ts
@@ -6,7 +6,7 @@ import type { AddressResponseModel } from './AddressResponseModel';
 export type OffererAddressResponseModel = {
   address: AddressResponseModel;
   id: number;
-  label: string;
+  label?: string | null;
   offererId: number;
 };
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29728

Afficher le nom du lieu pour un OA sans label. Ce cas concerne seulement les OA directement lié à une venue. 
