### PR TITLE
(BSR)[API] chore: Don't handle old construct of CDS uuid

### DIFF
--- a/api/src/pcapi/utils/cinema_providers.py
+++ b/api/src/pcapi/utils/cinema_providers.py
@@ -7,11 +7,7 @@ def get_cds_show_id_from_uuid(uuid: str | None) -> int | None:
     and returns the show_id as int, or None if it cannot
     """
     if uuid:
-        # TODO (dramelet, 2024-02-09): In a few months, we will be able to drop the name group `show_id_with_showtime`
-        # as we won't have any up-to-date stocks with an old idAtProviders construct
-        match = re_search(r"#(?P<show_id_with_showtime>\d*)/|#(?P<show_id_without_showtime>\d*)$", uuid)
-        if match and match["show_id_with_showtime"]:
-            return int(match["show_id_with_showtime"])
+        match = re_search(r"#(?P<show_id_without_showtime>\d*)$", uuid)
         if match and match["show_id_without_showtime"]:
             return int(match["show_id_without_showtime"])
 

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -828,7 +828,7 @@ class BookOfferTest:
                 subcategoryId=subcategories.SEANCE_CINE.id,
                 lastProviderId=cinema_provider_pivot.provider.id,
             )
-            stock_solo = offers_factories.EventStockFactory(offer=offer_solo, idAtProviders="1111%4444#111/datetime")
+            stock_solo = offers_factories.EventStockFactory(offer=offer_solo, idAtProviders="1111%4444#111")
 
             # When
             booking = api.book_offer(beneficiary=beneficiary, stock_id=stock_solo.id, quantity=1)
@@ -856,7 +856,7 @@ class BookOfferTest:
                 subcategoryId=subcategories.SEANCE_CINE.id,
                 lastProviderId=cinema_provider_pivot.provider.id,
             )
-            stock_duo = offers_factories.EventStockFactory(offer=offer_duo, idAtProviders="1111%4444#111/datetime")
+            stock_duo = offers_factories.EventStockFactory(offer=offer_duo, idAtProviders="1111%4444#111")
 
             # When
             booking = api.book_offer(beneficiary=beneficiary, stock_id=stock_duo.id, quantity=1)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2505,11 +2505,10 @@ class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
         offer = factories.EventOfferFactory(
             venue=venue_provider.venue, idAtProvider=offer_id_at_provider, lastProviderId=cds_provider.id
         )
-        showtime = "2023-02-08"
         stock = factories.EventStockFactory(
             offer=offer,
             quantity=10,
-            idAtProviders=f"{offer_id_at_provider}#{show_id}/{showtime}",
+            idAtProviders=f"{offer_id_at_provider}#{show_id}",
             beginningDatetime=show_beginning_datetime,
         )
 
@@ -2550,11 +2549,10 @@ class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
         offer = factories.EventOfferFactory(
             venue=venue_provider.venue, idAtProvider=offer_id_at_provider, lastProviderId=cds_provider.id
         )
-        show_time = "2023-02-08"
         stock = factories.EventStockFactory(
             offer=offer,
             quantity=10,
-            idAtProviders=f"{offer_id_at_provider}#{showtime_id}/{show_time}",
+            idAtProviders=f"{offer_id_at_provider}#{showtime_id}",
             beginningDatetime=self.DATETIME_10_DAYS_AFTER,
         )
 

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -406,7 +406,7 @@ class OffersTest:
         )
         stock = offers_factories.EventStockFactory(
             offer=offer,
-            idAtProviders=f"{offer_id_at_provider}#{show_id}/2022-12-03",
+            idAtProviders=f"{offer_id_at_provider}#{show_id}",
         )
 
         response = client.get(f"/native/v1/offer/{offer.id}")
@@ -1009,7 +1009,7 @@ class OffersV2Test:
         )
         stock = offers_factories.EventStockFactory(
             offer=offer,
-            idAtProviders=f"{offer_id_at_provider}#{show_id}/2022-12-03",
+            idAtProviders=f"{offer_id_at_provider}#{show_id}",
         )
 
         response = client.get(f"/native/v2/offer/{offer.id}")

--- a/api/tests/utils/cinema_providers_test.py
+++ b/api/tests/utils/cinema_providers_test.py
@@ -6,8 +6,6 @@ import pcapi.utils.cinema_providers as cinema_providers_utils
 @pytest.mark.parametrize(
     "uuid,result",
     [
-        ("123%12345678912345#111/2022-12-12 11:00:00", 111),
-        ("123%12345678912345#3/2022-12-12 11:00:00", 3),
         ("123%12345678912345#111", 111),
         ("123%12345678912345#5", 5),
         ("123445+43423", None),
@@ -61,7 +59,6 @@ def test_get_ems_showtime_id_from_uuid(stock_uuid, result):
 @pytest.mark.parametrize(
     "stock_uuid,provider_name,result",
     [
-        ("123%12345678912345#111/2022-12-12 11:00:00", "CDSStocks", 111),
         ("123%12345678912345#111", "BoostStocks", 111),
         ("123%12354114%CGR#111", "CGRStocks", 111),
         ("123%12354114%CGR#111", "EMSStocks", 111),


### PR DESCRIPTION
Following this commit 45c63da9e62605603eca94e401c1b14946acb1c7, we don't need to handle the old construct of CDS uuid.
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques