### PR TITLE
(PC-30259)[API] chore: script to build unique_ix_offer_id_id_at_provi…

### DIFF
--- a/api/src/pcapi/scripts/add_concurrent_index_on_stock_id_at_provider_offer_id/main.py
+++ b/api/src/pcapi/scripts/add_concurrent_index_on_stock_id_at_provider_offer_id/main.py
@@ -1,0 +1,29 @@
+from sqlalchemy import text
+
+from pcapi import settings
+from pcapi.app import app
+from pcapi.models import db
+
+
+app.app_context().push()
+
+
+def add_index() -> None:
+    # Disabling statement_timeout as we can't know in advance how long it would take
+    db.session.execute(text("SET statement_timeout = 0;"))
+
+    # The below statement can't run inside a transaction
+    db.session.execute(text("COMMIT;"))
+    db.session.execute(
+        text(
+            """ CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_ix_offer_id_id_at_providers" ON stock ("offerId", "idAtProviders"); """
+        )
+    )
+
+    # According to PostgreSQL, setting such values this way is affecting only the current session
+    # but let's be defensive by setting back to the original values
+    db.session.execute(text(f"SET statement_timeout = {settings.DATABASE_STATEMENT_TIMEOUT}"))
+
+
+if __name__ == "__main__":
+    add_index()


### PR DESCRIPTION
…ders outside of deployment

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30259

Ne sera pas mergée. Script pour créer l'index sur les stocks en dehors du déploiement. Sera exécuté dans un job k8s. 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques