### PR TITLE
(BSR)[BO] fix: prevent external call in invoices sandbox generator

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_commercial_gestures.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_commercial_gestures.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+from unittest.mock import patch
 
 from pcapi.core.bookings import api as bookings_api
 from pcapi.core.bookings import factories as bookings_factories
@@ -35,10 +36,11 @@ def _create_total_commercial_gesture_individual_offer(
             stock__price=decimal.Decimal("5.0"),
             stock__offer__venue=venue,
         )  # 200€
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
         finance_api.price_event(booking.finance_events[0])
 
     # Create the bookings and cancel them
@@ -50,15 +52,17 @@ def _create_total_commercial_gesture_individual_offer(
             stock__price=decimal.Decimal("10.1") + decimal.Decimal(i),
             quantity=1,
         )
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
         finance_api.price_event(booking.finance_events[0])
-        bookings_api.mark_as_cancelled(
-            booking=booking,
-            reason=bookings_models.BookingCancellationReasons.BACKOFFICE,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_cancelled(
+                booking=booking,
+                reason=bookings_models.BookingCancellationReasons.BACKOFFICE,
+            )
         for finance_event in booking.finance_events:
             if finance_event.status == finance_models.FinanceEventStatus.CANCELLED:
                 finance_api.price_event(finance_event)
@@ -73,10 +77,11 @@ def _create_total_commercial_gesture_individual_offer(
             stock__price=decimal.Decimal("99.9"),
             stock__offer__venue=venue,
         )
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
         finance_api.price_event(booking.finance_events[0])
 
     # Generate the commercial gestures
@@ -189,10 +194,11 @@ def _create_partial_commercial_gesture_multiple_individual_offer(
             stock__price=decimal.Decimal("5.0"),
             stock__offer__venue=venue,
         )  # 200€
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
 
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)
@@ -207,17 +213,19 @@ def _create_partial_commercial_gesture_multiple_individual_offer(
             stock__price=decimal.Decimal("10.1") + decimal.Decimal(i),
             quantity=1,
         )
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)
 
-        bookings_api.mark_as_cancelled(
-            booking=booking,
-            reason=bookings_models.BookingCancellationReasons.BACKOFFICE,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_cancelled(
+                booking=booking,
+                reason=bookings_models.BookingCancellationReasons.BACKOFFICE,
+            )
 
         for finance_event in booking.finance_events:
             if finance_event.status == finance_models.FinanceEventStatus.CANCELLED:
@@ -233,10 +241,11 @@ def _create_partial_commercial_gesture_multiple_individual_offer(
             stock__price=decimal.Decimal("99.9"),
             stock__offer__venue=venue,
         )
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)
 
@@ -275,10 +284,11 @@ def _generate_bookings_for_commercial_gesture_creation(venue: offerers_models.Ve
             stock__price=decimal.Decimal("5.0"),
             stock__offer__venue=venue,
         )  # 200€
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
 
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)
@@ -291,17 +301,19 @@ def _generate_bookings_for_commercial_gesture_creation(venue: offerers_models.Ve
             stock__price=decimal.Decimal("10.1") + decimal.Decimal(i),
             quantity=1,
         )
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)
 
-        bookings_api.mark_as_cancelled(
-            booking=booking,
-            reason=bookings_models.BookingCancellationReasons.BACKOFFICE,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_cancelled(
+                booking=booking,
+                reason=bookings_models.BookingCancellationReasons.BACKOFFICE,
+            )
 
         for finance_event in booking.finance_events:
             if finance_event.status == finance_models.FinanceEventStatus.CANCELLED:
@@ -315,10 +327,11 @@ def _generate_bookings_for_commercial_gesture_creation(venue: offerers_models.Ve
             stock__price=decimal.Decimal("99.9"),
             stock__offer__venue=venue,
         )
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_incidents.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_incidents.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import logging
+from unittest.mock import patch
 import uuid
 
 from pcapi.core.bookings import api as bookings_api
@@ -148,10 +149,11 @@ def _create_one_individual_incident(
 
     bookings = special_bookings + incident_bookings
     for booking in bookings:
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)
 
@@ -172,10 +174,11 @@ def _create_one_individual_incident(
             user__firstName=f"valent.incident_{uuid.uuid4()}@example.com",
         )
         for booking in new_bookings:
-            bookings_api.mark_as_used(
-                booking=booking,
-                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-            )
+            with patch("pcapi.core.bookings.api.update_external_user"):
+                bookings_api.mark_as_used(
+                    booking=booking,
+                    validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+                )
             finance_api.price_event(booking.finance_events[0])
 
     amount = None if len(bookings) > 1 else decimal.Decimal("10")

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from datetime import timedelta
 import logging
 import random
+from unittest.mock import patch
 
 from pcapi.connectors.big_query.queries.offerer_stats import DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE
 from pcapi.connectors.big_query.queries.offerer_stats import TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE
@@ -57,10 +58,11 @@ def create_free_invoice() -> None:
             stock=stock,
             user__deposit__source="create_free_invoice() in industrial sandbox",
         )
-        bookings_api.mark_as_used(
-            booking=booking,
-            validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
-        )
+        with patch("pcapi.core.bookings.api.update_external_user"):
+            bookings_api.mark_as_used(
+                booking=booking,
+                validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+            )
 
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)


### PR DESCRIPTION
## But de la pull request

Ne pas faire des appels à Batch lors de génération de justificatifs de remboursements dans la sandbox

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques