### PR TITLE
(PC-30087)[PRO] fix: Dont allow finished collective offers to be disa…

### DIFF
--- a/pro/src/pages/Offers/Offers/ActionsBar/ActionsBar.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/ActionsBar.tsx
@@ -185,7 +185,8 @@ function canDeactivateCollectiveOffers(
     return (
       offer.status === OfferStatus.ACTIVE ||
       (offer.status === OfferStatus.EXPIRED &&
-        offer.booking?.booking_status !== CollectiveBookingStatus.CANCELLED)
+        (!offer.booking?.booking_status ||
+          offer.booking.booking_status === CollectiveBookingStatus.CANCELLED))
     )
   })
 }

--- a/pro/src/pages/Offers/Offers/ActionsBar/__specs__/ActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/__specs__/ActionsBar.spec.tsx
@@ -266,7 +266,7 @@ describe('ActionsBar', () => {
       )
     ).toBeInTheDocument()
   })
-  it('should not deactivate offers on click on "Désactiver" when at least one offer expired but with booking cancelled', async () => {
+  it('should not deactivate offers on click on "Désactiver" when at least one offer expired but with booking finished', async () => {
     const expiredOffer = collectiveOfferFactory({
       id: 1,
       status: OfferStatus.EXPIRED,
@@ -277,7 +277,10 @@ describe('ActionsBar', () => {
       selectedOffers: [
         {
           ...expiredOffer,
-          booking: { booking_status: CollectiveBookingStatus.CANCELLED, id: 3 },
+          booking: {
+            booking_status: CollectiveBookingStatus.REIMBURSED,
+            id: 3,
+          },
         },
         collectiveOfferFactory({ id: 2, status: OfferStatus.ACTIVE }),
       ],


### PR DESCRIPTION
…bled.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30087

**Objectif**
Corriger la condition qui autorise une offre collective à être désactivée. On autorisait les offres expirées dont le booking status n'existe pas, ou est différent de cancelled. Ce qui autorisait les offres terminées (offre expired + booking reimbursed) à être désactivée.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques