### PR TITLE
(PC-30496)[API] public api: mark two routes as deprecated

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
@@ -220,7 +220,7 @@ def validate_booking_by_token(token: str) -> None:
 @api_key_required
 def cancel_booking_validation_by_token(token: str) -> None:
     """
-    Cancel a booking validation
+    Revert token validation
 
     Mark a booking as `unused`.
     """
@@ -262,12 +262,14 @@ def cancel_booking_validation_by_token(token: str) -> None:
 @api_key_required
 def cancel_booking_by_token(token: str) -> None:
     """
-    Cancel a booking
+    Delete a booking
 
     Cancel a booking that has not been used or refunded.
 
+    ::warning
     For events, a booking can only be cancelled if it is pending.
     Once it is confirmed, you cannot cancel it (for booking confirmation see [this page](/docs/understanding-our-api/resources/individual-offers#general-description-2)).
+    :::
     """
     booking = _get_booking_by_token(token)
     if booking is None:

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -8938,7 +8938,7 @@
         },
         "/public/bookings/v1/cancel/token/{token}": {
             "patch": {
-                "description": "Cancel a booking that has not been used or refunded.\n\nFor events, a booking can only be cancelled if it is pending. Once it is confirmed, you cannot cancel it (for booking confirmation see [this page](/docs/understanding-our-api/resources/individual-offers#general-description-2)).",
+                "description": "Cancel a booking that has not been used or refunded.\n\n::warning For events, a booking can only be cancelled if it is pending. Once it is confirmed, you cannot cancel it (for booking confirmation see [this page](/docs/understanding-our-api/resources/individual-offers#general-description-2)). :::",
                 "operationId": "CancelBookingByToken",
                 "parameters": [
                     {
@@ -9003,7 +9003,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "summary": "Cancel a booking",
+                "summary": "Delete a booking",
                 "tags": [
                     "Bookings"
                 ]
@@ -9066,7 +9066,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "summary": "Cancel a booking validation",
+                "summary": "Revert token validation",
                 "tags": [
                     "Bookings"
                 ]


### PR DESCRIPTION
cancel booking and cancel booking validation are now deprecated.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30496

Marquer deux routes (annulation de réservation, de validation d'annulation) comme obsolètes.