### PR TITLE
(PC-30405)[API] fix: remove mandatory collective offer's start/end da…

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -488,8 +488,8 @@ def create_collective_offer_public(
     collective_stock = educational_models.CollectiveStock(
         collectiveOffer=collective_offer,
         beginningDatetime=body.beginning_datetime,
-        startDatetime=body.start_datetime,
-        endDatetime=body.end_datetime,
+        startDatetime=body.start_datetime or body.beginning_datetime,
+        endDatetime=body.end_datetime or body.beginning_datetime,
         bookingLimitDatetime=body.booking_limit_datetime,
         price=body.total_price,
         numberOfTickets=body.number_of_tickets,

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -384,8 +384,8 @@ class PostCollectiveOfferBodyModel(BaseModel):
     nationalProgramId: int | None = fields.COLLECTIVE_OFFER_NATIONAL_PROGRAM_ID
     # stock part
     beginning_datetime: datetime = fields.COLLECTIVE_OFFER_BEGINNING_DATETIME
-    start_datetime: datetime = fields.COLLECTIVE_OFFER_START_DATETIME
-    end_datetime: datetime = fields.COLLECTIVE_OFFER_END_DATETIME
+    start_datetime: datetime | None = fields.COLLECTIVE_OFFER_START_DATETIME
+    end_datetime: datetime | None = fields.COLLECTIVE_OFFER_END_DATETIME
     booking_limit_datetime: datetime = fields.COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME
     total_price: decimal.Decimal = fields.COLLECTIVE_OFFER_TOTAL_PRICE
     number_of_tickets: int = fields.COLLECTIVE_OFFER_NB_OF_TICKETS_FIELD

--- a/api/tests/routes/public/collective/endpoints/post_collective_offer_test.py
+++ b/api/tests/routes/public/collective/endpoints/post_collective_offer_test.py
@@ -95,8 +95,6 @@ def minimal_payload_fixture(domain, institution, venue):
         },
         "isActive": True,
         "beginningDatetime": booking_beginning.isoformat(timespec="seconds"),
-        "startDatetime": booking_beginning.isoformat(timespec="seconds"),
-        "endDatetime": booking_beginning.isoformat(timespec="seconds"),
         "bookingLimitDatetime": booking_limit.isoformat(timespec="seconds"),
         "totalPrice": 600,
         "numberOfTickets": 30,

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -5751,6 +5751,7 @@
                         "description": "Collective offer end datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
                         "example": "2024-07-14T14:00:00+02:00",
                         "format": "date-time",
+                        "nullable": true,
                         "title": "Enddatetime",
                         "type": "string"
                     },
@@ -5825,6 +5826,7 @@
                         "description": "Collective offer start datetime. Replaces beginning dateime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
                         "example": "2024-07-14T14:00:00+02:00",
                         "format": "date-time",
+                        "nullable": true,
                         "title": "Startdatetime",
                         "type": "string"
                     },
@@ -5880,8 +5882,6 @@
                     "offerVenue",
                     "isActive",
                     "beginningDatetime",
-                    "startDatetime",
-                    "endDatetime",
                     "bookingLimitDatetime",
                     "totalPrice",
                     "numberOfTickets"


### PR DESCRIPTION
…tetimes

Collective Offer's startDatetime and endDatetime should be optionals to avoid breaking changes on the API.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques