### PR TITLE
(PC-30905)[API] feat: move endpoint security definition

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -76,8 +76,7 @@ def reset_recredit_amount_to_show(user: users_models.User) -> serializers.UserPr
 
 
 @blueprint.native_route("/profile/update_email", methods=["POST"])
-@blueprint.api.validate(deprecated=True)
-@spectree_serialize(on_success_status=204, api=blueprint.api)
+@spectree_serialize(on_success_status=204, api=blueprint.api, deprecated=True)
 @authenticated_and_active_user_required
 def update_user_email(user: users_models.User, body: serializers.UserProfileEmailUpdate) -> None:
     try:
@@ -95,11 +94,11 @@ def update_user_email(user: users_models.User, body: serializers.UserProfileEmai
 
 
 @blueprint.native_route("/profile/email_update/status", methods=["GET"])
-@blueprint.api.validate(deprecated=True)
 @spectree_serialize(
     on_success_status=200,
     api=blueprint.api,
     response_model=serializers.EmailUpdateStatus,
+    deprecated=True,
 )
 @authenticated_and_active_user_required
 def get_email_update_status(user: users_models.User) -> serializers.EmailUpdateStatus:

--- a/api/src/pcapi/routes/native/v1/offers.py
+++ b/api/src/pcapi/routes/native/v1/offers.py
@@ -30,8 +30,9 @@ from .serialization import subcategories_v2 as subcategories_v2_serializers
 
 # WebApp v2 proxy expects endpoint to be at "/offer/<int:offer_id>". This path MUST NOT be changed. Its response can be changed, though.
 @blueprint.native_route("/offer/<int:offer_id>", methods=["GET"])
-@blueprint.api.validate(deprecated=True)
-@spectree_serialize(response_model=serializers.OfferResponse, api=blueprint.api, on_error_statuses=[404])
+@spectree_serialize(
+    response_model=serializers.OfferResponse, api=blueprint.api, on_error_statuses=[404], deprecated=True
+)
 def get_offer(offer_id: str) -> serializers.OfferResponse:
     offer: Offer = (
         Offer.query.options(

--- a/api/src/pcapi/serialization/decorator.py
+++ b/api/src/pcapi/serialization/decorator.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from copy import deepcopy
 from functools import wraps
 import logging
 from typing import Any
@@ -137,8 +136,6 @@ def spectree_serialize(
         else:
             spectree_response = SpectreeResponse(**response_codes)
 
-        security = deepcopy(getattr(route, "requires_authentication", None))
-
         @wraps(route)
         @api.validate(
             after=after,
@@ -150,7 +147,6 @@ def spectree_serialize(
             json=body_in_kwargs,
             query=query_in_kwargs,
             resp=spectree_response,
-            security=security,
             tags=tags,
         )
         def sync_validate(*args: Any, **kwargs: Any) -> Response:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -39,6 +39,7 @@ from pcapi.utils import requests
 from pcapi.utils.module_loading import import_string
 
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_valid_token_with_email
+from tests.serialization.extended_spec_tree_test import test_extended_spec_tree_blueprint
 from tests.serialization.serialization_decorator_test import test_blueprint
 from tests.serialization.serialization_decorator_test import test_bookings_blueprint
 
@@ -115,6 +116,7 @@ def build_main_app():
         app.register_blueprint(test_blueprint, url_prefix="/test-blueprint")
         # Needed to test that /v2/bookings accepts invalid json
         app.register_blueprint(test_bookings_blueprint, url_prefix="/v2")
+        app.register_blueprint(test_extended_spec_tree_blueprint)
 
         install_database_extensions()
         run_migrations()

--- a/api/tests/routes/native/openapi_test.py
+++ b/api/tests/routes/native/openapi_test.py
@@ -3505,6 +3505,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "get_email_update_status <GET>",
                     "tags": [],
                 }
@@ -3588,6 +3589,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "update_user_email <POST>",
                     "tags": [],
                 }

--- a/api/tests/serialization/extended_spec_tree_test.py
+++ b/api/tests/serialization/extended_spec_tree_test.py
@@ -1,0 +1,99 @@
+from flask import Blueprint
+from spectree import SecurityScheme
+from spectree import Tag
+
+from pcapi.serialization.decorator import spectree_serialize
+from pcapi.serialization.spec_tree import ExtendedSpecTree
+from pcapi.serialization.spec_tree import _AUTHENTICATION_ATTRIBUTE
+from pcapi.serialization.spec_tree import add_security_scheme
+
+
+AUTH_KEY = "API_KEY"
+
+SECURITY_SCHEME = SecurityScheme(
+    name=AUTH_KEY,
+    data={"type": "http", "scheme": "bearer", "description": "Api key issued by passculture"},  # type: ignore[arg-type]
+)
+
+api_schema = ExtendedSpecTree(
+    "flask",
+    description="SpecTree schema using added by ExtendedSpecTree params",
+    tags=[
+        Tag(name="TAG_1", description="coucou toi"),
+        Tag(name="TAG_2", description="hey you!"),
+    ],
+    humanize_operation_id=True,
+    security_schemes=[SECURITY_SCHEME],
+)
+
+
+# Fake decorator
+def api_key_auth(func):
+    add_security_scheme(func, AUTH_KEY)
+    return func
+
+
+# Registered by flask_app in `conftest.py`
+test_extended_spec_tree_blueprint = Blueprint(
+    "test_extended_spec_tree_blueprint", "coucou", url_prefix="/test-extended-spec-tree"
+)
+
+
+# Fake endpoint with no auth
+@test_extended_spec_tree_blueprint.route("/", methods=["GET"])
+@spectree_serialize(
+    on_success_status=204,
+    api=api_schema,
+)
+def spectree_get_test_endpoint():
+    pass
+
+
+# Fake endpoint with auth
+@test_extended_spec_tree_blueprint.route("/require_auth", methods=["POST"])
+@api_key_auth
+@spectree_serialize(
+    on_success_status=204,
+    api=api_schema,
+)
+def spectree_post_test_endpoint():
+    pass
+
+
+# Register fake endpoints
+api_schema.register(test_extended_spec_tree_blueprint)
+
+
+class ExtendedSpecTreeTest:
+    def test_should_document_endpoint_security_properly(self):
+        spec = api_schema._generate_spec()
+        assert "security" not in spec["paths"]["/test-extended-spec-tree/"]["get"]
+        assert spec["paths"]["/test-extended-spec-tree/require_auth"]["post"]["security"] == [{AUTH_KEY: []}]
+
+    def test_should_order_tags(self):
+        spec = api_schema._generate_spec()
+        assert spec["tags"] == [
+            {"description": "coucou toi", "name": "TAG_1", "externalDocs": None},
+            {"description": "hey you!", "name": "TAG_2", "externalDocs": None},
+        ]
+
+    def test_should_humanize_operationId(self):
+        spec = api_schema._generate_spec()
+        assert spec["paths"]["/test-extended-spec-tree/"]["get"]["operationId"] == "SpectreeGetTestEndpoint"
+        assert (
+            spec["paths"]["/test-extended-spec-tree/require_auth"]["post"]["operationId"] == "SpectreePostTestEndpoint"
+        )
+
+
+class AddSecuritySchemeTest:
+    def test_should_add_security_scheme(self):
+        def controller():
+            pass
+
+        add_security_scheme(controller, "fingerprint")
+        add_security_scheme(controller, "faceid", ["pour les trucs vachement importants"])
+
+        assert getattr(controller, _AUTHENTICATION_ATTRIBUTE) == [
+            {"fingerprint": []},
+            {"faceid": ["pour les trucs vachement importants"]},
+        ]


### PR DESCRIPTION
Move it from `@spectree_serialize` to `ExtendedSpecTree`

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30905

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
