### PR TITLE
(PC-30648)[BO] feat: homologation - reason reject offerer

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-59d02d648922 (pre) (head)
+e9caf841c7d6 (pre) (head)
 943f189a4c71 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240711T131114_e9caf841c7d6_add_rejectreason_to_offerer.py
+++ b/api/src/pcapi/alembic/versions/20240711T131114_e9caf841c7d6_add_rejectreason_to_offerer.py
@@ -1,0 +1,25 @@
+"""
+add rejectionReason to Offerer
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi.core.offerers.models import OffererRejectionReason
+from pcapi.utils.db import MagicEnum
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "e9caf841c7d6"
+down_revision = "59d02d648922"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("offerer", sa.Column("rejectionReason", MagicEnum(OffererRejectionReason), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("offerer", "rejectionReason")

--- a/api/src/pcapi/core/mails/transactional/pro/new_offerer_validation.py
+++ b/api/src/pcapi/core/mails/transactional/pro/new_offerer_validation.py
@@ -19,7 +19,11 @@ def send_new_offerer_validation_email_to_pro(offerer: Offerer) -> None:
 
 def get_new_offerer_rejection_email_data(offerer: Offerer) -> models.TransactionalEmailData:
     return models.TransactionalEmailData(
-        template=TransactionalEmail.NEW_OFFERER_REJECTION.value, params={"OFFERER_NAME": offerer.name}
+        template=TransactionalEmail.NEW_OFFERER_REJECTION.value,
+        params={
+            "OFFERER_NAME": offerer.name,
+            "REJECTION_REASON": offerer.rejectionReason.name if offerer.rejectionReason else "",
+        },
     )
 
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1212,6 +1212,7 @@ def reject_offerer(
     applicants = users_repository.get_users_with_validated_attachment(offerer)
     first_user_to_register_offerer = applicants[0] if applicants else None
 
+    offerer.rejectionReason = action_args["rejection_reason"]
     was_validated = offerer.isValidated
     offerer.validationStatus = ValidationStatus.REJECTED
     offerer.dateValidated = None

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -192,6 +192,14 @@ VENUE_TYPE_DEFAULT_BANNERS: dict[VenueTypeCode, tuple[str, ...]] = {
 }
 
 
+class OffererRejectionReason(enum.Enum):
+    ELIGIBILITY = "ELIGIBILITY"
+    ERROR = "ERROR"
+    ADAGE_DECLINED = "ADAGE_DECLINED"
+    OUT_OF_TIME = "OUT_OF_TIME"
+    OTHER = "OTHER"
+
+
 class Target(enum.Enum):
     EDUCATIONAL = "EDUCATIONAL"
     INDIVIDUAL_AND_EDUCATIONAL = "INDIVIDUAL_AND_EDUCATIONAL"
@@ -985,6 +993,8 @@ class Offerer(
 
     hasNewNavUsers: sa_orm.Mapped["bool | None"] = sa.orm.query_expression()
     hasOldNavUsers: sa_orm.Mapped["bool | None"] = sa.orm.query_expression()
+
+    rejectionReason: OffererRejectionReason = Column(db_utils.MagicEnum(OffererRejectionReason), nullable=True)
 
     def __init__(self, street: str | None = None, **kwargs: typing.Any) -> None:
         if street:

--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -78,6 +78,7 @@ def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
                         author_user=None,
                         comment="La structure est détectée comme inactive via l'API Sirene (INSEE)",
                         modified_info={"tags": {"new_info": tag.label}},
+                        rejection_reason=offerers_models.OffererRejectionReason.OUT_OF_TIME,
                     )
                 else:
                     history_api.add_action(

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -196,6 +196,22 @@ def format_reason_label(reason: str | None) -> str:
     return ""
 
 
+def format_offerer_rejection_reason(rejection_reason: offerers_models.OffererRejectionReason | str) -> str:
+    match rejection_reason:
+        case offerers_models.OffererRejectionReason.ELIGIBILITY | "ELIGIBILITY":
+            return "Le compte pro n'est pas éligible"
+        case offerers_models.OffererRejectionReason.ERROR | "ERROR":
+            return "Activité non éligible, ce compte ne semble pas être un compte pro"
+        case offerers_models.OffererRejectionReason.ADAGE_DECLINED | "ADAGE_DECLINED":
+            return "Refus Adage"
+        case offerers_models.OffererRejectionReason.OUT_OF_TIME | "OUT_OF_TIME":
+            return "Inscription hors délai de réponse de 60 jours"
+        case offerers_models.OffererRejectionReason.OTHER | "OTHER":
+            return "Autre"
+        case _:
+            return rejection_reason
+
+
 def format_booking_cancellation_reason(
     reason: bookings_models.BookingCancellationReasons | educational_models.CollectiveBookingCancellationReasons | None,
 ) -> str:
@@ -1205,6 +1221,7 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_offer_status"] = format_offer_status
     app.jinja_env.filters["format_offer_category"] = format_offer_category
     app.jinja_env.filters["format_offer_subcategory"] = format_offer_subcategory
+    app.jinja_env.filters["format_offerer_rejection_reason"] = format_offerer_rejection_reason
     app.jinja_env.filters["format_collective_offer_formats"] = format_collective_offer_formats
     app.jinja_env.filters["format_subcategories"] = format_subcategories
     app.jinja_env.filters["format_as_badges"] = format_as_badges

--- a/api/src/pcapi/routes/backoffice/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offerers/forms.py
@@ -233,6 +233,24 @@ class BatchOptionalCommentForm(empty_forms.BatchForm, OptionalCommentForm):
     pass
 
 
+class OffererRejectionForm(OptionalCommentForm):
+    rejection_reason = fields.PCSelectField(
+        "Raison du rejet",
+        choices=utils.choices_from_enum(
+            offerers_models.OffererRejectionReason, filters.format_offerer_rejection_reason
+        ),
+    )
+
+    def validate_rejection(self, rejection_reason: fields.PCSelectField) -> fields.PCSelectField:
+        if not rejection_reason.data:
+            raise wtforms.validators.ValidationError("Aucune raison de rejet n'a été donnée")
+        return rejection_reason
+
+
+class BatchOffererRejectionForm(empty_forms.BatchForm, OffererRejectionForm):
+    pass
+
+
 class CommentAndTagOffererForm(OptionalCommentForm):
     tags = fields.PCQuerySelectMultipleField(
         "Tags Homologation",

--- a/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
@@ -31,6 +31,8 @@
               Lieu : {{ links.build_venue_name_to_details_link(action.venue) }}
             {% elif action.actionType.name == "OFFERER_ATTESTATION_CHECKED" %}
               L'état positif ou négatif de l'attestation {{ action.extraData['provider'] }} a été visualisé
+            {% elif action.extraData and action.actionType.name in ["OFFERER_REJECTED", "USER_OFFERER_REJECTED"] %}
+              Raison : {{ action.extraData["rejection_reason"] | format_offerer_rejection_reason }}
             {% endif %}
             {% if action.comment %}
               <p>

--- a/api/tests/core/mails/transactional/pro/new_offerer_validation_test.py
+++ b/api/tests/core/mails/transactional/pro/new_offerer_validation_test.py
@@ -5,6 +5,7 @@ import pytest
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.pro import new_offerer_validation
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.offerers import models as offerer_models
 from pcapi.core.offerers.factories import UserOffererFactory
 
 
@@ -27,7 +28,10 @@ class SendNewOffererValidationEmailTest:
 class SendNewOffererRejectionEmailTest:
     def test_send_mail(self):
         # Given
-        offerer = UserOffererFactory(user__email="test@example.com").offerer
+        offerer = UserOffererFactory(
+            user__email="test@example.com",
+            offerer__rejectionReason=offerer_models.OffererRejectionReason.ADAGE_DECLINED,
+        ).offerer
 
         # When
         new_offerer_validation.send_new_offerer_rejection_email_to_pro(offerer)
@@ -35,4 +39,7 @@ class SendNewOffererRejectionEmailTest:
         # Then
         assert mails_testing.outbox[0]["To"] == "test@example.com"
         assert mails_testing.outbox[0]["template"] == asdict(TransactionalEmail.NEW_OFFERER_REJECTION.value)
-        assert mails_testing.outbox[0]["params"] == {"OFFERER_NAME": offerer.name}
+        assert mails_testing.outbox[0]["params"] == {
+            "OFFERER_NAME": offerer.name,
+            "REJECTION_REASON": "ADAGE_DECLINED",
+        }

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -1520,7 +1520,7 @@ class RejectOffererTest:
         offerers_factories.UserOffererFactory(offerer=offerer)  # removed in reject_offerer()
 
         # When
-        offerers_api.reject_offerer(offerer, admin)
+        offerers_api.reject_offerer(offerer, admin, rejection_reason=offerers_models.OffererRejectionReason.OTHER)
 
         # Then
         assert not offerer.isValidated
@@ -1534,7 +1534,9 @@ class RejectOffererTest:
         user_offerer = offerers_factories.UserNotValidatedOffererFactory(user=user)
 
         # When
-        offerers_api.reject_offerer(user_offerer.offerer, admin)
+        offerers_api.reject_offerer(
+            user_offerer.offerer, admin, rejection_reason=offerers_models.OffererRejectionReason.OTHER
+        )
 
         # Then
         assert not user.has_pro_role
@@ -1547,7 +1549,9 @@ class RejectOffererTest:
         user_offerer = offerers_factories.UserNotValidatedOffererFactory(user=validated_user_offerer.user)
 
         # When
-        offerers_api.reject_offerer(user_offerer.offerer, admin)
+        offerers_api.reject_offerer(
+            user_offerer.offerer, admin, rejection_reason=offerers_models.OffererRejectionReason.OTHER
+        )
 
         # Then
         assert validated_user_offerer.user.has_pro_role
@@ -1559,7 +1563,9 @@ class RejectOffererTest:
         user_offerer = offerers_factories.UserNotValidatedOffererFactory()
 
         # When
-        offerers_api.reject_offerer(user_offerer.offerer, admin)
+        offerers_api.reject_offerer(
+            user_offerer.offerer, admin, rejection_reason=offerers_models.OffererRejectionReason.OTHER
+        )
 
         # Then
         user_offerer_query = offerers_models.UserOfferer.query
@@ -1573,7 +1579,9 @@ class RejectOffererTest:
         offerers_factories.ApiKeyFactory(offerer=user_offerer.offerer)
 
         # When
-        offerers_api.reject_offerer(user_offerer.offerer, admin)
+        offerers_api.reject_offerer(
+            user_offerer.offerer, admin, rejection_reason=offerers_models.OffererRejectionReason.OTHER
+        )
 
         # Then
         user_offerer_query = offerers_models.UserOfferer.query
@@ -1592,7 +1600,7 @@ class RejectOffererTest:
         offerers_factories.UserOffererFactory(offerer=offerer)  # removed in reject_offerer()
 
         # When
-        offerers_api.reject_offerer(offerer, admin)
+        offerers_api.reject_offerer(offerer, admin, rejection_reason=offerers_models.OffererRejectionReason.OTHER)
 
         # Then
         send_new_offerer_rejection_email_to_pro.assert_called_once_with(offerer)
@@ -1609,7 +1617,7 @@ class RejectOffererTest:
         )  # another applicant
 
         # When
-        offerers_api.reject_offerer(offerer, admin)
+        offerers_api.reject_offerer(offerer, admin, rejection_reason=offerers_models.OffererRejectionReason.OTHER)
 
         # Then
         action = history_models.ActionHistory.query.filter_by(

--- a/api/tests/core/offerers/test_tasks.py
+++ b/api/tests/core/offerers/test_tasks.py
@@ -220,7 +220,10 @@ class CheckOffererTest:
         assert offerer_action.authorUserId is None
         assert offerer_action.userId == user_offerer.user.id
         assert offerer_action.offererId == offerer.id
-        assert offerer_action.extraData == {"modified_info": {"tags": {"new_info": siren_caduc_tag.label}}}
+        assert offerer_action.extraData == {
+            "modified_info": {"tags": {"new_info": siren_caduc_tag.label}},
+            "rejection_reason": "OUT_OF_TIME",
+        }
 
         user_offerer_action = history_models.ActionHistory.query.filter_by(
             actionType=history_models.ActionType.USER_OFFERER_REJECTED
@@ -233,6 +236,7 @@ class CheckOffererTest:
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0]["To"] == user_offerer.user.email
         assert mails_testing.outbox[0]["template"] == asdict(TransactionalEmail.NEW_OFFERER_REJECTION.value)
+        assert mails_testing.outbox[0]["params"] == {"OFFERER_NAME": offerer.name, "REJECTION_REASON": "OUT_OF_TIME"}
 
         # Offerers report should only list validated offerers, not rejected
         mock_search_file.assert_not_called()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30648

## Vérifications

### verification front 

screen du formulaire : 
<img width="909" alt="Capture d’écran 2024-07-18 à 09 52 55" src="https://github.com/user-attachments/assets/f344a469-745f-4e14-8005-334d89e301a6">

screen de l'historique
<img width="1409" alt="Capture d’écran 2024-07-18 à 09 55 41" src="https://github.com/user-attachments/assets/50c8f95f-da04-4ec3-bc9a-6a2d4299f6df">


### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 

*test_batch_set_offerer_reject* pour l'action history
*SendNewOffererRejectionEmailTest* pour le mail 
Lorsqu'on rejete une structure, un commentaire apparait avec une demande de commentaire de la part de l'utilisateur ainsi qu'un choix de raison possible.
Lorsque l'on valide ce commentaire avec pour choix Eligibilité (par exemple):
- un log ( action history) affiche la raison, 
- un mail de rejet est envoyé contenant la raison du rejet, le mail est personnalisé en fonction de du choix Eligibilité 
- sur la page de l'offerer on peux voir la raison pour laquelle il a été rejeté. 


### Verification ticket

- nom du ticket conforme -> OK 
- auteur du ticket -> OK
- nombre de commit -> OK
- nom du commit -> OK
- mettre le ticket en code-review -> OK

### Tache restante si WIP + AUTRE

- refresh de la page github -> OK
- Rien de visible


