### PR TITLE
(PC-30796)[API] feat: public api doc: clean: subcategoryId

### DIFF
--- a/api/documentation/docs/tutorials/create-a-collective-offer.md
+++ b/api/documentation/docs/tutorials/create-a-collective-offer.md
@@ -75,7 +75,6 @@ Your JSON payload should look something like :
 | **venueId** | Integer | **`false`** | Your administrative venue that handles the offer. Note that it can also be the event location (see `offerVenue`) |
 | **name** | String | **`false`** | Bookable offer name |
 | **description** | String | **`false`** | Describe your offer, the educational purpose. Do not add any pricing detail here, see `educationalPriceDetail` |
-| **subcategoryId** | String | `true` | Deprecated. Use `formats` but keep in mind that at least one must be set |
 | **bookingEmails** | List[String] | **`false`** | Booking notification email addresses |
 | **contactEmail** | String | **`false`** | Contact email shown to the teacher/educational staff |
 | **contactPhone** | String | **`false`** |  Contact phone shown to the teacher/educational staff |
@@ -101,10 +100,7 @@ Your JSON payload should look something like :
 | **imageFile** | String | `true` | base64-encodede image. If set, `imageCredit` becomes mandatory|
 | **imageCredit** | String | `true` | Image author/owner. If set, `imageFile` becomes mandatory|
 
-### subcategoryId and formats
-List of known subcategories can be found using the this route:
-GET `/public/offers/v1/events/categories`
-
+### formats
 List of known formats can be found using this route:
 GET `/v2/collective/offers/formats`
 

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -188,7 +188,9 @@ class _FIELDS:
     COLLECTIVE_OFFER_DESCRIPTION = Field(
         description="Collective offer description", example="Atelier de peinture à la gouache pour élèves de 5ème"
     )
-    COLLECTIVE_OFFER_SUBCATEGORY_ID = Field(description="Event subcategory id", example="FESTIVAL_MUSIQUE")
+    COLLECTIVE_OFFER_SUBCATEGORY_ID = Field(
+        description="**(deprecated, use formats instead)** Event subcategory id", example="FESTIVAL_MUSIQUE"
+    )
     COLLECTIVE_OFFER_FORMATS = Field(description="Educational Formats", example=["Atelier de pratique"])
     COLLECTIVE_OFFER_BOOKING_EMAILS = Field(
         description="Recipient emails for notifications about bookings, cancellations, etc.",

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -4151,7 +4151,7 @@
                         "type": "array"
                     },
                     "subcategoryId": {
-                        "description": "Event subcategory id",
+                        "description": "**(deprecated, use formats instead)** Event subcategory id",
                         "example": "FESTIVAL_MUSIQUE",
                         "nullable": true,
                         "title": "Subcategoryid",
@@ -5714,7 +5714,7 @@
                         "type": "array"
                     },
                     "subcategoryId": {
-                        "description": "Event subcategory id",
+                        "description": "**(deprecated, use formats instead)** Event subcategory id",
                         "example": "FESTIVAL_MUSIQUE",
                         "nullable": true,
                         "title": "Subcategoryid",
@@ -5959,7 +5959,7 @@
                         "type": "array"
                     },
                     "subcategoryId": {
-                        "description": "Event subcategory id",
+                        "description": "**(deprecated, use formats instead)** Event subcategory id",
                         "example": "FESTIVAL_MUSIQUE",
                         "nullable": true,
                         "title": "Subcategoryid",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30796

1. Supprimer la sous-catégorie de l'exemple de création d'une offre collective (le champ est obsolète et sera bientôt supprimé).
2. Marquer ce même champ comme obsolète dans la documentation de l'API REST.