### PR TITLE
(PC-30716)[PRO] feat: Hide 'View Profile' menu link in structure creation funnel

### DIFF
--- a/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
+++ b/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
@@ -2,7 +2,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import cn from 'classnames'
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useSearchParams } from 'react-router-dom'
+import { useLocation, useSearchParams } from 'react-router-dom'
 import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
@@ -53,6 +53,14 @@ export const HeaderDropdown = () => {
       value: item['id'].toString(),
       label: item['name'],
     })) ?? []
+  )
+
+  const { pathname } = useLocation()
+  const IN_STRUCTURE_CREATION_FUNNEL = pathname.startsWith(
+    '/parcours-inscription'
+  )
+  const canSeeHisProfile = !(
+    IN_STRUCTURE_CREATION_FUNNEL && offererOptions.length === 0
   )
 
   const selectedOffererId =
@@ -243,11 +251,13 @@ export const HeaderDropdown = () => {
               Profil
             </DropdownMenu.Label>
             <div className={styles['menu-email']}>{currentUser?.email}</div>
-            <DropdownMenu.Item className={styles['menu-item']} asChild>
-              <ButtonLink icon={fullProfilIcon} to="/profil">
-                Voir mon profil
-              </ButtonLink>
-            </DropdownMenu.Item>
+            {canSeeHisProfile && (
+              <DropdownMenu.Item className={styles['menu-item']} asChild>
+                <ButtonLink icon={fullProfilIcon} to="/profil">
+                  Voir mon profil
+                </ButtonLink>
+              </DropdownMenu.Item>
+            )}
             <DropdownMenu.Separator
               className={cn(styles['separator'], styles['tablet-only'])}
             />

--- a/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
+++ b/pro/src/components/Header/HeaderDropdown/HeaderDropdown.tsx
@@ -59,9 +59,8 @@ export const HeaderDropdown = () => {
   const IN_STRUCTURE_CREATION_FUNNEL = pathname.startsWith(
     '/parcours-inscription'
   )
-  const canSeeHisProfile = !(
+  const hideProfile =
     IN_STRUCTURE_CREATION_FUNNEL && offererOptions.length === 0
-  )
 
   const selectedOffererId =
     // TODO remove this when noUncheckedIndexedAccess is enabled in TS config
@@ -251,7 +250,7 @@ export const HeaderDropdown = () => {
               Profil
             </DropdownMenu.Label>
             <div className={styles['menu-email']}>{currentUser?.email}</div>
-            {canSeeHisProfile && (
+            {!hideProfile && (
               <DropdownMenu.Item className={styles['menu-item']} asChild>
                 <ButtonLink icon={fullProfilIcon} to="/profil">
                   Voir mon profil


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30716

![image](https://github.com/pass-culture/pass-culture-main/assets/171674396/afa08d5e-bc75-48a8-a3ac-4d55f30dfe48)

Le lien "Voir le profil" disparaît uniquement si on est dans le parcours de création de structure et que l'on est pas encore rattaché à une structure.

## Vérifications

- [ ] J'ai écrit les tests nécessaires