### PR TITLE
(BSR)[PRO] fix: Makes cookies preferences popup over the 'skip-link' component

### DIFF
--- a/pro/src/components/SkipLinks/SkipLinks.module.scss
+++ b/pro/src/components/SkipLinks/SkipLinks.module.scss
@@ -11,7 +11,7 @@
   &:focus-within {
     height: rem.torem(32px);
     position: relative;
-    z-index: 2;
+    z-index: 13;
     top: 0;
   }
 

--- a/pro/src/components/SkipLinks/SkipLinks.module.scss
+++ b/pro/src/components/SkipLinks/SkipLinks.module.scss
@@ -1,5 +1,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/variables/_size.scss" as size;
+@use "styles/variables/_z-index.scss" as zIndex;
 @use "styles/mixins/_fonts.scss" as fonts;
 
 .skip-links {
@@ -11,7 +12,7 @@
   &:focus-within {
     height: rem.torem(32px);
     position: relative;
-    z-index: 13;
+    z-index: zIndex.$cookies-popup-z-index;
     top: 0;
   }
 

--- a/pro/src/styles/variables/_z-index.scss
+++ b/pro/src/styles/variables/_z-index.scss
@@ -6,8 +6,9 @@ $select-options-z-index: 3; // The sticky action bar z-index was set to 1. We ha
 $lateral-menu-backdrop-z-index: 10;
 $lateral-menu-z-index: 11;
 $top-header-z-index: 12;
-$lateral-menu-z-index-mobile: 13;
-$modal-z-index: 14;
-$modal-close-z-index: 15;
-$profil-pop-in-z-index: 16;
-$venues-pop-in-z-index: 17;
+$cookies-popup-z-index: 13;
+$lateral-menu-z-index-mobile: 14;
+$modal-z-index: 15;
+$modal-close-z-index: 16;
+$profil-pop-in-z-index: 17;
+$venues-pop-in-z-index: 18;


### PR DESCRIPTION
## But de la pull request

Fixe le problème remonté par la Qualité sur la modale de personnalisation des cookies, qui passait en dessous du header et composant <SkipLinks/>.

![image](https://github.com/pass-culture/pass-culture-main/assets/171674396/e0d9b61b-6f5c-4b5a-9d98-6b642bd60036)