### PR TITLE
(BSR)[PRO] test: Test offerer selection in financial view

### DIFF
--- a/pro/cypress/e2e/features/financialManagement.feature
+++ b/pro/cypress/e2e/features/financialManagement.feature
@@ -16,5 +16,11 @@ Feature: Financial Management - messages, links to external help page, reimburse
     When I download reimbursement details
     Then I can see the reimbursement details
 
+  Scenario: I can chose another offerer and see financial informations modified
+    Then These receipt results should be displayed
+      | Date du justificatif | Type de document | Compte bancaire | N° de virement                        | Montant remboursé | Actions |
+      |                      |                  | Remboursement   | Libellé des coordonnées bancaires n°0 | VIR1              |         |
+    When I select offerer "1 - [CB] Structure avec des coordonnées bancaires dans différents états"
+    Then No receipt results should be displayed
   # Scenario: I can download accounting receipt as pdf
   #   Then I can download accounting receipt as pdf

--- a/pro/cypress/e2e/features/financialManagement.feature
+++ b/pro/cypress/e2e/features/financialManagement.feature
@@ -1,26 +1,19 @@
 @P0
 Feature: Financial Management - messages, links to external help page, reimbursement details
 
-  Background:
+  Scenario: Check messages, reimbursement details and offerer selection change
     Given I am logged in with the new interface
-    And I select offerer "0 - Structure avec justificatif et compte bancaire"
-    And I go to the "Gestion financière" page
-
-  Scenario: I can see information message and links to help pages
+    When I go to the "Gestion financière" page
     Then I can see information message about reimbursement
     And I can see a link to the next reimbursement help page
-    When I open the "remboursements" page
-    Then I can see a link to the terms and conditions of reimbursement help page
-
-  Scenario: I can download reimbursement details
-    When I download reimbursement details
-    Then I can see the reimbursement details
-
-  Scenario: I can chose another offerer and see financial informations modified
+    And I can see a link to the terms and conditions of reimbursement help page
+    When I select offerer "1 - [CB] Structure avec des coordonnées bancaires dans différents états"
+    Then No receipt results should be displayed
+    When I select offerer "0 - Structure avec justificatif et compte bancaire"
     Then These receipt results should be displayed
       | Date du justificatif | Type de document | Compte bancaire | N° de virement                        | Montant remboursé | Actions |
       |                      |                  | Remboursement   | Libellé des coordonnées bancaires n°0 | VIR1              |         |
-    When I select offerer "1 - [CB] Structure avec des coordonnées bancaires dans différents états"
-    Then No receipt results should be displayed
+    When I download reimbursement details
+    Then I can see the reimbursement details
   # Scenario: I can download accounting receipt as pdf
   #   Then I can download accounting receipt as pdf

--- a/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
+++ b/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
@@ -31,24 +31,30 @@ Then('I can see information message about reimbursement', () => {
 })
 
 Then('I can see a link to the next reimbursement help page', () => {
-  cy.findByText(/En savoir plus sur les prochains remboursements/)
-    .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
-    .click()
-  cy.origin('https://passculture.zendesk.com', () => {
-    // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
-    cy.url().should('include', '4411992051601')
+  cy.url().then((url: string) => {
+    cy.findByText(/En savoir plus sur les prochains remboursements/)
+      .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
+      .click()
+    cy.origin('https://passculture.zendesk.com', () => {
+      // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
+      cy.url().should('include', '4411992051601')
+    })
+    cy.visit(url)
   })
 })
 
 Then(
   'I can see a link to the terms and conditions of reimbursement help page',
   () => {
-    cy.findByText(/Connaître les modalités de remboursement/)
-      .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
-      .click()
-    cy.origin('https://passculture.zendesk.com', () => {
-      // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
-      cy.url().should('include', '4412007300369')
+    cy.url().then((url: string) => {
+      cy.findByText(/Connaître les modalités de remboursement/)
+        .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
+        .click()
+      cy.origin('https://passculture.zendesk.com', () => {
+        // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
+        cy.url().should('include', '4412007300369')
+      })
+      cy.visit(url)
     })
   }
 )

--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
@@ -215,7 +215,7 @@ export const InvoiceTable = ({ invoices }: InvoiceTableProps) => {
           Justificatif de remboursement ou de trop perçu
         </caption>
         <thead className={styles['header']}>
-          <tr role="row">
+          <tr role="row" data-testid="invoice-title-row">
             <th
               role="columnheader"
               scope="col"
@@ -349,7 +349,12 @@ export const InvoiceTable = ({ invoices }: InvoiceTableProps) => {
         <tbody className={styles['body']}>
           {sortedInvoices.map((invoice) => {
             return (
-              <tr role="row" key={invoice.reference} className={styles['row']}>
+              <tr
+                role="row"
+                key={invoice.reference}
+                className={styles['row']}
+                data-testid="invoice-item-row"
+              >
                 <td
                   role="cell"
                   className={styles['data']}


### PR DESCRIPTION
## But de la pull request

Test e2e du choix de structure sur la page "Gestion financière" et vérification du changement des infos (onglet Justificatifs)

Warning: Les tests e2e échouent toujours sur le searchIndividualOffer (mais ça n'a rien à voir avec ce qui est fait ici, les données ont changé dans le sandbox et c'est en cours de correction par @Amine et Jean-Marie)

Info: Quand on aura la possibilité de créer nos propres datas sans celles pré-chargées dans la sandbox, alors on fera surement un cas sans justificatif puis un cas avec plusieurs justificatifs...mais là on fait avec ce qu'on a 😇

@ncanseco-pass : les `if` vont te faire tilter, mais c'est pour éviter de vérifier une ligne vide pour rien et pas trouvé mieux que mettre une valeur vide dans le dataTable du cucumber qui nous limite un peu. Le faire marche aussi, mais ça fait un  assert pour rien

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques