### PR TITLE
(PC-30307)[API] feat: Add external urls in `GET` endpoints

### DIFF
--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -86,6 +86,15 @@ class VenueProviderFactory(BaseFactory):
     venueIdAtOfferProvider = factory.SelfAttribute("venue.siret")
 
 
+class VenueProviderExternalUrlsFactory(BaseFactory):
+    class Meta:
+        model = models.VenueProviderExternalUrls
+
+    bookingExternalUrl = factory.Sequence("https://{}.example.org/booking".format)
+    cancelExternalUrl = factory.Sequence("https://{}.example.org/cancel".format)
+    notificationExternalUrl = factory.Sequence("https://{}.example.org/notification".format)
+
+
 class CinemaProviderPivotFactory(BaseFactory):
     class Meta:
         model = models.CinemaProviderPivot

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -230,6 +230,18 @@ class _FIELDS:
     )
     VENUE_LEGAL_NAME = Field(description="Venue legal name", example="SAS pass Culture")
     VENUE_PUBLIC_NAME = Field(description="Venue public name. If `null`, `legalName` is used.", example="pass Culture")
+    VENUE_NOTIFICATION_URL = Field(
+        description="Url on which notifications for this venues will be sent",
+        example="https://mysolution.com/pass-culture-endpoint",
+    )
+    VENUE_BOOKING_URL = Field(
+        description="Url on which request for tickets are sent when a beneficiary tries to book tickets for an event linked to this venue",
+        example="https://my-ticketing-solution.com/pass-culture-booking-endpoint",
+    )
+    VENUE_CANCEL_URL = Field(
+        description="Url on which ticket cancellation request are sent when a beneficiary cancels its tickets for an event linked to this venue",
+        example="https://my-ticketing-solution.com/pass-culture-cancellation-endpoint",
+    )
 
 
 fields = _FIELDS()

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -216,11 +216,30 @@ class _FIELDS:
     STUDENT_LEVEL_ID = Field(description="Student level id", example="COLLEGE6")
     STUDENT_LEVEL_NAME = Field(description="Student level name", example="Collège - 6e")
 
+    # Provider fields
+    PROVIDER_ID = Field(description="Provider id", example=123456)
+    PROVIDER_NAME = Field(description="Provider name", example="Ultimate ticketing solution")
+    PROVIDER_LOGO_URL = Field(
+        description="Provider logo url", example="https://ultimate-ticketing-solution.com/logo.png"
+    )
+    PROVIDER_NOTIFICATION_URL = Field(
+        description="Url on which booking notifications on offers you created are sent",
+        example="https://ultimate-ticketing-solution.com/pass-culture-endpoint",
+    )
+    PROVIDER_BOOKING_URL = Field(
+        description="Url on which tickets requests for events you created are sent",
+        example="https://ultimate-ticketing-solution.com/pass-culture-booking-endpoint",
+    )
+    PROVIDER_CANCEL_URL = Field(
+        description="Url on which tickets cancellation requests for events you created are sent",
+        example="https://ultimate-ticketing-solution.com/pass-culture-cancellation-endpoint",
+    )
+
     # Venue fields
-    VENUE_ACTIVITY_DOMAIN = Field(alias="activityDomain", description="Venue activity domain", example="RECORD_STORE")
-    VENUE_SIRET_COMMENT = Field(description="Applicable if siret is null and venue is physical.")
+    VENUE_ACTIVITY_DOMAIN = Field(description="Venue activity domain", example="RECORD_STORE")
+    VENUE_SIRET_COMMENT = Field(description="Applicable if siret is null and venue is physical")
     VENUE_SIRET = Field(
-        description="Venue siret. `null` when venue is digital or when `siretComment` field is not `null`.",
+        description="Venue siret. `null` when the venue is digital or when the `siretComment` field is not `null`.",
         example="85331845900049",
     )
     VENUE_CREATED_DATETIME = Field(description="When the venue was created")
@@ -229,17 +248,19 @@ class _FIELDS:
         discriminator="type",
     )
     VENUE_LEGAL_NAME = Field(description="Venue legal name", example="SAS pass Culture")
-    VENUE_PUBLIC_NAME = Field(description="Venue public name. If `null`, `legalName` is used.", example="pass Culture")
+    VENUE_PUBLIC_NAME = Field(
+        description="Venue public name. If `null`, `legalName` is used instead.", example="pass Culture"
+    )
     VENUE_NOTIFICATION_URL = Field(
-        description="Url on which notifications for this venues will be sent",
+        description="Url on which notifications for this venues will be sent. If not set, our system will use the notification url defined at provider level.",
         example="https://mysolution.com/pass-culture-endpoint",
     )
     VENUE_BOOKING_URL = Field(
-        description="Url on which request for tickets are sent when a beneficiary tries to book tickets for an event linked to this venue",
+        description="Url on which requests for tickets are sent when a beneficiary tries to book tickets for an event linked to this venue. If not set, our system will use the booking url defined at provider level.",
         example="https://my-ticketing-solution.com/pass-culture-booking-endpoint",
     )
     VENUE_CANCEL_URL = Field(
-        description="Url on which ticket cancellation request are sent when a beneficiary cancels its tickets for an event linked to this venue",
+        description="Url on which tickets cancellation requests are sent when a beneficiary cancels its tickets for an event linked to this venue. If not set, our system will use the cancel url defined at provider level.",
         example="https://my-ticketing-solution.com/pass-culture-cancellation-endpoint",
     )
 

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -216,5 +216,20 @@ class _FIELDS:
     STUDENT_LEVEL_ID = Field(description="Student level id", example="COLLEGE6")
     STUDENT_LEVEL_NAME = Field(description="Student level name", example="Collège - 6e")
 
+    # Venue fields
+    VENUE_ACTIVITY_DOMAIN = Field(alias="activityDomain", description="Venue activity domain", example="RECORD_STORE")
+    VENUE_SIRET_COMMENT = Field(description="Applicable if siret is null and venue is physical.")
+    VENUE_SIRET = Field(
+        description="Venue siret. `null` when venue is digital or when `siretComment` field is not `null`.",
+        example="85331845900049",
+    )
+    VENUE_CREATED_DATETIME = Field(description="When the venue was created")
+    VENUE_LOCATION = Field(
+        description="Location where the offers will be available or will take place. There is exactly one digital venue per offerer, which is listed although its id is not required to create a digital offer (see DigitalLocation model).",
+        discriminator="type",
+    )
+    VENUE_LEGAL_NAME = Field(description="Venue legal name", example="SAS pass Culture")
+    VENUE_PUBLIC_NAME = Field(description="Venue public name. If `null`, `legalName` is used.", example="pass Culture")
+
 
 fields = _FIELDS()

--- a/api/src/pcapi/routes/public/documentation_constants/tags.py
+++ b/api/src/pcapi/routes/public/documentation_constants/tags.py
@@ -24,6 +24,7 @@ PRODUCT_EAN_OFFERS = Tag(
     name="Product offer bulk operations",
     description="Endpoints to create and get products usings European Article Number (EAN-13).",
 )
+PROVIDERS = Tag(name="Providers")
 VENUES = Tag(name="Venues")
 OFFER_ATTRIBUTES = Tag(name="Offer attributes")
 
@@ -42,7 +43,9 @@ COLLECTIVE_VENUES = Tag(name="[DEPRECATED] Collective venues")
 
 
 OPEN_API_TAGS = [
-    # OFFERER VENUES
+    # PROVIDERS
+    PROVIDERS,
+    # VENUES
     VENUES,
     # PRODUCTS
     PRODUCT_EAN_OFFERS,

--- a/api/src/pcapi/routes/public/individual_offers/v1/__init__.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/__init__.py
@@ -6,3 +6,4 @@ def install_routes(app: Flask) -> None:
     from . import bookings
     from . import events
     from . import products
+    from . import providers

--- a/api/src/pcapi/routes/public/individual_offers/v1/providers.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/providers.py
@@ -1,0 +1,32 @@
+from pcapi.routes.public import blueprints
+from pcapi.routes.public import spectree_schemas
+from pcapi.routes.public.documentation_constants import http_responses
+from pcapi.routes.public.documentation_constants import tags
+from pcapi.routes.public.serialization import providers as providers_serialization
+from pcapi.serialization.decorator import spectree_serialize
+from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
+from pcapi.validation.routes.users_authentifications import api_key_required
+from pcapi.validation.routes.users_authentifications import current_api_key
+
+
+@blueprints.public_api.route("/public/providers/v1/provider", methods=["GET"])
+@spectree_serialize(
+    api=spectree_schemas.public_api_schema,
+    tags=[tags.PROVIDERS],
+    response_model=providers_serialization.ProviderResponse,
+    resp=SpectreeResponse(
+        **(
+            {"HTTP_200": (providers_serialization.ProviderResponse, "Your provider has been returned")}
+            # errors
+            | http_responses.HTTP_40X_SHARED_BY_API_ENDPOINTS
+        )
+    ),
+)
+@api_key_required
+def get_provider() -> providers_serialization.ProviderResponse:
+    """
+    Get my provider
+
+    Return your provider information.
+    """
+    return providers_serialization.ProviderResponse.build_model(current_api_key.provider)

--- a/api/src/pcapi/routes/public/serialization/providers.py
+++ b/api/src/pcapi/routes/public/serialization/providers.py
@@ -1,0 +1,25 @@
+from pcapi.core.providers import models as providers_models
+from pcapi.routes import serialization
+from pcapi.routes.public.documentation_constants.fields import fields
+
+
+class ProviderResponse(serialization.ConfiguredBaseModel):
+    id: int = fields.PROVIDER_ID
+    name: str = fields.PROVIDER_NAME
+
+    # External urls
+    logo_url: str | None = fields.PROVIDER_LOGO_URL
+    notification_url: str | None = fields.PROVIDER_NOTIFICATION_URL
+    booking_url: str | None = fields.PROVIDER_BOOKING_URL
+    cancel_url: str | None = fields.PROVIDER_CANCEL_URL
+
+    @classmethod
+    def build_model(cls, provider: providers_models.Provider) -> "ProviderResponse":
+        return cls(
+            id=provider.id,
+            name=provider.name,
+            logo_url=provider.logoUrl,
+            notification_url=provider.notificationExternalUrl,
+            booking_url=provider.bookingExternalUrl,
+            cancel_url=provider.cancelExternalUrl,
+        )

--- a/api/src/pcapi/routes/public/serialization/venues.py
+++ b/api/src/pcapi/routes/public/serialization/venues.py
@@ -6,6 +6,7 @@ import pydantic.v1 as pydantic_v1
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.api import OffererVenues
 from pcapi.routes import serialization
+from pcapi.routes.public.documentation_constants.fields import fields
 from pcapi.utils import date as date_utils
 
 from .accessibility import PartialAccessibility
@@ -29,39 +30,31 @@ class VenuePhysicalLocation(serialization.ConfiguredBaseModel):
 
 
 class VenueResponse(serialization.ConfiguredBaseModel):
-    comment: str | None = pydantic_v1.Field(
-        None, description="Applicable if siret is null and venue is physical.", alias="siretComment", example=None
-    )
-    dateCreated: datetime.datetime = pydantic_v1.Field(..., alias="createdDatetime")
-    id: int
-    location: VenuePhysicalLocation | VenueDigitalLocation = pydantic_v1.Field(
-        ...,
-        description="Location where the offers will be available or will take place. There is exactly one digital venue per offerer, which is listed although its id is not required to create a digital offer (see DigitalLocation model).",
-        discriminator="type",
-    )
-    name: str = pydantic_v1.Field(alias="legalName", example="Palais de l'Élysée")
-    publicName: str | None = pydantic_v1.Field(..., description="If null, legalName is used.", example="Élysée")
-    siret: str | None = pydantic_v1.Field(
-        description="Null when venue is digital or when siretComment field is not null.", example="12345678901234"
-    )
-    venueTypeCode: VenueTypeEnum = pydantic_v1.Field(alias="activityDomain")  # type: ignore[valid-type]
+    id: int = fields.VENUE_ID
+    siret_comment: str | None = fields.VENUE_SIRET_COMMENT
+    siret: str | None = fields.VENUE_SIRET
+    created_datetime: datetime.datetime = fields.VENUE_CREATED_DATETIME
+    location: VenuePhysicalLocation | VenueDigitalLocation = fields.VENUE_LOCATION
+    legal_name: str = fields.VENUE_LEGAL_NAME
+    public_name: str | None = fields.VENUE_PUBLIC_NAME
+    venue_type_code: VenueTypeEnum = fields.VENUE_ACTIVITY_DOMAIN  # type: ignore[valid-type]
     accessibility: PartialAccessibility
 
     @classmethod
     def build_model(cls, venue: offerers_models.Venue) -> "VenueResponse":
-        return cls(  # type: ignore[call-arg]
-            comment=venue.comment,
-            dateCreated=venue.dateCreated,
+        return cls(
+            siret_comment=venue.comment,
+            created_datetime=venue.dateCreated,
             id=venue.id,
             location=(
                 VenuePhysicalLocation(address=venue.street, city=venue.city, postalCode=venue.postalCode)
                 if not venue.isVirtual
                 else VenueDigitalLocation()
             ),
-            name=venue.name,
-            publicName=venue.publicName,
+            legal_name=venue.name,
+            public_name=venue.publicName,
             siret=venue.siret,
-            venueTypeCode=venue.venueTypeCode.name,
+            venue_type_code=venue.venueTypeCode.name,
             accessibility=PartialAccessibility.from_orm(venue),
         )
 

--- a/api/src/pcapi/routes/public/serialization/venues.py
+++ b/api/src/pcapi/routes/public/serialization/venues.py
@@ -40,8 +40,14 @@ class VenueResponse(serialization.ConfiguredBaseModel):
     venue_type_code: VenueTypeEnum = fields.VENUE_ACTIVITY_DOMAIN  # type: ignore[valid-type]
     accessibility: PartialAccessibility
 
+    # External urls
+    notification_url: str | None = fields.VENUE_NOTIFICATION_URL
+    booking_url: str | None = fields.VENUE_BOOKING_URL
+    cancel_url: str | None = fields.VENUE_CANCEL_URL
+
     @classmethod
     def build_model(cls, venue: offerers_models.Venue) -> "VenueResponse":
+        external_urls = venue.venueProviders[0].externalUrls
         return cls(
             siret_comment=venue.comment,
             created_datetime=venue.dateCreated,
@@ -56,6 +62,9 @@ class VenueResponse(serialization.ConfiguredBaseModel):
             siret=venue.siret,
             venue_type_code=venue.venueTypeCode.name,
             accessibility=PartialAccessibility.from_orm(venue),
+            notification_url=external_urls.notificationExternalUrl if external_urls else None,
+            booking_url=external_urls.bookingExternalUrl if external_urls else None,
+            cancel_url=external_urls.cancelExternalUrl if external_urls else None,
         )
 
     class Config:

--- a/api/src/pcapi/routes/public/serialization/venues.py
+++ b/api/src/pcapi/routes/public/serialization/venues.py
@@ -37,7 +37,7 @@ class VenueResponse(serialization.ConfiguredBaseModel):
     location: VenuePhysicalLocation | VenueDigitalLocation = fields.VENUE_LOCATION
     legal_name: str = fields.VENUE_LEGAL_NAME
     public_name: str | None = fields.VENUE_PUBLIC_NAME
-    venue_type_code: VenueTypeEnum = fields.VENUE_ACTIVITY_DOMAIN  # type: ignore[valid-type]
+    activity_domain: VenueTypeEnum = fields.VENUE_ACTIVITY_DOMAIN  # type: ignore[valid-type]
     accessibility: PartialAccessibility
 
     # External urls
@@ -60,7 +60,7 @@ class VenueResponse(serialization.ConfiguredBaseModel):
             legal_name=venue.name,
             public_name=venue.publicName,
             siret=venue.siret,
-            venue_type_code=venue.venueTypeCode.name,
+            activity_domain=venue.venueTypeCode.name,
             accessibility=PartialAccessibility.from_orm(venue),
             notification_url=external_urls.notificationExternalUrl if external_urls else None,
             booking_url=external_urls.bookingExternalUrl if external_urls else None,

--- a/api/tests/routes/public/collective/endpoints/get_collective_offers_venues_test.py
+++ b/api/tests/routes/public/collective/endpoints/get_collective_offers_venues_test.py
@@ -45,6 +45,9 @@ class CollectiveOffersGetVenuesTest:
                 "publicName": venue.publicName,
                 "siret": venue.siret,
                 "activityDomain": venue.venueTypeCode.name,
+                "bookingUrl": None,
+                "cancelUrl": None,
+                "notificationUrl": None,
                 "accessibility": {
                     "audioDisabilityCompliant": venue.audioDisabilityCompliant,
                     "mentalDisabilityCompliant": venue.mentalDisabilityCompliant,
@@ -118,6 +121,9 @@ class GetOfferersVenuesTest:
                         "createdDatetime": format_into_utc_date(venue.dateCreated),
                         "publicName": venue.publicName,
                         "siret": venue.siret,
+                        "bookingUrl": None,
+                        "cancelUrl": None,
+                        "notificationUrl": None,
                         "activityDomain": venue.venueTypeCode.name,
                         "accessibility": {
                             "audioDisabilityCompliant": venue.audioDisabilityCompliant,

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -6921,6 +6921,56 @@
                 "title": "ProductsOfferByEanCreation",
                 "type": "object"
             },
+            "ProviderResponse": {
+                "properties": {
+                    "bookingUrl": {
+                        "description": "Url on which tickets requests for events you created are sent",
+                        "example": "https://ultimate-ticketing-solution.com/pass-culture-booking-endpoint",
+                        "nullable": true,
+                        "title": "Bookingurl",
+                        "type": "string"
+                    },
+                    "cancelUrl": {
+                        "description": "Url on which tickets cancellation requests for events you created are sent",
+                        "example": "https://ultimate-ticketing-solution.com/pass-culture-cancellation-endpoint",
+                        "nullable": true,
+                        "title": "Cancelurl",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "Provider id",
+                        "example": 123456,
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "logoUrl": {
+                        "description": "Provider logo url",
+                        "example": "https://ultimate-ticketing-solution.com/logo.png",
+                        "nullable": true,
+                        "title": "Logourl",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Provider name",
+                        "example": "Ultimate ticketing solution",
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "notificationUrl": {
+                        "description": "Url on which booking notifications on offers you created are sent",
+                        "example": "https://ultimate-ticketing-solution.com/pass-culture-endpoint",
+                        "nullable": true,
+                        "title": "Notificationurl",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "title": "ProviderResponse",
+                "type": "object"
+            },
             "RENCONTRE_EN_LIGNE_create": {
                 "description": "Rencontre en ligne",
                 "properties": {
@@ -8404,14 +8454,14 @@
                         "example": "RECORD_STORE"
                     },
                     "bookingUrl": {
-                        "description": "Url on which request for tickets are sent when a beneficiary tries to book tickets for an event linked to this venue",
+                        "description": "Url on which requests for tickets are sent when a beneficiary tries to book tickets for an event linked to this venue. If not set, our system will use the booking url defined at provider level.",
                         "example": "https://my-ticketing-solution.com/pass-culture-booking-endpoint",
                         "nullable": true,
                         "title": "Bookingurl",
                         "type": "string"
                     },
                     "cancelUrl": {
-                        "description": "Url on which ticket cancellation request are sent when a beneficiary cancels its tickets for an event linked to this venue",
+                        "description": "Url on which tickets cancellation requests are sent when a beneficiary cancels its tickets for an event linked to this venue. If not set, our system will use the cancel url defined at provider level.",
                         "example": "https://my-ticketing-solution.com/pass-culture-cancellation-endpoint",
                         "nullable": true,
                         "title": "Cancelurl",
@@ -8455,28 +8505,28 @@
                         "title": "Location"
                     },
                     "notificationUrl": {
-                        "description": "Url on which notifications for this venues will be sent",
+                        "description": "Url on which notifications for this venues will be sent. If not set, our system will use the notification url defined at provider level.",
                         "example": "https://mysolution.com/pass-culture-endpoint",
                         "nullable": true,
                         "title": "Notificationurl",
                         "type": "string"
                     },
                     "publicName": {
-                        "description": "Venue public name. If `null`, `legalName` is used.",
+                        "description": "Venue public name. If `null`, `legalName` is used instead.",
                         "example": "pass Culture",
                         "nullable": true,
                         "title": "Publicname",
                         "type": "string"
                     },
                     "siret": {
-                        "description": "Venue siret. `null` when venue is digital or when `siretComment` field is not `null`.",
+                        "description": "Venue siret. `null` when the venue is digital or when the `siretComment` field is not `null`.",
                         "example": "85331845900049",
                         "nullable": true,
                         "title": "Siret",
                         "type": "string"
                     },
                     "siretComment": {
-                        "description": "Applicable if siret is null and venue is physical.",
+                        "description": "Applicable if siret is null and venue is physical",
                         "nullable": true,
                         "title": "Siretcomment",
                         "type": "string"
@@ -10703,6 +10753,57 @@
                 ]
             }
         },
+        "/public/providers/v1/provider": {
+            "get": {
+                "description": "Return your provider information.",
+                "operationId": "GetProvider",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProviderResponse"
+                                }
+                            }
+                        },
+                        "description": "Your provider has been returned"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthErrorResponseModel"
+                                }
+                            }
+                        },
+                        "description": "Authentication is necessary to use this API."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Get my provider",
+                "tags": [
+                    "Providers"
+                ]
+            }
+        },
         "/v2/collective/bookings/{booking_id}": {
             "patch": {
                 "description": "Cancel an collective event booking.",
@@ -11718,6 +11819,11 @@
         }
     ],
     "tags": [
+        {
+            "description": "",
+            "externalDocs": null,
+            "name": "Providers"
+        },
         {
             "description": "",
             "externalDocs": null,

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -8403,6 +8403,20 @@
                         "description": "Venue activity domain",
                         "example": "RECORD_STORE"
                     },
+                    "bookingUrl": {
+                        "description": "Url on which request for tickets are sent when a beneficiary tries to book tickets for an event linked to this venue",
+                        "example": "https://my-ticketing-solution.com/pass-culture-booking-endpoint",
+                        "nullable": true,
+                        "title": "Bookingurl",
+                        "type": "string"
+                    },
+                    "cancelUrl": {
+                        "description": "Url on which ticket cancellation request are sent when a beneficiary cancels its tickets for an event linked to this venue",
+                        "example": "https://my-ticketing-solution.com/pass-culture-cancellation-endpoint",
+                        "nullable": true,
+                        "title": "Cancelurl",
+                        "type": "string"
+                    },
                     "createdDatetime": {
                         "description": "When the venue was created",
                         "format": "date-time",
@@ -8439,6 +8453,13 @@
                             }
                         ],
                         "title": "Location"
+                    },
+                    "notificationUrl": {
+                        "description": "Url on which notifications for this venues will be sent",
+                        "example": "https://mysolution.com/pass-culture-endpoint",
+                        "nullable": true,
+                        "title": "Notificationurl",
+                        "type": "string"
                     },
                     "publicName": {
                         "description": "Venue public name. If `null`, `legalName` is used.",

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -8395,19 +8395,29 @@
                         "$ref": "#/components/schemas/PartialAccessibility"
                     },
                     "activityDomain": {
-                        "$ref": "#/components/schemas/VenueTypeEnum"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/VenueTypeEnum"
+                            }
+                        ],
+                        "description": "Venue activity domain",
+                        "example": "RECORD_STORE"
                     },
                     "createdDatetime": {
+                        "description": "When the venue was created",
                         "format": "date-time",
                         "title": "Createddatetime",
                         "type": "string"
                     },
                     "id": {
+                        "description": "Venue Id. The venues list is available on [**this endpoint (`Get offerer venues`)**](#tag/Offerer-and-Venues/operation/GetOffererVenues)",
+                        "example": 1234,
                         "title": "Id",
                         "type": "integer"
                     },
                     "legalName": {
-                        "example": "Palais de l'\u00c9lys\u00e9e",
+                        "description": "Venue legal name",
+                        "example": "SAS pass Culture",
                         "title": "Legalname",
                         "type": "string"
                     },
@@ -8431,33 +8441,31 @@
                         "title": "Location"
                     },
                     "publicName": {
-                        "description": "If null, legalName is used.",
-                        "example": "\u00c9lys\u00e9e",
+                        "description": "Venue public name. If `null`, `legalName` is used.",
+                        "example": "pass Culture",
                         "nullable": true,
                         "title": "Publicname",
                         "type": "string"
                     },
                     "siret": {
-                        "description": "Null when venue is digital or when siretComment field is not null.",
-                        "example": "12345678901234",
+                        "description": "Venue siret. `null` when venue is digital or when `siretComment` field is not `null`.",
+                        "example": "85331845900049",
                         "nullable": true,
                         "title": "Siret",
                         "type": "string"
                     },
                     "siretComment": {
                         "description": "Applicable if siret is null and venue is physical.",
-                        "example": null,
                         "nullable": true,
                         "title": "Siretcomment",
                         "type": "string"
                     }
                 },
                 "required": [
-                    "createdDatetime",
                     "id",
+                    "createdDatetime",
                     "location",
                     "legalName",
-                    "publicName",
                     "activityDomain",
                     "accessibility"
                 ],

--- a/api/tests/routes/public/individual_offers/v1/get_offerer_venue_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_offerer_venue_test.py
@@ -45,8 +45,14 @@ class GetOffererVenuesTest:
             siret="12345678112345",
             venueTypeCode=offerers_models.VenueTypeCode.BOOKSTORE,
         )
-        providers_factories.VenueProviderFactory(
+        venue_provider = providers_factories.VenueProviderFactory(
             venue=other_physical_venue, provider=provider, venueIdAtOfferProvider="Test"
+        )
+        providers_factories.VenueProviderExternalUrlsFactory(
+            venueProvider=venue_provider,
+            bookingExternalUrl="https://mysolution.com/booking",
+            cancelExternalUrl="https://mysolution.com/cancel",
+            notificationExternalUrl="https://mysolution.com/notif",
         )
         return offerer_with_two_venues, digital_venue, physical_venue, offerer_with_one_venue, other_physical_venue
 
@@ -81,6 +87,9 @@ class GetOffererVenuesTest:
                     },
                     "activityDomain": "ARTISTIC_COURSE",
                     "createdDatetime": "2023-01-16T00:00:00Z",
+                    "bookingUrl": None,
+                    "cancelUrl": None,
+                    "notificationUrl": None,
                     "id": digital_venue.id,
                     "legalName": "Do you diji",
                     "location": {"type": "digital"},
@@ -108,6 +117,9 @@ class GetOffererVenuesTest:
                     "publicName": "Tiff tuff",
                     "siret": "12345678912345",
                     "siretComment": None,
+                    "bookingUrl": None,
+                    "cancelUrl": None,
+                    "notificationUrl": None,
                 },
             ],
         }
@@ -139,6 +151,9 @@ class GetOffererVenuesTest:
                     "publicName": "wiff wuff",
                     "siret": "12345678112345",
                     "siretComment": None,
+                    "bookingUrl": "https://mysolution.com/booking",
+                    "cancelUrl": "https://mysolution.com/cancel",
+                    "notificationUrl": "https://mysolution.com/notif",
                 }
             ],
         }

--- a/api/tests/routes/public/individual_offers/v1/get_provider.py
+++ b/api/tests/routes/public/individual_offers/v1/get_provider.py
@@ -1,0 +1,31 @@
+import pytest
+
+from pcapi.core.offerers import factories as offerers_factories
+
+from . import utils
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class GetProviderTest:
+    PROVIDER_URL = "/public/providers/v1/provider"
+
+    def test_return_provider_information_with_charlie(self, client):
+        provider, _ = utils.create_offerer_provider(with_charlie=True)
+
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(self.PROVIDER_URL)
+
+        assert response.status_code == 200
+        assert response.json == {
+            "id": provider.id,
+            "name": provider.name,
+            "logoUrl": provider.logoUrl,
+            "notificationUrl": None,
+            "bookingUrl": provider.bookingExternalUrl,
+            "cancelUrl": provider.cancelExternalUrl,
+        }
+
+    def test_raiser_401(self, client):
+        response = client.get(self.PROVIDER_URL)
+        assert response.status_code == 401


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30307

Il y a deux choses dans cette PR:

- L'ajout des external URLS dans la réponse du endpoint GET `/public/offers/v1/offerer_venues`
- L'ajout du endpoint GET `/public/providers/v1/provider` qui retourne les information du provider authentifié par la clé

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques