### PR TITLE
(PC-30509)[BO] feat: Cancellation reason for booking and collective booking display user informations if done by BOuser or pro

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-e9caf841c7d6 (pre) (head)
-7ed9516f7af7 (post) (head)
+35d67a2cddcd (pre) (head)
+9118d1848c98 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240716T150036_5f46232cb72f_add_cancellationauthor_for_booking.py
+++ b/api/src/pcapi/alembic/versions/20240716T150036_5f46232cb72f_add_cancellationauthor_for_booking.py
@@ -1,0 +1,26 @@
+"""
+add cancellationAuthor for booking
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi import settings
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "5f46232cb72f"
+down_revision = "e9caf841c7d6"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    if not settings.IS_PROD:
+        op.add_column("booking", sa.Column("cancellationAuthorId", sa.BigInteger(), nullable=True))
+
+
+def downgrade() -> None:
+    if not settings.IS_PROD:
+        op.drop_column("booking", "cancellationAuthorId")

--- a/api/src/pcapi/alembic/versions/20240716T150204_35d67a2cddcd_add_cancellationauthor_for_collective_booking.py
+++ b/api/src/pcapi/alembic/versions/20240716T150204_35d67a2cddcd_add_cancellationauthor_for_collective_booking.py
@@ -1,0 +1,29 @@
+"""
+add cancellationAuthor for collective_booking
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "35d67a2cddcd"
+down_revision = "5f46232cb72f"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "collective_booking",
+        sa.Column(
+            "cancellationAuthorId",
+            sa.BigInteger(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("collective_booking", "cancellationAuthorId")

--- a/api/src/pcapi/alembic/versions/20240716T150303_ebbed0db4e99_add_cancellationauthor_foreign_key_for_booking.py
+++ b/api/src/pcapi/alembic/versions/20240716T150303_ebbed0db4e99_add_cancellationauthor_foreign_key_for_booking.py
@@ -1,0 +1,32 @@
+"""
+add cancellationAuthor to booking foreignkey
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "ebbed0db4e99"
+down_revision = "7ed9516f7af7"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    if not settings.IS_PROD:
+        op.create_foreign_key(
+            "booking_cancellation_author_fk",
+            "booking",
+            "user",
+            ["cancellationAuthorId"],
+            ["id"],
+            postgresql_not_valid=True,
+        )
+
+
+def downgrade() -> None:
+    if not settings.IS_PROD:
+        op.drop_constraint("booking_cancellation_author_fk", "booking", type_="foreignkey")

--- a/api/src/pcapi/alembic/versions/20240716T150445_9118d1848c98_add_cancellationauthor_foreign_key_for_collective_booking.py
+++ b/api/src/pcapi/alembic/versions/20240716T150445_9118d1848c98_add_cancellationauthor_foreign_key_for_collective_booking.py
@@ -1,0 +1,28 @@
+"""
+add cancellationAuthor to collective booking foreignkey
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "9118d1848c98"
+down_revision = "ebbed0db4e99"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_foreign_key(
+        "collective_booking_cancellation_author_fk",
+        "collective_booking",
+        "user",
+        ["cancellationAuthorId"],
+        ["id"],
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("collective_booking_cancellation_author_fk", "collective_booking", type_="foreignkey")

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -440,13 +440,25 @@ def _cancel_booking(
     cancel_even_if_used: bool = False,
     raise_if_error: bool = False,
     one_side_cancellation: bool = False,
+    author_id: int | None = None,
 ) -> bool:
     """Cancel booking and update a user's credit information on Batch"""
     try:
-        if not _execute_cancel_booking(booking, reason, cancel_even_if_used, raise_if_error, one_side_cancellation):
+        if not _execute_cancel_booking(
+            booking=booking,
+            reason=reason,
+            cancel_even_if_used=cancel_even_if_used,
+            raise_if_error=raise_if_error,
+            one_side_cancellation=one_side_cancellation,
+            author_id=author_id,
+        ):
             return False
     except external_bookings_exceptions.ExternalBookingAlreadyCancelledError as error:
-        booking.cancel_booking(reason, cancel_even_if_used)
+        booking.cancel_booking(
+            reason=reason,
+            cancel_even_if_used=cancel_even_if_used,
+            author_id=author_id,
+        )
         if error.remainingQuantity is None:
             booking.stock.quantity = None
         else:
@@ -486,6 +498,7 @@ def _execute_cancel_booking(
     cancel_even_if_used: bool = False,
     raise_if_error: bool = False,
     one_side_cancellation: bool = False,
+    author_id: int | None = None,
 ) -> bool:
     with transaction():
         with db.session.no_autoflush:
@@ -501,7 +514,11 @@ def _execute_cancel_booking(
             )
             try:
                 cancelled_event = finance_api.cancel_latest_event(booking)
-                booking.cancel_booking(reason, cancel_even_if_used)
+                booking.cancel_booking(
+                    reason=reason,
+                    cancel_even_if_used=cancel_even_if_used,
+                    author_id=author_id,
+                )
                 if cancelled_event:
                     finance_api.add_event(
                         finance_models.FinanceEventMotive.BOOKING_CANCELLED_AFTER_USE,
@@ -714,7 +731,10 @@ def mark_as_used_with_uncancelling(booking: Booking, validation_author_type: Boo
 
 
 def mark_as_cancelled(
-    booking: Booking, reason: BookingCancellationReasons, one_side_cancellation: bool = False
+    booking: Booking,
+    reason: BookingCancellationReasons,
+    one_side_cancellation: bool = False,
+    author_id: int | None = None,
 ) -> None:
     """
     A booking can be cancelled only if it has not been cancelled before and if
@@ -748,7 +768,12 @@ def mark_as_cancelled(
             raise exceptions.OneSideCancellationForbidden()
 
     _cancel_booking(
-        booking, reason, cancel_even_if_used=True, raise_if_error=True, one_side_cancellation=one_side_cancellation
+        booking=booking,
+        reason=reason,
+        cancel_even_if_used=True,
+        raise_if_error=True,
+        one_side_cancellation=one_side_cancellation,
+        author_id=author_id,
     )
 
     if one_side_cancellation:

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -150,6 +150,12 @@ class Booking(PcObject, Base, Model):
         postgresql_where=cancellationReason.is_not(None),
     )
 
+    cancellationAuthorId: int | None = Column(BigInteger, ForeignKey("user.id"), nullable=True)
+
+    cancellationAuthor: Mapped["users_models.User | None"] = relationship(
+        "User", foreign_keys=[cancellationAuthorId], backref="cancelledBookings"
+    )
+
     status: BookingStatus = Column(Enum(BookingStatus), nullable=False, default=BookingStatus.CONFIRMED)
     Index("ix_booking_status", status)
 
@@ -181,6 +187,7 @@ class Booking(PcObject, Base, Model):
         reason: BookingCancellationReasons,
         cancel_even_if_used: bool = False,
         cancel_even_if_reimbursed: bool = False,
+        author_id: int | None = None,
     ) -> None:
         if self.status is BookingStatus.CANCELLED:
             raise exceptions.BookingIsAlreadyCancelled()
@@ -192,6 +199,7 @@ class Booking(PcObject, Base, Model):
         self.cancellationDate = datetime.utcnow()
         self.cancellationReason = reason
         self.dateUsed = None
+        self.cancellationAuthorId = author_id
 
     def uncancel_booking_set_used(self) -> None:
         if not (self.status is BookingStatus.CANCELLED):
@@ -200,6 +208,7 @@ class Booking(PcObject, Base, Model):
         self.cancellationReason = None
         self.status = BookingStatus.USED
         self.dateUsed = datetime.utcnow()
+        self.cancellationAuthorId = None
 
     @property
     def expirationDate(self) -> datetime | None:

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -233,7 +233,7 @@ def find_user_ids_with_expired_individual_bookings(expired_on: date | None = Non
         user_id
         for user_id, in (
             db.session.query(User.id)
-            .join(Booking)
+            .join(Booking, User.userBookings)
             .filter(
                 Booking.status == BookingStatus.CANCELLED,
                 Booking.cancellationDate >= expired_on,

--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -392,6 +392,7 @@ def cancel_collective_booking(
     collective_booking: educational_models.CollectiveBooking,
     reason: educational_models.CollectiveBookingCancellationReasons,
     _from: str | None = None,
+    author_id: int | None = None,
 ) -> None:
     with transaction():
         educational_repository.get_and_lock_collective_stock(stock_id=collective_booking.collectiveStock.id)
@@ -399,7 +400,7 @@ def cancel_collective_booking(
         if finance_repository.has_reimbursement(collective_booking):
             raise exceptions.BookingIsAlreadyRefunded()
         cancelled_event = finance_api.cancel_latest_event(collective_booking)
-        collective_booking.cancel_booking(reason=reason, cancel_even_if_used=True)
+        collective_booking.cancel_booking(reason=reason, cancel_even_if_used=True, author_id=author_id)
         if cancelled_event:
             finance_api.add_event(
                 finance_models.FinanceEventMotive.BOOKING_CANCELLED_AFTER_USE,

--- a/api/src/pcapi/routes/backoffice/bookings/collective_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/collective_bookings_blueprint.py
@@ -238,6 +238,7 @@ def mark_booking_as_cancelled(collective_booking_id: int) -> utils.BackofficeRes
             collective_booking,
             educational_models.CollectiveBookingCancellationReasons(form.reason.data),
             _from="support",
+            author_id=current_user.id,
         )
     except educational_exceptions.CollectiveBookingAlreadyCancelled:
         repository.mark_transaction_as_invalid()

--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -168,7 +168,7 @@ class GetIndividualBookingListForm(BaseBookingListForm):
     cancellation_reason = fields.PCSelectMultipleField(
         "Raison d'annulation",
         choices=utils.choices_from_enum(
-            bookings_models.BookingCancellationReasons, formatter=filters.format_booking_cancellation_reason
+            bookings_models.BookingCancellationReasons, formatter=filters.format_booking_cancellation
         ),
     )
     deposit = fields.PCSelectField(
@@ -215,7 +215,7 @@ class CancelCollectiveBookingForm(FlaskForm):
         "Raison",
         choices=utils.choices_from_enum(
             educational_models.CollectiveBookingCancellationReasons,
-            formatter=filters.format_booking_cancellation_reason,
+            formatter=filters.format_booking_cancellation,
         ),
     )
 
@@ -224,7 +224,7 @@ class CancelIndividualBookingForm(FlaskForm):
     reason = fields.PCSelectWithPlaceholderValueField(
         "Raison",
         choices=utils.choices_from_enum(
-            bookings_models.BookingCancellationReasons, formatter=filters.format_booking_cancellation_reason
+            bookings_models.BookingCancellationReasons, formatter=filters.format_booking_cancellation
         ),
     )
 

--- a/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
@@ -282,7 +282,11 @@ def mark_booking_as_cancelled(booking_id: int) -> utils.BackofficeResponse:
         return _redirect_after_individual_booking_action()
 
     try:
-        bookings_api.mark_as_cancelled(booking, bookings_models.BookingCancellationReasons(form.reason.data))
+        bookings_api.mark_as_cancelled(
+            booking=booking,
+            reason=bookings_models.BookingCancellationReasons(form.reason.data),
+            author_id=current_user.id,
+        )
     except bookings_exceptions.BookingIsAlreadyCancelled:
         repository.mark_transaction_as_invalid()
         flash("Impossible d'annuler une réservation déjà annulée", "warning")
@@ -304,7 +308,10 @@ def mark_booking_as_cancelled(booking_id: int) -> utils.BackofficeResponse:
         )
         try:
             bookings_api.mark_as_cancelled(
-                booking, bookings_models.BookingCancellationReasons(form.reason.data), one_side_cancellation=True
+                booking=booking,
+                reason=bookings_models.BookingCancellationReasons(form.reason.data),
+                one_side_cancellation=True,
+                author_id=current_user.id,
             )
         except Exception as exception:  # pylint: disable=broad-except
             repository.mark_transaction_as_invalid()
@@ -391,7 +398,9 @@ def batch_cancel_individual_bookings() -> utils.BackofficeResponse:
     return _batch_individual_bookings_action(
         form,
         lambda booking: bookings_api.mark_as_cancelled(
-            booking, bookings_models.BookingCancellationReasons(form.reason.data)
+            booking=booking,
+            reason=bookings_models.BookingCancellationReasons(form.reason.data),
+            author_id=current_user.id,
         ),
         "Les réservations ont été annulées",
     )

--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/details/bookings.html
@@ -51,7 +51,7 @@
                 </p>
                 <p class="mb-1">
                   <span class="fw-bold">Motif d'annulation :</span>
-                  {{ booking.cancellationReason | format_booking_cancellation_reason }}
+                  {{ booking.cancellationReason | format_booking_cancellation }}
                 </p>
               {% endif %}
               <p class="mb-1">

--- a/api/src/pcapi/routes/backoffice/templates/components/bookings/extra_row.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/bookings/extra_row.html
@@ -49,7 +49,7 @@
                 </li>
                 <li>
                   Raison de l'annulation :
-                  {{ booking.cancellationReason | format_booking_cancellation_reason }}
+                  {{ booking.cancellationReason | format_booking_cancellation(booking.cancellationAuthor) }}
                 </li>
               {% endif %}
             </ul>

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/details/bookings.html
@@ -48,7 +48,7 @@
                 </p>
                 <p class="mb-1">
                   <span class="fw-bold">Motif d'annulation :</span>
-                  {{ booking_finance_incident.booking.cancellationReason | format_booking_cancellation_reason }}
+                  {{ booking_finance_incident.booking.cancellationReason | format_booking_cancellation }}
                 </p>
               {% endif %}
               <p class="mb-1">

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/details/collective_bookings.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/details/collective_bookings.html
@@ -49,7 +49,7 @@
                 </p>
                 <p class="mb-1">
                   <span class="fw-bold">Motif d'annulation :</span>
-                  {{ booking_finance_incident.collectiveBooking.cancellationReason | format_booking_cancellation_reason }}
+                  {{ booking_finance_incident.collectiveBooking.cancellationReason | format_booking_cancellation }}
                 </p>
               {% endif %}
               <p class="mb-1">

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -176,6 +176,38 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
         assert html_parser.extract_pagination_info(response.data) == (1, 1, len(rows))
 
     @pytest.mark.parametrize(
+        "cancellation_reason, expected_text",
+        [
+            (educational_models.CollectiveBookingCancellationReasons.BACKOFFICE, "Annulée sur le backoffice par"),
+            (educational_models.CollectiveBookingCancellationReasons.FRAUD, "Fraude"),
+        ],
+    )
+    def test_list_cancelled_collective_booking_information(
+        self, authenticated_client, legit_user, cancellation_reason, expected_text
+    ):
+        booking = educational_factories.CancelledCollectiveBookingFactory(
+            cancellationAuthor=legit_user,
+            cancellationReason=cancellation_reason,
+        )
+
+        response = authenticated_client.get(
+            url_for(self.endpoint, q=booking.id, cancellation_reason=["OFFERER", "FRAUD", "BACKOFFICE"])
+        )
+        assert response.status_code == 200
+
+        extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[0]
+
+        assert "Formats" in extra_data
+        assert "Date de confirmation de réservation" in extra_data
+        assert "Date limite de réservation" in extra_data
+        assert "Date d'annulation" in extra_data
+        assert "Raison de l'annulation" in extra_data
+        if expected_text == "Fraude":
+            assert expected_text in extra_data
+        else:
+            assert f"{expected_text} {legit_user.full_name}" in extra_data
+
+    @pytest.mark.parametrize(
         "query_args",
         [
             {},

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -563,6 +563,39 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         # booked J not used, booked J-2 not used, event J+12, event J+11, used J
         assert [row["Contremarque"] for row in rows] == ["ADFTH9", "ELBEIT", "REIMB3", "CNCL02", "WTRL00"]
 
+    @pytest.mark.parametrize(
+        "cancellation_reason, expected_text",
+        [
+            (bookings_models.BookingCancellationReasons.BACKOFFICE, "Annulée sur le backoffice par"),
+            (bookings_models.BookingCancellationReasons.FRAUD, "Fraude"),
+        ],
+    )
+    def test_list_cancelled_booking_information(
+        self, authenticated_client, legit_user, cancellation_reason, expected_text
+    ):
+        bookings_factories.CancelledBookingFactory(
+            cancellationReason=cancellation_reason,
+            cancellationAuthorId=legit_user.id,
+        )
+
+        response = authenticated_client.get(
+            url_for(self.endpoint, cancellation_reason=["OFFERER", "FRAUD", "BACKOFFICE"])
+        )
+        assert response.status_code == 200
+
+        extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[0]
+
+        assert "Catégorie" in extra_data
+        assert "Sous-catégorie" in extra_data
+        assert "Date d'annulation" in extra_data
+        assert "Raison de l'annulation" in extra_data
+        if expected_text == "Fraude":
+            assert expected_text in extra_data
+        else:
+            assert f"{expected_text} {legit_user.full_name}" in extra_data
+            link = '<a href="/admin/bo-users/' + str(legit_user.id) + '">' + legit_user.full_name + "</a>"
+            assert link in str(html_parser.get_soup(response.data))
+
 
 class MarkBookingAsUsedTest(PostEndpointHelper):
     endpoint = "backoffice_web.individual_bookings.mark_booking_as_used"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30509

## Vérifications

### verification front 

par l'acteur culturelle
<img width="1461" alt="Capture d’écran 2024-07-11 à 11 45 09" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/bf3b8968-84f3-447d-8e0b-00674121d2c2">

par le backoffice
<img width="1478" alt="Capture d’écran 2024-07-11 à 11 45 49" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/0d17492c-a198-47e5-985a-61dc39f0c739">

par autre:
<img width="926" alt="Capture d’écran 2024-07-11 à 11 46 20" src="https://github.com/pass-culture/pass-culture-main/assets/114911174/6c39af0e-535d-411c-80e7-226248ad90c0">


### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 

RESERVATION INDIVIDUELLE : _test_list_cancelled_booking_informations ligne 308 dans individual_booking_test_

Si un booking est annulé avec pour raison d'annulation "Annulée par l'acteur culturel" :
ALORS
- la phrase continue en donnant l'email de l'acteur culturel
- l'email contenue dans la phrase est un lien vers la page de l'acteur culturel

Si un booking est annulé avec pour raison d'annulation "Annulée sur le backoffice" :
ALORS
- la phrase continue en donnant le prénom et nom de l'utilisateur BO
- le nom et prénom de l'utilisateur BO contenu dans la phrase est un lien vers la page de l'utilisateur

Si un booking est annulé avec pour raison d'annulation autres:
ALORS
- Rien est écrit en dehors de la raison ( pas d'auteur)
- aucun lien

RESERVATION COLLECTIVE : _test_list_cancelled_collective_booking_informations ligne 186_

Si un booking est annulé avec pour raison d'annulation "Annulée par l'acteur culturel" :
ALORS
- la phrase continue en donnant l'email de l'acteur culturel
- l'email contenue dans la phrase est un lien vers la page de l'acteur culturel

Si un booking est annulé avec pour raison d'annulation "Annulée sur le backoffice" :
ALORS
- la phrase continue en donnant le prénom et nom de l'utilisateur BO
- le nom et prénom de l'utilisateur BO contenu dans la phrase est un lien vers la page de l'utilisateur

Si un booking est annulé avec pour raison d'annulation autres:
ALORS
- Rien est écrit en dehors de la raison ( pas d'auteur)
- aucun lien


### Verification ticket

- nom du ticket conforme -> OK
- auteur du ticket -> OK
- nombre de commit -> OK
- nom du commit -> OK
- mettre le ticket en code-review -> OK

### Tache restante si WIP + AUTRE

- refresh de la page github -> OK

A FAIRE => CONFIRMATION DE LA MIGRATION VALIDATE CONSTRAINT SUR UNE AUTRE PR