### PR TITLE
(PC-30372)[PRO] feat: return venue's address if offer has none.

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -841,6 +841,14 @@ def get_offer_by_id(offer_id: int, load_options: OFFER_LOAD_OPTIONS = ()) -> mod
                 sa_orm.joinedload(models.Offer.offererAddress).with_expression(
                     offerers_models.OffererAddress._isEditable, offerers_models.OffererAddress.isEditable.expression  # type: ignore [attr-defined]
                 ),
+                sa_orm.joinedload(models.Offer.venue)
+                .joinedload(offerers_models.Venue.offererAddress)
+                .joinedload(offerers_models.OffererAddress.address),
+                sa_orm.joinedload(models.Offer.venue)
+                .joinedload(offerers_models.Venue.offererAddress)
+                .with_expression(
+                    offerers_models.OffererAddress._isEditable, offerers_models.OffererAddress.isEditable.expression  # type: ignore [attr-defined]
+                ),
             )
         if "future_offer" in load_options:
             query = query.outerjoin(models.Offer.futureOffer).options(sa_orm.contains_eager(models.Offer.futureOffer))

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -393,15 +393,17 @@ class IndividualOfferResponseGetterDict(GetterDict):
     def get(self, key: str, default: Any | None = None) -> Any:
         if key == "address":
             if not self._obj.offererAddress:
-                return None
-            offererAddress = GetOffererAddressWithIsEditableResponseModel.from_orm(self._obj.offererAddress)
+                offerer_address = self._obj.venue.offererAddress
+            else:
+                offerer_address = self._obj.offererAddress
+            offererAddress = GetOffererAddressWithIsEditableResponseModel.from_orm(offerer_address)
             offererAddress.label = offererAddress.label or self._obj.venue.common_name
             return AddressResponseIsEditableModel(
-                id=self._obj.offererAddress.addressId,
-                banId=self._obj.offererAddress.address.banId,
-                inseeCode=self._obj.offererAddress.address.inseeCode,
-                longitude=self._obj.offererAddress.address.longitude,
-                latitude=self._obj.offererAddress.address.latitude,
+                id=offerer_address.addressId,
+                banId=offerer_address.address.banId,
+                inseeCode=offerer_address.address.inseeCode,
+                longitude=offerer_address.address.longitude,
+                latitude=offerer_address.address.latitude,
                 **offererAddress.dict(exclude={"id"}),
             )
         return super().get(key, default)


### PR DESCRIPTION
This is requied as long as the script to fill offer's offerer_address is not run for legacy offers.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30372

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques