### PR TITLE
(PC-30450)[API] fix: add csrf protection to discord auth

### DIFF
--- a/api/src/pcapi/app.py
+++ b/api/src/pcapi/app.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from flask_jwt_extended import JWTManager
+from flask_wtf.csrf import CSRFProtect
 from sentry_sdk import set_tag
 
 from pcapi import settings
@@ -22,6 +23,8 @@ app.config["JWT_ACCESS_TOKEN_EXPIRES"] = settings.JWT_ACCESS_TOKEN_EXPIRES
 app.config["WTF_CSRF_ENABLED"] = False
 
 jwt = JWTManager(app)
+csrf = CSRFProtect()
+csrf.init_app(app)
 
 
 with app.app_context():

--- a/api/src/pcapi/routes/auth/discord.py
+++ b/api/src/pcapi/routes/auth/discord.py
@@ -4,6 +4,7 @@ import urllib
 from flask import redirect
 from flask import render_template
 from flask import request
+from flask_wtf.csrf import CSRFProtect
 from werkzeug.wrappers.response import Response
 
 from pcapi import settings
@@ -37,6 +38,8 @@ def discord_signin() -> str:
 
 @blueprint.auth_blueprint.route("/discord/signin", methods=["POST"])
 def discord_signin_post() -> str | Response | None:
+    csrf = CSRFProtect()
+    csrf.protect()
     form = SigninForm()
     if not form.validate():
         form.error_message = "Identifiant ou Mot de passe incorrect"

--- a/api/src/pcapi/routes/auth/templates/discord_signin.html
+++ b/api/src/pcapi/routes/auth/templates/discord_signin.html
@@ -18,6 +18,8 @@
                     </div>
                     <form action="{{ url_for('.discord_signin_post') }}" name="{{ url_for('.discord_signin_post') }}" method="post" data-turbo="false">
                         {{ form.redirect_url }}
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
                         <div class=" col-10 gap-2 w-2  items-center">
                             <div>
                                 {{ form.redirect_url }}

--- a/api/tests/routes/auth/discord_test.py
+++ b/api/tests/routes/auth/discord_test.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from flask import g
 from flask import url_for
 import pytest
 
@@ -34,6 +35,10 @@ class DiscordSigninTest:
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     )
 
+    def fetch_csrf_token(self, client):
+        # will generate a csrf token
+        client.get(url_for("auth.discord_signin"))
+
     def post_to_endpoint(
         self,
         client,
@@ -43,12 +48,12 @@ class DiscordSigninTest:
         expected_num_queries: int | None = None,
         **url_kwargs,
     ):
-
+        self.fetch_csrf_token(client)
         url = url_for(self.endpoint, **url_kwargs)
 
         if form is None:
             form = {}
-
+        form["csrf_token"] = g.get("csrf_token", None)
         if expected_num_queries is not None:
             with assert_num_queries(expected_num_queries):
                 return client.post(url, form=form, headers=headers, follow_redirects=follow_redirects)


### PR DESCRIPTION
This feature was reverted by this pr: https://github.com/pass-culture/pass-culture-main/pull/12828

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30450

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques