### PR TITLE
(PC-30181)[API][Redoc] Enrichir la documentation des endpoints de la section "Collective educational data"

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1023,6 +1023,7 @@ class EducationalInstitution(PcObject, Base, Model):
 
     id: sa_orm.Mapped[int] = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
 
+    # this institutionId corresponds to the UAI ("Unité Administrative Immatriculée") code
     institutionId: str = sa.Column(sa.String(30), nullable=False, unique=True, index=True)
 
     institutionType: str = sa.Column(sa.String(80), nullable=False)

--- a/api/src/pcapi/routes/public/collective/serialization/domains.py
+++ b/api/src/pcapi/routes/public/collective/serialization/domains.py
@@ -1,13 +1,14 @@
 import typing
 
 from pcapi.core.educational import models
+from pcapi.routes.public.documentation_constants.fields import fields
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization.national_programs import NationalProgramModel
 
 
 class CollectiveOffersDomainResponseModel(BaseModel):
-    id: int
-    name: str
+    id: int = fields.EDUCATIONAL_DOMAIN_ID
+    name: str = fields.EDUCATIONAL_DOMAIN_NAME
     nationalPrograms: typing.Sequence[NationalProgramModel]
 
     class Config:

--- a/api/src/pcapi/routes/public/collective/serialization/institutions.py
+++ b/api/src/pcapi/routes/public/collective/serialization/institutions.py
@@ -1,6 +1,8 @@
+from pydantic.v1 import Field
 from pydantic.v1 import validator
 
 from pcapi.core.educational.models import EducationalInstitution
+from pcapi.routes.public.documentation_constants import fields
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
 
@@ -9,12 +11,12 @@ MAX_LIMIT_EDUCATIONAL_INSTITUTION = 20
 
 
 class CollectiveOffersEducationalInstitutionResponseModel(BaseModel):
-    id: int
-    uai: str
-    name: str
-    institutionType: str
-    city: str
-    postalCode: str
+    id: int = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID
+    uai: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
+    name: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME
+    institutionType: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE
+    city: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY
+    postalCode: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE
 
     class Config:
         orm_mode = True
@@ -30,13 +32,13 @@ class CollectiveOffersListEducationalInstitutionResponseModel(BaseModel):
 
 
 class GetListEducationalInstitutionsQueryModel(BaseModel):
-    id: int | None
-    name: str | None
-    institution_type: str | None
-    city: str | None
-    postal_code: str | None
-    uai: str | None
-    limit: int = MAX_LIMIT_EDUCATIONAL_INSTITUTION
+    id: int | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID
+    name: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME
+    institution_type: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE
+    city: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY
+    postal_code: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE
+    uai: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
+    limit: int = Field(MAX_LIMIT_EDUCATIONAL_INSTITUTION, description=fields.LIMIT_DESCRIPTION, example=10)
 
     @validator("limit")
     def validate_limit(cls, limit: int) -> int:

--- a/api/src/pcapi/routes/public/collective/serialization/institutions.py
+++ b/api/src/pcapi/routes/public/collective/serialization/institutions.py
@@ -12,12 +12,12 @@ MAX_LIMIT_EDUCATIONAL_INSTITUTION = 20
 
 
 class CollectiveOffersEducationalInstitutionResponseModel(BaseModel):
-    id: int = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID
-    uai: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
-    name: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME
-    institutionType: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE
-    city: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY
-    postalCode: str = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE
+    id: int = fields.EDUCATIONAL_INSTITUTION_ID
+    uai: str = fields.EDUCATIONAL_INSTITUTION_UAI
+    name: str = fields.EDUCATIONAL_INSTITUTION_NAME
+    institutionType: str = fields.EDUCATIONAL_INSTITUTION_TYPE
+    city: str = fields.EDUCATIONAL_INSTITUTION_CITY
+    postalCode: str = fields.EDUCATIONAL_INSTITUTION_POSTAL_CODE
 
     class Config:
         orm_mode = True
@@ -33,12 +33,12 @@ class CollectiveOffersListEducationalInstitutionResponseModel(BaseModel):
 
 
 class GetListEducationalInstitutionsQueryModel(BaseModel):
-    id: int | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID
-    name: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME
-    institution_type: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE
-    city: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY
-    postal_code: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE
-    uai: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
+    id: int | None = fields.EDUCATIONAL_INSTITUTION_ID
+    name: str | None = fields.EDUCATIONAL_INSTITUTION_NAME
+    institution_type: str | None = fields.EDUCATIONAL_INSTITUTION_TYPE
+    city: str | None = fields.EDUCATIONAL_INSTITUTION_CITY
+    postal_code: str | None = fields.EDUCATIONAL_INSTITUTION_POSTAL_CODE
+    uai: str | None = fields.EDUCATIONAL_INSTITUTION_UAI
     limit: int = Field(MAX_LIMIT_EDUCATIONAL_INSTITUTION, description=LIMIT_DESCRIPTION, example=10)
 
     @validator("limit")

--- a/api/src/pcapi/routes/public/collective/serialization/institutions.py
+++ b/api/src/pcapi/routes/public/collective/serialization/institutions.py
@@ -3,14 +3,12 @@ from pydantic.v1 import validator
 
 from pcapi.core.educational.models import EducationalInstitution
 from pcapi.routes.public.documentation_constants.fields import LIMIT_DESCRIPTION
-from pcapi.routes.public.documentation_constants.fields import get_fields
+from pcapi.routes.public.documentation_constants.fields import fields
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
 
 
 MAX_LIMIT_EDUCATIONAL_INSTITUTION = 20
-
-fields = get_fields()
 
 
 class CollectiveOffersEducationalInstitutionResponseModel(BaseModel):

--- a/api/src/pcapi/routes/public/collective/serialization/institutions.py
+++ b/api/src/pcapi/routes/public/collective/serialization/institutions.py
@@ -2,12 +2,15 @@ from pydantic.v1 import Field
 from pydantic.v1 import validator
 
 from pcapi.core.educational.models import EducationalInstitution
-from pcapi.routes.public.documentation_constants import fields
+from pcapi.routes.public.documentation_constants.fields import LIMIT_DESCRIPTION
+from pcapi.routes.public.documentation_constants.fields import get_fields
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
 
 
 MAX_LIMIT_EDUCATIONAL_INSTITUTION = 20
+
+fields = get_fields()
 
 
 class CollectiveOffersEducationalInstitutionResponseModel(BaseModel):
@@ -38,7 +41,7 @@ class GetListEducationalInstitutionsQueryModel(BaseModel):
     city: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY
     postal_code: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE
     uai: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
-    limit: int = Field(MAX_LIMIT_EDUCATIONAL_INSTITUTION, description=fields.LIMIT_DESCRIPTION, example=10)
+    limit: int = Field(MAX_LIMIT_EDUCATIONAL_INSTITUTION, description=LIMIT_DESCRIPTION, example=10)
 
     @validator("limit")
     def validate_limit(cls, limit: int) -> int:

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -351,10 +351,10 @@ class PostCollectiveOfferBodyModel(BaseModel):
     booking_limit_datetime: datetime = fields.COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME
     total_price: decimal.Decimal = fields.COLLECTIVE_OFFER_TOTAL_PRICE
     number_of_tickets: int = fields.COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD
-    educational_price_detail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL_FIELD
+    educational_price_detail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
     # link to educational institution
-    educational_institution_id: int | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID_FIELD
-    educational_institution: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_FIELD
+    educational_institution_id: int | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID
+    educational_institution: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
 
     _validate_number_of_tickets = number_of_tickets_validator("number_of_tickets")
     _validate_total_price = price_validator("total_price")
@@ -463,11 +463,11 @@ class PatchCollectiveOfferBodyModel(BaseModel):
         example=100.00,
         alias="totalPrice",
     )
-    educationalPriceDetail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL_FIELD
+    educationalPriceDetail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
     numberOfTickets: int | None = fields.COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD
     # educational_institution
-    educationalInstitutionId: int | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID_FIELD
-    educationalInstitution: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_FIELD
+    educationalInstitutionId: int | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID
+    educationalInstitution: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
 
     _validate_number_of_tickets = number_of_tickets_validator("numberOfTickets")
     _validate_total_price = price_validator("price")

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -13,7 +13,7 @@ from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.educational.models import StudentLevels
 from pcapi.models.offer_mixin import OfferStatus
-from pcapi.routes.public.documentation_constants import fields
+from pcapi.routes.public.documentation_constants.fields import get_fields
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import collective_offers_serialize
 from pcapi.routes.serialization.collective_offers_serialize import validate_venue_id
@@ -23,6 +23,9 @@ from pcapi.routes.shared.validation import phone_number_validator
 from pcapi.serialization.utils import to_camel
 from pcapi.utils import email as email_utils
 from pcapi.validation.routes.offers import check_collective_offer_name_length_is_valid
+
+
+fields = get_fields()
 
 
 class ListCollectiveOffersQueryModel(BaseModel):

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -13,7 +13,7 @@ from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.educational.models import StudentLevels
 from pcapi.models.offer_mixin import OfferStatus
-from pcapi.routes.public.documentation_constants.fields import get_fields
+from pcapi.routes.public.documentation_constants.fields import fields
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import collective_offers_serialize
 from pcapi.routes.serialization.collective_offers_serialize import validate_venue_id
@@ -23,9 +23,6 @@ from pcapi.routes.shared.validation import phone_number_validator
 from pcapi.serialization.utils import to_camel
 from pcapi.utils import email as email_utils
 from pcapi.validation.routes.offers import check_collective_offer_name_length_is_valid
-
-
-fields = get_fields()
 
 
 class ListCollectiveOffersQueryModel(BaseModel):

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -353,8 +353,8 @@ class PostCollectiveOfferBodyModel(BaseModel):
     number_of_tickets: int = fields.COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD
     educational_price_detail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
     # link to educational institution
-    educational_institution_id: int | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID
-    educational_institution: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
+    educational_institution_id: int | None = fields.EDUCATIONAL_INSTITUTION_ID
+    educational_institution: str | None = fields.EDUCATIONAL_INSTITUTION_UAI
 
     _validate_number_of_tickets = number_of_tickets_validator("number_of_tickets")
     _validate_total_price = price_validator("total_price")
@@ -466,8 +466,8 @@ class PatchCollectiveOfferBodyModel(BaseModel):
     educationalPriceDetail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
     numberOfTickets: int | None = fields.COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD
     # educational_institution
-    educationalInstitutionId: int | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID
-    educationalInstitution: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI
+    educationalInstitutionId: int | None = fields.EDUCATIONAL_INSTITUTION_ID
+    educationalInstitution: str | None = fields.EDUCATIONAL_INSTITUTION_UAI
 
     _validate_number_of_tickets = number_of_tickets_validator("numberOfTickets")
     _validate_total_price = price_validator("price")

--- a/api/src/pcapi/routes/public/collective/serialization/students_levels.py
+++ b/api/src/pcapi/routes/public/collective/serialization/students_levels.py
@@ -1,9 +1,10 @@
+from pcapi.routes.public.documentation_constants.fields import fields
 from pcapi.routes.serialization import BaseModel
 
 
 class CollectiveOffersStudentLevelResponseModel(BaseModel):
-    id: str
-    name: str
+    id: str = fields.STUDENT_LEVEL_ID
+    name: str = fields.STUDENT_LEVEL_NAME
 
 
 class CollectiveOffersListStudentLevelsResponseModel(BaseModel):

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -131,27 +131,28 @@ class _FIELDS:
     COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL = Field(
         description="The explanation of the offer price", example="10 tickets x 10 € = 100 €"
     )
-    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID = Field(
+    # Educational institution fields
+    EDUCATIONAL_INSTITUTION_ID = Field(
         description="Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
         example=1234,
     )
-    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI = Field(
+    EDUCATIONAL_INSTITUTION_UAI = Field(
         description='Educational institution UAI ("Unité Administrative Immatriculée") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**',
         example="0010008D",
     )
-    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME = Field(
+    EDUCATIONAL_INSTITUTION_NAME = Field(
         description="Educational institution name",
         example="Lycée Pontus de Tyard",
     )
-    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE = Field(
+    EDUCATIONAL_INSTITUTION_TYPE = Field(
         description="Educational institution type",
         example="LYCEE GENERAL",
     )
-    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY = Field(
+    EDUCATIONAL_INSTITUTION_CITY = Field(
         description="City where the educational institution is located",
         example="Chalon-sur-Saône",
     )
-    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE = Field(
+    EDUCATIONAL_INSTITUTION_POSTAL_CODE = Field(
         description="Educational institution postal code",
         example="71100",
     )

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -10,118 +10,150 @@ from pcapi.utils import date as date_utils
 _next_month = datetime.datetime.utcnow().replace(hour=12, minute=0, second=0) + relativedelta.relativedelta(months=1)
 _paris_tz_next_month = date_utils.utc_datetime_to_department_timezone(_next_month, "75")
 
+
 LIMIT_DESCRIPTION = "Number of items per page"
 
-VENUE_ID = Field(
-    example=1234,
-    description="Venue Id. The venues list is available on [**this endpoint (`Get offerer venues`)**](#tag/Offerer-and-Venues/operation/GetOffererVenues)",
-)
-DURATION_MINUTES = Field(
-    description="Event duration in minutes",
-    example=60,
-)
-OFFER_STATUS = Field(description=descriptions.OFFER_STATUS_FIELD_DESCRIPTION, example="ACTIVE")
+
+class _FIELDS:
+    def __init__(self) -> None:
+        self.VENUE_ID = Field(
+            example=1234,
+            description="Venue Id. The venues list is available on [**this endpoint (`Get offerer venues`)**](#tag/Offerer-and-Venues/operation/GetOffererVenues)",
+        )
+        self.DURATION_MINUTES = Field(
+            description="Event duration in minutes",
+            example=60,
+        )
+        self.OFFER_STATUS = Field(description=descriptions.OFFER_STATUS_FIELD_DESCRIPTION, example="ACTIVE")
+
+        self.PERIOD_BEGINNING_DATE = Field(
+            description="Period beginning date. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
+            example="2024-03-03T13:00:00+02:00",
+        )
+        self.PERIOD_ENDING_DATE = Field(
+            description="Period ending date. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
+            example="2024-05-10T15:00:00+02:00",
+        )
+
+        # Image Fields
+        self.IMAGE_CREDIT = Field(description="Image owner or author", example="Jane Doe")
+        self.IMAGE_FILE = Field(
+            description="Image file encoded in base64 string. Image format must be PNG or JPEG. Size must be between 400x600 and 800x1200 pixels. Aspect ratio must be 2:3 (portrait format).",
+            example="iVBORw0KGgoAAAANSUhEUgAAAhUAAAMgCAAAAACxT88IAAABImlDQ1BJQ0MgcHJvZmlsZQAAKJGdkLFKw1AUhr+0oiKKg6IgDhlcO5pFB6tCKCjEWMHqlCYpFpMYkpTiG/gm+jAdBMFXcFdw9r/RwcEs3nD4Pw7n/P+9gZadhGk5dwBpVhWu3x1cDq7shTfa+lbZZC8Iy7zreSc0ns9XLKMvHePVPPfnmY/iMpTOVFmYFxVY+2JnWuWGVazf9v0j8YPYjtIsEj+Jd6I0Mmx2/TSZhD+e5jbLcXZxbvqqbVx6nOJhM2TCmISKjjRT5xiHXalLQcA9JaE0IVZvqpmKG1EpJ5dDUV+k2zTkbdV5nlKG8hjLyyTckcrT5GH+7/fax1m9aW3M8qAI6lZb1RqN4P0RVgaw9gxL1w1Zi7/f1jDj1DP/fOMXG7hQfuNVil0AAAAJcEhZcwAALiMAAC4jAXilP3YAAAAHdElNRQfnAwMPGDrdy1JyAAABtElEQVR42u3BAQ0AAADCoPdPbQ8HFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8GaFGgABH6N7kwAAAABJRU5ErkJggg==",
+        )
+
+        # Disability fields
+        self.AUDIO_DISABILITY = Field(description="Is accessible for people with hearing disability", example=True)
+        self.MENTAL_DISABILITY = Field(description="Is accessible for people with mental disability", example=True)
+        self.MOTOR_DISABILITY = Field(description="Is accessible for people with motor disability", example=True)
+        self.VISUAL_DISABILITY = Field(description="Is accessible for people with visual disability", example=True)
+        self.AUDIO_DISABILITY_WITH_DEFAULT = Field(
+            False, description="Is accessible for people with hearing disability", example=True
+        )
+        self.MENTAL_DISABILITY_WITH_DEFAULT = Field(
+            False, description="Is accessible for people with mental disability", example=True
+        )
+        self.MOTOR_DISABILITY_WITH_DEFAULT = Field(
+            False, description="Is accessible for people with motor disability", example=True
+        )
+        self.VISUAL_DISABILITY_WITH_DEFAULT = Field(
+            False, description="Is accessible for people with visual disability", example=True
+        )
+
+        # Collective offer specific fields
+        self.COLLECTIVE_OFFER_NAME = Field(description="Collective offer name", example="Atelier de peinture")
+        self.COLLECTIVE_OFFER_DESCRIPTION = Field(
+            description="Collective offer description", example="Atelier de peinture à la gouache pour élèves de 5ème"
+        )
+        self.COLLECTIVE_OFFER_SUBCATEGORY_ID = Field(description="Event subcategory id", example="FESTIVAL_MUSIQUE")
+        self.COLLECTIVE_OFFER_FORMATS = Field(description="Educational Formats", example=["Atelier de pratique"])
+        self.COLLECTIVE_OFFER_BOOKING_EMAILS = Field(
+            description="Recipient emails for notifications about bookings, cancellations, etc.",
+            example=["some@email.com", "some.other@email.com"],
+        )
+        self.COLLECTIVE_OFFER_CONTACT_EMAIL = Field(
+            example="somebody.tocontact@gmail.com",
+            description="Email of the person to contact if there is an issue with the offer.",
+        )
+        self.COLLECTIVE_OFFER_CONTACT_PHONE = Field(
+            example="somebody.tocontact@gmail.com",
+            description="Phone of the person to contact if there is an issue with the offer.",
+        )
+        self.COLLECTIVE_OFFER_EDUCATIONAL_DOMAINS = Field(
+            example=[1, 2],
+            description="Educational domains ids linked to the offer. Those domains are available on **[this endpoint (`Get the eductional domains`)](#tag/Collective-educational-data/operation/ListEducationalDomains)**",
+        )
+        self.COLLECTIVE_OFFER_STUDENT_LEVELS = Field(
+            description="Student levels that can take pat to the collective offer. The student levels are available on [**this endpoint (`Get student levels eligible for collective offers`)**](#tag/Collective-educational-data/operation/ListStudentsLevels)",
+            example=["GENERAL2", "GENERAL1", "GENERAL0"],
+        )
+        self.COLLECTIVE_OFFER_IS_ACTIVE = Field(description="Is your offer active", example=True)
+        self.COLLECTIVE_OFFER_NATIONAL_PROGRAM_ID = Field(
+            description="Id of the national program linked to your offer. The national programs list can be found on **[this endpoint (`Get all known national programs`)](#tag/Collective-educational-data/operation/GetNationalPrograms)**",
+            example=123456,
+        )
+        self.COLLECTIVE_OFFER_BEGINNING_DATETIME = Field(
+            description="Collective offer beginning datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
+            example=_paris_tz_next_month.isoformat(timespec="seconds"),
+        )
+        self.COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME = Field(
+            description="Booking limit datetime. It must be anterior to the `beginning_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
+            example=_paris_tz_next_month.isoformat(timespec="seconds"),
+        )
+        self.COLLECTIVE_OFFER_TOTAL_PRICE = Field(example=100.00, description="Collective offer price (in €)")
+        self.COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD = Field(
+            example=10, description="Number of tickets for your collective offer"
+        )
+        self.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL = Field(
+            description="The explanation of the offer price", example="10 tickets x 10 € = 100 €"
+        )
+        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID = Field(
+            description="Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+            example=1234,
+        )
+        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI = Field(
+            description='Educational institution UAI ("Unité Administrative Immatriculée") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**',
+            example="0010008D",
+        )
+        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME = Field(
+            description="Educational institution name",
+            example="Lycée Pontus de Tyard",
+        )
+        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE = Field(
+            description="Educational institution type",
+            example="LYCEE GENERAL",
+        )
+        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY = Field(
+            description="City where the educational institution is located",
+            example="Chalon-sur-Saône",
+        )
+        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE = Field(
+            description="Educational institution postal code",
+            example="71100",
+        )
 
 
-PERIOD_BEGINNING_DATE = Field(
-    description="Period beginning date. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-    example="2024-03-03T13:00:00+02:00",
-)
-PERIOD_ENDING_DATE = Field(
-    description="Period ending date. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-    example="2024-05-10T15:00:00+02:00",
-)
+def get_fields() -> _FIELDS:
+    """
+    Returns an instance of the `_FIELDS` class. this is maint to avoid side-effects between classes that share a field.
 
+    Without this, here what happens :
 
-# Image Fields
-IMAGE_CREDIT = Field(description="Image owner or author", example="Jane Doe")
-IMAGE_FILE = Field(
-    description="Image file encoded in base64 string. Image format must be PNG or JPEG. Size must be between 400x600 and 800x1200 pixels. Aspect ratio must be 2:3 (portrait format).",
-    example="iVBORw0KGgoAAAANSUhEUgAAAhUAAAMgCAAAAACxT88IAAABImlDQ1BJQ0MgcHJvZmlsZQAAKJGdkLFKw1AUhr+0oiKKg6IgDhlcO5pFB6tCKCjEWMHqlCYpFpMYkpTiG/gm+jAdBMFXcFdw9r/RwcEs3nD4Pw7n/P+9gZadhGk5dwBpVhWu3x1cDq7shTfa+lbZZC8Iy7zreSc0ns9XLKMvHePVPPfnmY/iMpTOVFmYFxVY+2JnWuWGVazf9v0j8YPYjtIsEj+Jd6I0Mmx2/TSZhD+e5jbLcXZxbvqqbVx6nOJhM2TCmISKjjRT5xiHXalLQcA9JaE0IVZvqpmKG1EpJ5dDUV+k2zTkbdV5nlKG8hjLyyTckcrT5GH+7/fax1m9aW3M8qAI6lZb1RqN4P0RVgaw9gxL1w1Zi7/f1jDj1DP/fOMXG7hQfuNVil0AAAAJcEhZcwAALiMAAC4jAXilP3YAAAAHdElNRQfnAwMPGDrdy1JyAAABtElEQVR42u3BAQ0AAADCoPdPbQ8HFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8GaFGgABH6N7kwAAAABJRU5ErkJggg==",
-)
+        from pydantic.v1 import BaseModel
+        from pydantic.v1 import Field
+        from pcapi.serialization.utils import to_camel
 
-# Disability fields
-AUDIO_DISABILITY = Field(description="Is accessible for people with hearing disability", example=True)
-MENTAL_DISABILITY = Field(description="Is accessible for people with mental disability", example=True)
-MOTOR_DISABILITY = Field(description="Is accessible for people with motor disability", example=True)
-VISUAL_DISABILITY = Field(description="Is accessible for people with visual disability", example=True)
-AUDIO_DISABILITY_WITH_DEFAULT = Field(
-    False, description="Is accessible for people with hearing disability", example=True
-)
-MENTAL_DISABILITY_WITH_DEFAULT = Field(
-    False, description="Is accessible for people with mental disability", example=True
-)
-MOTOR_DISABILITY_WITH_DEFAULT = Field(False, description="Is accessible for people with motor disability", example=True)
-VISUAL_DISABILITY_WITH_DEFAULT = Field(
-    False, description="Is accessible for people with visual disability", example=True
-)
+        self.MY_FIELD_CONSTANT = Field(description="a field description")
 
-# Collective offer specific fields
-COLLECTIVE_OFFER_NAME = Field(description="Collective offer name", example="Atelier de peinture")
-COLLECTIVE_OFFER_DESCRIPTION = Field(
-    description="Collective offer description", example="Atelier de peinture à la gouache pour élèves de 5ème"
-)
-COLLECTIVE_OFFER_SUBCATEGORY_ID = Field(description="Event subcategory id", example="FESTIVAL_MUSIQUE")
-COLLECTIVE_OFFER_FORMATS = Field(description="Educational Formats", example=["Atelier de pratique"])
-COLLECTIVE_OFFER_BOOKING_EMAILS = Field(
-    description="Recipient emails for notifications about bookings, cancellations, etc.",
-    example=["some@email.com", "some.other@email.com"],
-)
-COLLECTIVE_OFFER_CONTACT_EMAIL = Field(
-    example="somebody.tocontact@gmail.com",
-    description="Email of the person to contact if there is an issue with the offer.",
-)
-COLLECTIVE_OFFER_CONTACT_PHONE = Field(
-    example="somebody.tocontact@gmail.com",
-    description="Phone of the person to contact if there is an issue with the offer.",
-)
-COLLECTIVE_OFFER_EDUCATIONAL_DOMAINS = Field(
-    example=[1, 2],
-    description="Educational domains ids linked to the offer. Those domains are available on **[this endpoint (`Get the eductional domains`)](#tag/Collective-educational-data/operation/ListEducationalDomains)**",
-)
-COLLECTIVE_OFFER_STUDENT_LEVELS = Field(
-    description="Student levels that can take pat to the collective offer. The student levels are available on [**this endpoint (`Get student levels eligible for collective offers`)**](#tag/Collective-educational-data/operation/ListStudentsLevels)",
-    example=["GENERAL2", "GENERAL1", "GENERAL0"],
-)
-COLLECTIVE_OFFER_IS_ACTIVE = Field(description="Is your offer active", example=True)
-COLLECTIVE_OFFER_NATIONAL_PROGRAM_ID = Field(
-    description="Id of the national program linked to your offer. The national programs list can be found on **[this endpoint (`Get all known national programs`)](#tag/Collective-educational-data/operation/GetNationalPrograms)**",
-    example=123456,
-)
-COLLECTIVE_OFFER_BEGINNING_DATETIME = Field(
-    description="Collective offer beginning datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-    example=_paris_tz_next_month.isoformat(timespec="seconds"),
-)
-COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME = Field(
-    description="Booking limit datetime. It must be anterior to the `beginning_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-    example=_paris_tz_next_month.isoformat(timespec="seconds"),
-)
-COLLECTIVE_OFFER_TOTAL_PRICE = Field(example=100.00, description="Collective offer price (in €)")
-COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD = Field(example=10, description="Number of tickets for your collective offer")
-COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL = Field(
-    description="The explanation of the offer price", example="10 tickets x 10 € = 100 €"
-)
-COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID = Field(
-    description="Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
-    example=1234,
-)
-COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI = Field(
-    description='Educational institution UAI ("Unité Administrative Immatriculée") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**',
-    example="0010008D",
-)
-COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME = Field(
-    description="Educational institution name",
-    example="Lycée Pontus de Tyard",
-)
-COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE = Field(
-    description="Educational institution type",
-    example="LYCEE GENERAL",
-)
-COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY = Field(
-    description="City where the educational institution is located",
-    example="Chalon-sur-Saône",
-)
-COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE = Field(
-    description="Educational institution postal code",
-    example="71100",
-)
+        class SomeResponseModel(BaseModel):
+            name_of_the_field: str = MY_FIELD_CONSTANT
+
+            class Config:
+                alias_generator = to_camel  # this will add an alias `nameOfTheField` to `MY_FIELD_CONSANT`
+
+        class SomeOtheResponseModel(BaseModel):
+            # now this model expects a field `nameOfTheField` instead of `another_field_name`
+            # because of the `SomeResponseModel` class definition
+            another_field_name: str = MY_FIELD_CONSTANT
+    """
+    return _FIELDS()

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 
 from dateutil import relativedelta
@@ -15,145 +16,145 @@ LIMIT_DESCRIPTION = "Number of items per page"
 
 
 class _FIELDS:
-    def __init__(self) -> None:
-        self.VENUE_ID = Field(
-            example=1234,
-            description="Venue Id. The venues list is available on [**this endpoint (`Get offerer venues`)**](#tag/Offerer-and-Venues/operation/GetOffererVenues)",
-        )
-        self.DURATION_MINUTES = Field(
-            description="Event duration in minutes",
-            example=60,
-        )
-        self.OFFER_STATUS = Field(description=descriptions.OFFER_STATUS_FIELD_DESCRIPTION, example="ACTIVE")
 
-        self.PERIOD_BEGINNING_DATE = Field(
-            description="Period beginning date. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-            example="2024-03-03T13:00:00+02:00",
-        )
-        self.PERIOD_ENDING_DATE = Field(
-            description="Period ending date. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-            example="2024-05-10T15:00:00+02:00",
-        )
+    def __getattribute__(self, name):  # type: ignore [no-untyped-def]
+        """
+        This is maint to avoid side-effects between classes that share a field.
 
-        # Image Fields
-        self.IMAGE_CREDIT = Field(description="Image owner or author", example="Jane Doe")
-        self.IMAGE_FILE = Field(
-            description="Image file encoded in base64 string. Image format must be PNG or JPEG. Size must be between 400x600 and 800x1200 pixels. Aspect ratio must be 2:3 (portrait format).",
-            example="iVBORw0KGgoAAAANSUhEUgAAAhUAAAMgCAAAAACxT88IAAABImlDQ1BJQ0MgcHJvZmlsZQAAKJGdkLFKw1AUhr+0oiKKg6IgDhlcO5pFB6tCKCjEWMHqlCYpFpMYkpTiG/gm+jAdBMFXcFdw9r/RwcEs3nD4Pw7n/P+9gZadhGk5dwBpVhWu3x1cDq7shTfa+lbZZC8Iy7zreSc0ns9XLKMvHePVPPfnmY/iMpTOVFmYFxVY+2JnWuWGVazf9v0j8YPYjtIsEj+Jd6I0Mmx2/TSZhD+e5jbLcXZxbvqqbVx6nOJhM2TCmISKjjRT5xiHXalLQcA9JaE0IVZvqpmKG1EpJ5dDUV+k2zTkbdV5nlKG8hjLyyTckcrT5GH+7/fax1m9aW3M8qAI6lZb1RqN4P0RVgaw9gxL1w1Zi7/f1jDj1DP/fOMXG7hQfuNVil0AAAAJcEhZcwAALiMAAC4jAXilP3YAAAAHdElNRQfnAwMPGDrdy1JyAAABtElEQVR42u3BAQ0AAADCoPdPbQ8HFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8GaFGgABH6N7kwAAAABJRU5ErkJggg==",
-        )
+        Without this, here what happens :
 
-        # Disability fields
-        self.AUDIO_DISABILITY = Field(description="Is accessible for people with hearing disability", example=True)
-        self.MENTAL_DISABILITY = Field(description="Is accessible for people with mental disability", example=True)
-        self.MOTOR_DISABILITY = Field(description="Is accessible for people with motor disability", example=True)
-        self.VISUAL_DISABILITY = Field(description="Is accessible for people with visual disability", example=True)
-        self.AUDIO_DISABILITY_WITH_DEFAULT = Field(
-            False, description="Is accessible for people with hearing disability", example=True
-        )
-        self.MENTAL_DISABILITY_WITH_DEFAULT = Field(
-            False, description="Is accessible for people with mental disability", example=True
-        )
-        self.MOTOR_DISABILITY_WITH_DEFAULT = Field(
-            False, description="Is accessible for people with motor disability", example=True
-        )
-        self.VISUAL_DISABILITY_WITH_DEFAULT = Field(
-            False, description="Is accessible for people with visual disability", example=True
-        )
+            from pydantic.v1 import BaseModel
+            from pydantic.v1 import Field
+            from pcapi.serialization.utils import to_camel
 
-        # Collective offer specific fields
-        self.COLLECTIVE_OFFER_NAME = Field(description="Collective offer name", example="Atelier de peinture")
-        self.COLLECTIVE_OFFER_DESCRIPTION = Field(
-            description="Collective offer description", example="Atelier de peinture à la gouache pour élèves de 5ème"
-        )
-        self.COLLECTIVE_OFFER_SUBCATEGORY_ID = Field(description="Event subcategory id", example="FESTIVAL_MUSIQUE")
-        self.COLLECTIVE_OFFER_FORMATS = Field(description="Educational Formats", example=["Atelier de pratique"])
-        self.COLLECTIVE_OFFER_BOOKING_EMAILS = Field(
-            description="Recipient emails for notifications about bookings, cancellations, etc.",
-            example=["some@email.com", "some.other@email.com"],
-        )
-        self.COLLECTIVE_OFFER_CONTACT_EMAIL = Field(
-            example="somebody.tocontact@gmail.com",
-            description="Email of the person to contact if there is an issue with the offer.",
-        )
-        self.COLLECTIVE_OFFER_CONTACT_PHONE = Field(
-            example="somebody.tocontact@gmail.com",
-            description="Phone of the person to contact if there is an issue with the offer.",
-        )
-        self.COLLECTIVE_OFFER_EDUCATIONAL_DOMAINS = Field(
-            example=[1, 2],
-            description="Educational domains ids linked to the offer. Those domains are available on **[this endpoint (`Get the eductional domains`)](#tag/Collective-educational-data/operation/ListEducationalDomains)**",
-        )
-        self.COLLECTIVE_OFFER_STUDENT_LEVELS = Field(
-            description="Student levels that can take pat to the collective offer. The student levels are available on [**this endpoint (`Get student levels eligible for collective offers`)**](#tag/Collective-educational-data/operation/ListStudentsLevels)",
-            example=["GENERAL2", "GENERAL1", "GENERAL0"],
-        )
-        self.COLLECTIVE_OFFER_IS_ACTIVE = Field(description="Is your offer active", example=True)
-        self.COLLECTIVE_OFFER_NATIONAL_PROGRAM_ID = Field(
-            description="Id of the national program linked to your offer. The national programs list can be found on **[this endpoint (`Get all known national programs`)](#tag/Collective-educational-data/operation/GetNationalPrograms)**",
-            example=123456,
-        )
-        self.COLLECTIVE_OFFER_BEGINNING_DATETIME = Field(
-            description="Collective offer beginning datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-            example=_paris_tz_next_month.isoformat(timespec="seconds"),
-        )
-        self.COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME = Field(
-            description="Booking limit datetime. It must be anterior to the `beginning_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-            example=_paris_tz_next_month.isoformat(timespec="seconds"),
-        )
-        self.COLLECTIVE_OFFER_TOTAL_PRICE = Field(example=100.00, description="Collective offer price (in €)")
-        self.COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD = Field(
-            example=10, description="Number of tickets for your collective offer"
-        )
-        self.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL = Field(
-            description="The explanation of the offer price", example="10 tickets x 10 € = 100 €"
-        )
-        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID = Field(
-            description="Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
-            example=1234,
-        )
-        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI = Field(
-            description='Educational institution UAI ("Unité Administrative Immatriculée") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**',
-            example="0010008D",
-        )
-        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME = Field(
-            description="Educational institution name",
-            example="Lycée Pontus de Tyard",
-        )
-        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE = Field(
-            description="Educational institution type",
-            example="LYCEE GENERAL",
-        )
-        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY = Field(
-            description="City where the educational institution is located",
-            example="Chalon-sur-Saône",
-        )
-        self.COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE = Field(
-            description="Educational institution postal code",
-            example="71100",
-        )
+            MY_FIELD_CONSTANT = Field(description="a field description")
+
+            class SomeResponseModel(BaseModel):
+                name_of_the_field: str = MY_FIELD_CONSTANT
+
+                class Config:
+                    alias_generator = to_camel  # this will add an alias `nameOfTheField` to `MY_FIELD_CONSANT`
+
+            class SomeOtheResponseModel(BaseModel):
+                # now this model expects a field `nameOfTheField` instead of `another_field_name`
+                # because of the `SomeResponseModel` class definition
+                another_field_name: str = MY_FIELD_CONSTANT
+        """
+        return copy.deepcopy(super().__getattribute__(name))
+
+    VENUE_ID = Field(
+        example=1234,
+        description="Venue Id. The venues list is available on [**this endpoint (`Get offerer venues`)**](#tag/Offerer-and-Venues/operation/GetOffererVenues)",
+    )
+    DURATION_MINUTES = Field(
+        description="Event duration in minutes",
+        example=60,
+    )
+    OFFER_STATUS = Field(description=descriptions.OFFER_STATUS_FIELD_DESCRIPTION, example="ACTIVE")
+
+    PERIOD_BEGINNING_DATE = Field(
+        description="Period beginning date. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
+        example="2024-03-03T13:00:00+02:00",
+    )
+    PERIOD_ENDING_DATE = Field(
+        description="Period ending date. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
+        example="2024-05-10T15:00:00+02:00",
+    )
+
+    # Image Fields
+    IMAGE_CREDIT = Field(description="Image owner or author", example="Jane Doe")
+    IMAGE_FILE = Field(
+        description="Image file encoded in base64 string. Image format must be PNG or JPEG. Size must be between 400x600 and 800x1200 pixels. Aspect ratio must be 2:3 (portrait format).",
+        example="iVBORw0KGgoAAAANSUhEUgAAAhUAAAMgCAAAAACxT88IAAABImlDQ1BJQ0MgcHJvZmlsZQAAKJGdkLFKw1AUhr+0oiKKg6IgDhlcO5pFB6tCKCjEWMHqlCYpFpMYkpTiG/gm+jAdBMFXcFdw9r/RwcEs3nD4Pw7n/P+9gZadhGk5dwBpVhWu3x1cDq7shTfa+lbZZC8Iy7zreSc0ns9XLKMvHePVPPfnmY/iMpTOVFmYFxVY+2JnWuWGVazf9v0j8YPYjtIsEj+Jd6I0Mmx2/TSZhD+e5jbLcXZxbvqqbVx6nOJhM2TCmISKjjRT5xiHXalLQcA9JaE0IVZvqpmKG1EpJ5dDUV+k2zTkbdV5nlKG8hjLyyTckcrT5GH+7/fax1m9aW3M8qAI6lZb1RqN4P0RVgaw9gxL1w1Zi7/f1jDj1DP/fOMXG7hQfuNVil0AAAAJcEhZcwAALiMAAC4jAXilP3YAAAAHdElNRQfnAwMPGDrdy1JyAAABtElEQVR42u3BAQ0AAADCoPdPbQ8HFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8GaFGgABH6N7kwAAAABJRU5ErkJggg==",
+    )
+
+    # Disability fields
+    AUDIO_DISABILITY = Field(description="Is accessible for people with hearing disability", example=True)
+    MENTAL_DISABILITY = Field(description="Is accessible for people with mental disability", example=True)
+    MOTOR_DISABILITY = Field(description="Is accessible for people with motor disability", example=True)
+    VISUAL_DISABILITY = Field(description="Is accessible for people with visual disability", example=True)
+    AUDIO_DISABILITY_WITH_DEFAULT = Field(
+        False, description="Is accessible for people with hearing disability", example=True
+    )
+    MENTAL_DISABILITY_WITH_DEFAULT = Field(
+        False, description="Is accessible for people with mental disability", example=True
+    )
+    MOTOR_DISABILITY_WITH_DEFAULT = Field(
+        False, description="Is accessible for people with motor disability", example=True
+    )
+    VISUAL_DISABILITY_WITH_DEFAULT = Field(
+        False, description="Is accessible for people with visual disability", example=True
+    )
+
+    # Collective offer specific fields
+    COLLECTIVE_OFFER_NAME = Field(description="Collective offer name", example="Atelier de peinture")
+    COLLECTIVE_OFFER_DESCRIPTION = Field(
+        description="Collective offer description", example="Atelier de peinture à la gouache pour élèves de 5ème"
+    )
+    COLLECTIVE_OFFER_SUBCATEGORY_ID = Field(description="Event subcategory id", example="FESTIVAL_MUSIQUE")
+    COLLECTIVE_OFFER_FORMATS = Field(description="Educational Formats", example=["Atelier de pratique"])
+    COLLECTIVE_OFFER_BOOKING_EMAILS = Field(
+        description="Recipient emails for notifications about bookings, cancellations, etc.",
+        example=["some@email.com", "some.other@email.com"],
+    )
+    COLLECTIVE_OFFER_CONTACT_EMAIL = Field(
+        example="somebody.tocontact@gmail.com",
+        description="Email of the person to contact if there is an issue with the offer.",
+    )
+    COLLECTIVE_OFFER_CONTACT_PHONE = Field(
+        example="somebody.tocontact@gmail.com",
+        description="Phone of the person to contact if there is an issue with the offer.",
+    )
+    COLLECTIVE_OFFER_EDUCATIONAL_DOMAINS = Field(
+        example=[1, 2],
+        description="Educational domains ids linked to the offer. Those domains are available on **[this endpoint (`Get the eductional domains`)](#tag/Collective-educational-data/operation/ListEducationalDomains)**",
+    )
+    COLLECTIVE_OFFER_STUDENT_LEVELS = Field(
+        description="Student levels that can take pat to the collective offer. The student levels are available on [**this endpoint (`Get student levels eligible for collective offers`)**](#tag/Collective-educational-data/operation/ListStudentsLevels)",
+        example=["GENERAL2", "GENERAL1", "GENERAL0"],
+    )
+    COLLECTIVE_OFFER_IS_ACTIVE = Field(description="Is your offer active", example=True)
+    COLLECTIVE_OFFER_NATIONAL_PROGRAM_ID = Field(
+        description="Id of the national program linked to your offer. The national programs list can be found on **[this endpoint (`Get all known national programs`)](#tag/Collective-educational-data/operation/GetNationalPrograms)**",
+        example=123456,
+    )
+    COLLECTIVE_OFFER_BEGINNING_DATETIME = Field(
+        description="Collective offer beginning datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
+        example=_paris_tz_next_month.isoformat(timespec="seconds"),
+    )
+    COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME = Field(
+        description="Booking limit datetime. It must be anterior to the `beginning_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
+        example=_paris_tz_next_month.isoformat(timespec="seconds"),
+    )
+    COLLECTIVE_OFFER_TOTAL_PRICE = Field(example=100.00, description="Collective offer price (in €)")
+    COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD = Field(example=10, description="Number of tickets for your collective offer")
+    COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL = Field(
+        description="The explanation of the offer price", example="10 tickets x 10 € = 100 €"
+    )
+    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID = Field(
+        description="Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+        example=1234,
+    )
+    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI = Field(
+        description='Educational institution UAI ("Unité Administrative Immatriculée") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**',
+        example="0010008D",
+    )
+    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME = Field(
+        description="Educational institution name",
+        example="Lycée Pontus de Tyard",
+    )
+    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE = Field(
+        description="Educational institution type",
+        example="LYCEE GENERAL",
+    )
+    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY = Field(
+        description="City where the educational institution is located",
+        example="Chalon-sur-Saône",
+    )
+    COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE = Field(
+        description="Educational institution postal code",
+        example="71100",
+    )
 
 
-def get_fields() -> _FIELDS:
-    """
-    Returns an instance of the `_FIELDS` class. this is maint to avoid side-effects between classes that share a field.
-
-    Without this, here what happens :
-
-        from pydantic.v1 import BaseModel
-        from pydantic.v1 import Field
-        from pcapi.serialization.utils import to_camel
-
-        self.MY_FIELD_CONSTANT = Field(description="a field description")
-
-        class SomeResponseModel(BaseModel):
-            name_of_the_field: str = MY_FIELD_CONSTANT
-
-            class Config:
-                alias_generator = to_camel  # this will add an alias `nameOfTheField` to `MY_FIELD_CONSANT`
-
-        class SomeOtheResponseModel(BaseModel):
-            # now this model expects a field `nameOfTheField` instead of `another_field_name`
-            # because of the `SomeResponseModel` class definition
-            another_field_name: str = MY_FIELD_CONSTANT
-    """
-    return _FIELDS()
+fields = _FIELDS()

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -158,10 +158,13 @@ class _FIELDS:
     )
     # Educational domain fields
     EDUCATIONAL_DOMAIN_ID = Field(description="Educational domain id", example=123456)
-    EDUCATIONAL_DOMAIN_NAME = Field(description="Educational domain name", example="Architecture")
+    EDUCATIONAL_DOMAIN_NAME = Field(description="Educational domain name", example="Cinéma, audiovisuel")
     # National program fields
     NATIONAL_PROGRAM_ID = Field(description="National program id", example=1223456)
     NATIONAL_PROGRAM_NAME = Field(description="National program name", example="Collège au cinéma")
+    # Student level fields
+    STUDENT_LEVEL_ID = Field(description="Student level id", example="COLLEGE6")
+    STUDENT_LEVEL_NAME = Field(description="Student level name", example="Collège - 6e")
 
 
 fields = _FIELDS()

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -156,6 +156,12 @@ class _FIELDS:
         description="Educational institution postal code",
         example="71100",
     )
+    # Educational domain fields
+    EDUCATIONAL_DOMAIN_ID = Field(description="Educational domain id", example=123456)
+    EDUCATIONAL_DOMAIN_NAME = Field(description="Educational domain name", example="Architecture")
+    # National program fields
+    NATIONAL_PROGRAM_ID = Field(description="National program id", example=1223456)
+    NATIONAL_PROGRAM_NAME = Field(description="National program name", example="Collège au cinéma")
 
 
 fields = _FIELDS()

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -10,6 +10,7 @@ from pcapi.utils import date as date_utils
 _next_month = datetime.datetime.utcnow().replace(hour=12, minute=0, second=0) + relativedelta.relativedelta(months=1)
 _paris_tz_next_month = date_utils.utc_datetime_to_department_timezone(_next_month, "75")
 
+LIMIT_DESCRIPTION = "Number of items per page"
 
 VENUE_ID = Field(
     example=1234,
@@ -97,14 +98,30 @@ COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME = Field(
 )
 COLLECTIVE_OFFER_TOTAL_PRICE = Field(example=100.00, description="Collective offer price (in €)")
 COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD = Field(example=10, description="Number of tickets for your collective offer")
-COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL_FIELD = Field(
+COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL = Field(
     description="The explanation of the offer price", example="10 tickets x 10 € = 100 €"
 )
-COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID_FIELD = Field(
-    description="Pass Culture id of the educational institution using this offer. The institions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_ID = Field(
+    description="Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
     example=1234,
 )
-COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_FIELD = Field(
-    description="Institution id of the educational institution using this offer. The institions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
-    example="uai",
+COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_UAI = Field(
+    description='Educational institution UAI ("Unité Administrative Immatriculée") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**',
+    example="0010008D",
+)
+COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_NAME = Field(
+    description="Educational institution name",
+    example="Lycée Pontus de Tyard",
+)
+COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_TYPE = Field(
+    description="Educational institution type",
+    example="LYCEE GENERAL",
+)
+COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_CITY = Field(
+    description="City where the educational institution is located",
+    example="Chalon-sur-Saône",
+)
+COLLECTIVE_OFFER_EDUCATIONAL_INSTITUTION_POSTAL_CODE = Field(
+    description="Educational institution postal code",
+    example="71100",
 )

--- a/api/src/pcapi/routes/serialization/national_programs.py
+++ b/api/src/pcapi/routes/serialization/national_programs.py
@@ -1,9 +1,10 @@
+from pcapi.routes.public.documentation_constants.fields import fields
 from pcapi.routes.serialization import BaseModel
 
 
 class NationalProgramModel(BaseModel):
-    id: int
-    name: str
+    id: int = fields.NATIONAL_PROGRAM_ID
+    name: str = fields.NATIONAL_PROGRAM_NAME
 
     class Config:
         orm_mode = True

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -1551,33 +1551,45 @@
             "CollectiveOffersEducationalInstitutionResponseModel": {
                 "properties": {
                     "city": {
+                        "description": "City where the educational institution is located",
+                        "example": "Chalon-sur-Sa\u00f4ne",
                         "title": "City",
                         "type": "string"
                     },
-                    "id": {
-                        "title": "Id",
+                    "educationalInstitution": {
+                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "example": "0010008D",
+                        "title": "Educationalinstitution",
+                        "type": "string"
+                    },
+                    "educationalInstitutionId": {
+                        "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "example": 1234,
+                        "title": "Educationalinstitutionid",
                         "type": "integer"
                     },
                     "institutionType": {
+                        "description": "Educational institution type",
+                        "example": "LYCEE GENERAL",
                         "title": "Institutiontype",
                         "type": "string"
                     },
                     "name": {
+                        "description": "Educational institution name",
+                        "example": "Lyc\u00e9e Pontus de Tyard",
                         "title": "Name",
                         "type": "string"
                     },
                     "postalCode": {
+                        "description": "Educational institution postal code",
+                        "example": "71100",
                         "title": "Postalcode",
-                        "type": "string"
-                    },
-                    "uai": {
-                        "title": "Uai",
                         "type": "string"
                     }
                 },
                 "required": [
-                    "id",
-                    "uai",
+                    "educationalInstitutionId",
+                    "educationalInstitution",
                     "name",
                     "institutionType",
                     "city",
@@ -3626,38 +3638,52 @@
                 "additionalProperties": false,
                 "properties": {
                     "city": {
+                        "description": "City where the educational institution is located",
+                        "example": "Chalon-sur-Sa\u00f4ne",
                         "nullable": true,
                         "title": "City",
                         "type": "string"
                     },
-                    "id": {
+                    "educationalInstitution": {
+                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "example": "0010008D",
                         "nullable": true,
-                        "title": "Id",
+                        "title": "Educationalinstitution",
+                        "type": "string"
+                    },
+                    "educationalInstitutionId": {
+                        "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "example": 1234,
+                        "nullable": true,
+                        "title": "Educationalinstitutionid",
                         "type": "integer"
                     },
                     "institutionType": {
+                        "description": "Educational institution type",
+                        "example": "LYCEE GENERAL",
                         "nullable": true,
                         "title": "Institutiontype",
                         "type": "string"
                     },
                     "limit": {
                         "default": 20,
+                        "description": "Number of items per page",
+                        "example": 10,
                         "title": "Limit",
                         "type": "integer"
                     },
                     "name": {
+                        "description": "Educational institution name",
+                        "example": "Lyc\u00e9e Pontus de Tyard",
                         "nullable": true,
                         "title": "Name",
                         "type": "string"
                     },
                     "postalCode": {
+                        "description": "Educational institution postal code",
+                        "example": "71100",
                         "nullable": true,
                         "title": "Postalcode",
-                        "type": "string"
-                    },
-                    "uai": {
-                        "nullable": true,
-                        "title": "Uai",
                         "type": "string"
                     }
                 },
@@ -5352,14 +5378,14 @@
                         "type": "integer"
                     },
                     "educationalInstitution": {
-                        "description": "Institution id of the educational institution using this offer. The institions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
-                        "example": "uai",
+                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "example": "0010008D",
                         "nullable": true,
                         "title": "Educationalinstitution",
                         "type": "string"
                     },
                     "educationalInstitutionId": {
-                        "description": "Pass Culture id of the educational institution using this offer. The institions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                         "example": 1234,
                         "nullable": true,
                         "title": "Educationalinstitutionid",
@@ -5599,14 +5625,14 @@
                         "type": "integer"
                     },
                     "educationalInstitution": {
-                        "description": "Institution id of the educational institution using this offer. The institions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
-                        "example": "uai",
+                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "example": "0010008D",
                         "nullable": true,
                         "title": "Educationalinstitution",
                         "type": "string"
                     },
                     "educationalInstitutionId": {
-                        "description": "Pass Culture id of the educational institution using this offer. The institions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                         "example": 1234,
                         "nullable": true,
                         "title": "Educationalinstitutionid",
@@ -10607,78 +10633,92 @@
                 "operationId": "ListEducationalInstitutions",
                 "parameters": [
                     {
-                        "description": "",
+                        "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                         "in": "query",
-                        "name": "id",
+                        "name": "educationalInstitutionId",
                         "required": false,
                         "schema": {
+                            "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                            "example": 1234,
                             "nullable": true,
-                            "title": "Id",
+                            "title": "Educationalinstitutionid",
                             "type": "integer"
                         }
                     },
                     {
-                        "description": "",
+                        "description": "Educational institution name",
                         "in": "query",
                         "name": "name",
                         "required": false,
                         "schema": {
+                            "description": "Educational institution name",
+                            "example": "Lyc\u00e9e Pontus de Tyard",
                             "nullable": true,
                             "title": "Name",
                             "type": "string"
                         }
                     },
                     {
-                        "description": "",
+                        "description": "Educational institution type",
                         "in": "query",
                         "name": "institutionType",
                         "required": false,
                         "schema": {
+                            "description": "Educational institution type",
+                            "example": "LYCEE GENERAL",
                             "nullable": true,
                             "title": "Institutiontype",
                             "type": "string"
                         }
                     },
                     {
-                        "description": "",
+                        "description": "City where the educational institution is located",
                         "in": "query",
                         "name": "city",
                         "required": false,
                         "schema": {
+                            "description": "City where the educational institution is located",
+                            "example": "Chalon-sur-Sa\u00f4ne",
                             "nullable": true,
                             "title": "City",
                             "type": "string"
                         }
                     },
                     {
-                        "description": "",
+                        "description": "Educational institution postal code",
                         "in": "query",
                         "name": "postalCode",
                         "required": false,
                         "schema": {
+                            "description": "Educational institution postal code",
+                            "example": "71100",
                             "nullable": true,
                             "title": "Postalcode",
                             "type": "string"
                         }
                     },
                     {
-                        "description": "",
+                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                         "in": "query",
-                        "name": "uai",
+                        "name": "educationalInstitution",
                         "required": false,
                         "schema": {
+                            "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                            "example": "0010008D",
                             "nullable": true,
-                            "title": "Uai",
+                            "title": "Educationalinstitution",
                             "type": "string"
                         }
                     },
                     {
-                        "description": "",
+                        "description": "Number of items per page",
                         "in": "query",
                         "name": "limit",
                         "required": false,
                         "schema": {
                             "default": 20,
+                            "description": "Number of items per page",
+                            "example": 10,
                             "title": "Limit",
                             "type": "integer"
                         }

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -1532,7 +1532,7 @@
                     },
                     "name": {
                         "description": "Educational domain name",
-                        "example": "Architecture",
+                        "example": "Cin\u00e9ma, audiovisuel",
                         "title": "Name",
                         "type": "string"
                     },
@@ -1690,10 +1690,14 @@
             "CollectiveOffersStudentLevelResponseModel": {
                 "properties": {
                     "id": {
+                        "description": "Student level id",
+                        "example": "COLLEGE6",
                         "title": "Id",
                         "type": "string"
                     },
                     "name": {
+                        "description": "Student level name",
+                        "example": "Coll\u00e8ge - 6e",
                         "title": "Name",
                         "type": "string"
                     }

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -1525,10 +1525,14 @@
             "CollectiveOffersDomainResponseModel": {
                 "properties": {
                     "id": {
+                        "description": "Educational domain id",
+                        "example": 123456,
                         "title": "Id",
                         "type": "integer"
                     },
                     "name": {
+                        "description": "Educational domain name",
+                        "example": "Architecture",
                         "title": "Name",
                         "type": "string"
                     },
@@ -1754,14 +1758,14 @@
                 "properties": {
                     "beginningDatetime": {
                         "description": "Beginning datetime of the event. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Beginningdatetime",
                         "type": "string"
                     },
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Bookinglimitdatetime",
                         "type": "string"
@@ -1801,7 +1805,7 @@
                 "properties": {
                     "beginningDatetime": {
                         "description": "Beginning datetime of the event. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Beginningdatetime",
@@ -1809,7 +1813,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -1845,7 +1849,7 @@
                 "properties": {
                     "beginningDatetime": {
                         "description": "Beginning datetime of the event. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Beginningdatetime",
                         "type": "string"
@@ -1858,7 +1862,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Bookinglimitdatetime",
                         "type": "string"
@@ -4930,10 +4934,14 @@
             "NationalProgramModel": {
                 "properties": {
                     "id": {
+                        "description": "National program id",
+                        "example": 1223456,
                         "title": "Id",
                         "type": "integer"
                     },
                     "name": {
+                        "description": "National program name",
+                        "example": "Coll\u00e8ge au cin\u00e9ma",
                         "title": "Name",
                         "type": "string"
                     }
@@ -5309,7 +5317,7 @@
                     },
                     "beginningDatetime": {
                         "description": "Collective offer beginning datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Beginningdatetime",
@@ -5330,7 +5338,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Booking limit datetime. It must be anterior to the `beginning_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -5563,7 +5571,7 @@
                     },
                     "beginningDatetime": {
                         "description": "Collective offer beginning datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Beginningdatetime",
                         "type": "string"
@@ -5582,7 +5590,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Booking limit datetime. It must be anterior to the `beginning_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Bookinglimitdatetime",
                         "type": "string"
@@ -6665,7 +6673,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -7614,7 +7622,7 @@
                 "properties": {
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -7657,7 +7665,7 @@
                 "properties": {
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-05T14:00:00+02:00",
+                        "example": "2024-07-06T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -1556,16 +1556,10 @@
                         "title": "City",
                         "type": "string"
                     },
-                    "educationalInstitution": {
-                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
-                        "example": "0010008D",
-                        "title": "Educationalinstitution",
-                        "type": "string"
-                    },
-                    "educationalInstitutionId": {
+                    "id": {
                         "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                         "example": 1234,
-                        "title": "Educationalinstitutionid",
+                        "title": "Id",
                         "type": "integer"
                     },
                     "institutionType": {
@@ -1585,11 +1579,17 @@
                         "example": "71100",
                         "title": "Postalcode",
                         "type": "string"
+                    },
+                    "uai": {
+                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "example": "0010008D",
+                        "title": "Uai",
+                        "type": "string"
                     }
                 },
                 "required": [
-                    "educationalInstitutionId",
-                    "educationalInstitution",
+                    "id",
+                    "uai",
                     "name",
                     "institutionType",
                     "city",
@@ -1754,14 +1754,14 @@
                 "properties": {
                     "beginningDatetime": {
                         "description": "Beginning datetime of the event. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Beginningdatetime",
                         "type": "string"
                     },
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Bookinglimitdatetime",
                         "type": "string"
@@ -1801,7 +1801,7 @@
                 "properties": {
                     "beginningDatetime": {
                         "description": "Beginning datetime of the event. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Beginningdatetime",
@@ -1809,7 +1809,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -1845,7 +1845,7 @@
                 "properties": {
                     "beginningDatetime": {
                         "description": "Beginning datetime of the event. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Beginningdatetime",
                         "type": "string"
@@ -1858,7 +1858,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Bookinglimitdatetime",
                         "type": "string"
@@ -3644,18 +3644,11 @@
                         "title": "City",
                         "type": "string"
                     },
-                    "educationalInstitution": {
-                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
-                        "example": "0010008D",
-                        "nullable": true,
-                        "title": "Educationalinstitution",
-                        "type": "string"
-                    },
-                    "educationalInstitutionId": {
+                    "id": {
                         "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                         "example": 1234,
                         "nullable": true,
-                        "title": "Educationalinstitutionid",
+                        "title": "Id",
                         "type": "integer"
                     },
                     "institutionType": {
@@ -3684,6 +3677,13 @@
                         "example": "71100",
                         "nullable": true,
                         "title": "Postalcode",
+                        "type": "string"
+                    },
+                    "uai": {
+                        "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
+                        "example": "0010008D",
+                        "nullable": true,
+                        "title": "Uai",
                         "type": "string"
                     }
                 },
@@ -5309,7 +5309,7 @@
                     },
                     "beginningDatetime": {
                         "description": "Collective offer beginning datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Beginningdatetime",
@@ -5330,7 +5330,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Booking limit datetime. It must be anterior to the `beginning_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -5563,7 +5563,7 @@
                     },
                     "beginningDatetime": {
                         "description": "Collective offer beginning datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Beginningdatetime",
                         "type": "string"
@@ -5582,7 +5582,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Booking limit datetime. It must be anterior to the `beginning_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "title": "Bookinglimitdatetime",
                         "type": "string"
@@ -6665,7 +6665,7 @@
                     },
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -7614,7 +7614,7 @@
                 "properties": {
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -7657,7 +7657,7 @@
                 "properties": {
                     "bookingLimitDatetime": {
                         "description": "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
-                        "example": "2024-07-03T14:00:00+02:00",
+                        "example": "2024-07-05T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Bookinglimitdatetime",
@@ -10635,13 +10635,13 @@
                     {
                         "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                         "in": "query",
-                        "name": "educationalInstitutionId",
+                        "name": "id",
                         "required": false,
                         "schema": {
                             "description": "Educational institution id in the pass Culture application. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                             "example": 1234,
                             "nullable": true,
-                            "title": "Educationalinstitutionid",
+                            "title": "Id",
                             "type": "integer"
                         }
                     },
@@ -10700,13 +10700,13 @@
                     {
                         "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                         "in": "query",
-                        "name": "educationalInstitution",
+                        "name": "uai",
                         "required": false,
                         "schema": {
                             "description": "Educational institution UAI (\"Unit\u00e9 Administrative Immatricul\u00e9e\") code. Institutions can be found on **[this endpoint (`Get all educational institutions`)](#tag/Collective-educational-data/operation/ListEducationalInstitutions)**",
                             "example": "0010008D",
                             "nullable": true,
-                            "title": "Educationalinstitution",
+                            "title": "Uai",
                             "type": "string"
                         }
                     },


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30181

Ce ticket s'est révélé un peu plus compliqué que prévu. En effet, il y a des effets de bords quand on utilise la même instance de `Field`. Voici ce qu'il se passe:
```python
from pydantic.v1 import BaseModel
from pydantic.v1 import Field
from pcapi.serialization.utils import to_camel

MY_FIELD_CONSTANT = Field(description="a field description")

class SomeResponseModel(BaseModel):
    name_of_the_field: str = MY_FIELD_CONSTANT

    class Config:
        alias_generator = to_camel  # this will add an alias `nameOfTheField` to `MY_FIELD_CONSTANT`

class SomeOtheResponseModel(BaseModel):
    # now this model expects a field `nameOfTheField` instead of `another_field_name`
    # because of the `SomeResponseModel` class definition
    another_field_name: str = MY_FIELD_CONSTANT
```

Pour palier à ce problème je propose la solution suivante :
- On transforme les constantes contenant les instances de `Field` en des attributs de classe de la classe `_FIELD`
- On définit la méthode `__getattribute__` pour qu'à chaque fois qu'on accède à une constante contenant un `Field`, on renvoie une deepcopy de l'objet


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques