### PR TITLE
(PC-30329)[API] feat: remove wip_enable_new_nav_ab_test ff and stop ff

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 e92c101b449f (pre) (head)
-17aa8cf97ab4 (post) (head)
+4b41a69dfe71 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240625T151325_4b41a69dfe71_remove_ff_wip_enable_new_nav_ab_test.py
+++ b/api/src/pcapi/alembic/versions/20240625T151325_4b41a69dfe71_remove_ff_wip_enable_new_nav_ab_test.py
@@ -1,0 +1,32 @@
+"""
+remove WIP_ENABLE_NEW_NAV_AB_TEST
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4b41a69dfe71"
+down_revision = "17aa8cf97ab4"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def get_flag():  # type: ignore[no-untyped-def]
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="ENABLE_FRATIBULATION",
+        isActive=True,
+        description="Activer l'A/B test de la nouvelle navigation du portail pro.",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -874,13 +874,12 @@ def create_pro_user(pro_user: ProUserCreationBodyV2Model) -> models.User:
                 newNavDate=datetime.datetime.utcnow(),
             )
             db.session.add(new_nav_pro)
-    elif feature.FeatureToggle.WIP_ENABLE_NEW_NAV_AB_TEST.is_active():
-        if new_pro_user.id % 2 == 0:
-            new_nav_pro = users_models.UserProNewNavState(
-                userId=new_pro_user.id,
-                newNavDate=datetime.datetime.utcnow(),
-            )
-            db.session.add(new_nav_pro)
+    else:
+        new_nav_pro = users_models.UserProNewNavState(
+            userId=new_pro_user.id,
+            newNavDate=datetime.datetime.utcnow(),
+        )
+        db.session.add(new_nav_pro)
 
     return new_pro_user
 

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -114,7 +114,6 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_NATIONAL_PROGRAM_NEW_RULES_PUBLIC_API = (
         "Activer les nouvelles règles de création et d'édition d'offres collecrives pour l'API publique (collective)"
     )
-    WIP_ENABLE_NEW_NAV_AB_TEST = "Activer l'A/B test de la nouvelle navigation du portail pro."
     WIP_SYNCHRONIZE_CINEMA_STOCKS_WITH_ALLOCINE_PRODUCTS = (
         "Synchroniser les offres et stocks de cinéma avec les produits allociné"
     )
@@ -182,7 +181,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_BENEFICIARY_EXTRACT_TOOL,
     FeatureToggle.WIP_CONNECT_AS,
     FeatureToggle.WIP_ENABLE_MOCK_UBBLE,
-    FeatureToggle.WIP_ENABLE_NEW_NAV_AB_TEST,
     FeatureToggle.WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY,
     FeatureToggle.WIP_ENABLE_TITELIVE_API_FOR_BOOKS,
     FeatureToggle.WIP_SYNCHRONIZE_CINEMA_STOCKS_WITH_ALLOCINE_PRODUCTS,

--- a/api/tests/routes/pro/signup_pro_V2_test.py
+++ b/api/tests/routes/pro/signup_pro_V2_test.py
@@ -8,7 +8,6 @@ import pcapi.core.history.models as history_models
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offerers.factories import OffererInvitationFactory
-from pcapi.core.testing import override_features
 from pcapi.core.users.factories import ProFactory
 from pcapi.core.users.factories import UserProNewNavStateFactory
 from pcapi.core.users.models import User
@@ -65,46 +64,44 @@ class Returns204Test:
         assert mails_testing.outbox[0]["To"] == user.email
         assert mails_testing.outbox[0]["template"] == asdict(TransactionalEmail.EMAIL_VALIDATION_TO_PRO.value)
 
-    @override_features(WIP_ENABLE_NEW_NAV_AB_TEST=True)
-    def test_user_inherit_new_nav_by_id_repartition_for_ab_test(self, client):
+    def test_new_user_should_always_have_NPP(self, client):
         data = BASE_DATA_PRO.copy()
         emails = ["user1@example.com", "user2@example.com"]
         for email in emails:
             response = client.post("/v2/users/signup/pro", json=data | {"email": email})
             assert response.status_code == 204
         users = User.query.options(joinedload(User.pro_new_nav_state)).filter(User.pro_new_nav_state.has()).all()
-        assert len(users) == 1
-        assert users[0].pro_new_nav_state.eligibilityDate is None
-        assert users[0].pro_new_nav_state.newNavDate is not None
+        assert len(users) == 2
+        for user in users:
+            assert user.pro_new_nav_state.eligibilityDate is None
+            assert user.pro_new_nav_state.newNavDate is not None
 
-    @pytest.mark.parametrize("ff_state", [True, False])
-    def test_user_inherit_new_nav_for_inviter(self, client, ff_state):
+    def test_user_inherit_new_nav_for_inviter(self, client):
         """Test the new navigation activation at creation. Only the newNavDate is set
         The eligibilityDate is used to distinguish between the beta test dans the A/B test so It should only be set manually
         """
-        with override_features(WIP_ENABLE_NEW_NAV_AB_TEST=ff_state):
-            inviter_with_new_nav = UserProNewNavStateFactory(newNavDate=datetime.utcnow()).user
-            invitation_with_new_nav = OffererInvitationFactory(user=inviter_with_new_nav)
-            inviter_with_old_nav = UserProNewNavStateFactory(newNavDate=None).user
-            invitation_with_old_nav = OffererInvitationFactory(user=inviter_with_old_nav)
-            inviter_without_nav_state = ProFactory()
-            invitation_without_nav_state = OffererInvitationFactory(user=inviter_without_nav_state)
-            data = BASE_DATA_PRO.copy()
-            response = client.post("/v2/users/signup/pro", json=data | {"email": invitation_with_new_nav.email})
-            assert response.status_code == 204
-            user_invited = User.query.filter_by(email=invitation_with_new_nav.email).one()
-            assert user_invited.pro_new_nav_state.eligibilityDate is None
-            assert user_invited.pro_new_nav_state.newNavDate is not None
+        inviter_with_new_nav = UserProNewNavStateFactory(newNavDate=datetime.utcnow()).user
+        invitation_with_new_nav = OffererInvitationFactory(user=inviter_with_new_nav)
+        inviter_with_old_nav = UserProNewNavStateFactory(newNavDate=None).user
+        invitation_with_old_nav = OffererInvitationFactory(user=inviter_with_old_nav)
+        inviter_without_nav_state = ProFactory()
+        invitation_without_nav_state = OffererInvitationFactory(user=inviter_without_nav_state)
+        data = BASE_DATA_PRO.copy()
+        response = client.post("/v2/users/signup/pro", json=data | {"email": invitation_with_new_nav.email})
+        assert response.status_code == 204
+        user_invited = User.query.filter_by(email=invitation_with_new_nav.email).one()
+        assert user_invited.pro_new_nav_state.eligibilityDate is None
+        assert user_invited.pro_new_nav_state.newNavDate is not None
 
-            response = client.post("/v2/users/signup/pro", json=data | {"email": invitation_with_old_nav.email})
-            assert response.status_code == 204
-            user_invited = User.query.filter_by(email=invitation_with_old_nav.email).one()
-            assert user_invited.pro_new_nav_state is None
+        response = client.post("/v2/users/signup/pro", json=data | {"email": invitation_with_old_nav.email})
+        assert response.status_code == 204
+        user_invited = User.query.filter_by(email=invitation_with_old_nav.email).one()
+        assert user_invited.pro_new_nav_state is None
 
-            response = client.post("/v2/users/signup/pro", json=data | {"email": invitation_without_nav_state.email})
-            assert response.status_code == 204
-            user_invited = User.query.filter_by(email=invitation_without_nav_state.email).one()
-            assert user_invited.pro_new_nav_state is None
+        response = client.post("/v2/users/signup/pro", json=data | {"email": invitation_without_nav_state.email})
+        assert response.status_code == 204
+        user_invited = User.query.filter_by(email=invitation_without_nav_state.email).one()
+        assert user_invited.pro_new_nav_state is None
 
     def when_successful_and_mark_pro_user_as_no_cultural_survey_needed(self, client):
         data = BASE_DATA_PRO.copy()


### PR DESCRIPTION
no NPP activation by id parity and FF removal. The behavior for invitation remain

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30329

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques