### PR TITLE
(PC-30306)[API] feat: add `venue_provider_external_urls` table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-e92c101b449f (pre) (head)
-4b41a69dfe71 (post) (head)
+e8732e562de5 (pre) (head)
+9708ed7dcc65 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240627T154807_e8732e562de5_add_venue_provider_external_urls.py
+++ b/api/src/pcapi/alembic/versions/20240627T154807_e8732e562de5_add_venue_provider_external_urls.py
@@ -1,0 +1,40 @@
+"""
+Add `venue_provider_external_urls` table
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "e8732e562de5"
+down_revision = "e92c101b449f"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "venue_provider_external_urls",
+        sa.Column("isActive", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("venueProviderId", sa.BigInteger(), nullable=False),
+        sa.Column("bookingExternalUrl", sa.Text(), nullable=True),
+        sa.Column("cancelExternalUrl", sa.Text(), nullable=True),
+        sa.Column("notificationExternalUrl", sa.Text(), nullable=True),
+        sa.CheckConstraint(
+            '"bookingExternalUrl" IS NOT NULL OR "notificationExternalUrl" IS NOT NULL',
+            name="check_at_least_one_of_the_external_url_is_set",
+        ),
+        sa.CheckConstraint(
+            '("bookingExternalUrl" IS NOT NULL AND "cancelExternalUrl" IS NOT NULL) OR ("bookingExternalUrl" IS NULL AND "cancelExternalUrl" IS NULL)',
+            name="check_ticketing_external_urls_both_set_or_null",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("venueProviderId"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("venue_provider_external_urls")

--- a/api/src/pcapi/alembic/versions/20240627T155103_9708ed7dcc65_add_fk_constraint_in_venue_provider_external_urls.py
+++ b/api/src/pcapi/alembic/versions/20240627T155103_9708ed7dcc65_add_fk_constraint_in_venue_provider_external_urls.py
@@ -1,0 +1,36 @@
+"""
+Add foreign key constraint on `venue_provider_external_urls.venueProviderId`
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "9708ed7dcc65"
+down_revision = "4b41a69dfe71"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_foreign_key(
+        "venue_provider_external_urls_venueProviderId_fkey",
+        "venue_provider_external_urls",
+        "venue_provider",
+        ["venueProviderId"],
+        ["id"],
+        ondelete="CASCADE",
+        postgresql_not_valid=True,
+    )
+    op.execute("COMMIT")
+    op.execute("BEGIN")
+    op.execute(
+        'ALTER TABLE "venue_provider_external_urls" VALIDATE CONSTRAINT "venue_provider_external_urls_venueProviderId_fkey"'
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "venue_provider_external_urls_venueProviderId_fkey", "venue_provider_external_urls", type_="foreignkey"
+    )


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30306

Ce qui a été décidé au final : création d'une table `VenueProviderExternalUrls` qui référence `VenueProvider` et qui se supprime en cascade quand `VenueProvider` est supprimé. Nous n'avons pas mis les external urls directement dans la table `venue_provider` car celles-ci ne seront remplies quand dans un nombre limité de cas (on ne veut pas polluer la table avec des valeurs null).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques