### PR TITLE
(BSR)[PRO] E2E: Financial page: messages and links

### DIFF
--- a/pro/cypress/e2e/features/financialManagement.feature
+++ b/pro/cypress/e2e/features/financialManagement.feature
@@ -1,11 +1,20 @@
 @P0
-Feature: Download of invoices and reimbursement details
+Feature: Financial Management - messages, links to external help page, reimbursement details
 
   Background:
     Given I am logged in with the new interface
     And I select offerer "0 - Structure avec justificatif et compte bancaire"
     And I go to the "Gestion financière" page
 
-  Scenario: I can download reimbursement details and invoices
+  Scenario: I can see information message and links to help pages
+    Then I can see information message about reimbursement
+    And I can see a link to the next reimbursement help page
+    When I open the "remboursements" page
+    Then I can see a link to the terms and conditions of reimbursement help page
+
+  Scenario: I can download reimbursement details
     When I download reimbursement details
     Then I can see the reimbursement details
+
+  # Scenario: I can download accounting receipt as pdf
+  #   Then I can download accounting receipt as pdf

--- a/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
+++ b/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
@@ -5,8 +5,50 @@ When('I download reimbursement details', () => {
   cy.findByText(/Télécharger le détail des réservations/).click()
 })
 
+// Does not work on CI: Error: connect ECONNREFUSED ::1:80
+// Then('I can download accounting receipt as pdf', () => {
+//   cy.findByTestId('dropdown-menu-trigger').click()
+//   cy.findByText(/Télécharger le justificatif comptable/).then(function ($a) {
+//     const href = $a.prop('href')
+//     cy.request(href).its('body').should('not.be.empty')
+//   })
+// })
+
 Then('I can see the reimbursement details', () => {
   const filename = `${Cypress.config('downloadsFolder')}/remboursements_pass_culture.csv`
 
   cy.readFile(filename, { timeout: 15000 }).should('not.be.empty')
 })
+
+Then('I can see information message about reimbursement', () => {
+  cy.findByText("Les remboursements s'effectuent toutes les 2 à 3 semaines")
+  cy.findByText(
+    'Nous remboursons en un virement toutes les réservations validées entre le 1ᵉʳ et le 15 du mois, et lors d’un second toutes celles validées entre le 16 et le 31 du mois.'
+  )
+  cy.findByText(
+    'Les offres de type événement se valident automatiquement 48h à 72h après leur date de réalisation, leurs remboursements peuvent se faire sur la quinzaine suivante.'
+  )
+})
+
+Then('I can see a link to the next reimbursement help page', () => {
+  cy.findByText(/En savoir plus sur les prochains remboursements/)
+    .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
+    .click()
+  cy.origin('https://passculture.zendesk.com', () => {
+    // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
+    cy.url().should('include', '4411992051601')
+  })
+})
+
+Then(
+  'I can see a link to the terms and conditions of reimbursement help page',
+  () => {
+    cy.findByText(/Connaître les modalités de remboursement/)
+      .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
+      .click()
+    cy.origin('https://passculture.zendesk.com', () => {
+      // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
+      cy.url().should('include', '4412007300369')
+    })
+  }
+)


### PR DESCRIPTION
## But de la pull request

Vérifie la conformité de la page de Gestion Financière: message d'information et liens vers pages externes

Un bout est commenté pour le téléchargement de justificatif de remboursement en pdf, mais cela ne marche pas en CI, seulement sur poste en local! J'ai préféré le garder

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques