### PR TITLE
(PC-30774)[API] fix: use more specific error for recommendation routes

### DIFF
--- a/api/src/pcapi/connectors/recommendation.py
+++ b/api/src/pcapi/connectors/recommendation.py
@@ -20,6 +20,10 @@ class RecommendationApiException(Exception):
     pass
 
 
+class RecommendationApiTimeoutException(Exception):
+    pass
+
+
 def _get_backend() -> "BaseBackend":
     backend_class = module_loading.import_string(settings.RECOMMENDATION_BACKEND)
     return backend_class()
@@ -73,6 +77,8 @@ class HttpBackend:
             else:
                 raise ValueError(f"Unexpected method: {method}")
             response.raise_for_status()
+        except requests.exceptions.Timeout:
+            raise RecommendationApiTimeoutException()
         except requests.exceptions.RequestException as exc:
             logger.info("Got error from Recommendation API", extra={"exc": str(exc)}, exc_info=True)
             raise RecommendationApiException(str(exc)) from exc

--- a/api/src/pcapi/routes/native/v1/recommendation.py
+++ b/api/src/pcapi/routes/native/v1/recommendation.py
@@ -26,8 +26,10 @@ def similar_offers(
             user,
             params=query.dict(),
         )
+    except recommendation_api.RecommendationApiTimeoutException:
+        raise ApiErrors({"code": "RECOMMENDATION_API_TIMEOUT"}, status_code=504)
     except recommendation_api.RecommendationApiException:
-        raise ApiErrors({"code": "RECOMMENDATION_API_ERROR"}, status_code=400)
+        raise ApiErrors({"code": "RECOMMENDATION_API_ERROR"}, status_code=502)
     if not raw_response:
         return serializers.SimilarOffersResponse(results=[], params=serializers.RecommendationApiParams())
     return serializers.SimilarOffersResponse.parse_raw(raw_response, content_type="application/json")
@@ -47,8 +49,10 @@ def playlist(
             params=query.dict(),
             body=body.dict(),
         )
+    except recommendation_api.RecommendationApiTimeoutException:
+        raise ApiErrors({"code": "RECOMMENDATION_API_TIMEOUT"}, status_code=504)
     except recommendation_api.RecommendationApiException:
-        raise ApiErrors({"code": "RECOMMENDATION_API_ERROR"}, status_code=400)
+        raise ApiErrors({"code": "RECOMMENDATION_API_ERROR"}, status_code=502)
 
     if not raw_response:
         return serializers.PlaylistResponse(


### PR DESCRIPTION
The backend acts as a proxy for these routes.
If we have a timeout for recommendation api we return a 504 to native front If we have any other errors we return a 502 to native front

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques