### PR TITLE
(PC-30041)[PRO] feat: Integration of accessibility pages

### DIFF
--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -317,4 +317,24 @@ export const routes: RouteConfig[] = [
     path: '/plan-du-site',
     title: 'Plan du site',
   },
+  {
+    lazy: () => import('pages/Accessibility/Accessibility'),
+    path: '/accessibilite',
+    title: 'Informations d’accessibilité',
+  },
+  {
+    lazy: () => import('pages/Accessibility/Commitment'),
+    path: '/accessibilite/engagements',
+    title: 'Les engagements du pass Culture',
+  },
+  {
+    lazy: () => import('pages/Accessibility/Declaration'),
+    path: '/accessibilite/declaration',
+    title: "Déclaration d'accessibilité",
+  },
+  {
+    lazy: () => import('pages/Accessibility/MultiyearScheme'),
+    path: '/accessibilite/schema-pluriannuel',
+    title: 'Schéma pluriannuel',
+  },
 ]

--- a/pro/src/pages/Accessibility/Accessibility.module.scss
+++ b/pro/src/pages/Accessibility/Accessibility.module.scss
@@ -1,0 +1,17 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.menu-accessibility {
+  display: flex;
+  flex-direction: column;
+  gap: rem.torem(8px);
+}
+
+.button-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title-accessibility {
+  margin-bottom: rem.torem(32px);
+}

--- a/pro/src/pages/Accessibility/Accessibility.tsx
+++ b/pro/src/pages/Accessibility/Accessibility.tsx
@@ -1,0 +1,55 @@
+import { AppLayout } from 'app/AppLayout'
+import strokeRigthIcon from 'icons/stroke-right.svg'
+import { ButtonLink } from 'ui-kit/Button/ButtonLink'
+import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
+
+import styles from './Accessibility.module.scss'
+
+export const Accessibility = () => {
+  return (
+    <AppLayout>
+      <h1 className={styles['title-accessibility']}>
+        Informations d’accessibilité
+      </h1>
+
+      <div className={styles['menu-accessibility']}>
+        <ButtonLink
+          link={{
+            to: `accessibilite/engagements`,
+          }}
+          variant={ButtonVariant.BOX}
+          icon={strokeRigthIcon}
+          iconPosition={IconPositionEnum.RIGHT}
+          className={styles['button-link']}
+        >
+          Les engagements du pass Culture
+        </ButtonLink>
+        <ButtonLink
+          link={{
+            to: `/accessibilite/declaration`,
+          }}
+          variant={ButtonVariant.BOX}
+          icon={strokeRigthIcon}
+          className={styles['button-link']}
+          iconPosition={IconPositionEnum.RIGHT}
+        >
+          Déclaration d’accessibilité
+        </ButtonLink>
+        <ButtonLink
+          link={{
+            to: `accessibilite/schema-pluriannuel`,
+          }}
+          variant={ButtonVariant.BOX}
+          icon={strokeRigthIcon}
+          className={styles['button-link']}
+          iconPosition={IconPositionEnum.RIGHT}
+        >
+          Schéma pluriannuel
+        </ButtonLink>
+      </div>
+    </AppLayout>
+  )
+}
+// Lazy-loaded by react-router-dom
+// ts-unused-exports:disable-next-line
+export const Component = Accessibility

--- a/pro/src/pages/Accessibility/Commitment.module.scss
+++ b/pro/src/pages/Accessibility/Commitment.module.scss
@@ -1,0 +1,5 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.title-accessibility {
+  margin-bottom: rem.torem(32px);
+}

--- a/pro/src/pages/Accessibility/Commitment.tsx
+++ b/pro/src/pages/Accessibility/Commitment.tsx
@@ -1,0 +1,26 @@
+import { AppLayout } from 'app/AppLayout'
+import fullBackIcon from 'icons/full-back.svg'
+import { ButtonLink } from 'ui-kit/Button/ButtonLink'
+
+import styles from './Commitment.module.scss'
+
+export const Commitment = () => {
+  return (
+    <AppLayout>
+      <ButtonLink
+        link={{
+          to: '/accessibilite/',
+        }}
+        icon={fullBackIcon}
+      >
+        Retour vers la page Informations d’accessibilité
+      </ButtonLink>
+      <h1 className={styles['title-accessibility']}>
+        Les engagements du pass Culture
+      </h1>
+    </AppLayout>
+  )
+}
+// Lazy-loaded by react-router-dom
+// ts-unused-exports:disable-next-line
+export const Component = Commitment

--- a/pro/src/pages/Accessibility/Declaration.module.scss
+++ b/pro/src/pages/Accessibility/Declaration.module.scss
@@ -1,0 +1,5 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.title-accessibility {
+  margin-bottom: rem.torem(32px);
+}

--- a/pro/src/pages/Accessibility/Declaration.tsx
+++ b/pro/src/pages/Accessibility/Declaration.tsx
@@ -1,0 +1,26 @@
+import { AppLayout } from 'app/AppLayout'
+import fullBackIcon from 'icons/full-back.svg'
+import { ButtonLink } from 'ui-kit/Button/ButtonLink'
+
+import styles from './Declaration.module.scss'
+
+export const Declaration = () => {
+  return (
+    <AppLayout>
+      <ButtonLink
+        link={{
+          to: '/accessibilite/',
+        }}
+        icon={fullBackIcon}
+      >
+        Retour vers la page Informations d’accessibilité
+      </ButtonLink>
+      <h1 className={styles['title-accessibility']}>
+        Déclaration d’accessibilité
+      </h1>
+    </AppLayout>
+  )
+}
+// Lazy-loaded by react-router-dom
+// ts-unused-exports:disable-next-line
+export const Component = Declaration

--- a/pro/src/pages/Accessibility/MultiyearScheme.module.scss
+++ b/pro/src/pages/Accessibility/MultiyearScheme.module.scss
@@ -1,0 +1,5 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.title-accessibility {
+  margin-bottom: rem.torem(32px);
+}

--- a/pro/src/pages/Accessibility/MultiyearScheme.tsx
+++ b/pro/src/pages/Accessibility/MultiyearScheme.tsx
@@ -1,0 +1,24 @@
+import { AppLayout } from 'app/AppLayout'
+import fullBackIcon from 'icons/full-back.svg'
+import { ButtonLink } from 'ui-kit/Button/ButtonLink'
+
+import styles from './MultiyearScheme.module.scss'
+
+export const MultiyearScheme = () => {
+  return (
+    <AppLayout>
+      <ButtonLink
+        link={{
+          to: '/accessibilite/',
+        }}
+        icon={fullBackIcon}
+      >
+        Retour vers la page Informations d’accessibilité
+      </ButtonLink>
+      <h1 className={styles['title-accessibility']}>Schéma pluriannuel</h1>
+    </AppLayout>
+  )
+}
+// Lazy-loaded by react-router-dom
+// ts-unused-exports:disable-next-line
+export const Component = MultiyearScheme

--- a/pro/src/pages/Accessibility/__specs__/Accessibility.spec.tsx
+++ b/pro/src/pages/Accessibility/__specs__/Accessibility.spec.tsx
@@ -1,0 +1,13 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { Accessibility } from '../Accessibility'
+
+describe('Statement of Accessibility page', () => {
+  it('should display Accessibility information message', () => {
+    renderWithProviders(<Accessibility />)
+    expect(screen.getByText('Informations d’accessibilité')).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/Accessibility/__specs__/Commitment.spec.tsx
+++ b/pro/src/pages/Accessibility/__specs__/Commitment.spec.tsx
@@ -1,0 +1,15 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { Commitment } from '../Commitment'
+
+describe('Statement of Commitment page', () => {
+  it('should display Commitment information message', () => {
+    renderWithProviders(<Commitment />)
+    expect(
+      screen.getByText('Les engagements du pass Culture')
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/Accessibility/__specs__/Declaration.spec.tsx
+++ b/pro/src/pages/Accessibility/__specs__/Declaration.spec.tsx
@@ -1,0 +1,13 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { Declaration } from '../Declaration'
+
+describe('Statement of Declaration page', () => {
+  it('should display Declaration information message', () => {
+    renderWithProviders(<Declaration />)
+    expect(screen.getByText('Déclaration d’accessibilité')).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/Accessibility/__specs__/MultiyearScheme.spec.tsx
+++ b/pro/src/pages/Accessibility/__specs__/MultiyearScheme.spec.tsx
@@ -1,0 +1,12 @@
+import { screen } from '@testing-library/react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import { MultiyearScheme } from '../MultiyearScheme'
+
+describe('Statement of MultiyearScheme page', () => {
+  it('should display MultiyearScheme information message', () => {
+    renderWithProviders(<MultiyearScheme />)
+    expect(screen.getByText('Schéma pluriannuel')).toBeInTheDocument()
+  })
+})

--- a/pro/src/ui-kit/Button/ButtonLink.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.tsx
@@ -73,6 +73,10 @@ export const ButtonLink = forwardRef(
         ) : (
           <>{children}</>
         )}
+        {
+          /* istanbul ignore next: graphic variation */
+          iconPosition === IconPositionEnum.RIGHT && svgIcon
+        }
       </>
     )
 


### PR DESCRIPTION
## [Accessibilité] Créer les pages vides pour intégrer la déclaration d'accessibilité

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30041

Exemple:

<img width="930" alt="Capture d’écran 2024-05-29 à 17 58 34" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/728f50dd-3353-4d9b-8da2-489331c527c8">
