### PR TITLE
(PC-30064)[PRO] feat: add onboarding banner to explain new archiving feature

### DIFF
--- a/pro/src/pages/Offers/Offers/Offers.module.scss
+++ b/pro/src/pages/Offers/Offers/Offers.module.scss
@@ -2,10 +2,6 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_size.scss" as size;
 
-.offers-count {
-  margin-bottom: rem.torem(32px);
-}
-
 .offers-pagination {
   margin-top: rem.torem(32px);
 }

--- a/pro/src/pages/Offers/Offers/Offers.scss
+++ b/pro/src/pages/Offers/Offers/Offers.scss
@@ -39,7 +39,7 @@
   }
 
   form {
-    margin-bottom: rem.torem(20px);
+    margin-bottom: rem.torem(32px);
   }
 
   .form-row {

--- a/pro/src/pages/Offers/Offers/Offers.tsx
+++ b/pro/src/pages/Offers/Offers/Offers.tsx
@@ -89,7 +89,7 @@ export const Offers = ({
             </Banner>
           )}
           {hasOffers && (
-            <div className={styles['offers-count']}>
+            <div>
               {`${getOffersCountToDisplay(offersCount)} ${
                 offersCount <= 1 ? 'offre' : 'offres'
               }`}

--- a/pro/src/screens/Offers/Offers.module.scss
+++ b/pro/src/screens/Offers/Offers.module.scss
@@ -1,0 +1,16 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.banner {
+    margin-bottom: rem.torem(16px);
+
+    &-onboarding {
+        display: flex;
+        flex-direction: column;
+        gap: rem.torem(8px);
+    
+        &-title {
+            @include fonts.button
+        }
+    }
+}

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -9,6 +9,8 @@ import {
   ListOffersOfferResponseModel,
   UserRole,
 } from 'apiClient/v1'
+import { Callout } from 'components/Callout/Callout'
+import { CalloutVariant } from 'components/Callout/types'
 import { NoData } from 'components/NoData/NoData'
 import { GET_VALIDATED_OFFERERS_NAMES_QUERY_KEY } from 'config/swrQueryKeys'
 import { isOfferEducational } from 'core/OfferEducational/types'
@@ -41,6 +43,7 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 import { Tabs } from 'ui-kit/Tabs/Tabs'
 import { Titles } from 'ui-kit/Titles/Titles'
 
+import styles from './Offers.module.scss'
 import { SearchFilters } from './SearchFilters/SearchFilters'
 
 export type OffersProps = {
@@ -298,6 +301,31 @@ export const Offers = ({
         venues={venues}
         isRestrictedAsAdmin={isRestrictedAsAdmin}
       />
+      {Audience.COLLECTIVE === audience && (
+        <Callout
+          className={styles['banner']}
+          variant={CalloutVariant.INFO}
+          links={[
+            {
+              href: 'https://aide.passculture.app/hc/fr/articles/4416082284945--Acteurs-Culturels-Quel-est-le-cycle-de-vie-de-votre-offre-collective-de-sa-cr%C3%A9ation-%C3%A0-son-remboursement',
+              label: 'En savoir plus sur les statuts',
+              isExternal: true,
+            },
+          ]}
+        >
+          <div className={styles['banner-onboarding']}>
+            <span className={styles['banner-onboarding-title']}>
+              C’est nouveau ! Vous pouvez désormais archiver vos offres
+              collectives.
+            </span>
+            <span>
+              Cliquez sur le bouton “Actions” pour archiver vos offres. Elles ne
+              seront plus visibles sur ADAGE. Vous pourrez les retrouver en
+              filtrant sur le statut “Archivée”.{' '}
+            </span>
+          </div>
+        </Callout>
+      )}
       {userHasNoOffers ? (
         <NoData page="offers" />
       ) : (

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -622,4 +622,24 @@ describe('screen Offers', () => {
     })
     expect(screen.queryByText(/Créer une offre/)).not.toBeInTheDocument()
   })
+
+  it('should display onboarding banner for archivage only in collective offer list', () => {
+    renderOffers({ ...props, audience: Audience.COLLECTIVE, offers: [] })
+
+    expect(
+      screen.getByText(
+        'C’est nouveau ! Vous pouvez désormais archiver vos offres collectives.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should not display onboarding banner for archivage when we are in individual offer list ', () => {
+    renderOffers(props)
+
+    expect(
+      screen.queryByText(
+        'C’est nouveau ! Vous pouvez désormais archiver vos offres collectives.'
+      )
+    ).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30064

Ajout d'une nouvelle bannière avant la liste des offres collectives pour expliquer la nouvelle fonctionnalité d'archivage

<img width="860" alt="Capture d’écran 2024-06-27 à 15 16 44" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/1343ce6b-762b-45b2-82c0-133572dc819b">

## Vérifications

- [x] J'ai écrit les tests nécessaires