### PR TITLE
(PC-30652)[API] feat: add mediations to cinema offers in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -193,8 +193,11 @@ def _create_offer_and_stocks_for_allocine_venues(
                 venue=venue,
                 extraData=product.extraData,
             )
+            mediation = offers_factories.MediationFactory(offer=movie_offer)
+            store_public_object_from_sandbox_assets("thumbs", mediation, movie_offer.subcategoryId)
+
             product_stocks = []
-            for daydelta in range(30):
+            for daydelta in range(0, 30, 2):
                 day = datetime.date.today() + datetime.timedelta(days=daydelta)
                 for hour in (0, 5, 11, 17, 21):
                     beginning_datetime = datetime.datetime.combine(day, datetime.time(hour=hour))


### PR DESCRIPTION
## But de la pull request

Lien du ticket Jira : https://passculture.atlassian.net/browse/PC-30652

Ajouter des images pour la sandbox, sans quoi les offres créés ne peuvent être affichées sur les page lieux cinéma.
Faire aussi en sorte qu'il y ait des jours où elles n'ont pas de séances

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques