### PR TITLE
(PC-30855)[PRO] fix: Fix main layout structure

### DIFF
--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -42,7 +42,7 @@
 
 .content-container {
   width: 100%;
-  height: 100%;
+  flex-grow: 1;
   padding: rem.torem(24px) rem.torem(24px) 0;
   background-color: var(--color-white);
   display: flex;

--- a/pro/src/components/Footer/Footer.module.scss
+++ b/pro/src/components/Footer/Footer.module.scss
@@ -9,6 +9,7 @@
 
   &-layout-sticky-actions {
     margin-bottom: size.$action-bar-sticky-height;
+    margin-top: rem.torem(24px);
   }
 
   &-layout-funnel {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30855

3 petites lignes, mais de grosses responsabilités. En effet, le `height: 100%` sur le `.content-container` était le principal responsable du bug reporté dans le ticket. En dessous d'une certaine hauteur, la valeur de 100% finissait par devenir plus petite que l'addition de toutes les marges ajoutées pour repositionner l'action-bar, et donc créait le problème de masquage du footer et d'une partie du contenu.

Le fait de virer cette règle et d'ajouter un `flex-grow` à la place laisse le navigateur calculer l'espace nécessaire en fonction de la hauteur.

https://github.com/user-attachments/assets/d4d85860-347f-485b-b8d1-26ad3433759e

## Vérifications

- [x] J'ai revérifié attentivement un grand nombre de pages pour vérifier d'éventuels changements apportés par cette modification de structure