### PR TITLE
(PC-30259)[API] chore: rebuild unique_ix_offer_id_id_at_providers

### DIFF
--- a/api/src/pcapi/scripts/rebuild_concurrent_indexes/main.py
+++ b/api/src/pcapi/scripts/rebuild_concurrent_indexes/main.py
@@ -1,0 +1,19 @@
+from sqlalchemy import text
+
+from pcapi import settings
+from pcapi.app import app
+from pcapi.models import db
+
+
+def rebuild_concurrent_index() -> None:
+    with app.app_context():
+        db.session.execute("SET statement_timeout = 0;")  # disable, as we can't know how much it will take
+        # Below concurrent queries won't run inside a transaction
+        db.session.execute("COMMIT")
+        # https://www.postgresql.org/docs/15/sql-reindex.html
+        db.session.execute(text("""REINDEX INDEX CONCURRENTLY "unique_ix_offer_id_id_at_providers" """))
+        db.session.execute(f"SET statement_timeout = {settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+if __name__ == "__main__":
+    rebuild_concurrent_index()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30259

Ne sera pas merge. Pour rebuild l'index `unique_ix_offer_id_id_at_providers` en staging via un job k8S. 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques