### PR TITLE
(PC-30145)[API] feat: create minimal data for CreateThiIndividualOffer e2e test

### DIFF
--- a/api/src/pcapi/routes/internal/__init__.py
+++ b/api/src/pcapi/routes/internal/__init__.py
@@ -12,4 +12,5 @@ def install_routes(app: Flask) -> None:
     if settings.ENABLE_LOCAL_DEV_MODE_FOR_STORAGE:
         from . import storage
     if settings.ENABLE_TEST_ROUTES:
+        from . import e2e
         from . import testing

--- a/api/src/pcapi/routes/internal/e2e.py
+++ b/api/src/pcapi/routes/internal/e2e.py
@@ -1,0 +1,35 @@
+from flask import jsonify
+
+from pcapi.models.api_errors import ApiErrors
+from pcapi.routes.apis import private_api
+from pcapi.sandboxes.scripts import getters
+
+
+@private_api.route("/sanboxes/<module_name>/<getter_name>", methods=["GET"])
+def get_sandbox(module_name, getter_name):  # type: ignore [no-untyped-def]
+    if not hasattr(getters, module_name):
+        errors = ApiErrors()
+        errors.add_error("module", 'Il n\'existe pas de tel "{}" module de getters pour la sandbox'.format(module_name))
+        raise errors
+
+    cypress_module = getattr(getters, module_name)
+
+    if not hasattr(cypress_module, getter_name):
+        errors = ApiErrors()
+        errors.add_error(
+            "getter", 'Il n\'existe pas de tel "{} {}" getter pour la sandbox'.format(module_name, getter_name)
+        )
+        raise errors
+
+    getter = getattr(cypress_module, getter_name)
+
+    try:
+        obj = getter()
+        return jsonify(obj)
+    except:
+        errors = ApiErrors()
+        errors.add_error(
+            "query",
+            'Une erreur s\'est produite lors du calcul de "{} {}" pour la sandbox'.format(module_name, getter_name),
+        )
+        raise errors

--- a/api/src/pcapi/sandboxes/scripts/getters/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/__init__.py
@@ -1,0 +1,1 @@
+import pcapi.sandboxes.scripts.getters.pro_01_create_pro_user

--- a/api/src/pcapi/sandboxes/scripts/getters/pro_01_create_pro_user.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro_01_create_pro_user.py
@@ -1,0 +1,13 @@
+from pcapi.core.finance import factories as finance_factories
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.users import factories as users_factories
+from pcapi.sandboxes.scripts.utils.helpers import get_pro_user_helper
+
+
+def create_pro_user_with_venue_bank_account_and_userofferer() -> dict:
+    pro_user = users_factories.ProFactory()
+    venue = offerers_factories.VenueFactory()
+
+    finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
+    offerers_factories.UserOffererFactory(user=pro_user, offerer=venue.managingOfferer)
+    return {"user": get_pro_user_helper(pro_user)}

--- a/api/src/pcapi/sandboxes/scripts/utils/helpers.py
+++ b/api/src/pcapi/sandboxes/scripts/utils/helpers.py
@@ -1,4 +1,12 @@
+from pcapi.core.users import models as users_models
+
+
 def get_email(first_name: str, last_name: str, domain: str) -> str:
     return "{}.{}@{}".format(
         first_name.replace(" ", "").strip().lower(), last_name.replace(" ", "").strip().lower(), domain
     )
+
+
+# helper to serialize pro user's
+def get_pro_user_helper(user: users_models.User) -> dict:
+    return {"email": user.email}


### PR DESCRIPTION
## But de la pull request

Cette PR permet d'avoir un jeu de données minimaliste pour le test CreateThingIndividualOffer sans passer par la sandbox

Idée : pour écrire un jeu de données de test : 
- on ajoute dans `pcapi/sandboxes/scripts/getters` un module correspondant à l'appel front de cypress (ici `create_pro_user`) (+ ne pas l'oublier dans le __ init__) et une méthode qui correspond à ce qu'on veut faire exactement (ici `create_pro_user_with_venue_bank_account_and_userofferer`) qui va créer les données dont on a besoin
- on ajoute un `helper`qui permet de renvoyer les données au bon format au front

A revoir ou valider ensuite côté front : 
- on appelle cette route depuis le front (ici dans `pro/cypress/e2e/step-definitions/commonSteps`) 
- on ajoute l'appel au front dans le scénario (ici dans `pro/cypress/e2e/createThingIndividualOffer.feature`)

Le fichier `pcapi/routes/internal/e2e.py` n'aura pas besoin d'être modifié par la suite

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30145

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques