### PR TITLE
(BSR)[API] fix: Restore Gunicorn "pre request" logs

### DIFF
--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pathlib
 
+import gunicorn.config
 import prometheus_client
 import prometheus_client.registry
 from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
@@ -65,6 +66,7 @@ def post_fork(server, worker):
 
 
 def pre_request(worker, req):
+    gunicorn.config.PreRequest.default(worker, req)
     if ENABLE_FLASK_PROMETHEUS_EXPORTER:
         worker.available_threads.dec()
 


### PR DESCRIPTION
Registering our own handler replaces the default Gunicorn handler,
which logs the start of the request, like this:

    [634677] [DEBUG] GET /health/api

... which is useful to analyze SIGKILL sent to Gunicorn workers (see
PC-27885 for an helper script).


---

Testé en local en lançant Gunicorn comme suit :


    $ ENABLE_FLASK_PROMETHEUS_EXPORTER=1 PROMETHEUS_MULTIPROC_DIR=/tmp/pass-culture-prometheus GUNICORN_PORT=4999 GUNICORN_MAX_REQUESTS=10 GUNICORN_MAX_REQUESTS_JITTER=10 GUNICORN_WORKERS=2 GUNICORN_THREADS=2 GUNICORN_TIMEOUT=10 GUNICORN_LOG_LEVEL=debug ./entrypoint.sh
    [...]
    [2024-06-24 09:52:28 +0200] [634677] [DEBUG] GET /health/api