### PR TITLE
(PC-30111) [API] Ajout du champ `idAtProvider` dans les endpoints de l'API publique

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -222,6 +222,7 @@ def update_offer(
     withdrawalType: models.WithdrawalTypeEnum | None | T_UNCHANGED = UNCHANGED,
     shouldSendMail: bool = False,
     is_from_private_api: bool = False,
+    idAtProvider: str | None | T_UNCHANGED = UNCHANGED,
 ) -> models.Offer:
     modifications = {
         field: new_value
@@ -241,6 +242,9 @@ def update_offer(
         )
     if isDuo is not UNCHANGED:
         validation.check_is_duo_compliance(isDuo, offer.subcategory)
+
+    if idAtProvider is not UNCHANGED:
+        validation.check_can_input_id_at_provider(offer.lastProvider, idAtProvider)
 
     withdrawal_updated = not (
         withdrawalType is UNCHANGED

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -148,6 +148,7 @@ def create_offer(
     withdrawal_details: str | None = None,
     withdrawal_type: models.WithdrawalTypeEnum | None = None,
     is_from_private_api: bool = False,
+    id_at_provider: str | None = None,
 ) -> models.Offer:
     validation.check_offer_withdrawal(withdrawal_type, withdrawal_delay, subcategory_id, booking_contact, provider)
     validation.check_offer_subcategory_is_valid(subcategory_id)
@@ -155,6 +156,7 @@ def create_offer(
     validation.check_offer_extra_data(subcategory_id, formatted_extra_data, venue, is_from_private_api)
     subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
     validation.check_is_duo_compliance(is_duo, subcategory)
+    validation.check_can_input_id_at_provider(provider, id_at_provider)
 
     is_national = True if url else bool(is_national)
 
@@ -182,6 +184,7 @@ def create_offer(
         withdrawalDetails=withdrawal_details,
         withdrawalType=withdrawal_type,
         offererAddress=venue.offererAddress,
+        idAtProvider=id_at_provider,
     )
 
     repository.add_to_session(offer)

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -128,6 +128,14 @@ class SubCategoryIsInactive(OfferCreationBaseException):
         )
 
 
+class CannotSetIdAtProviderWithoutAProvider(OfferCreationBaseException):
+    def __init__(self) -> None:
+        super().__init__(
+            "idAtProvider",
+            "Une offre ne peut être créée avec un idAtProvider si elle n'a pas de provider",
+        )
+
+
 class NoDelayWhenEventWithdrawalTypeHasNoTicket(OfferCreationBaseException):
     def __init__(self) -> None:
         super().__init__(

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -132,7 +132,7 @@ class CannotSetIdAtProviderWithoutAProvider(OfferCreationBaseException):
     def __init__(self) -> None:
         super().__init__(
             "idAtProvider",
-            "Une offre ne peut être créée avec un idAtProvider si elle n'a pas de provider",
+            "Une offre ne peut être créée ou éditée avec un idAtProvider si elle n'a pas de provider",
         )
 
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -270,6 +270,11 @@ def check_stock_is_deletable(stock: models.Stock) -> None:
         raise exceptions.TooLateToDeleteStock()
 
 
+def check_can_input_id_at_provider(provider: providers_models.Provider | None, id_at_provider: str | None) -> None:
+    if id_at_provider and not provider:
+        raise exceptions.CannotSetIdAtProviderWithoutAProvider()
+
+
 def check_update_only_allowed_stock_fields_for_allocine_offer(updated_fields: set) -> None:
     if not updated_fields.issubset(EDITABLE_FIELDS_FOR_ALLOCINE_STOCK):
         errors = api_errors.ApiErrors()

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -50,6 +50,7 @@ EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER = {
     "durationMinutes",
     "withdrawalDelay",
     "withdrawalType",
+    "idAtProvider",
 } | EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
 
 MAX_THUMBNAIL_SIZE = 10_000_000

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -50,6 +50,11 @@ class _FIELDS:
         description="Event duration in minutes",
         example=60,
     )
+    ID_AT_PROVIDER = Field(
+        description="Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
+        example="Your own id",
+    )
+
     OFFER_STATUS = Field(description=descriptions.OFFER_STATUS_FIELD_DESCRIPTION, example="ACTIVE")
 
     PERIOD_BEGINNING_DATE = Field(

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -54,7 +54,11 @@ class _FIELDS:
         description="Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
         example="Your own id",
     )
-
+    ID_AT_PROVIDER_WITH_MAX_LENGTH = Field(
+        description="Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
+        example="Your own id",
+        max_length=70,
+    )
     OFFER_STATUS = Field(description=descriptions.OFFER_STATUS_FIELD_DESCRIPTION, example="ACTIVE")
 
     PERIOD_BEGINNING_DATE = Field(

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -86,6 +86,7 @@ def post_event_offer(body: serialization.EventOfferCreation) -> serialization.Ev
                 visual_disability_compliant=body.accessibility.visual_disability_compliant,
                 withdrawal_details=body.withdrawal_details,
                 withdrawal_type=withdrawal_type,
+                id_at_provider=body.id_at_provider,
             )
             # To create the priceCategories, the offer needs to have an id
             db.session.flush()
@@ -220,6 +221,7 @@ def edit_event(event_id: int, body: serialization.EventOfferEdition) -> serializ
                 isDuo=update_body.get("is_duo", offers_api.UNCHANGED),
                 withdrawalDetails=update_body.get("withdrawal_details", offers_api.UNCHANGED),
                 description=update_body.get("description", offers_api.UNCHANGED),
+                idAtProvider=update_body.get("id_at_provider", offers_api.UNCHANGED),
                 **utils.compute_accessibility_edition_fields(update_body.get("accessibility")),
             )
             if body.image:

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -234,6 +234,7 @@ def post_product_offer(body: serialization.ProductOfferCreation) -> serializatio
                 venue=venue,
                 visual_disability_compliant=body.accessibility.visual_disability_compliant,
                 withdrawal_details=body.withdrawal_details,
+                id_at_provider=body.id_at_provider,
             )
 
             if body.image:
@@ -667,6 +668,7 @@ def edit_product(body: serialization.ProductOfferEdition) -> serialization.Produ
                 isActive=updated_offer_from_body.get("is_active", offers_api.UNCHANGED),
                 isDuo=updated_offer_from_body.get("is_duo", offers_api.UNCHANGED),
                 withdrawalDetails=updated_offer_from_body.get("withdrawal_details", offers_api.UNCHANGED),
+                idAtProvider=updated_offer_from_body.get("id_at_provider", offers_api.UNCHANGED),
                 **utils.compute_accessibility_edition_fields(updated_offer_from_body.get("accessibility")),
             )
             if body.image:

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -229,6 +229,7 @@ class OfferCreationBase(serialization.ConfiguredBaseModel):
     is_duo: bool | None = IS_DUO_BOOKINGS_FIELD
     name: str = NAME_FIELD
     withdrawal_details: str | None = WITHDRAWAL_DETAILS_FIELD
+    id_at_provider: str | None = fields.ID_AT_PROVIDER_WITH_MAX_LENGTH
 
 
 class Method(enum.Enum):
@@ -575,6 +576,7 @@ class OfferEditionBase(serialization.ConfiguredBaseModel):
     withdrawal_details: str | None = WITHDRAWAL_DETAILS_FIELD
     image: ImageBody | None
     description: str | None = DESCRIPTION_FIELD_MODEL
+    id_at_provider: str | None = fields.ID_AT_PROVIDER_WITH_MAX_LENGTH
 
     class Config:
         extra = "forbid"

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -21,6 +21,7 @@ from pcapi.domain import show_types
 from pcapi.models import offer_mixin
 from pcapi.routes import serialization
 from pcapi.routes.public.documentation_constants import descriptions
+from pcapi.routes.public.documentation_constants.fields import fields
 from pcapi.routes.public.individual_offers.v1.base_serialization import IndexPaginationQueryParams
 import pcapi.routes.public.serialization.accessibility as accessibility_serialization
 from pcapi.routes.public.serialization.utils import StrEnum
@@ -716,6 +717,7 @@ class OfferResponse(serialization.ConfiguredBaseModel):
         example=offer_mixin.OfferStatus.ACTIVE.name,
     )
     withdrawal_details: str | None = WITHDRAWAL_DETAILS_FIELD
+    id_at_provider: str | None = fields.ID_AT_PROVIDER
 
     class Config:
         json_encoders = {datetime.datetime: date_utils.format_into_utc_date}
@@ -735,6 +737,7 @@ class OfferResponse(serialization.ConfiguredBaseModel):
             name=offer.name,
             status=offer.status,
             withdrawal_details=offer.withdrawalDetails,
+            id_at_provider=offer.idAtProvider,
         )
 
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1318,6 +1318,40 @@ class UpdateOfferTest:
         pending_offer = models.Offer.query.one()
         assert pending_offer.name == "Soliloquy"
 
+    def test_success_on_updating_id_at_provider(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        offerer = offerers_factories.OffererFactory()
+        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
+        offer = factories.OfferFactory(
+            lastProvider=provider,
+            name="Offer linked to a provider",
+        )
+
+        api.update_offer(
+            offer,
+            idAtProvider="some_id_at_provider",
+        )
+
+        offer = models.Offer.query.one()
+        assert offer.name == "Offer linked to a provider"
+        assert offer.idAtProvider == "some_id_at_provider"
+
+    def test_raise_error_on_updating_id_at_provider(self):
+        offer = factories.OfferFactory(
+            lastProvider=None,
+            name="Offer linked to a provider",
+        )
+
+        with pytest.raises(exceptions.CannotSetIdAtProviderWithoutAProvider) as error:
+            api.update_offer(
+                offer,
+                idAtProvider="some_id_at_provider",
+            )
+
+        assert error.value.errors["idAtProvider"] == [
+            "Une offre ne peut être créée ou éditée avec un idAtProvider si elle n'a pas de provider"
+        ]
+
 
 @pytest.mark.usefixtures("db_session")
 class BatchUpdateOffersTest:

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1057,6 +1057,30 @@ class CreateOfferTest:
         assert not offer.bookingEmail
         assert models.Offer.query.count() == 1
 
+    def test_create_offer_with_id_at_provider(self):
+        venue = offerers_factories.VenueFactory()
+        provider = providers_factories.APIProviderFactory()
+
+        offer = api.create_offer(
+            venue=venue,
+            name="A pretty good offer",
+            subcategory_id=subcategories.SEANCE_CINE.id,
+            provider=provider,
+            id_at_provider="coucou",
+            audio_disability_compliant=True,
+            mental_disability_compliant=True,
+            motor_disability_compliant=True,
+            visual_disability_compliant=True,
+        )
+
+        assert offer.name == "A pretty good offer"
+        assert offer.venue == venue
+        assert offer.subcategoryId == subcategories.SEANCE_CINE.id
+        assert offer.validation == models.OfferValidationStatus.DRAFT
+        assert offer.extraData == {}
+        assert offer.idAtProvider == "coucou"
+        assert models.Offer.query.count() == 1
+
     def test_cannot_create_activation_offer(self):
         venue = offerers_factories.VenueFactory()
         with pytest.raises(exceptions.SubCategoryIsInactive) as error:

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -47,6 +47,25 @@ class CheckProviderCanEditStockTest:
 
 
 @pytest.mark.usefixtures("db_session")
+class CheckCanInputIdAtProviderTest:
+    def test_without_id_at_provider(self):
+        validation.check_can_input_id_at_provider(None, None)
+
+    def test_with_id_at_provider(self):
+        provider = providers_factories.APIProviderFactory()
+        validation.check_can_input_id_at_provider(provider, "an id at provider")
+
+    def test_raise_when_id_at_provider_given_without_a_provider(self):
+
+        with pytest.raises(exceptions.CannotSetIdAtProviderWithoutAProvider) as error:
+            validation.check_can_input_id_at_provider(None, "an id at provider")
+
+        assert error.value.errors["idAtProvider"] == [
+            "Une offre ne peut être créée avec un idAtProvider si elle n'a pas de provider"
+        ]
+
+
+@pytest.mark.usefixtures("db_session")
 class CheckPricesForStockTest:
     def test_event_prices(self):
         offer = offers_factories.EventOfferFactory()

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -61,7 +61,7 @@ class CheckCanInputIdAtProviderTest:
             validation.check_can_input_id_at_provider(None, "an id at provider")
 
         assert error.value.errors["idAtProvider"] == [
-            "Une offre ne peut être créée avec un idAtProvider si elle n'a pas de provider"
+            "Une offre ne peut être créée ou éditée avec un idAtProvider si elle n'a pas de provider"
         ]
 
 

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -2899,6 +2899,13 @@
                         "title": "Id",
                         "type": "integer"
                     },
+                    "idAtProvider": {
+                        "description": "Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
+                        "example": "Your own id",
+                        "nullable": true,
+                        "title": "Idatprovider",
+                        "type": "string"
+                    },
                     "image": {
                         "anyOf": [
                             {
@@ -6562,6 +6569,13 @@
                     "id": {
                         "title": "Id",
                         "type": "integer"
+                    },
+                    "idAtProvider": {
+                        "description": "Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
+                        "example": "Your own id",
+                        "nullable": true,
+                        "title": "Idatprovider",
+                        "type": "string"
                     },
                     "image": {
                         "anyOf": [

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -2499,6 +2499,14 @@
                         "title": "Hasticket",
                         "type": "boolean"
                     },
+                    "idAtProvider": {
+                        "description": "Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
+                        "example": "Your own id",
+                        "maxLength": 70,
+                        "nullable": true,
+                        "title": "Idatprovider",
+                        "type": "string"
+                    },
                     "image": {
                         "anyOf": [
                             {
@@ -2694,6 +2702,14 @@
                         "nullable": true,
                         "title": "Eventduration",
                         "type": "integer"
+                    },
+                    "idAtProvider": {
+                        "description": "Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
+                        "example": "Your own id",
+                        "maxLength": 70,
+                        "nullable": true,
+                        "title": "Idatprovider",
+                        "type": "string"
                     },
                     "image": {
                         "anyOf": [
@@ -6103,6 +6119,14 @@
                         "title": "Externalticketofficeurl",
                         "type": "string"
                     },
+                    "idAtProvider": {
+                        "description": "Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
+                        "example": "Your own id",
+                        "maxLength": 70,
+                        "nullable": true,
+                        "title": "Idatprovider",
+                        "type": "string"
+                    },
                     "image": {
                         "anyOf": [
                             {
@@ -6293,6 +6317,14 @@
                         "nullable": true,
                         "title": "Enabledoublebookings",
                         "type": "boolean"
+                    },
+                    "idAtProvider": {
+                        "description": "Id of the object (product, event...) on your side. It should not be more than 70 characters long.",
+                        "example": "Your own id",
+                        "maxLength": 70,
+                        "nullable": true,
+                        "title": "Idatprovider",
+                        "type": "string"
                     },
                     "image": {
                         "anyOf": [

--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -33,6 +33,7 @@ class GetEventTest:
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
             product=product,
+            idAtProvider="Oh le bel id <3",
         )
         event_offer_id = event_offer.id
 
@@ -71,6 +72,7 @@ class GetEventTest:
             "status": "SOLD_OUT",
             "hasTicket": False,
             "priceCategories": [],
+            "idAtProvider": "Oh le bel id <3",
         }
 
     def test_event_with_not_selectable_category_can_be_retrieved(self, client):

--- a/api/tests/routes/public/individual_offers/v1/get_product_by_ean_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_by_ean_test.py
@@ -49,6 +49,7 @@ class GetProductByEanTest:
                     "name": "Vieux motard que jamais",
                     "status": "SOLD_OUT",
                     "stock": None,
+                    "idAtProvider": None,
                 }
             ]
         }
@@ -109,6 +110,7 @@ class GetProductByEanTest:
                     "name": "Pump it",
                     "status": "SOLD_OUT",
                     "stock": None,
+                    "idAtProvider": None,
                 },
                 {
                     "bookingContact": None,
@@ -133,6 +135,7 @@ class GetProductByEanTest:
                     "name": "Poterie pour les nuls",
                     "status": "SOLD_OUT",
                     "stock": None,
+                    "idAtProvider": None,
                 },
                 {
                     "bookingContact": None,
@@ -157,6 +160,7 @@ class GetProductByEanTest:
                     "name": "Vieux motard que jamais",
                     "status": "SOLD_OUT",
                     "stock": None,
+                    "idAtProvider": None,
                 },
             ]
         }
@@ -283,6 +287,7 @@ class GetProductByEanTest:
                     "name": "Vieux motard que jamais",
                     "status": "SOLD_OUT",
                     "stock": None,
+                    "idAtProvider": None,
                 }
             ]
         }

--- a/api/tests/routes/public/individual_offers/v1/get_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_test.py
@@ -21,6 +21,7 @@ class GetProductTest:
             venue=venue,
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
+            idAtProvider="provider_id_at_provider",
         )
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
@@ -48,6 +49,7 @@ class GetProductTest:
             "name": "Vieux motard que jamais",
             "status": "SOLD_OUT",
             "stock": None,
+            "idAtProvider": "provider_id_at_provider",
         }
 
     def test_books_can_be_retrieved(self, client):

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -142,6 +142,7 @@ class PatchEventTest:
                 "itemCollectionDetails": "Here !",
                 "description": "A new description",
                 "image": {"file": image_data.GOOD_IMAGE},
+                "idAtProvider": "oh it has been updated",
             },
         )
 
@@ -153,6 +154,7 @@ class PatchEventTest:
         assert event_offer.bookingEmail == "test@myemail.com"
         assert event_offer.withdrawalDetails == "Here !"
         assert event_offer.description == "A new description"
+        assert event_offer.idAtProvider == "oh it has been updated"
 
         assert offers_models.Mediation.query.one()
         assert (

--- a/api/tests/routes/public/individual_offers/v1/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_event_test.py
@@ -83,6 +83,7 @@ class PostEventTest:
                 "name": "Nicolas Jaar dans ton salon",
                 "priceCategories": [{"price": 30000, "label": "triangle or"}],
                 "hasTicket": True,
+                "idAtProvider": "T'as un bel id tu sais",
             },
         )
 
@@ -111,6 +112,7 @@ class PostEventTest:
         assert created_offer.withdrawalDetails == "A retirer au 6ème sous-sol du parking de la gare entre minuit et 2"
         assert created_offer.withdrawalType == offers_models.WithdrawalTypeEnum.IN_APP
         assert created_offer.withdrawalDelay == None
+        assert created_offer.idAtProvider == "T'as un bel id tu sais"
 
         created_mediation = offers_models.Mediation.query.one()
         assert created_mediation.offer == created_offer
@@ -144,7 +146,7 @@ class PostEventTest:
             "eventDuration": 120,
             "externalTicketOfficeUrl": "https://maposaic.com",
             "id": created_offer.id,
-            "idAtProvider": None,
+            "idAtProvider": "T'as un bel id tu sais",
             "image": {
                 "credit": "Jean-Crédit Photo",
                 "url": f"http://localhost/storage/thumbs/mediations/{human_ids.humanize(created_mediation.id)}",

--- a/api/tests/routes/public/individual_offers/v1/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_event_test.py
@@ -144,6 +144,7 @@ class PostEventTest:
             "eventDuration": 120,
             "externalTicketOfficeUrl": "https://maposaic.com",
             "id": created_offer.id,
+            "idAtProvider": None,
             "image": {
                 "credit": "Jean-Crédit Photo",
                 "url": f"http://localhost/storage/thumbs/mediations/{human_ids.humanize(created_mediation.id)}",

--- a/api/tests/routes/public/individual_offers/v1/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_test.py
@@ -78,6 +78,7 @@ class PostProductTest:
             "name": "Le champ des possibles",
             "status": "SOLD_OUT",
             "stock": None,
+            "idAtProvider": None,
         }
 
     @pytest.mark.usefixtures("db_session")
@@ -169,6 +170,7 @@ class PostProductTest:
             "enableDoubleBookings": False,
             "externalTicketOfficeUrl": "https://maposaic.com",
             "id": created_offer.id,
+            "idAtProvider": None,
             "image": {
                 "credit": "Jean-Crédit Photo",
                 "url": f"http://localhost/storage/thumbs/mediations/{human_ids.humanize(created_mediation.id)}",

--- a/api/tests/routes/public/individual_offers/v1/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_test.py
@@ -117,6 +117,7 @@ class PostProductTest:
                     "price": 1234,
                     "quantity": 3,
                 },
+                "id_at_provider": "l'id du provider",
             },
         )
 
@@ -134,6 +135,7 @@ class PostProductTest:
         assert created_offer.isDuo is False
         assert created_offer.bookingEmail == "spam@example.com"
         assert created_offer.description == "Enregistrement pour la nuit des temps"
+        assert created_offer.idAtProvider == "l'id du provider"
         assert created_offer.externalTicketOfficeUrl == "https://maposaic.com"
         assert created_offer.status == offer_mixin.OfferStatus.ACTIVE
         assert created_offer.withdrawalDetails == "A retirer au 6ème sous-sol du parking de la gare entre minuit et 2"
@@ -170,7 +172,7 @@ class PostProductTest:
             "enableDoubleBookings": False,
             "externalTicketOfficeUrl": "https://maposaic.com",
             "id": created_offer.id,
-            "idAtProvider": None,
+            "idAtProvider": "l'id du provider",
             "image": {
                 "credit": "Jean-Crédit Photo",
                 "url": f"http://localhost/storage/thumbs/mediations/{human_ids.humanize(created_mediation.id)}",


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30111

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques