### PR TITLE
(PC-30833)[PRO] feat: add filter on OffererAddress with offers

### DIFF
--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -302,9 +302,11 @@ def get_offerer_v2_stats(offerer_id: int) -> offerers_serialize.GetOffererV2Stat
     api=blueprint.pro_private_schema,
     response_model=offerers_serialize.GetOffererAddressesResponseModel,
 )
-def get_offerer_addresses(offerer_id: int) -> offerers_serialize.GetOffererAddressesResponseModel:
+def get_offerer_addresses(
+    offerer_id: int, query: offerers_serialize.GetOffererAddressesQueryModel
+) -> offerers_serialize.GetOffererAddressesResponseModel:
     check_user_has_access_to_offerer(current_user, offerer_id)
-    offerer_addresses = repository.get_offerer_addresses(offerer_id)
+    offerer_addresses = repository.get_offerer_addresses(offerer_id, only_with_offers=query.onlyWithOffers)
     return offerers_serialize.GetOffererAddressesResponseModel(
         __root__=[
             offerers_serialize.GetOffererAddressResponseModel.from_orm(offerer_address)

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -425,6 +425,10 @@ class GetOffererAddressesResponseModel(BaseModel):
     __root__: list[GetOffererAddressResponseModel]
 
 
+class GetOffererAddressesQueryModel(BaseModel):
+    onlyWithOffers: bool = False
+
+
 class PatchOffererAddressRequest(BaseModel):
     label: str
 

--- a/api/tests/routes/pro/get_offerer_addresses_test.py
+++ b/api/tests/routes/pro/get_offerer_addresses_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
 from pcapi.core.users import factories as users_factories
 
 
@@ -70,6 +71,50 @@ def test_get_offerer_addresses_success(client):
             "street": None,
         },
     ]
+
+
+@pytest.mark.usefixtures("db_session")
+def test_get_offerer_addresses_with_offers(client):
+    user_offerer = offerers_factories.UserOffererFactory()
+    pro = user_offerer.user
+    offerer = user_offerer.offerer
+
+    offerer_address_1 = offerers_factories.OffererAddressFactory(
+        offerer=offerer,
+        label="1ere adresse",
+        address__street="1 boulevard Poissonnière",
+        address__postalCode="75002",
+        address__city="Paris",
+    )
+    offerers_factories.OffererAddressFactory(
+        offerer=offerer,
+        label="2eme adresse",
+        address__street="20 Avenue de Ségur",
+        address__postalCode="75007",
+        address__city="Paris",
+        address__banId="75107_7560_00001",
+    )
+    offers_factories.OfferFactory(
+        venue__offererAddress=offerer_address_1, venue__managingOfferer=offerer, offererAddress=offerer_address_1
+    )
+    response = client.with_session_auth(email=pro.email).get(f"/offerers/{offerer.id}/addresses?onlyWithOffers=true")
+
+    assert response.status_code == 200
+    assert response.json == [
+        {
+            "city": "Paris",
+            "id": offerer_address_1.id,
+            "isEditable": False,
+            "label": "1ere adresse",
+            "postalCode": "75002",
+            "street": "1 boulevard Poissonnière",
+        },
+    ]
+
+    # Try with the same data without the filter. We should get both OffererAddress
+    response = client.with_session_auth(email=pro.email).get(f"/offerers/{offerer.id}/addresses")
+    assert response.status_code == 200
+    assert len(response.json) == 2
 
 
 @pytest.mark.usefixtures("db_session")

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -109,6 +109,7 @@ export type { GetEducationalOffererVenueResponseModel } from './models/GetEducat
 export type { GetIndividualOfferResponseModel } from './models/GetIndividualOfferResponseModel';
 export type { GetIndividualOfferWithAddressResponseModel } from './models/GetIndividualOfferWithAddressResponseModel';
 export type { GetMusicTypesResponse } from './models/GetMusicTypesResponse';
+export type { GetOffererAddressesQueryModel } from './models/GetOffererAddressesQueryModel';
 export type { GetOffererAddressesResponseModel } from './models/GetOffererAddressesResponseModel';
 export type { GetOffererAddressResponseModel } from './models/GetOffererAddressResponseModel';
 export type { GetOffererBankAccountsResponseModel } from './models/GetOffererBankAccountsResponseModel';

--- a/pro/src/apiClient/v1/models/GetOffererAddressesQueryModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererAddressesQueryModel.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type GetOffererAddressesQueryModel = {
+  onlyWithOffers?: boolean;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1387,17 +1387,22 @@ export class DefaultService {
   /**
    * get_offerer_addresses <GET>
    * @param offererId
+   * @param onlyWithOffers
    * @returns GetOffererAddressesResponseModel OK
    * @throws ApiError
    */
   public getOffererAddresses(
     offererId: number,
+    onlyWithOffers: boolean = false,
   ): CancelablePromise<GetOffererAddressesResponseModel> {
     return this.httpRequest.request({
       method: 'GET',
       url: '/offerers/{offerer_id}/addresses',
       path: {
         'offerer_id': offererId,
+      },
+      query: {
+        'onlyWithOffers': onlyWithOffers,
       },
       errors: {
         403: `Forbidden`,

--- a/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
+++ b/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
@@ -12,8 +12,9 @@ import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 
-import { UserIdentityFormValues } from './types'
 import styles from '../UserPhoneForm/UserForm.module.scss'
+
+import { UserIdentityFormValues } from './types'
 import { validationSchema } from './validationSchema'
 
 export interface UserIdentityFormProps {

--- a/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
@@ -9,6 +9,7 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 import { PasswordInput } from 'ui-kit/form/PasswordInput/PasswordInput'
 
 import styles from '../UserPhoneForm/UserForm.module.scss'
+
 import { validationSchema } from './validationSchema'
 
 export interface UserPasswordFormProps {


### PR DESCRIPTION
Add filter to OffererAddress API to get those that have at least one offer.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30833

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques