### PR TITLE
(PC-28786)[BO] feat: Add specific reimbursement rule for commercial gestures

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -586,22 +586,18 @@ def _price_event(event: models.FinanceEvent) -> models.Pricing:
             ),
         ]
     elif event.motive == models.FinanceEventMotive.INCIDENT_COMMERCIAL_GESTURE:
-        original_pricing = [
-            pricing for pricing in booking.pricings if pricing.status == models.PricingStatus.CANCELLED
-        ][0]
-
-        rule = find_reimbursement_rule(original_pricing.customRuleId or original_pricing.standardRule)
-        amount = -rule.apply(booking, event.bookingFinanceIncident.commercial_gesture_amount)  # outgoing, thus negative
+        rule = reimbursement.CommercialGestureReimbursementRule()
+        amount = -event.bookingFinanceIncident.commercial_gesture_amount  # outgoing, thus negative
         offerer_revenue_amount = -event.bookingFinanceIncident.commercial_gesture_amount
         pricing_booking_id = None
         pricing_collective_booking_id = None
         lines = [
             models.PricingLine(
-                amount=offerer_revenue_amount,
+                amount=amount,
                 category=models.PricingLineCategory.OFFERER_REVENUE,
             ),
             models.PricingLine(
-                amount=amount - offerer_revenue_amount,
+                amount=0,
                 category=models.PricingLineCategory.OFFERER_CONTRIBUTION,
             ),
         ]

--- a/api/src/pcapi/domain/reimbursement.py
+++ b/api/src/pcapi/domain/reimbursement.py
@@ -41,6 +41,18 @@ class EducationalOffersReimbursement(finance_models.ReimbursementRule):
         return int(base * self.rate)
 
 
+class CommercialGestureReimbursementRule(finance_models.ReimbursementRule):
+    # This rule is used to allow full reimbursement of commercial gesture regardless of the cancelled related bookings
+    rate = Decimal(1)
+    description = "Remboursement total pour les gestes commerciaux"
+    group = finance_models.RuleGroup.STANDARD
+    valid_from = None
+    valid_until = None
+
+    def is_relevant(self, booking: Booking, cumulative_revenue: int) -> bool:
+        return False
+
+
 class PhysicalOffersReimbursement(finance_models.ReimbursementRule):
     rate = Decimal(1)
     description = "Remboursement total pour les offres physiques"
@@ -174,6 +186,7 @@ REGULAR_RULES = [
     DigitalThingsReimbursement(),
     EducationalOffersReimbursement(),
     PhysicalOffersReimbursement(),
+    CommercialGestureReimbursementRule(),
     LegacyPreSeptember2021ReimbursementRateByVenueBetween20000And40000(),
     LegacyPreSeptember2021ReimbursementRateByVenueBetween40000And150000(),
     LegacyPreSeptember2021ReimbursementRateByVenueAbove150000(),
@@ -189,6 +202,7 @@ assert [r.description for r in REGULAR_RULES] == [
     "Pas de remboursement pour les offres digitales",
     "Remboursement total pour les offres éducationnelles",
     "Remboursement total pour les offres physiques",
+    "Remboursement total pour les gestes commerciaux",
     "Remboursement à 95% entre 20 000 € et 40 000 € par lieu",
     "Remboursement à 85% entre 40 000 € et 150 000 € par lieu",
     "Remboursement à 70% au dessus de 150 000 € par lieu",

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_commercial_gestures.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_commercial_gestures.py
@@ -162,10 +162,6 @@ def _create_total_commercial_gesture_collective_offer(
             author=author_user,
         )
 
-        # TODO(amine) figure out why this is mandatory to be able to fetch the related pricings in `_price_event` function
-        # tried session.expire_all() and session.commit() but no effect
-        [p.id for p in booking.pricings]  # # pylint: disable=pointless-statement
-
         # Pricing of the commercial gestures
         for booking_finance_incident in commercial_gesture.booking_finance_incidents:
             for event in booking_finance_incident.finance_events:

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -40,10 +40,14 @@ def create_free_invoice() -> None:
     offerer = offerers_factories.OffererFactory(name="0 - Structure avec compte bancaire et justificatif à 0€")
     bank_account = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.UserOffererFactory(offerer=offerer, user__email="activation_new_nav@example.com")
+    pricing_point = offerers_factories.VenueFactory(
+        name="Point de valorisation pour justificatifs à 0€",
+        managingOfferer=offerer,
+    )
     venue = offerers_factories.VirtualVenueFactory(
         name="Lieu avec justificatif à 0€",
         managingOfferer=offerer,
-        pricing_point="self",
+        pricing_point=pricing_point,
         bank_account=bank_account,
     )
     digital_offer1 = offers_factories.DigitalOfferFactory(name="Specific free invoice digital offer 1", venue=venue)

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -730,6 +730,7 @@ class PriceEventTest:
         assert commercial_gesture_pricing.pricingPointId == venue.id
         assert commercial_gesture_pricing.bookingId is None
         assert commercial_gesture_pricing.collectiveBookingId is None
+        assert commercial_gesture_pricing.standardRule == "Remboursement total pour les gestes commerciaux"
 
         assert {line.category for line in commercial_gesture_pricing.lines} == {
             models.PricingLineCategory.OFFERER_REVENUE,


### PR DESCRIPTION

## But de la pull request

Ajout d'une nouvelle règle de remboursement à 100% utilisée pour les versements des gestes commerciaux

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques