### PR TITLE
(PC-30218)[PRO] fix: only call siren validation once on signup

### DIFF
--- a/pro/src/core/Venue/getSiretData.tsx
+++ b/pro/src/core/Venue/getSiretData.tsx
@@ -5,7 +5,7 @@ import { isErrorAPIError } from 'apiClient/helpers'
 import { unhumanizeSiret } from 'core/Venue/utils'
 import { validateSiret } from 'core/Venue/validate'
 
-type GetSiretDataResponse = {
+export type GetSiretDataResponse = {
   values?: {
     address: string
     city: string

--- a/pro/src/screens/SignupJourneyForm/Offerer/OffererForm.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/OffererForm.tsx
@@ -11,10 +11,17 @@ export interface OffererFormValues {
   siret: string
 }
 
-export const OffererForm = (): JSX.Element => {
+interface OffererFormProps {
+  setShowInvisibleBanner: (showBanner: boolean) => void
+}
+
+export const OffererForm = ({
+  setShowInvisibleBanner,
+}: OffererFormProps): JSX.Element => {
   const { setFieldValue } = useFormikContext<OffererFormValues>()
 
   const formatSiret = async (siret: string): Promise<void> => {
+    setShowInvisibleBanner(false)
     if ((siret && /^[0-9]+$/.test(unhumanizeSiret(siret))) || !siret) {
       await setFieldValue('siret', humanizeSiret(siret))
     }

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
@@ -5,9 +5,6 @@ import React from 'react'
 import createFetchMock from 'vitest-fetch-mock'
 
 import { api } from 'apiClient/api'
-import { ApiError } from 'apiClient/v1'
-import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
-import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import {
   SignupJourneyContextValues,
   SignupJourneyContext,
@@ -66,10 +63,10 @@ const renderOffererForm = ({
       <Formik
         initialValues={initialValues}
         onSubmit={onSubmit}
-        validationSchema={validationSchema(vi.fn())}
+        validationSchema={validationSchema}
       >
         <Form>
-          <OffererForm />
+          <OffererForm setShowInvisibleBanner={vi.fn()} />
           <Button type="submit" isLoading={false}>
             Submit
           </Button>
@@ -183,64 +180,6 @@ describe('screens:SignupJourney::OffererForm', () => {
     await userEvent.click(screen.getByText('Submit'))
     expect(
       await screen.findByText('Le SIRET doit comporter 14 caractères')
-    ).toBeInTheDocument()
-  })
-
-  it("should render error message when siret doesn't exist", async () => {
-    vi.spyOn(api, 'getSiretInfo').mockRejectedValueOnce(
-      new ApiError(
-        {} as ApiRequestOptions,
-        {
-          status: 422,
-          body: [{ error: ['No SIRET'] }],
-        } as ApiResult,
-        ''
-      )
-    )
-
-    renderOffererForm({
-      initialValues: initialValues,
-      contextValue,
-    })
-
-    await userEvent.type(
-      screen.getByLabelText('Numéro de SIRET à 14 chiffres *'),
-      '12345678999999'
-    )
-    await userEvent.click(screen.getByText('Submit'))
-    expect(await screen.findByText('Le SIRET n’existe pas')).toBeInTheDocument()
-  })
-
-  it('should render error message when siret is not visible', async () => {
-    vi.spyOn(api, 'getSiretInfo').mockRejectedValueOnce(
-      new ApiError(
-        {} as ApiRequestOptions,
-        {
-          status: 400,
-          body: {
-            global: [
-              'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles.',
-            ],
-          },
-        } as ApiResult,
-        ''
-      )
-    )
-
-    renderOffererForm({
-      initialValues: initialValues,
-      contextValue,
-    })
-
-    await userEvent.type(
-      screen.getByLabelText('Numéro de SIRET à 14 chiffres *'),
-      '12345678900001'
-    )
-    await userEvent.click(screen.getByText('Submit'))
-    expect(
-      await screen.findByText(
-        "Le propriétaire de ce SIRET s'oppose à la diffusion de ses données au public"
-      )
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/SignupJourneyForm/Offerer/validationSchema.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/validationSchema.tsx
@@ -1,34 +1,14 @@
 import * as yup from 'yup'
 
-import { siretApiValidate } from 'core/Venue/siretApiValidate'
 import { valideSiretLength } from 'pages/VenueCreation/SiretOrCommentFields/validationSchema'
 
-export const validationSchema = (
-  displayInvisibleSirenBanner: (showBanner: boolean) => void
-) =>
-  yup.object().shape({
-    siret: yup
-      .string()
-      .required('Veuillez renseigner un SIRET')
-      .test(
-        'len',
-        'Le SIRET doit comporter 14 caractères',
-        (siret) => !!siret && valideSiretLength(siret)
-      )
-      .test(
-        'apiSiretVisible',
-        "Le propriétaire de ce SIRET s'oppose à la diffusion de ses données au public",
-        async (siret) => {
-          const response = await siretApiValidate(siret || '')
-          const isInvisible =
-            response ===
-            'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles.'
-          displayInvisibleSirenBanner(isInvisible)
-          return !isInvisible
-        }
-      )
-      .test('apiSiretValid', 'Le SIRET n’existe pas', async (siret) => {
-        const response = await siretApiValidate(siret || '')
-        return !response
-      }),
-  })
+export const validationSchema = yup.object().shape({
+  siret: yup
+    .string()
+    .required('Veuillez renseigner un SIRET')
+    .test(
+      'len',
+      'Le SIRET doit comporter 14 caractères',
+      (siret) => !!siret && valideSiretLength(siret)
+    ),
+})


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30218

Lors du parcours d'inscription, faire en sorte de n'appeller qu'une seule fois la route API `/sirene/siret/{siret}` pour éviter les rate limit de cloudArmour (5 appels/min/IP)


**Solution :** 

On procède à la validation du SIRET seulement à la validation du formulaire et non plus dans le schéma de validation du formulaire