### PR TITLE
(PC-30671)[PRO] fix: Makes <ActionsBar> larger for NPP without frame

### DIFF
--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -16,7 +16,7 @@
 
   .actions-bar-content {
     width: 100%;
-    max-width: rem.torem(size.$desktop);
+    max-width: rem.torem(size.$main-content-width);
     margin: 0 auto;
     align-items: center;
     display: flex;
@@ -54,14 +54,17 @@
       flex-direction: column-reverse;
     }
   }
+
+  &-new-interface {
+    .actions-bar-content {
+      max-width: rem.torem(size.$desktop);
+    }
+  }
 }
 
 @media (min-width: size.$laptop) {
-  .actions-bar {
-    padding-right: size.$main-content-padding;
-  }
-
   .actions-bar-new-interface {
+    padding-right: size.$main-content-padding;
     padding-left: calc(rem.torem(size.$side-nav-width) + rem.torem(32px));
   }
 }

--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -16,7 +16,7 @@
 
   .actions-bar-content {
     width: 100%;
-    max-width: rem.torem(size.$main-content-width);
+    max-width: rem.torem(size.$desktop);
     margin: 0 auto;
     align-items: center;
     display: flex;
@@ -57,6 +57,10 @@
 }
 
 @media (min-width: size.$laptop) {
+  .actions-bar {
+    padding-right: size.$main-content-padding;
+  }
+
   .actions-bar-new-interface {
     padding-left: calc(rem.torem(size.$side-nav-width) + rem.torem(32px));
   }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30671

La ActionsBar occupe maintenant l'intégralité du corps de la version sans frames.
![image](https://github.com/pass-culture/pass-culture-main/assets/171674396/1c3859b9-1869-4004-b167-1db6ec4f64cb)
