### PR TITLE
(BSR)[PRO] fix: Fixing connect-as banner hiding elements.

### DIFF
--- a/pro/src/app/App/layout/LateralPanel/LateralPanel.module.scss
+++ b/pro/src/app/App/layout/LateralPanel/LateralPanel.module.scss
@@ -10,7 +10,7 @@
     left: 0;
     min-width: size.$side-nav-width;
     z-index: zIndex.$lateral-menu-z-index-mobile;
-    min-height: calc(100vh - size.$top-menu-height);
+    min-height: 100%;
 
     &::before {
       content: " ";

--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -3,6 +3,8 @@
 @use "styles/variables/_size.scss" as size;
 @use "styles/variables/_z-index.scss" as zIndex;
 
+$connect-as-header-height: rem.torem(52px);
+
 .layout {
   display: flex;
   flex-direction: column;
@@ -19,6 +21,10 @@
 
   &-funnel {
     width: 100%;
+  }
+
+  &-connect-as {
+    height: calc(100% - $connect-as-header-height);
   }
 
   @media (min-width: size.$desktop) {
@@ -67,9 +73,10 @@
 }
 
 .connect-as {
+  height: $connect-as-header-height;
   background-color: var(--color-grey-light);
   display: flex;
-  padding: 16px;
+  padding: rem.torem(16px);
   min-width: 100%;
 
   &-icon {

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -74,6 +74,7 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
         )}
         <div
           className={cn(styles['page-layout'], {
+            [styles['page-layout-connect-as']]: currentUser?.isImpersonated,
             [styles['page-layout-funnel']]: layout === 'funnel',
           })}
         >


### PR DESCRIPTION
## But de la pull request

Corriger l'affichage du menu latéral avec la bannière connect as.

## Affichage
### Avant

![image](https://github.com/user-attachments/assets/c14687a4-1636-46f0-b6bf-ee2049cb571b)


### Après

![image](https://github.com/user-attachments/assets/3669951d-7f34-4440-92c1-c3ded365864b)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques