### PR TITLE
(BSR)[API] feat: allow to set the backend's IP through os env

### DIFF
--- a/api/src/pcapi/app.py
+++ b/api/src/pcapi/app.py
@@ -34,6 +34,7 @@ with app.app_context():
 
 
 if __name__ == "__main__":
+    ip = settings.FLASK_IP
     port = settings.FLASK_PORT
     is_debugger_enabled = settings.IS_DEV and settings.DEBUG_ACTIVATED
     if is_debugger_enabled:
@@ -50,4 +51,4 @@ if __name__ == "__main__":
             print("🎉 Code debugger attached, enjoy debugging 🎉", flush=True)
 
     set_tag("pcapi.app_type", "app")
-    app.run(host="0.0.0.0", port=port, debug=True, use_reloader=not is_debugger_enabled)
+    app.run(host=ip, port=port, debug=True, use_reloader=not is_debugger_enabled)

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -74,6 +74,7 @@ SQLALCHEMY_ECHO = bool(int(os.environ.get("SQLALCHEMY_ECHO", "0")))
 # FLASK
 PROFILE_REQUESTS = bool(int(os.environ.get("PROFILE_REQUESTS", "0")))
 PROFILE_REQUESTS_LINES_LIMIT = int(os.environ.get("PROFILE_REQUESTS_LINES_LIMIT", 100))
+FLASK_IP = os.environ.get("FLASK_IP", "0.0.0.0")
 FLASK_PORT = int(os.environ.get("PORT", 5001))
 FLASK_BACKOFFICE_PORT = int(os.environ.get("FLASK_BACKOFFICE_PORT", 5001))
 FLASK_SECRET = secrets_utils.get("FLASK_SECRET", "+%+3Q23!zbc+!Dd@")

--- a/pro/README.md
+++ b/pro/README.md
@@ -38,6 +38,14 @@ Sur linux + chrome / chromium l’application peut se charger indéfiniment un w
     - Injection des données de test `pc sandbox -n industrial`
   - Lancement des tests depuis la ligne de commande `yarn test:e2e`
 
+Note, si vous lancez les tests e2e hors Docker et sous OSX, Cypress tentera de contacter le backoffice sur
+le localhost ipv6. Comme, par défaut, le backend écoute sur les ports en ipv4, il faudra lancer le backend
+avec:
+
+```bash
+$ FLASK_IP="::1" python src/pcapi/app.py
+```
+
 ## ADAGE
 
 Nous intégrons une sous-route du portail Pro (`/adage-iframe/`) dans une iframe au sein d'ADAGE, la plateforme des établissements scolaires permettant de gérer leurs activités culturelles.


### PR DESCRIPTION
## But de la pull request

BSR : rendre configurable l'IP utilisée par le backend.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques