### PR TITLE
(BSR)[PRO] test: timeout 15"->30" for createThingIndividualOffer

### DIFF
--- a/pro/cypress/e2e/step-definitions/adage.cy.ts
+++ b/pro/cypress/e2e/step-definitions/adage.cy.ts
@@ -19,7 +19,7 @@ When('I open adage iframe', () => {
   }).as('features')
   cy.visit(`/adage-iframe?token=${adageToken}`)
   cy.findAllByTestId('spinner').should('not.exist')
-  cy.wait(['@local_offerers', '@features'], { requestTimeout: 15 * 1000 }).then(
+  cy.wait(['@local_offerers', '@features'], { requestTimeout: 30 * 1000 }).then(
     (interception) => {
       if (interception[0].response) {
         expect(interception[0].response.statusCode).to.equal(200)
@@ -100,7 +100,7 @@ When('I add first offer to favorites', () => {
         url: '/adage-iframe/logs/fav-offer/',
       }).as('fav-offer')
       cy.findAllByTestId('favorite-inactive').click()
-      cy.wait('@fav-offer', { requestTimeout: 15 * 1000 })
+      cy.wait('@fav-offer', { requestTimeout: 30 * 1000 })
         .its('response.statusCode')
         .should('eq', 204)
     })

--- a/pro/cypress/e2e/step-definitions/createThingIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/createThingIndividualOffer.cy.ts
@@ -48,7 +48,7 @@ When('I validate stocks step', () => {
   cy.intercept({ method: 'GET', url: '/offers/*' }).as('getOffer')
   cy.findByText('Enregistrer et continuer').click()
   cy.wait(['@patchOffer', '@postStocks', '@getOffer'], {
-    requestTimeout: 15 * 1000,
+    requestTimeout: 30 * 1000,
   })
 })
 


### PR DESCRIPTION
## But de la pull request

Failed with a 15" timeout, previously was 30" so go back to 30"

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
