### PR TITLE
Pc 30620 npp sans frame corrections graphiques

### DIFF
--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -43,7 +43,7 @@
   height: 100%;
   padding: rem.torem(24px) rem.torem(24px) 0;
   overflow-y: auto;
-  background-color: var(--color-background-content);
+  background-color: var(--color-white);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -55,26 +55,13 @@
   &-funnel {
     background-color: var(--color-white);
   }
-
-  &-without-frame {
-    background-color: var(--color-white);
-  }
 }
 
 .content {
   background-color: var(--color-white);
-
-  @media (min-width: size.$mobile) {
-    border: rem.torem(1px) solid var(--color-grey-medium);
-    margin: rem.torem(32px);
-    border-radius: rem.torem(10px);
-  }
-
-  &-without-frame {
-    max-width: 100%;
-    border: none;
-    margin: 0;
-  }
+  max-width: 100%;
+  border: none;
+  margin: 0;
 }
 
 .connect-as {

--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -31,14 +31,26 @@
   }
 }
 
+.content-wrapper {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  width: 100%;
+}
+
 .content-container {
   width: 100%;
   height: 100%;
+  padding: rem.torem(24px) rem.torem(24px) 0;
   overflow-y: auto;
   background-color: var(--color-background-content);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+
+  @media (min-width: size.$mobile) {
+    padding: size.$main-content-padding size.$main-content-padding 0;
+  }
 
   &-funnel {
     background-color: var(--color-white);
@@ -51,8 +63,6 @@
 
 .content {
   background-color: var(--color-white);
-  padding: size.$main-content-padding;
-  max-width: rem.torem(size.$main-content-width);
 
   @media (min-width: size.$mobile) {
     border: rem.torem(1px) solid var(--color-grey-medium);

--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -36,13 +36,14 @@
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
+  overflow-y: auto;
+  background-color: var(--color-white);
 }
 
 .content-container {
   width: 100%;
   height: 100%;
   padding: rem.torem(24px) rem.torem(24px) 0;
-  overflow-y: auto;
   background-color: var(--color-white);
   display: flex;
   flex-direction: column;

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -6,7 +6,6 @@ import { Footer } from 'components/Footer/Footer'
 import { Header } from 'components/Header/Header'
 import { NewNavReview } from 'components/NewNavReview/NewNavReview'
 import { SkipLinks } from 'components/SkipLinks/SkipLinks'
-import { useWithoutFrame } from 'hooks/useWithoutFrame'
 import fullInfoIcon from 'icons/full-info.svg'
 import { selectCurrentUser } from 'store/user/selectors'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -33,8 +32,6 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
     Boolean(currentUser?.navState?.eligibilityDate) &&
     layout !== 'funnel' &&
     layout !== 'without-nav'
-
-  const isWithoutFrame = useWithoutFrame()
 
   return (
     <>
@@ -94,20 +91,13 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
             <div
               className={cn(styles['content-container'], {
                 [styles['content-container-funnel']]: layout === 'funnel',
-                [styles['content-container-without-frame']]: isWithoutFrame,
               })}
             >
               <main id="content">
                 {layout === 'funnel' || layout === 'without-nav' ? (
                   children
                 ) : (
-                  <div
-                    className={cn(styles.content, {
-                      [styles['content-without-frame']]: isWithoutFrame,
-                    })}
-                  >
-                    {children}
-                  </div>
+                  <div className={styles.content}>{children}</div>
                 )}
               </main>
               {layout !== 'funnel' && <Footer layout={layout} />}

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -6,7 +6,7 @@ import { Footer } from 'components/Footer/Footer'
 import { Header } from 'components/Header/Header'
 import { NewNavReview } from 'components/NewNavReview/NewNavReview'
 import { SkipLinks } from 'components/SkipLinks/SkipLinks'
-import { useActiveFeature } from 'hooks/useActiveFeature'
+import { useWithoutFrame } from 'hooks/useWithoutFrame'
 import fullInfoIcon from 'icons/full-info.svg'
 import { selectCurrentUser } from 'store/user/selectors'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -34,7 +34,7 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
     layout !== 'funnel' &&
     layout !== 'without-nav'
 
-  const isLayoutWithoutFrame = useActiveFeature('WIP_ENABLE_PRO_WITHOUT_FRAME')
+  const isWithoutFrame = useWithoutFrame()
 
   return (
     <>
@@ -92,7 +92,7 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
           <div
             className={cn(styles['content-container'], {
               [styles['content-container-funnel']]: layout === 'funnel',
-              [styles['content-container-without-frame']]: isLayoutWithoutFrame,
+              [styles['content-container-without-frame']]: isWithoutFrame,
             })}
           >
             <div>
@@ -103,7 +103,7 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
                 ) : (
                   <div
                     className={cn(styles.content, {
-                      [styles['content-without-frame']]: isLayoutWithoutFrame,
+                      [styles['content-without-frame']]: isWithoutFrame,
                     })}
                   >
                     {children}

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -89,14 +89,14 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
               navPanel={navPanel}
             />
           )}
-          <div
-            className={cn(styles['content-container'], {
-              [styles['content-container-funnel']]: layout === 'funnel',
-              [styles['content-container-without-frame']]: isWithoutFrame,
-            })}
-          >
-            <div>
-              {shouldDisplayNewNavReview && <NewNavReview />}
+          <div className={styles['content-wrapper']}>
+            {shouldDisplayNewNavReview && <NewNavReview />}
+            <div
+              className={cn(styles['content-container'], {
+                [styles['content-container-funnel']]: layout === 'funnel',
+                [styles['content-container-without-frame']]: isWithoutFrame,
+              })}
+            >
               <main id="content">
                 {layout === 'funnel' || layout === 'without-nav' ? (
                   children
@@ -110,8 +110,8 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
                   </div>
                 )}
               </main>
+              {layout !== 'funnel' && <Footer layout={layout} />}
             </div>
-            {layout !== 'funnel' && <Footer layout={layout} />}
           </div>
         </div>
       </div>

--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -65,7 +65,7 @@
 @media (min-width: size.$tablet) {
   .actions-bar {
     position: fixed;
-    box-shadow: 0 2px rem.torem(16px) var(--color-large-shadow);
+    box-shadow: 0 rem.torem(-2px) rem.torem(16px) var(--color-large-shadow);
     border-top: unset;
 
     &-new-interface {

--- a/pro/src/components/Footer/Footer.module.scss
+++ b/pro/src/components/Footer/Footer.module.scss
@@ -3,14 +3,8 @@
 @use "styles/variables/size.scss" as size;
 
 .footer {
-  margin-left: rem.torem(32px);
-  margin-right: rem.torem(32px);
   display: flex;
   align-items: center;
-
-  @media (min-width: size.$tablet) {
-    min-height: size.$footer-height;
-  }
 
   &-layout-sticky-actions {
     margin-bottom: size.$action-bar-sticky-height;
@@ -23,9 +17,16 @@
   }
 
   @media (min-width: size.$tablet) {
+    min-height: size.$footer-height;
+
     &-layout-without-nav {
       margin: -#{size.$footer-height} 0 0 size.$side-logo-width;
     }
+  }
+
+  @media (min-width: size.$mobile) {
+    margin-left: rem.torem(32px);
+    margin-right: rem.torem(32px);
   }
 
   ul {

--- a/pro/src/components/Footer/Footer.module.scss
+++ b/pro/src/components/Footer/Footer.module.scss
@@ -4,6 +4,7 @@
 
 .footer {
   display: flex;
+  justify-content: center;
   align-items: center;
 
   &-layout-sticky-actions {
@@ -34,14 +35,13 @@
     flex-direction: column;
     white-space: nowrap;
     margin: rem.torem(24px);
-    gap: rem.torem(16px);
+    gap: 0 rem.torem(16px);
     justify-content: center;
     align-items: flex-start;
 
     @media (min-width: size.$mobile) {
       flex-flow: row wrap;
       align-items: center;
-      margin: 0 auto;
     }
   }
 

--- a/pro/src/components/Footer/Footer.module.scss
+++ b/pro/src/components/Footer/Footer.module.scss
@@ -4,8 +4,11 @@
 
 .footer {
   margin-left: rem.torem(32px);
+  margin-right: rem.torem(32px);
+  display: flex;
+  align-items: center;
 
-  @media (min-width: size.$mobile) {
+  @media (min-width: size.$tablet) {
     min-height: size.$footer-height;
   }
 
@@ -27,17 +30,15 @@
 
   ul {
     display: flex;
-    height: 100%;
-    flex-flow: column;
+    flex-direction: column;
     white-space: nowrap;
-    width: 100%;
     margin: rem.torem(24px);
     gap: rem.torem(16px);
-    justify-content: flex-start;
+    justify-content: center;
     align-items: flex-start;
 
     @media (min-width: size.$mobile) {
-      flex-direction: row;
+      flex-flow: row wrap;
       align-items: center;
       margin: 0 auto;
     }

--- a/pro/src/components/FormLayout/FormLayout.module.scss
+++ b/pro/src/components/FormLayout/FormLayout.module.scss
@@ -20,6 +20,18 @@ $info-box-margin-left: rem.torem(24px);
     }
   }
 
+  &.medium-width-actions {
+    @media (min-width: size.$tablet) {
+      & > *:not(.form-layout-actions) {
+        max-width: rem.torem(826px);
+      }
+    }
+
+    .form-layout-actions {
+      justify-content: space-between;
+    }
+  }
+
   &-section {
     margin-bottom: rem.torem(24px);
 

--- a/pro/src/components/FormLayout/FormLayout.tsx
+++ b/pro/src/components/FormLayout/FormLayout.tsx
@@ -12,17 +12,20 @@ export interface FormLayoutProps {
   children: React.ReactNode | React.ReactNode[]
   className?: string
   fullWidthActions?: boolean
+  mediumWidthActions?: boolean
 }
 
 export const FormLayout = ({
   children,
   className,
   fullWidthActions = false,
+  mediumWidthActions = false,
 }: FormLayoutProps): JSX.Element => (
   <div
     className={cn(
       style['form-layout'],
       { [style['full-width-actions']]: fullWidthActions },
+      { [style['medium-width-actions']]: mediumWidthActions },
       className
     )}
   >

--- a/pro/src/components/StocksEventList/StocksEventList.module.scss
+++ b/pro/src/components/StocksEventList/StocksEventList.module.scss
@@ -138,11 +138,7 @@
   }
 
   .price-column {
-    width: rem.torem(174px);
-
-    &-without-frame {
-      width: rem.torem(300px);
-    }
+    width: rem.torem(300px);
   }
 
   .filter-input {

--- a/pro/src/components/StocksEventList/StocksEventList.tsx
+++ b/pro/src/components/StocksEventList/StocksEventList.tsx
@@ -17,7 +17,6 @@ import { Events } from 'core/FirebaseEvents/constants'
 import { SortingMode, useColumnSorting } from 'hooks/useColumnSorting'
 import { useNotification } from 'hooks/useNotification'
 import { usePaginationWithSearchParams } from 'hooks/usePagination'
-import { useWithoutFrame } from 'hooks/useWithoutFrame'
 import fullTrashIcon from 'icons/full-trash.svg'
 import { serializeStockEvents } from 'pages/IndividualOfferWizard/Stocks/serializeStockEvents'
 import { AddRecurrencesButton } from 'screens/IndividualOffer/StocksEventCreation/AddRecurrencesButton'
@@ -87,7 +86,6 @@ export const StocksEventList = ({
   const notify = useNotification()
   const [searchParams, setSearchParams] = useSearchParams()
   const { mutate } = useSWRConfig()
-  const isWithoutFrame = useWithoutFrame()
 
   // states
   const [allStocksChecked, setAllStocksChecked] = useState<PartialCheck>(
@@ -434,9 +432,7 @@ export const StocksEventList = ({
 
                 <th
                   scope="col"
-                  className={cn(styles['price-column'], styles['header'], {
-                    [styles['price-column-without-frame']]: isWithoutFrame,
-                  })}
+                  className={cn(styles['price-column'], styles['header'])}
                 >
                   <span className={styles['header-name']}>Tarif</span>
 

--- a/pro/src/components/StocksEventList/StocksEventList.tsx
+++ b/pro/src/components/StocksEventList/StocksEventList.tsx
@@ -597,7 +597,7 @@ export const StocksEventList = ({
                 return (
                   <tr key={stock.id} className={styles['row']}>
                     <td
-                      className={styles['data']}
+                      className={cn(styles['data'], styles['checkbox-column'])}
                       data-label="Sélection du stock"
                     >
                       {!readonly && (
@@ -608,7 +608,10 @@ export const StocksEventList = ({
                         />
                       )}
                     </td>
-                    <td className={styles['data']} data-label="Date">
+                    <td
+                      className={cn(styles['data'], styles['date-column'])}
+                      data-label="Date"
+                    >
                       <div
                         className={cn(
                           styles['date-cell-wrapper'],

--- a/pro/src/hooks/useWithoutFrame.tsx
+++ b/pro/src/hooks/useWithoutFrame.tsx
@@ -1,9 +1,0 @@
-import { useActiveFeature } from './useActiveFeature'
-import { useIsNewInterfaceActive } from './useIsNewInterfaceActive'
-
-export const useWithoutFrame = (): boolean => {
-  const isNewInterfaceActive = useIsNewInterfaceActive()
-  const isWithoutFrame = useActiveFeature('WIP_ENABLE_PRO_WITHOUT_FRAME')
-
-  return isNewInterfaceActive && isWithoutFrame
-}

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/CheckboxCell.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/CheckboxCell.tsx
@@ -2,6 +2,8 @@ import { CollectiveOfferStatus, OfferStatus } from 'apiClient/v1'
 import { isOfferDisabled } from 'core/Offers/utils/isOfferDisabled'
 import { BaseCheckbox } from 'ui-kit/form/shared/BaseCheckbox/BaseCheckbox'
 
+import styles from '../OfferItem.module.scss'
+
 interface CheckboxCellProps {
   offerName: string
   isSelected: boolean
@@ -18,7 +20,7 @@ export const CheckboxCell = ({
   selectOffer,
 }: CheckboxCellProps) => {
   return (
-    <td>
+    <td className={styles['checkbox-column']}>
       <BaseCheckbox
         checked={isSelected}
         className="select-offer-checkbox"

--- a/pro/src/pages/Offers/Offers/OfferItem/OfferItem.module.scss
+++ b/pro/src/pages/Offers/Offers/OfferItem/OfferItem.module.scss
@@ -188,6 +188,10 @@
       padding: rem.torem(8px);
     }
 
+    .checkbox-column {
+      width: rem.torem(32px);
+    }
+
     .venue-column,
     .institution-column,
     .title-column {
@@ -201,6 +205,7 @@
 
     .thumb-column {
       padding: rem.torem(8px);
+      max-width: rem.torem(80px);
 
       a {
         height: unset;

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/OffersSynchronization.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/OffersSynchronization.tsx
@@ -16,7 +16,7 @@ export const OffersSynchronization = ({
   venueProviders,
 }: OffersSynchronization) => {
   return (
-    <FormLayout fullWidthActions>
+    <FormLayout mediumWidthActions>
       <FormLayout.Section
         title="Gestion des synchronisations"
         description="Vous pouvez synchroniser votre lieu avec un logiciel tiers afin de faciliter la gestion de vos offres et de vos réservations."

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/VenueProviderItem.module.scss
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/VenueProviderItem.module.scss
@@ -3,25 +3,18 @@
 @use "styles/variables/_size.scss" as size;
 
 .venue-provider-row {
-  align-items: center;
+  align-items: normal;
   display: flex;
   flex-direction: column;
   width: 100%;
-
-  &-without-frame {
-    max-width: rem.torem(900px);
-    align-items: normal;
-  }
+  max-width: rem.torem(900px);
 }
 
 .venue-provider-item-info {
   display: flex;
   flex-direction: column;
   width: 100%;
-
-  &-without-frame {
-    max-width: rem.torem(900px);
-  }
+  max-width: rem.torem(900px);
 }
 
 .provider-name-container {

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/VenueProviderItem.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/VenueProviderItem.tsx
@@ -1,13 +1,9 @@
-import cn from 'classnames'
-import React from 'react'
-
 import { GetVenueResponseModel, VenueProviderResponse } from 'apiClient/v1'
 import { getProviderInfo } from 'core/Providers/utils/getProviderInfo'
 import {
   isAllocineProvider,
   isCinemaProvider,
 } from 'core/Providers/utils/utils'
-import { useWithoutFrame } from 'hooks/useWithoutFrame'
 import { formatLocalTimeDateString } from 'utils/timezone'
 
 import { AllocineProviderParameters } from './AllocineProviderParameters'
@@ -32,19 +28,10 @@ export const VenueProviderItem = ({
   const { lastSyncDate, provider, venueIdAtOfferProvider } = venueProvider
 
   const providerInfo = getProviderInfo(provider.name)
-  const isWithoutFrame = useWithoutFrame()
 
   return (
-    <li
-      className={cn(style['venue-provider-row'], {
-        [style['venue-provider-row-without-frame']]: isWithoutFrame,
-      })}
-    >
-      <div
-        className={cn(style['venue-provider-item-info'], {
-          [style['venue-provider-item-info-without-frame']]: isWithoutFrame,
-        })}
-      >
+    <li className={style['venue-provider-row']}>
+      <div className={style['venue-provider-item-info']}>
         <div className={style['provider-name-container']}>
           <div className={style['provider-name']}>
             {providerInfo?.name ?? provider.name}

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.module.scss
@@ -4,11 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  max-width: rem.torem(810px);
-
-  &-without-frame {
-    max-width: 100%;
-  }
+  max-width: 100%;
 }
 
 .help-section {

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useSWRConfig } from 'swr'
@@ -10,7 +9,6 @@ import { GET_OFFER_QUERY_KEY } from 'config/swrQueryKeys'
 import { getIndividualOfferUrl } from 'core/Offers/utils/getIndividualOfferUrl'
 import { useNotification } from 'hooks/useNotification'
 import { useOfferWizardMode } from 'hooks/useOfferWizardMode'
-import { useWithoutFrame } from 'hooks/useWithoutFrame'
 
 import { ActionBar } from '../ActionBar/ActionBar'
 
@@ -30,7 +28,6 @@ export const StocksEventCreation = ({
   const notify = useNotification()
 
   const [hasStocks, setHasStocks] = useState<boolean | null>(null)
-  const isWithoutFrame = useWithoutFrame()
 
   const handlePreviousStep = () => {
     /* istanbul ignore next: DEBT, TO FIX */
@@ -62,11 +59,7 @@ export const StocksEventCreation = ({
 
   return (
     <>
-      <div
-        className={classNames(styles['container'], {
-          [styles['container-without-frame']]: isWithoutFrame,
-        })}
-      >
+      <div className={styles['container']}>
         {hasStocks === false && (
           <HelpSection className={styles['help-section']} />
         )}

--- a/pro/src/screens/IndividualOffer/StocksThing/StockThing.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksThing/StockThing.module.scss
@@ -2,7 +2,6 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_size.scss" as size;
 
-
 .row {
   display: flex;
   flex-direction: column;
@@ -27,12 +26,14 @@
   .row {
     flex-direction: row;
     gap: rem.torem(16px);
-    align-items: flex-end;
+    align-items: flex-start;
   }
 
+  .field-layout-small {
+    width: rem.torem(252px);
+  }
 
   .field-layout-footer {
     min-height: rem.torem(32px);
   }
 }
-

--- a/pro/src/screens/IndividualOffer/StocksThing/StockThingFormActions/StockThingFormActions.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksThing/StockThingFormActions/StockThingFormActions.module.scss
@@ -29,8 +29,9 @@
 
 @media (min-width: size.$tablet) {
   .dropdown-actions {
-    align-self: center;
+    align-self: flex-start;
     display: flex;
+    margin-top: rem.torem(42px); // Vertically align with input field
   }
 
   .button-actions {

--- a/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
@@ -342,6 +342,7 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                 data-testid="input-price"
                 rightIcon={strokeEuroIcon}
                 step="0.01"
+                className={styles['field-layout-small']}
               />
               <DatePicker
                 smallLabel
@@ -352,6 +353,7 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                 minDate={today}
                 maxDate={getMaximumBookingDatetime(maxDateTime)}
                 disabled={readOnlyFields.includes('bookingLimitDatetime')}
+                className={styles['field-layout-small']}
               />
 
               {showExpirationDate && (
@@ -361,6 +363,7 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                   label="Date d'expiration"
                   classNameFooter={styles['field-layout-footer']}
                   disabled={true}
+                  className={styles['field-layout-small']}
                 />
               )}
               <TextInput
@@ -374,6 +377,7 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                 type="number"
                 hasDecimal={false}
                 onChange={onChangeQuantity}
+                className={styles['field-layout-small']}
               />
               {mode === OFFER_WIZARD_MODE.EDITION && stocks.length > 0 && (
                 <>

--- a/pro/src/styles/variables/_size.scss
+++ b/pro/src/styles/variables/_size.scss
@@ -7,7 +7,7 @@ $laptop: rem.torem(1024px);
 $tablet: rem.torem(744px);
 $mobile: rem.torem(380px);
 $main-content-width: rem.torem(874px);
-$main-content-padding: rem.torem(24px);
+$main-content-padding: rem.torem(32px);
 $checkbox-size: rem.torem(20px);
 $action-bar-sticky-height: rem.torem(72px);
 $image-banner-height: rem.torem(140px);

--- a/pro/src/styles/variables/_themes.scss
+++ b/pro/src/styles/variables/_themes.scss
@@ -54,7 +54,6 @@ html[data-theme="pink"],
   --color-background-valid: #eaf8f0;
   --color-background-alert: #fff8df;
   --color-background-error: #fdf4f6;
-  --color-background-content: #f6f6f6;
 
   // FORMS & INPUT COLORS
   --color-input-text-color: var(--color-black);


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30620

- **Commit 1 :** Uniformisation de l'utilisation du hook `useWithoutFrame` (qui sera en fait supprimé dans le commit final suite à décision PM)
- **Commit 2 :** Agrandit la taille du bloc gris représentant un pivot
- **Commit 3 :** Centre le footer et le rend responsive (correction/uniformisation de marges)
- **Commit 4 :** Fixe la taille des colonnes "checkbox" et "thumb" sur les tableaux pour les ferrer à gauche et éviter un espacement automatique incohérent visuellement
- **Commit 5 :** Fixe la tailles des colonnes de "checkbox" et de "date" sur les tableaux […]
- **Commit 6 :** Réduit en largeur les champs "prix", "date" et "quantité" dans la création d'offre physique (step 2)
- **Commit 7 :** Suppression du hook "useWithoutFrame" (la version sans frames sera la seule version proposée) et modification du padding du `<Layout>` (de 24px à 32px -> validé en revue PM+Design)
- **Commit 8 :** Rend la bannière de feedback non sticky (ce qui déporte le scroll vers le wrapper principal)