### PR TITLE
Bsr fix CI delete unused app versions from gcloud

### DIFF
--- a/.github/workflows/dev_on_workflow_deploy_app_engine_image_resizing.yml
+++ b/.github/workflows/dev_on_workflow_deploy_app_engine_image_resizing.yml
@@ -97,6 +97,6 @@ jobs:
       # This is a cleanup step to avoid having too many versions(limit is 210)
         run: |
           gcloud app versions list --service=image-resizing --format="table[no-heading](id)" --project=${{ inputs.google_project }} \
-            | grep -v $(gcloud app versions list --service=image-resizing --hide-no-traffic --format="table[no-heading](id)") --project=${{ inputs.google_project }} \
+            | grep -v $(gcloud app versions list --service=image-resizing --hide-no-traffic --format="table[no-heading](id)" --project=${{ inputs.google_project }}) \
             | xargs gcloud app versions delete --service=image-resizing --project=${{ inputs.google_project }}
           


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR ): fix CI delete unused app versions from gcloud

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques