### PR TITLE
(BSR)[API] refactor: Simplify booking date/datetime formatting in emails

### DIFF
--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -17,35 +17,35 @@ def build_pc_pro_reset_password_link(token_value: str) -> str:
 
 
 def format_booking_date_for_email(booking: Booking | CollectiveBooking) -> str:
-    if isinstance(booking, CollectiveBooking) or booking.stock.offer.isEvent:
-        stock = booking.collectiveStock if isinstance(booking, CollectiveBooking) else booking.stock
-        date_in_tz = get_event_datetime(stock)  # type: ignore[arg-type]
-        offer_date = date_in_tz.strftime("%d-%b-%Y")
-        return offer_date
-    return ""
+    if isinstance(booking, CollectiveBooking):
+        stock = booking.collectiveStock
+    else:
+        stock = booking.stock
+    if not stock.beginningDatetime:
+        return ""
+    date_in_tz = get_event_datetime(stock)
+    return date_in_tz.strftime("%d-%b-%Y")
 
 
 def format_booking_hours_for_email(booking: Booking | CollectiveBooking) -> str:
-    if isinstance(booking, CollectiveBooking) or booking.stock.offer.isEvent:
-        stock = booking.collectiveStock if isinstance(booking, CollectiveBooking) else booking.stock
-        date_in_tz = get_event_datetime(stock)  # type: ignore[arg-type]
-        event_hour = date_in_tz.hour
-        event_minute = date_in_tz.minute
-        return f"{event_hour}h" if event_minute == 0 else f"{event_hour}h{event_minute}"
-    return ""
+    if isinstance(booking, CollectiveBooking):
+        stock = booking.collectiveStock
+    else:
+        stock = booking.stock
+    if not stock.beginningDatetime:
+        return ""
+    date_in_tz = get_event_datetime(stock)
+    hour, minute = date_in_tz.hour, date_in_tz.minute
+    return f"{hour}h{minute}" if minute else f"{hour}h"
 
 
 def get_event_datetime(stock: CollectiveStock | Stock) -> datetime:
+    if not stock.beginningDatetime:
+        raise ValueError("Event stock is missing a beginningDatetime")
     if isinstance(stock, Stock):
         departement_code = stock.offer.venue.departementCode
     else:
         departement_code = stock.collectiveOffer.venue.departementCode
-    if departement_code is not None:
-        date_in_utc = stock.beginningDatetime
-        if date_in_utc is None:
-            raise ValueError("Can't convert None to local timezone")
-        date_in_tz = utc_datetime_to_department_timezone(date_in_utc, departement_code)
-    else:
-        date_in_tz = stock.beginningDatetime  # type: ignore[assignment]
-
-    return date_in_tz
+    if not departement_code:
+        return stock.beginningDatetime
+    return utc_datetime_to_department_timezone(stock.beginningDatetime, departement_code)


### PR DESCRIPTION
1. Raise a clearer exception if `get_event_datetime()` is called with
   a non-event stock.

2. Rewrite conditions to help mypy.

3. Use early exit for clarity and conciseness.