### PR TITLE
(BSR)[API] fix: skip migration e199b0790783 in prod to avoid timeout

### DIFF
--- a/api/src/pcapi/alembic/versions/20240710T153906_e199b0790783_skip_reimbursed_booking_trigger.py
+++ b/api/src/pcapi/alembic/versions/20240710T153906_e199b0790783_skip_reimbursed_booking_trigger.py
@@ -3,6 +3,8 @@
 
 from alembic import op
 
+from pcapi import settings
+
 
 # pre/post deployment: post
 # revision identifiers, used by Alembic.
@@ -13,24 +15,26 @@ depends_on: list[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute("DROP TRIGGER IF EXISTS booking_update ON booking")
-    op.execute(
-        """CREATE CONSTRAINT TRIGGER booking_update
+    if not settings.IS_PROD:
+        op.execute("DROP TRIGGER IF EXISTS booking_update ON booking")
+        op.execute(
+            """CREATE CONSTRAINT TRIGGER booking_update
 AFTER INSERT
 OR UPDATE OF quantity, amount, status, "userId"
 ON booking
 FOR EACH ROW
 WHEN (NEW.status <> 'REIMBURSED')
 EXECUTE PROCEDURE check_booking()"""
-    )
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP TRIGGER IF EXISTS booking_update ON booking")
-    op.execute(
-        """CREATE CONSTRAINT TRIGGER booking_update
+    if not settings.IS_PROD:
+        op.execute("DROP TRIGGER IF EXISTS booking_update ON booking")
+        op.execute(
+            """CREATE CONSTRAINT TRIGGER booking_update
 AFTER INSERT
 OR UPDATE OF quantity, amount, status, "userId"
 ON booking
 FOR EACH ROW EXECUTE PROCEDURE check_booking()"""
-    )
+        )


### PR DESCRIPTION
## But de la pull request

éviter de passer la migration `e199b0790783` en automatique en prod a cause de la difficulté de prendre le lock sur booking sur cette environnement.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques