### PR TITLE
Pc 29709 adapt anonymize public account with extract condition

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -141,7 +141,10 @@ def is_beneficiary_anonymizable(user: users_models.User) -> bool:
 def anonymize_public_account(user_id: int) -> utils.BackofficeResponse:
     user = (
         users_models.User.query.filter_by(id=user_id)
-        .options(sa.orm.joinedload(users_models.User.deposits))
+        .options(
+            sa.orm.joinedload(users_models.User.deposits),
+            sa.orm.joinedload(users_models.User.gdprUserDataExtract),
+        )
         .one_or_none()
     )
 
@@ -156,15 +159,18 @@ def anonymize_public_account(user_id: int) -> utils.BackofficeResponse:
         flash(utils.build_form_error_msg(form), "warning")
         return redirect(url_for("backoffice_web.public_accounts.get_public_account", user_id=user_id), code=303)
 
+    if users_api.has_unprocessed_extract(user):
+        flash("L'utilisateur possède une extraction qui est toujours en cours de traitement.", "warning")
+        return redirect(url_for(".get_public_account", user_id=user_id))
+
     user_anonymized = users_api.anonymize_user(user, author=current_user, force=True)
     if not user_anonymized:
         flash("Une erreur est survenue lors de l'anonymisation de l'utilisateur", "warning")
         return redirect(url_for(".get_public_account", user_id=user_id))
 
-    db.session.commit()
+    db.session.flush()
 
     flash("Les informations de l'utilisateur ont été anonymisées", "success")
-
     return redirect(url_for(".get_public_account", user_id=user_id))
 
 

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -2001,7 +2001,9 @@ class AnonymizeProUserTest:
         delete_beamer_user_mock.assert_called_once_with(user_id)
 
 
-class AnonymizeBeneficiaryUsersTest:
+class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
+    storage_folder = settings.LOCAL_STORAGE_DIR / settings.GCP_GDPR_EXTRACT_BUCKET / settings.GCP_GDPR_EXTRACT_FOLDER
+
     def import_iris(self):
         path = DATA_DIR / "iris_min.7z"
         geography_api.import_iris_from_7z(str(path))
@@ -2017,6 +2019,28 @@ class AnonymizeBeneficiaryUsersTest:
             firstName="user_underage_beneficiary_to_anonymize",
             age=17,
             lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+        )
+        user_with_ready_gdpr_extract_to_anonymize = users_factories.BeneficiaryFactory(
+            firstName="user_beneficiary_to_anonymize",
+            age=18,
+            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            gdprUserDataExtract=[
+                users_factories.GdprUserDataExtractBeneficiaryFactory(
+                    dateProcessed=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+                )
+            ],
+            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+        )
+        user_with_expired_gdpr_extract_to_anonymize = users_factories.BeneficiaryFactory(
+            firstName="user_beneficiary_to_anonymize",
+            age=18,
+            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            gdprUserDataExtract=[
+                users_factories.GdprUserDataExtractBeneficiaryFactory(
+                    dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=8)
+                )
+            ],
             deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
         )
         user_too_new = users_factories.BeneficiaryFactory(
@@ -2048,11 +2072,18 @@ class AnonymizeBeneficiaryUsersTest:
         self.import_iris()
         iris = geography_models.IrisFrance.query.first()
 
+        with open(
+            self.storage_folder / f"{user_with_expired_gdpr_extract_to_anonymize.gdprUserDataExtract[0].id}.zip", "wb"
+        ):
+            pass
+
         with mock.patch("pcapi.core.users.api.get_iris_from_address", return_value=iris):
             users_api.anonymize_beneficiary_users(force=False)
 
         db.session.refresh(user_beneficiary_to_anonymize)
         db.session.refresh(user_underage_beneficiary_to_anonymize)
+        db.session.refresh(user_with_ready_gdpr_extract_to_anonymize)
+        db.session.refresh(user_with_expired_gdpr_extract_to_anonymize)
         db.session.refresh(user_too_new)
         db.session.refresh(user_deposit_too_new)
         db.session.refresh(user_never_connected)
@@ -2061,10 +2092,15 @@ class AnonymizeBeneficiaryUsersTest:
         db.session.refresh(user_pass_culture)
         db.session.refresh(user_anonymized)
 
-        assert len(sendinblue_testing.sendinblue_requests) == 2
-        assert len(batch_testing.requests) == 2
+        assert len(sendinblue_testing.sendinblue_requests) == 4
+        assert len(batch_testing.requests) == 4
         user_id_set = set(request["user_id"] for request in batch_testing.requests)
-        assert user_id_set == {user_beneficiary_to_anonymize.id, user_underage_beneficiary_to_anonymize.id}
+        assert user_id_set == {
+            user_beneficiary_to_anonymize.id,
+            user_underage_beneficiary_to_anonymize.id,
+            user_with_ready_gdpr_extract_to_anonymize.id,
+            user_with_expired_gdpr_extract_to_anonymize.id,
+        }
 
         # these profiles should not have been anonymized
         assert user_too_new.firstName == "user_too_new"
@@ -2074,8 +2110,14 @@ class AnonymizeBeneficiaryUsersTest:
         assert user_pro.firstName == "user_pro"
         assert user_pass_culture.firstName == "user_pass_culture"
         assert user_anonymized.firstName == "user_anonymized"
+        assert len(os.listdir(self.storage_folder)) == 0
 
-        for user_to_anonymize in [user_beneficiary_to_anonymize, user_underage_beneficiary_to_anonymize]:
+        for user_to_anonymize in [
+            user_beneficiary_to_anonymize,
+            user_underage_beneficiary_to_anonymize,
+            user_with_ready_gdpr_extract_to_anonymize,
+            user_with_expired_gdpr_extract_to_anonymize,
+        ]:
             for beneficiary_fraud_check in user_to_anonymize.beneficiaryFraudChecks:
                 assert beneficiary_fraud_check.resultContent == None
                 assert beneficiary_fraud_check.reason == "Anonymized"
@@ -2089,6 +2131,13 @@ class AnonymizeBeneficiaryUsersTest:
 
             for deposit in user_to_anonymize.deposits:
                 assert deposit.source == "Anonymized"
+
+            assert (
+                users_models.GdprUserDataExtract.query.filter(
+                    users_models.GdprUserDataExtract.userId == user_to_anonymize.id
+                ).count()
+                == 0
+            )
 
             assert user_to_anonymize.email == f"anonymous_{user_to_anonymize.id}@anonymized.passculture"
             assert user_to_anonymize.password == b"Anonymized"
@@ -2146,6 +2195,27 @@ class AnonymizeBeneficiaryUsersTest:
 
         assert len(sendinblue_testing.sendinblue_requests) == 0
         assert user_to_anonymize.firstName == "user_to_anonymize"
+
+    def test_anonymize_beneficiary_user_with_unprocessed_gdpr_extract(self) -> None:
+        user_beneficiary_to_anonymize = users_factories.BeneficiaryFactory(
+            firstName="user_beneficiary_to_anonymize",
+            age=18,
+            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            gdprUserDataExtract=[users_factories.GdprUserDataExtractBeneficiaryFactory()],
+            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+        )
+
+        self.import_iris()
+        iris = geography_models.IrisFrance.query.first()
+
+        with mock.patch("pcapi.core.users.api.get_iris_from_address", return_value=iris):
+            users_api.anonymize_beneficiary_users(force=False)
+
+        db.session.refresh(user_beneficiary_to_anonymize)
+
+        assert len(sendinblue_testing.sendinblue_requests) == 0
+        assert user_beneficiary_to_anonymize.firstName == "user_beneficiary_to_anonymize"
+        assert users_models.GdprUserDataExtract.query.count() == 1
 
     def test_anonymize_beneficiary_user_no_addr_api(self) -> None:
         user_to_anonymize = users_factories.BeneficiaryFactory(

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import re
 from unittest import mock
 
@@ -7,6 +8,7 @@ from flask import url_for
 import pytest
 import pytz
 
+from pcapi import settings
 from pcapi.core import token as token_utils
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.categories import subcategories_v2 as subcategories
@@ -54,6 +56,8 @@ from pcapi.routes.backoffice.accounts.blueprint import get_eligibility_history
 from pcapi.routes.backoffice.accounts.blueprint import get_public_account_history
 from pcapi.tasks.serialization import gdpr_tasks
 from pcapi.utils import email as email_utils
+
+from tests.test_utils import StorageFolderManager
 
 from .helpers import button as button_helpers
 from .helpers import html_parser
@@ -2453,10 +2457,11 @@ class RegistrationStepTest:
         assert tunnel_end["progress"] == 100
 
 
-class AnonymizePublicAccountTest(PostEndpointHelper):
+class AnonymizePublicAccountTest(PostEndpointHelper, StorageFolderManager):
     endpoint = "backoffice_web.public_accounts.anonymize_public_account"
     endpoint_kwargs = {"user_id": 1}
     needed_permission = perm_models.Permissions.ANONYMIZE_PUBLIC_ACCOUNT
+    storage_folder = settings.LOCAL_STORAGE_DIR / settings.GCP_GDPR_EXTRACT_BUCKET / settings.GCP_GDPR_EXTRACT_FOLDER
 
     def test_anonymize_public_account(
         self,
@@ -2478,6 +2483,60 @@ class AnonymizePublicAccountTest(PostEndpointHelper):
         assert history.actionType == history_models.ActionType.USER_ANONYMIZED
         assert history.authorUser == legit_user
         assert history.user == user
+
+        response = authenticated_client.get(response.location)
+        assert "Les informations de l'utilisateur ont été anonymisées" in html_parser.extract_alert(response.data)
+
+    def test_anonymize_public_account_with_gdpr_extract(
+        self,
+        legit_user,
+        authenticated_client,
+    ):
+        user = users_factories.UserFactory(
+            gdprUserDataExtract=[
+                users_factories.GdprUserDataExtractBeneficiaryFactory(dateProcessed=datetime.datetime.today())
+            ]
+        )
+
+        with open(self.storage_folder / f"{user.gdprUserDataExtract[0].id}.zip", "wb"):
+            pass
+
+        response = self.post_to_endpoint(authenticated_client, user_id=user.id)
+        assert response.status_code == 302
+
+        expected_url = url_for("backoffice_web.public_accounts.get_public_account", user_id=user.id, _external=True)
+        assert response.location == expected_url
+
+        assert user.roles == [users_models.UserRole.ANONYMIZED]
+
+        assert users_models.GdprUserDataExtract.query.count() == 0
+        assert len(os.listdir(self.storage_folder)) == 0
+
+        response = authenticated_client.get(response.location)
+        assert "Les informations de l'utilisateur ont été anonymisées" in html_parser.extract_alert(response.data)
+
+    def test_anonymize_public_account_with_unprocessed_gdpr_extract(
+        self,
+        legit_user,
+        authenticated_client,
+    ):
+        user = users_factories.UserFactory(
+            gdprUserDataExtract=[users_factories.GdprUserDataExtractBeneficiaryFactory()]
+        )
+
+        response = self.post_to_endpoint(authenticated_client, user_id=user.id)
+        assert response.status_code == 302
+
+        expected_url = url_for("backoffice_web.public_accounts.get_public_account", user_id=user.id, _external=True)
+        assert response.location == expected_url
+
+        assert user.roles != [users_models.UserRole.ANONYMIZED]
+
+        response = authenticated_client.get(response.location)
+        assert (
+            "L'utilisateur possède une extraction qui est toujours en cours de traitement."
+            in html_parser.extract_alert(response.data)
+        )
 
     @pytest.mark.parametrize(
         "role",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29709

## Vérifications

### verification front 

None

### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 


Si l'utilisateur ne possède pas d'extract et que le reste des conditions sont remplie ( il peut etre anonymiser)
que l'on tente d'anonymiser l'utilisateur
la route redirige vers account, un flash retourne un succès ( j'ajoute ce flash dans les tests il n'y était pas ), l'utilisateur est bien anonymiser, la ligne extract est effacé, le fichier d'extract est effacé et un log (actionhistory) est crée.

Si l'utilisateur possède un ou plusieurs extract pret et que le reste des conditions sont remplie
que l'on tente d'anonymiser l'utilisateur
la route redirige vers account, un flash retourne un succès ( j'ajoute ce flash dans les tests il n'y était pas ), l'utilisateur est bien anonymiser, la ligne extract est effacé, le fichier d'extract est effacé et un log (actionhistory) est crée.

Si l'utilisateur possède un ou plusieurs extract et qu'au moins un extract est processed
que l'on tente d'anonymiser l'utilisateur _( le force est a True sur la route du bouton)_
la route redirige vers account, un flash retourne un warning avec message, l'utilisateur n'est pas anonymisé, la ligne d'extract n'est pas effacé, le fichier d'extract n'est pas effacé, aucun log actionhistory n'est crée

CONCERNANT LE CRON ET LES UTILISATEURS BENEFICIARY (anonymize_beneficiary_users):
SI un utilisateur possède un extract et que le reste des condition sont remplie (il peut etre anonymiser)
que l'on tente d'anonymiser l'utilisateur
La fonction ne retourne rien, l'utilisateur est anonymisé, le gdpr est supprimé, le fichier de l'extract est supprimé

SI un utilisateur possède un extract expiré et que le reste des condition sont remplie (il peut etre anonymiser)
que l'on tente d'anonymiser l'utilisateur
La fonction ne retourne rien, l'utilisateur est anonymisé, le gdpr est supprimé,  le fichier de l'extract est supprimé

SI un utilisateur possède un extract non expiré et non processed et que le reste des condition sont remplie 
que l'on tente d'anonymiser l'utilisateur
La fonction ne retourne rien, l'utilisateur n'est pas anonymisé, le gdpr est toujours présent,  le fichier de l'extract n'est pas présent ( car non processed)

CONCERNANT LE CRON ET LES UTILISATEURS NON_PRO_NON_BENEFICIARY
un non beneficiary ne peut pas avoir de gdpr car il n'est pas bénéficiary. 

CONCERNANT LE CRON ET LES UTILISATEURS PRO: ( un pro peut être bénéficiary)
mais la fonction gère en filtrant les beneficiary donc non 

### Verification ticket

- nom du ticket conforme -> OK
- auteur du ticket -> OK
- nombre de commit -> 2 ( mais j'arrive pas a comprendre comment un autre s'est inséré ni comment le retirer ) 
- nom du commit -> OK
- mettre le ticket en code-review -> OK

### Tache restante si WIP + AUTRE

- refresh de la page github -> OK






