### PR TITLE
(BSR)[API] feat: Change venue.name for offer.offererAddress.addressNa…

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -37,6 +37,7 @@ from pcapi.core.bookings.utils import convert_booking_dates_utc_to_venue_timezon
 from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers.models import Offerer
+from pcapi.core.offerers.models import OffererAddress
 from pcapi.core.offerers.models import UserOfferer
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Offer
@@ -859,6 +860,7 @@ def find_individual_bookings_event_happening_tomorrow_query() -> list[Booking]:
         .join(Offer.venue)
         .outerjoin(Booking.activationCode)
         .outerjoin(Offer.criteria)
+        .outerjoin(Offer.offererAddress)
         .filter(Stock.beginningDatetime >= tomorrow_min, Stock.beginningDatetime <= tomorrow_max)
         .filter(Offer.isEvent)
         .filter(not_(Offer.isDigital))
@@ -871,6 +873,7 @@ def find_individual_bookings_event_happening_tomorrow_query() -> list[Booking]:
             .options(
                 contains_eager(Offer.venue),
                 contains_eager(Offer.criteria),
+                contains_eager(Offer.offererAddress).load_only(OffererAddress.label),
             )
         )
         .all()

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
@@ -59,11 +59,7 @@ def get_booking_event_reminder_to_beneficiary_email_data(
             "USER_FIRST_NAME": booking.user.firstName,
             "VENUE_ADDRESS": bookings_common.get_venue_street(booking),
             "VENUE_CITY": booking.stock.offer.venue.city,
-            "VENUE_NAME": (
-                booking.stock.offer.venue.publicName
-                if booking.stock.offer.venue.publicName
-                else booking.stock.offer.venue.name
-            ),
+            "VENUE_NAME": booking.stock.offer.addressName,
             "VENUE_POSTAL_CODE": booking.stock.offer.venue.postalCode,
         },
     )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -845,6 +845,10 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
             return False
         return True
 
+    @property
+    def addressName(self) -> str:
+        return self.offererAddress.label if self.offererAddress else self.venue.common_name
+
 
 class ActivationCode(PcObject, Base, Model):
     __tablename__ = "activation_code"

--- a/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
@@ -62,6 +62,7 @@ class GetBookingEventReminderToBeneficiaryEmailDataTest:
                 offer__venue__name="Le Petit Rintintin",
                 offer__name="Product",
                 beginningDatetime=datetime.datetime(2032, 1, 1, 10, 30),
+                offer__offererAddress=None,
             ),
             token="N2XPV5",
         )
@@ -123,6 +124,7 @@ class GetBookingEventReminderToBeneficiaryEmailDataTest:
             stock=offers_factories.EventStockFactory(
                 offer__venue__publicName="Cinéma du bout de la rue",
                 offer__venue__name="Nom administratif du cinéma",
+                offer__offererAddress=None,
             )
         )
 
@@ -135,6 +137,7 @@ class GetBookingEventReminderToBeneficiaryEmailDataTest:
             stock=offers_factories.EventStockFactory(
                 offer__venue__publicName=None,
                 offer__venue__name="Cinéma du bout de la rue",
+                offer__offererAddress=None,
             )
         )
 


### PR DESCRIPTION
…me in beneficiary email

- Create offer.addressName property

When sending email event reminder to the beneficiary, if the offer is localized elsewhere than in the offer.venue, we want to display the offer.offererAddress.label

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques