### PR TITLE
(PC-30793)[PRO] feat: Dont add an icon when the button link already o…

### DIFF
--- a/pro/src/components/LegalInfos/LegalInfos.tsx
+++ b/pro/src/components/LegalInfos/LegalInfos.tsx
@@ -1,10 +1,8 @@
 import cn from 'classnames'
-import React from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { Events } from 'core/FirebaseEvents/constants'
-import fullLink from 'icons/full-link.svg'
 import fullMailIcon from 'icons/full-mail.svg'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -36,13 +34,7 @@ export const LegalInfos = ({
         opensInNewTab
         variant={ButtonVariant.QUATERNARY}
       >
-        <SvgIcon
-          src={fullLink}
-          alt="Site pass.culture.fr (Nouvelle fenêtre)"
-          className={styles['icon-legal-infos']}
-          width="22"
-        />
-        <span>Conditions Générales d’Utilisation</span>
+        Conditions Générales d’Utilisation
       </ButtonLink>
       <span>{' ainsi que notre '}</span>
       <ButtonLink
@@ -55,13 +47,7 @@ export const LegalInfos = ({
         opensInNewTab
         variant={ButtonVariant.QUATERNARY}
       >
-        <SvgIcon
-          src={fullLink}
-          alt="Site pass.culture.fr (Nouvelle fenêtre)"
-          className={styles['icon-legal-infos']}
-          width="22"
-        />
-        <span>Charte des Données Personnelles</span>
+        Charte des Données Personnelles
       </ButtonLink>
       <span>
         {
@@ -78,7 +64,6 @@ export const LegalInfos = ({
         }
         to="mailto:support-pro@passculture.app"
         isExternal
-        opensInNewTab
       >
         <SvgIcon
           src={fullMailIcon}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
@@ -7,10 +7,8 @@ import { CalloutVariant } from 'components/Callout/types'
 import { Dialog } from 'components/Dialog/Dialog/Dialog'
 import { MandatoryInfo } from 'components/FormLayout/FormLayoutMandatoryInfo'
 import { useNotification } from 'hooks/useNotification'
-import fullLinkIcon from 'icons/full-link.svg'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { isDateValid } from 'utils/date'
 
 import { createCollectiveRequestPayload } from './createCollectiveRequestPayload'
@@ -169,12 +167,6 @@ export const RequestFormDialog = ({
                 isExternal
                 opensInNewTab
               >
-                <SvgIcon
-                  className={styles['form-icon']}
-                  width="20"
-                  alt="Nouvelle fenêtre"
-                  src={fullLinkIcon}
-                />
                 Aller sur le site
               </ButtonLink>
             </div>
@@ -229,7 +221,6 @@ export const RequestFormDialog = ({
         isExternal
         opensInNewTab
       >
-        <SvgIcon width="20" alt="Nouvelle fenêtre" src={fullLinkIcon} />
         Aller sur le site
       </ButtonLink>
     </div>

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -30,6 +30,7 @@
     height: size.$button-icon-size;
     width: size.$button-icon-size;
     flex-shrink: 0;
+    vertical-align: text-bottom;
   }
 
   &.button-center {


### PR DESCRIPTION
…pens in a new tab.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30793

**Objectif**
En introduisant l'ajout de l'icon de nouvelle fenêtre automatique dans le button link en cas de `opensInNewTab`, on a oublié d'enlever l'icon qui était ajoutée explicitement à certains endroits. Cette PR retire les icons en doublon.

<img width="580" alt="Capture d’écran 2024-07-10 à 16 01 59" src="https://github.com/pass-culture/pass-culture-main/assets/139768952/4e3224ae-de67-4d34-a02c-d3ce80de6191">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques