### PR TITLE
Pc 30930 scss deprecation warnings

### DIFF
--- a/pro/.stylelintrc.json
+++ b/pro/.stylelintrc.json
@@ -1,9 +1,7 @@
 {
   "extends": ["stylelint-config-standard-scss"],
   "rules": {
-    "at-rule-no-unknown": null,
     "no-descending-specificity": null,
-    "scss/at-extend-no-missing-placeholder": null,
     "scss/operator-no-newline-after": null,
     "font-family-no-missing-generic-family-keyword": null,
     "selector-max-type": [
@@ -13,9 +11,5 @@
         "severity": "warning"
       }
     ]
-  },
-  "ignoreFiles": [
-    "src/pages/AdageIframe/app/ui-kit/MultiSelectAutoComplete/MultiSelectAutocomplete.scss",
-    "src/pages/AdageIframe/app/ui-kit/Button/Button.scss"
-  ]
+  }
 }

--- a/pro/src/components/FormLayout/FormLayout.module.scss
+++ b/pro/src/components/FormLayout/FormLayout.module.scss
@@ -96,12 +96,12 @@ $info-box-margin-left: rem.torem(24px);
   }
 
   &-action {
+    margin-left: rem.torem(24px);
+    text-align: center;
+
     @media (min-width: size.$tablet) {
       min-width: rem.torem(192px);
     }
-
-    margin-left: rem.torem(24px);
-    text-align: center;
 
     &:first-child {
       margin-left: 0;

--- a/pro/src/components/Header/Header.module.scss
+++ b/pro/src/components/Header/Header.module.scss
@@ -58,12 +58,11 @@
   .logo {
     display: inline-flex;
     height: 100%;
+    color: var(--color-input-text-color);
 
     svg {
       width: rem.torem(80px);
     }
-
-    color: var(--color-input-text-color);
 
     @media (min-width: size.$laptop) {
       margin-left: rem.torem(16px);

--- a/pro/src/components/Header/HeaderDropdown/HeaderDropdown.module.scss
+++ b/pro/src/components/Header/HeaderDropdown/HeaderDropdown.module.scss
@@ -28,18 +28,18 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
 }
 
 .pop-in {
-  &[data-state='open']{
-    animation: fade-in 150ms ease-out;
-  }
-
-  &[data-state='closed'] {
-    animation: fade-out 150ms ease-in;
-  }
-
   z-index: zIndex.$profil-pop-in-z-index;
   width: 100dvw;
   height: 100dvh;
   margin-top: rem.torem(8px);
+
+  &[data-state="open"] {
+    animation: fade-in 150ms ease-out;
+  }
+
+  &[data-state="closed"] {
+    animation: fade-out 150ms ease-in;
+  }
 
   @media (min-width: size.$mobile) {
     height: auto;
@@ -85,10 +85,6 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
 }
 
 .sub-popin {
-  &[data-state='open']{
-    animation: fade-in 150ms ease-out;
-  }
-
   z-index: zIndex.$venues-pop-in-z-index;
   width: 100dvw;
   height: 100dvh;
@@ -96,6 +92,10 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
   background-color: var(--color-white);
   margin-top: calc((100vh - var(--radix-popper-available-height)) * -1);
   overflow-y: scroll;
+
+  &[data-state="open"] {
+    animation: fade-in 150ms ease-out;
+  }
 
   @media (min-width: $sub-popin-full-width-breakpoint) {
     max-height: rem.torem(310px);
@@ -108,7 +108,6 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
     border: solid rem.torem(1px) var(--color-grey-medium);
   }
 }
-
 
 .sub-menu {
   display: flex;
@@ -235,7 +234,7 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
   }
 
   &[data-state="checked"] {
-    @include fonts.bold
+    @include fonts.bold;
   }
 
   &-name {
@@ -256,8 +255,6 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
     &[data-state="checked"] {
       border-radius: 6px;
       border: 1px solid var(--color-grey-dark);
-
-
 
       @media (min-width: $sub-popin-full-width-breakpoint) {
         border: none;
@@ -281,7 +278,7 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
     margin-top: rem.torem(8px);
     margin-bottom: rem.torem(16px);
 
-    @include fonts.title4
+    @include fonts.title4;
   }
 
   @media (min-width: $sub-popin-full-width-breakpoint) {

--- a/pro/src/components/TutorialDialog/TutorialDialog.module.scss
+++ b/pro/src/components/TutorialDialog/TutorialDialog.module.scss
@@ -2,10 +2,10 @@
 @use "styles/variables/_size.scss" as size;
 
 .tutorial-box {
+  margin-bottom: rem.torem(8px);
+
   @media (min-width: size.$tablet) {
     width: rem.torem(750px);
     height: rem.torem(620px);
   }
-  
-  margin-bottom: rem.torem(8px);
 }

--- a/pro/src/pages/Accessibility/AccessibilityLayout.module.scss
+++ b/pro/src/pages/Accessibility/AccessibilityLayout.module.scss
@@ -6,11 +6,11 @@
 }
 
 .layout {
-  @include layout.full-content-side;
-
   margin: unset;
   display: flex;
   flex-direction: column;
+
+  @include layout.full-content-side;
 }
 
 .content {

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
@@ -37,6 +37,8 @@
     border-top-right-radius: 0;
     padding-left: rem.torem(36px);
 
+    @include forms.input-theme-nested;
+
     &-span {
       position: absolute;
       top: 0;

--- a/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.module.scss
+++ b/pro/src/pages/Home/StatisticsDashboard/StatisticsDashboard.module.scss
@@ -28,13 +28,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-bottom: rem.torem(24px);
 
   &-icon {
     width: rem.torem(42px);
     height: rem.torem(32px);
   }
-
-  margin-bottom: rem.torem(24px);
 }
 
 .data-container {

--- a/pro/src/pages/LostPassword/LostPassword.module.scss
+++ b/pro/src/pages/LostPassword/LostPassword.module.scss
@@ -8,12 +8,14 @@
 }
 
 .content {
-  @include layout.full-content-side;
-
   display: flex;
   align-items: center;
+
+  @include layout.full-content-side;
 
   @media (min-width: size.$tablet) {
     min-height: 100vh;
   }
+
+  color: red;
 }

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.module.scss
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.module.scss
@@ -9,10 +9,10 @@
 }
 
 .content {
-  @include layout.full-content-side;
-
   display: flex;
   align-items: center;
+
+  @include layout.full-content-side;
 
   @media (min-width: size.$tablet) {
     min-height: 100vh;

--- a/pro/src/pages/Signup/SignupContainer/SignupContainer.module.scss
+++ b/pro/src/pages/Signup/SignupContainer/SignupContainer.module.scss
@@ -9,13 +9,13 @@
 }
 
 .content {
+  margin-bottom: size.$footer-height;
+
   @include layout.full-content-side;
 
   @media (min-width: size.$tablet) {
     margin-top: size.$top-menu-height;
   }
-
-  margin-bottom: size.$footer-height;
 
   .siren-field {
     margin-bottom: rem.torem(16px);

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/DayCheckbox.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/DayCheckbox.module.scss
@@ -5,6 +5,16 @@
 $checkbox-size: rem.torem(40px);
 
 .checkbox input {
+  position: relative;
+  width: $checkbox-size;
+  height: $checkbox-size;
+  background-color: var(--color-white);
+  border: rem.torem(1px) solid var(--color-grey-dark);
+  border-radius: 50%;
+  transition:
+    border 150ms ease,
+    background 150ms ease;
+
   &:hover,
   &:focus,
   &:checked {
@@ -16,16 +26,6 @@ $checkbox-size: rem.torem(40px);
   &::after {
     content: none;
   }
-
-  position: relative;
-  width: $checkbox-size;
-  height: $checkbox-size;
-  background-color: var(--color-white);
-  border: rem.torem(1px) solid var(--color-grey-dark);
-  border-radius: 50%;
-  transition:
-    border 150ms ease,
-    background 150ms ease;
 
   &:focus-within {
     outline: rem.torem(1px) solid var(--color-black);

--- a/pro/src/styles/components/layout/_CookieModals.scss
+++ b/pro/src/styles/components/layout/_CookieModals.scss
@@ -21,6 +21,8 @@ $action-gap: rem.torem(10px);
 
 .orejime-Notice-actionItem button,
 .orejime-Modal-form button {
+  @include fonts.button;
+
   text-align: center;
   border-radius: rem.torem(30px);
   border: rem.torem(2px) solid var(--color-primary);
@@ -38,8 +40,6 @@ $action-gap: rem.torem(10px);
     outline: rem.torem(1px) solid var(--color-input-text-color);
     outline-offset: rem.torem(2px);
   }
-
-  @include fonts.button;
 }
 
 .orejime-Notice {

--- a/pro/src/styles/mixins/_forms.scss
+++ b/pro/src/styles/mixins/_forms.scss
@@ -20,7 +20,9 @@
   transition:
     background 150ms ease,
     box-shadow 150ms ease;
+}
 
+@mixin input-theme-nested {
   &:focus {
     outline: solid size.$input-border-width
       var(--color-input-border-color-focus);
@@ -85,12 +87,6 @@
   :disabled + & {
     color: var(--color-input-text-color-disabled);
   }
-}
-
-@mixin input-icon-button-wrapper($icon-width: 32px) {
-  @include input-icon-wrapper($icon-width);
-
-  pointer-events: initial;
 }
 
 @mixin field-layout-footer() {

--- a/pro/src/ui-kit/Banners/Banner/Banner.module.scss
+++ b/pro/src/ui-kit/Banners/Banner/Banner.module.scss
@@ -5,6 +5,10 @@
 $banner-left-padding: rem.torem(16px);
 
 .bi-banner {
+  border-radius: rem.torem(6px);
+  margin: rem.torem(16px) 0;
+  padding: rem.torem(20px) rem.torem(16px) rem.torem(16px) rem.torem(16px);
+
   &.attention,
   &.notification-info {
     position: relative;
@@ -136,10 +140,6 @@ $banner-left-padding: rem.torem(16px);
       }
     }
   }
-
-  border-radius: rem.torem(6px);
-  margin: rem.torem(16px) 0;
-  padding: rem.torem(20px) rem.torem(16px) rem.torem(16px) rem.torem(16px);
 
   &-text {
     line-height: rem.torem(20px);

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -124,16 +124,15 @@
 
     color: var(--color-black);
     align-items: flex-start;
-
-    &-pink {
-      color: var(--color-primary);
-    }
-
     background-color: transparent;
     border-radius: rem.torem(4px);
     padding: 0;
     border: none;
     height: auto;
+
+    &-pink {
+      color: var(--color-primary);
+    }
 
     &:hover,
     &:focus-visible {

--- a/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
+++ b/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
@@ -23,11 +23,11 @@
 }
 
 .search-input {
-  border: none;
-
   @include forms.input-theme;
 
-  outline: none;
+  border: none;
+
+  @include forms.input-theme-nested;
 }
 
 input[type="search"]::-webkit-search-cancel-button {

--- a/pro/src/ui-kit/form/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
+++ b/pro/src/ui-kit/form/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
@@ -64,6 +64,8 @@ $text-padding-left: calc(
   border: unset;
   box-shadow: unset;
 
+  @include formsM.input-theme-nested;
+
   &:hover,
   &:hover:not(:focus),
   &:focus {

--- a/pro/src/ui-kit/form/Select/Select.module.scss
+++ b/pro/src/ui-kit/form/Select/Select.module.scss
@@ -10,6 +10,8 @@
   line-height: rem.torem(36px);
   padding-right: rem.torem(forms.$input-right-icon-padding);
 
+  @include formsM.input-theme-nested;
+
   &.filter-variant {
     border-radius: rem.torem(4px);
     padding: 0 size.$input-filter-variant-horizontal-padding;

--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectedValuesTags/SelectedValuesTags.module.scss
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectedValuesTags/SelectedValuesTags.module.scss
@@ -11,10 +11,6 @@
 .tag {
   @include fonts.highlight;
 
-  &:hover {
-    background-color: var(--color-grey-medium);
-  }
-
   white-space: nowrap;
   justify-content: center;
   border: solid rem.torem(1px) var(--color-grey-light);
@@ -24,6 +20,10 @@
   display: inline-flex;
   line-height: rem.torem(16px);
   padding: 0 rem.torem(4px) rem.torem(1px) rem.torem(4px);
+
+  &:hover {
+    background-color: var(--color-grey-medium);
+  }
 
   &-close-button {
     @include fonts.highlight;

--- a/pro/src/ui-kit/form/TextArea/TextArea.module.scss
+++ b/pro/src/ui-kit/form/TextArea/TextArea.module.scss
@@ -14,6 +14,8 @@
   overflow: hidden;
   border-radius: rem.torem(6px);
 
+  @include forms.input-theme-nested;
+
   &.has-error {
     @include forms.input-theme-error;
   }

--- a/pro/src/ui-kit/form/shared/BaseInput/BaseInput.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseInput/BaseInput.module.scss
@@ -4,6 +4,7 @@
 
 .base-input {
   @include forms.input-theme;
+  @include forms.input-theme-nested;
 
   &.filter-variant {
     border-radius: rem.torem(4px);
@@ -42,7 +43,8 @@
     padding-left: rem.torem(36px);
   }
 
-  &-right-icon, &-left-icon {
+  &-right-icon,
+  &-left-icon {
     @include forms.input-icon-wrapper(rem.torem(16px));
 
     &.filter-variant {
@@ -60,7 +62,9 @@
   }
 
   &-right-button {
-    @include forms.input-icon-button-wrapper(32px);
+    pointer-events: initial;
+
+    @include forms.input-icon-wrapper(rem.torem(32px));
 
     button {
       background: none;

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
@@ -83,12 +83,6 @@
 $icon-size: rem.torem(20px);
 
 .clear-button {
-  &-container {
-    position: absolute;
-    top: rem.torem(-4px);
-    right: 0;
-  }
-
   width: calc(#{$icon-size} + #{rem.torem(2px)});
   height: calc(#{$icon-size} + #{rem.torem(2px)});
   border: 1px solid var(--color-white);
@@ -97,6 +91,12 @@ $icon-size: rem.torem(20px);
 
   // Reset button styles
   line-height: 0;
+
+  &-container {
+    position: absolute;
+    top: rem.torem(-4px);
+    right: 0;
+  }
 
   &:focus {
     outline: 1px solid var(--color-black);


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30930

**Objectif**
Corriger les warnings de deprecation scss qu'on voit au moment du build. scss a ajouté [ce warning](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) il y a quelques jours. On ne doit plus avoir de styles non scopés avant des styles scopés.
J'ai résolu les pbs, à noter que j'ai du dupliquer la mixin `input-theme` pour pouvoir surcharger les styles de base de `input-theme` dans les styles qui s'en servent.

J'ai pas trouvé de règles pour avertir de cette deprecation (peut-être qu'elle existe pas encore ?)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
