### PR TITLE
(BSR)[PRO] chore: improve eslint config

### DIFF
--- a/pro/.eslintrc.cjs
+++ b/pro/.eslintrc.cjs
@@ -116,5 +116,14 @@ module.exports = {
         'import/no-default-export': 'off',
       },
     },
+    {
+      files: ['cypress/**/*.ts'],
+      parserOptions: {
+        project: ['cypress/tsconfig.json'],
+        tsconfigRootDir: __dirname,
+        sourceType: 'module',
+        ecmaVersion: 6,
+      },
+    },
   ],
 }

--- a/pro/.eslintrc.cjs
+++ b/pro/.eslintrc.cjs
@@ -88,6 +88,7 @@ module.exports = {
     eqeqeq: 'error',
     'require-await': 'error',
     'import/no-named-as-default': 'error',
+    'import/no-default-export': 'error',
     '@typescript-eslint/await-thenable': 'error',
     'react/prop-types': 'error',
     '@typescript-eslint/prefer-string-starts-ends-with': 'error',
@@ -108,4 +109,12 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ['*.stories.tsx'],
+      rules: {
+        'import/no-default-export': 'off',
+      },
+    },
+  ],
 }

--- a/pro/.eslintrc.cjs
+++ b/pro/.eslintrc.cjs
@@ -19,86 +19,23 @@ module.exports = {
     '**/*.jpg',
     '**/*.png',
     'src/index.html',
+    '.eslintrc.cjs',
   ],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx'],
-      parser: '@typescript-eslint/parser',
-      parserOptions: {
-        project: ['./tsconfig.json'],
-        tsconfigRootDir: __dirname,
-        sourceType: 'module',
-        ecmaVersion: 6,
-      },
-      plugins: ['@typescript-eslint'],
-      extends: [
-        'plugin:import/recommended',
-        'eslint:recommended',
-        'plugin:prettier/recommended',
-        'plugin:@typescript-eslint/recommended',
-        'plugin:react/recommended',
-        'plugin:react-hooks/recommended',
-      ],
-      rules: {
-        'import/no-unresolved': 0,
-        'import/named': 0,
-        curly: ['error', 'all'],
-        'no-console': 1,
-        'import/order': [
-          'warn',
-          {
-            groups: [
-              'builtin',
-              'external',
-              'internal',
-              'parent',
-              'sibling',
-              'index',
-            ],
-            'newlines-between': 'always',
-            alphabetize: { order: 'asc', caseInsensitive: true },
-          },
-        ],
-        '@typescript-eslint/ban-ts-comment': 'off',
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-empty-function': 'off',
-        'react/react-in-jsx-scope': 'off',
-        '@typescript-eslint/prefer-ts-expect-error': 'error',
-        'react/no-unescaped-entities': [
-          'error',
-          {
-            forbid: [
-              {
-                char: "'",
-                alternatives: ['’'],
-              },
-            ],
-          },
-        ],
-        eqeqeq: 'error',
-        'require-await': 'error',
-        'import/no-named-as-default': 'error',
-        '@typescript-eslint/await-thenable': 'error',
-        'react/prop-types': 'error',
-        '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-        '@typescript-eslint/ban-types': 'error',
-        '@typescript-eslint/switch-exhaustiveness-check': 'error',
-        '@typescript-eslint/no-unnecessary-type-arguments': 'error',
-        '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
-        '@typescript-eslint/no-floating-promises': 'error',
-
-        // TODO turn into errors
-        '@typescript-eslint/no-unnecessary-condition': 'warn',
-        'react-hooks/exhaustive-deps': 'warn',
-        'react/self-closing-comp': [
-          'error',
-          {
-            component: true,
-            html: true,
-          },
-        ],
-      },
-    },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+    ecmaVersion: 6,
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'plugin:import/recommended',
+    'eslint:recommended',
+    'plugin:prettier/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
   ],
   settings: {
     react: {
@@ -111,5 +48,64 @@ module.exports = {
         moduleDirectory: ['node_modules', 'src'],
       },
     },
+  },
+  rules: {
+    'import/no-unresolved': 0,
+    'import/named': 0,
+    curly: ['error', 'all'],
+    'no-console': 1,
+    'import/order': [
+      'warn',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+        ],
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true },
+      },
+    ],
+    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-empty-function': 'off',
+    'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/prefer-ts-expect-error': 'error',
+    'react/no-unescaped-entities': [
+      'error',
+      {
+        forbid: [
+          {
+            char: "'",
+            alternatives: ['’'],
+          },
+        ],
+      },
+    ],
+    eqeqeq: 'error',
+    'require-await': 'error',
+    'import/no-named-as-default': 'error',
+    '@typescript-eslint/await-thenable': 'error',
+    'react/prop-types': 'error',
+    '@typescript-eslint/prefer-string-starts-ends-with': 'error',
+    '@typescript-eslint/ban-types': 'error',
+    '@typescript-eslint/switch-exhaustiveness-check': 'error',
+    '@typescript-eslint/no-unnecessary-type-arguments': 'error',
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
+    '@typescript-eslint/no-floating-promises': 'error',
+
+    // TODO turn into errors
+    '@typescript-eslint/no-unnecessary-condition': 'warn',
+    'react-hooks/exhaustive-deps': 'warn',
+    'react/self-closing-comp': [
+      'error',
+      {
+        component: true,
+        html: true,
+      },
+    ],
   },
 }

--- a/pro/cypress/cypress.config.ts
+++ b/pro/cypress/cypress.config.ts
@@ -41,5 +41,5 @@ export default defineConfig({
   viewportWidth: 1920,
   video: true,
   videoCompression: true,
-  watchForFileChanges: false
+  watchForFileChanges: false,
 })

--- a/pro/cypress/tsconfig.json
+++ b/pro/cypress/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "es5",
     "lib": ["es5", "dom"],
     "types": ["cypress", "@testing-library/cypress", "node"],
-    "module": "nodenext"
+    "module": "nodenext",
+    "strict": true,
+    "strictNullChecks": true
   },
   "include": ["**/*.ts"]
 }

--- a/pro/src/custom_types/import-jpg.d.ts
+++ b/pro/src/custom_types/import-jpg.d.ts
@@ -1,4 +1,5 @@
 declare module '*.jpg' {
   const value: string
+  // eslint-disable-next-line import/no-default-export
   export default value
 }

--- a/pro/src/custom_types/import-png.d.ts
+++ b/pro/src/custom_types/import-png.d.ts
@@ -1,4 +1,5 @@
 declare module '*.png' {
   const value: string
+  // eslint-disable-next-line import/no-default-export
   export default value
 }

--- a/pro/src/custom_types/scssModules.d.ts
+++ b/pro/src/custom_types/scssModules.d.ts
@@ -1,4 +1,5 @@
 declare module '*.module.scss' {
   const classes: { [key: string]: string }
+  // eslint-disable-next-line import/no-default-export
   export default classes
 }

--- a/pro/src/custom_types/svgAsComponent.d.ts
+++ b/pro/src/custom_types/svgAsComponent.d.ts
@@ -6,5 +6,6 @@ declare module '*.svg' {
   >
 
   const src: string
+  // eslint-disable-next-line import/no-default-export
   export default src
 }


### PR DESCRIPTION
## But de la pull request

3 changements : 

- je ramène toutes les règles eslint à la racine (au lieu d'overrides). C'est devenu possible depuis la migration sur Vite car on n'a plus que des fichiers TS, aucun fichier JS
- rajout de la règle no default export
- maj de la config pour prendre en compte le nouveau tsconfig.json dans le dossier Cypress qui a été ajouté par le passage à cucumber