### PR TITLE
(BSR)[PRO] feat: convert query args to dict with list of values

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/offers.py
@@ -119,7 +119,6 @@ def get_collective_offer_template(
     response_model=serializers.ListCollectiveOfferTemplateResponseModel,
     api=blueprint.api,
     on_error_statuses=[404],
-    flatten=True,
 )
 @adage_jwt_required
 def get_collective_offer_templates(

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -6,7 +6,6 @@ import logging
 import typing
 
 from pydantic.v1 import Field
-from pydantic.v1 import root_validator
 from pydantic.v1.class_validators import validator
 
 import pcapi.core.categories.subcategories_v2 as subcategories
@@ -383,14 +382,3 @@ class PostCollectiveRequestBodyModel(BaseModel):
 
 class GetTemplateIdsModel(BaseModel):
     ids: typing.Sequence[int]
-
-    @root_validator(pre=True)
-    def format_ids(cls, values: dict) -> dict:
-        ids = values.get("ids")
-        if not ids:
-            return values
-
-        if not isinstance(ids, list):
-            values["ids"] = [ids]
-
-        return values

--- a/api/src/pcapi/routes/pro/finance.py
+++ b/api/src/pcapi/routes/pro/finance.py
@@ -64,7 +64,6 @@ def has_invoice(query: finance_serialize.HasInvoiceQueryModel) -> finance_serial
         "Content-Type": "application/pdf; charset=utf-8;",
         "Content-Disposition": "attachment; filename=justificatifs_de_remboursement.pdf",
     },
-    flatten=True,
 )
 def get_combined_invoices(query: finance_serialize.CombinedInvoiceListModel) -> bytes:
     invoices = finance_repository.get_invoices_by_references(query.invoiceReferences)

--- a/api/src/pcapi/routes/pro/reimbursements.py
+++ b/api/src/pcapi/routes/pro/reimbursements.py
@@ -65,7 +65,6 @@ def _get_reimbursements_csv_filter(user: User, query: ReimbursementCsvQueryModel
         "Content-Disposition": "attachment; filename=remboursements_pass_culture.csv",
     },
     api=blueprint.pro_private_schema,
-    flatten=True,
 )
 def get_reimbursements_csv_v2(query: ReimbursementCsvByInvoicesModel) -> bytes:
     reimbursement_details_csv = _get_reimbursments_csv_filter_by_invoices(current_user, query)

--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -61,12 +61,6 @@ class InvoiceResponseV2Model(BaseModel):
 class CombinedInvoiceListModel(BaseModel):
     invoiceReferences: list[str]
 
-    @pydantic_v1.validator("invoiceReferences", pre=True)
-    def ensure_list(cls, v: list[str] | str) -> list[str]:
-        if isinstance(v, str):
-            return [v]
-        return v
-
 
 class InvoiceListV2ResponseModel(BaseModel):
     __root__: list[InvoiceResponseV2Model]

--- a/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
+++ b/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
@@ -7,7 +7,6 @@ import typing
 from typing import Callable
 from typing import Iterable
 
-from pydantic.v1 import validator
 from pydantic.v1.main import BaseModel
 import pytz
 
@@ -272,9 +271,3 @@ class ReimbursementCsvQueryModel(BaseModel):
 
 class ReimbursementCsvByInvoicesModel(BaseModel):
     invoicesReferences: list[str]
-
-    @validator("invoicesReferences", pre=True)
-    def ensure_invoices_references_is_list(cls, v: list[str] | str) -> list[str]:
-        if isinstance(v, str):
-            return [v]
-        return v

--- a/api/tests/routes/pro/get_all_collective_offers_test.py
+++ b/api/tests/routes/pro/get_all_collective_offers_test.py
@@ -289,7 +289,7 @@ class Returns200Test:
 
         # When
         response = client.with_session_auth(user.email).get(
-            "/collective/offers?periodBeginningDate=2022-10-10&periodEndingDate=2022-10-11"
+            "/collective/offers?periodBeginningDate=2022-10-10&periodEndingDate=2022-10-11&status=PREBOOKED&status=BOOKED"
         )
 
         # Then


### PR DESCRIPTION
## But de la pull request

Use the schema provided by Pydantic to check whether a field is a list or not and use the proper method accordingly. This will only work on query arguments and is because there is no way to know from the query arguments whether one key is a list of values or a single value.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques