### PR TITLE
(BSR)[PRO] test: add cookie banner tests that were not yet migrated t…

### DIFF
--- a/pro/cypress/e2e/features/cookieBanner.feature
+++ b/pro/cypress/e2e/features/cookieBanner.feature
@@ -1,0 +1,45 @@
+@P0
+Feature: Cookie management
+
+  Background:
+    Given I open the "connexion" page
+
+  Scenario: The cookie banner should be displayed on cookie deletion
+    When I decline all cookies
+    And I clear all cookies in Browser
+    And I open the "connexion" page
+    Then The cookie banner should be displayed
+
+  Scenario: The user can accept all, and all the cookies are checked in the dialog
+    Then The cookie banner should be displayed
+    When I accept all cookies
+    Then The cookie banner should not be displayed
+    When I open the cookie management option
+    Then I should have 4 items checked
+
+  Scenario: The user can refuse all, and no cookie is checked in the dialog, except the required
+    When I decline all cookies
+    Then The cookie banner should not be displayed
+    When I open the cookie management option
+    Then I should have 1 items checked
+
+  Scenario: The user can choose a specific cookie, save and the status should be the same on modal re display
+    When I open the choose cookies option
+    And I select the "Beamer" cookie
+    And I save my choices
+    And I open the cookie management option
+    Then The Beamer cookie should be checked
+
+  Scenario: The user can choose a specific cookie, reload the page and the status should not have been changed
+    When I open the choose cookies option
+    And I select the "Beamer" cookie
+    And I open the "connexion" page
+    And I open the choose cookies option
+    Then The Beamer cookie should not be checked
+
+  Scenario: The user can choose a specific cookie, close the modal and the status should not have been changed
+    When I open the choose cookies option
+    And I select the "Beamer" cookie
+    And I close the cookie option
+    And I open the choose cookies option
+    Then The Beamer cookie should be checked

--- a/pro/cypress/e2e/features/cookieBanner.feature
+++ b/pro/cypress/e2e/features/cookieBanner.feature
@@ -4,10 +4,10 @@ Feature: Cookie management
   Background:
     Given I open the "connexion" page
 
-  Scenario: The cookie banner should be displayed on cookie deletion
+  Scenario: The cookie banner should remain displayed when opening a new page
     When I decline all cookies
     And I clear all cookies in Browser
-    And I open the "connexion" page
+    And I click on the "Accessibilité : non conforme" link
     Then The cookie banner should be displayed
 
   Scenario: The user can accept all, and all the cookies are checked in the dialog

--- a/pro/cypress/e2e/step-definitions/cookieBanner.cy.ts
+++ b/pro/cypress/e2e/step-definitions/cookieBanner.cy.ts
@@ -1,0 +1,56 @@
+import { When, Then } from '@badeball/cypress-cucumber-preprocessor'
+
+Then('The cookie banner should be displayed', () => {
+  cy.contains('Respect de votre vie privée').should('be.visible')
+})
+
+Then('The cookie banner should not be displayed', () => {
+  cy.contains('Respect de votre vie privée').should('not.exist')
+})
+
+When('I decline all cookies', () => {
+  cy.findByText('Tout refuser').click()
+})
+
+When('I accept all cookies', () => {
+  cy.findByText('Tout accepter').click()
+})
+
+When('I open the cookie management option', () => {
+  cy.findByText('Gestion des cookies').click()
+})
+
+Then('I should have {int} items checked', (int: number) => {
+  cy.get(".orejime-AppItem input[type='checkbox']:checked").should(
+    'have.length',
+    int
+  )
+})
+
+When('I open the choose cookies option', () => {
+  cy.findByText('Choisir les cookies').click()
+})
+
+When('I select the {string} cookie', (s: string) => {
+  cy.findByText(s).click()
+})
+
+When('I save my choices', () => {
+  cy.findByText('Enregistrer mes choix').click()
+})
+
+Then('The Beamer cookie should be checked', () => {
+  cy.get('#orejime-app-item-beamer').should('be.checked')
+})
+
+Then('The Beamer cookie should not be checked', () => {
+  cy.get('#orejime-app-item-beamer').should('not.be.checked')
+})
+
+When('I close the cookie option', () => {
+  cy.get('.orejime-Modal-closeButton').click()
+})
+
+When('I clear all cookies in Browser', () => {
+  cy.clearCookies()
+})

--- a/pro/cypress/e2e/step-definitions/cookieBanner.cy.ts
+++ b/pro/cypress/e2e/step-definitions/cookieBanner.cy.ts
@@ -54,3 +54,7 @@ When('I close the cookie option', () => {
 When('I clear all cookies in Browser', () => {
   cy.clearCookies()
 })
+
+When('I click on the {string} link', (link: string) => {
+  cy.findByText(link).click()
+})


### PR DESCRIPTION
## But de la pull request

Remettre les tests de cookie banner faits par Amine et supprimés dans cette PR #11779 
+ migration vers cucumber
+ testing-library

## Vérifications

- [-] J'ai écrit les tests nécessaires
- [-] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [-] J'ai ajouté des screenshots pour d'éventuels changements graphiques