### PR TITLE
(PC-30231)[PRO] fix: make only one call if ids selected comes from th…

### DIFF
--- a/pro/src/pages/Offers/Offers/ActionsBar/ActionsBar.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/ActionsBar.tsx
@@ -96,16 +96,19 @@ const handleCollectiveOffers = async (
         }
       }
 
-      await Promise.all([
-        api.patchCollectiveOffersActiveStatus({
+      if (collectiveOfferIds.length > 0) {
+        await api.patchCollectiveOffersActiveStatus({
           ids: collectiveOfferIds.map((id) => Number(id)),
           isActive,
-        }),
-        api.patchCollectiveOffersTemplateActiveStatus({
+        })
+      }
+
+      if (collectiveOfferTemplateIds.length > 0) {
+        await api.patchCollectiveOffersTemplateActiveStatus({
           ids: collectiveOfferTemplateIds.map((ids) => Number(ids)),
           isActive,
-        }),
-      ])
+        })
+      }
 
       notify.information(
         isActive


### PR DESCRIPTION
…e same offer type in collective list offer

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30231

Si les offres sélectionnées sont seulements des offres réservables, il est inutile de faire la requête pour les offres vitrines et inversement

## Vérifications

- [x] J'ai écrit les tests nécessaires