### PR TITLE
(BSR)[PRO] Add first tests of counter/guichet

### DIFF
--- a/pro/cypress/e2e/features/collectiveBooking.feature
+++ b/pro/cypress/e2e/features/collectiveBooking.feature
@@ -3,8 +3,8 @@ Feature: Search for collective bookings
 
   Background:
     Given I am logged in
-    And I go to "Réservations" page
-    And I go to "Réservations collectives" page
+    And I go to the "Réservations" page
+    And I go to the "Réservations collectives" page
 
   Scenario: It should find collective bookings by offers
     When I display offers

--- a/pro/cypress/e2e/features/counter.feature
+++ b/pro/cypress/e2e/features/counter.feature
@@ -1,0 +1,44 @@
+@P0
+Feature: Counter (Guichet) feature
+
+  Background:
+    Given I am logged in with new interface
+    And I go to "Guichet" page
+
+  Scenario: It should display identity check message
+    Then Identity check message is displayed
+    And I can click and open "Modalités de retrait et CGU" page
+
+#   Scenario: Saisie et validation d'une nouvelle contremarque @todo: besoin de données
+#     When I add this countermark "2XTM3W"
+#     And I validate the countermark // @todo: contremarque regénérées à chaque lancement de sandbox
+#     Then The booking is done
+
+  Scenario: It should decline a non-valid countermark
+    When I add this countermark "XXXXXX"
+    Then The countermark is refused because invalid
+
+#   Scenario: Saisie et invalidation d'une contremarque déjà validée @todo: besoin de données
+#     When I add this countermark "2XTM3W"
+#     And I validate the countermark
+#     Then...
+
+#   Scenario: Saisie d'une contremarque d'un autre pro @todo: besoin de données
+#     When I add this countermark "2XTM3W"
+#     And I validate the countermark
+#     Then...
+
+#   Scenario: Saisie de la contremarque d'une réservation non confirmée @todo: besoin de données
+#     When I add this countermark "2XTM3W"
+#     And I validate the countermark
+#     Then...
+
+#   Scenario: Saisie de la contremarque d'une réservation annulée @todo: besoin de données
+#     When I add this countermark "2XTM3W"
+#     And I validate the countermark
+#     Then...
+
+#   Scenario: Saisie de la contremarque d'une réservation déjà remboursée @todo: besoin de données
+#     When I add this countermark "2XTM3W"
+#     And I validate the countermark
+#     Then...

--- a/pro/cypress/e2e/features/counter.feature
+++ b/pro/cypress/e2e/features/counter.feature
@@ -2,42 +2,38 @@
 Feature: Counter (Guichet) feature
 
   Background:
-    Given I am logged in with new interface
-    And I go to "Guichet" page
+    Given I am logged in with the new interface
+    And I go to the "Guichet" page
 
   Scenario: It should display identity check message
-    Then Identity check message is displayed
-    And I can click and open "Modalités de retrait et CGU" page
+    Then The identity check message is displayed
+    And I can click and open the "Modalités de retrait et CGU" page
 
 #   Scenario: Saisie et validation d'une nouvelle contremarque @todo: besoin de données
 #     When I add this countermark "2XTM3W"
-#     And I validate the countermark // @todo: contremarque regénérées à chaque lancement de sandbox
+#     And I validate the countermark // @todo: contremarques regénérées à chaque lancement de sandbox
 #     Then The booking is done
 
   Scenario: It should decline a non-valid countermark
     When I add this countermark "XXXXXX"
-    Then The countermark is refused because invalid
+    Then The countermark is rejected as invalid
 
 #   Scenario: Saisie et invalidation d'une contremarque déjà validée @todo: besoin de données
 #     When I add this countermark "2XTM3W"
 #     And I validate the countermark
 #     Then...
-
 #   Scenario: Saisie d'une contremarque d'un autre pro @todo: besoin de données
 #     When I add this countermark "2XTM3W"
 #     And I validate the countermark
 #     Then...
-
 #   Scenario: Saisie de la contremarque d'une réservation non confirmée @todo: besoin de données
 #     When I add this countermark "2XTM3W"
 #     And I validate the countermark
 #     Then...
-
 #   Scenario: Saisie de la contremarque d'une réservation annulée @todo: besoin de données
 #     When I add this countermark "2XTM3W"
 #     And I validate the countermark
 #     Then...
-
 #   Scenario: Saisie de la contremarque d'une réservation déjà remboursée @todo: besoin de données
 #     When I add this countermark "2XTM3W"
 #     And I validate the countermark

--- a/pro/cypress/e2e/features/createAccount.feature
+++ b/pro/cypress/e2e/features/createAccount.feature
@@ -2,7 +2,7 @@
 Feature: Account creation
 
   Scenario: It should create an account
-    Given I open "inscription" page
+    Given I open the "inscription" page
     When I fill required information in create account form
     And I submit
     Then my account should be created

--- a/pro/cypress/e2e/features/createEventIndividualOffer.feature
+++ b/pro/cypress/e2e/features/createEventIndividualOffer.feature
@@ -3,7 +3,7 @@ Feature: Create an individual offer (event)
 
   Scenario: It should create an individual offer (event)
     Given I am logged in
-    When I go to "Créer une offre" page
+    When I go to the "Créer une offre" page
     And I want to create "Un évènement physique daté" offer
     And I fill in offer details
     And I validate offer details step
@@ -12,5 +12,5 @@ Feature: Create an individual offer (event)
     And I fill in recurrence
     And I validate recurrence step
     And I publish my offer
-    And I go to offers list
+    And I go to the offers list
     Then my new offer should be displayed

--- a/pro/cypress/e2e/features/createThingIndividualOffer.feature
+++ b/pro/cypress/e2e/features/createThingIndividualOffer.feature
@@ -3,12 +3,12 @@ Feature: Create an individual offer (thing)
 
   Scenario: It should create an individual offer (thing)
     Given I am logged in
-    When I go to "Créer une offre" page
+    When I go to the "Créer une offre" page
     And I want to create "Un bien physique" offer
     And I fill in details for physical offer
     And I validate offer details step
     And I fill in stocks
     And I validate stocks step
     And I publish my offer
-    And I go to offers list
+    And I go to the offers list
     Then my new physical offer should be displayed

--- a/pro/cypress/e2e/features/financialManagement.feature
+++ b/pro/cypress/e2e/features/financialManagement.feature
@@ -2,9 +2,9 @@
 Feature: Download of invoices and reimbursement details
 
   Background:
-    Given I am logged in with new interface
+    Given I am logged in with the new interface
     And I select offerer "0 - Structure avec justificatif et compte bancaire"
-    And I go to "Gestion financière" page
+    And I go to the "Gestion financière" page
 
   Scenario: I can download reimbursement details and invoices
     When I download reimbursement details

--- a/pro/cypress/e2e/features/searchCollectiveOffer.feature
+++ b/pro/cypress/e2e/features/searchCollectiveOffer.feature
@@ -3,7 +3,7 @@ Feature: Search collective offers
 
   Scenario: A search with several filters should display expected results
     Given I am logged in
-    And I go to "Offres" page
+    And I go to the "Offres" page
     And I go to "Offres collectives" view
     When I select "real_venue 1 eac_2_lieu [BON EAC]" in "Lieu"
     And I select "Projection audiovisuelle" in "Format"

--- a/pro/cypress/e2e/features/searchIndividualOffer.feature
+++ b/pro/cypress/e2e/features/searchIndividualOffer.feature
@@ -3,7 +3,7 @@ Feature: Search individual offers
 
   Background:
     Given I am logged in
-    And I go to "Offres" page
+    And I go to the "Offres" page
 
   Scenario: A search with a name should display expected results
     When I search with the text "Offer 1643"

--- a/pro/cypress/e2e/features/venue.feature
+++ b/pro/cypress/e2e/features/venue.feature
@@ -31,7 +31,7 @@ Feature: Create and update venue
     Then Paramètres généraux data should be updated
 
   Scenario: It should display venues of selected offerer
-    Given I am logged in with new interface
+    Given I am logged in with the new interface
     When I select offerer "0 - Structure avec justificatif copié"
     Then I should only see these venues
       | Offres numériques | Lieu avec justificatif copié |

--- a/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
+++ b/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
@@ -1,10 +1,10 @@
 import { When, Given, Then, DataTable } from '@badeball/cypress-cucumber-preprocessor'
 
-Given('I open {string} page', (page: string) => {
+Given('I open the {string} page', (page: string) => {
   cy.visit('/' + page)
 })
 
-When('I go to {string} page', (page: string) => {
+When('I go to the {string} page', (page: string) => {
   cy.url().then((urlSource) => {
     cy.findAllByText(page).first().click()
     cy.url().should('not.equal', urlSource)
@@ -18,7 +18,7 @@ Given('I am logged in', () => {
   })
 })
 
-Given('I am logged in with new interface', () => {
+Given('I am logged in with the new interface', () => {
   cy.login({
     email: 'activation_new_nav@example.com',
     password: 'user@AZERTY123',

--- a/pro/cypress/e2e/step-definitions/counter.cy.ts
+++ b/pro/cypress/e2e/step-definitions/counter.cy.ts
@@ -1,6 +1,6 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('Identity check message is displayed', () => {
+Then('The identity check message is displayed', () => {
   cy.findByTestId('desk-callout-message')
     .should(
       'contain',
@@ -12,7 +12,7 @@ Then('Identity check message is displayed', () => {
     )
 })
 
-When('I can click and open {string} page', (link: string) => {
+When('I can click and open the {string} page', (link: string) => {
   cy.findByText(link).invoke('removeAttr','target').click() // remove target to not open it in a new tab (not supported by cypress)
   cy.origin('https://aide.passculture.app/', () => {
     cy.url().should('include', 'Acteurs-Culturels-Modalit%C3%A9s-de-retrait-et-CGU')
@@ -31,7 +31,7 @@ When('I validate the countermark', () => {
     cy.findByText('Valider la contremarque').click()
 })
 
-Then('The countermark is refused because invalid', () => {
+Then('The countermark is rejected as invalid', () => {
   cy.findByTestId('desk-message').should('have.text', 'La contremarque n\'existe pas')
   cy.findByText('Valider la contremarque').should('be.disabled')
 })

--- a/pro/cypress/e2e/step-definitions/counter.cy.ts
+++ b/pro/cypress/e2e/step-definitions/counter.cy.ts
@@ -1,0 +1,39 @@
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor'
+
+Then('Identity check message is displayed', () => {
+  cy.findByTestId('desk-callout-message')
+    .should(
+      'contain',
+      'N’oubliez pas de vérifier l’identité du bénéficiaire avant de\n            valider la contremarque'
+    )
+    .and(
+      'contain',
+      'Les pièces d’identité doivent impérativement être présentées physiquement. Merci de ne pas accepter les pièces d’identité au format numérique.Modalités de retrait et CGU'
+    )
+})
+
+When('I can click and open {string} page', (link: string) => {
+  cy.findByText(link).invoke('removeAttr','target').click() // remove target to not open it in a new tab (not supported by cypress)
+  cy.origin('https://aide.passculture.app/', () => {
+    cy.url().should('include', 'Acteurs-Culturels-Modalit%C3%A9s-de-retrait-et-CGU')
+  })
+})
+
+Then('The booking is done', () => {
+  // Write code here that turns the phrase above into concrete actions
+})
+
+When('I add this countermark {string}', (countermark: string) => {
+  cy.findByLabelText('Contremarque').type(countermark)
+})
+
+When('I validate the countermark', () => {
+    cy.findByText('Valider la contremarque').click()
+})
+
+Then('The countermark is refused because invalid', () => {
+  cy.findByTestId('desk-message').should('have.text', 'La contremarque n\'existe pas')
+  cy.findByText('Valider la contremarque').should('be.disabled')
+})
+
+

--- a/pro/cypress/e2e/step-definitions/counter.cy.ts
+++ b/pro/cypress/e2e/step-definitions/counter.cy.ts
@@ -1,21 +1,21 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor'
 
 Then('The identity check message is displayed', () => {
-  cy.findByTestId('desk-callout-message')
-    .should(
-      'contain',
-      'N’oubliez pas de vérifier l’identité du bénéficiaire avant de\n            valider la contremarque'
-    )
-    .and(
-      'contain',
-      'Les pièces d’identité doivent impérativement être présentées physiquement. Merci de ne pas accepter les pièces d’identité au format numérique.Modalités de retrait et CGU'
-    )
+  cy.findByText(
+    'N’oubliez pas de vérifier l’identité du bénéficiaire avant de valider la contremarque.'
+  )
+  cy.findByText(
+    'Les pièces d’identité doivent impérativement être présentées physiquement. Merci de ne pas accepter les pièces d’identité au format numérique.'
+  )
 })
 
 When('I can click and open the {string} page', (link: string) => {
-  cy.findByText(link).invoke('removeAttr','target').click() // remove target to not open it in a new tab (not supported by cypress)
+  cy.findByText(link).invoke('removeAttr', 'target').click() // remove target to not open it in a new tab (not supported by cypress)
   cy.origin('https://aide.passculture.app/', () => {
-    cy.url().should('include', 'Acteurs-Culturels-Modalit%C3%A9s-de-retrait-et-CGU')
+    cy.url().should(
+      'include',
+      'Acteurs-Culturels-Modalit%C3%A9s-de-retrait-et-CGU'
+    )
   })
 })
 
@@ -28,12 +28,13 @@ When('I add this countermark {string}', (countermark: string) => {
 })
 
 When('I validate the countermark', () => {
-    cy.findByText('Valider la contremarque').click()
+  cy.findByText('Valider la contremarque').click()
 })
 
 Then('The countermark is rejected as invalid', () => {
-  cy.findByTestId('desk-message').should('have.text', 'La contremarque n\'existe pas')
+  cy.findByTestId('desk-message').should(
+    'have.text',
+    "La contremarque n'existe pas"
+  )
   cy.findByText('Valider la contremarque').should('be.disabled')
 })
-
-

--- a/pro/cypress/e2e/step-definitions/createEventIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/createEventIndividualOffer.cy.ts
@@ -130,7 +130,7 @@ When('I publish my offer', () => {
   cy.wait(['@publishOffer', '@getOffer'])
 })
 
-When('I go to offers list', () => {
+When('I go to the offers list', () => {
   cy.intercept({ method: 'GET', url: '/offers' }).as('getOffers')
   cy.findByText('Voir la liste des offres').click()
   cy.wait('@getOffers')

--- a/pro/src/components/Callout/Callout.tsx
+++ b/pro/src/components/Callout/Callout.tsx
@@ -70,7 +70,7 @@ export const Callout = ({
         className={styles['icon']}
         width="20"
       />
-      <div className={styles['content']} data-testid="desk-callout-message">
+      <div className={styles['content']}>
         {title && <div className={styles['title']}>{title}</div>}
         {children && <div className={styles['callout-text']}>{children}</div>}
         {links && <LinkNodes links={links} />}

--- a/pro/src/components/Callout/Callout.tsx
+++ b/pro/src/components/Callout/Callout.tsx
@@ -70,7 +70,7 @@ export const Callout = ({
         className={styles['icon']}
         width="20"
       />
-      <div className={styles['content']}>
+      <div className={styles['content']} data-testid="desk-callout-message">
         {title && <div className={styles['title']}>{title}</div>}
         {children && <div className={styles['callout-text']}>{children}</div>}
         {links && <LinkNodes links={links} />}

--- a/pro/src/pages/Desk/Desk.tsx
+++ b/pro/src/pages/Desk/Desk.tsx
@@ -195,8 +195,7 @@ export const Desk = (): JSX.Element => {
               },
             ]}
             className={`${styles['desk-callout']}`}
-            title=" N’oubliez pas de vérifier l’identité du bénéficiaire avant de
-            valider la contremarque."
+            title="N’oubliez pas de vérifier l’identité du bénéficiaire avant de valider la contremarque."
           >
             Les pièces d’identité doivent impérativement être présentées
             physiquement. Merci de ne pas accepter les pièces d’identité au


### PR DESCRIPTION
## But de la pull request

Dans cette PR, seulement 2 tests de la page du guichet:
- conformité de la page
- saisie d'une contremarque invalide


Comme on utilise la sandbox, on a des contremarque regénérée à chaque lancement de celle-ci donc on ne peut pas en utiliser une fixée dans le code.
Donc je met de côté pour l'instant en attendant une meilleure gestion du jeu de donnée.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques