### PR TITLE
(PC-29862)[API] feat: remove public API redoc/swagger redirects

### DIFF
--- a/api/src/pcapi/routes/public/blueprints.py
+++ b/api/src/pcapi/routes/public/blueprints.py
@@ -1,9 +1,7 @@
 from flask import Blueprint
-from flask import redirect
 from flask import request
 from flask_cors import CORS
 from werkzeug.exceptions import BadRequest
-from werkzeug.wrappers.response import Response
 
 from pcapi.models import api_errors
 
@@ -33,33 +31,7 @@ deprecated_v2_prefixed_public_api = Blueprint("deprecated_public_api", __name__,
 deprecated_v2_prefixed_public_api.register_blueprint(booking_token_blueprint.deprecated_booking_token_blueprint)
 deprecated_v2_prefixed_public_api.register_blueprint(booking_stocks_blueprint.deprecated_books_stocks_blueprint)
 
-
-# DOCUMENTATION REDIRECTS
-# TODO: Remove once all the providers have been informed that the documentation has changed location (by the end of year 2024).
-documentation_redirect_blueprint = Blueprint("documentation_redirect", __name__)
-
-
-@documentation_redirect_blueprint.route("/v2/swagger", methods=["GET"])
-@documentation_redirect_blueprint.route("/public/bookings/v1/swagger", methods=["GET"])
-@documentation_redirect_blueprint.route("/public/offers/v1/event/swagger", methods=["GET"])
-@documentation_redirect_blueprint.route("/public/offers/v1/swagger", methods=["GET"])
-def redirect_to_new_swagger() -> "Response":
-    return redirect("/swagger", code=301)
-
-
-@documentation_redirect_blueprint.route("/v2/redoc", methods=["GET"])
-@documentation_redirect_blueprint.route("/public/bookings/v1/redoc", methods=["GET"])
-@documentation_redirect_blueprint.route("/public/offers/v1/event/redoc", methods=["GET"])
-@documentation_redirect_blueprint.route("/public/offers/v1/redoc", methods=["GET"])
-def redirect_bookings_swagger_to_new_swagger() -> "Response":
-    return redirect("/redoc", code=301)
-
-
-public_api.register_blueprint(documentation_redirect_blueprint)
-# End TODO
-
-
-# Registering deprecated APIs
+# Setting CORS
 CORS(
     public_api,
     resources={r"/*": {"origins": "*"}},

--- a/api/tests/routes/public/blueprint_openapi_test.py
+++ b/api/tests/routes/public/blueprint_openapi_test.py
@@ -10,24 +10,6 @@ def _get_expected_json():
     return data
 
 
-def test_redirect_to_new_swagger(client, app):
-    response_collective = client.get("/v2/swagger")
-    assert response_collective.status_code == 301
-    assert response_collective.location == "http://localhost/swagger"
-
-    response_product = client.get("/public/offers/v1/swagger")
-    assert response_product.status_code == 301
-    assert response_product.location == "http://localhost/swagger"
-
-    response_event = client.get("/public/offers/v1/event/swagger")
-    assert response_event.status_code == 301
-    assert response_event.location == "http://localhost/swagger"
-
-    response_booking = client.get("/public/bookings/v1/swagger")
-    assert response_booking.status_code == 301
-    assert response_booking.location == "http://localhost/swagger"
-
-
 def test_public_api_openapi_json(client):
     response = client.get("/openapi.json")
     assert response.status_code == 200


### PR DESCRIPTION
Now that the URL of the new documentation has been communicated to providers they don't need to use the swaggers

## But de la pull request

Ticket Jira  : https://passculture.atlassian.net/browse/PC-29862

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques