### PR TITLE
(PC-27583)[API] fix: truncate long strings sent to Batch

### DIFF
--- a/api/src/pcapi/core/external/batch.py
+++ b/api/src/pcapi/core/external/batch.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import logging
+import textwrap
 
 from pcapi.core.cultural_survey import models as cultural_survey_models
 from pcapi.core.external.attributes import models as attributes_models
@@ -138,7 +139,7 @@ def format_offer_attributes(offer: offers_models.Offer) -> dict:
 
     offer_attributes = {
         "offer_id": offer.id,
-        "offer_name": offer.name,
+        "offer_name": textwrap.shorten(offer.name, width=64, placeholder="..."),
         "offer_category": offer.categoryId,
         "offer_subcategory": offer.subcategoryId,
         "offer_type": "duo" if offer.isDuo else "solo",

--- a/api/tests/routes/native/v1/favorites_test.py
+++ b/api/tests/routes/native/v1/favorites_test.py
@@ -335,7 +335,9 @@ class PostTest:
     def when_user_creates_a_favorite(self, client):
         # Given
         user = users_factories.UserFactory()
-        offer = offers_factories.EventOfferFactory()
+        offer = offers_factories.EventOfferFactory(
+            name="This is a long event name that has a space at the sixty-first character"
+        )
         earliest_stock = offers_factories.EventStockFactory(offer=offer, price=Decimal("10.1"), quantity=None)
         offers_factories.EventStockFactory(beginningDatetime=earliest_stock.beginningDatetime + timedelta(days=30))
 
@@ -368,6 +370,7 @@ class PostTest:
         )
         event_payload = favorite_creation_tracking_event["event_payload"]
         assert event_payload["event_date"] == earliest_stock.beginningDatetime.isoformat(timespec="seconds")
+        assert event_payload["offer_name"] == "This is a long event name that has a space at the sixty-first..."
         assert all(value is not None for value in event_payload.values())
 
     def when_user_creates_a_favorite_twice(self, client):


### PR DESCRIPTION
Batch refuses strings that are longer than 64 characters.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-27583