### PR TITLE
(BSR)[BO] fix: mock adage call in industrial incidents sandbox generator

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_incidents.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_incidents.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import logging
+from unittest.mock import patch
 import uuid
 
 from pcapi.core.bookings import api as bookings_api
@@ -301,11 +302,12 @@ def _create_one_collective_incident(
             author=pro,
             origin=comment,
         )
-        finance_api.validate_finance_overpayment_incident(
-            finance_incident=finance_incident,
-            force_debit_note=force_debit_note,
-            author=pro,
-        )
+        with patch("pcapi.core.finance.api.educational_api_booking.notify_reimburse_collective_booking"):
+            finance_api.validate_finance_overpayment_incident(
+                finance_incident=finance_incident,
+                force_debit_note=force_debit_note,
+                author=pro,
+            )
         for booking_finance_incident in finance_incident.booking_finance_incidents:
             for finance_event in booking_finance_incident.finance_events:
                 finance_api.price_event(finance_event)


### PR DESCRIPTION
## But de la pull request

Prévenir les appels vers adage lors de la génération de justificatifs de remboursement dans la sandbox

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques