### PR TITLE
(BSR)[API] fix: users generation

### DIFF
--- a/api/src/pcapi/scripts/beneficiary/import_test_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_test_users.py
@@ -245,7 +245,7 @@ def _add_or_update_admin(update_if_exists: bool) -> None:
 def _create_provider(venue: offerers_models.Venue, row: dict) -> None:
     provider = providers_models.Provider(name=row["Prénom"])
     offerer_provider = offerers_models.OffererProvider(offerer=venue.managingOfferer, provider=provider)
-    prefix = f"staging_{row['Prénom']}"
+    prefix = f"staging_{row['Mail']}"
     key = offerers_models.ApiKey(
         offerer=venue.managingOfferer, provider=provider, prefix=prefix, secret=crypto.hash_public_api_key(row["Mail"])
     )

--- a/api/tests/scripts/beneficiary/import_test_users_test.py
+++ b/api/tests/scripts/beneficiary/import_test_users_test.py
@@ -29,6 +29,7 @@ BOUNTY_FIRST_NAME = "Hackèrman"
 BOUNTY_CSV = f"""Nom,Prénom,Mail,Téléphone,Département,Code postal,Date de naissance,Role,SIREN,Mot de passe,Type
 Doux,{BOUNTY_FIRST_NAME},{BOUNTY_EMAIL},0102030405,86,86140,2000-01-01,PRO,10000135,,externe:bug-bounty
 Dur,Hubert,touriste@mars.org,0102030405,86,86140,2000-01-01,PRO,10000115,,interne:test
+Dur,{BOUNTY_FIRST_NAME},another_hunter@bugbounty.ninja,0102030405,86,86140,2000-01-01,PRO,10000105,,externe:bug-bounty
 """
 
 
@@ -129,7 +130,7 @@ class ReadFileTest:
         csv_file = io.StringIO(BOUNTY_CSV)
         import_test_users.create_users_from_csv(csv_file)
 
-        prefix = f"staging_{BOUNTY_FIRST_NAME}"
+        prefix = f"staging_{BOUNTY_EMAIL}"
         api_key = offerers_models.ApiKey.query.filter_by(prefix=prefix).one()
         assert crypto.hash_public_api_key(BOUNTY_EMAIL) == api_key.secret
 


### PR DESCRIPTION
There is a unique constraint on ApiKey.prefix but multiple users have the same "Prénom". 
In our file email is unique, let's use that. Fix [this issue](https://sentry.passculture.team/organizations/sentry/issues/1615506/?referrer=slack)

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques