### PR TITLE
(BSR)[PRO] feat: Enable SCSS sourcemaps in development

### DIFF
--- a/pro/vite.config.ts
+++ b/pro/vite.config.ts
@@ -48,5 +48,8 @@ export default defineConfig(({ mode }) => {
       maxThreads: 6,
       testTimeout: 30000,
     },
+    css: {
+      devSourcemap: true,
+    },
   }
 })


### PR DESCRIPTION
## But de la pull request

Génère les sourceMaps pour les fichiers SCSS en _development_. Ce qui est beaucoup plus pratique pour repérer les styles directement à partir du code source.

<img src="https://github.com/pass-culture/pass-culture-main/assets/171674396/0b7dfed0-0755-43cd-9e20-e83fc1b2d52a" width="550">

## Vérifications

- [x] J'ai vérifié que ces sourceMaps n'étaient pas générées en production lors de `yarn build:production`