### PR TITLE
(BSR)[API] feat: add new script type to commit labels

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -4,7 +4,7 @@ name = "cz_customize"
 [tool.commitizen.customize]
 message_template = "({{jira_ticket}}){% if affected_repository %}[{{affected_repository}}]{% endif %} {{change_type}}: {{message}}"
 schema = "(<ticket_number>)[<affected_repository>] <type>: <commit_message>"
-schema_pattern = "\\((PC-\\d+|BSR)\\)(\\[(API|PRO|ADAGE|BO)\\])? ?(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)(\\[[\\w\\s]+\\])?:[\\w\\s]+"
+schema_pattern = "\\((PC-\\d+|BSR)\\)(\\[(API|PRO|ADAGE|BO)\\])? ?(build|ci|docs|feat|fix|perf|refactor|script|style|test|chore|revert|bump)(\\[[\\w\\s]+\\])?:[\\w\\s]+"
 example = "(PC-88888)[API] feat: this is such a great commit"
 
 
@@ -29,9 +29,10 @@ message = "Select the repository affected by the change you are committing"
 type = "list"
 name = "change_type"
 choices = [
-    {value = "fix", name = "fix: A bug fix."}, 
-    {value = "feat",name = "feat: A new feature."}, 
+    {value = "fix", name = "fix: A bug fix"}, 
+    {value = "feat",name = "feat: A new feature"}, 
     {value = "docs", name = "docs: Documentation only changes"},
+    {value = "script", name = "script: A one-time only script"},
     {value = "style",name = "style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"},
     {value = "refactor",name = "refactor: A code change that neither fixes a bug nor adds a feature"},
     {value = "perf",name = "perf: A code change that improves performance"},

--- a/.git-commit-message-template
+++ b/.git-commit-message-template
@@ -1,3 +1,3 @@
 (PC-XXXX|BSR)[API|BO|PRO|ADAGE] <type>: <commit_message>
 
-type: build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump
+type: build|ci|docs|feat|fix|perf|refactor|script|style|test|chore|revert|bump


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) :  travaux d'intérêts généraux, pour pouvoir faire des labels de commit de type `script`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques