### PR TITLE
(PC-30117)[API] chore: Script to validate CollectiveOffer.offererAddressId FK constraint

### DIFF
--- a/api/src/pcapi/scripts/validate_collective_offer_offereraddressid_fk_constraint/main.py
+++ b/api/src/pcapi/scripts/validate_collective_offer_offereraddressid_fk_constraint/main.py
@@ -1,0 +1,26 @@
+from sqlalchemy import text
+
+from pcapi import settings
+from pcapi.app import app
+from pcapi.models import db
+
+
+app.app_context().push()
+
+
+def validate_constraint() -> None:
+    # Disabling statement_timeout as we can't know in advance how long it would take
+    db.session.execute(text("SET statement_timeout = 0;"))
+
+    db.session.execute(text("COMMIT;"))
+    db.session.execute(
+        text("""ALTER TABLE collective_offer VALIDATE CONSTRAINT "collective_offer_offererAddressId_fkey" """)
+    )
+
+    # According to PostgreSQL, setting such values this way is affecting only the current session
+    # but let's be defensive by setting back to the original values
+    db.session.execute(text(f"SET statement_timeout = {settings.DATABASE_STATEMENT_TIMEOUT}"))
+
+
+if __name__ == "__main__":
+    validate_constraint()


### PR DESCRIPTION
## But de la pull request

One time script that will be run inside a k8s job, won't be merged

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30117

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques