### PR TITLE
(PC-30123)[PRO] fix: Parse the adage template offer id considering th…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -91,7 +91,7 @@ export const Offers = ({
     !adageUser.preferences?.feedback_form_closed &&
     adageUser.role !== AdageFrontRoles.READONLY
 
-  const hitsIds = hits.map((hit) => Number(hit.objectID.split('-')[1]))
+  const hitsIds = hits.map((hit) => Number(hit.objectID.replace('T-', '')))
   const { data, isLoading } = useSWR(
     hitsIds.length > 0
       ? [GET_COLLECTIVE_OFFER_TEMPLATES_QUERY_KEY, ...hitsIds]


### PR DESCRIPTION
…at the offer id could not contain T-.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30123

**Objectif**
Certaines anciennes offres vitrine n'ont pas "T-" dans l'id sur algolia. Si c'est le cas, le parsing actuel va requêter NaN ce qui fait une erreur 400. Pour corriger ça j'ai modifié le parsing pour accepter les 2 cas.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques