### PR TITLE
(PC-30514)[PRO] test: Check if we can choose a SIRET for venues witho…

### DIFF
--- a/pro/cypress/e2e/features/searchIndividualOffer.feature
+++ b/pro/cypress/e2e/features/searchIndividualOffer.feature
@@ -6,7 +6,7 @@ Feature: Search individual offers
     And I go to the "Offres" page
 
   Scenario: A search with a name should display expected results
-    When I search with the text "Offer 1868"
+    When I search with the text "Offer 1643"
     Then These results should be displayed
       |  |  | Titre      | Lieu                             | Stocks | Status     |
       |  |  | Offer 1643 | Cinéma du coin - Offre numérique | 0      | désactivée |

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/LinkVenuesDialog.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/LinkVenuesDialog.spec.tsx
@@ -161,6 +161,7 @@ describe('LinkVenueDialog', () => {
       'Une erreur est survenue. Merci de réessayer plus tard'
     )
   })
+
   it('should display banner if at least one venue has no pricing point', () => {
     const managedVenues = [
       { ...defaultManagedVenues, id: 1, hasPricingPoint: true },
@@ -172,5 +173,47 @@ describe('LinkVenueDialog', () => {
     expect(
       screen.getByText('Certains de vos lieux n’ont pas de SIRET')
     ).toBeInTheDocument()
+  })
+
+  it('should display "Sélectionner un SIRET" button for venue that has no pricing point', () => {
+    const managedVenues = [
+      {
+        ...defaultManagedVenues,
+        id: 1,
+        hasPricingPoint: false,
+        commonName: 'Lieu sans SIRET',
+      },
+    ]
+
+    renderLinkVenuesDialog(1, defaultBankAccount, managedVenues)
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Lieu sans SIRET' })
+    ).toBeDisabled()
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Sélectionner un SIRET',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('should not display "Sélectionner un SIRET" button for venue that has pricing point', () => {
+    const managedVenues = [
+      {
+        ...defaultManagedVenues,
+        id: 1,
+        hasPricingPoint: true,
+        commonName: 'Lieu avec SIRET',
+      },
+    ]
+
+    renderLinkVenuesDialog(1, defaultBankAccount, managedVenues)
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Lieu avec SIRET' })
+    ).toBeEnabled()
+
+    expect(screen.queryByText('Sélectionner un SIRET')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30514

Il manquait des tests pour vérifier si un lieu sans SIRET permettait d'en choisir un, et inverrsement de ne pas pouvoir cocher un lieu sans SIRET sans en avoir choisi un au préalable.

![image](https://github.com/pass-culture/pass-culture-main/assets/171674396/0ff7c1f4-5f3b-44d4-b65e-5beb33a3e7e9)

## Vérifications

- [x] J'ai écrit les tests nécessaires