### PR TITLE
(BSR)[API] refactor: harmonize type ignore ; remove extra whitespace

### DIFF
--- a/api/src/pcapi/alembic/run_migrations.py
+++ b/api/src/pcapi/alembic/run_migrations.py
@@ -55,7 +55,7 @@ def run_online_migrations() -> None:
     if settings.DB_MIGRATION_STATEMENT_TIMEOUT:
         db_options.append("-c statement_timeout=%i" % settings.DB_MIGRATION_STATEMENT_TIMEOUT)
 
-    connectable = create_engine(settings.DATABASE_URL, connect_args={"options": " ".join(db_options)})  # type: ignore [arg-type]
+    connectable = create_engine(settings.DATABASE_URL, connect_args={"options": " ".join(db_options)})  # type: ignore[arg-type]
     logger.warning(
         "Alembic will use a DB connection with these settings: lock_timeout = %d ms, statement_timeout = %d ms",
         settings.DB_MIGRATION_LOCK_TIMEOUT,

--- a/api/src/pcapi/alembic/versions/20240112T134955_3467ee234047_delete_stats_ff.py
+++ b/api/src/pcapi/alembic/versions/20240112T134955_3467ee234047_delete_stats_ff.py
@@ -10,7 +10,7 @@ branch_labels = None
 depends_on = None
 
 
-def get_stats_flag():  # type: ignore [no-untyped-def]
+def get_stats_flag():  # type: ignore[no-untyped-def]
     from pcapi.models import feature
 
     return feature.Feature(
@@ -20,7 +20,7 @@ def get_stats_flag():  # type: ignore [no-untyped-def]
     )
 
 
-def get_stats_v2_flag():  # type: ignore [no-untyped-def]
+def get_stats_v2_flag():  # type: ignore[no-untyped-def]
     from pcapi.models import feature
 
     return feature.Feature(

--- a/api/src/pcapi/alembic/versions/20240411T075644_f77615489a01_delete_public_api_ffs.py
+++ b/api/src/pcapi/alembic/versions/20240411T075644_f77615489a01_delete_public_api_ffs.py
@@ -8,7 +8,7 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
-def get_features():  # type: ignore [no-untyped-def]
+def get_features():  # type: ignore[no-untyped-def]
     from pcapi.models import feature
 
     return [

--- a/api/src/pcapi/connectors/dms/serializer.py
+++ b/api/src/pcapi/connectors/dms/serializer.py
@@ -144,7 +144,7 @@ def parse_beneficiary_information_graphql(
             )
             break
 
-    return fraud_models.DMSContent(  # type: ignore [call-arg]
+    return fraud_models.DMSContent(  # type: ignore[call-arg]
         activity=activity,
         address=address,
         annotation=annotation,

--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -42,7 +42,7 @@ class BookingFactory(BaseFactory):
         else:
             self.cancellationLimitDate = api.compute_booking_cancellation_limit_date(
                 self.stock.beginningDatetime, self.dateCreated
-            )  # type: ignore [assignment]
+            )  # type: ignore[assignment]
         db.session.add(self)
         db.session.commit()
 

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -243,7 +243,7 @@ class Booking(PcObject, Base, Model):
     def isConfirmed(self) -> bool:
         return self.cancellationLimitDate is not None and self.cancellationLimitDate <= datetime.utcnow()
 
-    @isConfirmed.expression  # type: ignore [no-redef]
+    @isConfirmed.expression  # type: ignore[no-redef]
     def isConfirmed(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return and_(cls.cancellationLimitDate.is_not(None), cls.cancellationLimitDate <= datetime.utcnow())
 
@@ -251,7 +251,7 @@ class Booking(PcObject, Base, Model):
     def is_used_or_reimbursed(self) -> bool:
         return self.status in [BookingStatus.USED, BookingStatus.REIMBURSED]
 
-    @is_used_or_reimbursed.expression  # type: ignore [no-redef]
+    @is_used_or_reimbursed.expression  # type: ignore[no-redef]
     def is_used_or_reimbursed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status.in_([BookingStatus.USED, BookingStatus.REIMBURSED])
 
@@ -259,7 +259,7 @@ class Booking(PcObject, Base, Model):
     def isReimbursed(self) -> bool:
         return self.status == BookingStatus.REIMBURSED
 
-    @isReimbursed.expression  # type: ignore [no-redef]
+    @isReimbursed.expression  # type: ignore[no-redef]
     def isReimbursed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status == BookingStatus.REIMBURSED
 
@@ -267,7 +267,7 @@ class Booking(PcObject, Base, Model):
     def isCancelled(self) -> bool:
         return self.status == BookingStatus.CANCELLED
 
-    @isCancelled.expression  # type: ignore [no-redef]
+    @isCancelled.expression  # type: ignore[no-redef]
     def isCancelled(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status == BookingStatus.CANCELLED
 
@@ -291,7 +291,7 @@ class Booking(PcObject, Base, Model):
     def isExternal(self) -> bool:
         return any(externalBooking.id for externalBooking in self.externalBookings)
 
-    @isExternal.expression  # type: ignore [no-redef]
+    @isExternal.expression  # type: ignore[no-redef]
     def isExternal(cls) -> Label:  # pylint: disable=no-self-argument
         return select(
             [
@@ -361,7 +361,7 @@ class Booking(PcObject, Base, Model):
             self.stock.offer.subcategoryId in offers_models.Stock.AUTOMATICALLY_USED_SUBCATEGORIES and self.amount == 0
         )
 
-    @display_even_if_used.expression  # type: ignore [no-redef]
+    @display_even_if_used.expression  # type: ignore[no-redef]
     def display_even_if_used(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return and_(
             offers_models.Offer.subcategoryId.in_(offers_models.Stock.AUTOMATICALLY_USED_SUBCATEGORIES),

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -277,7 +277,7 @@ def get_validated_bookings_quantity_for_venue(venue_id: int) -> int:
     validated_bookings_quantity_query = Booking.query.filter(
         Booking.venueId == venue_id,
         Booking.status != BookingStatus.CANCELLED,
-        or_(Booking.is_used_or_reimbursed, Booking.isConfirmed),  # type: ignore [type-var]
+        or_(Booking.is_used_or_reimbursed, Booking.isConfirmed),  # type: ignore[type-var]
     )
 
     n_validated_bookings_quantity = validated_bookings_quantity_query.with_entities(
@@ -289,7 +289,7 @@ def get_validated_bookings_quantity_for_venue(venue_id: int) -> int:
             educational_models.CollectiveBooking.venueId == venue_id,
             educational_models.CollectiveBooking.status != educational_models.CollectiveBookingStatus.CANCELLED,
             educational_models.CollectiveBooking.status != educational_models.CollectiveBookingStatus.PENDING,
-            or_(  # type: ignore [type-var]
+            or_(  # type: ignore[type-var]
                 educational_models.CollectiveBooking.is_used_or_reimbursed,
                 educational_models.CollectiveBooking.isConfirmed,
             ),
@@ -352,7 +352,7 @@ def _create_export_query(offer_id: int, event_beginning_date: date) -> BaseQuery
             Booking.dateUsed.label("usedAt"),
             Booking.reimbursementDate.label("reimbursedAt"),
             Booking.cancellationDate.label("cancelledAt"),
-            Booking.isExternal.label("isExternal"),  # type: ignore [attr-defined]
+            Booking.isExternal.label("isExternal"),  # type: ignore[attr-defined]
             Booking.isConfirmed,
             # `get_batch` function needs a field called exactly `id` to work,
             # the label prevents SA from using a bad (prefixed) label for this field
@@ -528,7 +528,7 @@ def _get_filtered_booking_report(
             Booking.dateUsed.label("usedAt"),
             Booking.reimbursementDate.label("reimbursedAt"),
             Booking.cancellationDate.label("cancelledAt"),
-            Booking.isExternal.label("isExternal"),  # type: ignore [attr-defined]
+            Booking.isExternal.label("isExternal"),  # type: ignore[attr-defined]
             Booking.isConfirmed,
             # `get_batch` function needs a field called exactly `id` to work,
             # the label prevents SA from using a bad (prefixed) label for this field
@@ -575,7 +575,7 @@ def _get_filtered_booking_pro(
             Booking.cancellationLimitDate,
             Booking.status,
             Booking.reimbursementDate.label("reimbursedAt"),
-            Booking.isExternal.label("isExternal"),  # type: ignore [attr-defined]
+            Booking.isExternal.label("isExternal"),  # type: ignore[attr-defined]
             Booking.isConfirmed,
             Offer.name.label("offerName"),
             Offer.id.label("offerId"),
@@ -583,7 +583,7 @@ def _get_filtered_booking_pro(
             User.firstName.label("beneficiaryFirstname"),
             User.lastName.label("beneficiaryLastname"),
             User.email.label("beneficiaryEmail"),
-            User.phoneNumber.label("beneficiaryPhoneNumber"),  # type: ignore [attr-defined]
+            User.phoneNumber.label("beneficiaryPhoneNumber"),  # type: ignore[attr-defined]
             Stock.beginningDatetime.label("stockBeginningDatetime"),
             Booking.stockId,
             Venue.departementCode.label("venueDepartmentCode"),

--- a/api/src/pcapi/core/categories/categories.py
+++ b/api/src/pcapi/core/categories/categories.py
@@ -92,8 +92,8 @@ ALL_CATEGORIES = (
     TECHNIQUE,
 )
 ALL_CATEGORIES_DICT = {category.id: category for category in ALL_CATEGORIES}
-CategoryIdEnum = Enum("CategoryIdEnum", {category.id: category.id for category in ALL_CATEGORIES})  # type: ignore [misc]
-CategoryIdLabelEnum = Enum("CategoryIdLabelEnum", {category.id: category.pro_label for category in ALL_CATEGORIES})  # type: ignore [misc]
+CategoryIdEnum = Enum("CategoryIdEnum", {category.id: category.id for category in ALL_CATEGORIES})  # type: ignore[misc]
+CategoryIdLabelEnum = Enum("CategoryIdLabelEnum", {category.id: category.pro_label for category in ALL_CATEGORIES})  # type: ignore[misc]
 
 assert set(ALL_CATEGORIES) == set(category for category in locals().values() if isinstance(category, Category))
 

--- a/api/src/pcapi/core/categories/subcategories_v2.py
+++ b/api/src/pcapi/core/categories/subcategories_v2.py
@@ -97,7 +97,7 @@ class GenreType(Enum):
             type(self).MOVIE.name: movie_types,
         }[
             self.name
-        ]  # type: ignore [return-value]
+        ]  # type: ignore[return-value]
 
     def book_values(self) -> list[GenreTypeContent]:
         return [GenreTypeContent(name=value, value=value) for value in sorted(BOOK_MACRO_SECTIONS)]
@@ -1993,21 +1993,21 @@ assert set(subcategory.id for subcategory in ALL_SUBCATEGORIES) == set(
 )
 
 
-SubcategoryIdEnumv2 = Enum("SubcategoryIdEnumv2", {subcategory.id: subcategory.id for subcategory in ALL_SUBCATEGORIES})  # type: ignore [misc]
-SubcategoryProLabelEnumv2 = Enum("SubcategoryProLabelEnumv2", {subcategory.id: subcategory.pro_label for subcategory in ALL_SUBCATEGORIES})  # type: ignore [misc]
-SearchGroupNameEnumv2 = Enum(  # type: ignore [misc]
+SubcategoryIdEnumv2 = Enum("SubcategoryIdEnumv2", {subcategory.id: subcategory.id for subcategory in ALL_SUBCATEGORIES})  # type: ignore[misc]
+SubcategoryProLabelEnumv2 = Enum("SubcategoryProLabelEnumv2", {subcategory.id: subcategory.pro_label for subcategory in ALL_SUBCATEGORIES})  # type: ignore[misc]
+SearchGroupNameEnumv2 = Enum(  # type: ignore[misc]
     "SearchGroupNameEnumv2",
     {search_group_name: search_group_name for search_group_name in [c.name for c in SearchGroups]},
 )
-HomepageLabelNameEnumv2 = Enum(  # type: ignore [misc]
+HomepageLabelNameEnumv2 = Enum(  # type: ignore[misc]
     "(HomepageLabelNameEnumv2",
     {homepage_label_name: homepage_label_name for homepage_label_name in [h.name for h in HomepageLabels]},
 )
-OnlineOfflinePlatformChoicesEnumv2 = Enum(  # type: ignore [misc]
+OnlineOfflinePlatformChoicesEnumv2 = Enum(  # type: ignore[misc]
     "OnlineOfflinePlatformChoicesEnumv2",
     {choice: choice for choice in [c.value for c in OnlineOfflinePlatformChoices]},
 )
-NativeCategoryIdEnumv2 = Enum(  # type: ignore [misc]
+NativeCategoryIdEnumv2 = Enum(  # type: ignore[misc]
     "NativeCategoryIdEnumv2",
     {native_category.name: native_category.name for native_category in NativeCategory},
 )
@@ -2015,4 +2015,4 @@ NativeCategoryIdEnumv2 = Enum(  # type: ignore [misc]
 # Support for old enum names serializers
 # TODO: remove when old enum names are not used in the app anymore, and after a forced update
 # Jira: https://passculture.atlassian.net/browse/PC-25049
-SubcategoryIdEnum = Enum("SubcategoryIdEnum", {subcategory.id: subcategory.id for subcategory in ALL_SUBCATEGORIES})  # type: ignore [misc]
+SubcategoryIdEnum = Enum("SubcategoryIdEnum", {subcategory.id: subcategory.id for subcategory in ALL_SUBCATEGORIES})  # type: ignore[misc]

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -736,7 +736,7 @@ def create_offer_request(
     redactor: educational_models.EducationalRedactor,
 ) -> educational_models.CollectiveOfferRequest:
     request = educational_models.CollectiveOfferRequest(
-        phoneNumber=body.phone_number,  # type: ignore [call-arg]
+        phoneNumber=body.phone_number,  # type: ignore[call-arg]
         requestedDate=body.requested_date,
         totalStudents=body.total_students,
         totalTeachers=body.total_teachers,

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -281,7 +281,7 @@ class StatusMixin:
 
         return offer_mixin.OfferStatus.ACTIVE
 
-    @status.expression  # type: ignore [no-redef]
+    @status.expression  # type: ignore[no-redef]
     def status(cls) -> sa.sql.elements.Case:  # pylint: disable=no-self-argument
         return sa.case(
             (
@@ -571,7 +571,7 @@ class CollectiveOffer(
     def isEvent(self) -> bool:
         return self.subcategory.is_event
 
-    @isEvent.expression  # type: ignore [no-redef]
+    @isEvent.expression  # type: ignore[no-redef]
     def isEvent(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES)
 
@@ -604,7 +604,7 @@ class CollectiveOffer(
     def is_expired(self) -> bool:
         return self.hasBeginningDatetimePassed
 
-    @is_expired.expression  # type: ignore [no-redef]
+    @is_expired.expression  # type: ignore[no-redef]
     def is_expired(cls) -> UnaryExpression:  # pylint: disable=no-self-argument
         return cls.hasBeginningDatetimePassed
 
@@ -856,7 +856,7 @@ class CollectiveOfferTemplate(
     def isEvent(self) -> bool:
         return self.subcategory.is_event
 
-    @isEvent.expression  # type: ignore [no-redef]
+    @isEvent.expression  # type: ignore[no-redef]
     def isEvent(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES)
 
@@ -905,7 +905,7 @@ class CollectiveOfferTemplate(
     def is_expired(self) -> bool:
         return self.hasBeginningDatetimePassed
 
-    @is_expired.expression  # type: ignore [no-redef]
+    @is_expired.expression  # type: ignore[no-redef]
     def is_expired(cls) -> UnaryExpression:  # pylint: disable=no-self-argument
         return cls.hasBeginningDatetimePassed
 
@@ -1295,7 +1295,7 @@ class CollectiveBooking(PcObject, Base, Model):
     def isReimbursed(self) -> bool:
         return self.status == CollectiveBookingStatus.REIMBURSED
 
-    @isReimbursed.expression  # type: ignore [no-redef]
+    @isReimbursed.expression  # type: ignore[no-redef]
     def isReimbursed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status == CollectiveBookingStatus.REIMBURSED
 
@@ -1303,7 +1303,7 @@ class CollectiveBooking(PcObject, Base, Model):
     def isCancelled(self) -> bool:
         return self.status == CollectiveBookingStatus.CANCELLED
 
-    @isCancelled.expression  # type: ignore [no-redef]
+    @isCancelled.expression  # type: ignore[no-redef]
     def isCancelled(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.status == CollectiveBookingStatus.CANCELLED
 
@@ -1545,14 +1545,14 @@ class CollectiveOfferRequest(PcObject, Base, Model):
     def phoneNumber(self) -> str | None:
         return self._phoneNumber
 
-    @phoneNumber.setter  # type: ignore [no-redef]
+    @phoneNumber.setter  # type: ignore[no-redef]
     def phoneNumber(self, value: str | None) -> None:
         if not value:
             self._phoneNumber = None
         else:
             self._phoneNumber = ParsedPhoneNumber(value).phone_number
 
-    @phoneNumber.expression  # type: ignore [no-redef]
+    @phoneNumber.expression  # type: ignore[no-redef]
     def phoneNumber(cls) -> str | None:  # pylint: disable=no-self-argument
         return cls._phoneNumber
 

--- a/api/src/pcapi/core/external/attributes/api.py
+++ b/api/src/pcapi/core/external/attributes/api.py
@@ -236,7 +236,7 @@ def get_pro_attributes(email: str) -> models.ProAttributes:
         offerers_models.Venue.query.filter_by(bookingEmail=email)
         .join(
             offerers_models.Offerer,
-            sa.and_(  # type: ignore [type-var]
+            sa.and_(  # type: ignore[type-var]
                 offerers_models.Offerer.id == offerers_models.Venue.managingOffererId,
                 offerers_models.Offerer.isActive,
                 offerers_models.Offerer.isValidated,
@@ -302,7 +302,7 @@ def get_pro_attributes(email: str) -> models.ProAttributes:
         venues_ids={venue.id for venue in all_venues},
         venues_names={venue.publicName or venue.name for venue in all_venues},
         venues_types={venue.venueTypeCode.name for venue in all_venues},
-        venues_labels={venue.venueLabel.label for venue in all_venues if venue.venueLabelId},  # type: ignore [misc]
+        venues_labels={venue.venueLabel.label for venue in all_venues if venue.venueLabelId},  # type: ignore[misc]
         departement_code={venue.departementCode for venue in all_venues if venue.departementCode},
         postal_code={venue.postalCode for venue in all_venues if venue.postalCode},
         has_collective_offers=has_collective_offers,
@@ -321,7 +321,7 @@ def _check_if_pro_attribute_has_collective_offers(user: users_models.User) -> bo
             offerers_models.Offerer.isValidated,
             offerers_models.UserOfferer.isValidated,
             offerers_models.UserOfferer.userId == user.id,
-            educational_models.CollectiveOffer.status.in_([OfferStatus.ACTIVE, OfferStatus.SOLD_OUT]),  # type: ignore [attr-defined]
+            educational_models.CollectiveOffer.status.in_([OfferStatus.ACTIVE, OfferStatus.SOLD_OUT]),  # type: ignore[attr-defined]
         )
         .exists()
     )

--- a/api/src/pcapi/core/external/commands/update_sendinblue_pro_attributes.py
+++ b/api/src/pcapi/core/external/commands/update_sendinblue_pro_attributes.py
@@ -30,7 +30,7 @@ def get_all_pro_users_emails() -> set[str]:
         db.session.query(User.email)
         .filter(
             User.isActive,
-            sa.or_(User.has_pro_role, User.has_non_attached_pro_role),  # type: ignore [type-var]
+            sa.or_(User.has_pro_role, User.has_non_attached_pro_role),  # type: ignore[type-var]
             sa.not_(User.has_admin_role),
         )
         .all()

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -231,7 +231,7 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
                 raise ValueError(f"Barcode {barcode} contains one or more invalid char (only digit allowed)")
             barcodes_int.append(int(barcode))
 
-        cancel_body = cds_serializers.CancelBookingCDS(barcodes=barcodes_int, paiement_type_id=paiement_type_id)  # type: ignore [call-arg]
+        cancel_body = cds_serializers.CancelBookingCDS(barcodes=barcodes_int, paiement_type_id=paiement_type_id)  # type: ignore[call-arg]
         api_response = put_resource(self.api_url, self.account_id, self.token, ResourceCDS.CANCEL_BOOKING, cancel_body)
 
         if api_response:
@@ -259,7 +259,7 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         ticket_sale_collection = self._create_ticket_sale_dict(show, quantity, screen, show_voucher_type)
         payement_collection = self._create_transaction_payment(quantity, show_voucher_type)
 
-        create_transaction_body = cds_serializers.CreateTransactionBodyCDS(  # type: ignore [call-arg]
+        create_transaction_body = cds_serializers.CreateTransactionBodyCDS(  # type: ignore[call-arg]
             cinema_id=self.cinema_id,
             is_cancelled=False,
             transaction_date=datetime.datetime.utcnow().strftime(CDS_DATE_FORMAT),
@@ -311,7 +311,7 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
 
         ticket_sale_list = []
         for i in range(booking_quantity):
-            ticket_sale = cds_serializers.TicketSaleCDS(  # type: ignore [call-arg]
+            ticket_sale = cds_serializers.TicketSaleCDS(  # type: ignore[call-arg]
                 id=(i + 1) * -1,
                 cinema_id=self.cinema_id,
                 operation_date=datetime.datetime.utcnow().strftime(CDS_DATE_FORMAT),
@@ -336,7 +336,7 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         assert show_voucher_type.tariff
         payement_collection = []
         for i in range(booking_quantity):
-            payment = cds_serializers.TransactionPayementCDS(  # type: ignore [call-arg]
+            payment = cds_serializers.TransactionPayementCDS(  # type: ignore[call-arg]
                 id=(i + 1) * -1,
                 amount=show_voucher_type.tariff.price,
                 payement_type=cds_serializers.IdObjectCDS(id=payment_type.id),

--- a/api/src/pcapi/core/external_bookings/serialize.py
+++ b/api/src/pcapi/core/external_bookings/serialize.py
@@ -66,7 +66,7 @@ class ExternalEventBookingRequest(pydantic_v1.BaseModel):
             venue_department_code=stock.offer.venue.departementCode,
             venue_id=stock.offer.venue.id,
             venue_name=stock.offer.venue.name,
-            **price_data,  # type: ignore [arg-type]
+            **price_data,  # type: ignore[arg-type]
         )
 
 

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -178,13 +178,13 @@ def add_event(
     assert value_date is not None
 
     event = models.FinanceEvent(
-        booking=booking if isinstance(booking, bookings_models.Booking) and not booking_incident else None,  # type: ignore [arg-type]
+        booking=booking if isinstance(booking, bookings_models.Booking) and not booking_incident else None,  # type: ignore[arg-type]
         collectiveBooking=(
-            booking  # type: ignore [arg-type]
+            booking  # type: ignore[arg-type]
             if isinstance(booking, educational_models.CollectiveBooking) and not booking_incident
             else None
         ),
-        bookingFinanceIncident=booking_incident,  # type: ignore [arg-type]
+        bookingFinanceIncident=booking_incident,  # type: ignore[arg-type]
         status=status,
         motive=motive,
         valueDate=value_date,
@@ -1837,7 +1837,7 @@ def _generate_invoice(
         if isinstance(rule, models.CustomReimbursementRule):
             pricings_by_custom_rule[rule].append(pricing)
         else:
-            pricings_and_rates_by_rule_group[rule.group].append((pricing, rule.rate))  # type: ignore [attr-defined]
+            pricings_and_rates_by_rule_group[rule.group].append((pricing, rule.rate))  # type: ignore[attr-defined]
 
     invoice_lines = []
     for rule_group, pricings_and_rates in pricings_and_rates_by_rule_group.items():

--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -100,8 +100,8 @@ def add_custom_offer_reimbursement_rule(
     force: bool = False,
 ) -> None:
     """Add a custom reimbursement rule that is linked to an offer."""
-    offer_original_amount = decimal.Decimal(offer_original_amount.replace(",", "."))  # type: ignore [assignment]
-    reimbursed_amount = decimal.Decimal(reimbursed_amount.replace(",", "."))  # type: ignore [assignment]
+    offer_original_amount = decimal.Decimal(offer_original_amount.replace(",", "."))  # type: ignore[assignment]
+    reimbursed_amount = decimal.Decimal(reimbursed_amount.replace(",", "."))  # type: ignore[assignment]
 
     offer = (
         offers_models.Offer.query.options(
@@ -151,7 +151,7 @@ def add_custom_offer_reimbursement_rule(
 
     rule = finance_api.create_offer_reimbursement_rule(
         offer_id=offer.id,
-        amount=reimbursed_amount,  # type: ignore [arg-type]
+        amount=reimbursed_amount,  # type: ignore[arg-type]
         start_date=valid_from_dt,
         end_date=valid_until_dt,
     )

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -309,7 +309,7 @@ class PaymentFactory(BaseFactory):
     recipientSiren = factory.SelfAttribute("booking.stock.offer.venue.managingOfferer.siren")
     reimbursementRule = factory.Iterator(REIMBURSEMENT_RULE_DESCRIPTIONS)
     reimbursementRate = factory.LazyAttribute(
-        lambda payment: reimbursement.get_reimbursement_rule(  # type: ignore [attr-defined]
+        lambda payment: reimbursement.get_reimbursement_rule(  # type: ignore[attr-defined]
             payment.collectiveBooking or payment.booking, reimbursement.CustomRuleFinder(), 0
         ).rate
     )

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -544,7 +544,7 @@ class ReimbursementRule:
         custom_total_amount: int | None = None,
     ) -> int:
         base = custom_total_amount or utils.to_eurocents(booking.total_amount)
-        return utils.round_to_integer(base * self.rate)  # type: ignore [attr-defined]
+        return utils.round_to_integer(base * self.rate)  # type: ignore[attr-defined]
 
     @property
     def group(self) -> RuleGroup:
@@ -1047,7 +1047,7 @@ class FinanceIncident(Base, Model):
             for booking_incident in self.booking_finance_incidents
         )
 
-    @isClosed.expression  # type: ignore [no-redef]
+    @isClosed.expression  # type: ignore[no-redef]
     def isClosed(cls) -> Exists:  # pylint: disable=no-self-argument
         return (
             sqla.exists()

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -569,7 +569,7 @@ class BeneficiaryFraudCheck(PcObject, Base, Model):
             return min(self.dateCreated, registration_datetime)
         return self.dateCreated
 
-    def source_data(self) -> FraudCheckContent:  # type: ignore [type-var]
+    def source_data(self) -> FraudCheckContent:  # type: ignore[type-var]
         cls = FRAUD_CHECK_CONTENT_MAPPING[self.type]
         if not cls:
             raise NotImplementedError(f"Cannot unserialize type {self.type}")

--- a/api/src/pcapi/core/history/api.py
+++ b/api/src/pcapi/core/history/api.py
@@ -61,11 +61,11 @@ def add_action(
         authorUser=author.real_user if author else None,
         user=user,
         # FIXME remove type ignores when upgrading to sqlalchemy 2.0
-        offerer=offerer,  # type: ignore [arg-type]
-        venue=venue,  # type: ignore [arg-type]
-        financeIncident=finance_incident,  # type: ignore [arg-type]
-        bankAccount=bank_account,  # type: ignore [arg-type]
-        rule=rule,  # type: ignore [arg-type]
+        offerer=offerer,  # type: ignore[arg-type]
+        venue=venue,  # type: ignore[arg-type]
+        financeIncident=finance_incident,  # type: ignore[arg-type]
+        bankAccount=bank_account,  # type: ignore[arg-type]
+        rule=rule,  # type: ignore[arg-type]
         comment=comment or None,  # do not store empty string
         extraData=extra_data,
     )

--- a/api/src/pcapi/core/logging.py
+++ b/api/src/pcapi/core/logging.py
@@ -94,7 +94,7 @@ def get_api_key_offerer_id() -> int | None:
 
 
 def monkey_patch_logger_makeRecord() -> None:
-    def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None, extra=None, sinfo=None):  # type: ignore [no-untyped-def]
+    def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None, extra=None, sinfo=None):  # type: ignore[no-untyped-def]
         """Make a record but store ``extra`` arguments in an ``extra``
         attribute (not only as direct attributes of the object itself,
         like the original method does).
@@ -118,12 +118,12 @@ def monkey_patch_logger_makeRecord() -> None:
         record.extra = _extra
         return record
 
-    logging.Logger.__original_makeRecord = logging.Logger.makeRecord  # type: ignore [attr-defined]
-    logging.Logger.makeRecord = makeRecord  # type: ignore [method-assign]
+    logging.Logger.__original_makeRecord = logging.Logger.makeRecord  # type: ignore[attr-defined]
+    logging.Logger.makeRecord = makeRecord  # type: ignore[method-assign]
 
 
 def monkey_patch_logger_log() -> None:
-    def _log(  # type: ignore [no-untyped-def]
+    def _log(  # type: ignore[no-untyped-def]
         self,
         level,
         msg,
@@ -150,8 +150,8 @@ def monkey_patch_logger_log() -> None:
             stacklevel=stacklevel,
         )
 
-    logging.Logger.__original_log = logging.Logger._log  # type: ignore [attr-defined]
-    logging.Logger._log = _log  # type: ignore [method-assign]
+    logging.Logger.__original_log = logging.Logger._log  # type: ignore[attr-defined]
+    logging.Logger._log = _log  # type: ignore[method-assign]
 
 
 class JsonLogEncoder(json.JSONEncoder):
@@ -257,7 +257,7 @@ def install_logging() -> None:
         # pylint: disable=consider-using-with
         handler2 = logging.StreamHandler(stream=open("/proc/1/fd/1", "w", encoding="utf-8"))
         handler2.setFormatter(JsonFormatter())
-        handlers.append(handler2)  # type: ignore [arg-type]
+        handlers.append(handler2)  # type: ignore[arg-type]
     logging.basicConfig(level=settings.LOG_LEVEL, handlers=handlers, force=True)
 
     _internal_logger = logging.getLogger(__name__)

--- a/api/src/pcapi/core/mails/transactional/users/recredit_to_underage_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/users/recredit_to_underage_beneficiary.py
@@ -16,7 +16,7 @@ def get_recredit_to_underage_beneficiary_email_data(
         params={
             "FIRSTNAME": user.firstName,
             "NEW_CREDIT": recredit_amount,
-            "CREDIT": int(domains_credit.all.remaining),  # type: ignore [union-attr]
+            "CREDIT": int(domains_credit.all.remaining),  # type: ignore[union-attr]
         },
     )
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -749,7 +749,7 @@ def delete_api_key_by_user(user: users_models.User, api_key_prefix: str) -> None
 def _fill_in_offerer(
     offerer: offerers_models.Offerer, offerer_informations: offerers_serialize.CreateOffererQueryModel
 ) -> None:
-    offerer.street = offerer_informations.street  # type: ignore [method-assign]
+    offerer.street = offerer_informations.street  # type: ignore[method-assign]
     offerer.city = offerer_informations.city
     offerer.name = offerer_informations.name
     offerer.postalCode = offerer_informations.postalCode
@@ -835,7 +835,7 @@ def create_offerer(
         # in this case it is passed to NEW if the structure is not rejected
         user_offerer = (
             offerers_models.UserOfferer.query.filter_by(userId=user.id, offererId=offerer.id)
-            .filter(sa.or_(offerers_models.UserOfferer.isRejected, offerers_models.UserOfferer.isDeleted))  # type: ignore [type-var]
+            .filter(sa.or_(offerers_models.UserOfferer.isRejected, offerers_models.UserOfferer.isDeleted))  # type: ignore[type-var]
             .first()
         )
         if user_offerer:
@@ -941,7 +941,7 @@ def update_offerer(
         offerer.postalCode = postal_code
     if street is not offerers_constants.UNCHANGED and offerer.street != street:
         modified_info["street"] = {"old_info": offerer.street, "new_info": street}
-        offerer.street = street  # type: ignore [method-assign]
+        offerer.street = street  # type: ignore[method-assign]
     if tags is not offerers_constants.UNCHANGED:
         if set(offerer.tags) != set(tags):
             modified_info["tags"] = {
@@ -1240,8 +1240,8 @@ def rm_previous_venue_thumbs(venue: models.Venue) -> None:
         original_image_timestamp = get_timestamp_from_url(original_image_url)
         storage.remove_thumb(venue, storage_id_suffix=original_image_timestamp)
 
-    venue.bannerUrl = None  # type: ignore [method-assign]
-    venue.bannerMeta = None  # type: ignore [method-assign]
+    venue.bannerUrl = None  # type: ignore[method-assign]
+    venue.bannerMeta = None  # type: ignore[method-assign]
     venue.thumbCount = 1
 
 
@@ -1279,8 +1279,8 @@ def save_venue_banner(
         model_with_thumb=venue, image_as_bytes=content, storage_id_suffix_str=original_image_timestamp, keep_ratio=True
     )
 
-    venue.bannerUrl = f"{venue.thumbUrl}_{banner_timestamp}"  # type: ignore [method-assign]
-    venue.bannerMeta = {  # type: ignore [method-assign]
+    venue.bannerUrl = f"{venue.thumbUrl}_{banner_timestamp}"  # type: ignore[method-assign]
+    venue.bannerMeta = {  # type: ignore[method-assign]
         "image_credit": image_credit,
         "author_id": user.id,
         "original_image_url": f"{venue.thumbUrl}_{original_image_timestamp}",
@@ -1414,7 +1414,7 @@ def search_offerer(search_query: str, departments: typing.Iterable[str] = ()) ->
         return offerers.filter(False)
 
     if departments:
-        offerers = offerers.filter(models.Offerer.departementCode.in_(departments))  # type: ignore [attr-defined]
+        offerers = offerers.filter(models.Offerer.departementCode.in_(departments))  # type: ignore[attr-defined]
 
     if search_query.isnumeric():
         if len(search_query) == 9:
@@ -1621,7 +1621,7 @@ def get_offerer_offers_stats(offerer_id: int, max_offer_count: int = 0) -> dict:
                     ),
                     sa.and_(
                         sa.not_(offer_class.isActive),
-                        offer_class.validation.in_(  # type: ignore [attr-defined]
+                        offer_class.validation.in_(  # type: ignore[attr-defined]
                             [
                                 offers_models.OfferValidationStatus.APPROVED.value,
                                 offers_models.OfferValidationStatus.PENDING.value,
@@ -1718,7 +1718,7 @@ def get_venue_offers_stats(venue_id: int, max_offer_count: int = 0) -> dict:
                     sa.and_(
                         sa.not_(offer_class.isActive),
                         offer_class.venueId == venue_id,
-                        offer_class.validation.in_(  # type: ignore [attr-defined]
+                        offer_class.validation.in_(  # type: ignore[attr-defined]
                             [
                                 offers_models.OfferValidationStatus.APPROVED.value,
                                 offers_models.OfferValidationStatus.PENDING.value,
@@ -1886,7 +1886,7 @@ def create_from_onboarding_data(
                 siret=onboarding_data.siret,
             )
         venue_kwargs = common_kwargs | comment_and_siret
-        venue_creation_info = venues_serialize.PostVenueBodyModel(**venue_kwargs)  # type: ignore [arg-type]
+        venue_creation_info = venues_serialize.PostVenueBodyModel(**venue_kwargs)  # type: ignore[arg-type]
         venue = create_venue(venue_creation_info)
         create_venue_registration(venue.id, new_onboarding_info.target, new_onboarding_info.webPresence)
 

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -405,19 +405,19 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
 
     def __init__(self, street: str | None = None, **kwargs: typing.Any) -> None:
         if street:
-            self.street = street  # type: ignore [method-assign]
+            self.street = street  # type: ignore[method-assign]
         super().__init__(**kwargs)
 
     @hybrid_property
     def street(self) -> str | None:
         return self._address
 
-    @street.setter  # type: ignore [no-redef]
+    @street.setter  # type: ignore[no-redef]
     def street(self, value: str | None) -> None:
         self._address = value
         self._street = value
 
-    @street.expression  # type: ignore [no-redef]
+    @street.expression  # type: ignore[no-redef]
     def street(cls):  # pylint: disable=no-self-argument
         return cls._address
 
@@ -441,11 +441,11 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
             return self.googlePlacesInfo.bannerUrl
         return self._get_type_banner_url()
 
-    @bannerUrl.setter  # type: ignore [no-redef]
+    @bannerUrl.setter  # type: ignore[no-redef]
     def bannerUrl(self, value: str | None) -> None:
         self._bannerUrl = value
 
-    @bannerUrl.expression  # type: ignore [no-redef]
+    @bannerUrl.expression  # type: ignore[no-redef]
     def bannerUrl(cls):  # pylint: disable=no-self-argument
         return cls._bannerUrl
 
@@ -472,11 +472,11 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
                 return BannerMetaModel(image_credit=credit, image_credit_url=url, is_from_google=True)
         return None
 
-    @bannerMeta.setter  # type: ignore [no-redef]
+    @bannerMeta.setter  # type: ignore[no-redef]
     def bannerMeta(self, value: str | None) -> None:
         self._bannerMeta = value
 
-    @bannerMeta.expression  # type: ignore [no-redef]
+    @bannerMeta.expression  # type: ignore[no-redef]
     def bannerMeta(cls):  # pylint: disable=no-self-argument
         return cls._bannerMeta
 
@@ -530,7 +530,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     def dms_adage_status(self) -> str | None:
         return self.last_collective_dms_application.state if self.last_collective_dms_application else None
 
-    @dms_adage_status.expression  # type: ignore [no-redef]
+    @dms_adage_status.expression  # type: ignore[no-redef]
     def dms_adage_status(cls) -> str | None:  # pylint: disable=no-self-argument
         return (
             db.session.query(educational_models.CollectiveDmsApplication.state)
@@ -644,7 +644,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
             .scalar()
         )
 
-    @current_reimbursement_point_id.expression  # type: ignore [no-redef]
+    @current_reimbursement_point_id.expression  # type: ignore[no-redef]
     def current_reimbursement_point_id(cls) -> int | None:  # pylint: disable=no-self-argument # type: ignore[no-redef]
         now = datetime.utcnow()
 
@@ -718,7 +718,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     def common_name(self) -> str:
         return self.publicName or self.name
 
-    @common_name.expression  # type: ignore [no-redef]
+    @common_name.expression  # type: ignore[no-redef]
     def common_name(cls) -> str:  # pylint: disable=no-self-argument
         return sqla_func.coalesce(func.nullif(cls.publicName, ""), cls.name)
 
@@ -1030,19 +1030,19 @@ class Offerer(
 
     def __init__(self, street: str | None = None, **kwargs: typing.Any) -> None:
         if street:
-            self.street = street  # type: ignore [method-assign]
+            self.street = street  # type: ignore[method-assign]
         super().__init__(**kwargs)
 
     @hybrid_property
     def street(self) -> str | None:
         return self._address
 
-    @street.setter  # type: ignore [no-redef]
+    @street.setter  # type: ignore[no-redef]
     def street(self, value: str | None) -> None:
         self._address = value
         self._street = value
 
-    @street.expression  # type: ignore [no-redef]
+    @street.expression  # type: ignore[no-redef]
     def street(cls):  # pylint: disable=no-self-argument
         return cls._address
 
@@ -1071,7 +1071,7 @@ class Offerer(
     def departementCode(self) -> str:
         return postal_code_utils.PostalCode(self.postalCode).get_departement_code()
 
-    @departementCode.expression  # type: ignore [no-redef]
+    @departementCode.expression  # type: ignore[no-redef]
     def departementCode(cls) -> Case:  # pylint: disable=no-self-argument
         return case(
             (
@@ -1287,7 +1287,7 @@ class OffererAddress(PcObject, Base, Model):
     def isEditable(self) -> bool:
         return db.session.query(~sa.select(1).exists().where(Venue.offererAddressId == self.id)).scalar()
 
-    @isEditable.expression  # type: ignore [no-redef]
+    @isEditable.expression  # type: ignore[no-redef]
     def isEditable(cls) -> sa.sql.elements.BooleanClauseList:  # pylint: disable=no-self-argument
         return ~sa.select(1).where(Venue.offererAddressId == cls.id).exists()
 

--- a/api/src/pcapi/core/offerers/synchronize_venues_banners_with_google_places.py
+++ b/api/src/pcapi/core/offerers/synchronize_venues_banners_with_google_places.py
@@ -59,7 +59,7 @@ def get_venues_without_photo(frequency: int) -> list[offerers_models.Venue]:
         offerers_models.Venue.query.join(offerers_models.Offerer)
         .filter(
             offerers_models.Venue.isPermanent.is_(True),
-            offerers_models.Venue.bannerUrl.is_(None),  # type: ignore [attr-defined]
+            offerers_models.Venue.bannerUrl.is_(None),  # type: ignore[attr-defined]
             offerers_models.Venue.venueTypeCode != "Lieu administratif",
             offerers_models.Offerer.isActive.is_(True),
             offerers_models.Venue.id % (SHORTEST_MONTH_LENGTH // frequency) == (day - 1) // frequency,

--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -33,7 +33,7 @@ class CheckOffererSirenRequest(BaseModel):
     tag_when_inactive: bool
 
 
-@task(settings.GCP_CHECK_OFFERER_SIREN_QUEUE_NAME, "/offerers/check_offerer", task_request_timeout=3 * 60)  # type: ignore [arg-type]
+@task(settings.GCP_CHECK_OFFERER_SIREN_QUEUE_NAME, "/offerers/check_offerer", task_request_timeout=3 * 60)  # type: ignore[arg-type]
 def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
     if not siren_utils.is_valid_siren(payload.siren):
         logger.error("Invalid SIREN format in the database", extra={"siren": payload.siren})

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -533,7 +533,7 @@ def create_stock(
         quantity=quantity,
         beginningDatetime=beginning_datetime,
         bookingLimitDatetime=booking_limit_datetime,
-        priceCategory=price_category,  # type: ignore [arg-type]
+        priceCategory=price_category,  # type: ignore[arg-type]
     )
     created_activation_codes = []
 

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -102,7 +102,7 @@ def build_extra_data_from_subcategory(
             continue
         match field:
             case item if item in name_fields:
-                extradata[field] = fake.name()  # type: ignore [literal-required]
+                extradata[field] = fake.name()  # type: ignore[literal-required]
             case subcategories.ExtraDataFieldEnum.EAN.value:
                 extradata[field] = fake.ean13()
             case subcategories.ExtraDataFieldEnum.GTL_ID.value:

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -263,7 +263,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     def _bookable(self) -> bool:
         return not self.isExpired and not self.isSoldOut
 
-    @_bookable.expression  # type: ignore [no-redef]
+    @_bookable.expression  # type: ignore[no-redef]
     def _bookable(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(sa.not_(cls.isExpired), sa.not_(cls.isSoldOut))
 
@@ -277,7 +277,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     def hasBookingLimitDatetimePassed(self) -> bool:
         return bool(self.bookingLimitDatetime and self.bookingLimitDatetime <= datetime.datetime.utcnow())
 
-    @hasBookingLimitDatetimePassed.expression  # type: ignore [no-redef]
+    @hasBookingLimitDatetimePassed.expression  # type: ignore[no-redef]
     def hasBookingLimitDatetimePassed(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(cls.bookingLimitDatetime.is_not(None), cls.bookingLimitDatetime <= sa.func.now())
 
@@ -286,7 +286,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     def remainingQuantity(self) -> int | str:
         return "unlimited" if self.quantity is None else self.quantity - self.dnBookedQuantity
 
-    @remainingQuantity.expression  # type: ignore [no-redef]
+    @remainingQuantity.expression  # type: ignore[no-redef]
     def remainingQuantity(cls) -> Case:  # pylint: disable=no-self-argument
         return sa.case((cls.quantity.is_(None), None), else_=(cls.quantity - cls.dnBookedQuantity))
 
@@ -304,7 +304,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     def isEventExpired(self) -> bool:
         return bool(self.beginningDatetime and self.beginningDatetime <= datetime.datetime.utcnow())
 
-    @isEventExpired.expression  # type: ignore [no-redef]
+    @isEventExpired.expression  # type: ignore[no-redef]
     def isEventExpired(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(cls.beginningDatetime.is_not(None), cls.beginningDatetime <= sa.func.now())
 
@@ -312,7 +312,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
     def isExpired(self) -> bool:
         return self.isEventExpired or self.hasBookingLimitDatetimePassed
 
-    @isExpired.expression  # type: ignore [no-redef]
+    @isExpired.expression  # type: ignore[no-redef]
     def isExpired(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.or_(cls.isEventExpired, cls.hasBookingLimitDatetimePassed)
 
@@ -332,7 +332,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
             or (self.remainingQuantity != "unlimited" and self.remainingQuantity <= 0)
         )
 
-    @isSoldOut.expression  # type: ignore [no-redef]
+    @isSoldOut.expression  # type: ignore[no-redef]
     def isSoldOut(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.or_(
             cls.isSoftDeleted,
@@ -370,7 +370,7 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
             return None if self.remainingQuantity == "unlimited" else self.remainingQuantity
         return 0
 
-    @remainingStock.expression  # type: ignore [no-redef]
+    @remainingStock.expression  # type: ignore[no-redef]
     def remainingStock(cls) -> Case:  # pylint: disable=no-self-argument
         return sa.case((cls._bookable, cls.remainingQuantity), else_=0)
 
@@ -560,7 +560,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
                 return False
         return True
 
-    @isSoldOut.expression  # type: ignore [no-redef]
+    @isSoldOut.expression  # type: ignore[no-redef]
     def isSoldOut(cls) -> UnaryExpression:  # pylint: disable=no-self-argument
         return (
             ~sa.exists()
@@ -580,7 +580,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def canExpire(self) -> bool:
         return self.subcategoryId in subcategories_v2.EXPIRABLE_SUBCATEGORIES
 
-    @canExpire.expression  # type: ignore [no-redef]
+    @canExpire.expression  # type: ignore[no-redef]
     def canExpire(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories_v2.EXPIRABLE_SUBCATEGORIES)
 
@@ -593,7 +593,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def _released(self) -> bool:
         return self.isActive and self.validation == OfferValidationStatus.APPROVED
 
-    @_released.expression  # type: ignore [no-redef]
+    @_released.expression  # type: ignore[no-redef]
     def _released(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(cls.isActive, cls.validation == OfferValidationStatus.APPROVED)
 
@@ -601,7 +601,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def isPermanent(self) -> bool:
         return self.subcategoryId in subcategories_v2.PERMANENT_SUBCATEGORIES
 
-    @isPermanent.expression  # type: ignore [no-redef]
+    @isPermanent.expression  # type: ignore[no-redef]
     def isPermanent(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories_v2.PERMANENT_SUBCATEGORIES)
 
@@ -609,7 +609,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def isEvent(self) -> bool:
         return self.subcategory.is_event
 
-    @isEvent.expression  # type: ignore [no-redef]
+    @isEvent.expression  # type: ignore[no-redef]
     def isEvent(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories_v2.EVENT_SUBCATEGORIES)
 
@@ -621,7 +621,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def isDigital(self) -> bool:
         return self.url is not None and self.url != ""
 
-    @isDigital.expression  # type: ignore [no-redef]
+    @isDigital.expression  # type: ignore[no-redef]
     def isDigital(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(cls.url.is_not(None), cls.url != "")
 
@@ -655,7 +655,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def is_eligible_for_search(self) -> bool:
         return self.isReleased and self.isBookable
 
-    @is_eligible_for_search.expression  # type: ignore [no-redef]
+    @is_eligible_for_search.expression  # type: ignore[no-redef]
     def is_eligible_for_search(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(cls._released, Stock._bookable)
 
@@ -663,7 +663,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def is_offer_released_with_bookable_stock(self) -> bool:
         return self.isReleased and self.isBookable
 
-    @is_offer_released_with_bookable_stock.expression  # type: ignore [no-redef]
+    @is_offer_released_with_bookable_stock.expression  # type: ignore[no-redef]
     def is_offer_released_with_bookable_stock(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(cls._released, sa.exists().where(Stock.offerId == cls.id).where(Stock._bookable))
 
@@ -673,7 +673,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
             return all(stock.hasBookingLimitDatetimePassed for stock in self.activeStocks)
         return False
 
-    @hasBookingLimitDatetimesPassed.expression  # type: ignore [no-redef]
+    @hasBookingLimitDatetimesPassed.expression  # type: ignore[no-redef]
     def hasBookingLimitDatetimesPassed(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.and_(
             sa.exists().where(Stock.offerId == cls.id).where(Stock.isSoftDeleted.is_(False)),
@@ -690,7 +690,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         ]
         return min(stocks_with_date) if stocks_with_date else None
 
-    @firstBeginningDatetime.expression  # type: ignore [no-redef]
+    @firstBeginningDatetime.expression  # type: ignore[no-redef]
     def firstBeginningDatetime(cls) -> datetime.datetime | None:  # pylint: disable=no-self-argument
         return (
             sa.select(sa.func.min(Stock.beginningDatetime))
@@ -792,7 +792,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     def is_expired(self) -> bool:
         return self.hasBookingLimitDatetimesPassed
 
-    @is_expired.expression  # type: ignore [no-redef]
+    @is_expired.expression  # type: ignore[no-redef]
     def is_expired(cls) -> UnaryExpression:  # pylint: disable=no-self-argument
         return cls.hasBookingLimitDatetimesPassed
 
@@ -818,7 +818,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
 
         return OfferStatus.ACTIVE
 
-    @status.expression  # type: ignore [no-redef]
+    @status.expression  # type: ignore[no-redef]
     def status(cls) -> Case:  # pylint: disable=no-self-argument
         return sa.case(
             (cls.validation == OfferValidationStatus.REJECTED.name, OfferStatus.REJECTED.name),

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -690,7 +690,7 @@ def get_expired_offers(interval: list[datetime.datetime]) -> flask_sqlalchemy.Ba
             models.Stock.isSoftDeleted.is_(False),
             models.Stock.bookingLimitDatetime.is_not(None),
         )
-        .having(sa.func.max(models.Stock.bookingLimitDatetime).between(*interval))  # type: ignore [arg-type]
+        .having(sa.func.max(models.Stock.bookingLimitDatetime).between(*interval))  # type: ignore[arg-type]
         .group_by(models.Offer.id)
         .order_by(models.Offer.id)
     )
@@ -864,7 +864,7 @@ def _order_stocks_by(
         case StocksOrderedBy.BOOKING_LIMIT_DATETIME:
             column = models.Stock.bookingLimitDatetime
         case StocksOrderedBy.REMAINING_QUANTITY:
-            column = models.Stock.remainingQuantity  # type: ignore [assignment]
+            column = models.Stock.remainingQuantity  # type: ignore[assignment]
         case StocksOrderedBy.DN_BOOKED_QUANTITY:
             column = models.Stock.dnBookedQuantity
     if order_by_desc:
@@ -896,7 +896,7 @@ def get_filtered_stocks(
     if time is not None:
         # Transform user time input into the venue timezone
         dt = datetime.datetime.combine(datetime.datetime.today(), time)
-        venue_timezone = pytz.timezone(venue.timezone)  # type: ignore [arg-type]
+        venue_timezone = pytz.timezone(venue.timezone)  # type: ignore[arg-type]
         venue_time = dt.replace(tzinfo=pytz.utc).astimezone(venue_timezone).time()
 
         query = query.filter(

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -93,7 +93,7 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
 
     def getProviderAPI(self) -> ProviderAPI:
         return ProviderAPI(
-            api_url=self.apiUrl,  # type: ignore [arg-type]
+            api_url=self.apiUrl,  # type: ignore[arg-type]
             name=self.name,
             authentication_token=self.authToken,
         )
@@ -102,7 +102,7 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
     def allow_bo_sync(self) -> bool:
         return self.isActive and self.apiUrl != None and "praxiel" not in self.name.lower()
 
-    @allow_bo_sync.expression  # type: ignore [no-redef]
+    @allow_bo_sync.expression  # type: ignore[no-redef]
     def allow_bo_sync(cls) -> sa_sql.elements.BooleanClauseList:  # pylint: disable=no-self-argument
         # Praxiel API is very slow (with response times up to 30 seconds) and unstable (with frequent 50x
         # error responses). Full synchronization very rarely succeeds, don't bother trying.
@@ -132,7 +132,7 @@ class VenueProvider(PcObject, Base, Model, DeactivableMixin):
     # describe if synchronised offers are available for duo booking or not
     isDuoOffers = sa.Column(sa.Boolean, nullable=True)
 
-    isFromAllocineProvider = sa_orm.column_property(  # type: ignore [misc]
+    isFromAllocineProvider = sa_orm.column_property(  # type: ignore[misc]
         sa.exists(
             sa.select(Provider.id)
             .where(sa.and_(Provider.id == providerId, Provider.localClass == "AllocineStocks"))
@@ -140,7 +140,7 @@ class VenueProvider(PcObject, Base, Model, DeactivableMixin):
         )
     )
 
-    isFromCinemaProvider = sa_orm.column_property(  # type: ignore [misc]
+    isFromCinemaProvider = sa_orm.column_property(  # type: ignore[misc]
         sa.exists(sa.select(Provider.id))
         .where(
             sa.and_(

--- a/api/src/pcapi/core/providers/tasks.py
+++ b/api/src/pcapi/core/providers/tasks.py
@@ -17,7 +17,7 @@ class SynchronizeVenueProvidersRequest(BaseModel):
     venue_provider_ids: list[int]
 
 
-@task(settings.GCP_SYNCHRONIZE_VENUE_PROVIDERS_QUEUE_NAME, "/providers/synchronize_venue_providers", task_request_timeout=30 * 60)  # type: ignore [arg-type]
+@task(settings.GCP_SYNCHRONIZE_VENUE_PROVIDERS_QUEUE_NAME, "/providers/synchronize_venue_providers", task_request_timeout=30 * 60)  # type: ignore[arg-type]
 def synchronize_venue_providers_task(payload: SynchronizeVenueProvidersRequest) -> None:
     provider_id = payload.provider_id
     venue_provider_ids = payload.venue_provider_ids

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -79,7 +79,7 @@ def _log_async_request(
             "resource_type": resource_type,
             "reason": reason.value,
             # FIXME (dbaty, 2023-11-24) change `ids` to be a `Sequence[int]`
-            "count": len(ids),  # type: ignore [arg-type]
+            "count": len(ids),  # type: ignore[arg-type]
             "partial_ids": list(ids)[:50],  # avoid huge log
         }
         | extra,

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -165,7 +165,7 @@ class AlgoliaBackend(base.SearchBackend):
                     "currently_indexed_offers": currently_indexed_offers,
                     "offers_in_indexing_queue": offers_in_indexing_queue,
                     "partial_ids": list(offer_ids)[:50],
-                    "count": len(offer_ids),  # type: ignore [arg-type]
+                    "count": len(offer_ids),  # type: ignore[arg-type]
                     "limit": limit,
                 },
             )

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -91,7 +91,7 @@ def activate_beneficiary_for_eligibility(
     batch.track_deposit_activated_event(user.id, deposit)
     amplitude_events.track_deposit_activation_event(user.id, deposit, fraud_check)
 
-    if "apps_flyer" in user.externalIds:  # type: ignore [operator]
+    if "apps_flyer" in user.externalIds:  # type: ignore[operator]
         apps_flyer_job.log_user_becomes_beneficiary_event_job.delay(user.id)
 
     return user
@@ -324,7 +324,7 @@ def get_identity_check_subscription_item(
 def get_honor_statement_subscription_item(
     user: users_models.User, eligibility: users_models.EligibilityType | None
 ) -> models.SubscriptionItem:
-    if fraud_api.has_performed_honor_statement(user, eligibility):  # type: ignore [arg-type]
+    if fraud_api.has_performed_honor_statement(user, eligibility):  # type: ignore[arg-type]
         status = models.SubscriptionItemStatus.OK
     else:
         if is_eligibility_activable(user, eligibility):
@@ -586,11 +586,11 @@ def _is_ubble_allowed_if_subscription_overflow(user: users_models.User) -> bool:
 
     future_age = users_utils.get_age_at_date(
         user.birth_date,
-        datetime.datetime.utcnow() + datetime.timedelta(days=settings.UBBLE_SUBSCRIPTION_LIMITATION_DAYS),  # type: ignore [arg-type]
+        datetime.datetime.utcnow() + datetime.timedelta(days=settings.UBBLE_SUBSCRIPTION_LIMITATION_DAYS),  # type: ignore[arg-type]
     )
     eligibility_ranges = users_constants.ELIGIBILITY_UNDERAGE_RANGE + [users_constants.ELIGIBILITY_AGE_18]
     eligibility_ranges = [age + 1 for age in eligibility_ranges]
-    if future_age > user.age and future_age in eligibility_ranges:  # type: ignore [operator]
+    if future_age > user.age and future_age in eligibility_ranges:  # type: ignore[operator]
         return True
 
     return False

--- a/api/src/pcapi/core/subscription/phone_validation/api.py
+++ b/api/src/pcapi/core/subscription/phone_validation/api.py
@@ -150,7 +150,7 @@ def send_phone_validation_code(
         _check_sms_sending_is_allowed(user)
     _ensure_phone_number_unicity(user, phone_data.phone_number, change_owner=False)
 
-    user.phoneNumber = phone_data.phone_number  # type: ignore [method-assign]
+    user.phoneNumber = phone_data.phone_number  # type: ignore[method-assign]
     repository.save(user)
 
     phone_validation_token = users_api.create_phone_validation_token(
@@ -184,7 +184,7 @@ def validate_phone_number(user: users_models.User, code: str) -> None:
 
     _ensure_phone_number_unicity(user, phone_number, change_owner=True)
 
-    user.phoneNumber = phone_number  # type: ignore [method-assign]
+    user.phoneNumber = phone_number  # type: ignore[method-assign]
     user.phoneValidationStatus = users_models.PhoneValidationStatusType.VALIDATED
 
     fraud_check = fraud_models.BeneficiaryFraudCheck(
@@ -192,7 +192,7 @@ def validate_phone_number(user: users_models.User, code: str) -> None:
         type=fraud_models.FraudCheckType.PHONE_VALIDATION,
         status=fraud_models.FraudCheckStatus.OK,
         eligibilityType=user.eligibility,
-        resultContent=fraud_models.PhoneValidationFraudData(phone_number=phone_number),  # type: ignore [arg-type]
+        resultContent=fraud_models.PhoneValidationFraudData(phone_number=phone_number),  # type: ignore[arg-type]
         thirdPartyId=f"PC-{user.id}",
     )
 

--- a/api/src/pcapi/core/subscription/profile_options.py
+++ b/api/src/pcapi/core/subscription/profile_options.py
@@ -17,10 +17,10 @@ class SchoolType:
         super().__init__()
 
 
-SCHOOL_TYPE_ID_ENUM = enum.Enum(  # type: ignore [misc]
+SCHOOL_TYPE_ID_ENUM = enum.Enum(  # type: ignore[misc]
     "SchoolTypesIdEnum", {school_type.name: school_type.name for school_type in users_models.SchoolTypeEnum}
 )
-SCHOOL_TYPE_VALUE_ENUM = enum.Enum(  # type: ignore [misc]
+SCHOOL_TYPE_VALUE_ENUM = enum.Enum(  # type: ignore[misc]
     "SchoolTypesValueEnum", {school_type.value: school_type.value for school_type in users_models.SchoolTypeEnum}
 )
 
@@ -78,5 +78,5 @@ ALL_ACTIVITIES = [
     UNEMPLOYED,
 ]
 
-ACTIVITY_ID_ENUM = enum.Enum("ActivityIdEnum", {activity.id: activity.id for activity in ALL_ACTIVITIES})  # type: ignore [misc]
-ACTIVITY_VALUE_ENUM = enum.Enum("ActivityValueEnum", {activity.label: activity.label for activity in ALL_ACTIVITIES})  # type: ignore [misc]
+ACTIVITY_ID_ENUM = enum.Enum("ActivityIdEnum", {activity.id: activity.id for activity in ALL_ACTIVITIES})  # type: ignore[misc]
+ACTIVITY_VALUE_ENUM = enum.Enum("ActivityValueEnum", {activity.label: activity.label for activity in ALL_ACTIVITIES})  # type: ignore[misc]

--- a/api/src/pcapi/core/testing.py
+++ b/api/src/pcapi/core/testing.py
@@ -42,9 +42,9 @@ def assert_no_duplicated_queries() -> collections.abc.Generator[None, None, None
                 function_under_test()
     """
     # We record queries with _record_end_of_query and register_event_for_query_logger
-    flask._app_ctx_stack._query_logger = []  # type: ignore [attr-defined]
+    flask._app_ctx_stack._query_logger = []  # type: ignore[attr-defined]
     yield
-    queries = flask._app_ctx_stack._query_logger.copy()  # type: ignore [attr-defined]
+    queries = flask._app_ctx_stack._query_logger.copy()  # type: ignore[attr-defined]
 
     statements = [query["statement"] for query in queries if "from feature" not in query["statement"].lower()]
 
@@ -77,16 +77,16 @@ def assert_num_queries(expected_n_queries: int) -> collections.abc.Generator[Non
     """
     # Flask gracefully provides a global. Flask-SQLAlchemy uses it for
     # the same purpose. Let's do the same.
-    flask._app_ctx_stack._query_logger = []  # type: ignore [attr-defined]
+    flask._app_ctx_stack._query_logger = []  # type: ignore[attr-defined]
     yield
-    queries = flask._app_ctx_stack._query_logger.copy()  # type: ignore [attr-defined]
+    queries = flask._app_ctx_stack._query_logger.copy()  # type: ignore[attr-defined]
 
     if len(queries) != expected_n_queries:
         details = "\n".join(_format_sql_query(query, i, len(queries)) for i, query in enumerate(queries, start=1))
         pytest.fail(
             f"{len(queries)} queries executed, {expected_n_queries} expected\n" f"Captured queries were:\n{details}"
         )
-    del flask._app_ctx_stack._query_logger  # type: ignore [attr-defined]
+    del flask._app_ctx_stack._query_logger  # type: ignore[attr-defined]
 
 
 def _format_sql_query(query: dict, i: int, total: int) -> str:
@@ -173,8 +173,8 @@ class TestContextDecorator:
             if decorated_teardown_method:
                 decorated_teardown_method(inner_self)
 
-        cls.setup_method = setup_method  # type: ignore [attr-defined]
-        cls.teardown_method = teardown_method  # type: ignore [attr-defined]
+        cls.setup_method = setup_method  # type: ignore[attr-defined]
+        cls.teardown_method = teardown_method  # type: ignore[attr-defined]
         return cls
 
     def decorate_callable(self, func: typing.Callable) -> typing.Callable:

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -153,10 +153,10 @@ def create_account(
         user.externalIds = {}
 
     if apps_flyer_user_id and apps_flyer_platform:
-        user.externalIds["apps_flyer"] = {"user": apps_flyer_user_id, "platform": apps_flyer_platform.upper()}  # type: ignore [index, call-overload]
+        user.externalIds["apps_flyer"] = {"user": apps_flyer_user_id, "platform": apps_flyer_platform.upper()}  # type: ignore[index, call-overload]
 
     if firebase_pseudo_id:
-        user.externalIds["firebase_pseudo_id"] = firebase_pseudo_id  # type: ignore [index, call-overload]
+        user.externalIds["firebase_pseudo_id"] = firebase_pseudo_id  # type: ignore[index, call-overload]
 
     repository.save(user)
     logger.info("Created user account", extra={"user": user.id})
@@ -640,7 +640,7 @@ def update_user_info(
         user_phone_number = typing.cast(str, user.phoneNumber)
         if user_phone_number != phone_number:
             snapshot.set("phoneNumber", old=user_phone_number, new=phone_number)
-        user.phoneNumber = phone_number  # type: ignore [method-assign]
+        user.phoneNumber = phone_number  # type: ignore[method-assign]
     if address is not UNCHANGED:
         if address != user.address:
             snapshot.set("address", old=user.address, new=address)
@@ -1037,7 +1037,7 @@ def get_eligibility_at_date(
     eligibility_start = get_eligibility_start_datetime(date_of_birth)
     eligibility_end = get_eligibility_end_datetime(date_of_birth)
 
-    if not date_of_birth or not (eligibility_start <= specified_datetime < eligibility_end):  # type: ignore [operator]
+    if not date_of_birth or not (eligibility_start <= specified_datetime < eligibility_end):  # type: ignore[operator]
         return None
 
     age = users_utils.get_age_at_date(date_of_birth, specified_datetime)
@@ -1047,7 +1047,7 @@ def get_eligibility_at_date(
     if age in constants.ELIGIBILITY_UNDERAGE_RANGE:
         return models.EligibilityType.UNDERAGE
     # If the user is older than 18 in UTC timezone, we consider them eligible until they reach eligibility_end
-    if constants.ELIGIBILITY_AGE_18 <= age and specified_datetime < eligibility_end:  # type: ignore [operator]
+    if constants.ELIGIBILITY_AGE_18 <= age and specified_datetime < eligibility_end:  # type: ignore[operator]
         return models.EligibilityType.AGE18
 
     return None
@@ -1083,7 +1083,7 @@ def _filter_user_accounts(accounts: BaseQuery, search_term: str) -> BaseQuery:
     except phone_validation_exceptions.InvalidPhoneNumber:
         pass  # term can't be a phone number
     else:
-        term_filters.append(models.User.phoneNumber == term_as_phone_number)  # type: ignore [arg-type]
+        term_filters.append(models.User.phoneNumber == term_as_phone_number)  # type: ignore[arg-type]
 
     # numeric (single id or multiple ids)
     split_terms = re.split(r"[,;\s]+", search_term)
@@ -1167,7 +1167,7 @@ def get_public_account_base_query() -> BaseQuery:
     # using the same email as their personal account. So let's include "pro" users who are beneficiaries (doesn't
     # include those who are only in the subscription process).
     public_accounts = models.User.query.outerjoin(users_models.User.backoffice_profile).filter(
-        sa.or_(  # type: ignore [type-var]
+        sa.or_(  # type: ignore[type-var]
             sa.and_(
                 sa.not_(models.User.has_pro_role),
                 sa.not_(models.User.has_non_attached_pro_role),
@@ -1182,7 +1182,7 @@ def get_public_account_base_query() -> BaseQuery:
 # TODO (prouzet, 2023-11-02) This function should be moved in backoffice and use common _join_suspension_history()
 def search_pro_account(search_query: str, *_: typing.Any) -> BaseQuery:
     pro_accounts = models.User.query.filter(
-        sa.or_(  # type: ignore [type-var]
+        sa.or_(  # type: ignore[type-var]
             models.User.has_non_attached_pro_role,
             models.User.has_pro_role,
         )
@@ -1210,7 +1210,7 @@ def search_pro_account(search_query: str, *_: typing.Any) -> BaseQuery:
 def get_pro_account_base_query(pro_id: int) -> BaseQuery:
     return models.User.query.filter(
         models.User.id == pro_id,
-        sa.or_(  # type: ignore [type-var]
+        sa.or_(  # type: ignore[type-var]
             models.User.has_non_attached_pro_role,
             models.User.has_pro_role,
         ),
@@ -1544,7 +1544,7 @@ def anonymize_user(user: users_models.User, *, author: users_models.User | None 
     user.lastName = f"Anonymous_{user.id}"
     user.married_name = None
     user.postalCode = None
-    user.phoneNumber = None  # type: ignore [method-assign]
+    user.phoneNumber = None  # type: ignore[method-assign]
     user.dateOfBirth = user.dateOfBirth.replace(day=1, month=1) if user.dateOfBirth else None
     user.address = None
     user.city = None

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -134,7 +134,7 @@ class PhoneValidatedUserFactory(EmailValidatedUserFactory):
 
         fraud_checks = super().beneficiary_fraud_checks(obj, **kwargs)
         if obj.age == users_constants.ELIGIBILITY_AGE_18:
-            obj.phoneNumber = f"+336{obj.id:08}"  # type: ignore [method-assign]
+            obj.phoneNumber = f"+336{obj.id:08}"  # type: ignore[method-assign]
             obj.phoneValidationStatus = models.PhoneValidationStatusType.VALIDATED
             fraud_checks.append(fraud_factories.PhoneValidationFraudCheckFactory(user=obj))
         return fraud_checks

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -349,7 +349,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
             return self.dateOfBirth.date()
         return None
 
-    @birth_date.expression  # type: ignore [no-redef]
+    @birth_date.expression  # type: ignore[no-redef]
     def birth_date(cls) -> date | None:  # pylint: disable=no-self-argument
         return sa.case(
             (cls.validatedBirthDate.is_not(None), cls.validatedBirthDate),
@@ -399,7 +399,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
         # We use the email as a fallback because it is the most human-readable way to identify a single user
         return (f"{self.firstName or ''} {self.lastName or ''}".strip()) or self.email
 
-    @full_name.expression  # type: ignore [no-redef]
+    @full_name.expression  # type: ignore[no-redef]
     def full_name(cls) -> str:  # pylint: disable=no-self-argument
         return sa.func.coalesce(
             sa.func.nullif(
@@ -417,7 +417,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
 
     @property
     def has_active_deposit(self) -> bool:
-        return self.deposit.expirationDate > datetime.utcnow() if self.deposit else False  # type: ignore [operator]
+        return self.deposit.expirationDate > datetime.utcnow() if self.deposit else False  # type: ignore[operator]
 
     @property
     def is_eligible(self) -> bool:
@@ -526,7 +526,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def is_beneficiary(self) -> bool:
         return self.has_beneficiary_role or self.has_underage_beneficiary_role
 
-    @is_beneficiary.expression  # type: ignore [no-redef]
+    @is_beneficiary.expression  # type: ignore[no-redef]
     def is_beneficiary(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return expression.or_(
             cls.roles.contains([UserRole.BENEFICIARY]), cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
@@ -549,14 +549,14 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def phoneNumber(self) -> str | None:
         return self._phoneNumber
 
-    @phoneNumber.setter  # type: ignore [no-redef]
+    @phoneNumber.setter  # type: ignore[no-redef]
     def phoneNumber(self, value: str | None) -> None:
         if not value:
             self._phoneNumber = None
         else:
             self._phoneNumber = ParsedPhoneNumber(value).phone_number
 
-    @phoneNumber.expression  # type: ignore [no-redef]
+    @phoneNumber.expression  # type: ignore[no-redef]
     def phoneNumber(cls) -> str | None:  # pylint: disable=no-self-argument
         return cls._phoneNumber
 
@@ -564,7 +564,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def is_phone_validated(self) -> bool:
         return self.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
 
-    @is_phone_validated.expression  # type: ignore [no-redef]
+    @is_phone_validated.expression  # type: ignore[no-redef]
     def is_phone_validated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
 
@@ -572,7 +572,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def is_phone_validation_skipped(self) -> bool:
         return self.phoneValidationStatus == PhoneValidationStatusType.SKIPPED_BY_SUPPORT
 
-    @is_phone_validation_skipped.expression  # type: ignore [no-redef]
+    @is_phone_validation_skipped.expression  # type: ignore[no-redef]
     def is_phone_validation_skipped(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.phoneValidationStatus == PhoneValidationStatusType.SKIPPED_BY_SUPPORT
 
@@ -580,7 +580,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def has_admin_role(self) -> bool:
         return UserRole.ADMIN in self.roles
 
-    @has_admin_role.expression  # type: ignore [no-redef]
+    @has_admin_role.expression  # type: ignore[no-redef]
     def has_admin_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.ADMIN])
 
@@ -588,7 +588,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def has_beneficiary_role(self) -> bool:
         return UserRole.BENEFICIARY in self.roles
 
-    @has_beneficiary_role.expression  # type: ignore [no-redef]
+    @has_beneficiary_role.expression  # type: ignore[no-redef]
     def has_beneficiary_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.BENEFICIARY])
 
@@ -596,7 +596,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def has_pro_role(self) -> bool:
         return UserRole.PRO in self.roles
 
-    @has_pro_role.expression  # type: ignore [no-redef]
+    @has_pro_role.expression  # type: ignore[no-redef]
     def has_pro_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.PRO])
 
@@ -604,7 +604,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def has_non_attached_pro_role(self) -> bool:
         return UserRole.NON_ATTACHED_PRO in self.roles
 
-    @has_non_attached_pro_role.expression  # type: ignore [no-redef]
+    @has_non_attached_pro_role.expression  # type: ignore[no-redef]
     def has_non_attached_pro_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.NON_ATTACHED_PRO])
 
@@ -612,7 +612,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def has_underage_beneficiary_role(self) -> bool:
         return UserRole.UNDERAGE_BENEFICIARY in self.roles
 
-    @has_underage_beneficiary_role.expression  # type: ignore [no-redef]
+    @has_underage_beneficiary_role.expression  # type: ignore[no-redef]
     def has_underage_beneficiary_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
 
@@ -620,7 +620,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def has_test_role(self) -> bool:
         return UserRole.TEST in self.roles
 
-    @has_test_role.expression  # type: ignore [no-redef]
+    @has_test_role.expression  # type: ignore[no-redef]
     def has_test_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.TEST])
 
@@ -628,7 +628,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def has_anonymized_role(self) -> bool:
         return UserRole.ANONYMIZED in self.roles
 
-    @has_anonymized_role.expression  # type: ignore [no-redef]
+    @has_anonymized_role.expression  # type: ignore[no-redef]
     def has_anonymized_role(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.ANONYMIZED])
 
@@ -830,7 +830,7 @@ class UserEmailHistory(PcObject, Base, Model):
     def oldEmail(self) -> str:
         return f"{self.oldUserEmail}@{self.oldDomainEmail}"
 
-    @oldEmail.expression  # type: ignore [no-redef]
+    @oldEmail.expression  # type: ignore[no-redef]
     def oldEmail(cls):  # pylint: disable=no-self-argument
         return cls.oldUserEmail + "@" + cls.oldDomainEmail
 
@@ -840,7 +840,7 @@ class UserEmailHistory(PcObject, Base, Model):
             return f"{self.newUserEmail}@{self.newDomainEmail}"
         return None
 
-    @newEmail.expression  # type: ignore [no-redef]
+    @newEmail.expression  # type: ignore[no-redef]
     def newEmail(cls):  # pylint: disable=no-self-argument
         return sa.case(
             (

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -75,7 +75,7 @@ def find_pro_user_by_email_query(email: str) -> BaseQuery:
 
 
 def find_pro_or_non_attached_pro_user_by_email_query(email: str) -> BaseQuery:
-    return _find_user_by_email_query(email).filter(sa.or_(models.User.has_pro_role, models.User.has_non_attached_pro_role))  # type: ignore [type-var]
+    return _find_user_by_email_query(email).filter(sa.or_(models.User.has_pro_role, models.User.has_non_attached_pro_role))  # type: ignore[type-var]
 
 
 def get_newly_eligible_age_18_users(since: date) -> list[models.User]:
@@ -100,11 +100,11 @@ def get_newly_eligible_age_18_users(since: date) -> list[models.User]:
             sa.not_(models.User.has_admin_role),  # not an admin
             offerers_models.UserOfferer.userId.is_(None),  # not a pro
             # less than 19yo
-            models.User.birth_date > today - relativedelta(years=(constants.ELIGIBILITY_AGE_18 + 1)),  # type: ignore [operator]
+            models.User.birth_date > today - relativedelta(years=(constants.ELIGIBILITY_AGE_18 + 1)),  # type: ignore[operator]
             # more than or 18yo
-            models.User.birth_date <= today - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # type: ignore [operator]
+            models.User.birth_date <= today - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # type: ignore[operator]
             # less than 18yo at since
-            models.User.birth_date > since - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # type: ignore [operator]
+            models.User.birth_date > since - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # type: ignore[operator]
             models.User.dateCreated < today,
         )
         .all()

--- a/api/src/pcapi/domain/password.py
+++ b/api/src/pcapi/domain/password.py
@@ -13,7 +13,7 @@ def random_password() -> str:
     special_chars = [secrets.choice("#~|=;:,+><?!@$%^&*_.-")]
 
     password_chars = uppercase + lowercase + special_chars + number
-    secrets._sysrand.shuffle(password_chars)  # type: ignore [attr-defined]
+    secrets._sysrand.shuffle(password_chars)  # type: ignore[attr-defined]
 
     return "".join(password_chars)
 

--- a/api/src/pcapi/infrastructure/repository/venue/venue_with_basic_information/venue_with_basic_information_domain_converter.py
+++ b/api/src/pcapi/infrastructure/repository/venue/venue_with_basic_information/venue_with_basic_information_domain_converter.py
@@ -6,7 +6,7 @@ def to_domain(venue_sql_entity: Venue) -> VenueWithBasicInformation:
     return VenueWithBasicInformation(
         identifier=venue_sql_entity.id,
         name=venue_sql_entity.name,
-        siret=venue_sql_entity.siret,  # type: ignore [arg-type]
-        publicName=venue_sql_entity.publicName,  # type: ignore [arg-type]
+        siret=venue_sql_entity.siret,  # type: ignore[arg-type]
+        publicName=venue_sql_entity.publicName,  # type: ignore[arg-type]
         bookingEmail=venue_sql_entity.bookingEmail,
     )

--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -147,7 +147,7 @@ class AllocineStocks(LocalProvider):
         self.last_offer = offer
 
     def fill_stock_attributes(self, allocine_stock: offers_models.Stock) -> None:
-        showtime_uuid = _get_showtimes_uuid_by_idAtProvider(allocine_stock.idAtProviders)  # type: ignore [arg-type]
+        showtime_uuid = _get_showtimes_uuid_by_idAtProvider(allocine_stock.idAtProviders)  # type: ignore[arg-type]
         showtime = _find_showtime_by_showtime_uuid(self.showtimes, showtime_uuid)
         if not showtime:
             self.log_provider_event(

--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -68,7 +68,7 @@ class CDSStocks(LocalProvider):
         movie_infos = next(self.movies)
         if movie_infos:
             self.movie_information = movie_infos
-            self.filtered_movie_showtimes = _find_showtimes_by_movie_id(self.shows, int(self.movie_information.id))  # type: ignore [assignment]
+            self.filtered_movie_showtimes = _find_showtimes_by_movie_id(self.shows, int(self.movie_information.id))  # type: ignore[assignment]
             if not self.filtered_movie_showtimes:
                 return []
 
@@ -91,7 +91,7 @@ class CDSStocks(LocalProvider):
         )
         providable_information_list.append(offer_providable_info)
 
-        for show in self.filtered_movie_showtimes:  # type: ignore [attr-defined]
+        for show in self.filtered_movie_showtimes:  # type: ignore[attr-defined]
             stock_showtime_unique_id = _build_stock_uuid(
                 self.movie_information.id, self.venue, show["show_information"]
             )
@@ -203,7 +203,7 @@ class CDSStocks(LocalProvider):
         # have any remaining up-to-date stocks using old construct `idAtProviders`
         cds_stock.idAtProviders = _clean_cds_id_at_providers(cds_stock.idAtProviders)
 
-        showtime = _find_showtime_by_showtime_uuid(self.filtered_movie_showtimes, showtime_uuid)  # type: ignore [arg-type]
+        showtime = _find_showtime_by_showtime_uuid(self.filtered_movie_showtimes, showtime_uuid)  # type: ignore[arg-type]
 
         if showtime:
             price_label = showtime["price_label"]

--- a/api/src/pcapi/local_providers/local_provider.py
+++ b/api/src/pcapi/local_providers/local_provider.py
@@ -114,7 +114,7 @@ class LocalProvider(Iterator):
         pc_object = providable_info.type()
         pc_object.idAtProviders = providable_info.id_at_providers
         pc_object.idAtProvider = providable_info.new_id_at_provider
-        pc_object.lastProviderId = self.provider.id  # type: ignore [assignment]
+        pc_object.lastProviderId = self.provider.id  # type: ignore[assignment]
 
         self.fill_object_attributes(pc_object)
         pc_object.dateModifiedAtLastProvider = providable_info.date_modified_at_provider

--- a/api/src/pcapi/local_providers/titelive_thing_descriptions/titelive_thing_descriptions.py
+++ b/api/src/pcapi/local_providers/titelive_thing_descriptions/titelive_thing_descriptions.py
@@ -91,7 +91,7 @@ class TiteLiveThingDescriptions(LocalProvider):
         if latest_sync_part_end_event is None:
             return iter(all_zips)
         return iter(
-            filter(lambda z: get_date_from_filename(z, DATE_REGEXP) > int(latest_sync_part_end_event.payload), all_zips)  # type: ignore [arg-type]
+            filter(lambda z: get_date_from_filename(z, DATE_REGEXP) > int(latest_sync_part_end_event.payload), all_zips)  # type: ignore[arg-type]
         )
 
     def get_description_files_from_zip_info(self) -> Iterator[ZipInfo]:

--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -396,7 +396,7 @@ class TiteLiveThings(LocalProvider):
 
         self.data_lines = get_lines_from_thing_file(str(self.products_file))
 
-    def get_remaining_files_to_check(self, ordered_thing_files: list) -> iter:  # type: ignore [valid-type]
+    def get_remaining_files_to_check(self, ordered_thing_files: list) -> iter:  # type: ignore[valid-type]
         latest_sync_part_end_event = providers_repository.find_latest_sync_part_end_event(self.provider)
         if latest_sync_part_end_event is None:
             logger.info(
@@ -405,7 +405,7 @@ class TiteLiveThings(LocalProvider):
             )
             return iter(ordered_thing_files)
         for index, filename in enumerate(ordered_thing_files):
-            if get_date_from_filename(filename, DATE_REGEXP) == int(latest_sync_part_end_event.payload):  # type: ignore [arg-type]
+            if get_date_from_filename(filename, DATE_REGEXP) == int(latest_sync_part_end_event.payload):  # type: ignore[arg-type]
                 ordered_thing_files_from_date = ordered_thing_files[index + 1 :]
                 logger.info(
                     "get_remaining_files_to_check: %s",

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -57,7 +57,7 @@ class BeneficiaryImport(PcObject, Base, Model):
     def currentStatus(self):
         return self._last_status().status
 
-    @currentStatus.expression  # type: ignore [no-redef]
+    @currentStatus.expression  # type: ignore[no-redef]
     def currentStatus(cls):  # pylint: disable=no-self-argument
         return cls._query_last_status(BeneficiaryImportStatus.status)
 
@@ -65,7 +65,7 @@ class BeneficiaryImport(PcObject, Base, Model):
     def updatedAt(self):
         return self._last_status().date
 
-    @updatedAt.expression  # type: ignore [no-redef]
+    @updatedAt.expression  # type: ignore[no-redef]
     def updatedAt(cls):  # pylint: disable=no-self-argument
         return cls._query_last_status(BeneficiaryImportStatus.date)
 
@@ -73,7 +73,7 @@ class BeneficiaryImport(PcObject, Base, Model):
     def detail(self):
         return self._last_status().detail
 
-    @detail.expression  # type: ignore [no-redef]
+    @detail.expression  # type: ignore[no-redef]
     def detail(cls):  # pylint: disable=no-self-argument
         return cls._query_last_status(BeneficiaryImportStatus.detail)
 
@@ -82,7 +82,7 @@ class BeneficiaryImport(PcObject, Base, Model):
         author = self._last_status().author
         return author.email or None
 
-    @authorEmail.expression  # type: ignore [no-redef]
+    @authorEmail.expression  # type: ignore[no-redef]
     def authorEmail(cls):  # pylint: disable=no-self-argument
         return cls._query_last_status(BeneficiaryImportStatus.author)
 

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -141,7 +141,7 @@ class FeatureToggle(enum.Enum):
                     "_cached_features",
                     {f.name: f.isActive for f in db.session.query(Feature.name, Feature.isActive)},
                 )
-            return flask.request._cached_features[self.name]  # type: ignore [attr-defined]
+            return flask.request._cached_features[self.name]  # type: ignore[attr-defined]
         return Feature.query.filter_by(name=self.name).one().isActive
 
 

--- a/api/src/pcapi/models/pc_object.py
+++ b/api/src/pcapi/models/pc_object.py
@@ -22,7 +22,7 @@ class DeletedRecordException(Exception):
 
 
 class PcObject:
-    id: sa_orm.Mapped[int] = Column(BigInteger, primary_key=True, autoincrement=True)  # type: ignore [assignment]
+    id: sa_orm.Mapped[int] = Column(BigInteger, primary_key=True, autoincrement=True)  # type: ignore[assignment]
 
     def __init__(self, **kwargs: typing.Any) -> None:
         from_dict = kwargs.pop("from_dict", None)

--- a/api/src/pcapi/models/validation_status_mixin.py
+++ b/api/src/pcapi/models/validation_status_mixin.py
@@ -24,7 +24,7 @@ class ValidationStatusMixin:
     def isNew(self) -> bool:
         return self.validationStatus == ValidationStatus.NEW
 
-    @isNew.expression  # type: ignore [no-redef]
+    @isNew.expression  # type: ignore[no-redef]
     def isNew(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.validationStatus == ValidationStatus.NEW
 
@@ -32,7 +32,7 @@ class ValidationStatusMixin:
     def isPending(self) -> bool:
         return self.validationStatus == ValidationStatus.PENDING
 
-    @isPending.expression  # type: ignore [no-redef]
+    @isPending.expression  # type: ignore[no-redef]
     def isPending(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.validationStatus == ValidationStatus.PENDING
 
@@ -40,7 +40,7 @@ class ValidationStatusMixin:
     def isWaitingForValidation(self) -> bool:
         return self.validationStatus in (ValidationStatus.NEW, ValidationStatus.PENDING)
 
-    @isWaitingForValidation.expression  # type: ignore [no-redef]
+    @isWaitingForValidation.expression  # type: ignore[no-redef]
     def isWaitingForValidation(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.validationStatus.in_([ValidationStatus.NEW, ValidationStatus.PENDING])
 
@@ -48,7 +48,7 @@ class ValidationStatusMixin:
     def isValidated(self) -> bool:
         return self.validationStatus == ValidationStatus.VALIDATED
 
-    @isValidated.expression  # type: ignore [no-redef]
+    @isValidated.expression  # type: ignore[no-redef]
     def isValidated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.validationStatus == ValidationStatus.VALIDATED
 
@@ -56,7 +56,7 @@ class ValidationStatusMixin:
     def isRejected(self) -> bool:
         return self.validationStatus == ValidationStatus.REJECTED
 
-    @isRejected.expression  # type: ignore [no-redef]
+    @isRejected.expression  # type: ignore[no-redef]
     def isRejected(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         # sqla.not_(isRejected) works only if we check None separately.
         return cls.validationStatus == ValidationStatus.REJECTED
@@ -65,7 +65,7 @@ class ValidationStatusMixin:
     def isDeleted(self) -> bool:
         return self.validationStatus == ValidationStatus.DELETED
 
-    @isDeleted.expression  # type: ignore [no-redef]
+    @isDeleted.expression  # type: ignore[no-redef]
     def isDeleted(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         # sqla.not_(isDeleted) works only if we check None separately.
         return cls.validationStatus == ValidationStatus.DELETED

--- a/api/src/pcapi/repository/__init__.py
+++ b/api/src/pcapi/repository/__init__.py
@@ -88,7 +88,7 @@ class atomic:
     # decorator part
     def __call__(self, func: typing.Callable) -> typing.Callable:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):  # type: ignore [no-untyped-def]
+        def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
             if _is_managed_session():
                 # use the context manager part to make the decorator reeantrant.
                 with type(self):

--- a/api/src/pcapi/routes/adage/v1/blueprint.py
+++ b/api/src/pcapi/routes/adage/v1/blueprint.py
@@ -13,7 +13,7 @@ EAC_API_KEY_AUTH = "ApiKeyAuth"
 SECURITY_SCHEMES = [
     SecurityScheme(
         name=EAC_API_KEY_AUTH,
-        data={"type": "http", "scheme": "bearer", "description": "API key shared by Adage and pass Culture"},  # type: ignore [arg-type]
+        data={"type": "http", "scheme": "bearer", "description": "API key shared by Adage and pass Culture"},  # type: ignore[arg-type]
     ),
 ]
 

--- a/api/src/pcapi/routes/adage/v1/educational_institution.py
+++ b/api/src/pcapi/routes/adage/v1/educational_institution.py
@@ -40,7 +40,7 @@ def get_educational_institution(year_id: str, uai_code: str) -> EducationalInsti
         educational_year_id=year_id, educational_institution_id=educational_institution.id
     )
     return EducationalInstitutionResponse(
-        credit=educational_deposit.amount if educational_deposit else 0,  # type: ignore [arg-type]
+        credit=educational_deposit.amount if educational_deposit else 0,  # type: ignore[arg-type]
         isFinal=educational_deposit.isFinal if educational_deposit else False,
         prebookings=prebookings,
     )

--- a/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
+++ b/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
@@ -135,7 +135,7 @@ def get_collective_bookings_per_year_response(
         EducationalBookingPerYearResponse(
             id=booking.id,
             UAICode=booking.educationalInstitution.institutionId,
-            status=get_collective_booking_status(booking),  # type: ignore [arg-type]
+            status=get_collective_booking_status(booking),  # type: ignore[arg-type]
             confirmationLimitDate=booking.confirmationLimitDate,
             totalAmount=booking.collectiveStock.price,
             beginningDatetime=booking.collectiveStock.beginningDatetime,
@@ -190,7 +190,7 @@ def serialize_collective_booking(collective_booking: CollectiveBooking) -> Educa
         confirmationDate=collective_booking.confirmationDate,
         confirmationLimitDate=collective_booking.confirmationLimitDate,
         contact=_get_collective_offer_contact(offer),
-        coordinates={  # type: ignore [arg-type]
+        coordinates={  # type: ignore[arg-type]
             "latitude": venue.latitude,
             "longitude": venue.longitude,
         },
@@ -208,16 +208,16 @@ def serialize_collective_booking(collective_booking: CollectiveBooking) -> Educa
         postalCode=venue.postalCode,
         price=stock.price,
         quantity=1,
-        redactor={  # type: ignore [arg-type]
+        redactor={  # type: ignore[arg-type]
             "email": collective_booking.educationalRedactor.email,
             "redactorFirstName": collective_booking.educationalRedactor.firstName,
             "redactorLastName": collective_booking.educationalRedactor.lastName,
             "redactorCivility": collective_booking.educationalRedactor.civility,
         },
         UAICode=collective_booking.educationalInstitution.institutionId,
-        yearId=collective_booking.educationalYearId,  # type: ignore [arg-type]
-        status=get_collective_booking_status(collective_booking),  # type: ignore [arg-type]
-        venueTimezone=venue.timezone,  # type: ignore [arg-type]
+        yearId=collective_booking.educationalYearId,  # type: ignore[arg-type]
+        status=get_collective_booking_status(collective_booking),  # type: ignore[arg-type]
+        venueTimezone=venue.timezone,  # type: ignore[arg-type]
         subcategoryLabel=offer.subcategory.app_label if offer.subcategory else "",
         totalAmount=stock.price,
         url=offer_app_link(offer),
@@ -315,7 +315,7 @@ def serialize_reimbursement_notification(
         confirmationDate=collective_booking.confirmationDate,
         confirmationLimitDate=collective_booking.confirmationLimitDate,
         contact=_get_collective_offer_contact(offer),
-        coordinates={  # type: ignore [arg-type]
+        coordinates={  # type: ignore[arg-type]
             "latitude": venue.latitude,
             "longitude": venue.longitude,
         },
@@ -333,16 +333,16 @@ def serialize_reimbursement_notification(
         postalCode=venue.postalCode,
         price=stock.price,
         quantity=1,
-        redactor={  # type: ignore [arg-type]
+        redactor={  # type: ignore[arg-type]
             "email": collective_booking.educationalRedactor.email,
             "redactorFirstName": collective_booking.educationalRedactor.firstName,
             "redactorLastName": collective_booking.educationalRedactor.lastName,
             "redactorCivility": collective_booking.educationalRedactor.civility,
         },
         UAICode=collective_booking.educationalInstitution.institutionId,
-        yearId=collective_booking.educationalYearId,  # type: ignore [arg-type]
-        status=get_collective_booking_status(collective_booking),  # type: ignore [arg-type]
-        venueTimezone=venue.timezone,  # type: ignore [arg-type]
+        yearId=collective_booking.educationalYearId,  # type: ignore[arg-type]
+        status=get_collective_booking_status(collective_booking),  # type: ignore[arg-type]
+        venueTimezone=venue.timezone,  # type: ignore[arg-type]
         subcategoryLabel=offer.subcategory.app_label if offer.subcategory else "",
         totalAmount=stock.price,
         url=offer_app_link(offer),

--- a/api/src/pcapi/routes/adage_iframe/blueprint.py
+++ b/api/src/pcapi/routes/adage_iframe/blueprint.py
@@ -16,7 +16,7 @@ CORS(
 JWT_AUTH = "JWTAuth"
 
 SECURITY_SCHEMES = [
-    SecurityScheme(name=JWT_AUTH, data={"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}),  # type: ignore [arg-type]
+    SecurityScheme(name=JWT_AUTH, data={"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}),  # type: ignore[arg-type]
 ]
 
 

--- a/api/src/pcapi/routes/adage_iframe/features.py
+++ b/api/src/pcapi/routes/adage_iframe/features.py
@@ -15,4 +15,4 @@ def list_features(authenticated_information: AuthenticatedInformation) -> featur
     features = feature_queries.find_all()
     # Pydantic manages to convert a list of Feature to a list of FeatureResponseModel, with orm_mode=True
     # This apparently confuses mypy
-    return features_serialize.ListFeatureResponseModel(__root__=features)  # type: ignore [arg-type]
+    return features_serialize.ListFeatureResponseModel(__root__=features)  # type: ignore[arg-type]

--- a/api/src/pcapi/routes/backoffice/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/blueprint.py
@@ -22,7 +22,7 @@ COOKIE_AUTH = "SessionAuth"
 
 
 SECURITY_SCHEMES = [
-    SecurityScheme(name=COOKIE_AUTH, data={"type": "apiKey", "in": "cookie", "name": "session"}),  # type: ignore [arg-type]
+    SecurityScheme(name=COOKIE_AUTH, data={"type": "apiKey", "in": "cookie", "name": "session"}),  # type: ignore[arg-type]
 ]
 
 

--- a/api/src/pcapi/routes/backoffice/bookings/helpers.py
+++ b/api/src/pcapi/routes/backoffice/bookings/helpers.py
@@ -78,7 +78,7 @@ def get_bookings(
             for status in form.status.data:
                 if status == BookingStatus.CONFIRMED.name:
                     status_filters.append(
-                        and_(  # type: ignore [type-var]
+                        and_(  # type: ignore[type-var]
                             booking_class.isConfirmed,
                             booking_class.status == BookingStatus.CONFIRMED.name,
                         )
@@ -86,7 +86,7 @@ def get_bookings(
                 elif status == BookingStatus.BOOKED.name:
                     status_filters.append(
                         and_(
-                            ~booking_class.isConfirmed,  # type: ignore [operator]
+                            ~booking_class.isConfirmed,  # type: ignore[operator]
                             booking_class.status == BookingStatus.CONFIRMED.name,
                         )
                     )
@@ -94,7 +94,7 @@ def get_bookings(
                     status_in.append(status)
 
             if status_in:
-                status_filters.append(booking_class.status.in_(status_in))  # type: ignore [arg-type]
+                status_filters.append(booking_class.status.in_(status_in))  # type: ignore[arg-type]
 
             if len(status_filters) > 1:
                 base_query = base_query.filter(or_(*status_filters))

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
@@ -93,7 +93,7 @@ def _get_collective_offer_templates(
         )
 
     if form.status.data:
-        base_query = base_query.filter(educational_models.CollectiveOfferTemplate.validation.in_(form.status.data))  # type: ignore [attr-defined]
+        base_query = base_query.filter(educational_models.CollectiveOfferTemplate.validation.in_(form.status.data))  # type: ignore[attr-defined]
 
     if form.only_validated_offerers.data:
         base_query = (

--- a/api/src/pcapi/routes/backoffice/collective_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/forms.py
@@ -225,7 +225,7 @@ class GetCollectiveOfferAdvancedSearchForm(forms.GetOffersBaseFields):
         operator = sub_search.get("operator")
         if field_name:
             field_attribute_name = form_field_configuration.get(field_name, {}).get("field", "")
-            field_data = sub_search.get(field_attribute_name)  # type: ignore [call-overload]
+            field_data = sub_search.get(field_attribute_name)  # type: ignore[call-overload]
             if field_data:
                 return False
             if operator in operator_no_require_value:

--- a/api/src/pcapi/routes/backoffice/fraud/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/fraud/blueprint.py
@@ -85,7 +85,7 @@ def _list_non_pro_suspensions(domain_name: str) -> list[str]:
 
 def _list_untouched_pro_accounts(domain_name: str) -> list[str]:
     query = users_models.User.query.filter(
-        sa.or_(  # type: ignore [type-var]
+        sa.or_(  # type: ignore[type-var]
             users_models.User.has_pro_role,
             users_models.User.has_non_attached_pro_role,
         ),

--- a/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
@@ -85,7 +85,7 @@ def _apply_query_filters(
         department_codes: list[str] = []
         for region in regions:
             department_codes += get_department_codes_for_region(region)
-        query = query.filter(offerers_models.Offerer.departementCode.in_(department_codes))  # type: ignore [attr-defined]
+        query = query.filter(offerers_models.Offerer.departementCode.in_(department_codes))  # type: ignore[attr-defined]
 
     if q:
         sanitized_q = email_utils.sanitize_email(q)
@@ -240,7 +240,7 @@ def list_offerers_to_be_validated(
         .select_from(offerers_models.Venue)
         .filter(
             offerers_models.Venue.managingOffererId == offerers_models.Offerer.id,
-            offerers_models.Venue.dms_adage_status.is_not(None),  # type: ignore [attr-defined]
+            offerers_models.Venue.dms_adage_status.is_not(None),  # type: ignore[attr-defined]
         )
         .correlate(offerers_models.Offerer)
         .scalar_subquery()
@@ -252,7 +252,7 @@ def list_offerers_to_be_validated(
             _get_tags_subquery().label("tags"),
             last_comment_subquery.label("last_comment"),
             users_models.User.id.label("creator_id"),
-            users_models.User.full_name.label("creator_name"),  # type: ignore [attr-defined]
+            users_models.User.full_name.label("creator_name"),  # type: ignore[attr-defined]
             users_models.User.email.label("creator_email"),
             dms_applications_subquery.label("dms_venues"),
         )

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -177,7 +177,7 @@ SEARCH_FIELD_TO_PYTHON = {
         "field": "price",
         "column": offers_models.Stock.price,
         "subquery_join": "stock",
-        "custom_filter_all_operators": sa.and_(  # type: ignore [type-var]
+        "custom_filter_all_operators": sa.and_(  # type: ignore[type-var]
             offers_models.Stock._bookable,
             offers_models.Offer._released,
         ),
@@ -292,7 +292,7 @@ def _get_offers(form: forms.GetOfferAdvancedSearchForm) -> list[offers_models.Of
         remaining_quantity_case = sa.case(
             (
                 # Same as Offer.isReleased which is not an hybrid property
-                sa.and_(  # type: ignore [type-var]
+                sa.and_(  # type: ignore[type-var]
                     offers_models.Offer._released,
                     offerers_models.Offerer.isActive,
                     offerers_models.Offerer.isValidated,
@@ -302,7 +302,7 @@ def _get_offers(form: forms.GetOfferAdvancedSearchForm) -> list[offers_models.Of
                         sa.case(
                             (
                                 sa.func.coalesce(
-                                    sa.func.max(sa.case((offers_models.Stock.remainingStock.is_(None), 1), else_=0)), 0  # type: ignore [attr-defined]
+                                    sa.func.max(sa.case((offers_models.Stock.remainingStock.is_(None), 1), else_=0)), 0  # type: ignore[attr-defined]
                                 )
                                 == 0,
                                 sa.func.coalesce(sa.func.sum(offers_models.Stock.remainingStock), 0).cast(sa.String),

--- a/api/src/pcapi/routes/backoffice/offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offers/forms.py
@@ -366,7 +366,7 @@ class GetOfferAdvancedSearchForm(GetOffersBaseFields):
         operator = sub_search.get("operator")
         if field_name:
             field_attribute_name = form_field_configuration.get(field_name, {}).get("field", "")
-            field_data = sub_search.get(field_attribute_name)  # type: ignore [call-overload]
+            field_data = sub_search.get(field_attribute_name)  # type: ignore[call-overload]
             if field_data:
                 return False
             if operator in operator_no_require_value:

--- a/api/src/pcapi/routes/backoffice/pro/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro/blueprint.py
@@ -228,17 +228,17 @@ def create_offerer() -> utils.BackofficeResponse:
     )
 
     venue_creation_info = venues_serialize.PostVenueBodyModel(
-        siret=form.siret_info.siret,  # type: ignore [arg-type]
-        street=address.street,  # type: ignore [arg-type]
-        banId=city_info.id,  # type: ignore [arg-type]
-        bookingEmail=pro_user.email,  # type: ignore [arg-type]
-        city=address.city,  # type: ignore [arg-type]
+        siret=form.siret_info.siret,  # type: ignore[arg-type]
+        street=address.street,  # type: ignore[arg-type]
+        banId=city_info.id,  # type: ignore[arg-type]
+        bookingEmail=pro_user.email,  # type: ignore[arg-type]
+        city=address.city,  # type: ignore[arg-type]
         latitude=city_info.latitude,
         longitude=city_info.longitude,
         managingOffererId=user_offerer.offererId,
         name=form.public_name.data,
         publicName=form.public_name.data,
-        postalCode=postal_code,  # type: ignore [arg-type]
+        postalCode=postal_code,  # type: ignore[arg-type]
         venueLabelId=None,
         venueTypeCode=form.venue_type_code.data,
         withdrawalDetails=None,

--- a/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
@@ -11,7 +11,7 @@ JsonResponse = tuple[Response, int]
 
 
 # mypy does not like us using `@app.errorhandler` more than once.
-@app.errorhandler(exceptions.OfferIsAlreadyBooked)  # type: ignore [arg-type]
+@app.errorhandler(exceptions.OfferIsAlreadyBooked)  # type: ignore[arg-type]
 @app.errorhandler(exceptions.QuantityIsInvalid)
 @app.errorhandler(exceptions.StockIsNotBookable)
 @app.errorhandler(exceptions.CannotBookFreeOffers)

--- a/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -113,8 +113,8 @@ def ratelimit_handler(error: Exception) -> ApiErrorResponse:
     mark_transaction_as_invalid()
     identifier = None
     try:
-        if request.is_json and "identifier" in request.json:  # type: ignore [operator]
-            identifier = request.json["identifier"]  # type: ignore [index]
+        if request.is_json and "identifier" in request.json:  # type: ignore[operator]
+            identifier = request.json["identifier"]  # type: ignore[index]
     except (json.JSONDecodeError, werkzeug_exceptions.BadRequest) as e:
         logger.info("Could not extract user identifier from request: %s", e)
     auth = get_request_authorization()

--- a/api/src/pcapi/routes/external/sendinblue.py
+++ b/api/src/pcapi/routes/external/sendinblue.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def _toggle_marketing_email_subscription(subscribe: bool) -> None:
-    user_email = request.json.get("email")  # type: ignore [union-attr]
+    user_email = request.json.get("email")  # type: ignore[union-attr]
     if not user_email:
         raise ApiErrors(
             {"email": "Email missing in request payload"},

--- a/api/src/pcapi/routes/external/users_subscription.py
+++ b/api/src/pcapi/routes/external/users_subscription.py
@@ -30,9 +30,9 @@ def dms_webhook_update_application_status(form: dms_validation.DMSWebhookRequest
 @public_api.route("/webhooks/ubble/application_status", methods=["POST"])
 @ubble_validation.require_ubble_signature
 @spectree_serialize(
-    headers=ubble_validation.WebhookRequestHeaders,  # type: ignore [arg-type]
+    headers=ubble_validation.WebhookRequestHeaders,  # type: ignore[arg-type]
     on_success_status=200,
-    response_model=ubble_validation.WebhookDummyReponse,  # type: ignore [arg-type]
+    response_model=ubble_validation.WebhookDummyReponse,  # type: ignore[arg-type]
 )
 def ubble_webhook_update_application_status(
     body: ubble_validation.WebhookRequest,
@@ -66,7 +66,7 @@ def ubble_webhook_update_application_status(
 @public_api.route("/webhooks/ubble/store_id_pictures", methods=["POST"])
 @spectree_serialize(
     on_success_status=200,
-    response_model=ubble_validation.WebhookDummyReponse,  # type: ignore [arg-type]
+    response_model=ubble_validation.WebhookDummyReponse,  # type: ignore[arg-type]
 )
 def ubble_webhook_store_id_pictures(
     body: ubble_validation.WebhookStoreIdPicturesRequest,

--- a/api/src/pcapi/routes/native/blueprint.py
+++ b/api/src/pcapi/routes/native/blueprint.py
@@ -20,7 +20,7 @@ CORS(
 
 JWT_AUTH = "JWTAuth"
 SECURITY_SCHEMES = [
-    SecurityScheme(name=JWT_AUTH, data={"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}),  # type: ignore [arg-type]
+    SecurityScheme(name=JWT_AUTH, data={"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}),  # type: ignore[arg-type]
 ]
 
 api = ExtendedSpecTree("flask", MODE="strict", before=before_handler, PATH="/", security_schemes=SECURITY_SCHEMES)

--- a/api/src/pcapi/routes/native/v1/cultural_survey.py
+++ b/api/src/pcapi/routes/native/v1/cultural_survey.py
@@ -40,7 +40,7 @@ def get_cultural_survey_questions(user: users_models.User) -> serializers.Cultur
 def post_cultural_survey_answers(user: users_models.User, body: serializers.CulturalSurveyAnswersRequest) -> None:
     payload = CulturalSurveyAnswersForData(
         user_id=user.id,
-        submitted_at=datetime.datetime.utcnow().isoformat(),  # type: ignore [arg-type]
+        submitted_at=datetime.datetime.utcnow().isoformat(),  # type: ignore[arg-type]
         answers=body.answers,
     )
 
@@ -50,5 +50,5 @@ def post_cultural_survey_answers(user: users_models.User, body: serializers.Cult
         user.culturalSurveyFilledDate = datetime.datetime.utcnow()
 
     update_external_user(
-        user, cultural_survey_answers={answer.question_id: answer.answer_ids for answer in body.answers}  # type: ignore [misc]
+        user, cultural_survey_answers={answer.question_id: answer.answer_ids for answer in body.answers}  # type: ignore[misc]
     )

--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -184,7 +184,7 @@ def get_favorites(user: User) -> serializers.PaginatedFavoritesResponse:
         "nbFavorites": len(favorites),
         "favorites": favorites,
     }
-    return serializers.PaginatedFavoritesResponse(**paginated_favorites)  # type: ignore [arg-type]
+    return serializers.PaginatedFavoritesResponse(**paginated_favorites)  # type: ignore[arg-type]
 
 
 @blueprint.native_route("/me/favorites", methods=["POST"])

--- a/api/src/pcapi/routes/native/v1/offers.py
+++ b/api/src/pcapi/routes/native/v1/offers.py
@@ -125,7 +125,7 @@ def report_offer_reasons(user: User) -> serializers.OfferReportReasons:
 @spectree_serialize(on_success_status=200, api=blueprint.api, response_model=serializers.UserReportedOffersResponse)
 @authenticated_and_active_user_required
 def user_reported_offers(user: User) -> serializers.UserReportedOffersResponse:
-    return serializers.UserReportedOffersResponse(reportedOffers=user.reported_offers)  # type: ignore [call-arg]
+    return serializers.UserReportedOffersResponse(reportedOffers=user.reported_offers)  # type: ignore[call-arg]
 
 
 @blueprint.native_route("/send_offer_webapp_link_by_email/<int:offer_id>", methods=["POST"])

--- a/api/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -45,7 +45,7 @@ class VenueTypeCode(enum.Enum):
         return value
 
 
-VenueTypeCodeKey = enum.Enum(  # type: ignore [misc]
+VenueTypeCodeKey = enum.Enum(  # type: ignore[misc]
     "VenueTypeCodeKey",
     {code.name: code.name for code in VenueTypeCode},
 )

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -254,7 +254,7 @@ class BaseOfferResponse(BaseModel):
                 if gtl_id is not None:
                     result.extraData.gtlLabels = get_gtl_labels(gtl_id)
         else:
-            result.extraData = OfferExtraData(durationMinutes=offer.durationMinutes)  # type: ignore [call-arg]
+            result.extraData = OfferExtraData(durationMinutes=offer.durationMinutes)  # type: ignore[call-arg]
 
         if offer.product:
             result.last30DaysBookings = offer.product.last_30_days_booking

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -49,7 +49,7 @@ def next_subscription_step(
         allowed_identity_check_methods=subscription_api.get_allowed_identity_check_methods(user),
         maintenance_page_type=subscription_api.get_maintenance_page_type(user),
         has_identity_check_pending=fraud_api.has_user_pending_identity_check(user),
-        subscription_message=user_subscription_state.subscription_message,  # type: ignore [arg-type]
+        subscription_message=user_subscription_state.subscription_message,  # type: ignore[arg-type]
     )
 
 
@@ -116,7 +116,7 @@ def get_subscription_stepper(user: users_models.User) -> serializers.Subscriptio
         next_subscription_step=user_subscription_state.next_step,
         title=stepper_header.title,
         subtitle=stepper_header.subtitle,
-        subscription_message=user_subscription_state.subscription_message,  # type: ignore [arg-type]
+        subscription_message=user_subscription_state.subscription_message,  # type: ignore[arg-type]
     )
 
 
@@ -129,7 +129,7 @@ def get_profile(user: users_models.User) -> serializers.ProfileResponse | None:
             return serializers.ProfileResponse(profile=serializers.ProfileContent(**profile_data.dict()))
         except ValidationError as e:
             logger.error("Invalid profile data for user %s: %s", user.id, e)
-            return serializers.ProfileResponse()  # type: ignore [call-arg]
+            return serializers.ProfileResponse()  # type: ignore[call-arg]
 
     raise api_errors.ResourceNotFoundError()
 
@@ -223,7 +223,7 @@ def start_identification_session(
         identification_url = ubble_subscription_api.start_ubble_workflow(
             user, declared_names[0], declared_names[1], body.redirectUrl
         )
-        return serializers.IdentificationSessionResponse(identificationUrl=identification_url)  # type: ignore [arg-type]
+        return serializers.IdentificationSessionResponse(identificationUrl=identification_url)  # type: ignore[arg-type]
 
     except requests_utils.ExternalAPIException as exception:
         if exception.is_retryable:

--- a/api/src/pcapi/routes/pro/blueprint.py
+++ b/api/src/pcapi/routes/pro/blueprint.py
@@ -19,10 +19,10 @@ CORS(
 SECURITY_SCHEMES = [
     SecurityScheme(
         name=users_authentifications.API_KEY_AUTH_NAME,
-        data={"type": "http", "scheme": "bearer", "description": "Api key issued by passculture"},  # type: ignore [arg-type]
+        data={"type": "http", "scheme": "bearer", "description": "Api key issued by passculture"},  # type: ignore[arg-type]
     ),
     SecurityScheme(
-        name=users_authentifications.COOKIE_AUTH_NAME, data={"type": "apiKey", "in": "cookie", "name": "session"}  # type: ignore [arg-type]
+        name=users_authentifications.COOKIE_AUTH_NAME, data={"type": "apiKey", "in": "cookie", "name": "session"}  # type: ignore[arg-type]
     ),
 ]
 

--- a/api/src/pcapi/routes/pro/features.py
+++ b/api/src/pcapi/routes/pro/features.py
@@ -12,4 +12,4 @@ def list_features() -> features_serialize.ListFeatureResponseModel:
     features = feature_queries.find_all()
     # Pydantic manages to convert a list of Feature to a list of FeatureResponseModel, with orm_mode=True
     # This apparently confuses mypy
-    return features_serialize.ListFeatureResponseModel(__root__=features)  # type: ignore [arg-type]
+    return features_serialize.ListFeatureResponseModel(__root__=features)  # type: ignore[arg-type]

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -221,7 +221,7 @@ def delete_draft_offers(body: offers_serialize.DeleteOfferRequestBody) -> None:
             },
             status_code=404,
         )
-    query = offers_repository.get_offers_by_ids(current_user, body.ids)  # type: ignore [arg-type]
+    query = offers_repository.get_offers_by_ids(current_user, body.ids)  # type: ignore[arg-type]
     offers_api.batch_delete_draft_offers(query)
 
 
@@ -425,7 +425,7 @@ def create_thumbnail(form: CreateThumbnailBodyModel) -> CreateThumbnailResponseM
             crop_params=form.crop_params,
         )
 
-    return CreateThumbnailResponseModel(id=thumbnail.id, url=thumbnail.thumbUrl, credit=thumbnail.credit)  # type: ignore [arg-type]
+    return CreateThumbnailResponseModel(id=thumbnail.id, url=thumbnail.thumbUrl, credit=thumbnail.credit)  # type: ignore[arg-type]
 
 
 @private_api.route("/offers/thumbnails/<int:offer_id>", methods=["DELETE"])

--- a/api/src/pcapi/routes/pro/providers.py
+++ b/api/src/pcapi/routes/pro/providers.py
@@ -12,7 +12,7 @@ from . import blueprint
 @blueprint.pro_private_api.route("/venueProviders/<int:venue_id>", methods=["GET"])
 @login_required
 @spectree_serialize(
-    response_model=ListProviderResponse,  # type: ignore [arg-type]
+    response_model=ListProviderResponse,  # type: ignore[arg-type]
     on_success_status=200,
     on_error_statuses=[401, 404],
     api=blueprint.pro_private_schema,

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -87,7 +87,7 @@ def post_create_venue(body: venues_serialize.PostVenueBodyModel) -> venues_seria
         siret_info = sirene.get_siret(body.siret)
         if not siret_info.active:
             raise ApiErrors(errors={"siret": ["SIRET is no longer active"]})
-        body.name = siret_info.name  # type: ignore [assignment]
+        body.name = siret_info.name  # type: ignore[assignment]
     validation.check_accessibility_compliance(body)
     venue = offerers_api.create_venue(body)
 
@@ -197,7 +197,7 @@ def upsert_venue_banner(venue_id: int) -> venues_serialize.GetVenueResponseModel
         user=current_user,
         venue=venue,
         content=venue_banner.content,
-        image_credit=venue_banner.image_credit,  # type: ignore [arg-type]
+        image_credit=venue_banner.image_credit,  # type: ignore[arg-type]
         crop_params=venue_banner.crop_params,
     )
 
@@ -247,7 +247,7 @@ def get_venue_stats(venue_id: int) -> venues_serialize.VenueStatsResponseModel:
 )
 def get_venues_educational_statuses() -> venues_serialize.VenuesEducationalStatusesResponseModel:
     statuses = offerers_api.get_venues_educational_statuses()
-    return venues_serialize.VenuesEducationalStatusesResponseModel(statuses=statuses)  # type: ignore [arg-type]
+    return venues_serialize.VenuesEducationalStatusesResponseModel(statuses=statuses)  # type: ignore[arg-type]
 
 
 @private_api.route("/venues/<int:venue_id>/dashboard", methods=["GET"])

--- a/api/src/pcapi/routes/public/booking_token/v2/serialization.py
+++ b/api/src/pcapi/routes/public/booking_token/v2/serialization.py
@@ -68,7 +68,7 @@ def get_booking_response(booking: Booking) -> GetBookingResponse:
 
     birth_date = isoformat(booking.user.birth_date) if booking.user.birth_date else None
     return GetBookingResponse(
-        bookingId=humanize(booking.id),  # type: ignore [arg-type]
+        bookingId=humanize(booking.id),  # type: ignore[arg-type]
         dateOfBirth=birth_date,
         datetime=(format_into_utc_date(booking.stock.beginningDatetime) if booking.stock.beginningDatetime else ""),
         ean13=(
@@ -78,7 +78,7 @@ def get_booking_response(booking: Booking) -> GetBookingResponse:
         formula=formula,
         isUsed=booking.is_used_or_reimbursed,
         offerId=booking.stock.offer.id,
-        publicOfferId=humanize(booking.stock.offer.id),  # type: ignore [arg-type]
+        publicOfferId=humanize(booking.stock.offer.id),  # type: ignore[arg-type]
         offerName=booking.stock.offer.name,
         offerType=BookingOfferType.EVENEMENT if booking.stock.offer.isEvent else BookingOfferType.EVENEMENT,
         phoneNumber=booking.user.phoneNumber,

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -289,8 +289,8 @@ class GetPublicCollectiveOfferResponseModel(BaseModel):
             description=offer.description,
             subcategoryId=offer.subcategoryId,
             bookingEmails=offer.bookingEmails,
-            contactEmail=offer.contactEmail,  # type: ignore [arg-type]
-            contactPhone=offer.contactPhone,  # type: ignore [arg-type]
+            contactEmail=offer.contactEmail,  # type: ignore[arg-type]
+            contactPhone=offer.contactPhone,  # type: ignore[arg-type]
             domains=[domain.id for domain in offer.domains],
             durationMinutes=offer.durationMinutes,
             interventionArea=offer.interventionArea,
@@ -311,7 +311,7 @@ class GetPublicCollectiveOfferResponseModel(BaseModel):
             educationalPriceDetail=offer.collectiveStock.priceDetail,
             educationalInstitution=offer.institution.institutionId if offer.institutionId else None,
             educationalInstitutionId=offer.institution.id if offer.institutionId else None,
-            offerVenue={  # type: ignore [arg-type]
+            offerVenue={  # type: ignore[arg-type]
                 "venueId": offer.offerVenue.get("venueId"),
                 "addressType": offer.offerVenue["addressType"],
                 "otherAddress": offer.offerVenue["otherAddress"] or None,

--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings_serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings_serialization.py
@@ -61,7 +61,7 @@ class GetBookingResponse(serialization.ConfiguredBaseModel):
             price=finance_utils.to_eurocents(booking.amount),
             status=booking.status,
             price_category_id=booking.stock.priceCategory.id if booking.stock.priceCategory else None,
-            price_category_label=booking.stock.priceCategory.label if booking.stock.priceCategory else None,  # type: ignore [arg-type]
+            price_category_label=booking.stock.priceCategory.label if booking.stock.priceCategory else None,  # type: ignore[arg-type]
             offer_id=booking.stock.offer.id,
             stock_id=booking.stock.id,
             offer_name=booking.stock.offer.name,
@@ -69,7 +69,7 @@ class GetBookingResponse(serialization.ConfiguredBaseModel):
             venue_id=booking.venue.id,
             venue_name=booking.venue.name,
             venue_address=booking.venue.street,
-            venue_departement_code=booking.venue.departementCode,  # type: ignore [arg-type]
+            venue_departement_code=booking.venue.departementCode,  # type: ignore[arg-type]
             user_email=booking.email,
             user_birth_date=birth_date,
             user_first_name=booking.user.firstName,

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -300,8 +300,8 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
     offer_to_update_by_ean = {}
     ean_list_to_update = set()
     for offer in offers_to_update:
-        ean_list_to_update.add(offer.extraData["ean"])  # type: ignore [index]
-        offer_to_update_by_ean[offer.extraData["ean"]] = offer  # type: ignore [index]
+        ean_list_to_update.add(offer.extraData["ean"])  # type: ignore[index]
+        offer_to_update_by_ean[offer.extraData["ean"]] = offer  # type: ignore[index]
 
     ean_list_to_create = ean_to_create_or_update - ean_list_to_update
     offers_to_index = []
@@ -309,7 +309,7 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
         if ean_list_to_create:
             created_offers = []
             existing_products = _get_existing_products(ean_list_to_create)
-            product_by_ean = {product.extraData["ean"]: product for product in existing_products}  # type: ignore [index]
+            product_by_ean = {product.extraData["ean"]: product for product in existing_products}  # type: ignore[index]
             not_found_eans = [ean for ean in ean_list_to_create if ean not in product_by_ean.keys()]
             if not_found_eans:
                 logger.warning(
@@ -347,7 +347,7 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
             reloaded_offers = _get_existing_offers(ean_list_to_create, venue)
             for offer in reloaded_offers:
                 try:
-                    ean = offer.extraData["ean"]  # type: ignore [index]
+                    ean = offer.extraData["ean"]  # type: ignore[index]
                     stock_data = serialized_products_stocks[ean]
                     # FIXME (mageoffray, 2023-05-26): stock saving optimisation
                     # Stocks are inserted one by one for now, we need to improve create_stock to remove the repository.session.add()
@@ -378,7 +378,7 @@ def _create_or_update_ean_offers(serialized_products_stocks: dict, venue_id: int
                 offer.lastProvider = provider
                 offer.isActive = True
 
-                ean = offer.extraData["ean"]  # type: ignore [index]
+                ean = offer.extraData["ean"]  # type: ignore[index]
                 stock_data = serialized_products_stocks[ean]
                 # FIXME (mageoffray, 2023-05-26): stock upserting optimisation
                 # Stocks are edited one by one for now, we need to improve edit_stock to remove the repository.session.add()
@@ -547,7 +547,7 @@ def get_product_by_ean(
     """
     utils.check_venue_id_is_tied_to_api_key(query.venueId)
     offers: list[offers_models.Offer] | None = (
-        utils.retrieve_offer_relations_query(_retrieve_offer_by_eans_query(query.eans, query.venueId))  # type: ignore [arg-type]
+        utils.retrieve_offer_relations_query(_retrieve_offer_by_eans_query(query.eans, query.venueId))  # type: ignore[arg-type]
         .filter(sqla.not_(offers_models.Offer.isEvent))
         .all()
     )

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -65,25 +65,25 @@ ALLOWED_PRODUCT_SUBCATEGORIES = [
 ]
 
 
-MusicTypeEnum = StrEnum(  # type: ignore [call-overload]
+MusicTypeEnum = StrEnum(  # type: ignore[call-overload]
     "MusicTypeEnum",
     {music_sub_type_slug: music_sub_type_slug for music_sub_type_slug in music_types.MUSIC_SUB_TYPES_BY_SLUG},
 )
 
-TiteliveMusicTypeEnum = StrEnum(  # type: ignore [call-overload]
+TiteliveMusicTypeEnum = StrEnum(  # type: ignore[call-overload]
     "TiteliveMusicTypeEnum", {music_type: music_type for music_type in constants.GTL_ID_BY_TITELIVE_MUSIC_GENRE}
 )
 
-ShowTypeEnum = StrEnum(  # type: ignore [call-overload]
+ShowTypeEnum = StrEnum(  # type: ignore[call-overload]
     "ShowTypeEnum",
     {show_sub_type_slug: show_sub_type_slug for show_sub_type_slug in show_types.SHOW_SUB_TYPES_BY_SLUG},
 )
 
-EventCategoryEnum = StrEnum(  # type:ignore [call-overload]
+EventCategoryEnum = StrEnum(  # type: ignore[call-overload]
     "CategoryEnum", {subcategory_id: subcategory_id for subcategory_id in subcategories.EVENT_SUBCATEGORIES}
 )
 
-ProductCategoryEnum = StrEnum(  # type:ignore [call-overload]
+ProductCategoryEnum = StrEnum(  # type: ignore[call-overload]
     "CategoryEnum", {subcategory.id: subcategory.id for subcategory in ALLOWED_PRODUCT_SUBCATEGORIES}
 )
 
@@ -132,10 +132,10 @@ EAN_FIELD = pydantic_v1.Field(example="1234567890123", description="European Art
 class ExtraDataModel(serialization.ConfiguredBaseModel):
     author: str | None = pydantic_v1.Field(example="Jane Doe")
     ean: str | None = EAN_FIELD
-    musicType: TiteliveMusicTypeEnum | MusicTypeEnum | None  # type: ignore [valid-type]
+    musicType: TiteliveMusicTypeEnum | MusicTypeEnum | None  # type: ignore[valid-type]
     performer: str | None = pydantic_v1.Field(example="Jane Doe")
     stageDirector: str | None = pydantic_v1.Field(example="Jane Doe")
-    showType: ShowTypeEnum | None  # type: ignore [valid-type]
+    showType: ShowTypeEnum | None  # type: ignore[valid-type]
     speaker: str | None = pydantic_v1.Field(example="Jane Doe")
     visa: str | None = pydantic_v1.Field(example="140843")
 
@@ -300,7 +300,7 @@ def serialize_extra_data(offer: offers_models.Offer) -> CategoryRelatedFields:
             constants.TITELIVE_MUSIC_GENRES_BY_GTL_ID[gtl_id[:2] + "0" * 6]
         )  # Only take the first level of the GTL ID
 
-    return category_fields_model(**serialized_data, subcategory_id=offer.subcategory.id)  # type: ignore [misc, call-arg]
+    return category_fields_model(**serialized_data, subcategory_id=offer.subcategory.id)  # type: ignore[misc, call-arg]
 
 
 def deserialize_extra_data(
@@ -671,7 +671,7 @@ class BaseStockResponse(serialization.ConfiguredBaseModel):
 
     @classmethod
     def build_stock(cls, stock: offers_models.Stock) -> "BaseStockResponse":
-        return cls(  # type: ignore [call-arg]
+        return cls(  # type: ignore[call-arg]
             booking_limit_datetime=stock.bookingLimitDatetime,
             dnBookedQuantity=stock.dnBookedQuantity,
             quantity=stock.quantity if stock.quantity is not None else "unlimited",
@@ -689,7 +689,7 @@ class DateResponse(BaseStockResponse):
         stock_response = BaseStockResponse.build_stock(stock)
         return cls(
             id=stock.id,
-            beginning_datetime=stock.beginningDatetime,  # type: ignore [arg-type]
+            beginning_datetime=stock.beginningDatetime,  # type: ignore[arg-type]
             price_category=PriceCategoryResponse.from_orm(stock.priceCategory),
             **stock_response.dict(),
         )
@@ -729,7 +729,7 @@ class OfferResponse(serialization.ConfiguredBaseModel):
             description=offer.description,
             accessibility=AccessibilityResponse.from_orm(offer),
             external_ticket_office_url=offer.externalTicketOfficeUrl,
-            image=offer.image,  # type: ignore [arg-type]
+            image=offer.image,  # type: ignore[arg-type]
             is_duo=offer.isDuo,
             location=DigitalLocation.from_orm(offer) if offer.isDigital else PhysicalLocation.from_orm(offer),
             name=offer.name,
@@ -838,7 +838,7 @@ class GetProductsListByEansQuery(serialization.ConfiguredBaseModel):
 
 
 class EventCategoryResponse(serialization.ConfiguredBaseModel):
-    id: EventCategoryEnum  # type: ignore [valid-type]
+    id: EventCategoryEnum  # type: ignore[valid-type]
     conditional_fields: dict[str, bool] = pydantic_v1.Field(
         description="The keys are fields that should be set in the category_related_fields of an event. The values indicate whether their associated field is mandatory during event creation."
     )
@@ -860,7 +860,7 @@ class LocationTypeEnum(str, enum.Enum):
 
 
 class ProductCategoryResponse(serialization.ConfiguredBaseModel):
-    id: ProductCategoryEnum  # type: ignore [valid-type]
+    id: ProductCategoryEnum  # type: ignore[valid-type]
     conditional_fields: dict[str, bool] = pydantic_v1.Field(
         description="The keys are fields that should be set in the category_related_fields of a product. The values indicate whether their associated field is mandatory during product creation."
     )
@@ -894,7 +894,7 @@ class GetProductCategoriesResponse(serialization.ConfiguredBaseModel):
 
 
 class ShowTypeResponse(serialization.ConfiguredBaseModel):
-    id: ShowTypeEnum  # type: ignore [valid-type]
+    id: ShowTypeEnum  # type: ignore[valid-type]
     label: str
 
 
@@ -903,12 +903,12 @@ class GetShowTypesResponse(serialization.ConfiguredBaseModel):
 
 
 class MusicTypeResponse(serialization.ConfiguredBaseModel):
-    id: MusicTypeEnum  # type: ignore [valid-type]
+    id: MusicTypeEnum  # type: ignore[valid-type]
     label: str
 
 
 class TiteliveMusicTypeResponse(serialization.ConfiguredBaseModel):
-    id: TiteliveMusicTypeEnum  # type: ignore [valid-type]
+    id: TiteliveMusicTypeEnum  # type: ignore[valid-type]
     label: str
 
 

--- a/api/src/pcapi/routes/public/serialization/venues.py
+++ b/api/src/pcapi/routes/public/serialization/venues.py
@@ -12,7 +12,7 @@ from .accessibility import PartialAccessibility
 from .utils import StrEnum
 
 
-VenueTypeEnum = StrEnum(  # type: ignore [call-overload]
+VenueTypeEnum = StrEnum(  # type: ignore[call-overload]
     "VenueTypeEnum", {venue_type.name: venue_type.name for venue_type in offerers_models.VenueTypeCode}
 )
 
@@ -44,12 +44,12 @@ class VenueResponse(serialization.ConfiguredBaseModel):
     siret: str | None = pydantic_v1.Field(
         description="Null when venue is digital or when siretComment field is not null.", example="12345678901234"
     )
-    venueTypeCode: VenueTypeEnum = pydantic_v1.Field(alias="activityDomain")  # type: ignore [valid-type]
+    venueTypeCode: VenueTypeEnum = pydantic_v1.Field(alias="activityDomain")  # type: ignore[valid-type]
     accessibility: PartialAccessibility
 
     @classmethod
     def build_model(cls, venue: offerers_models.Venue) -> "VenueResponse":
-        return cls(  # type: ignore [call-arg]
+        return cls(  # type: ignore[call-arg]
             comment=venue.comment,
             dateCreated=venue.dateCreated,
             id=venue.id,

--- a/api/src/pcapi/routes/public/spectree_schemas.py
+++ b/api/src/pcapi/routes/public/spectree_schemas.py
@@ -29,7 +29,7 @@ public_api_schema = ExtendedSpecTree(
     security_schemes=[
         SecurityScheme(
             name=users_authentifications.API_KEY_AUTH_NAME,
-            data={"type": "http", "scheme": "bearer", "description": "Api key issued by passculture"},  # type: ignore [arg-type]
+            data={"type": "http", "scheme": "bearer", "description": "Api key issued by passculture"},  # type: ignore[arg-type]
         ),
     ],
     servers=_servers,
@@ -47,10 +47,10 @@ deprecated_public_api_schema = ExtendedSpecTree(
     security_schemes=[
         SecurityScheme(
             name=users_authentifications.API_KEY_AUTH_NAME,
-            data={"type": "http", "scheme": "bearer", "description": "Api key issued by passculture"},  # type: ignore [arg-type]
+            data={"type": "http", "scheme": "bearer", "description": "Api key issued by passculture"},  # type: ignore[arg-type]
         ),
         SecurityScheme(
-            name=users_authentifications.COOKIE_AUTH_NAME, data={"type": "apiKey", "in": "cookie", "name": "session"}  # type: ignore [arg-type]
+            name=users_authentifications.COOKIE_AUTH_NAME, data={"type": "apiKey", "in": "cookie", "name": "session"}  # type: ignore[arg-type]
         ),
     ],
     servers=_servers,

--- a/api/src/pcapi/routes/serialization/__init__.py
+++ b/api/src/pcapi/routes/serialization/__init__.py
@@ -7,7 +7,7 @@ from pcapi.serialization import utils as serialization_utils
 
 class BaseModel(pydantic_v1.BaseModel):
     @pydantic_v1.validator("*")
-    def do_not_allow_nan(cls, v, field):  # type: ignore [no-untyped-def]
+    def do_not_allow_nan(cls, v, field):  # type: ignore[no-untyped-def]
         if field.allow_none and v is None:
             return v
 
@@ -17,7 +17,7 @@ class BaseModel(pydantic_v1.BaseModel):
 
     class Config:
         @staticmethod
-        def schema_extra(schema, model):  # type: ignore [no-untyped-def]
+        def schema_extra(schema, model):  # type: ignore[no-untyped-def]
             for prop, value in schema.get("properties", {}).items():
                 # retrieve right field from alias or name
                 field = [x for x in model.__fields__.values() if x.alias == prop][0]

--- a/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
+++ b/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
@@ -93,7 +93,7 @@ def _serialize_booking_status_info(
 
     return BookingRecapResponseBookingStatusHistoryModel(
         status=booking_status,
-        date=serialized_booking_status_date,  # type: ignore [arg-type]
+        date=serialized_booking_status_date,  # type: ignore[arg-type]
     )
 
 
@@ -137,8 +137,8 @@ def serialize_booking_status_history(
 
 def serialize_bookings(booking: Booking) -> BookingRecapResponseModel:
     stock_beginning_datetime = _apply_departement_timezone(booking.stockBeginningDatetime, booking.venueDepartmentCode)
-    serialized_booking_recap = BookingRecapResponseModel(  # type: ignore [call-arg]
-        stock={  # type: ignore [arg-type]
+    serialized_booking_recap = BookingRecapResponseModel(  # type: ignore[call-arg]
+        stock={  # type: ignore[arg-type]
             "stockIdentifier": booking.stockId,
             "offerName": booking.offerName,
             "offerId": booking.offerId,
@@ -146,7 +146,7 @@ def serialize_bookings(booking: Booking) -> BookingRecapResponseModel:
             "offerIsbn": booking.offerEan,
             "offerIsEducational": False,
         },
-        beneficiary={  # type: ignore [arg-type]
+        beneficiary={  # type: ignore[arg-type]
             "lastname": booking.beneficiaryLastname,
             "firstname": booking.beneficiaryFirstname,
             "email": booking.beneficiaryEmail,

--- a/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
@@ -207,14 +207,14 @@ def _serialize_collective_booking_status_info(
 
     return BookingStatusHistoryResponseModel(
         status=collective_booking_status.value,
-        date=serialized_collective_booking_status_date,  # type: ignore [arg-type]
+        date=serialized_collective_booking_status_date,  # type: ignore[arg-type]
     )
 
 
 def serialize_collective_booking_stock(
     collective_booking: models.CollectiveBooking,
 ) -> CollectiveBookingCollectiveStockResponseModel:
-    return CollectiveBookingCollectiveStockResponseModel(  # type: ignore [call-arg]
+    return CollectiveBookingCollectiveStockResponseModel(  # type: ignore[call-arg]
         offerName=collective_booking.collectiveStock.collectiveOffer.name,
         offerId=collective_booking.collectiveStock.collectiveOfferId,
         eventBeginningDatetime=typing.cast(
@@ -278,7 +278,7 @@ def _serialize_collective_booking_recap_status(
 
 
 def serialize_collective_booking(collective_booking: models.CollectiveBooking) -> CollectiveBookingResponseModel:
-    return CollectiveBookingResponseModel(  # type: ignore [call-arg]
+    return CollectiveBookingResponseModel(  # type: ignore[call-arg]
         stock=serialize_collective_booking_stock(collective_booking),
         institution=serialize_collective_booking_institution(collective_booking),
         bookingId=collective_booking.id,
@@ -477,7 +477,7 @@ class CollectiveBookingByIdResponseModel(BaseModel):
 
         return cls(
             id=booking.id,
-            offerVenue=booking.collectiveStock.collectiveOffer.offerVenue,  # type: ignore [arg-type]
+            offerVenue=booking.collectiveStock.collectiveOffer.offerVenue,  # type: ignore[arg-type]
             beginningDatetime=booking.collectiveStock.beginningDatetime,
             students=booking.collectiveStock.collectiveOffer.students,
             price=booking.collectiveStock.price,

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -165,18 +165,18 @@ def _serialize_offer_paginated(offer: CollectiveOffer | CollectiveOfferTemplate)
     institution = getattr(offer, "institution", None)
     templateId = getattr(offer, "templateId", None)
 
-    return CollectiveOfferResponseModel(  # type: ignore [call-arg]
+    return CollectiveOfferResponseModel(  # type: ignore[call-arg]
         hasBookingLimitDatetimesPassed=offer.hasBookingLimitDatetimesPassed if not is_offer_template else False,
         id=offer.id,
         isActive=False if offer.status == OfferStatus.INACTIVE else offer.isActive,
         isEditable=offer.isEditable,
         isEducational=True,
         name=offer.name,
-        stocks=serialized_stocks,  # type: ignore [arg-type]
+        stocks=serialized_stocks,  # type: ignore[arg-type]
         booking=last_booking,
         thumbUrl=None,
-        subcategoryId=offer.subcategoryId,  # type: ignore [arg-type]
-        venue=_serialize_venue(offer.venue),  # type: ignore [arg-type]
+        subcategoryId=offer.subcategoryId,  # type: ignore[arg-type]
+        venue=_serialize_venue(offer.venue),  # type: ignore[arg-type]
         status=offer.status.name,
         isShowcase=is_offer_template,
         educationalInstitution=EducationalInstitutionResponseModel.from_orm(institution) if institution else None,
@@ -595,7 +595,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
 
 class PostCollectiveOfferTemplateBodyModel(PostCollectiveOfferBodyModel):
     price_detail: PriceDetail | None
-    contact_email: EmailStr | None  # type: ignore [assignment]
+    contact_email: EmailStr | None  # type: ignore[assignment]
     contact_url: AnyHttpUrl | None
     contact_form: OfferContactFormEnum | None
 

--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -54,7 +54,7 @@ class InvoiceResponseV2Model(BaseModel):
         invoice.bankAccountLabel = invoice.bankAccount.label
         invoice.cashflowLabels = [cashflow.batch.label for cashflow in invoice.cashflows]
         res = super().from_orm(invoice)
-        res.amount = -finance_utils.to_euros(res.amount)  # type: ignore [assignment, arg-type]
+        res.amount = -finance_utils.to_euros(res.amount)  # type: ignore[assignment, arg-type]
         return res
 
 

--- a/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
+++ b/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
@@ -233,7 +233,7 @@ def find_offerer_reimbursement_details(
     reimbursements_period: tuple[datetime.date | None, datetime.date | None],
     bank_account_id: int | None = None,
 ) -> list[ReimbursementDetails]:
-    offerer_payments = finance_repository.find_offerer_payments(offerer_id, reimbursements_period, bank_account_id)  # type: ignore [arg-type]
+    offerer_payments = finance_repository.find_offerer_payments(offerer_id, reimbursements_period, bank_account_id)  # type: ignore[arg-type]
     reimbursement_details = [ReimbursementDetails(offerer_payment) for offerer_payment in offerer_payments]
 
     return reimbursement_details

--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_venues.py
@@ -76,8 +76,8 @@ def create_data_venues(offerers_by_name: dict) -> dict[str, Venue]:
         venue = offerers_factories.VenueFactory(
             managingOfferer=offerer,
             bookingEmail="data@example.com",
-            latitude=float(geoloc_match.group(2)),  # type: ignore [union-attr]
-            longitude=float(geoloc_match.group(3)),  # type: ignore [union-attr]
+            latitude=float(geoloc_match.group(2)),  # type: ignore[union-attr]
+            longitude=float(geoloc_match.group(3)),  # type: ignore[union-attr]
             comment=comment,
             name=venue_name,
             siret=siret,

--- a/api/src/pcapi/scripts/beneficiary/import_test_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_test_users.py
@@ -85,7 +85,7 @@ def _create_beneficiary(row: dict, role: UserRole | None) -> User:
 
 def _create_pro_user(row: dict) -> User:
     user = users_api.create_pro_user(
-        ProUserCreationBodyV2Model(  # type: ignore [call-arg]
+        ProUserCreationBodyV2Model(  # type: ignore[call-arg]
             email=row["Mail"],
             firstName=row["Prénom"],
             lastName=row["Nom"],
@@ -195,7 +195,7 @@ def _add_or_update_user_from_row(row: dict, update_if_exists: bool) -> User | No
 
     user.lastName = row["Nom"]
     user.firstName = row["Prénom"]
-    user.phoneNumber = row["Téléphone"]  # type: ignore [method-assign]
+    user.phoneNumber = row["Téléphone"]  # type: ignore[method-assign]
     user.departementCode = row["Département"]
     user.postalCode = row["Code postal"]
     user.comment = row["Type"]

--- a/api/src/pcapi/scripts/bulk_activate_offers.py
+++ b/api/src/pcapi/scripts/bulk_activate_offers.py
@@ -15,7 +15,7 @@ def process_batch(offer_ids: list[str]) -> None:
     offer_ids = [offer_id for offer_id, in offers.with_entities(Offer.id)]
     offers.update({"isActive": True}, synchronize_session=False)
     db.session.commit()
-    search.reindex_offer_ids(offer_ids)  # type: ignore [arg-type]
+    search.reindex_offer_ids(offer_ids)  # type: ignore[arg-type]
 
 
 def bulk_activate_offers(iterable: Iterable[str], batch_size: int) -> None:

--- a/api/src/pcapi/scripts/bulk_inactivate_offers.py
+++ b/api/src/pcapi/scripts/bulk_inactivate_offers.py
@@ -15,7 +15,7 @@ def process_batch(offer_ids: list[str]) -> None:
     offer_ids = [offer_id for offer_id, in offers.with_entities(Offer.id)]
     offers.update({"isActive": False}, synchronize_session=False)
     db.session.commit()
-    search.unindex_offer_ids(offer_ids)  # type: ignore [arg-type]
+    search.unindex_offer_ids(offer_ids)  # type: ignore[arg-type]
 
 
 def bulk_inactivate_offers(iterable: Iterable[str], batch_size: int) -> None:

--- a/api/src/pcapi/serialization/spec_tree.py
+++ b/api/src/pcapi/serialization/spec_tree.py
@@ -23,8 +23,8 @@ def add_security_scheme(route_function: Callable, auth_key: str, scopes: list[st
     the SpecTree initialization of the route's BluePrint.
     """
     if not hasattr(route_function, "requires_authentication"):
-        route_function.requires_authentication = []  # type: ignore [attr-defined]
-    route_function.requires_authentication.append({auth_key: scopes or []})  # type: ignore [attr-defined]
+        route_function.requires_authentication = []  # type: ignore[attr-defined]
+    route_function.requires_authentication.append({auth_key: scopes or []})  # type: ignore[attr-defined]
 
 
 def build_operation_id(func: Callable) -> str:

--- a/api/src/pcapi/tasks/batch_tasks.py
+++ b/api/src/pcapi/tasks/batch_tasks.py
@@ -32,17 +32,17 @@ class TrackBatchEventRequest(BaseModel):
     event_payload: dict
 
 
-@task(settings.GCP_BATCH_CUSTOM_DATA_ANDROID_QUEUE_NAME, "/batch/android/update_user_attributes")  # type: ignore [arg-type]
+@task(settings.GCP_BATCH_CUSTOM_DATA_ANDROID_QUEUE_NAME, "/batch/android/update_user_attributes")  # type: ignore[arg-type]
 def update_user_attributes_android_task(payload: UpdateBatchAttributesRequest) -> None:
     update_user_attributes(BatchAPI.ANDROID, payload.user_id, payload.attributes, can_be_asynchronously_retried=True)
 
 
-@task(settings.GCP_BATCH_CUSTOM_DATA_IOS_QUEUE_NAME, "/batch/ios/update_user_attributes")  # type: ignore [arg-type]
+@task(settings.GCP_BATCH_CUSTOM_DATA_IOS_QUEUE_NAME, "/batch/ios/update_user_attributes")  # type: ignore[arg-type]
 def update_user_attributes_ios_task(payload: UpdateBatchAttributesRequest) -> None:
     update_user_attributes(BatchAPI.IOS, payload.user_id, payload.attributes, can_be_asynchronously_retried=True)
 
 
-@task(settings.GCP_BATCH_CUSTOM_DATA_QUEUE_NAME, "/batch/delete_user_attributes")  # type: ignore [arg-type]
+@task(settings.GCP_BATCH_CUSTOM_DATA_QUEUE_NAME, "/batch/delete_user_attributes")  # type: ignore[arg-type]
 def delete_user_attributes_task(payload: DeleteBatchUserAttributesRequest) -> None:
     delete_user_attributes(payload.user_id, can_be_asynchronously_retried=True)
 

--- a/api/src/pcapi/tasks/beamer_tasks.py
+++ b/api/src/pcapi/tasks/beamer_tasks.py
@@ -12,7 +12,7 @@ BEAMER_PRO_QUEUE_NAME = settings.GCP_BEAMER_PRO_QUEUE_NAME
 
 # Deduplicate and delay by 12 hours.
 # See api/src/pcapi/tasks/sendinblue_tasks.py comment for more details
-@task(BEAMER_PRO_QUEUE_NAME, "/beamer/update_pro_attributes", True, 43_200)  # type: ignore [arg-type]
+@task(BEAMER_PRO_QUEUE_NAME, "/beamer/update_pro_attributes", True, 43_200)  # type: ignore[arg-type]
 def update_beamer_pro_attributes_task(payload: UpdateProAttributesRequest) -> None:
     from pcapi.connectors import beamer
     from pcapi.core.external.attributes.api import get_pro_attributes

--- a/api/src/pcapi/tasks/compliance_tasks.py
+++ b/api/src/pcapi/tasks/compliance_tasks.py
@@ -9,11 +9,11 @@ from pcapi.tasks.serialization.compliance_tasks import GetComplianceScoreRequest
 logger = logging.getLogger(__name__)
 
 
-@task(settings.GCP_COMPLIANCE_API_PRIMARY_QUEUE_NAME, "/compliance/scoring-primary")  # type: ignore [arg-type]
+@task(settings.GCP_COMPLIANCE_API_PRIMARY_QUEUE_NAME, "/compliance/scoring-primary")  # type: ignore[arg-type]
 def update_offer_compliance_score_primary_task(payload: GetComplianceScoreRequest) -> None:
     compliance.make_update_offer_compliance_score(payload)
 
 
-@task(settings.GCP_COMPLIANCE_API_SECONDARY_QUEUE_NAME, "/compliance/scoring-secondary")  # type: ignore [arg-type]
+@task(settings.GCP_COMPLIANCE_API_SECONDARY_QUEUE_NAME, "/compliance/scoring-secondary")  # type: ignore[arg-type]
 def update_offer_compliance_score_secondary_task(payload: GetComplianceScoreRequest) -> None:
     compliance.make_update_offer_compliance_score(payload)

--- a/api/src/pcapi/tasks/decorator.py
+++ b/api/src/pcapi/tasks/decorator.py
@@ -53,7 +53,7 @@ def task(
                 task_request_timeout=task_request_timeout,
             )
 
-        f.delay = delay  # type: ignore [attr-defined]
+        f.delay = delay  # type: ignore[attr-defined]
         return f
 
     return decorator
@@ -66,7 +66,7 @@ def _define_handler(
 ) -> None:
     @cloud_task_api.route(path, methods=["POST"], endpoint=path)
     @spectree_serialize(on_success_status=204)
-    def handle_task(body: payload_type) -> None:  # type: ignore [valid-type]
+    def handle_task(body: payload_type) -> None:  # type: ignore[valid-type]
         queue_name = request.headers.get("HTTP_X_CLOUDTASKS_QUEUENAME")
         task_id = request.headers.get("HTTP_X_CLOUDTASKS_TASKNAME")
         retry_attempt = request.headers.get("X-CloudTasks-TaskRetryCount")
@@ -82,7 +82,7 @@ def _define_handler(
 
         if request.headers.get(cloud_task.AUTHORIZATION_HEADER_KEY) != cloud_task.AUTHORIZATION_HEADER_VALUE:
             logger.info("Unauthorized request on cloud task %s", path, extra=job_details)
-            raise ApiErrors("Unauthorized", status_code=299)  # type: ignore [arg-type] # status code 2xx to prevent retry
+            raise ApiErrors("Unauthorized", status_code=299)  # type: ignore[arg-type] # status code 2xx to prevent retry
 
         try:
             f(body)

--- a/api/src/pcapi/tasks/mails_tasks.py
+++ b/api/src/pcapi/tasks/mails_tasks.py
@@ -5,7 +5,7 @@ from pcapi.tasks.serialization.mails_tasks import WithdrawalChangedMailRequest
 
 
 @task(
-    GCP_SENDINBLUE_TRANSACTIONAL_EMAILS_WITHDRAWAL_UPDATED_QUEUE_NAME,  # type: ignore [arg-type]
+    GCP_SENDINBLUE_TRANSACTIONAL_EMAILS_WITHDRAWAL_UPDATED_QUEUE_NAME,  # type: ignore[arg-type]
     "/sendinblue/send-withdrawal-updated-emails",
 )
 def send_withdrawal_detail_changed_emails(payload: WithdrawalChangedMailRequest) -> None:

--- a/api/src/pcapi/tasks/sendinblue_tasks.py
+++ b/api/src/pcapi/tasks/sendinblue_tasks.py
@@ -17,17 +17,17 @@ SENDINBLUE_TRANSACTIONAL_EMAILS_PRIMARY_QUEUE_NAME = settings.GCP_SENDINBLUE_TRA
 SENDINBLUE_TRANSACTIONAL_EMAILS_SECONDARY_QUEUE_NAME = settings.GCP_SENDINBLUE_TRANSACTIONAL_EMAILS_SECONDARY_QUEUE_NAME
 
 
-@task(SENDINBLUE_CONTACTS_QUEUE_NAME, "/sendinblue/update_contact_attributes")  # type: ignore [arg-type]
+@task(SENDINBLUE_CONTACTS_QUEUE_NAME, "/sendinblue/update_contact_attributes")  # type: ignore[arg-type]
 def update_contact_attributes_task(payload: UpdateSendinblueContactRequest) -> None:
     sendinblue.make_update_request(payload)
 
 
-@task(SENDINBLUE_TRANSACTIONAL_EMAILS_PRIMARY_QUEUE_NAME, "/sendinblue/send-transactional-email-primary")  # type: ignore [arg-type]
+@task(SENDINBLUE_TRANSACTIONAL_EMAILS_PRIMARY_QUEUE_NAME, "/sendinblue/send-transactional-email-primary")  # type: ignore[arg-type]
 def send_transactional_email_primary_task(payload: SendTransactionalEmailRequest) -> None:
     send_transactional_email(payload)
 
 
-@task(SENDINBLUE_TRANSACTIONAL_EMAILS_SECONDARY_QUEUE_NAME, "/sendinblue/send-transactional-email-secondary")  # type: ignore [arg-type]
+@task(SENDINBLUE_TRANSACTIONAL_EMAILS_SECONDARY_QUEUE_NAME, "/sendinblue/send-transactional-email-secondary")  # type: ignore[arg-type]
 def send_transactional_email_secondary_task(payload: SendTransactionalEmailRequest) -> None:
     send_transactional_email(payload)
 
@@ -42,7 +42,7 @@ def send_transactional_email_secondary_task(payload: SendTransactionalEmailReque
 #
 # So time_id parameter in UpdateProAttributesRequest helps to generate different hashes, so different task ids, every
 # 12 hours. Keep delayed_seconds below consistent with time_id generation.
-@task(SENDINBLUE_PRO_QUEUE_NAME, "/sendinblue/update_pro_attributes", True, 43_200)  # type: ignore [arg-type]
+@task(SENDINBLUE_PRO_QUEUE_NAME, "/sendinblue/update_pro_attributes", True, 43_200)  # type: ignore[arg-type]
 def update_sib_pro_attributes_task(payload: UpdateProAttributesRequest) -> None:
     from pcapi.core.external.attributes.api import get_pro_attributes
     from pcapi.core.external.sendinblue import update_contact_attributes

--- a/api/src/pcapi/tasks/ubble_tasks.py
+++ b/api/src/pcapi/tasks/ubble_tasks.py
@@ -17,7 +17,7 @@ class StoreIdPictureRequest(BaseModel):
     identification_id: str
 
 
-@task(UBBLE_ARCHIVE_ID_PICTURES_QUEUE_NAME, "/ubble/store_id_pictures")  # type: ignore [arg-type]
+@task(UBBLE_ARCHIVE_ID_PICTURES_QUEUE_NAME, "/ubble/store_id_pictures")  # type: ignore[arg-type]
 def store_id_pictures_task(payload: StoreIdPictureRequest) -> None:
     try:
         ubble_subscription_api.archive_ubble_user_id_pictures(payload.identification_id)

--- a/api/src/pcapi/tasks/zendesk_sell_tasks.py
+++ b/api/src/pcapi/tasks/zendesk_sell_tasks.py
@@ -16,7 +16,7 @@ class VenuePayload(BaseModel):
     venue_id: int
 
 
-@task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/create_offerer")  # type: ignore [arg-type]
+@task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/create_offerer")  # type: ignore[arg-type]
 def create_offerer_task(payload: OffererPayload) -> None:
     from pcapi.core.external import zendesk_sell
 
@@ -24,7 +24,7 @@ def create_offerer_task(payload: OffererPayload) -> None:
     zendesk_sell.do_create_offerer(payload.offerer_id)
 
 
-@task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/update_offerer")  # type: ignore [arg-type]
+@task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/update_offerer")  # type: ignore[arg-type]
 def update_offerer_task(payload: OffererPayload) -> None:
     from pcapi.core.external import zendesk_sell
 
@@ -32,7 +32,7 @@ def update_offerer_task(payload: OffererPayload) -> None:
     zendesk_sell.do_update_offerer(payload.offerer_id)
 
 
-@task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/create_venue")  # type: ignore [arg-type]
+@task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/create_venue")  # type: ignore[arg-type]
 def create_venue_task(payload: VenuePayload) -> None:
     from pcapi.core.external import zendesk_sell
 
@@ -40,7 +40,7 @@ def create_venue_task(payload: VenuePayload) -> None:
     zendesk_sell.do_create_venue(payload.venue_id)
 
 
-@task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/update_venue")  # type: ignore [arg-type]
+@task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/update_venue")  # type: ignore[arg-type]
 def update_venue_task(payload: VenuePayload) -> None:
     from pcapi.core.external import zendesk_sell
 

--- a/api/src/pcapi/tasks/zendesk_tasks.py
+++ b/api/src/pcapi/tasks/zendesk_tasks.py
@@ -16,7 +16,7 @@ class UpdateZendeskAttributesRequest(BaseModel):
     phone_number: str | None
 
 
-@task(GCP_ZENDESK_ATTRIBUTES_QUEUE_NAME, "/zendesk/update_user_attributes")  # type: ignore [arg-type]
+@task(GCP_ZENDESK_ATTRIBUTES_QUEUE_NAME, "/zendesk/update_user_attributes")  # type: ignore[arg-type]
 def update_zendesk_attributes_task(payload: UpdateZendeskAttributesRequest) -> None:
     from pcapi.core.external.zendesk import update_contact_attributes
 

--- a/api/src/pcapi/utils/cache.py
+++ b/api/src/pcapi/utils/cache.py
@@ -19,7 +19,7 @@ class _CacheProxy:
     def __getattr__(self, name: str) -> Any:
         if self._data is None:
             self._data = json.loads(self._json)
-        return self._data.get(name)  # type: ignore [attr-defined]
+        return self._data.get(name)  # type: ignore[attr-defined]
 
     def json(self, *args: Iterable[Any], **kwargs: dict[str, Any]) -> str:
         return self._json

--- a/api/src/pcapi/utils/login_manager.py
+++ b/api/src/pcapi/utils/login_manager.py
@@ -23,7 +23,7 @@ def get_request_authorization() -> werkzeug.datastructures.Authorization | None:
         return None
 
 
-@app.login_manager.user_loader  # type: ignore [attr-defined]
+@app.login_manager.user_loader  # type: ignore[attr-defined]
 def get_user_with_id(user_id: str) -> users_models.User | None:
     flask.session.permanent = True
     session_uuid = flask.session.get("session_uuid")
@@ -31,7 +31,7 @@ def get_user_with_id(user_id: str) -> users_models.User | None:
         return None
 
     try:
-        if flask.request.blueprint.startswith(backoffice_web.name):  # type: ignore [union-attr]
+        if flask.request.blueprint.startswith(backoffice_web.name):  # type: ignore[union-attr]
             return backoffice_api.fetch_user_with_profile(int(user_id))
     except AttributeError:
         pass
@@ -45,7 +45,7 @@ def get_user_with_id(user_id: str) -> users_models.User | None:
     return user
 
 
-@app.login_manager.unauthorized_handler  # type: ignore [attr-defined]
+@app.login_manager.unauthorized_handler  # type: ignore[attr-defined]
 def send_401() -> tuple[flask.Response, int]:
     e = ApiErrors()
     e.add_error("global", "Authentification nécessaire")

--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -19,7 +19,7 @@ def build_pc_pro_reset_password_link(token_value: str) -> str:
 def format_booking_date_for_email(booking: Booking | CollectiveBooking) -> str:
     if isinstance(booking, CollectiveBooking) or booking.stock.offer.isEvent:
         stock = booking.collectiveStock if isinstance(booking, CollectiveBooking) else booking.stock
-        date_in_tz = get_event_datetime(stock)  # type: ignore [arg-type]
+        date_in_tz = get_event_datetime(stock)  # type: ignore[arg-type]
         offer_date = date_in_tz.strftime("%d-%b-%Y")
         return offer_date
     return ""
@@ -28,7 +28,7 @@ def format_booking_date_for_email(booking: Booking | CollectiveBooking) -> str:
 def format_booking_hours_for_email(booking: Booking | CollectiveBooking) -> str:
     if isinstance(booking, CollectiveBooking) or booking.stock.offer.isEvent:
         stock = booking.collectiveStock if isinstance(booking, CollectiveBooking) else booking.stock
-        date_in_tz = get_event_datetime(stock)  # type: ignore [arg-type]
+        date_in_tz = get_event_datetime(stock)  # type: ignore[arg-type]
         event_hour = date_in_tz.hour
         event_minute = date_in_tz.minute
         return f"{event_hour}h" if event_minute == 0 else f"{event_hour}h{event_minute}"
@@ -46,6 +46,6 @@ def get_event_datetime(stock: CollectiveStock | Stock) -> datetime:
             raise ValueError("Can't convert None to local timezone")
         date_in_tz = utc_datetime_to_department_timezone(date_in_utc, departement_code)
     else:
-        date_in_tz = stock.beginningDatetime  # type: ignore [assignment]
+        date_in_tz = stock.beginningDatetime  # type: ignore[assignment]
 
     return date_in_tz

--- a/api/src/pcapi/utils/requests.py
+++ b/api/src/pcapi/utils/requests.py
@@ -142,7 +142,7 @@ class CustomGqlTransport(gql.transport.requests.RequestsHTTPTransport):
         # says that `session` has type `None` (because of the
         # constructor of the parent class) and that triggers an error
         # in `connect()` when setting the attribute.
-        self.session: requests.Session | None = None  # type: ignore [assignment]
+        self.session: requests.Session | None = None  # type: ignore[assignment]
         super().__init__(*args, **kwargs)
 
     def connect(self) -> None:

--- a/api/src/pcapi/validation/routes/users_authentifications.py
+++ b/api/src/pcapi/validation/routes/users_authentifications.py
@@ -91,7 +91,7 @@ def _get_current_api_key() -> ApiKey | None:
     return g.current_api_key
 
 
-current_api_key: ApiKey = LocalProxy(_get_current_api_key)  # type: ignore [assignment]
+current_api_key: ApiKey = LocalProxy(_get_current_api_key)  # type: ignore[assignment]
 
 
 def basic_authentication() -> User | None:

--- a/api/src/pcapi/workers/decorators.py
+++ b/api/src/pcapi/workers/decorators.py
@@ -62,7 +62,7 @@ def job(queue: Queue) -> typing.Callable:
                 extra={**job_extra_description(current_job), "status": "enqueued"},
             )
 
-        job_func.delay = delay  # type: ignore [attr-defined]
+        job_func.delay = delay  # type: ignore[attr-defined]
         return job_func
 
     return decorator

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -136,7 +136,7 @@ class UnindexExpiredOffersTest:
 class GetCulturalPartnersTest:
     def test_cultural_partners_no_cache(self) -> None:
         # given
-        redis_client = current_app.redis_client  # type: ignore [attr-defined]
+        redis_client = current_app.redis_client  # type: ignore[attr-defined]
         redis_client.delete("api:adage_cultural_partner:cache")
 
         # when
@@ -208,7 +208,7 @@ class GetCulturalPartnersTest:
 
     def test_cultural_partners_get_cache(self) -> None:
         # given
-        redis_client = current_app.redis_client  # type: ignore [attr-defined]
+        redis_client = current_app.redis_client  # type: ignore[attr-defined]
         data = [
             {
                 "id": 23,
@@ -282,7 +282,7 @@ class GetCulturalPartnersTest:
 
     def test_cultural_partners_force_update(self) -> None:
         # given
-        redis_client = current_app.redis_client  # type: ignore [attr-defined]
+        redis_client = current_app.redis_client  # type: ignore[attr-defined]
         data = [
             {
                 "id": 23,


### PR DESCRIPTION
## But de la pull request

Description :

Pour ignorer les erreurs mypy on utilise le commentaire spécial `# type: ignore[code]`, souvent avec un espace en trop entre `ignore` et `[code]`, ie `# type: ignore [code]` au lieu de `# type: ignore[code]`.
Dans la documentation mypy ( https://mypy.readthedocs.io/en/stable/error_codes.html#error-codes ), la forme indiquée est `# type: ignore[code]` (sans espace).

Dans certains IDE (PyCharm notamment), la forme avec un espace entraîne un warning :

<img width="1047" alt="Screenshot 2024-06-01 at 13 22 38" src="https://github.com/pass-culture/pass-culture-main/assets/164168889/a96551b2-070a-438f-acb7-b6c1a7b8722a">
<br/><br/>
Alors que la forme sans espace n'en entraîne pas :
<br/><br/>
<img width="1047" alt="Screenshot 2024-06-01 at 13 23 04" src="https://github.com/pass-culture/pass-culture-main/assets/164168889/585a7126-5a12-4f03-b86b-819a8c0e59d5">
<br/><br/>
Commandes utilisées (testées avec MacOS) :
<br/><br/>

```
% grep -RE "# type: ?ignore \[" api/src api/tests | wc -l
    359

% grep -RE "# type: ?ignore\[" api/src api/tests | wc -l
    56

% find api/src api/tests -name "*.py" -exec sed -E -i '' -e 's/# type: ?ignore \[/# type: ignore\[/g' {} \;

% git diff --shortstat
119 files changed, 359 insertions(+), 359 deletions(-)

% grep -RE "# type: ?ignore \[" api/src api/tests | wc -l
    0

% grep -RE "# type: ?ignore\[" api/src api/tests | wc -l
    415
```

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques