### PR TITLE
(PC-30660)[PRO] style: Correction composant de téléchargement de PDF, GF 

### DIFF
--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceActions.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceActions.tsx
@@ -6,7 +6,6 @@ import { GET_DATA_ERROR_MESSAGE } from 'core/shared/constants'
 import { useNotification } from 'hooks/useNotification'
 import fullDownloadIcon from 'icons/full-download.svg'
 import { Button } from 'ui-kit/Button/Button'
-import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { DropdownItem } from 'ui-kit/DropdownMenuWrapper/DropdownItem'
 import { DropdownMenuWrapper } from 'ui-kit/DropdownMenuWrapper/DropdownMenuWrapper'
@@ -20,6 +19,22 @@ export function InvoiceActions({ invoice }: InvoiceActionsProps) {
   const notify = useNotification()
   const { logEvent } = useAnalytics()
 
+  async function downloadPDFFile(url: string) {
+    try {
+      logEvent(Events.CLICKED_INVOICES_DOWNLOAD, {
+        fileType: 'justificatif',
+        filesCount: 1,
+        buttonType: 'unique',
+      })
+      downloadFile(
+        await fetch(url).then((res) => res.blob()),
+        'justificatif_comptable.pdf'
+      )
+    } catch {
+      notify.error(GET_DATA_ERROR_MESSAGE)
+    }
+  }
+
   async function downloadCSVFile(reference: string) {
     try {
       logEvent(Events.CLICKED_INVOICES_DOWNLOAD, {
@@ -29,7 +44,7 @@ export function InvoiceActions({ invoice }: InvoiceActionsProps) {
       })
       downloadFile(
         await api.getReimbursementsCsvV2([reference]),
-        'remboursements_pass_culture'
+        'remboursements_pass_culture.csv'
       )
     } catch {
       notify.error(GET_DATA_ERROR_MESSAGE)
@@ -37,26 +52,15 @@ export function InvoiceActions({ invoice }: InvoiceActionsProps) {
   }
 
   return (
-    <DropdownMenuWrapper title="Téléchargment des justificatifs">
+    <DropdownMenuWrapper title="Téléchargement des justificatifs">
       <>
-        <DropdownItem title="Télécharger le justificatif comptable (.pdf)">
-          <ButtonLink
-            isExternal
-            to={invoice.url}
-            opensInNewTab
-            download
-            icon={fullDownloadIcon}
-            variant={ButtonVariant.TERNARY}
-            onClick={() =>
-              logEvent(Events.CLICKED_INVOICES_DOWNLOAD, {
-                fileType: 'justificatif',
-                filesCount: 1,
-                buttonType: 'unique',
-              })
-            }
-          >
+        <DropdownItem
+          title="Télécharger le justificatif comptable (.pdf)"
+          onSelect={() => downloadPDFFile(invoice.url)}
+        >
+          <Button icon={fullDownloadIcon} variant={ButtonVariant.TERNARY}>
             Télécharger le justificatif comptable (.pdf)
-          </ButtonLink>
+          </Button>
         </DropdownItem>
         <DropdownItem
           title="Télécharger le détail des réservations (.csv)"


### PR DESCRIPTION
## Correction composant de téléchargement de PDF, GF 

Problème: En cliquant sur deux boutons EN GRIS, mais pas directement sur leurs textes, le dropdown se ferme et le document PDF (/CSV) n'est pas téléchargé.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30660

<img width="928" alt="Capture d’écran 2024-07-10 à 11 11 35" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/3adce679-8597-4d7a-9794-9a6aa72c5912">
