### PR TITLE
(BSR)[API] fix: public api doc: rm subcategory from payload example

### DIFF
--- a/api/documentation/docs/tutorials/create-a-collective-offer.md
+++ b/api/documentation/docs/tutorials/create-a-collective-offer.md
@@ -28,7 +28,6 @@ Your JSON payload should look something like :
   "venueId": 1234,
   "name": "Atelier de peinture",
   "description": "Describe your offer",
-  "subcategoryId": "ATELIER_PRATIQUE_ART",
   "formats": [
     "Atelier de pratique"
   ],


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

Retirer le champ subcategoryId de l'exemple de JSON fourni dans le tutoriel de la création d'une offre collective car ce champ est obsolète.