### PR TITLE
(PC-30893)[BO] feat: add button to generate API key in Offerer view

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -26,6 +26,10 @@
                 {{ build_modal_form("edit-offerer", url_for("backoffice_web.offerer.update_offerer", offerer_id=offerer.id) ,
                 edit_offerer_form, "Modifier les informations", "Modifier les informations de la structure", "Enregistrer") }}
               {% endif %}
+              {% if has_permission("ADVANCED_PRO_SUPPORT") %}
+                {{ build_modal_form("generate-api-key", url_for("backoffice_web.offerer.generate_api_key", offerer_id=offerer.id) ,
+                generate_api_key_form, "Générer une clé API", "Générer une clé API pour la structure " + offerer.name, "Confirmer la génération") }}
+              {% endif %}
               {% if has_permission("PRO_FRAUD_ACTIONS") %}
                 {% if offerer.isActive %}
                   {{ build_modal_form("suspend-offerer", url_for("backoffice_web.offerer.suspend_offerer", offerer_id=offerer.id) ,


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30893

**Contexte :** La possibilité de générer les anciennes clés API a été retirée "trop rapidement" du front PRO. Le temps que les providers qui utilisent les anciennes API stocks et contre-marques fassent leur migration, nous ajoutons ce bouton de génération dans le BO pour que les personnes aillant les accès support de niveau 2 puissent générer des anciennes clés pour les providers.

![image](https://github.com/user-attachments/assets/d97318e6-7ee5-4ac2-acc2-4ce7e00d6af7)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques