### PR TITLE
(PC-30661)[API] feat: fix error on old CM endpoint

### DIFF
--- a/api/src/pcapi/routes/__init__.py
+++ b/api/src/pcapi/routes/__init__.py
@@ -45,6 +45,7 @@ def install_all_routes(app: Flask) -> None:
     app.register_blueprint(adage_v1_blueprint, url_prefix="/adage/v1")
     app.register_blueprint(native_blueprint, url_prefix="/native")
     app.register_blueprint(public_blueprint.public_api)
+    app.register_blueprint(public_blueprint.deprecated_v2_prefixed_public_api)
     app.register_blueprint(pro_private_api_blueprint)
     app.register_blueprint(adage_iframe_blueprint, url_prefix="/adage-iframe")
     app.register_blueprint(saml_blueprint_blueprint, url_prefix="/saml")

--- a/api/src/pcapi/routes/public/blueprints.py
+++ b/api/src/pcapi/routes/public/blueprints.py
@@ -29,9 +29,9 @@ public_api.before_request(_check_api_is_enabled_and_json_valid)
 
 
 # [OLD] Old tokens and stocks apis
-_deprecated_v2_prefixed_public_api = Blueprint("deprecated_public_api", __name__, url_prefix="/v2")
-_deprecated_v2_prefixed_public_api.register_blueprint(booking_token_blueprint.deprecated_booking_token_blueprint)
-_deprecated_v2_prefixed_public_api.register_blueprint(booking_stocks_blueprint.deprecated_books_stocks_blueprint)
+deprecated_v2_prefixed_public_api = Blueprint("deprecated_public_api", __name__, url_prefix="/v2")
+deprecated_v2_prefixed_public_api.register_blueprint(booking_token_blueprint.deprecated_booking_token_blueprint)
+deprecated_v2_prefixed_public_api.register_blueprint(booking_stocks_blueprint.deprecated_books_stocks_blueprint)
 
 
 # DOCUMENTATION REDIRECTS
@@ -60,7 +60,6 @@ public_api.register_blueprint(documentation_redirect_blueprint)
 
 
 # Registering deprecated APIs
-public_api.register_blueprint(_deprecated_v2_prefixed_public_api)
 CORS(
     public_api,
     resources={r"/*": {"origins": "*"}},
@@ -70,4 +69,4 @@ CORS(
 
 # Registering spectree schemas
 spectree_schemas.public_api_schema.register(public_api)
-spectree_schemas.deprecated_public_api_schema.register(_deprecated_v2_prefixed_public_api)
+spectree_schemas.deprecated_public_api_schema.register(deprecated_v2_prefixed_public_api)


### PR DESCRIPTION
## But de la pull request

Ticket Jira  : https://passculture.atlassian.net/browse/PC-30661

L'erreur est due à l'extension de `_check_api_is_enabled_and_json_valid` à la vieille API. Hors certains de nos partenaires techniques nous envoie des JSON dans les GET.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques