### PR TITLE
(BSR)[API] refactor: harmonize type ignore ; add missing whitespace

### DIFF
--- a/api/src/pcapi/alembic/versions/20240130T153836_9607ada7a6b6_delete_search_history_adage_ff.py
+++ b/api/src/pcapi/alembic/versions/20240130T153836_9607ada7a6b6_delete_search_history_adage_ff.py
@@ -10,7 +10,7 @@ branch_labels = None
 depends_on = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240215T092219_88d300a290b1_delete_adage_discovery_ff.py
+++ b/api/src/pcapi/alembic/versions/20240215T092219_88d300a290b1_delete_adage_discovery_ff.py
@@ -10,7 +10,7 @@ branch_labels = None
 depends_on = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240221T150541_00738a9d13b0_remove_ff_wip_category_selection.py
+++ b/api/src/pcapi/alembic/versions/20240221T150541_00738a9d13b0_remove_ff_wip_category_selection.py
@@ -10,7 +10,7 @@ branch_labels = None
 depends_on = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240221T153023_04c2660a8169_remove_ff_wip_partner_page.py
+++ b/api/src/pcapi/alembic/versions/20240221T153023_04c2660a8169_remove_ff_wip_partner_page.py
@@ -10,7 +10,7 @@ branch_labels = None
 depends_on = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240227T161721_6f80f864d7ed_remove_feature_flag_enable_format.py
+++ b/api/src/pcapi/alembic/versions/20240227T161721_6f80f864d7ed_remove_feature_flag_enable_format.py
@@ -10,7 +10,7 @@ branch_labels = None
 depends_on = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240308T135307_8d5148b6b128_remove_ff_wip_adage_satisfaction_survey.py
+++ b/api/src/pcapi/alembic/versions/20240308T135307_8d5148b6b128_remove_ff_wip_adage_satisfaction_survey.py
@@ -10,7 +10,7 @@ branch_labels = None
 depends_on = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240308T143042_4df45e259f14_rmove_ff_wip_adage_diffuse_help.py
+++ b/api/src/pcapi/alembic/versions/20240308T143042_4df45e259f14_rmove_ff_wip_adage_diffuse_help.py
@@ -10,7 +10,7 @@ branch_labels = None
 depends_on = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240327T141058_4959dc20bd41_remove_wip_enable_compliance_call_ff.py
+++ b/api/src/pcapi/alembic/versions/20240327T141058_4959dc20bd41_remove_wip_enable_compliance_call_ff.py
@@ -7,7 +7,7 @@ revision = "4959dc20bd41"
 down_revision = "c7d04bd67054"
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240402T121757_a70801516cff_remove_ff_double_model_writing.py
+++ b/api/src/pcapi/alembic/versions/20240402T121757_a70801516cff_remove_ff_double_model_writing.py
@@ -9,7 +9,7 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240419T084536_9660ff700ed1_remove_ff_wip_ff_side_nav.py
+++ b/api/src/pcapi/alembic/versions/20240419T084536_9660ff700ed1_remove_ff_wip_ff_side_nav.py
@@ -9,7 +9,7 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240506T132505_26fdf6be1ace_drop_wip_enable_boost_prefixed_external_booking_ff.py
+++ b/api/src/pcapi/alembic/versions/20240506T132505_26fdf6be1ace_drop_wip_enable_boost_prefixed_external_booking_ff.py
@@ -9,7 +9,7 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240515T125314_34a1a2acff4f_delete_enable_offer_price_limitation_ff.py
+++ b/api/src/pcapi/alembic/versions/20240515T125314_34a1a2acff4f_delete_enable_offer_price_limitation_ff.py
@@ -9,7 +9,7 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240521T094246_fbb9ccd03884_delete_acces_libre_ff.py
+++ b/api/src/pcapi/alembic/versions/20240521T094246_fbb9ccd03884_delete_acces_libre_ff.py
@@ -10,7 +10,7 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.

--- a/api/src/pcapi/alembic/versions/20240603T124838_1161bdcd0100_remove_ff_wip_opening_hours.py
+++ b/api/src/pcapi/alembic/versions/20240603T124838_1161bdcd0100_remove_ff_wip_opening_hours.py
@@ -10,7 +10,7 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
-def get_flag():  # type:ignore[no-untyped-def]
+def get_flag():  # type: ignore[no-untyped-def]
     # Do not import `pcapi.models.feature` at module-level. It breaks
     # `alembic history` with a SQLAlchemy error that complains about
     # an unknown table name while initializing the ORM mapper.


### PR DESCRIPTION
## But de la pull request

Description : Semblable à cette PR: https://github.com/pass-culture/pass-culture-main/pull/12506 mais cette fois-ci pour ajouter un espace manquant : `type: ignore` au lieu de `type:ignore`. 
Remarque : la forme sans espace (`type:ignore`) n'est pas détectée par mypy cop report

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques