### PR TITLE
(BSR)[PRO] E2E: Test offerer selection and venue display

### DIFF
--- a/pro/cypress/e2e/features/financialManagement.feature
+++ b/pro/cypress/e2e/features/financialManagement.feature
@@ -2,8 +2,8 @@
 Feature: Download of invoices and reimbursement details
 
   Background:
-    Given I am logged in with financial informations
-    And I choose an offerer with financial informations
+    Given I am logged in with new interface
+    And I select offerer "0 - Structure avec justificatif et compte bancaire"
     And I go to "Gestion financière" page
 
   Scenario: I can download reimbursement details and invoices

--- a/pro/cypress/e2e/features/venue.feature
+++ b/pro/cypress/e2e/features/venue.feature
@@ -1,10 +1,8 @@
 @P0
 Feature: Create and update venue
 
-  Background:
-    Given I am logged in
-
   Scenario: A pro user can add a venue without SIRET
+    Given I am logged in
     When I want to add a venue
     And I choose a venue which already has a Siret
     And I add venue without Siret details
@@ -15,6 +13,7 @@ Feature: Create and update venue
     Then I should see details of my venue
 
   Scenario: A pro user can add a venue with SIRET
+    Given I am logged in
     When I want to add a venue
     And I add a valid Siret
     And I add venue with Siret details
@@ -23,9 +22,22 @@ Feature: Create and update venue
     Then I should see my venue with Siret resume
 
   Scenario: It should update a venue
+    Given I am logged in
     When I go to the venue page in Individual section
     And I update Individual section data
     Then Individual section data should be updated
     When I go to the venue page in Paramètres généraux
     And I update Paramètres généraux data
     Then Paramètres généraux data should be updated
+
+  Scenario: It should display venues of selected offerer
+    Given I am logged in with new interface
+    When I select offerer "0 - Structure avec justificatif copié"
+    Then I should only see these venues
+      | Offres numériques | Lieu avec justificatif copié |
+    When I select offerer "1 - [CB] Structure avec plusieurs de ses lieux non rattachés à des coordonnées bancaires"
+    Then I should only see these venues
+      | Le Petit Rintintin 972 | Le Petit Rintintin 973 | Le Petit Rintintin 974 |
+    When I select offerer "1 - [CB] Structure sans coordonnées bancaires"
+    Then I should only see these venues
+      | Le Petit Rintintin 962 |

--- a/pro/cypress/e2e/features/venue.feature
+++ b/pro/cypress/e2e/features/venue.feature
@@ -35,9 +35,3 @@ Feature: Create and update venue
     When I select offerer "0 - Structure avec justificatif copié"
     Then I should only see these venues
       | Offres numériques | Lieu avec justificatif copié |
-    When I select offerer "1 - [CB] Structure avec plusieurs de ses lieux non rattachés à des coordonnées bancaires"
-    Then I should only see these venues
-      | Le Petit Rintintin 972 | Le Petit Rintintin 973 | Le Petit Rintintin 974 |
-    When I select offerer "1 - [CB] Structure sans coordonnées bancaires"
-    Then I should only see these venues
-      | Le Petit Rintintin 962 |

--- a/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
+++ b/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
@@ -15,7 +15,7 @@ Given('I am logged in', () => {
   })
 })
 
-Given('I am logged in with financial informations', () => {
+Given('I am logged in with new interface', () => {
   cy.login({
     email: 'activation_new_nav@example.com',
     password: 'user@AZERTY123',

--- a/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
+++ b/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
@@ -31,3 +31,7 @@ When('I want to create {string} offer', (offerType: string) => {
   cy.findByText('Étape suivante').click()
   cy.wait('@getCategories')
 })
+
+When('I select offerer {string}', (offererName: string) => {
+  cy.findByLabelText('Structure').select(offererName)
+})

--- a/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
+++ b/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
@@ -1,11 +1,5 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor'
 
-Given('I choose an offerer with financial informations', () => {
-  cy.findByLabelText('Structure').select(
-    '0 - Structure avec justificatif et compte bancaire'
-  )
-})
-
 When('I download reimbursement details', () => {
   cy.findByTestId('dropdown-menu-trigger').click()
   cy.findByText(/Télécharger le détail des réservations/).click()

--- a/pro/cypress/e2e/step-definitions/venue.cy.ts
+++ b/pro/cypress/e2e/step-definitions/venue.cy.ts
@@ -185,10 +185,6 @@ Then('Paramètres généraux data should be updated', () => {
   cy.findByText('Musée de France').should('be.visible')
 })
 
-When('I select offerer {string}', (offererName: string) => {
-  cy.findByTestId('offererId').select(offererName)
-})
-
 Then('I should only see these venues', (venues: DataTable) => {
   cy.findAllByTestId(/^venue-name-(span|div)/)
     .then(($element) => Cypress._.map($element, (el) => el.innerText))

--- a/pro/cypress/e2e/step-definitions/venue.cy.ts
+++ b/pro/cypress/e2e/step-definitions/venue.cy.ts
@@ -1,4 +1,9 @@
-import { When, Then, Given } from '@badeball/cypress-cucumber-preprocessor'
+import {
+  When,
+  Then,
+  Given,
+  DataTable,
+} from '@badeball/cypress-cucumber-preprocessor'
 
 // siret of Bar des amis
 let siret: string
@@ -178,4 +183,17 @@ Then('Individual section data should be updated', () => {
 
 Then('Paramètres généraux data should be updated', () => {
   cy.findByText('Musée de France').should('be.visible')
+})
+
+When('I select offerer {string}', (offererName: string) => {
+  cy.findByTestId('offererId').select(offererName)
+})
+
+Then('I should only see these venues', (venues: DataTable) => {
+  cy.findAllByTestId('venue-name')
+    .then(($element) => Cypress._.map($element, (el) => el.innerText))
+    .should('be.an', 'array')
+    .then((list: string[]) => {
+      expect(list).to.have.members(Object.values(venues.raw()[0]))
+    })
 })

--- a/pro/cypress/e2e/step-definitions/venue.cy.ts
+++ b/pro/cypress/e2e/step-definitions/venue.cy.ts
@@ -190,9 +190,8 @@ When('I select offerer {string}', (offererName: string) => {
 })
 
 Then('I should only see these venues', (venues: DataTable) => {
-  cy.findAllByTestId('venue-name')
+  cy.findAllByTestId(/^venue-name-(span|div)/)
     .then(($element) => Cypress._.map($element, (el) => el.innerText))
-    .should('be.an', 'array')
     .then((list: string[]) => {
       expect(list).to.have.members(Object.values(venues.raw()[0]))
     })

--- a/pro/src/pages/Home/Offerers/OffererDetails.tsx
+++ b/pro/src/pages/Home/Offerers/OffererDetails.tsx
@@ -63,7 +63,6 @@ export const OffererDetails = ({
           <SelectInput
             onChange={handleChangeOfferer}
             name="offererId"
-            data-testid="offererId"
             options={[...offererOptions, addOffererOption]}
             value={selectedOffererId ? String(selectedOffererId) : ''}
             aria-label="Structure"

--- a/pro/src/pages/Home/Offerers/OffererDetails.tsx
+++ b/pro/src/pages/Home/Offerers/OffererDetails.tsx
@@ -63,6 +63,7 @@ export const OffererDetails = ({
           <SelectInput
             onChange={handleChangeOfferer}
             name="offererId"
+            data-testid="offererId"
             options={[...offererOptions, addOffererOption]}
             value={selectedOffererId ? String(selectedOffererId) : ''}
             aria-label="Structure"

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -81,10 +81,15 @@ export const Venue = ({ offerer, venue, isFirstVenue }: VenueProps) => {
                 viewBox="0 0 16 16"
                 src={isToggleOpen ? fullDisclosureOpen : fullDisclosureClose}
               />
-              <span data-testid="venue-name">{venueDisplayName}</span>
+              <span data-testid={'venue-name-span-' + venue.id}>
+                {venueDisplayName}
+              </span>
             </button>
           ) : (
-            <div className={styles['venue-name']} data-testid="venue-name">
+            <div
+              className={styles['venue-name']}
+              data-testid={'venue-name-div-' + venue.id}
+            >
               {venueDisplayName}
             </div>
           )}

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -81,10 +81,12 @@ export const Venue = ({ offerer, venue, isFirstVenue }: VenueProps) => {
                 viewBox="0 0 16 16"
                 src={isToggleOpen ? fullDisclosureOpen : fullDisclosureClose}
               />
-              <span>{venueDisplayName}</span>
+              <span data-testid="venue-name">{venueDisplayName}</span>
             </button>
           ) : (
-            <div className={styles['venue-name']}>{venueDisplayName}</div>
+            <div className={styles['venue-name']} data-testid="venue-name">
+              {venueDisplayName}
+            </div>
           )}
 
           {shouldShowVenueOfferSteps && !venue.isVirtual && (


### PR DESCRIPTION
## But de la pull request

Le but est de vérifier l'affichage des lieux/partenaires/venues selon la sélection de structure/offerer

J'utilise le compte `activation_new_nav@example.com` avec la nouvelle interface (qu'on doit préférer à partir de maintenant, ce n'est pas encore fait pour les autres cas), et son contenu avec plusieurs structures et 1 ou plusieurs lieux associés. A terme, il est probable qu'on n'utilise plus les données générées par la sandbox (car elles peuvent changer à tout moment et faire échouer les tests auto) mais qu'on charge les données de test utiles pour le test. **Ne pas trop s'attarder là-dessus**...

Le principe du nouveau cas:

- on sélectionne une structure avec 2 lieux, on vérifie que seuls ces 2 lieux sont affichés
- on sélectionne une structure avec 3 lieux, on vérifie que seuls ces 3 lieux sont affichés
- on sélectionne une structure avec 1 lieu, on vérifie que seuls ce lieu est affiché


L'échec des tests unitaires sur la couverture par Sonar est visiblement normal selon Amine: https://passcultureteam.slack.com/archives/C04MZ0AKC0P/p1717686989088089

## Vérifications

- [-] J'ai écrit les tests nécessaires
- [-] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [-] J'ai ajouté des screenshots pour d'éventuels changements graphiques