### PR TITLE
(PC-30158)[PRO] fix: Use venue departmentCode with correct value.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout.tsx
@@ -70,6 +70,7 @@ export const AdagePreviewLayout = ({ offer }: AdagePreviewLayoutProps) => {
       postalCode: venue.postalCode,
       city: venue.city,
       address: venue.street,
+      departmentCode: venue.departementCode,
     },
   }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30158

**Objectif**
Quand on affiche l'aperçu ADAGE dans pro, on doit recréer une "fausse" offre avec le model ADAGE à partir de la "vraie" offre PRO. Pour ça on construit l'offre en requêtant celle de pro, et en ajustant les clés pour coller au model. On pensait qu'il y avait rien à modifier sur la clé "departementCode", sauf que côté ADAGE c'est "departmentCode".

Ce qui fait que dans l'aperçu, on utilise systématiquement la tz par défaut Europe/Paris.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques