### PR TITLE
(PC-30745)[PRO] fix: Reset autocomplete to an empty array and not to …

### DIFF
--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
@@ -81,7 +81,7 @@ export const SelectAutocomplete = ({
   useEffect(() => {
     const resetSearchField = async () => {
       await setFieldValue(`search-${name}`, '', false)
-      await setFieldValue(name, '', false)
+      await setFieldValue(name, multi ? [] : '', false)
       onReset()
     }
     if (isOpen && resetOnOpen && searchField.value !== '') {


### PR DESCRIPTION
…an empty string when it is multi.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30745

**Objectif**
Corriger une erreur sentry. Quand on réinitialise le SelectAutocomplete au moment ou on click dans l'input de recherche après avoir déjà fait une recherche, la valeur du select est fixée à un string vide. Mais si on est en mode multi, il faut réinitialiser à une liste vide.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques