### PR TITLE
(BSR)[API] chore: Remove unused pgcrypto PostgreSQL extension

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 0fdfda2e6800 (pre) (head)
-1b973a88081d (post) (head)
+e77d24667815 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240529T183331_e77d24667815_remove_pgcrypto_extension.py
+++ b/api/src/pcapi/alembic/versions/20240529T183331_e77d24667815_remove_pgcrypto_extension.py
@@ -1,0 +1,20 @@
+"""Drop pgcrypto extension
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "e77d24667815"
+down_revision = "1b973a88081d"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("drop extension if exists pgcrypto")
+
+
+def downgrade() -> None:
+    op.execute("create extension if not exists pgcrypto")

--- a/api/src/pcapi/alembic/versions/sql/schema_init.sql
+++ b/api/src/pcapi/alembic/versions/sql/schema_init.sql
@@ -89,6 +89,9 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
 
 
+-- FIXME (dbaty, 2024-05-29), if you are squashing migrations, you may
+-- remove this statement and the next one. We don't need "pgcrypto"
+-- anymore (Alembic migration e77d24667815 drops it).
 --
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
 --

--- a/api/src/pcapi/install_database_extensions.py
+++ b/api/src/pcapi/install_database_extensions.py
@@ -7,7 +7,6 @@ def install_database_extensions() -> None:
     _create_text_search_configuration_if_not_exists()
     _create_index_btree_gist_extension()
     _create_postgis_extension()
-    _create_pgcrypto_extension()
 
 
 def _create_text_search_configuration_if_not_exists() -> None:
@@ -35,9 +34,3 @@ def _create_index_btree_gist_extension() -> None:
 def _create_postgis_extension() -> None:
     with db.engine.begin() as connection:
         connection.execute(text("CREATE EXTENSION IF NOT EXISTS postgis;"))
-
-
-def _create_pgcrypto_extension() -> None:
-    # The `pgcrypto` is required to use `gen_random_uuid()` until PostgreSQL 13.
-    with db.engine.begin() as connection:
-        connection.execute(text("CREATE EXTENSION IF NOT EXISTS pgcrypto;"))


### PR DESCRIPTION
We needed it for the `gen_random_uuid` function. But PostgreSQL ships
an internal function with the same name since version 13.

See https://www.postgresql.org/docs/15/pgcrypto.html#id-1.11.7.37.11