### PR TITLE
Pc 29616 collective offers accessibility

### DIFF
--- a/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
+++ b/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
@@ -12,8 +12,9 @@ import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 
-import { UserIdentityFormValues } from './types'
 import styles from '../UserPhoneForm/UserForm.module.scss'
+
+import { UserIdentityFormValues } from './types'
 import { validationSchema } from './validationSchema'
 
 export interface UserIdentityFormProps {

--- a/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
@@ -9,6 +9,7 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 import { PasswordInput } from 'ui-kit/form/PasswordInput/PasswordInput'
 
 import styles from '../UserPhoneForm/UserForm.module.scss'
+
 import { validationSchema } from './validationSchema'
 
 export interface UserPasswordFormProps {

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -51,7 +51,7 @@ export const AdageHeader = () => {
         <div className={styles['adage-header-nav-brand']}>
           <SvgIcon
             src={logoPassCultureIcon}
-            alt="Logo du pass Culture"
+            alt="pass Culture"
             width="109"
             viewBox="0 0 71 24"
           />

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout.tsx
@@ -112,7 +112,7 @@ export const AdagePreviewLayout = ({ offer }: AdagePreviewLayoutProps) => {
     <div className={styles['fake-adage-page']}>
       <div className={styles['fake-adage-page-header']}>
         <div className={styles['fake-adage-page-header-logo']}>
-          <img src={adageLogo} alt="Logo de la plateforme ADAGE" />
+          <img src={adageLogo} alt="Plateforme ADAGE" />
         </div>
         <img
           src={adageBurger}
@@ -126,7 +126,7 @@ export const AdagePreviewLayout = ({ offer }: AdagePreviewLayoutProps) => {
           <div className={styles['fake-adage-page-pass-header']}>
             <SvgIcon
               src={logoPassCultureIcon}
-              alt="Logo du pass Culture"
+              alt="pass Culture"
               width="98"
               viewBox="0 0 71 24"
             />

--- a/pro/src/pages/AdageIframe/app/components/UnauthenticatedError/UnauthenticatedError.tsx
+++ b/pro/src/pages/AdageIframe/app/components/UnauthenticatedError/UnauthenticatedError.tsx
@@ -10,7 +10,7 @@ export function UnauthenticatedError(): JSX.Element {
         <div className={styles['error-header-brand']}>
           <SvgIcon
             src={logoPassCultureIcon}
-            alt="Logo du pass Culture"
+            alt="pass Culture"
             width="109"
             viewBox="0 0 71 24"
           />

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/EmailInputRow/EmailInputRow.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/EmailInputRow/EmailInputRow.tsx
@@ -1,5 +1,3 @@
-import React, { ForwardedRef, forwardRef } from 'react'
-
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import fullTrashIcon from 'icons/full-trash.svg'
 import { NOTIFICATIONS_EMAIL_LABEL } from 'screens/OfferEducational/constants/labels'
@@ -14,38 +12,38 @@ interface EmailInputRowProps {
   displayTrash?: boolean
   name: string
   onDelete?: () => void
+  autoFocus?: boolean
 }
 
-export const EmailInputRow = forwardRef(
-  (
-    { disableForm, displayTrash = true, name, onDelete }: EmailInputRowProps,
-    inputRef: ForwardedRef<HTMLInputElement>
-  ): JSX.Element => {
-    return (
-      <FormLayout.Row className={styles['notification-mail']}>
-        <TextInput
-          label={NOTIFICATIONS_EMAIL_LABEL}
-          name={name}
-          disabled={disableForm}
-          className={styles['notification-mail-input']}
-          refForInput={inputRef}
-        />
-        {displayTrash && (
-          <div className={styles['trash']}>
-            <Button
-              onClick={onDelete}
-              icon={fullTrashIcon}
-              iconPosition={IconPositionEnum.CENTER}
-              variant={ButtonVariant.TERNARY}
-              hasTooltip
-            >
-              Supprimer l’email
-            </Button>
-          </div>
-        )}
-      </FormLayout.Row>
-    )
-  }
-)
-
-EmailInputRow.displayName = 'EmailInputRow'
+export const EmailInputRow = ({
+  disableForm,
+  displayTrash = true,
+  name,
+  onDelete,
+  autoFocus,
+}: EmailInputRowProps): JSX.Element => {
+  return (
+    <FormLayout.Row className={styles['notification-mail']}>
+      <TextInput
+        label={NOTIFICATIONS_EMAIL_LABEL}
+        name={name}
+        disabled={disableForm}
+        className={styles['notification-mail-input']}
+        autoFocus={autoFocus}
+      />
+      {displayTrash && (
+        <div className={styles['trash']}>
+          <Button
+            onClick={onDelete}
+            icon={fullTrashIcon}
+            iconPosition={IconPositionEnum.CENTER}
+            variant={ButtonVariant.TERNARY}
+            hasTooltip
+          >
+            Supprimer l’email
+          </Button>
+        </div>
+      )}
+    </FormLayout.Row>
+  )
+}

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/EmailInputRow/EmailInputRow.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/EmailInputRow/EmailInputRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ForwardedRef, forwardRef } from 'react'
 
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import fullTrashIcon from 'icons/full-trash.svg'
@@ -16,33 +16,36 @@ interface EmailInputRowProps {
   onDelete?: () => void
 }
 
-export const EmailInputRow = ({
-  disableForm,
-  displayTrash = true,
-  name,
-  onDelete,
-}: EmailInputRowProps) => {
-  return (
-    <FormLayout.Row className={styles['notification-mail']}>
-      <TextInput
-        label={NOTIFICATIONS_EMAIL_LABEL}
-        name={name}
-        disabled={disableForm}
-        className={styles['notification-mail-input']}
-      />
-      {displayTrash && (
-        <div className={styles['trash']}>
-          <Button
-            onClick={onDelete}
-            icon={fullTrashIcon}
-            iconPosition={IconPositionEnum.CENTER}
-            variant={ButtonVariant.TERNARY}
-            hasTooltip
-          >
-            Supprimer l’email
-          </Button>
-        </div>
-      )}
-    </FormLayout.Row>
-  )
-}
+export const EmailInputRow = forwardRef(
+  (
+    { disableForm, displayTrash = true, name, onDelete }: EmailInputRowProps,
+    inputRef: ForwardedRef<HTMLInputElement>
+  ): JSX.Element => {
+    return (
+      <FormLayout.Row className={styles['notification-mail']}>
+        <TextInput
+          label={NOTIFICATIONS_EMAIL_LABEL}
+          name={name}
+          disabled={disableForm}
+          className={styles['notification-mail-input']}
+          refForInput={inputRef}
+        />
+        {displayTrash && (
+          <div className={styles['trash']}>
+            <Button
+              onClick={onDelete}
+              icon={fullTrashIcon}
+              iconPosition={IconPositionEnum.CENTER}
+              variant={ButtonVariant.TERNARY}
+              hasTooltip
+            >
+              Supprimer l’email
+            </Button>
+          </div>
+        )}
+      </FormLayout.Row>
+    )
+  }
+)
+
+EmailInputRow.displayName = 'EmailInputRow'

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/FormNotifications.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/FormNotifications.tsx
@@ -1,5 +1,5 @@
 import { FieldArray, useFormikContext } from 'formik'
-import React from 'react'
+import { useRef } from 'react'
 
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { OfferEducationalFormValues } from 'core/OfferEducational/types'
@@ -19,12 +19,14 @@ export const FormNotifications = ({
 }: FormNotificationsProps): JSX.Element => {
   const { values } = useFormikContext<OfferEducationalFormValues>()
 
+  const lastButtonRef = useRef<HTMLInputElement>(null)
+
   return (
     <FormLayout.Section title="Notifications">
       <FieldArray name="notificationEmails">
         {({ remove, push }) => (
           <>
-            {values.notificationEmails.map((_, index) => (
+            {values.notificationEmails.map((_, index, self) => (
               <EmailInputRow
                 disableForm={disableForm}
                 displayTrash={index > 0}
@@ -33,12 +35,20 @@ export const FormNotifications = ({
                 onDelete={() => {
                   remove(index)
                 }}
+                ref={index === self.length - 1 ? lastButtonRef : null}
               />
             ))}
             <Button
               variant={ButtonVariant.TERNARY}
               icon={fullMoreIcon}
-              onClick={() => push('')}
+              onClick={() => {
+                push('')
+
+                //  The additional input does not esist just yet
+                setTimeout(() => {
+                  lastButtonRef.current?.focus()
+                })
+              }}
               disabled={values.notificationEmails.length >= 5}
               className={styles['add-notification-button']}
             >

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/FormNotifications.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/FormNotifications.tsx
@@ -1,5 +1,4 @@
 import { FieldArray, useFormikContext } from 'formik'
-import { useRef } from 'react'
 
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { OfferEducationalFormValues } from 'core/OfferEducational/types'
@@ -19,14 +18,12 @@ export const FormNotifications = ({
 }: FormNotificationsProps): JSX.Element => {
   const { values } = useFormikContext<OfferEducationalFormValues>()
 
-  const lastButtonRef = useRef<HTMLInputElement>(null)
-
   return (
     <FormLayout.Section title="Notifications">
       <FieldArray name="notificationEmails">
         {({ remove, push }) => (
           <>
-            {values.notificationEmails.map((_, index, self) => (
+            {values.notificationEmails.map((email, index, self) => (
               <EmailInputRow
                 disableForm={disableForm}
                 displayTrash={index > 0}
@@ -35,7 +32,12 @@ export const FormNotifications = ({
                 onDelete={() => {
                   remove(index)
                 }}
-                ref={index === self.length - 1 ? lastButtonRef : null}
+                //  The field should autoFocus only if it's the last of the emails list (the one being just added)
+                //  if the list has more than one emails (the first one is always there and cannot appear)
+                //  and if that last email is empty (otherwise it would focus the last email in an edition form with more than one email)
+                autoFocus={
+                  self.length - 1 === index && self.length > 1 && email === ''
+                }
               />
             ))}
             <Button
@@ -43,11 +45,6 @@ export const FormNotifications = ({
               icon={fullMoreIcon}
               onClick={() => {
                 push('')
-
-                //  The additional input does not esist just yet
-                setTimeout(() => {
-                  lastButtonRef.current?.focus()
-                })
               }}
               disabled={values.notificationEmails.length >= 5}
               className={styles['add-notification-button']}

--- a/pro/src/ui-kit/Tooltip/useTooltipProps.ts
+++ b/pro/src/ui-kit/Tooltip/useTooltipProps.ts
@@ -1,13 +1,26 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 export const useTooltipProps = ({
   onMouseOver,
   onMouseOut,
   onFocus,
   onBlur,
-  onKeyDown,
 }: Partial<React.HTMLProps<HTMLButtonElement | HTMLAnchorElement>>) => {
   const [isTooltipHidden, setIsTooltipHidden] = useState(true)
+
+  useEffect(() => {
+    const closeTooltipOnEscapePressed = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsTooltipHidden(true)
+        event.stopPropagation()
+      }
+    }
+    document.addEventListener('keydown', closeTooltipOnEscapePressed)
+
+    return () => {
+      document.removeEventListener('keydown', closeTooltipOnEscapePressed)
+    }
+  }, [])
 
   return {
     isTooltipHidden,
@@ -34,15 +47,6 @@ export const useTooltipProps = ({
     ) => {
       setIsTooltipHidden(true)
       onBlur?.(event)
-    },
-    onKeyDown: (
-      event: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>
-    ) => {
-      if (event.key === 'Escape' && !isTooltipHidden) {
-        setIsTooltipHidden(true)
-        event.stopPropagation()
-      }
-      onKeyDown?.(event)
     },
   }
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29616

**Objectif**
Corriger 3 non conformités de l'audit a11y :
- Le texte alternatif des logos ne doivent pas préciser qu'il s'agit d'un logo, l'info est redondante.
- Dans le formulaire de création d'offres collectives, quand on clic sur "Ajouter un email de notification" le champ qui apparait doit recevoir le focus automatiquement.
- Les tooltips doivent se fermer lorsqu'on clic sur la touche "Escape" (même si on n'est pas en focus dedans).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques