### PR TITLE
(PC-30372)[PRO] fix: offer and venue without address crash

### DIFF
--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -396,6 +396,11 @@ class IndividualOfferResponseGetterDict(GetterDict):
                 offerer_address = self._obj.venue.offererAddress
             else:
                 offerer_address = self._obj.offererAddress
+            # TODO(xordoquy): the following code should be removed once the
+            # migration of offerer_address from venues is performed.
+            # Alternatively, might be a good idea to keep it and log a warning too
+            if not offerer_address:
+                return None
             offererAddress = GetOffererAddressWithIsEditableResponseModel.from_orm(offerer_address)
             offererAddress.label = offererAddress.label or self._obj.venue.common_name
             return AddressResponseIsEditableModel(

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -360,6 +360,26 @@ class Returns200Test:
             "isEditable": offer_offerer_address.isEditable,
         }
 
+    def test_do_not_fail_if_no_address_at_all(self, client):
+        """If offer has no offererAddress nor its venue, it should be not fail"""
+        # Given
+        user_offerer = offerers_factories.UserOffererFactory()
+        offer = offers_factories.ThingOfferFactory(
+            venue__managingOfferer=user_offerer.offerer,
+            venue__offererAddress=None,
+            offererAddress=None,
+        )
+
+        # When
+        auth_client = client.with_session_auth(email=user_offerer.user.email)
+        offer_id = offer.id
+        with testing.assert_num_queries(self.num_queries):
+            response = auth_client.get(f"/offers/{offer_id}")
+
+        # Then
+        assert response.status_code == 200
+        assert not response.json["address"]
+
     def test_return_venue_offerer_address(self, client):
         # Given
         user_offerer = offerers_factories.UserOffererFactory()


### PR DESCRIPTION
At the moment, the venue data are not yet migrated to OffererAddress. We still have to consider cases where the offer has no address and the venue does not either.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30372

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques