### PR TITLE
(PC-29926)[PRO] fix: Escape special characters before searching in th…

### DIFF
--- a/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.tsx
+++ b/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.tsx
@@ -27,7 +27,10 @@ interface AdageMultiselectProps {
 }
 
 const filterItems = (items: ItemProps[], inputValue: string) => {
-  const regExp = new RegExp(inputValue, 'i')
+  const regExp = new RegExp(
+    inputValue.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, ''),
+    'i'
+  )
   return items.filter((item) => item.label.match(regExp))
 }
 


### PR DESCRIPTION
…e adage multiselect dropdown.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29926

**Objectif**
L'application crash quand on entre un caractère spécial (exemple "?") dans l'input des dropdowns de filtre de la recherche ADAGE.

Dans cette interface ⬇️ 
<img width="442" alt="Capture d’écran 2024-06-18 à 10 11 15" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/789aee59-8bfd-4c70-88d6-005651cf79a9">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques