### PR TITLE
(PC-30423)[BO] fix: sqlalchemy.exc.RemovedIn20Warning: Using strings …

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1189,8 +1189,8 @@ def search_pro_account(search_query: str, *_: typing.Any) -> BaseQuery:
     )
 
     return _filter_user_accounts(pro_accounts, search_query).options(
-        sa.orm.with_expression("suspension_reason_expression", users_models.User.suspension_reason.expression),  # type: ignore[attr-defined]
-        sa.orm.with_expression("suspension_date_expression", users_models.User.suspension_date.expression),  # type: ignore[attr-defined]
+        sa.orm.with_expression(users_models.User.suspension_reason_expression, users_models.User.suspension_reason.expression),  # type: ignore[attr-defined]
+        sa.orm.with_expression(users_models.User.suspension_date_expression, users_models.User.suspension_date.expression),  # type: ignore[attr-defined]
         sa.orm.joinedload(users_models.User.UserOfferers).load_only(offerers_models.UserOfferer.validationStatus),
     )
 
@@ -1207,8 +1207,8 @@ def get_pro_account_base_query(pro_id: int) -> BaseQuery:
 
 def search_backoffice_accounts(search_query: str) -> BaseQuery:
     bo_accounts = models.User.query.join(users_models.User.backoffice_profile).options(
-        sa.orm.with_expression("suspension_reason_expression", users_models.User.suspension_reason.expression),  # type: ignore[attr-defined]
-        sa.orm.with_expression("suspension_date_expression", users_models.User.suspension_date.expression),  # type: ignore[attr-defined]
+        sa.orm.with_expression(users_models.User.suspension_reason_expression, users_models.User.suspension_reason.expression),  # type: ignore[attr-defined]
+        sa.orm.with_expression(users_models.User.suspension_date_expression, users_models.User.suspension_date.expression),  # type: ignore[attr-defined]
     )
 
     if not search_query:

--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -68,8 +68,8 @@ def _load_suspension_info(query: BaseQuery) -> BaseQuery:
     # So these expressions use a subquery so that result count is accurate, and the redirection well forced when a
     # single card would be displayed.
     return query.options(
-        sa.orm.with_expression("suspension_reason_expression", users_models.User.suspension_reason.expression),  # type: ignore[attr-defined]
-        sa.orm.with_expression("suspension_date_expression", users_models.User.suspension_date.expression),  # type: ignore[attr-defined]
+        sa.orm.with_expression(users_models.User.suspension_reason_expression, users_models.User.suspension_reason.expression),  # type: ignore[attr-defined]
+        sa.orm.with_expression(users_models.User.suspension_date_expression, users_models.User.suspension_date.expression),  # type: ignore[attr-defined]
     )
 
 


### PR DESCRIPTION
…to indicate column or relationship paths in loader options is deprecated and will be removed in SQLAlchemy 2.0.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30423
PR supplémentaire pour corriger des alertes apparues aujourd'hui.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques