### PR TITLE
(PC-30661)[API] feat: add tests to prevent faulty GET bug on `/v2/boo…

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -459,6 +459,17 @@ class TestClient:
         self._print_spec("GET", route, None, result)
         return result
 
+    def get_with_invalid_json_body(self, route: str, headers=None, raw_json=None):
+        headers = headers or {}
+        result = self.client.get(
+            route,
+            data=raw_json,
+            content_type="application/json",
+            headers={**self.auth_header, **headers},
+        )
+        self._print_spec("GET", route, raw_json, result)
+        return result
+
     def post(
         self,
         route: str,


### PR DESCRIPTION
…kings/token/<token>` to happen in the future

## But de la pull request

Test backend pour éviter à [ce bug](https://www.notion.so/passcultureapp/Impossibilit-de-valider-les-contremarques-pour-certains-utilisateurs-9a65352ba3be4328a29aa8cb5713e39c?pvs=4) de réapparaître en prod.

Pour tester que le test prévient bien la réapparition du bug :
- Rajouter la ligne `deprecated_v2_prefixed_public_api.before_request(_check_api_is_enabled_and_json_valid)
` à [cette ligne de ce fichier](https://github.com/pass-culture/pass-culture-main/blob/d2580657ffd3ef6b6a5322c54d06cc20f9054815/api/src/pcapi/routes/public/blueprints.py#L35).
- `pc test-backend tests/routes/public/booking_token/v2/get_booking_by_token_v2_test.py::NonStandardGetTest` -> devrait être rouge 🚫

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques