### PR TITLE
(PC-30115)[BO] feat: filter offerers to validate on AE documents received status

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offerers/forms.py
@@ -117,6 +117,10 @@ class OffererValidationListForm(utils.PCForm):
             ValidationStatus, formatter=filters.format_validation_status, exclude_opts=(ValidationStatus.DELETED,)
         ),
     )
+    ae_documents_received = fields.PCSelectMultipleField(
+        "Documents reçus",
+        choices=[("yes", "Oui"), ("no", "Non")],
+    )
     instructors = fields.PCTomSelectField(
         "Auteur de la dernière action",
         multiple=True,

--- a/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
@@ -68,6 +68,7 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
         form.regions.data,
         form.tags.data,
         form.status.data,
+        form.ae_documents_received.data,
         form.instructors.data,
         form.dms_adage_status.data,
         date_utils.date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30115

![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/7d6847e4-7276-469d-8a1c-f37cac4f5155)

![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/767460fd-9d91-41c7-a511-ca17d9bed978)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques