### PR TITLE
(PC-30932)[PRO] style: Replace misuses of button font with the bold f…

### DIFF
--- a/pro/src/components/AdageButtonFilter/AdageButtonFilter.module.scss
+++ b/pro/src/components/AdageButtonFilter/AdageButtonFilter.module.scss
@@ -18,13 +18,13 @@
   cursor: pointer;
 
   &-is-active {
-    @include fonts.button;
+    @include fonts.bold;
 
     line-height: rem.torem(20px);
   }
 
   &-selected {
-    @include fonts.button;
+    @include fonts.bold;
 
     line-height: rem.torem(20px);
     border: rem.torem(2px) solid var(--color-primary);

--- a/pro/src/components/Header/Header.module.scss
+++ b/pro/src/components/Header/Header.module.scss
@@ -78,34 +78,6 @@
       margin-left: rem.torem(16px);
     }
   }
-
-  .logout {
-    @include fonts.button;
-
-    display: none;
-    align-items: center;
-    color: var(--color-input-text-color);
-    padding: 0 rem.torem(24px);
-
-    &-mobile {
-      display: inline-flex;
-      padding: 0;
-      justify-content: center;
-      align-items: center;
-      height: rem.torem(50px);
-      width: rem.torem(50px);
-      margin: 0;
-    }
-
-    @media (min-width: size.$tablet) {
-      display: flex;
-      gap: rem.torem(8px);
-
-      &-mobile {
-        display: none;
-      }
-    }
-  }
 }
 
 .tablet-and-above {

--- a/pro/src/components/Header/OldHeader.module.scss
+++ b/pro/src/components/Header/OldHeader.module.scss
@@ -28,7 +28,7 @@
       }
 
       .nav-item {
-        @include fonts.button;
+        @include fonts.bold;
 
         align-items: center;
         color: var(--color-white);

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageEdit.module.scss
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ButtonImageEdit.module.scss
@@ -51,7 +51,7 @@
 }
 
 .label {
-  @include fonts.button;
+  @include fonts.bold;
 
   line-height: rem.torem(20px);
 }

--- a/pro/src/components/NewNavReview/NewNavReview.module.scss
+++ b/pro/src/components/NewNavReview/NewNavReview.module.scss
@@ -19,6 +19,6 @@
   }
 
   &-bold-text {
-    @include fonts.button;
+    @include fonts.bold;
   }
 }

--- a/pro/src/components/OfferAppPreview/OfferAppPreview.module.scss
+++ b/pro/src/components/OfferAppPreview/OfferAppPreview.module.scss
@@ -36,7 +36,7 @@
   margin-bottom: rem.torem(16px);
 
   .offer-title {
-    @include fonts.button;
+    @include fonts.bold;
 
     max-width: rem.torem(224px);
     overflow-wrap: break-word;

--- a/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.module.scss
+++ b/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.module.scss
@@ -21,7 +21,7 @@
 }
 
 .title {
-  @include fonts.button;
+  @include fonts.bold;
 
   margin-bottom: rem.torem(16px);
 }

--- a/pro/src/components/Stepper/Stepper.module.scss
+++ b/pro/src/components/Stepper/Stepper.module.scss
@@ -35,7 +35,7 @@ $number-size: rem.torem(30px);
       padding-right: rem.torem(8px);
 
       .inner {
-        @include fonts.button;
+        @include fonts.bold;
 
         border: solid 1px var(--color-grey-dark);
         border-radius: 50%;

--- a/pro/src/components/Tutorial/Step/Step.module.scss
+++ b/pro/src/components/Tutorial/Step/Step.module.scss
@@ -34,7 +34,7 @@
   }
 
   .subtitle {
-    @include fonts.button;
+    @include fonts.body-important;
 
     line-height: rem.torem(20px);
     margin-bottom: rem.torem(8px);
@@ -122,7 +122,7 @@
     .offers,
     .booking,
     .reimbursements {
-      @include fonts.button;
+      @include fonts.body-important;
 
       display: flex;
       align-items: center;

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscovery.module.scss
@@ -11,33 +11,6 @@
     gap: rem.torem(40px);
     margin: rem.torem(32px) 0;
   }
-
-  &-suggestion {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    background-color: var(--color-background-secondary);
-    width: auto;
-    height: rem.torem(158px);
-    padding-left: rem.torem(24px);
-
-    h1.section-title {
-      margin-bottom: rem.torem(8px);
-    }
-
-    &-link {
-      @include fonts.button;
-
-      align-items: center;
-      width: max-content;
-      margin: 0;
-
-      svg {
-        max-width: rem.torem(16px);
-        margin-right: rem.torem(4px) !important;
-      }
-    }
-  }
 }
 
 .playlist-carousel-title {

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/DomainsCard/DomainsCard.module.scss
@@ -31,7 +31,7 @@
   }
 
   &-title {
-    @include fonts.button;
+    @include fonts.bold;
 
     position: relative;
     padding: 0 rem.torem(12px) rem.torem(12px) rem.torem(12px);

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
@@ -99,7 +99,7 @@ $offer-image-width: rem.torem(216px);
 }
 
 .offer-name {
-  @include fonts.button;
+  @include fonts.bold;
 
   display: -webkit-box;
   -webkit-box-orient: vertical;

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.module.scss
@@ -68,7 +68,7 @@ $venue-image-width: rem.torem(276px);
   word-break: break-word;
 
   &-name {
-    @include fonts.button;
+    @include fonts.bold;
 
     overflow: hidden;
   }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
@@ -126,7 +126,7 @@
       }
 
       &-category {
-        @include fonts.button;
+        @include fonts.bold;
 
         color: var(--color-primary);
       }

--- a/pro/src/pages/Collaborators/Collaborators.module.scss
+++ b/pro/src/pages/Collaborators/Collaborators.module.scss
@@ -25,7 +25,7 @@
   }
 
   .subtitle {
-    @include fonts.button;
+    @include fonts.bold;
 
     margin-bottom: rem.torem(8px);
   }

--- a/pro/src/pages/Home/StatisticsDashboard/CumulatedViews.module.scss
+++ b/pro/src/pages/Home/StatisticsDashboard/CumulatedViews.module.scss
@@ -8,7 +8,7 @@
 }
 
 .block-title {
-  @include fonts.button;
+  @include fonts.bold;
 }
 
 .no-data {

--- a/pro/src/pages/Home/StatisticsDashboard/MostViewedOffers.module.scss
+++ b/pro/src/pages/Home/StatisticsDashboard/MostViewedOffers.module.scss
@@ -8,7 +8,7 @@
 }
 
 .block-title {
-  @include fonts.button;
+  @include fonts.bold;
 }
 
 .caption {
@@ -27,7 +27,7 @@
   gap: rem.torem(16px);
 
   &-rank {
-    @include fonts.button;
+    @include fonts.bold;
   }
 
   &-thumbnail {

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.module.scss
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.module.scss
@@ -61,6 +61,6 @@
   .card-title {
     margin-bottom: 0;
 
-    @include fonts.button;
+    @include fonts.bold;
   }
 }

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/ThumbCell.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/ThumbCell.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Link } from 'react-router-dom'
 
 import {

--- a/pro/src/pages/Offers/Offers/OfferItem/OfferItem.module.scss
+++ b/pro/src/pages/Offers/Offers/OfferItem/OfferItem.module.scss
@@ -40,8 +40,6 @@
     align-items: flex-start;
 
     &-link {
-      @include fonts.button;
-
       display: block;
       overflow-wrap: break-word;
 

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/DuoCheckbox/DuoCheckbox.module.scss
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/DuoCheckbox/DuoCheckbox.module.scss
@@ -22,10 +22,9 @@
   }
 
   &-selected {
+    @include fonts.bold;
+
     border: rem.torem(2px) solid var(--color-secondary-light);
-
-    @include fonts.button;
-
     background-color: var(--color-background-secondary);
   }
 

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingOfferCell.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingOfferCell.module.scss
@@ -2,7 +2,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .booking-offer-name {
-  @include fonts.button;
+  @include fonts.bold;
 
   display: block;
   overflow-wrap: break-word;

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingStatusCell.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingStatusCell.module.scss
@@ -49,7 +49,7 @@
 }
 
 .bs-offer-title {
-  @include fonts.button;
+  @include fonts.bold;
 
   display: block;
 }

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveBookingDetails.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveBookingDetails.module.scss
@@ -20,7 +20,7 @@
 }
 
 .contact-details-title {
-  @include fonts.button;
+  @include fonts.bold;
 
   margin-bottom: rem.torem(8px);
 }

--- a/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.module.scss
+++ b/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.module.scss
@@ -49,7 +49,7 @@
   margin-top: rem.torem(45px);
 
   &-title {
-    @include fonts.button;
+    @include fonts.bold;
 
     margin-bottom: rem.torem(4px);
     line-height: normal;

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/DayCheckbox.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/DayCheckbox.module.scss
@@ -53,7 +53,7 @@ $checkbox-size: rem.torem(40px);
     border: rem.torem(2px) solid var(--color-secondary-light);
     background-color: var(--color-background-secondary);
 
-    @include fonts.button;
+    @include fonts.bold;
 
     &:focus {
       border: rem.torem(2px) solid var(--color-secondary-light);

--- a/pro/src/screens/Offers/Offers.module.scss
+++ b/pro/src/screens/Offers/Offers.module.scss
@@ -2,15 +2,15 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 
 .banner {
-    margin-bottom: rem.torem(16px);
+  margin-bottom: rem.torem(16px);
 
-    &-onboarding {
-        display: flex;
-        flex-direction: column;
-        gap: rem.torem(8px);
-    
-        &-title {
-            @include fonts.button
-        }
+  &-onboarding {
+    display: flex;
+    flex-direction: column;
+    gap: rem.torem(8px);
+
+    &-title {
+      @include fonts.bold;
     }
+  }
 }

--- a/pro/src/screens/SignupJourneyForm/Offerers/Offerers.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Offerers/Offerers.module.scss
@@ -57,12 +57,6 @@ $small-gap: rem.torem(8px);
   @include fonts.title4;
 }
 
-.dialog-subtitle {
-  @include fonts.button;
-
-  line-height: rem.torem(20px);
-}
-
 .dialog-content {
   margin-top: rem.torem(24px);
 }

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -120,8 +120,6 @@
   &-quaternary,
   &-ternary-pink,
   &-quaternary-pink {
-    @include fonts.button;
-
     color: var(--color-black);
     align-items: flex-start;
     background-color: transparent;

--- a/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.module.scss
+++ b/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.module.scss
@@ -50,10 +50,9 @@ $radio-size: rem.torem(16px);
   }
 
   &.is-selected {
+    @include fonts.bold;
+
     border: $border-size-selected solid var(--color-secondary-light);
-
-    @include fonts.button;
-
     background-color: var(--color-background-secondary);
   }
 

--- a/pro/src/ui-kit/form/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
+++ b/pro/src/ui-kit/form/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
@@ -50,7 +50,7 @@ $text-padding-left: calc(
 
 .select-input {
   @include formsM.input-theme;
-  @include fonts.button;
+  @include fonts.bold;
 
   padding-left: $text-padding-left;
   padding-right: rem.torem(8px);

--- a/pro/src/ui-kit/form/Slider/Slider.module.scss
+++ b/pro/src/ui-kit/form/Slider/Slider.module.scss
@@ -7,7 +7,7 @@
 }
 
 .slider-value {
-  @include fonts.button;
+  @include fonts.bold;
 }
 
 .slider-header {
@@ -18,7 +18,7 @@
   margin-bottom: rem.torem(12px);
 
   .input-value {
-    @include fonts.button;
+    @include fonts.bold;
   }
 }
 

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
@@ -130,7 +130,7 @@
     background-color: var(--color-background-secondary);
 
     .base-radio-label {
-      @include fonts.button;
+      @include fonts.bold;
 
       padding: rem.torem(16px) rem.torem(16px) rem.torem(16px) 0;
     }


### PR DESCRIPTION
…ont.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30932
**Objectif**
On a tendance à utiliser la typo "button" pour faire du gras. Cette PR remplace ces utilisations de la typo button inappropriées par la typo bold (qui fait juste du gras).
L'idée est qu'à terme la typo button du DS risque d'avoir des styles spécifiques au design de différent types de bouton.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
