### PR TITLE
Add prune option to argocd app sync

### DIFF
--- a/.github/workflows/dev_on_workflow_deploy.yml
+++ b/.github/workflows/dev_on_workflow_deploy.yml
@@ -136,7 +136,7 @@ jobs:
         id: check_status
         run: |
           kubectl config set-context --current --namespace=argocd
-          argocd app sync pcapi-${{ inputs.environment }} --core --async
+          argocd app sync pcapi-${{ inputs.environment }} --core --async --prune
           argocd app wait pcapi-${{ inputs.environment }} --core --timeout 600
       - name: "Play post-migrations"
         run: |


### PR DESCRIPTION
## But de la pull request
In order to fix some sync timeouts while syncing app like in the example below, addition of --prune option to argocd sync command.
![image](https://github.com/pass-culture/pass-culture-main/assets/165149080/d45d9066-b982-485b-a563-26166396d742)
https://github.com/pass-culture/pass-culture-main/actions/runs/9443459787/job/26007709946
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques