### PR TITLE
(BSR)[PRO] feat: raise an exception when educational year is missing

### DIFF
--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -190,10 +190,12 @@ def _check_start_and_end_dates_in_same_educational_year(
     end_datetime: datetime.datetime, start_datetime: datetime.datetime
 ) -> None:
     start_year = educational_repository.find_educational_year_by_date(start_datetime)
-    assert start_year
+    if not start_year:
+        raise exceptions.StartEducationalYearMissing()
 
     end_year = educational_repository.find_educational_year_by_date(end_datetime)
-    assert end_year
+    if not end_year:
+        raise exceptions.EndEducationalYearMissing()
 
     if start_year.id != end_year.id:
         raise exceptions.StartAndEndEducationalYearDifferent()

--- a/api/src/pcapi/core/educational/exceptions.py
+++ b/api/src/pcapi/core/educational/exceptions.py
@@ -210,3 +210,13 @@ class StartsBeforeOfferCreation(UpdateCollectiveOfferTemplateError):
 class StartAndEndEducationalYearDifferent(Exception):
     field = "dates.start"
     msg = "start and end dates in different school year"
+
+
+class StartEducationalYearMissing(Exception):
+    field = "dates.start"
+    msg = "no educational year/budget for the given start date"
+
+
+class EndEducationalYearMissing(Exception):
+    field = "dates.end"
+    msg = "no educational year/budget for the given end date"

--- a/api/src/pcapi/routes/pro/collective_stocks.py
+++ b/api/src/pcapi/routes/pro/collective_stocks.py
@@ -43,6 +43,10 @@ def create_collective_stock(
         raise ApiErrors({"code": "EDUCATIONAL_STOCK_ALREADY_EXISTS"}, status_code=400)
     except educational_exceptions.StartAndEndEducationalYearDifferent:
         raise ApiErrors({"code": "START_AND_END_EDUCATIONAL_YEAR_DIFFERENT"}, status_code=400)
+    except educational_exceptions.StartEducationalYearMissing:
+        raise ApiErrors({"code": "START_EDUCATIONAL_YEAR_MISSING"}, status_code=400)
+    except educational_exceptions.EndEducationalYearMissing:
+        raise ApiErrors({"code": "END_EDUCATIONAL_YEAR_MISSING"}, status_code=400)
 
     return collective_stock_serialize.CollectiveStockResponseModel.from_orm(collective_stock)
 
@@ -90,3 +94,7 @@ def edit_collective_stock(
         raise ApiErrors(error.errors, status_code=400)
     except educational_exceptions.StartAndEndEducationalYearDifferent:
         raise ApiErrors({"code": "START_AND_END_EDUCATIONAL_YEAR_DIFFERENT"}, status_code=400)
+    except educational_exceptions.StartEducationalYearMissing:
+        raise ApiErrors({"code": "START_EDUCATIONAL_YEAR_MISSING"}, status_code=400)
+    except educational_exceptions.EndEducationalYearMissing:
+        raise ApiErrors({"code": "END_EDUCATIONAL_YEAR_MISSING"}, status_code=400)


### PR DESCRIPTION
## But de la pull request

Au vu de ce bug Sentry -> https://sentry.passculture.team/organizations/sentry/issues/1616947/?referrer=slack, @ogeber a proposé de lever une exception plutôt que d'assert la présence de l'année scholaire.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques