### PR TITLE
(BSR)[API] ci: clear unused app versions from image resizing service when deploying to ehp

### DIFF
--- a/.github/workflows/dev_on_workflow_deploy_app_engine_image_resizing.yml
+++ b/.github/workflows/dev_on_workflow_deploy_app_engine_image_resizing.yml
@@ -92,3 +92,11 @@ jobs:
             --service-account=${{ steps.secrets.outputs.APP_ENGINE_IMAGE_RESIZING_SERVICE_ACCOUNT }} \
             --project=${{ inputs.google_project }} \
             --version=$(echo ${{ inputs.base_ref }}| tr '.' '-'| tr '/' '-'| tr '[:upper:]' '[:lower:]' | cut -c1-25)
+      - name: 'Clear unused apps'
+      # Delete all versions that are not serving traffic
+      # This is a cleanup step to avoid having too many versions(limit is 210)
+        run: |
+          gcloud app versions list --service=image-resizing --format="table[no-heading](id)" --project=${{ inputs.google_project }} \
+            | grep -v $(gcloud app versions list --service=image-resizing --hide-no-traffic --format="table[no-heading](id)") --project=${{ inputs.google_project }} \
+            | xargs gcloud app versions delete --service=image-resizing --project=${{ inputs.google_project }}
+          


### PR DESCRIPTION


## But de la pull request

Ticket Jira (ou description si BSR) :  clear unused app versions from image resizing service when deploying to ehp

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques