### PR TITLE
(BSR)[PRO] test: try to fix flaky signup with wait

### DIFF
--- a/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
@@ -92,6 +92,7 @@ When('I fill activity form without target audience', () => {
 
 When('I validate the registration', () => {
   cy.intercept({ method: 'POST', url: '/offerers/new' }).as('createOfferer')
+  cy.wait(2000)
   cy.findByText('Valider et créer ma structure').click()
 })
 

--- a/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
@@ -92,7 +92,7 @@ When('I fill activity form without target audience', () => {
 
 When('I validate the registration', () => {
   cy.intercept({ method: 'POST', url: '/offerers/new' }).as('createOfferer')
-  cy.wait(2000)
+  cy.wait(2000) // @todo: delete this when random failures fixed
   cy.findByText('Valider et créer ma structure').click()
 })
 


### PR DESCRIPTION
## But de la pull request

Cela ne me satisfait pas particulièrement, mais à défaut de trouver la root cause, j'ai ajouté une pause de 2 secondes avant la création de l'offre pour éviter les échecs qui se répètent. On perd 2", mais avoir un échec fait perdre encore plus de temps, et de confiance...
A voir si c'est mieux sur les multiples runs sur master.

Ces tests flaky seront à revoir quand on aura une utilisation de donnée définitives (données créées au début du test n'utilisant plus celles de la sandbox)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques