### PR TITLE
PC-30398 - Modified image tags / Promoting

### DIFF
--- a/.github/workflows/dev_on_pull_request_workflow.yml
+++ b/.github/workflows/dev_on_pull_request_workflow.yml
@@ -11,18 +11,21 @@ concurrency:
 
 permissions: write-all
 
+env:
+  docker_registry: "europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry"
+
 jobs:
-  check-folders-changes:
-    # Perform all changes checks at once to remove the need for multiple checkouts accross jobs
-    name: "Check changes in folders"
+  pcapi-init-job:
+    name: "Init job"
     runs-on: ubuntu-latest
     outputs:
       api-changed: ${{ steps.check-api-changes.outputs.any_modified }}
       pro-changed: ${{ steps.check-pro-changes.outputs.any_modified }}
-      maintenance-site-changed: ${{ steps.check-maintenance-site-changes.outputs.any_modified }}
-      db-migrations-changed: ${{ steps.check-db-migrations-changes.outputs.any_modified }}
       dependencies-changed: ${{ steps.check-dependencies-changes.outputs.any_modified }}
-      docker-image-tags: ${{ steps.define-image-tags.outputs.docker-image-tags }}
+      push-tags: ${{ steps.pcapi-tags.outputs.push-tags }}
+      checksum-tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+      checksum-tag-exists: ${{ steps.check-checksum-tag.outputs.tag-exists }}
+      checksum-console-tag-exists: ${{ steps.check-console-checksum-tag.outputs.tag-exists }}
     steps:
       - uses: actions/checkout@v4.1.7
         with:
@@ -38,18 +41,6 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: pro/**
-      - name: "Check maintenance-site folder changes"
-        id: check-maintenance-site-changes
-        uses: tj-actions/changed-files@v44
-        with:
-          files: maintenance-site/**
-      - name: "Check db migration folder changes"
-        id: check-db-migrations-changes
-        uses: tj-actions/changed-files@v44
-        with:
-          files: |-
-            api/src/pcapi/alembic/versions/**
-            api/src/pcapi/alembic/run_migrations.py
       - name: "Check changes in dependencies (frontend + backend)"
         id: check-dependencies-changes
         uses: tj-actions/changed-files@v44
@@ -57,96 +48,169 @@ jobs:
           files: |
             api/poetry.lock
             pro/yarn.lock
-      - name: "Define docker image tags."
-        id: define-image-tags
+      # checkout source branch of the pull request 
+      - uses: actions/checkout@v4.1.7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          fetch-tags: false
+      - name: "Define pcapi image tags."
+        id: pcapi-tags
         run: |
-          DOCKER_REGISTRY="europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry"
-          OUTPUT="docker-image-tags="
-          OUTPUT+="$DOCKER_REGISTRY/DOCKER_IMAGE:${{ github.event.pull_request.head.sha }}"
-          echo $OUTPUT
-          echo $OUTPUT >> "$GITHUB_OUTPUT"
+          DOCKER_IMAGE="${{ env.docker_registry }}/pcapi"
+          API_CHECKSUM=`tar --sort=name --owner=0 --group=0 --mtime='UTC 2019-01-01' -cf - api | sha1sum | awk '{ print $1 }'`
+          PUSH_TAGS="push-tags=$DOCKER_IMAGE:${{ github.event.pull_request.head.sha }},$DOCKER_IMAGE:$API_CHECKSUM"
+          API_TAG="checksum-tag=$API_CHECKSUM"
+          echo "PUSH_TAGS=$PUSH_TAGS"
+          echo "API_TAG=$API_TAG"
+          echo $PUSH_TAGS >> "$GITHUB_OUTPUT"
+          echo $API_TAG >> "$GITHUB_OUTPUT"
+      - name: "Authentification to Google"
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      - name: "Get Secret"
+        id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        with:
+          secrets: |-
+            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
+            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+      - name: "OpenID Connect Authentication"
+        id: "openid-auth"
+        uses: "google-github-actions/auth@v2"
+        with:
+          create_credentials_file: false
+          token_format: "access_token"
+          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      - name: "Docker login"
+        id: "docker-login"
+        uses: "docker/login-action@v3"
+        with:
+          registry: "europe-west1-docker.pkg.dev"
+          username: "oauth2accesstoken"
+          password: "${{ steps.openid-auth.outputs.access_token }}"
+      - name: "pcapi"
+        id: check-checksum-tag
+        run: ./.github/workflows/scripts/check-image-tag-exists.sh
+        env:
+          image: pcapi
+          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }} 
+      - name: "pcapi-console"
+        id: check-console-checksum-tag
+        run: ./.github/workflows/scripts/check-image-tag-exists.sh
+        env:
+          image: pcapi-console
+          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+      - name: "Summary"
+        run: |
+          echo "[api] folder changed : ${{ steps.check-api-changes.outputs.any_modified }}"
+          echo "[pro] folder changed : ${{ steps.check-pro-changes.outputs.any_modified }}"
+          echo "[dependencies] changed : ${{ steps.check-dependencies-changes.outputs.any_modified }}"
+          echo "[pcapi] push-tags : ${{ steps.pcapi-tags.outputs.push-tags }}"
+          echo "[pcapi] checksum-tag : ${{ steps.pcapi-tags.outputs.checksum-tag }}"
+          echo "[pcapi] image tag ${{ steps.pcapi-tags.outputs.checksum-tag }} exists : ${{ steps.check-checksum-tag.outputs.tag-exists }}"
+          echo "[pcapi-console] image tag ${{ steps.pcapi-tags.outputs.checksum-tag }} exists : ${{ steps.check-console-checksum-tag.outputs.tag-exists }}"
 
   build-pcapi:
-    name: "[pcapi] build and push docker image."
-    needs: check-folders-changes
-    if: needs.check-folders-changes.outputs.api-changed == 'true'
-    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+    name: "[pcapi] build docker image."
+    needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.api-changed == 'true' && needs.pcapi-init-job.outputs.checksum-tag-exists == 'false'
+    uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       image: pcapi
-      tags: ${{ needs.check-folders-changes.outputs.docker-image-tags }}
+      tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  # Always build pcapi-tests image if api changed
+  build-pcapi-tests:
+    name: "[pcapi-tests] build docker image."
+    needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.api-changed == 'true'
+    uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      image: pcapi-tests
+      tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
   build-pcapi-console:
-    name: "[pcapi-console] build and push docker image."
-    needs: check-folders-changes
-    if: |
-      needs.check-folders-changes.outputs.api-changed == 'true' ||
-      needs.check-folders-changes.outputs.pro-changed == 'true'
-    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+    name: "[pcapi-console] build docker image."
+    needs: [pcapi-init-job]
+    if: (needs.pcapi-init-job.outputs.api-changed == 'true' || needs.pcapi-init-job.outputs.pro-changed == 'true') && needs.pcapi-init-job.outputs.checksum-console-tag-exists == 'false'
+    uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       image: pcapi-console
-      tags: ${{ needs.check-folders-changes.outputs.docker-image-tags }}
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-
-  build-pcapi-tests:
-    name: "[pcapi-tests] build and push docker image."
-    needs: check-folders-changes
-    if: |
-      needs.check-folders-changes.outputs.api-changed == 'true'
-    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
-    with:
-      ref: ${{ github.event.pull_request.head.sha }}
-      image: pcapi-tests
-      tags: ${{ needs.check-folders-changes.outputs.docker-image-tags }}
+      tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
   run-mypy-cop:
     name: "MyPy cop"
-    needs: check-folders-changes
+    needs: [pcapi-init-job]
     if: |
       github.event_name == 'pull_request' &&
-      needs.check-folders-changes.outputs.api-changed == 'true'
+      needs.pcapi-init-job.outputs.api-changed == 'true'
     uses: ./.github/workflows/dev_on_workflow_mypy_cop.yml
 
   update-api-client-template:
     name: "Update api client template"
-    needs: [check-folders-changes, build-pcapi]
+    needs: [pcapi-init-job, build-pcapi]
     uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
     concurrency:
       group: update-api-client-template-${{ github.ref }}
       cancel-in-progress: true
     with:
-      PCAPI_DOCKER_TAG: ${{ github.event.pull_request.head.sha }}
+      PCAPI_DOCKER_TAG: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
       TRIGGER_ONLY_ON_API_CHANGE: true
       TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+      api-changed: ${{ needs.pcapi-init-job.outputs.api-changed }}
+      dependencies-changed: ${{ needs.pcapi-init-job.outputs.dependencies-changed }}
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
   test-api:
-    name: "Test api"
-    needs: [check-folders-changes, build-pcapi-tests]
-    if: needs.check-folders-changes.outputs.api-changed == 'true'
+    name: "Tests api"
+    needs: [pcapi-init-job, build-pcapi-tests]
     uses: ./.github/workflows/dev_on_workflow_tests_api.yml
+    with:
+      tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+    secrets:
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+
+  test-pro:
+    name: "Tests pro"
+    needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.pro-changed == 'true'
+    uses: ./.github/workflows/dev_on_workflow_tests_pro.yml
+    with:
+      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  test-pro:
-    name: "Tests pro"
-    needs: check-folders-changes
-    if: needs.check-folders-changes.outputs.pro-changed == 'true'
-    uses: ./.github/workflows/dev_on_workflow_tests_pro.yml
+  test-pro-e2e:
+    name: "Tests pro E2E"
+    needs: [pcapi-init-job, build-pcapi]
+    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+    if: |
+      always() &&
+      needs.pcapi-init-job.outputs.api-changed == 'true' || 
+      needs.pcapi-init-job.outputs.pro-changed == 'true'
     with:
+      tag: ${{ needs.build-pcapi.result == 'skipped' && 'latest' || needs.pcapi-init-job.outputs.checksum-tag }}
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -158,37 +222,35 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     uses: ./.github/workflows/dev_on_workflow_dependabot_auto_merge.yml
 
-  test-pro-e2e-latest:
-    name: "Tests pro E2E (pcapi:latest)"
-    needs: [check-folders-changes]
-    if: ${{ needs.check-folders-changes.outputs.pro-changed == 'true' && needs.check-folders-changes.outputs.api-changed == 'false' }}
-    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+  push-pcapi:
+    name: "Push pcapi docker image to registry"
+    needs: [pcapi-init-job, test-api, test-pro-e2e]
+    uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+    with:
+      image: pcapi
+      commit-hash: ${{ github.event.pull_request.head.sha }}
+      checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-    with:
-      TAG: 'latest'
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
 
-  test-pro-e2e:
-    name: "Tests pro E2E"
-    needs: [check-folders-changes, build-pcapi]
-    if: ${{ needs.check-folders-changes.outputs.pro-changed == 'true' || needs.check-folders-changes.outputs.api-changed == 'true' }}
-    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+  push-pcapi-console:
+    name: "Push pcapi-console docker image to registry"
+    needs: [pcapi-init-job, test-api, test-pro-e2e]
+    uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+    with:
+      image: pcapi-console
+      commit-hash: ${{ github.event.pull_request.head.sha }}
+      checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-    with:
-      TAG: ${{ needs.check-folders-changes.outputs.api-changed == 'true' && github.event.pull_request.head.sha || 'latest' }}
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
 
-  deploy-validation-env:
+  deploy-pro-on-firebase-pullrequest:
     name: "[PRO] Deploy PR version for validation"
-    needs: check-folders-changes
+    needs: [pcapi-init-job, test-pro]
     uses: ./.github/workflows/dev_on_workflow_deploy_pro_pr_version_generic.yml
-    if: |
-      always() &&
-      needs.check-folders-changes.outputs.pro-changed == 'true'
+    if: always() &&  needs.pcapi-init-job.outputs.pro-changed == 'true'
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -9,17 +9,17 @@ on:
 permissions: write-all
 
 jobs:
-  check-folders-changes:
-    # Perform all changes checks at once to remove the need for multiple checkouts accross jobs
-    name: "Check changes in folders"
+  pcapi-init-job:
+    name: "pcapi init job"
     runs-on: ubuntu-latest
     outputs:
       api-changed: ${{ steps.check-api-changes.outputs.any_modified }}
       pro-changed: ${{ steps.check-pro-changes.outputs.any_modified }}
-      maintenance-site-changed: ${{ steps.check-maintenance-site-changes.outputs.any_modified }}
-      db-migrations-changed: ${{ steps.check-db-migrations-changes.outputs.any_modified }}
       dependencies-changed: ${{ steps.check-dependencies-changes.outputs.any_modified }}
-      docker-image-tags: ${{ steps.define-image-tags.outputs.docker-image-tags }}
+      push-tags: ${{ steps.pcapi-tags.outputs.push-tags }}
+      checksum-tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+      checksum-tag-exists: ${{ steps.check-checksum-tag.outputs.tag-exists }}
+      checksum-console-tag-exists: ${{ steps.check-console-checksum-tag.outputs.tag-exists }}
     steps:
       - uses: actions/checkout@v4.1.7
         with:
@@ -35,6 +35,83 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: pro/**
+      - name: "Check changes in dependencies (frontend + backend)"
+        id: check-dependencies-changes
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            api/poetry.lock
+            pro/yarn.lock
+      - name: "Define pcapi image tags."
+        id: pcapi-tags
+        run: |
+          DOCKER_IMAGE="${{ env.docker_registry }}/pcapi"
+          API_CHECKSUM=`tar --sort=name --owner=0 --group=0 --mtime='UTC 2019-01-01' -cf - api | sha1sum | awk '{ print $1 }'`
+          PUSH_TAGS="push-tags=$DOCKER_IMAGE:${{ github.sha }},$DOCKER_IMAGE:$API_CHECKSUM,$DOCKER_IMAGE:latest"
+          API_TAG="checksum-tag=$API_CHECKSUM"
+          echo "PUSH_TAGS=$PUSH_TAGS"
+          echo "API_TAG=$API_TAG"
+          echo $PUSH_TAGS >> "$GITHUB_OUTPUT"
+          echo $API_TAG >> "$GITHUB_OUTPUT"
+      - name: "Authentification to Google"
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      - name: "Get Secret"
+        id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        with:
+          secrets: |-
+            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
+            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+      - name: "OpenID Connect Authentication"
+        id: "openid-auth"
+        uses: "google-github-actions/auth@v2"
+        with:
+          create_credentials_file: false
+          token_format: "access_token"
+          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      - name: "Docker login"
+        id: "docker-login"
+        uses: "docker/login-action@v3"
+        with:
+          registry: "europe-west1-docker.pkg.dev"
+          username: "oauth2accesstoken"
+          password: "${{ steps.openid-auth.outputs.access_token }}"
+      - name: "pcapi"
+        id: check-checksum-tag
+        run: ./.github/workflows/scripts/check-image-tag-exists.sh
+        env:
+          image: pcapi
+          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+      - name: "pcapi-console"
+        id: check-console-checksum-tag
+        run: ./.github/workflows/scripts/check-image-tag-exists.sh
+        env:
+          image: pcapi-console
+          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+      - name: "Summary"
+        run: |
+          echo "[api] folder changed : ${{ steps.check-api-changes.outputs.any_modified }}"
+          echo "[pcapi] push-tags : ${{ steps.pcapi-tags.outputs.push-tags }}"
+          echo "[pcapi] checksum-tag : ${{ steps.pcapi-tags.outputs.checksum-tag }}"
+          echo "[pcapi] image tag ${{ steps.pcapi-tags.outputs.checksum-tag }} exists : ${{ steps.check-checksum-tag.outputs.tag-exists }}"
+          echo "[pcapi-console] image tag ${{ steps.pcapi-tags.outputs.checksum-tag }} exists : ${{ steps.check-console-checksum-tag.outputs.tag-exists }}"
+
+  check-folders-changes:
+    # Perform all changes checks at once to remove the need for multiple checkouts accross jobs
+    name: "Check changes in folders"
+    runs-on: ubuntu-latest
+    outputs:
+      maintenance-site-changed: ${{ steps.check-maintenance-site-changes.outputs.any_modified }}
+      db-migrations-changed: ${{ steps.check-db-migrations-changes.outputs.any_modified }}
+    steps:
+      - uses: actions/checkout@v4.1.7
+        with:
+          fetch-depth: 0
+          fetch-tags: false
       - name: "Check maintenance-site folder changes"
         id: check-maintenance-site-changes
         uses: tj-actions/changed-files@v44
@@ -47,94 +124,80 @@ jobs:
           files: |-
             api/src/pcapi/alembic/versions/**
             api/src/pcapi/alembic/run_migrations.py
-      - name: "Check changes in dependencies (frontend + backend)"
-        id: check-dependencies-changes
-        uses: tj-actions/changed-files@v44
-        with:
-          files: |
-            api/poetry.lock
-            pro/yarn.lock
-      - name: "Define docker image tags."
-        id: define-image-tags
-        run: |
-          DOCKER_REGISTRY="europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry"
-          OUTPUT="docker-image-tags="
-          OUTPUT+="$DOCKER_REGISTRY/DOCKER_IMAGE:${{ github.sha }}"
-          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-            OUTPUT+=",$DOCKER_REGISTRY/DOCKER_IMAGE:latest"
-          fi
-          echo $OUTPUT
-          echo $OUTPUT >> "$GITHUB_OUTPUT"
 
   build-pcapi:
-    name: "[pcapi] build and push docker image."
-    needs: check-folders-changes
-    if: needs.check-folders-changes.outputs.api-changed == 'true'
-    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+    name: "[pcapi] build docker image."
+    needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.api-changed == 'true' && needs.pcapi-init-job.outputs.checksum-tag-exists == 'false'
+    uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
     with:
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      ref: ${{ github.sha }}
       image: pcapi
-      tags: ${{ needs.check-folders-changes.outputs.docker-image-tags }}
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-
-  build-pcapi-console:
-    name: "[pcapi-console] build and push docker image."
-    needs: check-folders-changes
-    if: |
-      needs.check-folders-changes.outputs.api-changed == 'true' ||
-      needs.check-folders-changes.outputs.pro-changed == 'true' ||
-      github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
-    with:
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      image: pcapi-console
-      tags: ${{ needs.check-folders-changes.outputs.docker-image-tags }}
+      tags: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
   build-pcapi-tests:
-    name: "[pcapi-tests] build and push docker image."
-    needs: check-folders-changes
-    if: needs.check-folders-changes.outputs.api-changed == 'true' 
-    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+    name: "[pcapi-tests] build docker image."
+    needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.api-changed == 'true'
+    uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
     with:
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      ref: ${{ github.sha }}
       image: pcapi-tests
-      tags: ${{ needs.check-folders-changes.outputs.docker-image-tags }}
+      tags: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  build-pcapi-console:
+    name: "[pcapi-console] build docker image."
+    needs: [pcapi-init-job]
+    if: |
+      ( needs.pcapi-init-job.outputs.api-changed == 'true' ||
+      needs.pcapi-init-job.outputs.pro-changed == 'true' ) &&
+      needs.pcapi-init-job.outputs.checksum-console-tag-exists == 'false' &&
+      github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
+    with:
+      ref: ${{ github.sha }}
+      image: pcapi-console
+      tags: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
   prepare-cache-master:  # on "master" branch only
     name: "Reset cache on master on dependency update"
-    needs: [check-folders-changes, build-pcapi]
+    needs: [build-pcapi]
     uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
     if: github.ref == 'refs/heads/master'
     with:
-      PCAPI_DOCKER_TAG: ${{ github.sha }}
+      PCAPI_DOCKER_TAG: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
       TRIGGER_ONLY_ON_API_CHANGE: false
       TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+      api-changed: ${{ needs.pcapi-init-job.outputs.api-changed }}
+      dependencies-changed: ${{ needs.pcapi-init-job.outputs.dependencies-changed }}
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
   test-api:
     name: "Test api"
-    needs: [check-folders-changes, build-pcapi-tests]
-    if: needs.check-folders-changes.outputs.api-changed == 'true'
+    needs: [pcapi-init-job, build-pcapi-tests]
     uses: ./.github/workflows/dev_on_workflow_tests_api.yml
+    with:
+      tag: ${{ needs.build-pcapi-tests.result == 'skipped' && 'latest' || needs.pcapi-init-job.outputs.checksum-tag }}
     secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
   test-pro:
     name: "Tests pro"
-    needs: check-folders-changes
-    if: needs.check-folders-changes.outputs.pro-changed == 'true'
+    needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.pro-changed == 'true'
     uses: ./.github/workflows/dev_on_workflow_tests_pro.yml
     with:
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
@@ -144,23 +207,50 @@ jobs:
 
   test-pro-e2e:
     name: "Tests pro E2E"
-    needs: [check-folders-changes, build-pcapi]
-    if: |
-      needs.check-folders-changes.outputs.api-changed == 'true' ||
-      needs.check-folders-changes.outputs.pro-changed == 'true'
+    needs: [pcapi-init-job, build-pcapi]
     uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+    if: |
+      always() &&
+      needs.pcapi-init-job.outputs.api-changed == 'true' ||
+      needs.pcapi-init-job.outputs.pro-changed == 'true'
+    with:
+      tag: ${{ needs.build-pcapi.result == 'skipped' && 'latest' || needs.pcapi-init-job.outputs.checksum-tag }}
+      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-    with:
-      TAG: ${{ needs.check-folders-changes.outputs.api-changed == 'true' && github.sha || 'latest' }}
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
 
   deploy-storybook:
     name: "Deploy Storybook"
-    needs: check-folders-changes
-    if: ${{ github.ref == 'refs/heads/master' && needs.check-folders-changes.outputs.pro-changed == 'true' }}
+    needs: [pcapi-init-job]
+    if: ${{ github.ref == 'refs/heads/master' && needs.pcapi-init-job.outputs.pro-changed == 'true' }}
     uses: ./.github/workflows/dev_on_workflow_deploy_storybook.yml
+
+  push-pcapi:
+    name: "Push pcapi docker image to registry"
+    needs: [pcapi-init-job, test-api, test-pro-e2e]
+    uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+    with:
+      image: pcapi
+      commit-hash: ${{ github.sha }}
+      checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+      tag-latest: true
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  push-pcapi-console:
+    name: "Push pcapi-console docker image to registry"
+    needs: [pcapi-init-job, test-api, test-pro-e2e]
+    uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+    with:
+      image: pcapi-console
+      commit-hash: ${{ github.sha }}
+      checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+      tag-latest: true
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
   deploy-to-testing:
     name: "Deploy to testing"

--- a/.github/workflows/dev_on_workflow_build_docker_image.yml
+++ b/.github/workflows/dev_on_workflow_build_docker_image.yml
@@ -1,0 +1,75 @@
+name: '3 [on_workflow/Deprecated] Build docker image'
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        # The git ref to build from.
+        # Can be a branch name, a tag or a commit.
+        required: false
+        type: string
+      tag:
+        # The docker image tag
+        required: true
+        type: string
+      image:
+        required: true
+        type: string
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      GCP_EHP_SERVICE_ACCOUNT:
+        required: true
+
+env:
+  registry: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry
+
+jobs:
+  build-docker-image:
+    name: "Build ${{ inputs.image }}:${{ inputs.tag }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: "Add version to api"
+        working-directory: api
+        run: |
+          echo "${{ inputs.ref }}" > version.txt
+          git add version.txt
+
+      - name: "Install poetry"
+        run: pip install poetry
+
+      - name: "check poetry lock is up to date"
+        working-directory: api
+        run: poetry check
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+
+      - name: "Compute docker image name:tag"
+        id: compute-image-name
+        run: echo "image_name=${{ env.registry }}/${{ inputs.image }}:${{ inputs.tag }}" | tee -a ${GITHUB_OUTPUT}
+          
+      - name: "Build ${{ steps.compute-image-name.outputs.image_name }} image"
+        uses: docker/build-push-action@v5
+        with:
+          context: api
+          target: ${{ inputs.image }}
+          tags: ${{ steps.compute-image-name.outputs.image_name }}
+
+      - name: "Store artifact"
+        run: |
+          docker images
+          docker save ${{ steps.compute-image-name.outputs.image_name }} > ${{ inputs.image }}-${{ inputs.tag }}.tar
+
+      - name: "Upload of artifact content to blob storage"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.image }}-${{ inputs.tag }}.tar
+          path: ./
+          retention-days: 1

--- a/.github/workflows/dev_on_workflow_deploy_pro_pr_version_generic.yml
+++ b/.github/workflows/dev_on_workflow_deploy_pro_pr_version_generic.yml
@@ -91,6 +91,7 @@ jobs:
           version: ${{ inputs.CHANNEL }}
           url_prefix: "~"
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        id: firebase-deploy
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: ${{ steps.secrets.outputs.FIREBASE_TOKEN }}
@@ -98,3 +99,6 @@ jobs:
           projectId: pc-pro-${{ inputs.ENV }}
           entryPoint: pro
           channelId: ${{ inputs.CHANNEL }}
+      - name: "Firebase Deployment URL"
+        run: |
+          echo "::notice:: Firebase deployment is available at : ${{ steps.firebase-deploy.outputs.details_url }}"

--- a/.github/workflows/dev_on_workflow_push_docker_image.yml
+++ b/.github/workflows/dev_on_workflow_push_docker_image.yml
@@ -1,33 +1,35 @@
-name: '3 [on_workflow/Deprecated] Build and push docker images to Artifact Registry'
+name: '3 [on_workflow] push docker image'
 
 on:
   workflow_call:
     inputs:
-      ref:
-        # The git ref to build from.
-        # Can be a branch name, a tag or a commit.
-        required: false
-        type: string
-      tags:
-        # The docker image tag(s)
-        required: true
-        type: string
       image:
         required: true
         type: string
+      commit-hash:
+        required: true
+        type: string
+      checksum-tag:
+        required: true
+        type: string
+      tag-latest:
+        required: false
+        type: boolean
+        default: false
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
       GCP_EHP_SERVICE_ACCOUNT:
         required: true
 
+env:
+  registry: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry
+
 jobs:
-  build-and-push-docker-images:
+  push-docker-image:
+    name: "Push ${{ inputs.image }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
-        with:
-          ref: ${{ inputs.ref }}
       - name: "Authentification to Google"
         uses: 'google-github-actions/auth@v2'
         with:
@@ -55,29 +57,18 @@ jobs:
           registry: 'europe-west1-docker.pkg.dev'
           username: 'oauth2accesstoken'
           password: '${{ steps.openid-auth.outputs.access_token }}'
-      - name: "Add version to api"
-        working-directory: api
-        run: |
-          echo "${{ inputs.ref }}" > version.txt
-          git add version.txt
-      - name: "Install poetry"
-        run: pip install poetry
-      - name: "check poetry lock is up to date"
-        working-directory: api
-        run: poetry check
-      - name: Replace image name in tags inputs
-        id: define-docker-image-tags
-        run: |
-          echo "tags-to-push=${{ inputs.tags }}" | sed 's/DOCKER_IMAGE/${{ inputs.image }}/g'
-          echo "tags-to-push=${{ inputs.tags }}" | sed 's/DOCKER_IMAGE/${{ inputs.image }}/g' >> "$GITHUB_OUTPUT"
-      - name: "Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+      - name: "Compute docker image name:tag"
+        id: compute-image-name
+        run: echo "image_name=${{ env.registry }}/${{ inputs.image }}:${{ inputs.checksum-tag }}" | tee -a ${GITHUB_OUTPUT}
+      - name: "Download artifact"
+        uses: actions/download-artifact@v4
         with:
-          driver: docker
-      - name: "Build and push ${{ inputs.image }} image"
-        uses: docker/build-push-action@v5
-        with:
-          context: api
-          push: true
-          target: ${{ inputs.image }}
-          tags: ${{ steps.define-docker-image-tags.outputs.tags-to-push }}
+          name: ${{ inputs.image }}-${{ inputs.checksum-tag }}.tar
+      - name: "Load and push docker image"
+        run: |
+          docker load --input $GITHUB_WORKSPACE/${{ inputs.image }}-${{ inputs.checksum-tag }}.tar
+          docker image tag ${{ steps.compute-image-name.outputs.image_name }} "${{ env.registry }}/${{ inputs.image }}:${{ inputs.commit-hash }}"
+          if [ ${{ inputs.tag-latest }} == 'true' ]; then
+            docker image tag ${{ steps.compute-image-name.outputs.image_name }} "${{ env.registry }}/${{ inputs.image }}:latest"
+          fi
+          docker image push --all-tags ${{ env.registry }}/${{ inputs.image }} 

--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -2,6 +2,14 @@ name: "3 [on_workflow/API] Tests"
 
 on:
   workflow_call:
+    inputs:
+      image:
+        type: string
+        required: false
+        default: pcapi-tests
+      tag:
+        type: string
+        required: true
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -9,7 +17,7 @@ on:
         required: true
 
 env:
-  tests_docker_image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi-tests:${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  registry: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry
 
 defaults:
   run:
@@ -21,52 +29,67 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
+      - name: "Compute docker image name:tag"
+        id: compute-image-name
+        run: |
+          echo "image_name=${{ env.registry }}/${{ inputs.image }}:${{ inputs.tag }}" | tee -a ${GITHUB_OUTPUT}
+          echo "::notice:: Running tests api with ${{ env.registry }}/${{ inputs.image }}:${{ inputs.tag }}"
+      - name: "Download artifact"
+        if: ${{ inputs.tag }} != 'latest'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.image }}-${{ inputs.tag }}.tar
+      - name: "Docker load artifact."
+        if: ${{ inputs.tag }} != 'latest'
+        run: |
+          docker load --input $GITHUB_WORKSPACE/${{ inputs.image }}-${{ inputs.tag }}.tar
       - name: "Authentification to Google"
         uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Get Secret"
-        id: "secrets"
+        id: secrets
         uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
             SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/infra-prod-gcp-workload-identity-provider
+            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
       - name: "OpenID Connect Authentication"
-        id: "openid-auth"
+        id: openid-auth
         uses: "google-github-actions/auth@v2"
         with:
           create_credentials_file: false
           token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER  }}
           service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - uses: docker/login-action@v3
+      - name: "Docker login"
+        id: docker-login
+        uses: "docker/login-action@v1"
         with:
           registry: "europe-west1-docker.pkg.dev"
-          username: oauth2accesstoken
-          password: ${{ steps.openid-auth.outputs.access_token }}
-      - run: docker pull ${{ env.tests_docker_image }}
+          username: "oauth2accesstoken"
+          password: "${{ steps.openid-auth.outputs.access_token }}"
       - name: "Show installed Python packages"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           run: pip freeze
       - name: "Check imports are well organized with isort"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           run: isort . --check-only
       - name: "Check code is well formatted with black"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           run: black . --check
       - name: "Run mypy"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           run: mypy src
       - name: "Slack Notification"
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
@@ -99,42 +122,55 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - name: Authentification to Google
+      - name: "Compute docker image name:tag"
+        id: compute-image-name
+        run: echo "image_name=${{ env.registry }}/${{ inputs.image }}:${{ inputs.tag }}" | tee -a ${GITHUB_OUTPUT}
+      - name: "Download artifact"
+        if: ${{ inputs.tag }} != 'latest'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.image }}-${{ inputs.tag }}.tar
+      - name: "Docker load artifact."
+        if: ${{ inputs.tag }} != 'latest'
+        run: |
+          docker load --input $GITHUB_WORKSPACE/${{ inputs.image }}-${{ inputs.tag }}.tar
+      - name: "Authentification to Google"
         uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Get Secret"
-        id: "secrets"
+        id: secrets
         uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
             SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
-      - id: "openid-auth"
-        name: "OpenID Connect Authentication"
+            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/infra-prod-gcp-workload-identity-provider
+            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+      - name: "OpenID Connect Authentication"
+        id: openid-auth
         uses: "google-github-actions/auth@v2"
         with:
           create_credentials_file: false
           token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER  }}
           service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - uses: docker/login-action@v3
+      - name: "Docker login"
+        id: docker-login
+        uses: "docker/login-action@v1"
         with:
           registry: "europe-west1-docker.pkg.dev"
-          username: oauth2accesstoken
-          password: ${{ steps.openid-auth.outputs.access_token }}
-      - run: docker pull ${{ env.tests_docker_image }}
+          username: "oauth2accesstoken"
+          password: "${{ steps.openid-auth.outputs.access_token }}"
       - name: "Show installed Python packages"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           run: pip freeze
       - name: "Run pylint"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           run: pylint src tests --jobs=15
       - name: "Slack Notification"
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
@@ -196,32 +232,6 @@ jobs:
           # feature branch on top of the master branch). We don't want
           # that, we want the latest commit of the branch.
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      - name: "Authentification to Google"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v2"
-        with:
-          secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
-            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
-      - name: "OpenID Connect Authentication"
-        id: "openid-auth"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: false
-          token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - uses: docker/login-action@v3
-        with:
-          registry: "europe-west1-docker.pkg.dev"
-          username: oauth2accesstoken
-          password: ${{ steps.openid-auth.outputs.access_token }}
       - name: "Checkout HEAD (on master) or the parent of the first commit (pull request)"
         run: |
           if [[ "${{ github.ref }}" == "master" ]];
@@ -238,11 +248,50 @@ jobs:
           post=$(tail --lines 1 alembic_version_conflict_detection.txt | cut --fields 1 --delimiter " ")
           echo "pre=$pre" >> $GITHUB_OUTPUT
           echo "post=$post" >> $GITHUB_OUTPUT
-      - run: docker pull ${{ env.tests_docker_image }}
+      - name: "Compute docker image name:tag"
+        id: compute-image-name
+        run: echo "image_name=${{ env.registry }}/${{ inputs.image }}:${{ inputs.tag }}" | tee -a ${GITHUB_OUTPUT}
+      - name: "Download artifact"
+        if: ${{ inputs.tag }} != 'latest'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.image }}-${{ inputs.tag }}.tar
+      - name: "Docker load artifact."
+        if: ${{ inputs.tag }} != 'latest'
+        run: |
+          docker load --input $GITHUB_WORKSPACE/${{ inputs.image }}-${{ inputs.tag }}.tar
+      - name: "Authentification to Google"
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      - name: "Get Secret"
+        id: secrets
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
+        with:
+          secrets: |-
+            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/infra-prod-gcp-workload-identity-provider
+            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+      - name: "OpenID Connect Authentication"
+        id: openid-auth
+        uses: "google-github-actions/auth@v2"
+        with:
+          create_credentials_file: false
+          token_format: "access_token"
+          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER  }}
+          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      - name: "Docker login"
+        id: docker-login
+        uses: "docker/login-action@v1"
+        with:
+          registry: "europe-west1-docker.pkg.dev"
+          username: "oauth2accesstoken"
+          password: "${{ steps.openid-auth.outputs.access_token }}"
       - name: "Check for alembic multiple heads"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           shell: bash
           run: |
             LINE_COUNT=$(wc -l <<< "$(alembic heads)")
@@ -251,7 +300,7 @@ jobs:
       - name: "Check database and model are aligned"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST
           run: |
@@ -264,7 +313,7 @@ jobs:
       - name: "Check that downgrade scripts are correctly written"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST
           run: |
@@ -276,7 +325,7 @@ jobs:
       - name: "Lint migration upgrades"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST
           run: |
@@ -300,7 +349,7 @@ jobs:
       - name: "Lint migration downgrades"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST
           run: |
@@ -387,37 +436,50 @@ jobs:
           POSTGRES_DB: pass_culture
     steps:
       - uses: actions/checkout@v4.1.7
+      - name: "Compute docker image name:tag"
+        id: compute-image-name
+        run: echo "image_name=${{ env.registry }}/${{ inputs.image }}:${{ inputs.tag }}" | tee -a ${GITHUB_OUTPUT}
+      - name: "Download artifact"
+        if: ${{ inputs.tag }} != 'latest'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.image }}-${{ inputs.tag }}.tar
+      - name: "Docker load artifact."
+        if: ${{ inputs.tag }} != 'latest'
+        run: |
+          docker load --input $GITHUB_WORKSPACE/${{ inputs.image }}-${{ inputs.tag }}.tar
       - name: "Authentification to Google"
         uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Get Secret"
-        id: "secrets"
+        id: secrets
         uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
             SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/infra-prod-gcp-workload-identity-provider
+            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
       - name: "OpenID Connect Authentication"
-        id: "openid-auth"
+        id: openid-auth
         uses: "google-github-actions/auth@v2"
         with:
           create_credentials_file: false
           token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER  }}
           service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - uses: docker/login-action@v3
+      - name: "Docker login"
+        id: docker-login
+        uses: "docker/login-action@v1"
         with:
           registry: "europe-west1-docker.pkg.dev"
-          username: oauth2accesstoken
-          password: ${{ steps.openid-auth.outputs.access_token }}
-      - run: docker pull ${{ env.tests_docker_image }}
+          username: "oauth2accesstoken"
+          password: "${{ steps.openid-auth.outputs.access_token }}"
       - name: "Setup database"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST
           run: |
@@ -429,7 +491,7 @@ jobs:
       - name: "Mount a Volume with pcapi rights"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests -u 0
           run: |
@@ -438,7 +500,7 @@ jobs:
       - name: "Run tests"
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ env.tests_docker_image }}
+          image: ${{ steps.compute-image-name.outputs.image_name }}
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -e SQLALCHEMY_WARN_20 -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests
           run: |

--- a/.github/workflows/dev_on_workflow_tests_pro.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   type-check:
-    name: "Type check"
+    name: "Type check / Quality check / Style quality check"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
@@ -43,60 +43,8 @@ jobs:
             v1-yarn-pro-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --immutable
       - run: yarn tsc -b
-
-  quality-check:
-    name: "Quality check"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: "pro/.nvmrc"
-      - name: "OpenID Connect Authentication"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Cache the node_modules"
-        id: "yarn-modules-cache"
-        uses: pass-culture-github-actions/cache@v1.0.0
-        with:
-          compression-method: "gzip"
-          bucket: ${{ inputs.CACHE_BUCKET_NAME }}
-          path: |
-            **/node_modules
-          key: v1-yarn-pro-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            v1-yarn-pro-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --immutable
       - run: yarn lint:dead-code
       - run: yarn lint:js
-
-  style-quality-check:
-    name: "Style quality check"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: "pro/.nvmrc"
-      - name: "OpenID Connect Authentication"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Cache the node_modules"
-        id: "yarn-modules-cache"
-        uses: pass-culture-github-actions/cache@v1.0.0
-        with:
-          compression-method: "gzip"
-          bucket: ${{ inputs.CACHE_BUCKET_NAME }}
-          path: |
-            **/node_modules
-          key: v1-yarn-pro-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            v1-yarn-pro-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --immutable
       - run: yarn lint:scss
 
   tests-pro-unit-tests:

--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -3,7 +3,11 @@ name: "3 [on_workflow] Tests E2E"
 on:
   workflow_call:
     inputs:
-      TAG:
+      image:
+        type: string
+        required: false
+        default: pcapi
+      tag:
         type: string
         required: true
       CACHE_BUCKET_NAME:
@@ -15,30 +19,60 @@ on:
       GCP_EHP_SERVICE_ACCOUNT:
         required: true
 
+env:
+  registry: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry
+
 defaults:
   run:
     working-directory: pro
 
 jobs:
   tests-pro-e2e-tests:
-    name: "E2E tests"
+    name: "E2E tests and notifications"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
+      - uses: technote-space/workflow-conclusion-action@v3
       - name: "Authentification to Google"
         uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Get Secret"
-        id: "secrets"
+        id: secrets
         uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
+            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
             ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/infra-prod-gcp-workload-identity-provider
             ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
             CYPRESS_CLOUD_RECORD_KEY:passculture-metier-ehp/e2e-tests-pro-cypress-cloud-record-key
             CYPRESS_CLOUD_PROJECT_ID:passculture-metier-ehp/e2e-tests-pro-cypress-cloud-project-id
+      - name: "OpenID Connect Authentication"
+        id: openid-auth
+        uses: "google-github-actions/auth@v2"
+        with:
+          create_credentials_file: false
+          token_format: "access_token"
+          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER  }}
+          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      - name: "Docker login"
+        id: docker-login
+        uses: "docker/login-action@v1"
+        with:
+          registry: "europe-west1-docker.pkg.dev"
+          username: "oauth2accesstoken"
+          password: "${{ steps.openid-auth.outputs.access_token }}"
+      - name: "Compute docker image name:tag"
+        id: compute-image-name
+        run: |
+          echo "image_name=${{ env.registry }}/${{ inputs.image }}:${{ inputs.tag }}" | tee -a ${GITHUB_OUTPUT}
+          echo "::notice:: Running e2e-tests with ${{ env.registry }}/${{ inputs.image }}:${{ inputs.tag }}"
+      - name: "Download artifact"
+        if: ${{ inputs.tag != 'latest' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.image }}-${{ inputs.tag }}.tar
       - uses: actions/setup-node@v3
         with:
           node-version-file: "pro/.nvmrc"
@@ -51,11 +85,6 @@ jobs:
         env:
           PCAPI_UID: 1000
           PCAPI_GID: 1000
-      - name: "OpenID Connect Authentication"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Cache the node_modules"
         id: "yarn-modules-cache"
         uses: pass-culture-github-actions/cache@v1.0.0
@@ -71,25 +100,13 @@ jobs:
       - run: yarn install --immutable
       - name: "Run postgres and redis server"
         run: docker-compose -f ../docker-compose-backend.yml up postgres redis -d
-      - id: "openid-auth"
-        name: "OpenID Connect Authentication"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: false
-          token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER  }}
-          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"
-      - id: "docker-login"
-        uses: "docker/login-action@v1"
-        name: "Docker login"
-        with:
-          registry: "europe-west1-docker.pkg.dev"
-          username: "oauth2accesstoken"
-          password: "${{ steps.openid-auth.outputs.access_token }}"
       - name: "Run API server"
         run: |
+          if [ "${{ inputs.tag }}" != "latest" ]; then
+            docker load --input $GITHUB_WORKSPACE/${{ inputs.image }}-${{ inputs.tag }}.tar
+          fi
           docker run \
             --name pc-api \
             --workdir /usr/src/app \
@@ -102,7 +119,7 @@ jobs:
             --publish 5001:5001 \
             --publish 10002:10002 \
             --entrypoint bash \
-            europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi:${{ inputs.TAG }} \
+            ${{ steps.compute-image-name.outputs.image_name }} \
             -c "set -e ; flask install_postgres_extensions ; alembic upgrade pre@head ; alembic upgrade post@head ; flask install_data ; python src/pcapi/app.py"
       - name: "Wait for migrations to be run"
         uses: iFaxity/wait-on-action@v1
@@ -121,7 +138,6 @@ jobs:
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:3001)" != "200" ]]; do sleep 5; done' || false
       # Doc : https://github.com/cypress-io/github-action
       - name: "Cypress run"
-        if: always()
         uses: cypress-io/github-action@v6
         with:
           wait-on: "http://localhost:5001/health/api,http://localhost:5001/health/database"
@@ -149,26 +165,8 @@ jobs:
       - name: 'Show pcapi log when it fails'
         if: failure()
         run: docker logs pc-api
-
-  notification:
-    name: "Notification"
-    runs-on: ubuntu-latest
-    if: ${{ failure() && github.ref == 'refs/heads/master' }}
-    needs: tests-pro-e2e-tests
-    steps:
-      - uses: technote-space/workflow-conclusion-action@v3
-      - name: "Authentification to Google"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v2"
-        with:
-          secrets: |-
-            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
       - name: "Post to a Slack channel"
+        if: always() && failure() && github.ref == 'refs/heads/master'
         uses: slackapi/slack-github-action@v1.26.0
         with:
           # channel #dev

--- a/.github/workflows/dev_on_workflow_update_api_client_template.yml
+++ b/.github/workflows/dev_on_workflow_update_api_client_template.yml
@@ -15,11 +15,20 @@ on:
       CACHE_BUCKET_NAME:
         type: string
         required: true
+      api-changed:
+        type: string
+        required: true
+      dependencies-changed:
+        type: string
+        required: true
     secrets:
       GCP_EHP_SERVICE_ACCOUNT:
         required: true
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
+
+env:
+  registry: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry
 
 jobs:
   update-api-client:
@@ -35,21 +44,27 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
-        with:
-          secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/infra-prod-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
       - name: "Should run cache"
         id: "evaluate-variables"
         run: |
-          if ${{ (!inputs.TRIGGER_ONLY_ON_API_CHANGE && !inputs.TRIGGER_ONLY_ON_DEPENDENCY_CHANGE) || (inputs.TRIGGER_ONLY_ON_API_CHANGE && needs.check-folders-changed.outputs.api-changed == 'true') || (inputs.TRIGGER_ONLY_ON_DEPENDENCY_CHANGE && needs.check-folder-changes.outputs.dependencies-changed == 'true') }}; then
+          if ${{ (!inputs.TRIGGER_ONLY_ON_API_CHANGE && !inputs.TRIGGER_ONLY_ON_DEPENDENCY_CHANGE) || (inputs.TRIGGER_ONLY_ON_API_CHANGE && inputs.api-changed == 'true') || (inputs.TRIGGER_ONLY_ON_DEPENDENCY_CHANGE && inputs.dependencies-changed == 'true') }}; then
             echo "should-run-cache=true" | tee -a $GITHUB_OUTPUT
           else
             echo "should-run-cache=false" | tee -a $GITHUB_OUTPUT
           fi
+        shell: bash
+      - name: "Compute docker image name:tag"
+        if: steps.evaluate-variables.outputs.should-run-cache == 'true'
+        id: compute-image-name
+        run: |
+          echo "image_name=${{ env.registry }}/pcapi:${{ inputs.PCAPI_DOCKER_TAG }}" | tee -a ${GITHUB_OUTPUT}
+          echo "::notice:: Running update api client template with ${{ env.registry }}/pcapi:${{ inputs.PCAPI_DOCKER_TAG }}"
+      - name: "Download artifact"
+        if: steps.evaluate-variables.outputs.should-run-cache == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: pcapi-${{ inputs.PCAPI_DOCKER_TAG }}.tar
+          path: ${{ github.workspace }}
       - name: "Fix local permissions"
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'
         run: sudo chown -R $PCAPI_UID:$PCAPI_GID .
@@ -63,29 +78,15 @@ jobs:
       - name: "Run API"
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'
         run: docker-compose -f docker-compose-backend.yml up postgres redis -d
-      - id: 'openid-auth'
-        if: steps.evaluate-variables.outputs.should-run-cache == 'true'
-        name: "OpenID Connect Authentication"
-        uses: 'google-github-actions/auth@v2'
-        with:
-          create_credentials_file: false
-          token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER  }}
-          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
       - name: 'Set up Cloud SDK'
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'
         uses: 'google-github-actions/setup-gcloud@v2'
-      - id: 'docker-login'
-        if: steps.evaluate-variables.outputs.should-run-cache == 'true'
-        uses: "docker/login-action@v1"
-        name: "Docker login"
-        with:
-          registry: "europe-west1-docker.pkg.dev"
-          username: "oauth2accesstoken"
-          password: "${{ steps.openid-auth.outputs.access_token }}"
       - name: "Run API server"
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'
         run: |
+          if [ "${{ inputs.PCAPI_DOCKER_TAG }}" != "latest" ]; then
+            docker load --input $GITHUB_WORKSPACE/pcapi-${{ inputs.PCAPI_DOCKER_TAG }}.tar
+          fi
           docker run \
             --name pc-api \
             --workdir /usr/src/app \
@@ -98,7 +99,7 @@ jobs:
             --publish 5001:5001 \
             --publish 10002:10002 \
             --entrypoint bash \
-            europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi:${{ inputs.PCAPI_DOCKER_TAG }} \
+            ${{ steps.compute-image-name.outputs.image_name }} \
             -c "set -e ; flask install_postgres_extensions ; alembic upgrade pre@head ; alembic upgrade post@head ; flask install_data ; python src/pcapi/app.py"
       - name: "Wait for migrations to be run"
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'

--- a/.github/workflows/scripts/check-image-tag-exists.sh
+++ b/.github/workflows/scripts/check-image-tag-exists.sh
@@ -1,0 +1,9 @@
+RESULT=`curl -s -o /dev/null -w "%{http_code}" https://europe-west1-docker.pkg.dev/v2/passculture-infra-prod/pass-culture-artifact-registry/$image/manifests/$tag`
+OUTPUT="tag-exists="
+if [[ $RESULT == "200" ]]; then
+  OUTPUT+="true"
+else
+  OUTPUT+="false"
+fi
+echo $OUTPUT
+echo $OUTPUT >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## But de la pull request

Changes :

ONLY AFFECTING ON PULLREQUESTS AND ON PUSH MASTER for now 
Create Release-Hotfix / Deploy Release-hotfix will be done incrementally once the following changes will  run smoothly for several weeks to ensure stability and not potentially affecting MEPs

- Grouped test-pro Type check / Quality Check / Style Quality check in a single job.
- Grouped tests-e2e and its notifications to the same job
- Fixed Update api template not executing
- Fixed e2e tests not executing
- Create new docker tag (in addition to the commit-sha tag) for pcapi and pcapi-console images. This tag is a hash of files inside pcapi.
- Check if thus hash exists in registry before building. If, yes, do not build and do no execute tests (images in registry had their tests being run succesfully already ). Useful for other changes (workflows...) or deploying pullrequests on merge without rebuilding if the same exact image was built and pushed already from the PR.
- Splitted single action build-push docker images into 2 : build | push  for the following actions : 
    - Build docker images and store them as github artifacts, then use artifacts to execute all tests
    - Only push docker image to registry if all tests are OK
    
- We do not push pcapi-tests image to registry anymore as it is not used in any deployment.


Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30398

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques