### PR TITLE
(BSR)[PRO] test: For parallelization using cypress cloud (activated only for runs on master)

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -23,6 +23,10 @@ jobs:
   tests-pro-e2e-tests:
     name: "E2E tests"
     runs-on: ubuntu-latest
+    # strategy: # parallélisation pour Cypress Cloud
+    #   fail-fast: false
+    #   matrix:
+    #     containers: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4.1.7
       - name: "Authentification to Google"
@@ -130,6 +134,7 @@ jobs:
           browser: chrome
           config-file: cypress/cypress.config.ts
           env: TAGS="@P0"
+          # parallel: ${{ github.ref != 'refs/heads/master' }} # pour Cypress Cloud
           record: ${{ github.ref == 'refs/heads/master' }} # pour Cypress Cloud
         env:
           CYPRESS_RECORD_KEY: ${{ steps.secrets.outputs.CYPRESS_CLOUD_RECORD_KEY }}


### PR DESCRIPTION
## But de la pull request

Besoin d'activer la parallélisation sur 4 machines uniquement pour les jobs sur master....besoin d'aide pour faire ça dans `.github/workflows/dev_on_workflow_tests_pro_e2e.yml`

Ce qu'il faut activer seulement pour master est en commentaire dans le commit

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques