### PR TITLE
jeremieb/fix public api allocine filter edge update loc

### DIFF
--- a/api/src/pcapi/connectors/serialization/allocine_serializers.py
+++ b/api/src/pcapi/connectors/serialization/allocine_serializers.py
@@ -358,6 +358,12 @@ class AllocineShowtime(pydantic.BaseModel):
     def get_first_projection_mode(cls, projection: list[AllocineShowtimeProjection]) -> AllocineShowtimeProjection:
         return projection[0]
 
+    @pydantic.field_validator("languages", mode="before")
+    def drop_none_values(cls, languages: list | None) -> list | None:
+        if languages:
+            return [l for l in languages if l is not None]
+        return languages
+
 
 class AllocineMovieShowtime(pydantic.BaseModel):
     movie: AllocineMovie

--- a/api/tests/connectors/api_allocine_test.py
+++ b/api/tests/connectors/api_allocine_test.py
@@ -148,7 +148,20 @@ class GetMovieShowtimeListTest:
         valid_edge = copy.deepcopy(payload["movieShowtimeList"]["edges"][0])
         payload["movieShowtimeList"]["edges"].append(valid_edge)
         # one and only movie becomes invalid because of one showtime language
-        payload["movieShowtimeList"]["edges"][0]["node"]["showtimes"][0]["languages"] = [None]
+        payload["movieShowtimeList"]["edges"][0]["node"]["showtimes"][0]["languages"] = ["invalid"]
+
+        requests_mock.get.return_value = MockedResponse(data=payload, status_code=200)
+        api_response = get_movies_showtimes_from_allocine("does not matter")
+
+        expected_result = copy.deepcopy(fixtures.MOVIE_SHOWTIME_LIST)
+        assert api_response == allocine_serializers.AllocineMovieShowtimeListResponse.model_validate(expected_result)
+
+    @patch("pcapi.connectors.api_allocine.requests")
+    def test_accept_showtimes_with_a_none_language(self, requests_mock):
+        payload = copy.deepcopy(fixtures.MOVIE_SHOWTIME_LIST)
+
+        # invalid language should be filtered and the edge kept
+        payload["movieShowtimeList"]["edges"][0]["node"]["showtimes"][0]["languages"].append(None)
 
         requests_mock.get.return_value = MockedResponse(data=payload, status_code=200)
         api_response = get_movies_showtimes_from_allocine("does not matter")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

Bug : un précédent fix essayait de filtrer les séances de cinémas qui contenaient des informations invalides (les `edges` au niveau de la sérialisation).
Le problème est que chaque élément était retiré au fur et à mesure alors que les index des éléments à retirer l'étaient tout au début et n'évoluaient pas. Par exemple, si les erreurs étaient aux index 3 et 5, le troisième élément de la liste était retiré et la fonction de nettoyage retirait ensuite le cinquième... alors qu'il l'élément invalide était remonté de fait à la quatrième position.

Fix : les index sont triés du plus plus grand au plus petit, ce qui règle ce problème.

### Au passage

Un second commit aider à éviter certaines erreurs courantes : on filtre la langue `None` pour une séance de cinéma avant de lancer la validation.