### PR TITLE
(BSR)[API] refactor: use sync job env var to enable cloud tasks

### DIFF
--- a/api/.env.rebuild_staging
+++ b/api/.env.rebuild_staging
@@ -14,3 +14,4 @@ SEARCH_BACKEND=pcapi.core.search.backends.testing.TestingBackend
 SIRENE_BACKEND=pcapi.connectors.entreprise.backends.testing.TestingBackend
 SMS_NOTIFICATION_BACKEND=pcapi.notifications.sms.backends.logger.LoggerBackend
 ZENDESK_SELL_BACKEND=pcapi.core.external.zendesk_sell_backends.logger.LoggerBackend
+IS_JOB_SYNCHRONOUS=1

--- a/api/src/pcapi/tasks/decorator.py
+++ b/api/src/pcapi/tasks/decorator.py
@@ -38,7 +38,7 @@ def task(
 
         @wraps(f)
         def delay(payload: pydantic_v1.BaseModel) -> None:
-            if settings.IS_RUNNING_TESTS or settings.IS_REBUILD_STAGING:
+            if settings.IS_JOB_SYNCHRONOUS:
                 f(payload)
                 return
 

--- a/api/tests/tasks/decorator_test.py
+++ b/api/tests/tasks/decorator_test.py
@@ -37,7 +37,7 @@ class CloudTaskDecoratorTest:
 
         assert slow_chouquette_handler.call_args_list == [mock.call(12), mock.call(12)]
 
-    @override_settings(IS_RUNNING_TESTS=False, IS_REBUILD_STAGING=True)
+    @override_settings(IS_REBUILD_STAGING=True)
     @mock.patch("pcapi.tasks.cloud_task.requests.post")
     def test_rebuild_staging_does_not_create_cloud_task(self, requests_post):
         # When rebuilding staging, we do not call any cloud_task
@@ -50,7 +50,7 @@ class CloudTaskDecoratorTest:
         assert slow_chouquette_handler.call_args_list == [mock.call(12), mock.call(12)]
 
     @mock.patch("pcapi.tasks.cloud_task.AUTHORIZATION_HEADER_VALUE", "Bearer secret-token")
-    @override_settings(IS_RUNNING_TESTS=False, IS_DEV=True)
+    @override_settings(IS_JOB_SYNCHRONOUS=False)
     @mock.patch("pcapi.tasks.cloud_task.requests.post")
     def test_calling_function_in_development_environment(self, requests_post):
         # When running locally ("development" environment), the
@@ -79,7 +79,7 @@ class CloudTaskDecoratorTest:
         )
 
     @mock.patch("pcapi.tasks.cloud_task.AUTHORIZATION_HEADER_VALUE", "Bearer secret-token")
-    @override_settings(IS_RUNNING_TESTS=False, CLOUD_TASK_CALL_INTERNAL_API_ENDPOINT=False)
+    @override_settings(IS_JOB_SYNCHRONOUS=False, CLOUD_TASK_CALL_INTERNAL_API_ENDPOINT=False)
     def test_calling_function_calls_google_cloud_tasks(self, cloud_task_client):
         # When running in production, the decorated function is not
         # directly executed. Instead, we call Google Cloud Tasks and


### PR DESCRIPTION
The development env will no longer call cloud tasks. Likewise, the sandbox script is executed in the dev env, so it will no longer call cloud tasks.