### PR TITLE
(PC-30377)[PRO] fix: reorder query params on reservations page

### DIFF
--- a/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
+++ b/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
@@ -184,11 +184,11 @@ class ListBookingsQueryModel(BaseModel):
     page: int = 1
     venue_id: int | None
     offer_id: int | None
-    offerer_address_id: int | None
     event_date: date | None
     booking_status_filter: BookingStatusFilter | None
     booking_period_beginning_date: date | None
     booking_period_ending_date: date | None
+    offerer_address_id: int | None
     export_type: BookingExportType | None
 
     class Config:

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -128,11 +128,11 @@ export class DefaultService {
    * @param page
    * @param venueId
    * @param offerId
-   * @param offererAddressId
    * @param eventDate
    * @param bookingStatusFilter
    * @param bookingPeriodBeginningDate
    * @param bookingPeriodEndingDate
+   * @param offererAddressId
    * @param exportType
    * @returns any OK
    * @throws ApiError
@@ -141,11 +141,11 @@ export class DefaultService {
     page: number = 1,
     venueId?: number | null,
     offerId?: number | null,
-    offererAddressId?: number | null,
     eventDate?: string | null,
     bookingStatusFilter?: BookingStatusFilter | null,
     bookingPeriodBeginningDate?: string | null,
     bookingPeriodEndingDate?: string | null,
+    offererAddressId?: number | null,
     exportType?: BookingExportType | null,
   ): CancelablePromise<any> {
     return this.httpRequest.request({
@@ -155,11 +155,11 @@ export class DefaultService {
         'page': page,
         'venueId': venueId,
         'offerId': offerId,
-        'offererAddressId': offererAddressId,
         'eventDate': eventDate,
         'bookingStatusFilter': bookingStatusFilter,
         'bookingPeriodBeginningDate': bookingPeriodBeginningDate,
         'bookingPeriodEndingDate': bookingPeriodEndingDate,
+        'offererAddressId': offererAddressId,
         'exportType': exportType,
       },
       errors: {
@@ -194,11 +194,11 @@ export class DefaultService {
    * @param page
    * @param venueId
    * @param offerId
-   * @param offererAddressId
    * @param eventDate
    * @param bookingStatusFilter
    * @param bookingPeriodBeginningDate
    * @param bookingPeriodEndingDate
+   * @param offererAddressId
    * @param exportType
    * @returns any OK
    * @throws ApiError
@@ -207,11 +207,11 @@ export class DefaultService {
     page: number = 1,
     venueId?: number | null,
     offerId?: number | null,
-    offererAddressId?: number | null,
     eventDate?: string | null,
     bookingStatusFilter?: BookingStatusFilter | null,
     bookingPeriodBeginningDate?: string | null,
     bookingPeriodEndingDate?: string | null,
+    offererAddressId?: number | null,
     exportType?: BookingExportType | null,
   ): CancelablePromise<any> {
     return this.httpRequest.request({
@@ -221,11 +221,11 @@ export class DefaultService {
         'page': page,
         'venueId': venueId,
         'offerId': offerId,
-        'offererAddressId': offererAddressId,
         'eventDate': eventDate,
         'bookingStatusFilter': bookingStatusFilter,
         'bookingPeriodBeginningDate': bookingPeriodBeginningDate,
         'bookingPeriodEndingDate': bookingPeriodEndingDate,
+        'offererAddressId': offererAddressId,
         'exportType': exportType,
       },
       errors: {
@@ -297,11 +297,11 @@ export class DefaultService {
    * @param page
    * @param venueId
    * @param offerId
-   * @param offererAddressId
    * @param eventDate
    * @param bookingStatusFilter
    * @param bookingPeriodBeginningDate
    * @param bookingPeriodEndingDate
+   * @param offererAddressId
    * @param exportType
    * @returns ListBookingsResponseModel OK
    * @throws ApiError
@@ -310,11 +310,11 @@ export class DefaultService {
     page: number = 1,
     venueId?: number | null,
     offerId?: number | null,
-    offererAddressId?: number | null,
     eventDate?: string | null,
     bookingStatusFilter?: BookingStatusFilter | null,
     bookingPeriodBeginningDate?: string | null,
     bookingPeriodEndingDate?: string | null,
+    offererAddressId?: number | null,
     exportType?: BookingExportType | null,
   ): CancelablePromise<ListBookingsResponseModel> {
     return this.httpRequest.request({
@@ -324,11 +324,11 @@ export class DefaultService {
         'page': page,
         'venueId': venueId,
         'offerId': offerId,
-        'offererAddressId': offererAddressId,
         'eventDate': eventDate,
         'bookingStatusFilter': bookingStatusFilter,
         'bookingPeriodBeginningDate': bookingPeriodBeginningDate,
         'bookingPeriodEndingDate': bookingPeriodEndingDate,
+        'offererAddressId': offererAddressId,
         'exportType': exportType,
       },
       errors: {

--- a/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -283,7 +283,6 @@ describe('components | BookingsRecap | Pro user', () => {
       null,
       null,
       null,
-      null,
       DEFAULT_PRE_FILTERS.bookingStatusFilter,
       DEFAULT_PRE_FILTERS.bookingBeginningDate,
       DEFAULT_PRE_FILTERS.bookingEndingDate

--- a/pro/src/pages/Bookings/downloadIndividualBookingsCSVFile.ts
+++ b/pro/src/pages/Bookings/downloadIndividualBookingsCSVFile.ts
@@ -13,7 +13,6 @@ export const downloadIndividualBookingsCSVFile = async (
       ? Number(filters.offerVenueId)
       : null,
     null,
-    null,
     filters.offerEventDate !== DEFAULT_PRE_FILTERS.offerEventDate &&
       isDateValid(filters.offerEventDate)
       ? filters.offerEventDate

--- a/pro/src/pages/Bookings/downloadIndividualBookingsXLSFile.ts
+++ b/pro/src/pages/Bookings/downloadIndividualBookingsXLSFile.ts
@@ -14,7 +14,6 @@ export const downloadIndividualBookingsXLSFile = async (
       ? Number(filters.offerVenueId)
       : null,
     null,
-    null,
     filters.offerEventDate !== DEFAULT_PRE_FILTERS.offerEventDate &&
       isDateValid(filters.offerEventDate)
       ? filters.offerEventDate


### PR DESCRIPTION
It turns out Front does not like when query params order is changed. Before this fix, the default filters would be:
page=1&eventDate=booked&bookingStatusFilter=2024-06-01&bookingPeriodBeginningDate=2024-07-01
After:
page=1&bookingStatusFilter=booked&bookingPeriodBeginningDate=2024-06-01&bookingPeriodEndingDate=2024-07-01

This is because the front passes the query arguments as positional arguments rather than keyword arguments when building the url.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30377

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques