### PR TITLE
(PC-30376)[PRO] feat: Display the address instead of the venue.

### DIFF
--- a/pro/src/pages/Offers/Offers/OfferItem/IndividualOfferItem.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/IndividualOfferItem.tsx
@@ -5,6 +5,9 @@ import {
   ListOffersVenueResponseModel,
 } from 'apiClient/v1'
 import { Audience } from 'core/shared/types'
+import { useActiveFeature } from 'hooks/useActiveFeature'
+import styles from 'pages/Offers/Offers/OfferItem/OfferItem.module.scss'
+import { computeAddressDisplayName } from 'repository/venuesService'
 
 import { CheckboxCell } from './Cells/CheckboxCell'
 import { IndividualActionsCells } from './Cells/IndividualActionsCell'
@@ -35,6 +38,8 @@ export const IndividualOfferItem = ({
   venue,
   audience,
 }: IndividualOfferItemProps) => {
+  const offerAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
+
   return (
     <>
       <CheckboxCell
@@ -53,7 +58,13 @@ export const IndividualOfferItem = ({
         audience={audience}
       />
 
-      <OfferVenueCell venue={venue} />
+      {offerAddressEnabled && offer.address ? (
+        <td className={styles['venue-column']}>
+          {computeAddressDisplayName(offer.address)}
+        </td>
+      ) : (
+        <OfferVenueCell venue={venue} />
+      )}
 
       <OfferRemainingStockCell stocks={offer.stocks} />
 

--- a/pro/src/pages/Offers/Offers/OffersTableHead/OffersTableHead.tsx
+++ b/pro/src/pages/Offers/Offers/OffersTableHead/OffersTableHead.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 
 import { Audience } from 'core/shared/types'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 
 type OffersTableHeadProps = {
   audience: Audience
@@ -9,12 +10,17 @@ type OffersTableHeadProps = {
 export const OffersTableHead = ({
   audience,
 }: OffersTableHeadProps): JSX.Element => {
+  const offerAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
   return (
     <thead>
       <tr>
         <th colSpan={3} />
 
-        <th>Lieu</th>
+        <th>
+          {offerAddressEnabled && audience === Audience.INDIVIDUAL
+            ? 'Adresse'
+            : 'Lieu'}
+        </th>
         <th>{audience === Audience.COLLECTIVE ? 'Établissement' : 'Stocks'}</th>
         <th>Statut</th>
         <th

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -56,7 +56,8 @@ const renderOffers = async (
   filters: Partial<SearchFiltersParams> & {
     page?: number
     audience?: Audience
-  } = DEFAULT_SEARCH_FILTERS
+  } = DEFAULT_SEARCH_FILTERS,
+  features: string[] = []
 ) => {
   const route = computeOffersUrl(filters)
 
@@ -71,6 +72,7 @@ const renderOffers = async (
     {
       user: sharedCurrentUserFactory(),
       initialRouterEntries: [route],
+      features,
     }
   )
 
@@ -752,6 +754,44 @@ describe('route Offers', () => {
         undefined,
         undefined
       )
+    })
+  })
+
+  describe('With WIP_ENABLE_OFFER_ADDRESS FF', () => {
+    it('should display venue header without the FF', async () => {
+      await renderOffers()
+      expect(
+        screen.queryByRole('columnheader', { name: 'Lieu' })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('columnheader', { name: 'Adresse' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('should display address header with the FF', async () => {
+      await renderOffers(DEFAULT_SEARCH_FILTERS, ['WIP_ENABLE_OFFER_ADDRESS'])
+      expect(
+        screen.queryByRole('columnheader', { name: 'Lieu' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('columnheader', { name: 'Adresse' })
+      ).toBeInTheDocument()
+    })
+
+    it('should display venue header with the FF for collective offers', async () => {
+      await renderOffers(
+        {
+          ...DEFAULT_SEARCH_FILTERS,
+          audience: Audience.COLLECTIVE,
+        },
+        ['WIP_ENABLE_OFFER_ADDRESS']
+      )
+      expect(
+        screen.queryByRole('columnheader', { name: 'Lieu' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('columnheader', { name: 'Adresse' })
+      ).toBeInTheDocument()
     })
   })
 })

--- a/pro/src/repository/__specs__/venuesService.spec.ts
+++ b/pro/src/repository/__specs__/venuesService.spec.ts
@@ -1,6 +1,11 @@
+import { addressResponseIsEditableModelFactory } from 'utils/commonOffersApiFactories'
 import { venueListItemFactory } from 'utils/individualApiFactories'
 
-import { computeVenueDisplayName, formatAndOrderVenues } from '../venuesService'
+import {
+  computeAddressDisplayName,
+  computeVenueDisplayName,
+  formatAndOrderVenues,
+} from '../venuesService'
 
 describe('formatAndOrderVenues', () => {
   it('should sort venues alphabetically', () => {
@@ -94,5 +99,25 @@ describe('computeVenueDisplayName', () => {
     const computedVenueDisplayName = computeVenueDisplayName(venue)
 
     expect(computedVenueDisplayName).toBe('gilbert Joseph - Offre numérique')
+  })
+})
+
+describe('computeAddressDisplayName', () => {
+  it('should format the address without the label', () => {
+    const computedAddressDisplayName = computeAddressDisplayName(
+      addressResponseIsEditableModelFactory({ label: undefined })
+    )
+
+    expect(computedAddressDisplayName).toBe('ma super rue 75008 city')
+  })
+
+  it('should format the address with the the label', () => {
+    const computedAddressDisplayName = computeAddressDisplayName(
+      addressResponseIsEditableModelFactory({ label: 'Mon Label' })
+    )
+
+    expect(computedAddressDisplayName).toBe(
+      'Mon Label - ma super rue 75008 city'
+    )
   })
 })

--- a/pro/src/repository/venuesService.ts
+++ b/pro/src/repository/venuesService.ts
@@ -1,6 +1,7 @@
 import {
-  VenueListItemResponseModel,
+  type AddressResponseIsEditableModel,
   ListOffersVenueResponseModel,
+  VenueListItemResponseModel,
 } from 'apiClient/v1'
 import { SelectOption } from 'custom_types/form'
 
@@ -12,6 +13,15 @@ export const computeVenueDisplayName = (
   } else {
     return venue.publicName || venue.name
   }
+}
+
+export const computeAddressDisplayName = (
+  address: AddressResponseIsEditableModel
+): string => {
+  return (
+    (address.label ? `${address.label} - ` : '') +
+    `${address.street} ${address.postalCode} ${address.city}`
+  )
 }
 
 const sortAlphabeticallyByLabel = (a: SelectOption, b: SelectOption) => {

--- a/pro/src/utils/commonOffersApiFactories.ts
+++ b/pro/src/utils/commonOffersApiFactories.ts
@@ -1,0 +1,19 @@
+import { AddressResponseIsEditableModel } from 'apiClient/v1'
+
+export const addressResponseIsEditableModelFactory = (
+  customAddressResponseIsEditableModelFactory: Partial<AddressResponseIsEditableModel> = {}
+): AddressResponseIsEditableModel => {
+  return {
+    banId: 'ban',
+    city: 'city',
+    id: 1,
+    inseeCode: 'inseeCode',
+    isEditable: true,
+    label: 'label',
+    latitude: 48.866667,
+    longitude: 2.333333,
+    postalCode: '75008',
+    street: 'ma super rue',
+    ...customAddressResponseIsEditableModelFactory,
+  }
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30376

Afficher l'adresse à la place de la venue dans la liste des offres individuelles.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques