### PR TITLE
(BSR)[PRO] test: flaky: wait for header menu to be closed

### DIFF
--- a/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
+++ b/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
@@ -48,6 +48,7 @@ When('I select offerer {string}', (offererName: string) => {
   cy.findByTestId('offerer-select').click()
   cy.findByText(/Changer de structure/).click()
   cy.findByTestId('offerers-selection-menu').findByText(offererName).click()
+  cy.findByTestId('header-dropdown-menu-div').should('not.exist')
   cy.findAllByTestId('spinner').should('not.exist')
 })
 

--- a/pro/cypress/e2e/step-definitions/searchIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/searchIndividualOffer.cy.ts
@@ -14,6 +14,7 @@ When('I select offerer {string} in offer page', (offererName: string) => {
   cy.findByText(/Changer de structure/).click()
   cy.findByTestId('offerers-selection-menu').findByText(offererName).click()
   cy.wait('@getOffererId')
+  cy.findByTestId('header-dropdown-menu-div').should('not.exist')
   cy.findAllByTestId('spinner').should('not.exist')
 })
 

--- a/pro/cypress/e2e/step-definitions/venue.cy.ts
+++ b/pro/cypress/e2e/step-definitions/venue.cy.ts
@@ -129,8 +129,8 @@ Then('I should see details of my venue', () => {
 
 When('I go to the venue page in Individual section', () => {
   initValuesAndIntercept()
-  cy.findByText('Votre page partenaire').should('be.visible')
-  cy.findByText('Carnet d’adresses').should('be.visible')
+  cy.findByText('Votre page partenaire').scrollIntoView().should('be.visible')
+  cy.findByText('Carnet d’adresses').scrollIntoView().should('be.visible')
   cy.get('a[aria-label^="Gérer la page de Lieu avec Siret"]').eq(0).click()
   cy.findByText('À propos de votre activité').should('be.visible')
   cy.findByText('Modifier').click()
@@ -151,7 +151,7 @@ When('I go to the venue page in Paramètres généraux', () => {
   cy.findAllByTestId('spinner').should('not.exist')
   cy.url().should('not.include', '/parametres')
   cy.findByText('Paramètres généraux').click()
-  cy.url().should('include', '/structures').and('include', 'lieux')
+  cy.url().should('include', '/parametres')
   cy.findAllByTestId('spinner').should('not.exist')
 })
 

--- a/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
+++ b/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
@@ -123,7 +123,10 @@ export const HeaderDropdown = () => {
           align="end"
           sideOffset={7}
         >
-          <div className={styles['menu']}>
+          <div
+            className={styles['menu']}
+            data-testid="header-dropdown-menu-div"
+          >
             <DropdownMenu.Item className={styles['close-item']}>
               <button className={styles['close-button']}>
                 <SvgIcon


### PR DESCRIPTION
## But de la pull request

Quelques petites modifs suite à l'observation de cas flaky (échoue une première fois, puisse passe) notamment pour attendre la fermeture du menu de sélection en haut à droite.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques