### PR TITLE
(PC-30742)[PRO] feat: Make new tab icon automatic in button links.

### DIFF
--- a/pro/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/pro/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 import rightIcon from 'icons/stroke-right.svg'
-import { ButtonLink, ButtonLinkProps } from 'ui-kit/Button/ButtonLink'
+import { ButtonLink, LinkProps } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
@@ -7,7 +7,7 @@ import styles from './Breadcrumb.module.scss'
 
 export type Crumb = {
   title: string
-  link: ButtonLinkProps['link']
+  link: LinkProps
   icon?: string
 }
 
@@ -29,9 +29,7 @@ export const Breadcrumb = ({ crumbs }: BreadcrumbProps) => {
                 </span>
               ) : (
                 <ButtonLink
-                  link={{
-                    ...crumb.link,
-                  }}
+                  {...crumb.link}
                   className={styles['breadcrumb-list-item-link']}
                   variant={ButtonVariant.QUATERNARYPINK}
                 >

--- a/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
@@ -212,23 +212,11 @@ export const CollectiveOfferNavigation = ({
     <>
       <div className={styles['duplicate-offer']}>
         {!location.pathname.includes('edition') && (
-          <ButtonLink
-            link={{
-              to: offerEditLink,
-              isExternal: false,
-            }}
-            icon={fullEditIcon}
-          >
+          <ButtonLink to={offerEditLink} icon={fullEditIcon}>
             Modifier l’offre
           </ButtonLink>
         )}
-        <ButtonLink
-          link={{
-            to: previewLink,
-            isExternal: false,
-          }}
-          icon={fullShowIcon}
-        >
+        <ButtonLink to={previewLink} icon={fullShowIcon}>
           Aperçu dans ADAGE
         </ButtonLink>
 

--- a/pro/src/components/Dialog/RedirectDialog/RedirectDialog.tsx
+++ b/pro/src/components/Dialog/RedirectDialog/RedirectDialog.tsx
@@ -48,7 +48,7 @@ export const RedirectDialog = ({
       <div className={styles['redirect-dialog-actions']}>
         <ButtonLink
           data-testid="redirect-dialog-link"
-          link={redirectLink}
+          {...redirectLink}
           variant={ButtonVariant.PRIMARY}
           onClick={onRedirect}
           icon={withRedirectLinkIcon ? fullLinkIcon : undefined}

--- a/pro/src/components/Footer/Footer.tsx
+++ b/pro/src/components/Footer/Footer.tsx
@@ -33,13 +33,10 @@ export const Footer = ({ layout }: FooterProps) => {
         <li>
           <ButtonLink
             variant={ButtonVariant.QUATERNARY}
-            link={{
-              to: 'https://pass.culture.fr/cgu-professionnels/',
-              isExternal: true,
-              target: '_blank',
-            }}
+            to="https://pass.culture.fr/cgu-professionnels/"
+            isExternal
+            opensInNewTab
             icon={fullLinkIcon}
-            svgAlt="Nouvelle fenêtre"
           >
             CGU professionnels
           </ButtonLink>
@@ -47,35 +44,22 @@ export const Footer = ({ layout }: FooterProps) => {
         <li>
           <ButtonLink
             variant={ButtonVariant.QUATERNARY}
-            link={{
-              to: 'https://pass.culture.fr/donnees-personnelles/',
-              isExternal: true,
-              target: '_blank',
-            }}
+            to="https://pass.culture.fr/donnees-personnelles/"
+            isExternal
+            opensInNewTab
             icon={fullLinkIcon}
-            svgAlt="Nouvelle fenêtre"
           >
             Charte des Données Personnelles
           </ButtonLink>
         </li>
         <li>
-          <ButtonLink
-            variant={ButtonVariant.QUATERNARY}
-            link={{
-              to: '/accessibilite',
-            }}
-          >
+          <ButtonLink variant={ButtonVariant.QUATERNARY} to="/accessibilite">
             Accessibilité : non conforme
           </ButtonLink>
         </li>
         {currentUser && (
           <li>
-            <ButtonLink
-              variant={ButtonVariant.QUATERNARY}
-              link={{
-                to: '/plan-du-site',
-              }}
-            >
+            <ButtonLink variant={ButtonVariant.QUATERNARY} to="/plan-du-site">
               Plan du site
             </ButtonLink>
           </li>

--- a/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
+++ b/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
@@ -223,7 +223,7 @@ export const HeaderDropdown = () => {
                           <ButtonLink
                             icon={fullMoreIcon}
                             className={styles['menu-item']}
-                            link={{ to: '/parcours-inscription/structure' }}
+                            to="/parcours-inscription/structure"
                           >
                             Ajouter une nouvelle structure
                           </ButtonLink>
@@ -241,7 +241,7 @@ export const HeaderDropdown = () => {
             </DropdownMenu.Label>
             <div className={styles['menu-email']}>{currentUser?.email}</div>
             <DropdownMenu.Item className={styles['menu-item']} asChild>
-              <ButtonLink icon={fullProfilIcon} link={{ to: '/profil' }}>
+              <ButtonLink icon={fullProfilIcon} to="/profil">
                 Voir mon profil
               </ButtonLink>
             </DropdownMenu.Item>
@@ -260,7 +260,7 @@ export const HeaderDropdown = () => {
             <DropdownMenu.Item className={styles['menu-item']} asChild>
               <ButtonLink
                 icon={fullLogoutIcon}
-                link={{ to: `${location.pathname}?logout}` }}
+                to={`${location.pathname}?logout}`}
                 onClick={() =>
                   logEvent(Events.CLICKED_LOGOUT, {
                     from: location.pathname,

--- a/pro/src/components/Header/HeaderHelpDropdown/HelpDropdownMenu.tsx
+++ b/pro/src/components/Header/HeaderHelpDropdown/HelpDropdownMenu.tsx
@@ -13,18 +13,15 @@ export const HelpDropdownMenu = () => {
     <>
       <DropdownMenu.Item className={dropdownStyles['menu-item']} asChild>
         <ButtonLink
-          link={{
-            to: 'https://aide.passculture.app',
-            isExternal: true,
-            target: '_blank',
-          }}
+          to="https://aide.passculture.app"
+          isExternal
+          opensInNewTab
           icon={fullLinkIcon}
           onClick={() =>
             logEvent(Events.CLICKED_HELP_CENTER, {
               from: location.pathname,
             })
           }
-          svgAlt="Nouvelle fenêtre"
         >
           Consulter le centre d’aide
         </ButtonLink>
@@ -32,17 +29,14 @@ export const HelpDropdownMenu = () => {
       <DropdownMenu.Item className={dropdownStyles['menu-item']} asChild>
         <ButtonLink
           icon={fullLinkIcon}
-          link={{
-            to: 'https://aide.passculture.app/hc/fr/articles/13155602579356--Acteurs-Culturels-Quelle-%C3%A9quipe-contacter-selon-votre-demande',
-            isExternal: true,
-            target: '_blank',
-          }}
+          to="https://aide.passculture.app/hc/fr/articles/13155602579356--Acteurs-Culturels-Quelle-%C3%A9quipe-contacter-selon-votre-demande"
+          isExternal
+          opensInNewTab
           onClick={() =>
             logEvent(Events.CLICKED_CONTACT_OUR_TEAMS, {
               from: location.pathname,
             })
           }
-          svgAlt="Nouvelle fenêtre"
         >
           Contacter nos équipes
         </ButtonLink>
@@ -50,17 +44,14 @@ export const HelpDropdownMenu = () => {
       <DropdownMenu.Item className={dropdownStyles['menu-item']} asChild>
         <ButtonLink
           icon={fullLinkIcon}
-          link={{
-            to: 'https://passcultureapp.notion.site/pass-Culture-Documentation-323b1a0ec309406192d772e7d803fbd0',
-            isExternal: true,
-            target: '_blank',
-          }}
+          to="https://passcultureapp.notion.site/pass-Culture-Documentation-323b1a0ec309406192d772e7d803fbd0"
+          isExternal
+          opensInNewTab
           onClick={() =>
             logEvent(Events.CLICKED_BEST_PRACTICES_STUDIES, {
               from: location.pathname,
             })
           }
-          svgAlt="Nouvelle fenêtre"
         >
           Bonnes pratiques et études
         </ButtonLink>

--- a/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
+++ b/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
@@ -184,9 +184,8 @@ export const Categories = ({
               isExternal: true,
               to: 'https://aide.passculture.app/hc/fr/articles/4411999013265--Acteurs-Culturels-Quelle-cat%C3%A9gorie-et-sous-cat%C3%A9gorie-choisir-lors-de-la-cr%C3%A9ation-d-offres-',
               text: 'Quelles catégories choisir ?',
-              target: '_blank',
+              opensInNewTab: true,
             }}
-            svgAlt="Nouvelle fenêtre"
           >
             Une sélection précise de vos catégories permettra au grand public de
             facilement trouver votre offre. Une fois validées, vous ne pourrez

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
@@ -88,7 +88,6 @@ export const UsefulInformations = ({
               to: 'https://aide.passculture.app/hc/fr/articles/4413389597329--Acteurs-Culturels-Quelles-modalit%C3%A9s-de-retrait-indiquer-pour-ma-structure-',
               text: 'Quelles modalités de retrait choisir ?',
             }}
-            svgAlt="Nouvelle fenêtre"
           >
             {isVenueVirtual
               ? 'Indiquez ici tout ce qui peut être utile au bénéficiaire pour le retrait de l’offre.'

--- a/pro/src/components/LegalInfos/LegalInfos.tsx
+++ b/pro/src/components/LegalInfos/LegalInfos.tsx
@@ -31,11 +31,9 @@ export const LegalInfos = ({
         onClick={() =>
           logEvent(Events.CLICKED_CONSULT_CGU, { from: location.pathname })
         }
-        link={{
-          to: 'https://pass.culture.fr/cgu-professionnels/',
-          isExternal: true,
-          target: '_blank',
-        }}
+        to="https://pass.culture.fr/cgu-professionnels/"
+        isExternal
+        opensInNewTab
         variant={ButtonVariant.QUATERNARY}
       >
         <SvgIcon
@@ -52,11 +50,9 @@ export const LegalInfos = ({
         onClick={() =>
           logEvent(Events.CLICKED_PERSONAL_DATA, { from: location.pathname })
         }
-        link={{
-          to: 'https://pass.culture.fr/donnees-personnelles/',
-          isExternal: true,
-          target: '_blank',
-        }}
+        to="https://pass.culture.fr/donnees-personnelles/"
+        isExternal
+        opensInNewTab
         variant={ButtonVariant.QUATERNARY}
       >
         <SvgIcon
@@ -80,11 +76,9 @@ export const LegalInfos = ({
             from: location.pathname,
           })
         }
-        link={{
-          to: 'mailto:support-pro@passculture.app',
-          isExternal: true,
-          target: '_blank',
-        }}
+        to="mailto:support-pro@passculture.app"
+        isExternal
+        opensInNewTab
       >
         <SvgIcon
           src={fullMailIcon}

--- a/pro/src/components/Newsletter/Newsletter.tsx
+++ b/pro/src/components/Newsletter/Newsletter.tsx
@@ -13,11 +13,9 @@ export const Newsletter = () => {
       <ButtonLink
         className={styles['newsletter-link']}
         variant={ButtonVariant.TERNARY}
-        link={{
-          to: 'https://0d5544dc.sibforms.com/serve/MUIEALeDGWdeK5Sx3mk95POo84LXw0wfRuL7M0YSLmEBQczDtyf9RchpzXzPpraWplBsNGz3nhwEpSpqOVUz_OeUCphS-ds635cE-vXDtQwLDc76VZ4GgUuqnsONKJ1FX6oBCslhYqgA6kB2vcv4_tNTLKesJvidy2o24roIqFRdfawXEOgz8LBQ1C9dlrDpO_Dz6E5L0IO_Gzs1',
-          isExternal: true,
-          target: '_blank',
-        }}
+        to="https://0d5544dc.sibforms.com/serve/MUIEALeDGWdeK5Sx3mk95POo84LXw0wfRuL7M0YSLmEBQczDtyf9RchpzXzPpraWplBsNGz3nhwEpSpqOVUz_OeUCphS-ds635cE-vXDtQwLDc76VZ4GgUuqnsONKJ1FX6oBCslhYqgA6kB2vcv4_tNTLKesJvidy2o24roIqFRdfawXEOgz8LBQ1C9dlrDpO_Dz6E5L0IO_Gzs1"
+        isExternal
+        opensInNewTab
         icon={fullLinkIcon}
       >
         Inscrivez-vous à notre newsletter pour recevoir les actualités du pass

--- a/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
+++ b/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
@@ -176,7 +176,7 @@ export const OfferEducationalActions = ({
             <ButtonLink
               variant={ButtonVariant.TERNARY}
               className={style['button-link']}
-              link={{ isExternal: false, to: getBookingLink() }}
+              to={getBookingLink()}
               icon={fullNextIcon}
               iconPosition={IconPositionEnum.LEFT}
               onClick={() =>

--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -83,15 +83,14 @@ export const ReimbursementBankAccount = ({
             </span>
           </div>
           <ButtonLink
-            link={{
-              to:
-                bankAccount.status === BankAccountApplicationStatus.A_CORRIGER
-                  ? `https://www.demarches-simplifiees.fr/dossiers/${bankAccount.dsApplicationId}`
-                  : `https://www.demarches-simplifiees.fr/dossiers/${bankAccount.dsApplicationId}/messagerie`,
-              isExternal: true,
-              'aria-label': 'Nouvelle fenêtre',
-              target: '_blank',
-            }}
+            to={
+              bankAccount.status === BankAccountApplicationStatus.A_CORRIGER
+                ? `https://www.demarches-simplifiees.fr/dossiers/${bankAccount.dsApplicationId}`
+                : `https://www.demarches-simplifiees.fr/dossiers/${bankAccount.dsApplicationId}/messagerie`
+            }
+            isExternal
+            aria-label="Nouvelle fenêtre"
+            opensInNewTab
             onClick={() => {
               logEvent(
                 BankAccountEvents.CLICKED_BANK_DETAILS_RECORD_FOLLOW_UP,

--- a/pro/src/components/SideNavLinks/SideNavLinks.tsx
+++ b/pro/src/components/SideNavLinks/SideNavLinks.tsx
@@ -112,10 +112,7 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
       <div className={styles['nav-links-first-group']}>
         {selectedOffererQuery.data && isUserOffererValidated && (
           <li className={styles['nav-links-create-offer-wrapper']}>
-            <ButtonLink
-              variant={ButtonVariant.PRIMARY}
-              link={{ isExternal: false, to: createOfferPageUrl }}
-            >
+            <ButtonLink variant={ButtonVariant.PRIMARY} to={createOfferPageUrl}>
               Créer une offre
             </ButtonLink>
           </li>

--- a/pro/src/components/SkipLinks/SkipLinks.tsx
+++ b/pro/src/components/SkipLinks/SkipLinks.tsx
@@ -28,10 +28,8 @@ export const SkipLinks = ({
               return (
                 <li key={button.anchor}>
                   <ButtonLink
-                    link={{
-                      to: button.anchor,
-                      isExternal: true,
-                    }}
+                    to={button.anchor}
+                    isExternal
                     icon={fullNextIcon}
                     className={styles['skip-list-button']}
                     variant={ButtonVariant.QUATERNARY}
@@ -45,10 +43,8 @@ export const SkipLinks = ({
         ) : (
           <div className={styles['skip-list']}>
             <ButtonLink
-              link={{
-                to: '#content',
-                isExternal: true,
-              }}
+              to="#content"
+              isExternal
               icon={fullNextIcon}
               className={styles['skip-list-button']}
               variant={ButtonVariant.QUATERNARY}

--- a/pro/src/components/SoftDeletedOffererWarning/SoftDeletedOffererWarning.tsx
+++ b/pro/src/components/SoftDeletedOffererWarning/SoftDeletedOffererWarning.tsx
@@ -17,16 +17,14 @@ export const SoftDeletedOffererWarning = (): JSX.Element => {
         <div className="actions-container">
           <ButtonLink
             variant={ButtonVariant.PRIMARY}
-            link={{ isExternal: false, to: '/parcours-inscription/structure' }}
+            to="/parcours-inscription/structure"
           >
             Ajouter une nouvelle structure
           </ButtonLink>
           <ButtonLink
             variant={ButtonVariant.SECONDARY}
-            link={{
-              isExternal: true,
-              to: 'mailto:support-pro@passculture.app',
-            }}
+            isExternal
+            to="mailto:support-pro@passculture.app"
           >
             Contacter le support
           </ButtonLink>

--- a/pro/src/components/SummaryLayout/SummarySection.tsx
+++ b/pro/src/components/SummaryLayout/SummarySection.tsx
@@ -27,11 +27,8 @@ export const SummarySection = ({
 
       {typeof editLink === 'string' ? (
         <ButtonLink
-          link={{
-            to: editLink,
-            isExternal: false,
-            'aria-label': props['aria-label'],
-          }}
+          to={editLink}
+          aria-label={props['aria-label']}
           className={style['summary-layout-section-header-edit-link']}
           icon={fullEditIcon}
         >

--- a/pro/src/pages/Accessibility/AccessibilityLayout.tsx
+++ b/pro/src/pages/Accessibility/AccessibilityLayout.tsx
@@ -39,7 +39,7 @@ export const AccessibilityLayout = ({
         <div className={styles['content']}>{children}</div>
         {showBackToSignInButton && (
           <ButtonLink
-            link={{ to: 'connexion' }}
+            to="connexion"
             icon={fullBackIcon}
             className={styles['back-to-signin-button']}
           >

--- a/pro/src/pages/Accessibility/AccessibilityMenu.tsx
+++ b/pro/src/pages/Accessibility/AccessibilityMenu.tsx
@@ -14,9 +14,7 @@ export function AccessibilityMenu() {
 
       <div className={styles['menu-accessibility']}>
         <ButtonLink
-          link={{
-            to: `/accessibilite/engagements`,
-          }}
+          to="/accessibilite/engagements"
           variant={ButtonVariant.BOX}
           icon={strokeRigthIcon}
           iconPosition={IconPositionEnum.RIGHT}
@@ -25,9 +23,7 @@ export function AccessibilityMenu() {
           Les engagements du pass Culture
         </ButtonLink>
         <ButtonLink
-          link={{
-            to: `/accessibilite/declaration`,
-          }}
+          to="/accessibilite/declaration"
           variant={ButtonVariant.BOX}
           icon={strokeRigthIcon}
           className={styles['button-link']}
@@ -36,9 +32,7 @@ export function AccessibilityMenu() {
           Déclaration d’accessibilité
         </ButtonLink>
         <ButtonLink
-          link={{
-            to: `/accessibilite/schema-pluriannuel`,
-          }}
+          to="/accessibilite/schema-pluriannuel"
           variant={ButtonVariant.BOX}
           icon={strokeRigthIcon}
           className={styles['button-link']}

--- a/pro/src/pages/Accessibility/Commitment.tsx
+++ b/pro/src/pages/Accessibility/Commitment.tsx
@@ -9,12 +9,7 @@ import styles from './Commitment.module.scss'
 export const Commitment = () => {
   return (
     <AccessibilityLayout>
-      <ButtonLink
-        link={{
-          to: '/accessibilite/',
-        }}
-        icon={fullBackIcon}
-      >
+      <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>
       <h1 className={styles['heading1-commitment']}>

--- a/pro/src/pages/Accessibility/Declaration.tsx
+++ b/pro/src/pages/Accessibility/Declaration.tsx
@@ -9,12 +9,7 @@ import styles from './Declaration.module.scss'
 export const Declaration = () => {
   return (
     <AccessibilityLayout>
-      <ButtonLink
-        link={{
-          to: '/accessibilite/',
-        }}
-        icon={fullBackIcon}
-      >
+      <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>
       <h1 className={styles['heading1-declaration']}>

--- a/pro/src/pages/Accessibility/MultiyearScheme.tsx
+++ b/pro/src/pages/Accessibility/MultiyearScheme.tsx
@@ -7,12 +7,7 @@ import styles from './MultiyearScheme.module.scss'
 export const MultiyearScheme = () => {
   return (
     <AccessibilityLayout>
-      <ButtonLink
-        link={{
-          to: '/accessibilite/',
-        }}
-        icon={fullBackIcon}
-      >
+      <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>
       <h1 className={styles['heading1-scheme']}>

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -70,11 +70,9 @@ export const AdageHeader = () => {
           Besoin d’aide pour réserver des offres pass Culture ?
           <ButtonLink
             variant={ButtonVariant.TERNARY}
-            link={{
-              to: `${document.referrer}adage/index/docGet/format/pptx/doc/PRESENTATION_J_UTILISE_PASS_CULTURE`,
-              isExternal: true,
-              download: true,
-            }}
+            to={`${document.referrer}adage/index/docGet/format/pptx/doc/PRESENTATION_J_UTILISE_PASS_CULTURE`}
+            isExternal
+            download
             icon={fullDownloadIcon}
           >
             Télécharger l’aide

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
@@ -1,8 +1,6 @@
 import { AdageHeaderLink } from 'apiClient/adage'
-import fullLinkIcon from 'icons/full-link.svg'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './AdageHeaderBudget.module.scss'
 
@@ -19,20 +17,13 @@ export const AdageHeaderBudget = ({
     <div className={styles['adage-header-budget']}>
       <ButtonLink
         variant={ButtonVariant.TERNARY}
-        link={{
-          to: `${document.referrer}adage/passculture/index`,
-          isExternal: true,
-          target: '_blank',
-        }}
+        to={`${document.referrer}adage/passculture/index`}
+        isExternal
+        opensInNewTab
+        icon={null}
         className={styles['adage-header-budget-link']}
         onClick={() => logAdageLinkClick(AdageHeaderLink.ADAGE_LINK)}
       >
-        <SvgIcon
-          width="16"
-          alt="Nouvelle fenêtre"
-          src={fullLinkIcon}
-          className={styles['adage-header-budget-icon']}
-        />
         Solde prévisionnel
       </ButtonLink>
       <div className={styles['adage-header-budget-value']}>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
@@ -75,15 +75,12 @@ export function AdageOfferPartnerPanel({
           <p className={styles['partner-panel-info-name']}>{venue.name}</p>
           {venue.adageId && !isPreview && (
             <ButtonLink
-              link={{
-                isExternal: true,
-                to: `${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`,
-                target: '_blank',
-              }}
+              isExternal
+              to={`${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`}
+              opensInNewTab
               variant={ButtonVariant.TERNARY}
               className={styles['partner-panel-info-link']}
               icon={fullLinkIcon}
-              svgAlt="Nouvelle fenêtre"
             >
               Voir la page partenaire
             </ButtonLink>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -138,10 +138,7 @@ export const OfferInfos = () => {
             Cette offre est introuvable
           </h1>
           <ButtonLink
-            link={{
-              isExternal: false,
-              to: `/adage-iframe/recherche?token=${adageAuthToken}`,
-            }}
+            to={`/adage-iframe/recherche?token=${adageAuthToken}`}
             variant={ButtonVariant.PRIMARY}
           >
             Explorer le catalogue

--- a/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavoritesNoResult/OffersFavoritesNoResult.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavoritesNoResult/OffersFavoritesNoResult.tsx
@@ -27,10 +27,7 @@ export const OffersFavoritesNoResult = () => {
           retrouver facilement !
         </p>
         <ButtonLink
-          link={{
-            to: `/adage-iframe/recherche?token=${adageAuthToken}`,
-            isExternal: false,
-          }}
+          to={`/adage-iframe/recherche?token=${adageAuthToken}`}
           variant={ButtonVariant.PRIMARY}
         >
           Explorer le catalogue

--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
@@ -79,10 +79,7 @@ export const OffersForMyInstitution = () => {
               Vous n’avez pas d’offre à préréserver
             </h2>
             <ButtonLink
-              link={{
-                to: `/adage-iframe/recherche?token=${adageAuthToken}`,
-                isExternal: false,
-              }}
+              to={`/adage-iframe/recherche?token=${adageAuthToken}`}
               variant={ButtonVariant.PRIMARY}
             >
               Explorer le catalogue

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
@@ -165,11 +165,9 @@ export const RequestFormDialog = ({
                 onClick={logContactUrl}
                 variant={ButtonVariant.TERNARYPINK}
                 className={styles['form-description-link-text']}
-                link={{
-                  to: contactUrl,
-                  isExternal: true,
-                  target: '_blank',
-                }}
+                to={contactUrl}
+                isExternal
+                opensInNewTab
               >
                 <SvgIcon
                   className={styles['form-icon']}
@@ -227,11 +225,9 @@ export const RequestFormDialog = ({
         onClick={logContactUrl}
         variant={ButtonVariant.TERNARYPINK}
         className={styles['form-description-link-text']}
-        link={{
-          to: contactUrl,
-          isExternal: true,
-          target: '_blank',
-        }}
+        to={contactUrl}
+        isExternal
+        opensInNewTab
       >
         <SvgIcon width="20" alt="Nouvelle fenêtre" src={fullLinkIcon} />
         Aller sur le site

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/NoResultsPage.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/NoResultsPage.tsx
@@ -39,14 +39,11 @@ export const NoResultsPage = ({
       </p>
       {venue?.adageId && (
         <ButtonLink
-          link={{
-            isExternal: true,
-            to: `${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`,
-            target: '_blank',
-          }}
+          isExternal
+          to={`${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`}
+          opensInNewTab
           variant={ButtonVariant.TERNARY}
           icon={fullLinkIcon}
-          svgAlt="Nouvelle fenêtre"
         >
           Voir la fiche du partenaire
         </ButtonLink>

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
@@ -77,13 +77,10 @@ export const SurveySatisfaction = ({
 
           <ButtonLink
             variant={ButtonVariant.PRIMARY}
-            link={{
-              to: 'https://passculture.qualtrics.com/jfe/form/SV_8w5mdHmrxly9bcW',
-              isExternal: true,
-              target: '_blank',
-            }}
+            to="https://passculture.qualtrics.com/jfe/form/SV_8w5mdHmrxly9bcW"
+            isExternal
+            opensInNewTab
             icon={fullLinkIcon}
-            svgAlt="Nouvelle fenêtre"
             className={styles['survey-button']}
             onClick={logOpenSatisfactionSurvey}
           >

--- a/pro/src/pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.tsx
@@ -28,13 +28,7 @@ export const CollectiveOfferPreviewEdition = ({
         <AdagePreviewLayout offer={offer} />
         <ActionsBarSticky>
           <ActionsBarSticky.Left>
-            <ButtonLink
-              variant={ButtonVariant.PRIMARY}
-              link={{
-                to: backRedirectionUrl,
-                isExternal: false,
-              }}
-            >
+            <ButtonLink variant={ButtonVariant.PRIMARY} to={backRedirectionUrl}>
               Retour vers l’offre
             </ButtonLink>
           </ActionsBarSticky.Left>

--- a/pro/src/pages/CookiesFooter/CookiesFooter.tsx
+++ b/pro/src/pages/CookiesFooter/CookiesFooter.tsx
@@ -23,22 +23,15 @@ export const CookiesFooter = ({ className }: { className?: string }) => {
           <li>
             <ButtonLink
               variant={ButtonVariant.QUATERNARY}
-              link={{
-                to: 'https://pass.culture.fr/cgu-professionnels/',
-                isExternal: true,
-                target: '_blank',
-              }}
+              to="https://pass.culture.fr/cgu-professionnels/"
+              isExternal
+              opensInNewTab
             >
               CGU professionnels
             </ButtonLink>
           </li>
           <li>
-            <ButtonLink
-              variant={ButtonVariant.QUATERNARY}
-              link={{
-                to: '/accessibilite',
-              }}
-            >
+            <ButtonLink variant={ButtonVariant.QUATERNARY} to="/accessibilite">
               Accessibilité : non conforme
             </ButtonLink>
           </li>
@@ -46,11 +39,9 @@ export const CookiesFooter = ({ className }: { className?: string }) => {
             <ButtonLink
               variant={ButtonVariant.QUATERNARY}
               className={styles['cookies-footer-link']}
-              link={{
-                to: 'https://pass.culture.fr/donnees-personnelles/',
-                isExternal: true,
-                target: '_blank',
-              }}
+              to="https://pass.culture.fr/donnees-personnelles/"
+              isExternal
+              opensInNewTab
             >
               Charte des Données Personnelles
             </ButtonLink>

--- a/pro/src/pages/Errors/NotFound/NotFound.tsx
+++ b/pro/src/pages/Errors/NotFound/NotFound.tsx
@@ -22,7 +22,7 @@ export const NotFound = ({ redirect = '/accueil' }: NotFoundProps) => (
     <ButtonLink
       className={styles['nm-redirection-link']}
       variant={ButtonVariant.SECONDARY}
-      link={{ to: redirect, isExternal: false }}
+      to={redirect}
     >
       Retour à la page d’accueil
     </ButtonLink>

--- a/pro/src/pages/Home/Offerers/OffererCreationLinks.tsx
+++ b/pro/src/pages/Home/Offerers/OffererCreationLinks.tsx
@@ -20,17 +20,15 @@ export const OffererCreationLinks = () => (
       <div className={styles['actions-container']}>
         <ButtonLink
           variant={ButtonVariant.PRIMARY}
-          link={{ isExternal: false, to: '/parcours-inscription/structure' }}
+          to="/parcours-inscription/structure"
         >
           Ajouter une nouvelle structure
         </ButtonLink>
 
         <ButtonLink
           variant={ButtonVariant.SECONDARY}
-          link={{
-            isExternal: true,
-            to: 'mailto:support-pro@passculture.app',
-          }}
+          isExternal
+          to="mailto:support-pro@passculture.app"
         >
           Contacter le support
         </ButtonLink>

--- a/pro/src/pages/Home/Offerers/OffererDetails.tsx
+++ b/pro/src/pages/Home/Offerers/OffererDetails.tsx
@@ -74,10 +74,7 @@ export const OffererDetails = ({
 
           <ButtonLink
             variant={ButtonVariant.TERNARY}
-            link={{
-              to: `/collaborateurs`,
-              isExternal: false,
-            }}
+            to="/collaborateurs"
             icon={fullAddUserIcon}
             isDisabled={!isUserOffererValidated}
             onClick={() => {

--- a/pro/src/pages/Home/Offerers/PartnerPageCollectiveSection.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPageCollectiveSection.tsx
@@ -77,12 +77,9 @@ export function PartnerPageCollectiveSection({
         <ButtonLink
           variant={ButtonVariant.TERNARY}
           icon={fullLinkIcon}
-          link={{
-            to: 'https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage',
-            isExternal: true,
-            target: '_blank',
-          }}
-          svgAlt="Nouvelle fenêtre"
+          to="https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage"
+          isExternal
+          opensInNewTab
           className={styles['details-link']}
           onClick={logDMSApplicationLinkClick}
         >
@@ -92,12 +89,9 @@ export function PartnerPageCollectiveSection({
         <ButtonLink
           variant={ButtonVariant.TERNARY}
           icon={fullInfoIcon}
-          link={{
-            to: 'https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires',
-            isExternal: true,
-            target: '_blank',
-          }}
-          svgAlt="Nouvelle fenêtre"
+          to="https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires"
+          isExternal
+          opensInNewTab
           className={styles['details-link']}
           onClick={logCollectiveHelpLinkClick}
         >
@@ -140,12 +134,9 @@ export function PartnerPageCollectiveSection({
       <ButtonLink
         variant={ButtonVariant.TERNARY}
         icon={fullInfoIcon}
-        link={{
-          to: 'https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires',
-          isExternal: true,
-          target: '_blank',
-        }}
-        svgAlt="Nouvelle fenêtre"
+        to="https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires"
+        isExternal
+        opensInNewTab
         className={styles['details-link']}
         onClick={logCollectiveHelpLinkClick}
       >
@@ -199,10 +190,8 @@ function AdageInformations({
         <ButtonLink
           variant={ButtonVariant.TERNARY}
           className={styles['details-link']}
-          link={{
-            to: `/structures/${offererId}/lieux/${venueId}/collectif`,
-            'aria-label': `Gérer la page pour les enseignants ${venueName}`,
-          }}
+          to={`/structures/${offererId}/lieux/${venueId}/collectif`}
+          aria-label={`Gérer la page pour les enseignants ${venueName}`}
           icon={fullNextIcon}
           onClick={() =>
             logEvent(Events.CLICKED_PAGE_FOR_ADAGE_HOME, {

--- a/pro/src/pages/Home/Offerers/PartnerPageIndividualSection.tsx
+++ b/pro/src/pages/Home/Offerers/PartnerPageIndividualSection.tsx
@@ -78,10 +78,8 @@ export function PartnerPageIndividualSection({
         <ButtonLink
           variant={ButtonVariant.TERNARY}
           className={styles['details-link']}
-          link={{
-            to: `/structures/${offererId}/lieux/${venueId}`,
-            'aria-label': `Gérer la page ${venueName}`,
-          }}
+          to={`/structures/${offererId}/lieux/${venueId}`}
+          aria-label={`Gérer la page ${venueName}`}
           icon={fullNextIcon}
           onClick={() =>
             logEvent(Events.CLICKED_PAGE_FOR_APP_HOME, {
@@ -98,12 +96,9 @@ export function PartnerPageIndividualSection({
           <ButtonLink
             variant={ButtonVariant.TERNARY}
             icon={fullLinkIcon}
-            link={{
-              to: venuePreviewLink,
-              isExternal: true,
-              target: '_blank',
-            }}
-            svgAlt="Nouvelle fenêtre"
+            to={venuePreviewLink}
+            isExternal
+            opensInNewTab
             className={styles['details-link']}
             onClick={logVenueLinkClick}
           >

--- a/pro/src/pages/Home/Offerers/VenueCreationLinks.tsx
+++ b/pro/src/pages/Home/Offerers/VenueCreationLinks.tsx
@@ -43,10 +43,7 @@ export const VenueCreationLinks = ({ offerer }: VenueCreationLinksProps) => {
       <div className={styles['add-venue-button']}>
         <ButtonLink
           variant={ButtonVariant.SECONDARY}
-          link={{
-            to: venueCreationUrl,
-            isExternal: false,
-          }}
+          to={venueCreationUrl}
           onClick={() => {
             logEvent(Events.CLICKED_CREATE_VENUE, {
               from: location.pathname,

--- a/pro/src/pages/Home/ProfileAndSupport/Profile.tsx
+++ b/pro/src/pages/Home/ProfileAndSupport/Profile.tsx
@@ -63,7 +63,7 @@ export const Profile = () => {
 
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{ to: '/profil', isExternal: false }}
+          to="/profil"
           icon={fullEditIcon}
           onClick={() => logEvent(Events.CLICKED_EDIT_PROFILE)}
         >

--- a/pro/src/pages/Home/ProfileAndSupport/Support.tsx
+++ b/pro/src/pages/Home/ProfileAndSupport/Support.tsx
@@ -29,18 +29,15 @@ export const Support: () => JSX.Element | null = () => {
         <ul>
           <li>
             <ButtonLink
-              link={{
-                to: 'https://aide.passculture.app',
-                isExternal: true,
-                target: '_blank',
-              }}
+              to="https://aide.passculture.app"
+              isExternal
+              opensInNewTab
               icon={fullLinkIcon}
               onClick={() =>
                 logEvent(Events.CLICKED_HELP_CENTER, {
                   from: location.pathname,
                 })
               }
-              svgAlt="Nouvelle fenêtre"
             >
               Centre d’aide
             </ButtonLink>
@@ -48,18 +45,15 @@ export const Support: () => JSX.Element | null = () => {
 
           <li>
             <ButtonLink
-              link={{
-                to: 'https://passcultureapp.notion.site/pass-Culture-Documentation-323b1a0ec309406192d772e7d803fbd0',
-                isExternal: true,
-                target: '_blank',
-              }}
+              to="https://passcultureapp.notion.site/pass-Culture-Documentation-323b1a0ec309406192d772e7d803fbd0"
+              isExternal
+              opensInNewTab
               icon={fullLinkIcon}
               onClick={() =>
                 logEvent(Events.CLICKED_BEST_PRACTICES_STUDIES, {
                   from: location.pathname,
                 })
               }
-              svgAlt="Nouvelle fenêtre"
             >
               Bonnes pratiques et études
             </ButtonLink>
@@ -67,11 +61,9 @@ export const Support: () => JSX.Element | null = () => {
 
           <li>
             <ButtonLink
-              link={{
-                to: 'mailto:support-pro@passculture.app',
-                isExternal: true,
-                target: '_blank',
-              }}
+              to="mailto:support-pro@passculture.app"
+              isExternal
+              opensInNewTab
               icon={fullMailIcon}
               onClick={() =>
                 logEvent(Events.CLICKED_CONSULT_SUPPORT, {
@@ -87,18 +79,15 @@ export const Support: () => JSX.Element | null = () => {
             <>
               <li>
                 <ButtonLink
-                  link={{
-                    to: 'https://pass.culture.fr/cgu-professionnels/',
-                    isExternal: true,
-                    target: '_blank',
-                  }}
+                  to="https://pass.culture.fr/cgu-professionnels/"
+                  isExternal
+                  opensInNewTab
                   icon={fullLinkIcon}
                   onClick={() =>
                     logEvent(Events.CLICKED_CONSULT_CGU, {
                       from: location.pathname,
                     })
                   }
-                  svgAlt="Nouvelle fenêtre"
                 >
                   Conditions Générales d’Utilisation
                 </ButtonLink>

--- a/pro/src/pages/Home/StatisticsDashboard/CumulatedViews.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/CumulatedViews.tsx
@@ -78,12 +78,9 @@ export const CumulatedViews = ({ dailyViews }: CumulatedViewsProps) => {
 
           <div>
             <ButtonLink
-              link={{
-                to: 'https://passcultureapp.notion.site/Les-bonnes-pratiques-et-tudes-du-pass-Culture-323b1a0ec309406192d772e7d803fbd0',
-                isExternal: true,
-                target: '_blank',
-              }}
-              svgAlt="Nouvelle fenêtre"
+              to="https://passcultureapp.notion.site/Les-bonnes-pratiques-et-tudes-du-pass-Culture-323b1a0ec309406192d772e7d803fbd0"
+              isExternal
+              opensInNewTab
               variant={ButtonVariant.TERNARY}
               icon={fullLinkIcon}
             >

--- a/pro/src/pages/Home/StatisticsDashboard/OfferStats.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/OfferStats.tsx
@@ -52,7 +52,7 @@ const StatBlock = ({ icon, count, label, link, linkLabel }: StatBlockProps) => (
       <ButtonLink
         variant={ButtonVariant.QUATERNARY}
         icon={fullShowIcon}
-        link={{ to: link, isExternal: false }}
+        to={link}
       >
         {linkLabel}
       </ButtonLink>
@@ -124,12 +124,9 @@ export const OfferStats = ({ offerer, className }: OfferStatsProps) => {
 
               <ButtonLink
                 variant={ButtonVariant.QUATERNARY}
-                link={{
-                  to: 'https://aide.passculture.app/hc/fr/articles/4412007222289--Acteurs-Culturels-Quelles-sont-les-raisons-possibles-de-refus-de-votre-offre-',
-                  isExternal: true,
-                }}
+                to="https://aide.passculture.app/hc/fr/articles/4412007222289--Acteurs-Culturels-Quelles-sont-les-raisons-possibles-de-refus-de-votre-offre-"
+                isExternal
                 icon={fullLinkIcon}
-                svgAlt="Nouvelle fenêtre"
                 onClick={() =>
                   logEvent(Events.CLICKED_HOME_STATS_PENDING_OFFERS_FAQ)
                 }

--- a/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
+++ b/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.tsx
@@ -59,10 +59,7 @@ export const StatisticsDashboard = ({ offerer }: StatisticsDashboardProps) => {
         {displayCreateOfferButton && (
           <ButtonLink
             variant={ButtonVariant.PRIMARY}
-            link={{
-              isExternal: false,
-              to: createOfferLink,
-            }}
+            to={createOfferLink}
             icon={fullMoreIcon}
           >
             Créer une offre

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -94,9 +94,7 @@ export const VenueOfferSteps = ({
                   )}
                   variant={ButtonVariant.BOX}
                   icon={fullNextIcon}
-                  link={{
-                    to: venueCreationUrl,
-                  }}
+                  to={venueCreationUrl}
                   onClick={() => {
                     logEvent(Events.CLICKED_CREATE_VENUE, {
                       from: location.pathname,
@@ -113,11 +111,9 @@ export const VenueOfferSteps = ({
                     styles['step-button-info']
                   )}
                   variant={ButtonVariant.QUATERNARY}
-                  link={{
-                    to: 'https://aide.passculture.app/hc/fr/articles/4411992075281--Acteurs-Culturels-Comment-cr%C3%A9er-un-lieu-',
-                    isExternal: true,
-                    target: '_blank',
-                  }}
+                  to="https://aide.passculture.app/hc/fr/articles/4411992075281--Acteurs-Culturels-Comment-cr%C3%A9er-un-lieu-"
+                  isExternal
+                  opensInNewTab
                   icon={fullInfoIcon}
                   onClick={() => {
                     logEvent(Events.CLICKED_NO_VENUE, {
@@ -138,9 +134,7 @@ export const VenueOfferSteps = ({
                 isDisabled={!hasVenue}
                 variant={ButtonVariant.BOX}
                 icon={fullNextIcon}
-                link={{
-                  to: `/offre/creation?lieu=${venue.id}&structure=${offerer.id}`,
-                }}
+                to={`/offre/creation?lieu=${venue.id}&structure=${offerer.id}`}
               >
                 Créer une offre
               </ButtonLink>
@@ -152,9 +146,7 @@ export const VenueOfferSteps = ({
                 isDisabled={!hasVenue}
                 variant={ButtonVariant.BOX}
                 icon={fullNextIcon}
-                link={{
-                  to: `remboursements/informations-bancaires?structure=${offerer.id}`,
-                }}
+                to={`remboursements/informations-bancaires?structure=${offerer.id}`}
                 onClick={() => {
                   logEvent(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
                     venue_id: venue?.id ?? '',
@@ -171,9 +163,7 @@ export const VenueOfferSteps = ({
                 isDisabled={!venue.hasAdageId}
                 variant={ButtonVariant.BOX}
                 icon={fullNextIcon}
-                link={{
-                  to: `/structures/${offerer.id}/lieux/${venue.id}/collectif`,
-                }}
+                to={`/structures/${offerer.id}/lieux/${venue.id}/collectif`}
               >
                 Renseigner mes informations à destination des enseignants
               </ButtonLink>
@@ -191,9 +181,7 @@ export const VenueOfferSteps = ({
               className={styles['step-button-width']}
               variant={ButtonVariant.BOX}
               icon={fullNextIcon}
-              link={{
-                to: `/structures/${offerer.id}/lieux/${venue.id}/collectif`,
-              }}
+              to={`/structures/${offerer.id}/lieux/${venue.id}/collectif`}
               onClick={() => {
                 logEvent(Events.CLICKED_EAC_DMS_TIMELINE, {
                   from: location.pathname,

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -105,11 +105,8 @@ export const Venue = ({ offerer, venue, isFirstVenue }: VenueProps) => {
         <div className={styles['button-group']}>
           <ButtonLink
             variant={ButtonVariant.SECONDARY}
-            link={{
-              to: editVenueLink,
-              isExternal: false,
-              'aria-label': `Gérer la page de ${venueDisplayName}`,
-            }}
+            to={editVenueLink}
+            aria-label={`Gérer la page de ${venueDisplayName}`}
             onClick={() =>
               logEvent(
                 VenueEvents.CLICKED_VENUE_PUBLISHED_OFFERS_LINK,

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
@@ -228,10 +228,7 @@ export const CollectiveDataForm = ({
           <div className={styles['action-bar']}>
             <ButtonLink
               variant={ButtonVariant.SECONDARY}
-              link={{
-                to: `/structures/${venue.managingOfferer.id}/lieux/${venue.id}/collectif`,
-                isExternal: false,
-              }}
+              to={`/structures/${venue.managingOfferer.id}/lieux/${venue.id}/collectif`}
             >
               Annuler et quitter
             </ButtonLink>

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
@@ -111,10 +111,8 @@ export const PricingPoint = ({ offerer, venue }: PricingPointProps) => {
           </p>
           <ButtonLink
             icon={fullLinkIcon}
-            link={{
-              to: 'https://aide.passculture.app/hc/fr/sections/4411991876241-Modalités-de-remboursements',
-              isExternal: true,
-            }}
+            to="https://aide.passculture.app/hc/fr/sections/4411991876241-Modalités-de-remboursements"
+            isExternal
           >
             En savoir plus sur les remboursements
           </ButtonLink>

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/CollectiveActionsCells.tsx
@@ -231,7 +231,7 @@ export const CollectiveActionsCells = ({
                         asChild
                       >
                         <ButtonLink
-                          link={{ to: bookingLink, isExternal: false }}
+                          to={bookingLink}
                           icon={fullNextIcon}
                           onClick={() =>
                             logEvent(
@@ -288,7 +288,7 @@ export const CollectiveActionsCells = ({
                   offer.status !== CollectiveOfferStatus.ARCHIVED && (
                     <DropdownMenu.Item className={styles['menu-item']} asChild>
                       <ButtonLink
-                        link={{ to: editionOfferLink, isExternal: false }}
+                        to={editionOfferLink}
                         icon={fullPenIcon}
                         className={styles['button']}
                       >

--- a/pro/src/pages/Reimbursements/BankInformations/AddBankInformationsDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/AddBankInformationsDialog.tsx
@@ -29,15 +29,12 @@ export const AddBankInformationsDialog = ({
       onCancel={closeDialog}
     >
       <ButtonLink
-        link={{
-          to: DS_BANK_ACCOUNT_PROCEDURE_ID,
-          isExternal: true,
-          target: '_blank',
-        }}
+        to={DS_BANK_ACCOUNT_PROCEDURE_ID}
+        isExternal
+        opensInNewTab
         icon={fullLinkIcon}
         className={styles['link-button']}
         variant={ButtonVariant.PRIMARY}
-        svgAlt="Nouvelle fenêtre"
         onClick={() => {
           logEvent(BankAccountEvents.CLICKED_CONTINUE_TO_DS, {
             offererId,

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -118,11 +118,9 @@ export const BankInformations = (): JSX.Element => {
         )}
 
         <ButtonLink
-          link={{
-            to: '', // TODO: le liens manque
-            isExternal: true,
-            target: '_blank',
-          }}
+          to="" // TODO: le liens manque
+          isExternal
+          opensInNewTab
           icon={fullLinkIcon}
           className={styles['information-link-button']}
         >

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -11,12 +11,10 @@ import { useAnalytics } from 'app/App/analytics/firebase'
 import { ReimbursementBankAccount } from 'components/ReimbursementBankAccount/ReimbursementBankAccount'
 import { BankAccountEvents } from 'core/FirebaseEvents/constants'
 import { useNotification } from 'hooks/useNotification'
-import fullLinkIcon from 'icons/full-link.svg'
 import fullMoreIcon from 'icons/full-more.svg'
 import { LinkVenuesDialog } from 'pages/Reimbursements/BankInformations/LinkVenuesDialog'
 import { ReimbursementsContextProps } from 'pages/Reimbursements/Reimbursements'
 import { Button } from 'ui-kit/Button/Button'
-import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { Spinner } from 'ui-kit/Spinner/Spinner'
 
@@ -116,16 +114,6 @@ export const BankInformations = (): JSX.Element => {
             distincts. <br />
           </>
         )}
-
-        <ButtonLink
-          to="" // TODO: le liens manque
-          isExternal
-          opensInNewTab
-          icon={fullLinkIcon}
-          className={styles['information-link-button']}
-        >
-          En savoir plus
-        </ButtonLink>
       </div>
       {selectedOffererBankAccounts &&
         selectedOffererBankAccounts.bankAccounts.length > 0 && (

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/BankInformations.spec.tsx
@@ -80,7 +80,6 @@ describe('BankInformations page', () => {
       )
     ).toBeInTheDocument()
     expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
-    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
   })
 
   it('should render message when the user has a valid bank account and no pending one', async () => {
@@ -102,7 +101,6 @@ describe('BankInformations page', () => {
       )
     ).toBeInTheDocument()
     expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
-    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
   })
 
   it('should render message when has a pending bank account and no valid one', async () => {
@@ -120,7 +118,6 @@ describe('BankInformations page', () => {
       )
     ).toBeInTheDocument()
     expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
-    expect(screen.getByText('En savoir plus')).toBeInTheDocument()
   })
 
   it('should render default page if error on getOffererBankAccountsAndAttachedVenues request', async () => {

--- a/pro/src/pages/Reimbursements/ReimbursementsDetails/ReimbursementsDetails.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsDetails/ReimbursementsDetails.tsx
@@ -155,11 +155,8 @@ export const ReimbursementsDetails = (): JSX.Element => {
 
         <ButtonLink
           isDisabled={shouldDisableButtons}
-          link={{
-            to: `/remboursements-details?${getCsvQueryParams(bankAccount, selectedOfferer?.id, periodStart, periodEnd)}`,
-            target: '_blank',
-            isExternal: false,
-          }}
+          to={`/remboursements-details?${getCsvQueryParams(bankAccount, selectedOfferer?.id, periodStart, periodEnd)}`}
+          opensInNewTab
           variant={ButtonVariant.SECONDARY}
           icon={fullLinkIcon}
         >

--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceActions.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceActions.tsx
@@ -41,14 +41,11 @@ export function InvoiceActions({ invoice }: InvoiceActionsProps) {
       <>
         <DropdownItem title="Télécharger le justificatif comptable (.pdf)">
           <ButtonLink
-            link={{
-              isExternal: true,
-              to: invoice.url,
-              target: '_blank',
-              download: true,
-            }}
+            isExternal
+            to={invoice.url}
+            opensInNewTab
+            download
             icon={fullDownloadIcon}
-            svgAlt=""
             variant={ButtonVariant.TERNARY}
             onClick={() =>
               logEvent(Events.CLICKED_INVOICES_DOWNLOAD, {

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementDetails.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementDetails.spec.tsx
@@ -108,7 +108,9 @@ describe('reimbursementsWithFilters', () => {
         name: /Télécharger/i,
       })
     ).toBeEnabled()
-    expect(screen.getByRole('link', { name: 'Afficher' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Nouvelle fenêtre Afficher' })
+    ).toBeInTheDocument()
   })
 
   it('should disable buttons if user is admin and no bank account filter is selected', async () => {
@@ -122,7 +124,9 @@ describe('reimbursementsWithFilters', () => {
       })
     ).toBeDisabled()
     expect(
-      screen.getByRole('link', { name: 'Afficher Action non disponible' })
+      screen.getByRole('link', {
+        name: 'Nouvelle fenêtre Afficher Action non disponible',
+      })
     ).toBeInTheDocument()
   })
 

--- a/pro/src/pages/SignIn/SigninForm.tsx
+++ b/pro/src/pages/SignIn/SigninForm.tsx
@@ -46,10 +46,7 @@ export const SigninForm = (): JSX.Element => {
         <ButtonLink
           icon={fullKeyIcon}
           variant={ButtonVariant.TERNARY}
-          link={{
-            to: '/demande-mot-de-passe',
-            isExternal: false,
-          }}
+          to="/demande-mot-de-passe"
           onClick={() =>
             logEvent(Events.CLICKED_FORGOTTEN_PASSWORD, {
               from: location.pathname,
@@ -62,10 +59,7 @@ export const SigninForm = (): JSX.Element => {
           <ButtonLink
             className={styles['buttons']}
             variant={ButtonVariant.SECONDARY}
-            link={{
-              to: accountCreationUrl,
-              isExternal: false,
-            }}
+            to={accountCreationUrl}
             onClick={() =>
               logEvent(Events.CLICKED_CREATE_ACCOUNT, {
                 from: location.pathname,

--- a/pro/src/pages/VenueCreation/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/pages/VenueCreation/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -86,10 +86,8 @@ export const CollectiveDmsTimeline = ({
         </div>
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{
-            to: collectiveDmsApplicationLink,
-            isExternal: true,
-          }}
+          to={collectiveDmsApplicationLink}
+          isExternal
           icon={fullLinkIcon}
           onClick={() =>
             logClickOnDmsLink(DMSApplicationstatus.EN_CONSTRUCTION)
@@ -99,10 +97,8 @@ export const CollectiveDmsTimeline = ({
         </ButtonLink>
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{
-            to: collectiveDmsContactSupport,
-            isExternal: true,
-          }}
+          to={collectiveDmsContactSupport}
+          isExternal
           icon={fullLinkIcon}
         >
           Contacter les services des Ministères de l’Education Nationale et de
@@ -130,10 +126,8 @@ export const CollectiveDmsTimeline = ({
         </div>
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{
-            to: collectiveDmsApplicationLink,
-            isExternal: true,
-          }}
+          to={collectiveDmsApplicationLink}
+          isExternal
           icon={fullLinkIcon}
           onClick={() => logClickOnDmsLink(DMSApplicationstatus.EN_INSTRUCTION)}
         >
@@ -173,10 +167,8 @@ export const CollectiveDmsTimeline = ({
         </div>
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{
-            to: collectiveDmsApplicationLink,
-            isExternal: true,
-          }}
+          to={collectiveDmsApplicationLink}
+          isExternal
           icon={fullLinkIcon}
           onClick={() => logClickOnDmsLink(DMSApplicationstatus.ACCEPTE)}
         >

--- a/pro/src/pages/VenueCreation/VenueCreationForm.tsx
+++ b/pro/src/pages/VenueCreation/VenueCreationForm.tsx
@@ -187,13 +187,7 @@ export const VenueCreationForm = ({
 
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
-          <ButtonLink
-            variant={ButtonVariant.SECONDARY}
-            link={{
-              to: '/accueil',
-              isExternal: false,
-            }}
-          >
+          <ButtonLink variant={ButtonVariant.SECONDARY} to="/accueil">
             Annuler et quitter
           </ButtonLink>
         </ActionsBarSticky.Left>

--- a/pro/src/pages/VenueCreation/VenueFormActionBar/VenueFormActionBar.tsx
+++ b/pro/src/pages/VenueCreation/VenueFormActionBar/VenueFormActionBar.tsx
@@ -20,10 +20,7 @@ export const VenueFormActionBar = ({ venue }: VenueFormActionBarProps) => {
     <div className={styles['action-bar']}>
       <ButtonLink
         variant={ButtonVariant.SECONDARY}
-        link={{
-          to: `/structures/${venue?.managingOfferer.id}/lieux/${venue?.id}`,
-          isExternal: false,
-        }}
+        to={`/structures/${venue?.managingOfferer.id}/lieux/${venue?.id}`}
       >
         Annuler
       </ButtonLink>

--- a/pro/src/pages/VenueEdition/AccesLibreSection/AccesLibreSection.tsx
+++ b/pro/src/pages/VenueEdition/AccesLibreSection/AccesLibreSection.tsx
@@ -27,10 +27,8 @@ export const AccesLibreSection = ({ venue }: AccesLibreSectionProps) => {
       title="Modalités d’accessibilité via acceslibre"
       editLink={
         <ButtonLink
-          link={{
-            to: `https://acceslibre.beta.gouv.fr/contrib/edit-infos/${venue.externalAccessibilityId}/`,
-            isExternal: true,
-          }}
+          to={`https://acceslibre.beta.gouv.fr/contrib/edit-infos/${venue.externalAccessibilityId}/`}
+          isExternal
           icon={fullLinkIcon}
         >
           Éditer sur acceslibre
@@ -41,12 +39,10 @@ export const AccesLibreSection = ({ venue }: AccesLibreSectionProps) => {
         Les modalités ci-dessous sont issues de la plateforme{' '}
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{
-            isExternal: true,
-            to:
-              venue.externalAccessibilityUrl ??
-              'https://acceslibre.beta.gouv.fr/',
-          }}
+          isExternal
+          to={
+            venue.externalAccessibilityUrl ?? 'https://acceslibre.beta.gouv.fr/'
+          }
         >
           acceslibre.gouv.fr
         </ButtonLink>

--- a/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
@@ -148,9 +148,7 @@ export const VenueEditionHeader = ({
         <ButtonLink
           variant={ButtonVariant.TERNARY}
           icon={fullParametersIcon}
-          link={{
-            to: `/structures/${venue.managingOfferer.id}/lieux/${venue.id}/parametres`,
-          }}
+          to={`/structures/${venue.managingOfferer.id}/lieux/${venue.id}/parametres`}
         >
           Paramètres généraux
         </ButtonLink>
@@ -172,9 +170,7 @@ export const VenueEditionHeader = ({
             variant={ButtonVariant.PRIMARY}
             icon={fullPlusIcon}
             className={styles['venue-button']}
-            link={{
-              to: `/offre/creation?lieu=${venue.id}&structure=${offerer.id}`,
-            }}
+            to={`/offre/creation?lieu=${venue.id}&structure=${offerer.id}`}
           >
             Créer une offre
           </ButtonLink>

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/StocksProviderForm/StocksProviderForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/StocksProviderForm/StocksProviderForm.tsx
@@ -109,12 +109,10 @@ export const StocksProviderForm = ({
           <ButtonLink
             className={styles['aide-stock-button']}
             icon={fullLinkIcon}
-            link={{
-              isExternal: true,
-              to: 'https://aide.passculture.app/hc/fr/articles/10616916478236',
-              target: '_blank',
-              'aria-label': 'Nouvelle fenêtre',
-            }}
+            isExternal
+            to="https://aide.passculture.app/hc/fr/articles/10616916478236"
+            opensInNewTab
+            aria-label="Nouvelle fenêtre"
             variant={ButtonVariant.QUATERNARY}
           >
             Visitez notre FAQ pour plus d’informations

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons.tsx
@@ -81,10 +81,7 @@ export const CollectiveActionButtons = ({
           </Button>
         )}
         {bookingRecap.bookingStatus === BOOKING_STATUS.PENDING && (
-          <ButtonLink
-            link={{ isExternal: false, to: offerEditionUrl }}
-            variant={ButtonVariant.PRIMARY}
-          >
+          <ButtonLink to={offerEditionUrl} variant={ButtonVariant.PRIMARY}>
             Modifier l’offre
           </ButtonLink>
         )}

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.tsx
@@ -153,10 +153,7 @@ export const CollectiveTimeLine = ({
               </div>
               <ButtonLink
                 variant={ButtonVariant.TERNARY}
-                link={{
-                  to: `/offre/${bookingRecap.stock.offerId}/collectif/stocks/edition`,
-                  isExternal: false,
-                }}
+                to={`/offre/${bookingRecap.stock.offerId}/collectif/stocks/edition`}
                 icon={fullEditIcon}
                 onClick={logModifyBookingLimitDateClick}
               >
@@ -174,10 +171,7 @@ export const CollectiveTimeLine = ({
                 </div>
                 <ButtonLink
                   variant={ButtonVariant.TERNARY}
-                  link={{
-                    to: `/offre/${bookingRecap.stock.offerId}/collectif/stocks/edition`,
-                    isExternal: false,
-                  }}
+                  to={`/offre/${bookingRecap.stock.offerId}/collectif/stocks/edition`}
                   icon={fullEditIcon}
                   onClick={logModifyBookingLimitDateClick}
                 >
@@ -185,10 +179,8 @@ export const CollectiveTimeLine = ({
                 </ButtonLink>
                 <ButtonLink
                   variant={ButtonVariant.TERNARY}
-                  link={{
-                    to: 'https://aide.passculture.app/hc/fr/articles/4405297381788--Acteurs-Culturels-Que-faire-si-le-groupe-scolaire-n-est-pas-au-complet-ou-doit-annuler-sa-participation-',
-                    isExternal: true,
-                  }}
+                  to="https://aide.passculture.app/hc/fr/articles/4405297381788--Acteurs-Culturels-Que-faire-si-le-groupe-scolaire-n-est-pas-au-complet-ou-doit-annuler-sa-participation-"
+                  isExternal
                   icon={fullLinkIcon}
                 >
                   Je rencontre un problème à cette étape
@@ -217,10 +209,7 @@ export const CollectiveTimeLine = ({
           </div>
           <ButtonLink
             variant={ButtonVariant.TERNARY}
-            link={{
-              to: `/offre/${bookingRecap.stock.offerId}/collectif/stocks/edition`,
-              isExternal: false,
-            }}
+            to={`/offre/${bookingRecap.stock.offerId}/collectif/stocks/edition`}
             icon={fullEditIcon}
             onClick={logModifyBookingLimitDateClick}
           >
@@ -270,10 +259,8 @@ export const CollectiveTimeLine = ({
           Nous espérons que votre évènement s’est bien déroulé.
           <ButtonLink
             variant={ButtonVariant.TERNARY}
-            link={{
-              to: 'https://aide.passculture.app/hc/fr/articles/4405297381788--Acteurs-Culturels-Que-faire-si-le-groupe-scolaire-n-est-pas-au-complet-ou-doit-annuler-sa-participation-',
-              isExternal: true,
-            }}
+            to="https://aide.passculture.app/hc/fr/articles/4405297381788--Acteurs-Culturels-Que-faire-si-le-groupe-scolaire-n-est-pas-au-complet-ou-doit-annuler-sa-participation-"
+            isExternal
             icon={fullLinkIcon}
           >
             Je rencontre un problème à cette étape
@@ -332,10 +319,8 @@ export const CollectiveTimeLine = ({
         </div>
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{
-            to: 'https://aide.passculture.app/hc/fr/articles/4411992051601',
-            isExternal: true,
-          }}
+          to="https://aide.passculture.app/hc/fr/articles/4411992051601"
+          isExternal
           icon={fullLinkIcon}
         >
           Voir le calendrier des remboursements
@@ -398,10 +383,7 @@ export const CollectiveTimeLine = ({
         </div>
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{
-            to: `remboursements/informations-bancaires?structure=${bookingDetails.offererId}`,
-            isExternal: false,
-          }}
+          to={`remboursements/informations-bancaires?structure=${bookingDetails.offererId}`}
           icon={fullLinkIcon}
           className={styles['button-important']}
         >
@@ -425,10 +407,8 @@ export const CollectiveTimeLine = ({
         </div>
         <ButtonLink
           variant={ButtonVariant.TERNARY}
-          link={{
-            to: `https://www.demarches-simplifiees.fr/dossiers/${bookingDetails.venueDMSApplicationId}/messagerie`,
-            isExternal: true,
-          }}
+          to={`https://www.demarches-simplifiees.fr/dossiers/${bookingDetails.venueDMSApplicationId}/messagerie`}
+          isExternal
           icon={fullLinkIcon}
         >
           Voir le dossier en cours

--- a/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
+++ b/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
@@ -138,19 +138,14 @@ export const CollectiveOfferConfirmationScreen = ({
           <ButtonLink
             variant={ButtonVariant.SECONDARY}
             className={styles['confirmation-action']}
-            link={{ to: '/offres/collectives', isExternal: false }}
+            to="/offres/collectives"
           >
             Voir mes offres
           </ButtonLink>
           <ButtonLink
             variant={ButtonVariant.PRIMARY}
             className={styles['confirmation-action']}
-            link={{
-              to: `/offre/creation${
-                offererId ? `?structure=${offererId}` : ''
-              }`,
-              isExternal: false,
-            }}
+            to={`/offre/creation${offererId ? `?structure=${offererId}` : ''}`}
           >
             Créer une nouvelle offre
           </ButtonLink>

--- a/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -98,13 +98,7 @@ export const CollectiveOfferPreviewCreationScreen = ({
       <AdagePreviewLayout offer={offer} />
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
-          <ButtonLink
-            variant={ButtonVariant.SECONDARY}
-            link={{
-              to: backRedirectionUrl,
-              isExternal: false,
-            }}
-          >
+          <ButtonLink variant={ButtonVariant.SECONDARY} to={backRedirectionUrl}>
             Étape précédente
           </ButtonLink>
         </ActionsBarSticky.Left>

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
@@ -210,7 +210,7 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
                 <ActionsBarSticky.Left>
                   <ButtonLink
                     variant={ButtonVariant.SECONDARY}
-                    link={{ isExternal: false, to: computeOffersUrl({}) }}
+                    to={computeOffersUrl({})}
                   >
                     Annuler et quitter
                   </ButtonLink>

--- a/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -44,22 +44,10 @@ export const CollectiveOfferSummaryCreationScreen = ({
       />
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
-          <ButtonLink
-            variant={ButtonVariant.SECONDARY}
-            link={{
-              to: backRedirectionUrl,
-              isExternal: false,
-            }}
-          >
+          <ButtonLink variant={ButtonVariant.SECONDARY} to={backRedirectionUrl}>
             Étape précédente
           </ButtonLink>
-          <ButtonLink
-            variant={ButtonVariant.PRIMARY}
-            link={{
-              to: nextRedirectionUrl,
-              isExternal: false,
-            }}
-          >
+          <ButtonLink variant={ButtonVariant.PRIMARY} to={nextRedirectionUrl}>
             Étape suivante
           </ButtonLink>
         </ActionsBarSticky.Left>

--- a/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -60,7 +60,7 @@ export const CollectiveOfferSummaryEditionScreen = ({
         <ActionsBarSticky.Left>
           <ButtonLink
             variant={ButtonVariant.PRIMARY}
-            link={{ isExternal: false, to: computeCollectiveOffersUrl({}) }}
+            to={computeCollectiveOffersUrl({})}
           >
             Retour à la liste des offres
           </ButtonLink>

--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -306,15 +306,13 @@ export const CollectiveOfferVisibilityScreen = ({
               <ActionsBarSticky.Left>
                 <ButtonLink
                   variant={ButtonVariant.SECONDARY}
-                  link={{
-                    to:
-                      mode === Mode.CREATION
-                        ? `/offre/${offer.id}/collectif/stocks${
-                            requestId ? `?requete=${requestId}` : ''
-                          }`
-                        : '/offres/collectives',
-                    isExternal: false,
-                  }}
+                  to={
+                    mode === Mode.CREATION
+                      ? `/offre/${offer.id}/collectif/stocks${
+                          requestId ? `?requete=${requestId}` : ''
+                        }`
+                      : '/offres/collectives'
+                  }
                 >
                   {mode === Mode.CREATION
                     ? 'Étape précédente'

--- a/pro/src/screens/EmailChangeValidation/EmailChangeValidation.tsx
+++ b/pro/src/screens/EmailChangeValidation/EmailChangeValidation.tsx
@@ -32,10 +32,7 @@ export const EmailChangeValidationScreen = ({
           <p className={styles['subtitle']}>
             Merci d’avoir confirmé votre changement d’adresse email.
           </p>
-          <ButtonLink
-            variant={ButtonVariant.PRIMARY}
-            link={{ to: '/', isExternal: false }}
-          >
+          <ButtonLink variant={ButtonVariant.PRIMARY} to="/">
             Se connecter
           </ButtonLink>
         </section>
@@ -50,10 +47,7 @@ export const EmailChangeValidationScreen = ({
           <p className={styles['subtitle']}>
             Connectez-vous avec votre ancienne adresse email.
           </p>
-          <ButtonLink
-            variant={ButtonVariant.PRIMARY}
-            link={{ to: '/', isExternal: false }}
-          >
+          <ButtonLink variant={ButtonVariant.PRIMARY} to="/">
             Se connecter
           </ButtonLink>
         </section>

--- a/pro/src/screens/IndividualOffer/ActionBar/ActionBar.tsx
+++ b/pro/src/screens/IndividualOffer/ActionBar/ActionBar.tsx
@@ -49,10 +49,7 @@ export const ActionBar = ({
 
     // mode === OFFER_WIZARD_MODE.EDITION
     return step === OFFER_WIZARD_STEP_IDS.SUMMARY ? (
-      <ButtonLink
-        link={{ to: backOfferUrl, isExternal: false }}
-        variant={ButtonVariant.PRIMARY}
-      >
+      <ButtonLink to={backOfferUrl} variant={ButtonVariant.PRIMARY}>
         Retour à la liste des offres
       </ButtonLink>
     ) : (
@@ -92,7 +89,7 @@ export const ActionBar = ({
           {step === OFFER_WIZARD_STEP_IDS.SUMMARY ? (
             <>
               <ButtonLink
-                link={{ to: '/offres', isExternal: false }}
+                to="/offres"
                 variant={ButtonVariant.SECONDARY}
                 onClick={() => {
                   notify.success(

--- a/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/InformationsScreen.RouteLeavingGuard.spec.tsx
@@ -72,12 +72,8 @@ const renderInformationsScreen = (
             element={
               <IndividualOfferContext.Provider value={contextValue}>
                 <InformationsScreen {...props} />
-                <ButtonLink link={{ to: '/outside', isExternal: false }}>
-                  Go outside !
-                </ButtonLink>
-                <ButtonLink link={{ to: '/stocks', isExternal: false }}>
-                  Go to stocks !
-                </ButtonLink>
+                <ButtonLink to="/outside">Go outside !</ButtonLink>
+                <ButtonLink to="/stocks">Go to stocks !</ButtonLink>
               </IndividualOfferContext.Provider>
             }
           />

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategories.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategories.RouteLeavingGuard.spec.tsx
@@ -39,17 +39,12 @@ const renderPriceCategories = (
           element={
             <>
               <PriceCategoriesScreen {...props} />
-              <ButtonLink link={{ to: '/outside', isExternal: false }}>
-                Go outside !
-              </ButtonLink>
+              <ButtonLink to="/outside">Go outside !</ButtonLink>
               <ButtonLink
-                link={{
-                  to: getIndividualOfferPath({
-                    step: OFFER_WIZARD_STEP_IDS.STOCKS,
-                    mode: OFFER_WIZARD_MODE.CREATION,
-                  }),
-                  isExternal: false,
-                }}
+                to={getIndividualOfferPath({
+                  step: OFFER_WIZARD_STEP_IDS.STOCKS,
+                  mode: OFFER_WIZARD_MODE.CREATION,
+                })}
               >
                 Go to stocks !
               </ButtonLink>

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
@@ -406,12 +406,10 @@ export const RecurrenceForm = ({
                       onClick={() =>
                         arrayHelpers.push(INITIAL_QUANTITY_PER_PRICE_CATEGORY)
                       }
-                      link={{
-                        to: `#quantityPerPriceCategories[${
-                          values.quantityPerPriceCategories.length - 1
-                        }].quantity`,
-                        isExternal: true,
-                      }}
+                      to={`#quantityPerPriceCategories[${
+                        values.quantityPerPriceCategories.length - 1
+                      }].quantity`}
+                      isExternal
                     >
                       Ajouter d’autres places et tarifs
                     </ButtonLink>

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
@@ -52,9 +52,7 @@ const renderStockEventCreation = async (
         element={
           <>
             <StocksEventCreation {...props} />
-            <ButtonLink link={{ to: '/outside', isExternal: false }}>
-              Go outside !
-            </ButtonLink>
+            <ButtonLink to="/outside">Go outside !</ButtonLink>
             <Notification />
           </>
         }

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
@@ -97,9 +97,7 @@ const renderStockEventScreen = async (
           element={
             <IndividualOfferContextProvider>
               <Stocks />
-              <ButtonLink link={{ to: '/outside', isExternal: false }}>
-                Go outside !
-              </ButtonLink>
+              <ButtonLink to="/outside">Go outside !</ButtonLink>
             </IndividualOfferContextProvider>
           }
         />

--- a/pro/src/screens/IndividualOffer/StocksThing/ActivationCodeFormDialog/AddActivationCodeForm.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/ActivationCodeFormDialog/AddActivationCodeForm.tsx
@@ -46,12 +46,10 @@ export const AddActivationCodeForm = ({
       <div className={styles['activation-codes-upload-template-section']}>
         <p className={styles['activation-codes-upload-gabarit']}>Gabarits</p>
         <ButtonLink
-          link={{
-            isExternal: true,
-            to: '/csvtemplates/CodesActivations-Gabarit.csv',
-            type: 'text/csv',
-            target: '_blank',
-          }}
+          isExternal
+          to="/csvtemplates/CodesActivations-Gabarit.csv"
+          type="text/csv"
+          opensInNewTab
           icon={fullDownloadIcon}
         >
           Gabarit CSV

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
@@ -67,9 +67,7 @@ const renderStockThingScreen = async (
           element={
             <IndividualOfferContext.Provider value={contextValue}>
               <StocksThing {...props} />
-              <ButtonLink link={{ to: '/outside', isExternal: false }}>
-                Go outside !
-              </ButtonLink>
+              <ButtonLink to="/outside">Go outside !</ButtonLink>
             </IndividualOfferContext.Provider>
           }
         />

--- a/pro/src/screens/IndividualOffer/SummaryScreen/DisplayOfferInAppLink/DisplayOfferInAppLink.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/DisplayOfferInAppLink/DisplayOfferInAppLink.tsx
@@ -7,22 +7,21 @@ import { WEBAPP_URL } from 'utils/config'
 interface DisplayOfferInAppLinkProps extends SharedButtonProps {
   id: number
   icon?: string
-  svgAlt?: string
   children: React.ReactNode
   onClick?: () => void
 }
 
 export const DisplayOfferInAppLink: FunctionComponent<
   DisplayOfferInAppLinkProps
-> = ({ id, icon, children, variant, svgAlt, onClick }) => {
+> = ({ id, icon, children, variant, onClick }) => {
   const offerPreviewUrl = `${WEBAPP_URL}/offre/${id}`
 
   return (
     <ButtonLink
-      link={{ to: offerPreviewUrl, isExternal: true }}
+      to={offerPreviewUrl}
+      isExternal
       variant={variant}
       icon={icon}
-      svgAlt={svgAlt}
       onClick={(event) => {
         event.preventDefault()
         onClick?.()

--- a/pro/src/screens/IndividualOfferConfirmationScreen/IndividualOfferConfirmationScreen.tsx
+++ b/pro/src/screens/IndividualOfferConfirmationScreen/IndividualOfferConfirmationScreen.tsx
@@ -96,7 +96,6 @@ export const IndividualOfferConfirmationScreen = ({
         <div className={styles['display-in-app-link']}>
           <DisplayOfferInAppLink
             id={offer.id}
-            svgAlt="Nouvelle fenêtre"
             icon={fullLinkIcon}
             onClick={() => {
               logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
@@ -116,10 +115,8 @@ export const IndividualOfferConfirmationScreen = ({
 
       <div className={styles['confirmation-actions']}>
         <ButtonLink
-          link={{
-            to: '/offre/creation' + queryString,
-            isExternal: true,
-          }}
+          to={`/offre/creation${queryString}`}
+          isExternal
           className={styles['confirmation-action']}
           variant={ButtonVariant.SECONDARY}
         >
@@ -127,10 +124,7 @@ export const IndividualOfferConfirmationScreen = ({
         </ButtonLink>
 
         <ButtonLink
-          link={{
-            to: `/offres`,
-            isExternal: false,
-          }}
+          to="/offres"
           className={styles['confirmation-action']}
           variant={ButtonVariant.PRIMARY}
         >

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
@@ -27,12 +27,9 @@ export const FormContactTemplateCustomForm = ({
           value="form"
         />
         <ButtonLink
-          link={{
-            isExternal: true,
-            to: 'https://aide.passculture.app/hc/fr/articles/12957173606940--Acteurs-Culturels-Comment-paramétrer-les-options-de-contact-pour-les-enseignants-dans-le-cadre-d-une-offre-vitrine',
-            target: '_blank',
-          }}
-          svgAlt="Nouvelle fenêtre"
+          isExternal
+          to="https://aide.passculture.app/hc/fr/articles/12957173606940--Acteurs-Culturels-Comment-paramétrer-les-options-de-contact-pour-les-enseignants-dans-le-cadre-d-une-offre-vitrine"
+          opensInNewTab
           icon={fullLinkIcon}
           className={styles['custom-form-radio-link']}
         >

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -197,7 +197,7 @@ export const OfferEducationalForm = ({
         <ActionsBarSticky.Left>
           <ButtonLink
             variant={ButtonVariant.SECONDARY}
-            link={{ to: computeCollectiveOffersUrl({}), isExternal: false }}
+            to={computeCollectiveOffersUrl({})}
           >
             Annuler et quitter
           </ButtonLink>

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -211,15 +211,13 @@ export const OfferEducationalStock = <
               <ActionsBarSticky.Left>
                 <ButtonLink
                   variant={ButtonVariant.SECONDARY}
-                  link={{
-                    to:
-                      mode === Mode.CREATION
-                        ? `/offre/collectif/${offer.id}/creation${
-                            requestId ? `?requete=${requestId}` : ''
-                          }`
-                        : '/offres/collectives',
-                    isExternal: false,
-                  }}
+                  to={
+                    mode === Mode.CREATION
+                      ? `/offre/collectif/${offer.id}/creation${
+                          requestId ? `?requete=${requestId}` : ''
+                        }`
+                      : '/offres/collectives'
+                  }
                 >
                   {mode === Mode.CREATION
                     ? 'Étape précédente'

--- a/pro/src/screens/OfferType/ActionsBar/ActionsBar.tsx
+++ b/pro/src/screens/OfferType/ActionsBar/ActionsBar.tsx
@@ -22,7 +22,7 @@ export const ActionsBar = ({
     <ActionsBarSticky>
       <ActionsBarSticky.Left>
         <ButtonLink
-          link={{ to: computeOffersUrl({}), isExternal: false }}
+          to={computeOffersUrl({})}
           variant={ButtonVariant.SECONDARY}
           onClick={() => logEvent(Events.CLICKED_CANCEL_OFFER_CREATION)}
         >

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -122,10 +122,7 @@ export const Offers = ({
   const actionLink = displayCreateOfferButton ? (
     <ButtonLink
       variant={ButtonVariant.PRIMARY}
-      link={{
-        isExternal: false,
-        to: `/offre/creation${selectedOffererId ? `?structure=${selectedOffererId}` : ''}`,
-      }}
+      to={`/offre/creation${selectedOffererId ? `?structure=${selectedOffererId}` : ''}`}
       icon={fullPlusIcon}
     >
       Créer une offre

--- a/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/ConfirmedAttachment.tsx
+++ b/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/ConfirmedAttachment.tsx
@@ -33,7 +33,7 @@ export const ConfirmedAttachment = (): JSX.Element => {
         onClick={logNavigation}
         className={styles['home-button']}
         variant={ButtonVariant.PRIMARY}
-        link={{ isExternal: false, to: '/accueil' }}
+        to="/accueil"
       >
         Accéder à votre espace
       </ButtonLink>

--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
@@ -121,10 +121,7 @@ export const Validation = (): JSX.Element => {
         <h2 className={styles['subtitle']}>
           Identification
           <ButtonLink
-            link={{
-              to: '/parcours-inscription/identification',
-              isExternal: false,
-            }}
+            to="/parcours-inscription/identification"
             onClick={() => {
               logEvent(Events.CLICKED_ONBOARDING_FORM_NAVIGATION, {
                 from: location.pathname,
@@ -154,10 +151,7 @@ export const Validation = (): JSX.Element => {
         <h2 className={styles['subtitle']}>
           Activité
           <ButtonLink
-            link={{
-              to: '/parcours-inscription/activite',
-              isExternal: false,
-            }}
+            to="/parcours-inscription/activite"
             onClick={() => {
               logEvent(Events.CLICKED_ONBOARDING_FORM_NAVIGATION, {
                 from: location.pathname,

--- a/pro/src/screens/SignupJourneyForm/Welcome/Welcome.tsx
+++ b/pro/src/screens/SignupJourneyForm/Welcome/Welcome.tsx
@@ -15,7 +15,7 @@ export const Welcome = (): JSX.Element => {
       <ButtonLink
         className={styles['continue-button']}
         variant={ButtonVariant.PRIMARY}
-        link={{ isExternal: false, to: '/parcours-inscription/structure' }}
+        to="/parcours-inscription/structure"
       >
         Commencer
       </ButtonLink>

--- a/pro/src/ui-kit/Banners/Banner/__specs__/Banner.spec.tsx
+++ b/pro/src/ui-kit/Banners/Banner/__specs__/Banner.spec.tsx
@@ -23,7 +23,7 @@ describe('Banner', () => {
     // then
     expect(screen.getByText('This is the banner content')).toBeInTheDocument()
     const link = screen.getByRole('link', {
-      name: props.links?.[0]?.label,
+      name: `Nouvelle fenêtre ${props.links?.[0]?.label}`,
     })
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', props.links?.[0]?.href)

--- a/pro/src/ui-kit/Banners/LinkNodes/LinkNodes.tsx
+++ b/pro/src/ui-kit/Banners/LinkNodes/LinkNodes.tsx
@@ -32,35 +32,17 @@ export const LinkNode = ({
   'aria-label': ariaLabel,
 }: Link): React.ReactNode => {
   const forwardLink: LinkProps = { to: href, isExternal }
-  if (isExternal) {
-    forwardLink.target = '_blank'
-  }
   if (ariaLabel) {
     forwardLink['aria-label'] = ariaLabel
   }
   return (
     <ButtonLink
-      link={forwardLink}
-      icon={
-        icon === null
-          ? undefined
-          : icon
-            ? icon.src
-            : isExternal
-              ? fullLinkIcon
-              : fullNextIcon
-      }
+      {...forwardLink}
+      //  If the link is external, the link automatically opens in a new tab
+      opensInNewTab={isExternal}
+      icon={isExternal ? fullLinkIcon : icon?.src ?? fullNextIcon}
       className={styles['bi-link']}
       onClick={onClick}
-      svgAlt={
-        icon === null
-          ? undefined
-          : icon?.alt
-            ? icon.alt
-            : isExternal
-              ? 'Nouvelle fenêtre'
-              : ''
-      }
     >
       {label}
     </ButtonLink>

--- a/pro/src/ui-kit/Banners/LinkNodes/__specs__/LinkNodes.spec.tsx
+++ b/pro/src/ui-kit/Banners/LinkNodes/__specs__/LinkNodes.spec.tsx
@@ -39,7 +39,7 @@ describe('LinkNodes', () => {
       <LinkNode
         href="mailto:support-pro@passculture.app"
         isExternal
-        icon={{ src: fullMailIcon, alt: 'Nouvelle fenêtre, par email' }}
+        icon={{ src: fullMailIcon, alt: '' }}
         label="Contacter le support"
       />
     )
@@ -51,7 +51,7 @@ describe('LinkNodes', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     expect(screen.getByRole('img')).toHaveAttribute(
       'aria-label',
-      'Nouvelle fenêtre, par email'
+      'Nouvelle fenêtre'
     )
   })
 })

--- a/pro/src/ui-kit/Button/ButtonLink.stories.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.stories.tsx
@@ -28,7 +28,8 @@ export const Ternary: StoryObj<typeof ButtonLink> = {
   args: {
     children: 'Éditer',
     variant: ButtonVariant.TERNARY,
-    link: { to: '/my-path', isExternal: false },
+    to: '/my-path',
+    isExternal: false,
   },
 }
 
@@ -51,7 +52,8 @@ export const QuaternaryWithIcon: StoryObj<typeof ButtonLink> = {
     children: 'Accueil',
     variant: ButtonVariant.QUATERNARY,
     icon: fullBackIcon,
-    link: { to: '/my-path', isExternal: false },
+    to: '/my-path',
+    isExternal: false,
   },
 }
 

--- a/pro/src/ui-kit/Button/ButtonLink.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.tsx
@@ -2,29 +2,26 @@ import cn from 'classnames'
 import React, { ForwardedRef, forwardRef, MouseEventHandler } from 'react'
 import { Link } from 'react-router-dom'
 
+import fullLinkIcon from 'icons/full-link.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './Button.module.scss'
 import { ButtonVariant, IconPositionEnum, SharedButtonProps } from './types'
 
 export type LinkProps = {
+  isDisabled?: boolean
+  svgAlt?: string
   isExternal?: boolean
   to: string
-  target?: string
-  rel?: string
+  opensInNewTab?: boolean
   'aria-label'?: string
-  'aria-current'?: 'page'
   type?: string
   download?: boolean
 }
 
-export interface ButtonLinkProps
-  extends SharedButtonProps,
-    React.HTMLProps<HTMLAnchorElement> {
-  link: LinkProps
-  isDisabled?: boolean
-  svgAlt?: string
-}
+type ButtonLinkProps = LinkProps &
+  SharedButtonProps &
+  React.HTMLProps<HTMLAnchorElement>
 
 export const ButtonLink = forwardRef(
   (
@@ -35,10 +32,12 @@ export const ButtonLink = forwardRef(
       isDisabled = false,
       onClick,
       variant = ButtonVariant.TERNARY,
-      link,
       iconPosition = IconPositionEnum.LEFT,
-      svgAlt = '',
+      svgAlt,
       onBlur,
+      isExternal = false,
+      opensInNewTab,
+      to,
       ...props
     }: ButtonLinkProps,
     forwadedRef: ForwardedRef<HTMLAnchorElement>
@@ -51,36 +50,33 @@ export const ButtonLink = forwardRef(
       styles['button-link'],
       className
     )
-    const svgIcon = icon ? (
+    const svgIcon = opensInNewTab ? (
       <SvgIcon
-        src={icon}
-        alt={svgAlt}
+        src={icon ?? fullLinkIcon}
+        alt={svgAlt ?? 'Nouvelle fenêtre'}
         className={styles['button-icon']}
         width="22"
       />
-    ) : (
-      <></>
-    )
+    ) : icon ? (
+      <SvgIcon
+        src={icon}
+        alt={svgAlt ?? ''}
+        className={styles['button-icon']}
+        width="22"
+      />
+    ) : null
 
     let body = (
       <>
-        {
-          /* istanbul ignore next: graphic variation */
-          iconPosition !== IconPositionEnum.RIGHT && svgIcon
-        }
+        {iconPosition !== IconPositionEnum.RIGHT && svgIcon}
         {variant === ButtonVariant.BOX ? (
           <div className={styles['button-arrow-content']}>{children}</div>
         ) : (
           <>{children}</>
         )}
-        {
-          /* istanbul ignore next: graphic variation */
-          iconPosition === IconPositionEnum.RIGHT && svgIcon
-        }
+        {iconPosition === IconPositionEnum.RIGHT && svgIcon}
       </>
     )
-
-    const { to, isExternal, ...linkProps } = link
 
     // react-router v6 accepts relative links
     // That is, if you use "offers" as link, it will be relative to the current path
@@ -105,22 +101,21 @@ export const ButtonLink = forwardRef(
         onClick={callback}
         onBlur={(e) => onBlur?.(e)}
         rel="noopener noreferrer"
-        {...linkProps}
         {...props}
+        target={opensInNewTab ? '_blank' : '_self'}
         ref={forwadedRef}
       >
         {body}
         {disabled}
       </a>
     ) : (
-      /* istanbul ignore next: graphic variation */ <Link
+      <Link
         className={classNames}
         onClick={callback}
         onBlur={(e) => onBlur?.(e)}
         to={absoluteUrl}
-        aria-label={linkProps['aria-label']}
-        aria-current={linkProps['aria-current'] ?? false}
-        target={linkProps.target}
+        aria-label={props['aria-label']}
+        target={opensInNewTab ? '_blank' : '_self'}
         {...props}
         ref={forwadedRef}
       >

--- a/pro/src/ui-kit/Button/__specs__/ButtonLink.spec.tsx
+++ b/pro/src/ui-kit/Button/__specs__/ButtonLink.spec.tsx
@@ -13,7 +13,7 @@ describe('ButtonLink', () => {
   it('should call callback action when clicking the button', async () => {
     const onClick = vi.fn()
     render(
-      <ButtonLink link={props} onClick={onClick}>
+      <ButtonLink {...props} onClick={onClick}>
         test
       </ButtonLink>
     )
@@ -28,7 +28,7 @@ describe('ButtonLink', () => {
   it('should call callback action onblur when clicking outside the button', async () => {
     const onBlur = vi.fn()
     render(
-      <ButtonLink link={props} onBlur={onBlur}>
+      <ButtonLink {...props} onBlur={onBlur}>
         test
       </ButtonLink>
     )
@@ -55,9 +55,7 @@ describe('ButtonLink', () => {
                     <div>
                       sub route{' '}
                       {/* here the link is missing the starting slash to be an absolute link */}
-                      <ButtonLink link={{ to: 'offers', isExternal: false }}>
-                        test
-                      </ButtonLink>
+                      <ButtonLink to="offers">test</ButtonLink>
                     </div>
                   }
                 />
@@ -77,7 +75,7 @@ describe('ButtonLink', () => {
   it('should not call callback action when button disabled', async () => {
     const onClick = vi.fn()
     render(
-      <ButtonLink link={props} onClick={onClick} isDisabled>
+      <ButtonLink {...props} onClick={onClick} isDisabled>
         test
       </ButtonLink>
     )
@@ -87,19 +85,5 @@ describe('ButtonLink', () => {
 
     expect(onClick).not.toHaveBeenCalled()
     expect(screen.getByText('Action non disponible')).toBeInTheDocument()
-  })
-
-  it('should not be considered the current page if not specified', () => {
-    renderWithProviders(
-      <ButtonLink link={{ to: '#' }} isDisabled>
-        test
-      </ButtonLink>
-    )
-
-    expect(
-      screen
-        .getByRole('link', { name: 'test Action non disponible' })
-        .getAttribute('aria-current')
-    ).toEqual('false')
   })
 })

--- a/pro/src/ui-kit/Button/types.ts
+++ b/pro/src/ui-kit/Button/types.ts
@@ -15,7 +15,7 @@ export enum IconPositionEnum {
 }
 
 export type SharedButtonProps = {
-  icon?: string
+  icon?: string | null
   variant?: ButtonVariant
   iconPosition?: IconPositionEnum
   testId?: string

--- a/pro/src/ui-kit/Hero/Hero.tsx
+++ b/pro/src/ui-kit/Hero/Hero.tsx
@@ -22,10 +22,7 @@ export const Hero = ({
     <div className={styles['hero-body']}>
       <h1 className={styles['title']}>{title}</h1>
       <h2 className={styles['subtitle']}>{text}</h2>
-      <ButtonLink
-        variant={ButtonVariant.PRIMARY}
-        link={{ isExternal: false, to: linkTo }}
-      >
+      <ButtonLink variant={ButtonVariant.PRIMARY} to={linkTo}>
         {linkLabel}
       </ButtonLink>
     </div>

--- a/pro/src/ui-kit/InfoBox/InfoBox.tsx
+++ b/pro/src/ui-kit/InfoBox/InfoBox.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from 'react'
 
 import fullLinkIcon from 'icons/full-link.svg'
 import shadowTipsHelpIcon from 'icons/shadow-tips-help.svg'
-import { ButtonLink, type LinkProps } from 'ui-kit/Button/ButtonLink'
+import { ButtonLink, LinkProps } from 'ui-kit/Button/ButtonLink'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './InfoBox.module.scss'
@@ -15,14 +15,9 @@ interface InfoBoxLinkProps extends LinkProps {
 interface InfoBoxProps {
   children: ReactNode
   link?: InfoBoxLinkProps
-  svgAlt?: string
 }
 
-export const InfoBox = ({
-  children,
-  link,
-  svgAlt,
-}: InfoBoxProps): JSX.Element => {
+export const InfoBox = ({ children, link }: InfoBoxProps): JSX.Element => {
   return (
     <div className={cn(styles['info-box'])}>
       <div className={styles['info-box-header']}>
@@ -42,10 +37,9 @@ export const InfoBox = ({
 
       {link && (
         <ButtonLink
-          link={link}
+          {...link}
           icon={fullLinkIcon}
           className={styles['info-box-link']}
-          svgAlt={svgAlt || ''}
         >
           {link.text}
         </ButtonLink>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30742

**Objectif**
Avoir par défaut l'icon de nouvelle fenêtre et le texte alternatif "Nouvelle fenêtre" sur l'icon du `BottonLink` quand on a `target="_blank"` (remplacé par `opensInNewTab` pour être plus explicite).
On a aussi aligné les props pour avoir un seul niveau (et pas l'objet link). Le gros des changements (2e commit) est juste l'adaptation de toutes les props des ButtonLinks.

**A noter**
Le composant `LinkNodes` a un comportement spécial, dès qu'un lien est en `isExternal`, le lien s'ouvre dans un nouvel onglet. On a gardé ce comportement iso.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques