### PR TITLE
(PC-29856)[API] feat: public api: double booking enabled by default

### DIFF
--- a/api/documentation/src/pages/change-logs.md
+++ b/api/documentation/src/pages/change-logs.md
@@ -17,6 +17,7 @@ title: Pass Culture API change logs
 
 - You can now access your provider information using [**this endpoint**](/rest-api#tag/Providers/operation/GetProvider).
 - You can now set your messaging URLs using the API. Futhermore you can now specify them a 2 levels: either at [**provider level**](/rest-api#tag/Providers/operation/UpdateProvider) or at [**venue level**](/rest-api#tag/Providers/operation/UpdateVenueExternalUrls).
+- `enableDoubleDookings` field's default value is now true on event creation or update.
 
 ## June 2024
 

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -137,6 +137,11 @@ class _FIELDS:
         example=True,
         default=False,
     )
+    OFFER_ENABLE_DOUBLE_BOOKINGS_ENABLED = Field(
+        description="If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
+        example=True,
+        default=True,
+    )
 
     # Products fields
     EANS_FILTER = Field(description="EANs list (max 100)", example="3700551782888,9782895761792")

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -488,6 +488,7 @@ class EventOfferCreation(OfferCreationBase):
     has_ticket: bool = fields.EVENT_HAS_TICKET
     price_categories: list[PriceCategoryCreation] | None = fields.PRICE_CATEGORIES
     publication_date: datetime.datetime | None = fields.OFFER_PUBLICATION_DATE
+    enable_double_bookings: bool | None = fields.OFFER_ENABLE_DOUBLE_BOOKINGS_ENABLED
 
     @pydantic_v1.validator("price_categories")
     def get_unique_price_categories(

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -2522,7 +2522,7 @@
                         "type": "string"
                     },
                     "enableDoubleBookings": {
-                        "default": false,
+                        "default": true,
                         "description": "If set to true, users may book the offer for two persons. Second item will be delivered at the same price as the first one. Category must be compatible with this feature.",
                         "example": true,
                         "nullable": true,

--- a/api/tests/routes/public/individual_offers/v1/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_event_test.py
@@ -43,7 +43,7 @@ class PostEventTest:
         assert created_offer.mentalDisabilityCompliant is True
         assert created_offer.motorDisabilityCompliant is True
         assert created_offer.visualDisabilityCompliant is True
-        assert not created_offer.isDuo
+        assert created_offer.isDuo
         assert created_offer.extraData == {}
         assert created_offer.bookingEmail is None
         assert created_offer.publicationDate is None


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29856

La création d'un événement via l'API publique n'avait pas le même comportement par défaut que son homologue côté portail pro au niveau du champ `enableDoubleBookings` :  faux pour l'API publique et vrai pour le portail pro. Maintenant la valeur par défaut est vraie partout.

PS : si quelqu'un sait comment éviter le `type: ignore` au niveau de la fonction `OFFER_ENABLE_DOUBLE_BOOKINGS`, je suis preneur.