### PR TITLE
(BSR) refactor: sort readme & add verification to setup to avoid rewriting lines

### DIFF
--- a/infra/pc_scripts/start_backend_no_docker.sh
+++ b/infra/pc_scripts/start_backend_no_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-API_DIR="$PASS_CULTURE_DIR/pass-culture-main/api"
+API_DIR="$ROOT_PATH/api"
 RUN="${RUN:=''}" # avoid unbound variable error
 
 # Recreate databases
@@ -91,8 +91,23 @@ setup_no_docker() {
         echo "Requirements check failed. Exiting setup."
         return 1
     fi
-    echo "DATABASE_URL=postgresql://pass_culture:passq@localhost:5432/pass_culture" >> $API_DIR/.env.local.secret
-    echo "DATABASE_URL_TEST=postgresql://pytest:pytest@localhost:5432/pass_culture_test" >> $API_DIR/.env.local.secret
+    passculture_db="DATABASE_URL=postgresql://pass_culture:passq@localhost:5432/pass_culture"
+    passculture_test_db="DATABASE_URL_TEST=postgresql://pytest:pytest@localhost:5432/pass_culture_test"
+    backoffice_port="FLASK_BACKOFFICE_PORT=5002"
+    flask_ip="FLASK_IP=::1"
+    secret_file="$API_DIR/.env.local.secret"
+    if ! grep -qF "$passculture_db" "$secret_file"; then
+        echo "$passculture_db" >> "$secret_file"
+    fi
+    if ! grep -qF "$passculture_test_db" "$secret_file"; then
+        echo "$passculture_test_db" >> "$secret_file"
+    fi
+    if ! grep -qF "$backoffice_port" "$secret_file"; then
+        echo "$backoffice_port" >> "$secret_file"
+    fi
+    if ! grep -qF "$flask_ip" "$secret_file"; then
+        echo "$flask_ip" >> "$secret_file"
+    fi
     recreate_database
     recreate_database_test
     flask install_postgres_extensions


### PR DESCRIPTION

## But de la pull request

BSR pour:
- modifier le readme afin de créer les superuser hors script (trop compliqué à gérer dans le script car `create user if not exist `n'existe pas avec postgresql )
- ne pas ajouter les lignes de db dans le fichier local si elles existent déjà


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques