### PR TITLE
(PC-30118)[PRO] fix: fix bold regex in markdown component

### DIFF
--- a/pro/src/components/Markdown/Markdown.tsx
+++ b/pro/src/components/Markdown/Markdown.tsx
@@ -2,8 +2,8 @@ import DOMPurify from 'dompurify'
 
 import { useActiveFeature } from 'hooks/useActiveFeature'
 
-const BOLD_REGEXP = /\*\*(.*)\*\*/gim
-const ITALIC_REGEXP = /_(.*)_/gim
+const BOLD_REGEXP = /\*\*(.*?)\*\*/gim
+const ITALIC_REGEXP = /_(.*?)_/gim
 const URL_REGEXP = /((https?:\/\/)|(www\.))[^\s/$.?#].[^\s]*/gim
 const EMAIL_REGEXP =
   /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/gim

--- a/pro/src/components/Markdown/__specs__/Markdown.spec.tsx
+++ b/pro/src/components/Markdown/__specs__/Markdown.spec.tsx
@@ -38,6 +38,20 @@ describe('Markdown', () => {
         '<span><a href="mailto:test@example.com">test@example.com</a></span>'
       )
     })
+
+    it('should render multiple strong tags when multiple words are surrounded with double asterisks', () => {
+      const component = renderMarkdown('**texte** en **gras**')
+      expect(component.container.innerHTML).toContain(
+        '<span><strong>texte</strong> en <strong>gras</strong></span>'
+      )
+    })
+
+    it('should render multiple em tags when multiple words are surrounded with underscores', () => {
+      const component = renderMarkdown('_texte_ en _italique_')
+      expect(component.container.innerHTML).toContain(
+        '<span><em>texte</em> en <em>italique</em></span>'
+      )
+    })
   })
 
   it('should render unformatted text when feature flag WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION is off', () => {


### PR DESCRIPTION
## But de la pull request

https://passculture.atlassian.net/browse/PC-30118

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques