### PR TITLE
(PC-30259)[API] Ajout d'une contrainte d'unicité sur la pair (`idAtProvider`, `VenueId`) dans la table offre

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 a909ecd976dc (pre) (head)
-3e180517700b (post) (head)
+3f81e39451a0 (post) (head)

--- a/api/src/pcapi/alembic/CONTRIBUTING.md
+++ b/api/src/pcapi/alembic/CONTRIBUTING.md
@@ -72,7 +72,7 @@ pc alembic downgrade post@-1
 
 ### 6. Mettre à jour le fichier alembic_version_conflict_detection.txt
 
-Ce fichier contient les numéros des dernières migrations pre et post du code.
+[Ce fichier](../../../alembic_version_conflict_detection.txt) contient les numéros des dernières migrations pre et post du code.
 
 Il permet de générer un conflit git lorsqu'un commit ajoutant une migration a été poussé sur la branche visée et n'est pas présent sur la branche courante.
 

--- a/api/src/pcapi/alembic/versions/20240613T133241_3f81e39451a0_add_unicity_constraint_on_offer_id_at_provider.py
+++ b/api/src/pcapi/alembic/versions/20240613T133241_3f81e39451a0_add_unicity_constraint_on_offer_id_at_provider.py
@@ -1,0 +1,38 @@
+"""
+Add unicity constraint on the pair `idAtProvider` and `venueId` in `offer` table.
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "3f81e39451a0"
+down_revision = "3e180517700b"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    # Should be executed quickly as we are using an index
+    op.execute(
+        """
+        ALTER TABLE "offer" ADD CONSTRAINT "unique_idAtProvider_venueId" UNIQUE USING INDEX "venueId_idAtProvider_index"
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE "offer" DROP CONSTRAINT IF EXISTS "unique_idAtProvider_venueId";
+        """
+    )
+    # `COMMIT` and isolation of the `CREATE UNIQUE INDEX CONCURRENTLY` command necessary since it cannot run in a transaction block
+    op.execute("COMMIT;")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "venueId_idAtProvider_index" ON offer ("venueId", "idAtProvider");
+        """
+    )
+    op.execute("BEGIN;")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 import sqlalchemy.exc as sa_exc
 from sqlalchemy.ext import mutable as sa_mutable
+from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict
 import sqlalchemy.orm as sa_orm
@@ -18,7 +19,6 @@ from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.elements import BooleanClauseList
 from sqlalchemy.sql.elements import Case
 from sqlalchemy.sql.elements import UnaryExpression
-from sqlalchemy.ext.declarative import declared_attr
 
 import pcapi.core.bookings.constants as bookings_constants
 from pcapi.core.categories import categories


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30259

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques