### PR TITLE
(BSR)[PRO] test: We should not wait for a GET /venue-types

### DIFF
--- a/pro/cypress/e2e/step-definitions/venue.cy.ts
+++ b/pro/cypress/e2e/step-definitions/venue.cy.ts
@@ -71,15 +71,9 @@ When('I add venue without Siret details', () => {
 })
 
 When('I validate venue step', () => {
-  cy.intercept({ method: 'GET', url: '/venue-types' }).as('getVenues')
   cy.intercept({ method: 'POST', url: '/venues' }).as('postVenues')
   cy.findByText('Enregistrer et créer le lieu').click()
-  cy.wait(['@getVenues', '@postVenues']).then((interception) => {
-    if (interception[0].response)
-      expect(interception[0].response.statusCode).to.equal(200)
-    if (interception[1].response)
-      expect(interception[1].response.statusCode).to.equal(201)
-  })
+  cy.wait('@postVenues').its('response.statusCode').should('eq', 201)
 })
 
 When('I add venue with Siret details', () => {


### PR DESCRIPTION
## But de la pull request

Suite à 1 échec (3 fois de suite avec le retry) sur master, le `GET venue-type` n'est pas toujours présent ici, je le supprime donc.

Voir https://cloud.cypress.io/projects/rit5sb/runs/43/overview/cb1e2567-cca1-4b3f-b202-0cd8d01e6041/replay?att=1&roarHideRunsWithDiffGroupsAndTags=1&ts=1719421101022.7808

![CleanShot 2024-06-27 at 10 42 01@2x](https://github.com/pass-culture/pass-culture-main/assets/168726433/c83eceff-bd3a-4b69-8970-5cb08595e42f)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques