### PR TITLE
(PC-29098)[PRO] feat: Add current step in hidden text for stepper acc…

### DIFF
--- a/pro/src/components/Stepper/Stepper.module.scss
+++ b/pro/src/components/Stepper/Stepper.module.scss
@@ -1,5 +1,6 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_a11y.scss" as a11y;
 @use "styles/variables/_size.scss" as size;
 
 $step-label-height: rem.torem(12px);
@@ -108,6 +109,10 @@ $number-size: rem.torem(30px);
       }
     }
   }
+}
+
+.visually-hidden {
+  @include a11y.visually-hidden;
 }
 
 @media (min-width: size.$tablet) {

--- a/pro/src/components/Stepper/Stepper.tsx
+++ b/pro/src/components/Stepper/Stepper.tsx
@@ -54,6 +54,12 @@ export const Stepper = ({
               data-testid={`step-${step.id}`}
             >
               <StepContent step={step} stepIndex={stepIndex} />
+              {isActive && (
+                <span className={styles['visually-hidden']}>
+                  {' '}
+                  (étape en cours)
+                </span>
+              )}
               {!isLastStep && (
                 <div
                   className={cn(

--- a/pro/src/components/Stepper/__specs__/Stepper.spec.tsx
+++ b/pro/src/components/Stepper/__specs__/Stepper.spec.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
+import { axe } from 'vitest-axe'
 
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -43,6 +43,12 @@ describe('Stepper', () => {
       activeStep: '2',
       steps: steps,
     }
+  })
+
+  it('should check content for accessibility', async () => {
+    const { container } = renderStepper(props)
+
+    expect(await axe(container)).toHaveNoViolations()
   })
 
   it('should display stepper with number and label', async () => {


### PR DESCRIPTION
…essiiblity.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29098

**Objectif**
Quand le CSS est désactivé ou que l'utilisateur utilise un lecteur d'écran, annoncer clairement l'étape active du stepper.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques