### PR TITLE
(PC-30315)[PRO] feat: fill collective stock start/end datetime

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-12f6f068d2bc (pre) (head)
-0126d932677e (post) (head)
+a909ecd976dc (pre) (head)
+3e180517700b (post) (head)

--- a/api/src/pcapi/alembic/versions/20240612T221427_a909ecd976dc_fill_start_end_datetime_for_collective_stock.py
+++ b/api/src/pcapi/alembic/versions/20240612T221427_a909ecd976dc_fill_start_end_datetime_for_collective_stock.py
@@ -1,0 +1,29 @@
+"""Fill CollectiveStock's startDatetime and endDatetime
+"""
+
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "a909ecd976dc"
+down_revision = "12f6f068d2bc"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE collective_stock SET "startDatetime" = "beginningDatetime" WHERE "startDatetime" IS NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE collective_stock SET "endDatetime" = "beginningDatetime" WHERE "endDatetime" IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20240612T221917_3e180517700b_fill_start_end_datetime_for_collective_stock.py
+++ b/api/src/pcapi/alembic/versions/20240612T221917_3e180517700b_fill_start_end_datetime_for_collective_stock.py
@@ -1,0 +1,29 @@
+"""Fill CollectiveStock's startDatetime and endDatetime
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "3e180517700b"
+down_revision = "0126d932677e"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE collective_stock SET "startDatetime" = "beginningDatetime" WHERE "startDatetime" IS NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE collective_stock SET "endDatetime" = "beginningDatetime" WHERE "endDatetime" IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Fill `startDatetime` / `endDatetime` with the value of `beginningDatetime` on CollectiveStock.
First batch is pre deployment to make sure the code work as expected. Also performs the same operation after deployment to make sure any stock created between the pre migration and the deployment also has its values correctly filled.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30315

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques