### PR TITLE
(PC-30193)[BO] perf: add missing index on offer_criterion."criterionId"

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 2e66d0e6d190 (pre) (head)
-869f869ef1bc (post) (head)
+ff36979aea69 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240604T155723_ff36979aea69_create_index_on_offer_criterion_criterion_id.py
+++ b/api/src/pcapi/alembic/versions/20240604T155723_ff36979aea69_create_index_on_offer_criterion_criterion_id.py
@@ -1,0 +1,34 @@
+"""Create index on offer_criterion."criterionId"
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "ff36979aea69"
+down_revision = "869f869ef1bc"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            op.f("ix_offer_criterion_criterionId"),
+            "offer_criterion",
+            ["criterionId"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            op.f("ix_offer_criterion_criterionId"),
+            table_name="offer_criterion",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/api/src/pcapi/core/criteria/models.py
+++ b/api/src/pcapi/core/criteria/models.py
@@ -41,7 +41,9 @@ class OfferCriterion(PcObject, Base, Model):
     offerId: int = sqla.Column(
         sqla.BigInteger, sqla.ForeignKey("offer.id", ondelete="CASCADE"), index=True, nullable=False
     )
-    criterionId: int = sqla.Column(sqla.BigInteger, sqla.ForeignKey("criterion.id", ondelete="CASCADE"), nullable=False)
+    criterionId: int = sqla.Column(
+        sqla.BigInteger, sqla.ForeignKey("criterion.id", ondelete="CASCADE"), index=True, nullable=False
+    )
 
     __table_args__ = (
         sqla.UniqueConstraint(


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30193

La recherche par tag est très utilisée par la Dir Dev dans le BO.
Il y avait déjà un index sur `venue_criterion."criterionId"`, mais pas sur `offer_criterion."criterionId"`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques