### PR TITLE
(PC-30259)[API] feat: add unique index in stock on `idAtProviders`, `o…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 3e52841cdafa (pre) (head)
-20579712cf72 (post) (head)
+f11f5d888f80 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240617T082127_f11f5d888f80_add_unique_index_on_offerid_id_at_provider.py
+++ b/api/src/pcapi/alembic/versions/20240617T082127_f11f5d888f80_add_unique_index_on_offerid_id_at_provider.py
@@ -1,0 +1,33 @@
+"""
+Add unique index on offerId/idAtProviders in stock table
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "f11f5d888f80"
+down_revision = "20579712cf72"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT;")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_ix_offer_id_id_at_providers" ON stock ("offerId", "idAtProviders");
+        """
+    )
+    op.execute("BEGIN;")
+
+
+def downgrade() -> None:
+    op.execute("COMMIT;")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "unique_ix_offer_id_id_at_providers";
+        """
+    )
+    op.execute("BEGIN;")


### PR DESCRIPTION
…fferId`

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30259

Contexte :
- On va ouvrir la possibilité à nos partenaires techniques de renseigner l'`idAtProviders` des stocks par API
- Actuellement il y a une contrainte d'unicité sur `idAtProviders`, ce qui est beaucoup trop fort car on peut imaginer que deux stocks appartenant à deux providers différents aient le même id
- La stratégie est donc de remplacer cette contrainte d'unicité sur `idAtProviders` par une contrainte d'unicité sur le couple (`idAtProviders`, `offerId`). **Cette PR est la première étape de ce remplacement : la création de l'index unique sur le couple (`idAtProviders`, `offerId`).** La deuxième étape sera de créer une contrainte d'unicité à partir de cette index et de dropper la contrainte d'unicité sur `idAtProviders`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques