### PR TITLE
(BSR)[PRO] fix: color lostpassword page

### DIFF
--- a/pro/src/pages/LostPassword/LostPassword.module.scss
+++ b/pro/src/pages/LostPassword/LostPassword.module.scss
@@ -16,6 +16,4 @@
   @media (min-width: size.$tablet) {
     min-height: 100vh;
   }
-
-  color: red;
 }


### PR DESCRIPTION
## Vérifications

Une couleur rouge s'était introduite sur la page de mot de passe oublié, on l'enlève 

Avant : 
<img width="1331" alt="Capture d’écran 2024-07-22 à 12 07 15" src="https://github.com/user-attachments/assets/0a9f65f1-344f-475d-b3b0-d2edc8c3a05c">

Après : 
<img width="1331" alt="Capture d’écran 2024-07-22 à 12 08 01" src="https://github.com/user-attachments/assets/e73c496b-04f0-41ef-8215-dbfe650b5290">
