### PR TITLE
(PC-30376)[API] feat: sending oa label when not linked to venue

### DIFF
--- a/api/src/pcapi/routes/serialization/address_serialize.py
+++ b/api/src/pcapi/routes/serialization/address_serialize.py
@@ -26,7 +26,7 @@ class AddressResponseModel(BaseModel):
 
 
 class AddressResponseIsEditableModel(AddressResponseModel):
-    label: str
+    label: str | None = None
     isEditable: bool
 
 

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -246,7 +246,7 @@ class ListOffersOfferResponseModelsGetterDict(GetterDict):
             ):  # The only offers without oa neither in themselves nor in venues are the numerics ones.
                 return None
             offererAddress = GetOffererAddressWithIsEditableResponseModel.from_orm(offerer_address)
-            offererAddress.label = offererAddress.label or self._obj.venue.common_name
+            offererAddress.label = offererAddress.label if offererAddress.isEditable else self._obj.venue.common_name
             return AddressResponseIsEditableModel(
                 **retrieve_address_info_from_oa(offerer_address),
                 **offererAddress.dict(exclude={"id"}),

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -635,7 +635,6 @@ class Returns200Test:
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
         offerer_address1 = offerers_factories.OffererAddressFactory(
-            label="Accor Arena 1",
             offerer=offerer,
             address__street="4 Boulevard de Bercy",
             address__banId="75112_0877_00001",
@@ -643,7 +642,9 @@ class Returns200Test:
             address__longitude=1.34765,
             address__latitude=4.34765,
         )
-        venue = offerers_factories.VenueFactory(managingOfferer=offerer, offererAddress=offerer_address1)
+        venue = offerers_factories.VenueFactory(
+            managingOfferer=offerer, offererAddress=offerer_address1, name="Best Place to be"
+        )
 
         event_offer1 = offers_factories.EventOfferFactory(
             name="The Weeknd", subcategoryId=subcategories.CONCERT.id, venue=venue, offererAddress=None
@@ -681,7 +682,7 @@ class Returns200Test:
                         "id": offerer_address1.address.id,
                         "banId": "75112_0877_00001",
                         "inseeCode": "75112",
-                        "label": "Accor Arena 1",
+                        "label": "Best Place to be",
                         "street": "4 Boulevard de Bercy",
                         "postalCode": "75001",
                         "city": "Paris",

--- a/pro/src/apiClient/v1/models/AddressResponseIsEditableModel.ts
+++ b/pro/src/apiClient/v1/models/AddressResponseIsEditableModel.ts
@@ -8,7 +8,7 @@ export type AddressResponseIsEditableModel = {
   id: number;
   inseeCode?: string | null;
   isEditable: boolean;
-  label: string;
+  label?: string | null;
   latitude: number;
   longitude: number;
   postalCode: string;


### PR DESCRIPTION
## But de la pull request
renvoyer le label de la venue uniquement que quand l'oa est lié à une venue
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30376

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
