### PR TITLE
(PC-30412)[API] fix: update sandbox users for discord auth

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -610,8 +610,8 @@ def create_product_with_multiple_images() -> None:
 
 
 def create_discord_users() -> None:
-    for i in range(10):
-        user = users_factories.UserFactory(
+    for i in range(10, 20):
+        user = users_factories.BeneficiaryGrant18Factory(
             email=f"discordUser{i}@test.com", firstName=f"discord{i}", lastName=f"user{i}"
         )
-        users_factories.DiscordUserFactory(userId=user.id, discordId=None, hasAccess=True)
+        users_factories.DiscordUserFactory(user=user, discordId=None, hasAccess=True)


### PR DESCRIPTION
## But de la pull request

Update de la sandbox après revue PM, pour avoir les bons users avec les bons liens
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30412

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques