### PR TITLE
(PC-30053)[PRO] feat: Make toaster notification content accessible by…

### DIFF
--- a/pro/src/components/Notification/Notification.tsx
+++ b/pro/src/components/Notification/Notification.tsx
@@ -11,7 +11,6 @@ import { NotificationToaster } from 'ui-kit/NotificationToaster/NotificationToas
 
 export const Notification = (): JSX.Element | null => {
   const [isVisible, setIsVisible] = useState(false)
-  const [isInDom, setIsInDom] = useState(false)
   const notification = useSelector(notificationSelector)
   const isStickyBarOpen = useSelector(isStickyBarOpenSelector)
   const notificationHook = useNotification()
@@ -22,14 +21,12 @@ export const Notification = (): JSX.Element | null => {
     }
 
     setIsVisible(true)
-    setIsInDom(true)
 
     const hideNotificationTimer = setTimeout(() => {
       setIsVisible(false)
     }, notification.duration)
 
     const removeNotificationFromDOMTimer = setTimeout(() => {
-      setIsInDom(false)
       notificationHook.close()
     }, notification.duration + NOTIFICATION_TRANSITION_DURATION)
 
@@ -37,11 +34,7 @@ export const Notification = (): JSX.Element | null => {
       clearTimeout(hideNotificationTimer)
       clearTimeout(removeNotificationFromDOMTimer)
     }
-  }, [notification])
-
-  if (!notification || !isInDom) {
-    return null
-  }
+  }, [notification, notificationHook])
 
   return (
     <NotificationToaster

--- a/pro/src/components/Notification/__specs__/Notification.spec.tsx
+++ b/pro/src/components/Notification/__specs__/Notification.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Notification } from 'components/Notification/Notification'
 import { NotificationTypeEnum } from 'hooks/useNotification'
 import { Notification as NotificationType } from 'store/notifications/reducer'
+import { notificationAdditionalAttributes } from 'ui-kit/NotificationToaster/NotificationToaster'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 describe('Notification', () => {
@@ -14,30 +15,33 @@ describe('Notification', () => {
       },
     })
 
-  const notificationTypes = [
-    { type: NotificationTypeEnum.SUCCESS, role: 'status' },
-    { type: NotificationTypeEnum.ERROR, role: 'alert' },
-    { type: NotificationTypeEnum.INFORMATION, role: 'status' },
-    { type: NotificationTypeEnum.PENDING, role: 'progressbar' },
-  ]
-  it.each(notificationTypes)(
-    'should display given %s text with icon',
-    (notificationType) => {
-      const notification = {
-        text: 'Mon petit succès',
-        type: notificationType.type,
-        duration: 100,
-      } satisfies NotificationType
+  const types = Object.keys(
+    notificationAdditionalAttributes
+  ) as NotificationTypeEnum[]
 
-      renderNotification(notification)
+  it.each(types)('should display given %s text with icon', (type) => {
+    const notification = {
+      text: 'Mon petit succès',
+      type: type,
+      duration: 100,
+    } satisfies NotificationType
 
-      const notificationElement = screen.getByText(notification.text)
-      expect(notificationElement).toBeInTheDocument()
-      expect(notificationElement).toHaveClass('show')
-      expect(notificationElement).toHaveClass(`is-${notificationType.type}`)
-      expect(notificationElement).toHaveAttribute('role', notificationType.role)
-    }
-  )
+    renderNotification(notification)
+
+    const notificationElement = screen.getByTestId(
+      `global-notification-${type}`
+    )
+
+    expect(notificationElement).toHaveProperty(
+      'role',
+      notificationAdditionalAttributes[type].role ?? null
+    )
+
+    const notificationContentElement = screen.getByText(notification.text)
+    expect(notificationContentElement).toBeInTheDocument()
+    expect(notificationContentElement).toHaveClass('show')
+    expect(notificationContentElement).toHaveClass(`is-${type}`)
+  })
 
   it('should remove notification after fixed show and transition duration', async () => {
     const notification = {

--- a/pro/src/pages/Offers/Offers/ActionsBar/__specs__/ActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/__specs__/ActionsBar.spec.tsx
@@ -80,7 +80,6 @@ describe('ActionsBar', () => {
     renderActionsBar(props)
 
     expect(screen.queryByText('1 offre sélectionnée')).toBeInTheDocument()
-    expect(screen.getByRole('status')).toBeInTheDocument()
   })
 
   it('should say how many offers are selected when more than 1 offer are selected', () => {


### PR DESCRIPTION
… annuncing them to at users.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30053

**Objectif**
Les toasters de notification ne sont pas annoncés aux utilisateurs de lecteur d'écran. Ca arrive quand l'élément ayant l'attribut `aria-live` (ou les roles `alert` / `status`) n'est pas déjà présent au moment du déclenchement de la notif, ou bien s'il est modifié.
J'ai ajouté un container pour chaque type de notif qui ne bouge pas, et dans lesquels on injecte le contenu de la notification.

J'ai aussi apporté une modif au type PENDING qui ajoute un rôle `progressbar`. Ce rôle existe bien mais il ne correspond pas à une zone live, et donc il n'annonce pas de lui-même les changements (il semble même empêcher de les annoncer c'est pourquoi je l'ai complètement enlevé au profit de l'attribut `"aria-live"="polite"`).

Testé uniquement avec voiceover

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques