### PR TITLE
(PC-29065)[API] fix: commit secret changes even on GET

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -1085,7 +1085,7 @@ class ApiKey(PcObject, Base, Model):
         if crypto.check_password(clear_text, self.secret):
             if FeatureToggle.WIP_ENABLE_NEW_HASHING_ALGORITHM.is_active():
                 self.secret = crypto.hash_public_api_key(clear_text)
-                db.session.flush()  # it may not be committed but the hash recompute cost is low
+                db.session.commit()
                 logger.info("Switched hash of API key from bcrypt to SHA3-512", extra={"key_id": self.id})
             return True
         return False


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29065

For GET routes, the changes were never commited to the database. Even if this hash changes should be done only once, some of our users only use GET routes. 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques