### PR TITLE
(PC-30120)[PRO] fix: Make the adage offer date tag be the date of boo…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/utils/getOfferTags.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/utils/getOfferTags.ts
@@ -101,7 +101,7 @@ export function getOfferTags(
     tags.push({
       icon: '🕐',
       text: `${formatLocalTimeDateString(
-        '2024-06-13T08:33:26.210795Z',
+        offer.stock.beginningDatetime,
         offer.venue.departmentCode,
         'EEEE d MMM yyyy à HH:mm'
       )}`,


### PR DESCRIPTION
…king.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30120

**Objectif**
Corriger l'affichage du tag ADAGE de date de réservation qui affiche une date en dur.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques