### PR TITLE
(PC-30212)[API] feat: Use offer address instead of venue address when relevant

### DIFF
--- a/api/src/pcapi/core/bookings/utils.py
+++ b/api/src/pcapi/core/bookings/utils.py
@@ -33,9 +33,9 @@ def generate_hmac_signature(
 def convert_real_booking_dates_utc_to_venue_timezone(
     date_without_timezone: datetime | None, booking: "CollectiveBooking"
 ) -> datetime | None:
-    if booking.venue.departementCode:
+    if booking.stock.offer.departementCode:
         return _apply_departement_timezone(
-            naive_datetime=date_without_timezone, departement_code=booking.venue.departementCode
+            naive_datetime=date_without_timezone, departement_code=booking.stock.offer.departementCode
         )
     offerer_department_code = postal_code_utils.PostalCode(booking.offerer.postalCode).get_departement_code()
     return _apply_departement_timezone(naive_datetime=date_without_timezone, departement_code=offerer_department_code)

--- a/api/src/pcapi/core/bookings/validation.py
+++ b/api/src/pcapi/core/bookings/validation.py
@@ -128,11 +128,10 @@ def check_is_usable(booking: Booking) -> None:
     if is_booking_for_event_and_not_confirmed:
         if booking.cancellationLimitDate is None:
             raise ValueError("Can't compute max_cancellation_date with None as cancellationLimitDate")
-        venue_departement_code = booking.venue.departementCode
         max_cancellation_date = datetime.datetime.strftime(
             utc_datetime_to_department_timezone(
                 booking.cancellationLimitDate,
-                venue_departement_code,
+                booking.stock.offer.departementCode,
             ),
             "%d/%m/%Y à %H:%M",
         )

--- a/api/src/pcapi/core/external_bookings/serialize.py
+++ b/api/src/pcapi/core/external_bookings/serialize.py
@@ -62,8 +62,8 @@ class ExternalEventBookingRequest(pydantic_v1.BaseModel):
             user_first_name=user.firstName,
             user_last_name=user.lastName,
             user_phone=user.phoneNumber,
-            venue_address=stock.offer.venue.street,
-            venue_department_code=stock.offer.venue.departementCode,
+            venue_address=stock.offer.street,
+            venue_department_code=stock.offer.departementCode,
             venue_id=stock.offer.venue.id,
             venue_name=stock.offer.venue.name,
             **price_data,  # type: ignore[arg-type]

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation.py
@@ -79,6 +79,7 @@ def get_booking_cancellation_confirmation_by_pro_email_data(
         number_of_bookings=len(ongoing_stock_bookings),
         stock_bookings=ongoing_stock_bookings,
         stock_name=stock_name,
+        offer=booking.stock.offer,
         venue=venue,
     )
 

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
@@ -28,9 +28,7 @@ def get_booking_cancellation_by_beneficiary_email_data(
     if offer.isEvent:
         if stock.beginningDatetime is None:
             raise ValueError("Can't convert None to local timezone")
-        beginning_date_time_in_tz = utc_datetime_to_department_timezone(
-            stock.beginningDatetime, offer.venue.departementCode
-        )
+        beginning_date_time_in_tz = utc_datetime_to_department_timezone(stock.beginningDatetime, offer.departementCode)
         event_date = get_date_formatted_for_email(beginning_date_time_in_tz)
         event_hour = get_time_formatted_for_email(beginning_date_time_in_tz)
     else:

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
@@ -33,7 +33,7 @@ def get_booking_cancellation_by_beneficiary_to_pro_email_data(
     return models.TransactionalEmailData(
         template=TransactionalEmail.BOOKING_CANCELLATION_BY_BENEFICIARY_TO_PRO.value,
         params={
-            "DEPARTMENT_CODE": booking.stock.offer.venue.departementCode or "numérique",
+            "DEPARTMENT_CODE": booking.stock.offer.departementCode or "numérique",
             "EVENT_DATE": format_booking_date_for_email(booking),
             "EVENT_HOUR": format_booking_hours_for_email(booking),
             "EXTERNAL_BOOKING_INFORMATION": external_booking_information,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -38,7 +38,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
     else:
         expiration_delay = None
 
-    department_code = venue.departementCode if not offer.isDigital else beneficiary.departementCode
+    department_code = offer.departementCode if not offer.isDigital else beneficiary.departementCode
     booking_date_in_tz = utc_datetime_to_department_timezone(booking.dateCreated, department_code)
     formatted_booking_date = get_date_formatted_for_email(booking_date_in_tz)
     formatted_booking_time = get_time_formatted_for_email(booking_date_in_tz)
@@ -87,8 +87,8 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "CODE_EXPIRATION_DATE": code_expiration_date,
             "VENUE_NAME": venue.publicName if venue.publicName else venue.name,
             "VENUE_ADDRESS": bookings_common.get_venue_street(booking),
-            "VENUE_POSTAL_CODE": venue.postalCode,
-            "VENUE_CITY": venue.city,
+            "VENUE_POSTAL_CODE": offer.postalCode,
+            "VENUE_CITY": offer.city,
             "ALL_BUT_NOT_VIRTUAL_THING": offer.isEvent or (not offer.isEvent and not offer.isDigital),
             "ALL_THINGS_NOT_VIRTUAL_THING": not offer.isEvent and not offer.isDigital,
             "IS_EVENT": offer.isEvent,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
@@ -26,9 +26,8 @@ def get_booking_event_reminder_to_beneficiary_email_data(
     if booking.stock.beginningDatetime is None:
         return None
 
-    department_code = (
-        booking.stock.offer.venue.departementCode if not booking.stock.offer.isDigital else booking.user.departementCode
-    )
+    offer = booking.stock.offer
+    department_code = offer.departementCode if not offer.isDigital else booking.user.departementCode
 
     event_beginning_date_in_tz = utc_datetime_to_department_timezone(booking.stock.beginningDatetime, department_code)
     formatted_event_beginning_date = get_date_formatted_for_email(event_beginning_date_in_tz)
@@ -58,12 +57,8 @@ def get_booking_event_reminder_to_beneficiary_email_data(
             "SUBCATEGORY": booking.stock.offer.subcategoryId,
             "USER_FIRST_NAME": booking.user.firstName,
             "VENUE_ADDRESS": bookings_common.get_venue_street(booking),
-            "VENUE_CITY": booking.stock.offer.venue.city,
-            "VENUE_NAME": (
-                booking.stock.offer.venue.publicName
-                if booking.stock.offer.venue.publicName
-                else booking.stock.offer.venue.name
-            ),
-            "VENUE_POSTAL_CODE": booking.stock.offer.venue.postalCode,
+            "VENUE_CITY": offer.city,
+            "VENUE_NAME": offer.venue.common_name,
+            "VENUE_POSTAL_CODE": offer.postalCode,
         },
     )

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_withdrawal_updated.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_withdrawal_updated.py
@@ -26,15 +26,11 @@ def send_email_for_each_ongoing_booking(offer: Offer) -> None:
         )
         .options(
             sqla.orm.joinedload(bookings_models.Booking.user).load_only(User.firstName, User.email),
-            sqla.orm.joinedload(bookings_models.Booking.stock)
-            .joinedload(Stock.offer)
-            .joinedload(Offer.venue)
-            .load_only(Venue.street),
             sqla.orm.joinedload(bookings_models.Booking.activationCode).load_only(ActivationCode.code),
         )
     )
 
-    venue_address = " ".join(filter(None, (offer.venue.street, offer.venue.postalCode, offer.venue.city)))
+    venue_address = " ".join(filter(None, (offer.street, offer.postalCode, offer.city)))
     mails_request = WithdrawalChangedMailRequest(
         offer_withdrawal_delay=(
             format_time_in_second_to_human_readable(offer.withdrawalDelay) if offer.withdrawalDelay else None

--- a/api/src/pcapi/core/mails/transactional/bookings/common.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/common.py
@@ -27,4 +27,4 @@ def get_offerer_name(booking: Booking) -> str:
 
 
 def get_venue_street(booking: Booking) -> str:
-    return booking.stock.offer.venue.street
+    return booking.stock.offer.street

--- a/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
@@ -76,7 +76,7 @@ def get_new_booking_to_pro_email_data(
         params={
             "CAN_EXPIRE": can_expire,
             "COUNTERMARK": booking.token,
-            "DEPARTMENT_CODE": venue.departementCode if not offer.isDigital else "numérique",
+            "DEPARTMENT_CODE": offer.departementCode if not offer.isDigital else "numérique",
             "EVENT_DATE": event_date,
             "EVENT_HOUR": event_hour,
             "IS_BOOKING_AUTOVALIDATED": is_booking_autovalidated,

--- a/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
+++ b/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
@@ -25,23 +25,20 @@ class OnlineEventReminderData:
     withdrawal_details: str
 
     def __init__(self, booking: booking_models.Booking) -> None:
-        event_hour_utc = booking.stock.beginningDatetime
-        event_hour_localized = (
-            date_utils.utc_datetime_to_department_timezone(
-                event_hour_utc,
-                booking.venue.departementCode,
+        offer = booking.stock.offer
+        if booking.stock.beginningDatetime:
+            self.event_hour = date_utils.utc_datetime_to_department_timezone(
+                booking.stock.beginningDatetime,
+                offer.departementCode,
             )
-            if event_hour_utc
-            else None
-        )
+        else:
+            self.event_hour = None
 
-        stock = booking.stock
-        self.event_hour = event_hour_localized
-        self.offer_name = stock.offer.name
-        self.offer_url = stock.offer.url
+        self.offer_name = offer.name
+        self.offer_url = offer.url
         self.recipients = []
         self.booking_id = booking.id
-        self.withdrawal_details = stock.offer.withdrawalDetails
+        self.withdrawal_details = offer.withdrawalDetails
 
     def add_recipient(self, email: str) -> None:
         self.recipients.append(email)

--- a/api/src/pcapi/core/offers/offer_metadata.py
+++ b/api/src/pcapi/core/offers/offer_metadata.py
@@ -2,7 +2,6 @@ import datetime
 import typing
 
 from pcapi.core.categories import subcategories_v2
-from pcapi.core.offerers.models import Venue
 import pcapi.core.offers.models as offers_models
 from pcapi.core.offers.utils import offer_app_link
 from pcapi.core.providers import constants as providers_constants
@@ -17,20 +16,20 @@ book_subcategories = {
 }
 
 
-def _get_metadata_from_venue(venue: Venue) -> Metadata:
+def _get_location_metadata(offer: offers_models.Offer) -> Metadata:
     return {
         "@type": "Place",
-        "name": venue.name,
+        "name": offer.venue.name,
         "address": {
             "@type": "PostalAddress",
-            "streetAddress": venue.street,
-            "postalCode": venue.postalCode,
-            "addressLocality": venue.city,
+            "streetAddress": offer.street,
+            "postalCode": offer.postalCode,
+            "addressLocality": offer.city,
         },
         "geo": {
             "@type": "GeoCoordinates",
-            "latitude": str(venue.latitude),
-            "longitude": str(venue.longitude),
+            "latitude": str(offer.latitude),
+            "longitude": str(offer.longitude),
         },
     }
 
@@ -74,7 +73,7 @@ def _get_event_metadata_from_offer(offer: offers_models.Offer) -> Metadata:
         event_metadata["eventAttendanceMode"] = "OnlineEventAttendanceMode"
     else:
         event_metadata["eventAttendanceMode"] = "OfflineEventAttendanceMode"
-        event_metadata["location"] = _get_metadata_from_venue(offer.venue)
+        event_metadata["location"] = _get_location_metadata(offer)
 
     if offer.metadataFirstBeginningDatetime:
         firstBeginningDatetime: datetime.datetime = offer.metadataFirstBeginningDatetime

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -453,10 +453,10 @@ def check_booking_limit_datetime(
         else:
             offer = stock.offer
 
-        if beginning and booking_limit_datetime and offer and offer.venue.departementCode is not None:
-            beginning_tz = date.utc_datetime_to_department_timezone(beginning, offer.venue.departementCode)
+        if beginning and booking_limit_datetime and offer and offer.departementCode is not None:
+            beginning_tz = date.utc_datetime_to_department_timezone(beginning, offer.departementCode)
             booking_limit_datetime_tz = date.utc_datetime_to_department_timezone(
-                booking_limit_datetime, offer.venue.departementCode
+                booking_limit_datetime, offer.departementCode
             )
 
             same_date = beginning_tz.date() == booking_limit_datetime_tz.date()

--- a/api/src/pcapi/routes/backoffice/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/list.html
@@ -179,7 +179,7 @@
                 <td>{{ offer.validation | format_offer_validation_status }}</td>
                 <td>{{ offer.dateCreated | format_date("%d/%m/%Y") }}</td>
                 <td>{{ offer.lastValidationDate | format_date("%d/%m/%Y") }}</td>
-                <td>{{ offer.venue.departementCode | empty_string_if_null }}</td>
+                <td>{{ offer.departementCode | empty_string_if_null }}</td>
                 <td>
                   {{ links.build_offerer_name_to_details_link(offer.venue.managingOfferer) }}
                   {% if has_permission("PRO_FRAUD_ACTIONS") %}{{ offer.venue.managingOfferer.confidenceLevel | format_confidence_level_badge }}{% endif %}

--- a/api/src/pcapi/routes/native/v1/serialization/favorites.py
+++ b/api/src/pcapi/routes/native/v1/serialization/favorites.py
@@ -50,7 +50,7 @@ class FavoriteOfferResponse(BaseModel):
 
     @classmethod
     def from_orm(cls, offer: Offer) -> "FavoriteOfferResponse":
-        offer.coordinates = {"latitude": offer.venue.latitude, "longitude": offer.venue.longitude}
+        offer.coordinates = {"latitude": offer.latitude, "longitude": offer.longitude}
         offer.venueName = offer.venue.managingOfferer.name if offer.isDigital else offer.venue.common_name
         offer.expenseDomains = get_expense_domains(offer)
         return super().from_orm(offer)

--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings_serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings_serialization.py
@@ -68,8 +68,8 @@ class GetBookingResponse(serialization.ConfiguredBaseModel):
             offer_ean=extra_data.get("ean"),
             venue_id=booking.venue.id,
             venue_name=booking.venue.name,
-            venue_address=booking.venue.street,
-            venue_departement_code=booking.venue.departementCode,  # type: ignore[arg-type]
+            venue_address=booking.stock.offer.street,
+            venue_departement_code=booking.stock.offer.departementCode,
             user_email=booking.email,
             user_birth_date=birth_date,
             user_first_name=booking.user.firstName,

--- a/api/src/pcapi/templates/mails/offerer_recap_email_after_offerer_cancellation.html
+++ b/api/src/pcapi/templates/mails/offerer_recap_email_after_offerer_cancellation.html
@@ -19,7 +19,7 @@
         {% if venue.isVirtual %}
         <br /> Offre numérique proposée par {{ venue.name }}.
         {% else %}
-        <br /> proposé par {{ venue.name }} (Adresse : {{ venue.street }}, {{ venue.postalCode }} {{ venue.city }}).
+        <br /> proposé par {{ venue.name }} (Adresse : {{ offer.street }}, {{ offer.postalCode }} {{ offer.city }}).
         {% endif %}
     </p>
     {% if stock_bookings %}

--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -37,9 +37,9 @@ def format_booking_hours_for_email(booking: Booking | CollectiveBooking) -> str:
 
 def get_event_datetime(stock: CollectiveStock | Stock) -> datetime:
     if isinstance(stock, Stock):
-        departement_code = stock.offer.venue.departementCode
+        departement_code = stock.offer.departementCode
     else:
-        departement_code = stock.collectiveOffer.venue.departementCode
+        departement_code = stock.collectiveOffer.departementCode
     if departement_code is not None:
         date_in_utc = stock.beginningDatetime
         if date_in_utc is None:


### PR DESCRIPTION
Cette pull request suppose que le modèle `Offer` se verra ajouter des propriétés `street`, `city`, etc. qui pointeront soit sur l'adresse de l'offre (si elle est spécifique), soit sur l'adresse de sa "Venue".