### PR TITLE
(PC-30878)[API] fix: fix validation of `bookingDatetimeLimit`

### DIFF
--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -16,6 +16,7 @@ from pcapi.models import db
 from pcapi.repository import transaction
 from pcapi.routes.serialization.collective_stock_serialize import CollectiveStockCreationBodyModel
 from pcapi.serialization import utils as serialization_utils
+from pcapi.utils import date
 
 
 logger = logging.getLogger(__name__)
@@ -122,6 +123,21 @@ def edit_collective_stock(
     if booking_limit is None:
         check_booking_limit_datetime = stock.bookingLimitDatetime
 
+    # bypass check because when beginning and booking_limit_datetime are on the
+    # same day, booking_limit_datetime is set to beginning
+    should_bypass_check_booking_limit_datetime = False
+
+    if stock.collectiveOffer.venue.departementCode is not None:
+        check_beginning_with_tz = date.utc_datetime_to_department_timezone(
+            check_beginning, stock.collectiveOffer.venue.departementCode  # type: ignore[arg-type]
+        )
+        check_booking_limit_datetime_with_tz = date.utc_datetime_to_department_timezone(
+            check_booking_limit_datetime, stock.collectiveOffer.venue.departementCode  # type: ignore[arg-type]
+        )
+        should_bypass_check_booking_limit_datetime = (
+            check_beginning_with_tz.date() == check_booking_limit_datetime_with_tz.date()
+        )
+
     current_booking = educational_models.CollectiveBooking.query.filter(
         educational_models.CollectiveBooking.collectiveStockId == stock.id,
         sa.sql.elements.not_(
@@ -144,7 +160,8 @@ def edit_collective_stock(
             validation.check_collective_stock_is_editable(stock)
     else:
         validation.check_collective_stock_is_editable(stock)
-        offer_validation.check_booking_limit_datetime(stock, check_beginning, check_booking_limit_datetime)
+        if not should_bypass_check_booking_limit_datetime:
+            offer_validation.check_booking_limit_datetime(stock, check_beginning, check_booking_limit_datetime)
         if current_booking:
             validation.check_collective_booking_status_pending(current_booking)
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -451,24 +451,22 @@ def check_booking_limit_datetime(
     beginning: datetime.datetime | None,
     booking_limit_datetime: datetime.datetime | None,
 ) -> None:
+    if not (beginning and booking_limit_datetime):  # nothing to check
+        return
+
     if stock:
         if isinstance(stock, educational_models.CollectiveStock):
             offer = stock.collectiveOffer
         else:
             offer = stock.offer
 
-        if beginning and booking_limit_datetime and offer and offer.venue.departementCode is not None:
-            beginning_tz = date.utc_datetime_to_department_timezone(beginning, offer.venue.departementCode)
-            booking_limit_datetime_tz = date.utc_datetime_to_department_timezone(
+        if offer.venue.departementCode is not None:  # update to timezone
+            beginning = date.utc_datetime_to_department_timezone(beginning, offer.venue.departementCode)
+            booking_limit_datetime = date.utc_datetime_to_department_timezone(
                 booking_limit_datetime, offer.venue.departementCode
             )
 
-            same_date = beginning_tz.date() == booking_limit_datetime_tz.date()
-            if not same_date and booking_limit_datetime_tz > beginning_tz:
-                raise exceptions.BookingLimitDatetimeTooLate()
-            return
-
-    if beginning and booking_limit_datetime and booking_limit_datetime > beginning:
+    if booking_limit_datetime > beginning:
         raise exceptions.BookingLimitDatetimeTooLate()
 
 


### PR DESCRIPTION
It did not raised as it should when the venue `departmentCode` was not null and the `bookingDatetimeLimit` was only a few hours too late. This caused 500 hundreds as the check at DB level raised an error

## But de la pull request

Ticket Jira  : https://passculture.atlassian.net/browse/PC-30878

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
