### PR TITLE
(PC-30090)[PRO] fix: Last adage playlist title.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/VenuePlaylist.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/VenuePlaylist.tsx
@@ -27,9 +27,9 @@ function getPlaylistTitle(distanceMax: number) {
     return 'À moins de 30 minutes à pieds de mon établissement'
   }
   if (distanceMax <= 15) {
-    return 'À environ 30 minutes de transport de mon établissement'
+    return 'À environ 30 minutes en transport de mon établissement'
   }
-  return 'À environ 1h de transport de mon établissement'
+  return 'À environ 1h en transport de mon établissement'
 }
 
 export const VenuePlaylist = ({

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/__specs__/VenuePlaylist.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/Playlist/VenuePlaylist/__specs__/VenuePlaylist.spec.tsx
@@ -65,7 +65,7 @@ describe('VenuePlaylist', () => {
 
     expect(
       await screen.findByText(
-        'À environ 30 minutes de transport de mon établissement'
+        'À environ 30 minutes en transport de mon établissement'
       )
     ).toBeInTheDocument()
   })
@@ -91,11 +91,11 @@ describe('VenuePlaylist', () => {
     },
     {
       distance: 15,
-      title: 'À environ 30 minutes de transport de mon établissement',
+      title: 'À environ 30 minutes en transport de mon établissement',
     },
     {
       distance: 30,
-      title: 'À environ 1h de transport de mon établissement',
+      title: 'À environ 1h en transport de mon établissement',
     },
   ])(
     'should display the playlist title based on the maximum venue distance',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30090

**Objectif**
Dans le titre de la dernière playlist ADAGE, remplacer "de transport" par "en transport".

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques