### PR TITLE
(BSR) ci: push pod console image should be trigger when build has been done

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -231,7 +231,7 @@ jobs:
 
   push-pcapi:
     name: "Push pcapi docker image to registry"
-    needs: [pcapi-init-job, test-api, test-pro-e2e]
+    needs: [build-pcapi, pcapi-init-job, test-api, test-pro-e2e]
     uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
     with:
       image: pcapi
@@ -244,7 +244,7 @@ jobs:
 
   push-pcapi-console:
     name: "Push pcapi-console docker image to registry"
-    needs: [pcapi-init-job, test-api, test-pro-e2e]
+    needs: [build-pcapi-console, pcapi-init-job, test-api, test-pro-e2e]
     uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
     with:
       image: pcapi-console


### PR DESCRIPTION
For example https://github.com/pass-culture/pass-culture-main/actions/runs/9858204355/job/27220115110