### PR TITLE
(BSR)[PRO] E2E: search name and EAN

### DIFF
--- a/pro/cypress/e2e/features/searchIndividualOffer.feature
+++ b/pro/cypress/e2e/features/searchIndividualOffer.feature
@@ -1,0 +1,27 @@
+@P0
+Feature: Search individual offers
+
+  Background:
+    Given I am logged in
+    And I go to "Offres" page
+
+  Scenario: A search with a name should display expected results
+    When I search with the text "Offer 1643"
+    Then These results should be displayed
+      | Titre      | Lieu             | Stocks | Status  |
+      | Offer 1643 | Espace des Gnoux |     20 | publiée |
+
+  Scenario: A search with a EAN should display expected results
+    When I search with the text "9780000000004"
+    Then These results should be displayed
+      | Titre            | Lieu         | Stocks | Status     |
+      | Livre 4 avec EAN | Librairie 10 |     10 | publiée    |
+      | Livre 4 avec EAN | Librairie 9  |     10 | désactivée |
+      | Livre 4 avec EAN | Librairie 8  |     10 | publiée    |
+      | Livre 4 avec EAN | Librairie 7  |     10 | publiée    |
+      | Livre 4 avec EAN | Librairie 6  |     10 | en attente |
+      | Livre 4 avec EAN | Librairie 5  |     10 | publiée    |
+      | Livre 4 avec EAN | Librairie 4  |     10 | publiée    |
+      | Livre 4 avec EAN | Librairie 3  |     10 | désactivée |
+      | Livre 4 avec EAN | Librairie 2  |     10 | publiée    |
+      | Livre 4 avec EAN | Librairie 1  |     10 | publiée    |

--- a/pro/cypress/e2e/step-definitions/searchIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/searchIndividualOffer.cy.ts
@@ -1,0 +1,35 @@
+import { When, Then, DataTable } from '@badeball/cypress-cucumber-preprocessor'
+
+When('I search with the text {string}', (title: string) => {
+  cy.findByPlaceholderText('Rechercher par nom d’offre ou par EAN-13').type(
+    title
+  )
+  cy.findByText('Rechercher').click()
+})
+
+Then('These results should be displayed', (dataTable: DataTable) => {
+  const numRows = dataTable.rows().length
+  cy.findAllByTestId('offer-item-row').should('have.length', numRows)
+  cy.contains(numRows + ' offre' + (numRows > 1 ? 's' : ''))
+
+  const data = dataTable.raw()
+
+  for (var rowLine = 0; rowLine < numRows; rowLine++) {
+    const bookLineArray = data[rowLine + 1]
+
+    cy.findAllByTestId('offer-item-row')
+      .eq(rowLine)
+      .within(() => {
+        cy.get('td').then(($elt) => {
+          // Check title
+          cy.wrap($elt).eq(2).should('contain', bookLineArray[0])
+          // Check venue
+          cy.wrap($elt).eq(3).should('contain', bookLineArray[1])
+          // Check Stock
+          cy.wrap($elt).eq(4).should('contain', bookLineArray[2])
+          // Check Status
+          cy.wrap($elt).eq(5).should('contain', bookLineArray[3])
+        })
+      })
+  }
+})

--- a/pro/src/pages/Offers/Offers/OfferItem/OfferItem.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/OfferItem.tsx
@@ -58,6 +58,7 @@ export const OfferItem = ({
       className={cn(styles['offer-item'], {
         [styles['inactive']]: isOfferInactiveOrExpiredOrDisabled,
       })}
+      data-testid="offer-item-row"
     >
       {/* TODO the audience prop could probably be removed in the future */}
       {/* as it is redundant with the offer.isEducational property */}


### PR DESCRIPTION
## But de la pull request

Recherche d'offre individuelle par nom ou EAN. On vérifie que les 4 colonnes en réponse à la recherche contiennent bien ce qui est attendu + le label du nombre d'offres.

## Vérifications

- [-] J'ai écrit les tests nécessaires
- [-] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [-] J'ai ajouté des screenshots pour d'éventuels changements graphiques