### PR TITLE
(PC-30724) fix: allow start and end dates set to 01/09/N and 31/08/N+1 on educational offers

### DIFF
--- a/pro/src/screens/OfferEducationalStock/__specs__/validationSchema.spec.ts
+++ b/pro/src/screens/OfferEducationalStock/__specs__/validationSchema.spec.ts
@@ -1,0 +1,45 @@
+import { getYupValidationSchemaErrors } from 'utils/yupValidationTestHelpers'
+
+import { generateValidationSchema } from '../validationSchema'
+
+describe('validationSchema', () => {
+  const values = {
+    startDatetime: '2024-09-01',
+    endDatetime: '2024-09-01',
+    bookingLimitDatetime: '2024-09-01',
+    eventTime: '05:05',
+    numberOfPlaces: '56',
+    priceDetail: 'Détails sur le prix',
+    totalPrice: '1500',
+  }
+
+  it('should generate an error when start date and end date are not in the same school year', async () => {
+    const formValues = {
+      ...values,
+      startDatetime: '2024-09-01',
+      endDatetime: '2025-09-01',
+    }
+
+    const errors = await getYupValidationSchemaErrors(
+      generateValidationSchema(false, 0),
+      formValues
+    )
+    expect(errors).toEqual([
+      'Les dates doivent être sur la même année scolaire',
+    ])
+  })
+
+  it('should allow a start datetime set on 01/09/N and an end datetime set on 31/08/N+1', async () => {
+    const formValues = {
+      ...values,
+      startDatetime: '2024-09-01',
+      endDatetime: '2025-08-31',
+    }
+
+    const errors = await getYupValidationSchemaErrors(
+      generateValidationSchema(false, 0),
+      formValues
+    )
+    expect(errors).toEqual([])
+  })
+})

--- a/pro/src/screens/OfferEducationalStock/validationSchema.ts
+++ b/pro/src/screens/OfferEducationalStock/validationSchema.ts
@@ -76,7 +76,8 @@ export const generateValidationSchema = (
             .test({
               message: 'Les dates doivent être sur la même année scolaire',
               test: (value, context) =>
-                value < getMaxEndDateInSchoolYear(context.parent.startDatetime),
+                value <=
+                getMaxEndDateInSchoolYear(context.parent.startDatetime),
             }),
       }),
     eventTime: yup


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30724

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques