### PR TITLE
(BSR)[PRO] test: no screenshot and video recording with cloud

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -147,18 +147,18 @@ jobs:
           browser: chrome
           config-file: cypress/cypress.config.ts
           env: TAGS="@P0"
-          record: ${{ github.ref == 'refs/heads/master' }} # pour Cypress Cloud
+          record: ${{ github.ref == 'refs/heads/master' }} # for Cypress Cloud
         env:
           CYPRESS_RECORD_KEY: ${{ steps.secrets.outputs.CYPRESS_CLOUD_RECORD_KEY }}
           CYPRESS_PROJECT_ID: ${{ steps.secrets.outputs.CYPRESS_CLOUD_PROJECT_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Move cypress videos"
-        if: always()
+        if: ${{ github.ref != 'refs/heads/master' }} # useless on master bc Cypress Cloud
         run: |
           mkdir -p cypress/videos/${{ github.ref }}/${{ github.sha }} && \
           mv cypress/videos/*.mp4 cypress/videos/${{ github.ref }}/${{ github.sha }}/
       - name: "Archive E2E results"
-        if: always()
+        if: ${{ github.ref != 'refs/heads/master' }} # useless on master bc Cypress Cloud
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "pro/cypress/videos"


### PR DESCRIPTION
## But de la pull request

Skip l'étape de déplacement et upload des vidéos vers Google Storage si run sur master....car on a tout ce qu'il faut dans Cypress Cloud

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques