### PR TITLE
(PC-30670)[BO] feat: Include cashflow batch's label in exported finance csv's names

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1150,7 +1150,7 @@ def generate_payment_files(batch: models.CashflowBatch) -> None:
     file_paths["bank_accounts"] = _generate_bank_accounts_file(batch.cutoff)
 
     logger.info("Generating payments file")
-    file_paths["payments"] = _generate_payments_file(batch.id)
+    file_paths["payments"] = _generate_payments_file(batch)
 
     logger.info(
         "Finance files have been generated",
@@ -1316,7 +1316,8 @@ def _clean_for_accounting(value: str) -> str:
     return value.strip().replace('"', "").replace(";", "").replace("\n", "")
 
 
-def _generate_payments_file(batch_id: int) -> pathlib.Path:
+def _generate_payments_file(batch: models.CashflowBatch) -> pathlib.Path:
+    batch_id = batch.id
     header = [
         "Identifiant des coordonnées bancaires",
         "SIREN de la structure",
@@ -1457,7 +1458,7 @@ def _generate_payments_file(batch_id: int) -> pathlib.Path:
     )
 
     return _write_csv(
-        "down_payment",
+        f"down_payment_{batch.label}",
         header,
         rows=itertools.chain(indiv_data, collective_data),
         row_formatter=_payment_details_row_formatter,
@@ -1783,7 +1784,7 @@ def generate_invoice_file(batch: models.CashflowBatch) -> pathlib.Path:
     )
 
     return _write_csv(
-        "invoices",
+        f"invoices_{batch.label}",
         header,
         rows=itertools.chain(indiv_data, collective_data),
         row_formatter=_invoice_row_formatter,

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1775,7 +1775,7 @@ def test_generate_payment_files(mocked_gdrive_create_file):
     gdrive_file_names = {call.args[1] for call in mocked_gdrive_create_file.call_args_list}
     assert gdrive_file_names == {
         "bank_accounts_20230201_133456.csv",
-        "down_payment_20230201_133456.csv",
+        f"down_payment_{cashflow.batch.label}_20230201_133456.csv",
     }
 
 
@@ -2081,11 +2081,11 @@ def test_generate_payments_file():
         api.price_event(event)
 
     cutoff = datetime.datetime(actual_year, 2, 15)
-    batch_id = api.generate_cashflows(cutoff).id
+    batch = api.generate_cashflows(cutoff)
 
-    n_queries = 2  # select pricings
+    n_queries = 3  # select pricings + select batch
     with assert_num_queries(n_queries):
-        path = api._generate_payments_file(batch_id)
+        path = api._generate_payments_file(batch)
 
     with open(path, encoding="utf-8") as fp:
         reader = csv.DictReader(fp, quoting=csv.QUOTE_NONNUMERIC)
@@ -2306,7 +2306,7 @@ def test_generate_invoice_file():
     with time_machine.travel(datetime.datetime(2023, 2, 1, 12, 34, 56)):
         path = api.generate_invoice_file(cashflow1.batch)
     with zipfile.ZipFile(path) as zfile:
-        with zfile.open("invoices_20230201_133456.csv") as csv_bytefile:
+        with zfile.open(f"invoices_{cashflow1.batch.label}_20230201_133456.csv") as csv_bytefile:
             csv_textfile = io.TextIOWrapper(csv_bytefile)
             reader = csv.DictReader(csv_textfile, quoting=csv.QUOTE_NONNUMERIC)
             rows = list(reader)


### PR DESCRIPTION
## But de la pull request

Ajouter le label du cashflow batch dans le nom des fichiers csv (invoices et down_payment) exportés

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30670

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~