### PR TITLE
(BSR)[PRO] test: no more big default timeouts

### DIFF
--- a/pro/cypress/cypress.config.ts
+++ b/pro/cypress/cypress.config.ts
@@ -35,8 +35,6 @@ export default defineConfig({
     runMode: 2,
     openMode: 0,
   },
-  defaultCommandTimeout: 30000,
-  requestTimeout: 30000,
   viewportHeight: 1080,
   viewportWidth: 1920,
   video: true,

--- a/pro/cypress/e2e/step-definitions/adage.cy.ts
+++ b/pro/cypress/e2e/step-definitions/adage.cy.ts
@@ -18,14 +18,17 @@ When('I open adage iframe', () => {
     url: '/features',
   }).as('features')
   cy.visit(`/adage-iframe?token=${adageToken}`)
-  cy.wait(['@local_offerers', '@features']).then((interception) => {
-    if (interception[0].response) {
-      expect(interception[0].response.statusCode).to.equal(200)
+  cy.findAllByTestId('spinner').should('not.exist')
+  cy.wait(['@local_offerers', '@features'], { requestTimeout: 15 * 1000 }).then(
+    (interception) => {
+      if (interception[0].response) {
+        expect(interception[0].response.statusCode).to.equal(200)
+      }
+      if (interception[1].response) {
+        expect(interception[1].response.statusCode).to.equal(200)
+      }
     }
-    if (interception[1].response) {
-      expect(interception[1].response.statusCode).to.equal(200)
-    }
-  })
+  )
   cy.findAllByTestId('spinner').should('not.exist')
   cy.wait(500) // la liste des offres se réordonne, d'où cette attente
 })
@@ -97,7 +100,9 @@ When('I add first offer to favorites', () => {
         url: '/adage-iframe/logs/fav-offer/',
       }).as('fav-offer')
       cy.findAllByTestId('favorite-inactive').click()
-      cy.wait('@fav-offer').its('response.statusCode').should('eq', 204)
+      cy.wait('@fav-offer', { requestTimeout: 15 * 1000 })
+        .its('response.statusCode')
+        .should('eq', 204)
     })
   cy.findByTestId('global-notification-success').should(
     'contain',

--- a/pro/cypress/e2e/step-definitions/createThingIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/createThingIndividualOffer.cy.ts
@@ -47,7 +47,9 @@ When('I validate stocks step', () => {
   cy.intercept({ method: 'POST', url: '/stocks/bulk' }).as('postStocks')
   cy.intercept({ method: 'GET', url: '/offers/*' }).as('getOffer')
   cy.findByText('Enregistrer et continuer').click()
-  cy.wait(['@patchOffer', '@postStocks', '@getOffer'])
+  cy.wait(['@patchOffer', '@postStocks', '@getOffer'], {
+    requestTimeout: 15 * 1000,
+  })
 })
 
 Then('my new physical offer should be displayed', () => {

--- a/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
@@ -169,10 +169,10 @@ Then('the offerer is created', () => {
     'Votre structure a bien été créée'
   )
   cy.url().should('contain', '/accueil')
-  cy.findAllByTestId('spinner').should('not.exist')
+  cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
 
   cy.findByTestId('offerer-details-offerId').select(offererName)
-  cy.findAllByTestId('spinner').should('not.exist')
+  cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
 })
 
 Then('An error message is raised', () => {

--- a/pro/cypress/e2e/step-definitions/venue.cy.ts
+++ b/pro/cypress/e2e/step-definitions/venue.cy.ts
@@ -116,7 +116,7 @@ When('I add an image to my venue', () => {
   cy.findByText('Suivant').click()
   cy.contains('Prévisualisation de votre image dans l’application pass Culture')
   cy.findByText('Enregistrer').click()
-  cy.findByTestId('global-notification-success').should(
+  cy.findByTestId('global-notification-success', { timeout: 30 * 1000 }).should(
     'contain',
     'Vos modifications ont bien été prises en compte'
   )

--- a/pro/cypress/support/commands.ts
+++ b/pro/cypress/support/commands.ts
@@ -43,26 +43,25 @@ Cypress.on('uncaught:exception', () => {
   return false
 })
 
-Cypress.Commands.add(
-  'login',
-  ({ email, password, redirectUrl}) => {
-    cy.intercept({ method: 'POST', url: '/users/signin' }).as('signinUser')
+Cypress.Commands.add('login', ({ email, password, redirectUrl }) => {
+  cy.intercept({ method: 'POST', url: '/users/signin' }).as('signinUser')
 
-    cy.visit('/connexion')
-      cy.acceptCookies()
+  cy.visit('/connexion')
+  cy.acceptCookies()
 
-    cy.get('#email').type(email)
-    cy.get('#password').type(password)
-    cy.get('button[type=submit]').click()
-    cy.wait('@signinUser')
+  cy.get('#email').type(email)
+  cy.get('#password').type(password)
+  cy.get('button[type=submit]').click()
+  cy.wait('@signinUser')
 
-    cy.url().should('contain', redirectUrl ?? '/accueil')
-    cy.findAllByTestId('spinner').should('not.exist')
-  }
-)
+  cy.url().should('contain', redirectUrl ?? '/accueil')
+  cy.findAllByTestId('spinner').should('not.exist')
+})
 
 Cypress.Commands.add('acceptCookies', () => {
-  cy.get('button').contains('Tout accepter').click()
+  cy.get('button', { timeout: 15 * 1000 })
+    .contains('Tout accepter')
+    .click()
 })
 
 Cypress.Commands.add('setFeatureFlags', (features: Feature[]) => {


### PR DESCRIPTION
## But de la pull request

Suppression des timeouts par défaut de 30 secondes pour utiliser les valeurs par défaut de Cypress (voir [ici](https://docs.cypress.io/guides/references/configuration#Timeouts))
+ quelques timeouts définis pour les zones de lenteur

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques