### PR TITLE
(PC-30917)[PRO] fix: Address search should ignore accents for options.

### DIFF
--- a/pro/src/components/Address/Address.tsx
+++ b/pro/src/components/Address/Address.tsx
@@ -6,6 +6,7 @@ import { AdresseData } from 'apiClient/adresse/types'
 import { serializeAdressData } from 'components/Address/serializer'
 import { SelectOption } from 'custom_types/form'
 import { SelectAutocomplete } from 'ui-kit/form/SelectAutoComplete/SelectAutocomplete'
+import { normalizeStrForAdressSearch } from 'utils/searchPatternInOptions'
 
 interface AddressProps {
   description?: string
@@ -92,6 +93,16 @@ export const AddressSelect = ({
     return []
   }
 
+  function searchInOptions(options: SelectOption[], pattern: string) {
+    return options.filter((option) => {
+      return normalizeStrForAdressSearch(pattern || '')
+        .split(' ')
+        .every((word) =>
+          normalizeStrForAdressSearch(option.label).includes(word)
+        )
+    })
+  }
+
   return (
     <SelectAutocomplete
       name="addressAutocomplete"
@@ -101,6 +112,7 @@ export const AddressSelect = ({
       hideArrow={true}
       resetOnOpen={false}
       description={description}
+      searchInOptions={searchInOptions}
     />
   )
 }

--- a/pro/src/utils/searchPatternInOptions.ts
+++ b/pro/src/utils/searchPatternInOptions.ts
@@ -2,6 +2,10 @@ import { SelectOption } from 'custom_types/form'
 
 export type SelectOptionNormalized = SelectOption & { normalizedLabel?: string }
 
+export const normalizeStrForAdressSearch = (str: string): string => {
+  return normalizeStrForSearch(str).replace(/[^\w ]/, '')
+}
+
 export const normalizeStrForSearch = (str: string): string => {
   return (
     str


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30917

Meilleur filtre pour l'autocomplétion des adresses

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
