### PR TITLE
(BSR)[BO] fix: skip check_booking trigger function when generating the invoices

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 e0d7e16bcbaa (pre) (head)
-361fc0a4ba9b (post) (head)
+e199b0790783 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240710T153906_e199b0790783_skip_reimbursed_booking_trigger.py
+++ b/api/src/pcapi/alembic/versions/20240710T153906_e199b0790783_skip_reimbursed_booking_trigger.py
@@ -1,0 +1,36 @@
+"""Skip check_booking function trigger when setting the status field's value to REIMBURSED
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "e199b0790783"
+down_revision = "361fc0a4ba9b"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS booking_update ON booking")
+    op.execute(
+        """CREATE CONSTRAINT TRIGGER booking_update
+AFTER INSERT
+OR UPDATE OF quantity, amount, status, "userId"
+ON booking
+FOR EACH ROW
+WHEN (NEW.status <> 'REIMBURSED')
+EXECUTE PROCEDURE check_booking()"""
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS booking_update ON booking")
+    op.execute(
+        """CREATE CONSTRAINT TRIGGER booking_update
+AFTER INSERT
+OR UPDATE OF quantity, amount, status, "userId"
+ON booking
+FOR EACH ROW EXECUTE PROCEDURE check_booking()"""
+    )

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -474,7 +474,10 @@ Booking.trig_ddl = f"""
     AFTER INSERT
     OR UPDATE OF quantity, amount, status, "userId"
     ON booking
-    FOR EACH ROW EXECUTE PROCEDURE check_booking()
+    FOR EACH ROW
+    -- Happens only for USED to REIMBURSED transition
+    WHEN (NEW.status <> '{BookingStatus.REIMBURSED.value}')
+    EXECUTE PROCEDURE check_booking()
     """
 event.listen(Booking.__table__, "after_create", DDL(Booking.trig_ddl))
 


### PR DESCRIPTION

## But de la pull request

Finance: éviter de vérifier les quantités des stocks lors de la génération des exports finance.

Problème: Lors de la création des invoice, il se peut qu'on ait à passer des centaines de booking de "USED" à "REIMBURSED" et ça engendre des timeouts quand on lance la commande `generate_invoices`

Solution: cette vérification est inutile à ce stade du workflow finance donc on ne garde le check que pour les autres changement d'état des bookings

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~