### PR TITLE
Pc 30958 fix todos

### DIFF
--- a/pro/src/components/Breadcrumb/Breadcrumb.module.scss
+++ b/pro/src/components/Breadcrumb/Breadcrumb.module.scss
@@ -3,7 +3,6 @@
 
 .breadcrumb {
   &-list {
-    list-style: none;
     display: flex;
     align-items: center;
     gap: rem.torem(8px);

--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
@@ -1,15 +1,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
 
-// Add padding/margin because stepper labels are absolute positioned
-// 20px is a magical value to visually align the stepper labels
-// TODO (alberict): refactor the stepper component CSS so that the labels
-// can't overflow the container (should be possible with flexbox and/or ::before pseudo-elements)
-.stepper-navigation {
-  padding-left: rem.torem(20px);
-  padding-right: rem.torem(20px);
-}
-
 .eac-layout {
   position: relative;
 

--- a/pro/src/components/IndividualOfferNavigation/IndividualOfferNavigation.module.scss
+++ b/pro/src/components/IndividualOfferNavigation/IndividualOfferNavigation.module.scss
@@ -8,9 +8,3 @@
 .tabs {
   margin: rem.torem(32px) 0;
 }
-
-@media (min-width: size.$tablet) {
-  .stepper {
-    padding: 0 rem.torem(10px);
-  }
-}

--- a/pro/src/components/Stepper/StepContent.tsx
+++ b/pro/src/components/Stepper/StepContent.tsx
@@ -7,15 +7,28 @@ import styles from './Stepper.module.scss'
 interface StepContent {
   step: Step
   stepIndex: number
+  stepsCount: number
+  stepperWidth?: number
 }
 
-export const StepContent = ({ step, stepIndex }: StepContent): JSX.Element => {
+export const StepContent = ({
+  step,
+  stepIndex,
+  stepsCount,
+  stepperWidth,
+}: StepContent): JSX.Element => {
   const stepContent = (
     <>
       <div className={styles['number']}>
         <div className={styles['inner']}>{stepIndex + 1}</div>
       </div>
-      <div className={styles['label']}>
+      <div
+        className={styles['label']}
+        style={{
+          //  Give a width to the label based on the total width available
+          width: `${(stepperWidth ?? stepsCount * 100) / (stepsCount + 1)}px`,
+        }}
+      >
         <div className={styles['inner']}>
           <span>{step.label}</span>
         </div>

--- a/pro/src/components/Stepper/Stepper.module.scss
+++ b/pro/src/components/Stepper/Stepper.module.scss
@@ -146,17 +146,34 @@ $number-size: rem.torem(30px);
         }
       }
 
+      .step {
+        justify-content: center;
+      }
+
       .label {
-        margin-left: 50%;
         position: absolute;
-        white-space: nowrap;
-        line-height: $step-label-height;
-        bottom: rem.torem(-17.274px);
+        width: 7rem;
+        text-align: center;
+        top: calc($number-size + rem.torem(4px));
         text-decoration: underline transparent;
         transition: text-decoration 250ms;
+      }
 
-        .inner {
-          margin-left: -50%;
+      &:first-child {
+        //  so that the first label does not overlfow the list container on the left
+        .label {
+          width: unset;
+          left: 0;
+          text-align: left;
+        }
+      }
+
+      &:last-child {
+        //  so that the last label does not overlfow the list container on the right
+        .label {
+          width: unset;
+          right: 0;
+          text-align: right;
         }
       }
     }

--- a/pro/src/components/Stepper/Stepper.tsx
+++ b/pro/src/components/Stepper/Stepper.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import React from 'react'
+import React, { useLayoutEffect, useRef, useState } from 'react'
 
 import { StepContent } from 'components/Stepper/StepContent'
 import { findLastIndex } from 'utils/findLastIndex'
@@ -32,12 +32,27 @@ export const Stepper = ({
   steps,
   className,
 }: StepperProps): JSX.Element => {
+  const listRef = useRef<HTMLOListElement>(null)
+  const [stepperWidth, setStepperWidth] = useState(0)
+
   const lastStepIndex = steps.length - 1
   const lastLineToActivate = findLastIndex(steps, (step: Step) => !!step.url)
 
+  useLayoutEffect(() => {
+    //  Before the first render, get the list total width
+    if (listRef.current) {
+      const { width } = listRef.current.getBoundingClientRect()
+      setStepperWidth(width)
+    }
+  }, [])
+
   return (
     <>
-      <ol className={cn(styles[`stepper`], className)} data-testid="stepper">
+      <ol
+        className={cn(styles[`stepper`], className)}
+        data-testid="stepper"
+        ref={listRef}
+      >
         {steps.map((step, stepIndex) => {
           const isActive = activeStep === step.id
           const isLastStep = lastStepIndex === stepIndex
@@ -53,7 +68,12 @@ export const Stepper = ({
               key={`step-${step.id}`}
               data-testid={`step-${step.id}`}
             >
-              <StepContent step={step} stepIndex={stepIndex} />
+              <StepContent
+                step={step}
+                stepIndex={stepIndex}
+                stepsCount={steps.length}
+                stepperWidth={stepperWidth}
+              />
               {isActive && (
                 <span className={styles['visually-hidden']}>
                   {' '}

--- a/pro/src/screens/IndividualOffer/StocksEventCreation/HelpSection/HelpSection.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksEventCreation/HelpSection/HelpSection.module.scss
@@ -25,7 +25,6 @@
 
 .steps-list {
   display: flex;
-  list-style: none;
   justify-content: space-evenly;
   flex-wrap: wrap;
 }

--- a/pro/src/styles/global/_layout.scss
+++ b/pro/src/styles/global/_layout.scss
@@ -55,7 +55,8 @@ address {
   font-style: normal;
 }
 
-ul {
+ul,
+ol {
   list-style: none;
 }
 

--- a/pro/src/styles/variables/_themes.scss
+++ b/pro/src/styles/variables/_themes.scss
@@ -65,10 +65,6 @@ html[data-theme="pink"],
   --color-input-bg-color-disabled: var(--color-grey-light);
   --color-input-text-color-disabled: var(--color-grey-dark);
 
-  // TODO used in button, should be remplaced by real disable colors
-  // see ticket PC-27778
-  --color-primary-disabled: #ff99be;
-
   // ADAGE COLORS
   // waiting for designer approval :
   --color-adage-discovery-background: #fbfafc;
@@ -158,10 +154,6 @@ html[data-theme="blue"],
   --color-input-bg-color: var(--color-white);
   --color-input-bg-color-disabled: var(--color-grey-light);
   --color-input-text-color-disabled: var(--color-grey-dark);
-
-  // TODO used in button, should be remplaced by real disable colors
-  // see ticket PC-27778
-  --color-primary-disabled: var(--color-grey-light);
 
   // ADAGE COLORS
   // waiting for designer approval :

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -101,9 +101,9 @@
 
     &:disabled,
     &.button-disabled {
-      background-color: var(--color-white);
-      border-color: var(--color-primary-disabled);
-      color: var(--color-primary-disabled);
+      background-color: var(--color-grey-light);
+      color: var(--color-grey-dark);
+      border-color: var(--color-grey-light);
     }
 
     &:disabled .button-icon,

--- a/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.module.scss
+++ b/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.module.scss
@@ -32,11 +32,9 @@ $radio-size: rem.torem(16px);
 
   &-icon {
     flex-shrink: 0;
-    size: 44px;
     width: rem.torem(44px);
     height: rem.torem(44px);
     color: var(--color-secondary-light);
-    fill: var(--color-secondary-light); // TODO: delete after all icons update
   }
 
   &:hover {

--- a/pro/src/ui-kit/Timeline/Timeline.module.scss
+++ b/pro/src/ui-kit/Timeline/Timeline.module.scss
@@ -10,10 +10,6 @@ $time-line-width: rem.torem(2px);
   display: flex;
   gap: $margin-between-steps;
   flex-direction: column;
-
-  // TODO This kind of reset should be in a global reset file
-  list-style: none;
-  padding-left: 0;
 }
 
 .icon {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30958

**Objectif**
Correction de 4 TODO dans des fichiers de styles : 
- Ajout d'un style par défaut du `ol` dans le fichier de reset `layout.scss`
- Remplacement de la couleur `disabled` du button secondary par du gris, comme dans la maquette de la lib
- Suppression du style `fill` sur les icons des readio buttons avec image (le style n'ayant plus d'utilité)
- Rework du stepper pour que le premier et dernier éléments ne dépassent pas du container de la liste (et éviter d'avoir à ajouter des marges autour du stepper qui dépendent de la longueur du texte qui dépasse)

Pour le stepper, voici un avant/après
**Avant**
<img width="777" alt="Capture d’écran 2024-07-22 à 12 21 00" src="https://github.com/user-attachments/assets/74b0e270-bbb2-427e-b89e-53ddd74ea51f">

**Après**
<img width="785" alt="Capture d’écran 2024-07-22 à 12 21 29" src="https://github.com/user-attachments/assets/98646ee5-830d-43af-b705-4a9c99507ec3">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
