### PR TITLE
(PC-30741)[BO] feat: log user sync in pro venue pivot

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -63,7 +63,8 @@ class ActionType(enum.Enum):
     VENUE_CREATED = "Lieu créé"
     LINK_VENUE_BANK_ACCOUNT_DEPRECATED = "Lieu dissocié d'un compte bancaire"
     LINK_VENUE_BANK_ACCOUNT_CREATED = "Lieu associé à un compte bancaire"
-    LINK_VENUE_PROVIDER_DELETED = "Suppression du lien avec le provider"
+    LINK_VENUE_PROVIDER_DELETED = "Suppression du lien avec le partenaire technique"
+    SYNC_VENUE_TO_PROVIDER = "synchronisation du lieu avec un partenaire technique"
 
     # Permissions role changes:
     ROLE_PERMISSIONS_CHANGED = "Modification des permissions du rôle"
@@ -75,6 +76,7 @@ class ActionType(enum.Enum):
     RULE_MODIFIED = "Modification d'une règle de conformité"
     # Pivot changes
     PIVOT_DELETED = "Suppression d'un pivot"
+    PIVOT_CREATED = "Création d'un pivot"
 
 
 ACTION_HISTORY_ORDER_BY = "ActionHistory.actionDate.asc().nulls_first()"

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -45,6 +45,7 @@ UNCHANGED = T_UNCHANGED.TOKEN
 def create_venue_provider(
     provider_id: int,
     venue_id: int,
+    current_user: users_models.User,
     payload: providers_models.VenueProviderCreationPayload = providers_models.VenueProviderCreationPayload(),
 ) -> providers_models.VenueProvider:
     provider = providers_repository.get_provider_enabled_for_pro_by_id(provider_id)
@@ -79,6 +80,14 @@ def create_venue_provider(
             [venue.id],
             reason=search.IndexationReason.VENUE_PROVIDER_CREATION,
         )
+
+    history_api.add_action(
+        history_models.ActionType.SYNC_VENUE_TO_PROVIDER,
+        author=current_user,
+        venue=venue,
+        provider_name=provider.name,
+    )
+    db.session.commit()
 
     logger.info(
         "La synchronisation d'offre a été activée",

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -634,6 +634,22 @@ def _format_modified_info_value(value: typing.Any, name: str | None = None) -> s
     return str(value)
 
 
+def format_pivot_name(pivot_name: str) -> str:
+    match pivot_name:
+        case "allocine":
+            return "Allociné"
+        case "boost":
+            return "Boost"
+        case "cgr":
+            return "CGR"
+        case "cineoffice":
+            return "CineOffice"
+        case "ems":
+            return "EMS"
+        case _:
+            return pivot_name
+
+
 def format_modified_info_values(modified_info: typing.Any, name: str | None = None) -> str:
     old_info = modified_info.get("old_info")
     new_info = modified_info.get("new_info")
@@ -1259,6 +1275,7 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_offer_types"] = format_offer_types
     app.jinja_env.filters["format_website"] = format_website
     app.jinja_env.filters["format_venue_target"] = format_venue_target
+    app.jinja_env.filters["format_pivot_name"] = format_pivot_name
     app.jinja_env.filters["format_titelive_id_lectorat"] = format_titelive_id_lectorat
     app.jinja_env.filters["format_date_range"] = format_date_range
     app.jinja_env.filters["parse_referrer"] = parse_referrer

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/allocine.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/allocine.py
@@ -107,3 +107,7 @@ class AllocineContext(PivotContext):
             db.session.delete(venue_provider)
         db.session.delete(pivot)
         return True
+
+    @staticmethod
+    def get_cinema_id(form: forms.EditPivotForm) -> str:
+        return form.theater_id.data

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/base.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/base.py
@@ -108,3 +108,7 @@ class PivotContext:
         db.session.delete(pivot)
         db.session.delete(cinema_provider_pivot)
         return True
+
+    @staticmethod
+    def get_cinema_id(form: forms.EditPivotForm) -> str:
+        return form.cinema_id.data

--- a/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
@@ -31,6 +31,12 @@
               Lieu : {{ links.build_venue_name_to_details_link(action.venue) }}
             {% elif action.actionType.name == "OFFERER_ATTESTATION_CHECKED" %}
               L'état positif ou négatif de l'attestation {{ action.extraData['provider'] }} a été visualisé
+            {% elif action.actionType.name in ["SYNC_VENUE_TO_PROVIDER"] %}
+              Partenaire technique : {{ action.extraData["provider_name"] }}
+            {% elif action.actionType.name in ["PIVOT_CREATED"] %}
+              Création d'un pivot {{ action.extraData["pivot_name"] | format_pivot_name }},
+              <br />
+              Identifiant du cinéma : {{ action.extraData["cinema_id"] }}
             {% elif action.extraData and action.actionType.name in ["OFFERER_REJECTED", "USER_OFFERER_REJECTED"] %}
               Raison : {{ action.extraData["rejection_reason"] | format_offerer_rejection_reason }}
             {% endif %}

--- a/api/src/pcapi/routes/pro/venue_providers.py
+++ b/api/src/pcapi/routes/pro/venue_providers.py
@@ -52,9 +52,10 @@ def create_venue_provider(body: PostVenueProviderBody) -> VenueProviderResponse:
 
     try:
         new_venue_provider = api.create_venue_provider(
-            body.providerId,
-            body.venueId,
-            VenueProviderCreationPayload(
+            provider_id=body.providerId,
+            venue_id=body.venueId,
+            current_user=current_user,
+            payload=VenueProviderCreationPayload(
                 isDuo=body.isDuo,
                 price=body.price,
                 quantity=body.quantity,

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -36,10 +36,11 @@ class CreateVenueProviderTest:
         # Given
         providerId = 1
         venueId = 2
+        author = users_factories.UserFactory()
 
         # When
         with pytest.raises(exceptions.ProviderNotFound):
-            api.create_venue_provider(providerId, venueId)
+            api.create_venue_provider(providerId, venueId, current_user=author)
 
         # Then
         assert not providers_models.VenueProvider.query.first()
@@ -72,9 +73,10 @@ class CreateVenueProviderTest:
             apiUrl="https://example.com/api",
             localClass=None,
         )
+        author = users_factories.UserFactory()
 
         # When
-        api.create_venue_provider(provider.id, venue.id)
+        api.create_venue_provider(provider.id, venue.id, current_user=author)
 
         # Then
         assert venue.isPermanent == is_permanent

--- a/api/tests/routes/pro/post_venue_provider_test.py
+++ b/api/tests/routes/pro/post_venue_provider_test.py
@@ -8,6 +8,7 @@ from pcapi.connectors.serialization.cine_digital_service_serializers import Show
 from pcapi.connectors.serialization.cine_digital_service_serializers import ShowTariffCDS
 from pcapi.connectors.serialization.cine_digital_service_serializers import ShowsMediaoptionsCDS
 from pcapi.core.external_bookings.models import Movie
+from pcapi.core.history import models as history_models
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.providers.factories import CinemaProviderPivotFactory
@@ -54,6 +55,10 @@ class Returns201Test:
         assert venue_provider.providerId == provider.id
         assert venue_provider.venueIdAtOfferProvider == "12345678912345"
         assert "id" in response.json
+        action = history_models.ActionHistory.query.one()
+        assert action.actionType == history_models.ActionType.SYNC_VENUE_TO_PROVIDER
+        assert action.authorUser == user
+        assert action.extraData["provider_name"] == venue_provider.provider.name
 
         venue_provider_id = response.json["id"]
         mock_synchronize_venue_provider.assert_called_once_with(venue_provider_id)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30741

## Vérifications

### verification front 

Lorsque je syncrhonise via pro : 
<img width="918" alt="Capture d’écran 2024-07-24 à 17 17 09" src="https://github.com/user-attachments/assets/21099600-8623-47e6-b5ee-5935b970a9e1">
ALORS un action history est crée avec ces informations 
<img width="1012" alt="Capture d’écran 2024-07-24 à 17 18 45" src="https://github.com/user-attachments/assets/b05b2761-3dcf-4f29-9247-005dfb22cc70">
ET L'aciont history est visible ainsi dans le lieu en question
<img width="1062" alt="Capture d’écran 2024-07-24 à 17 19 36" src="https://github.com/user-attachments/assets/2888831b-19f3-47cd-87f5-d93e85af2eb4">

Lorsque je créer un pivot : 
<img width="836" alt="Capture d’écran 2024-07-24 à 17 21 14" src="https://github.com/user-attachments/assets/f348a315-2622-40c6-8aad-8f1a0516c3ec">
ALORS 
un action history est crée : 
<img width="940" alt="Capture d’écran 2024-07-24 à 17 23 37" src="https://github.com/user-attachments/assets/02f186c0-4929-4ca9-84c3-15901baa8e5b">
on peut voir cet action history ici : 
<img width="1512" alt="Capture d’écran 2024-07-24 à 17 25 57" src="https://github.com/user-attachments/assets/0d4042e1-809e-4a7d-ae81-b92105447940">


### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 

Dans l'application pro, dans les parametres generaux, 
lorsque le formulaire de syncronisation d'un lieu a un pivot et utilisé avec : le logiciel, le siret du lieu, la raison sociale, et eventuellement le nom public ALORS
- la synchronisation est lancé en asynchrone _deja fait_
- un log historique est fait et qui apporte les informations  concernant le logiciel, le nom de l'auteur, la date

_test observé_ => _test_when_venue_provider_is_successfully_created_ j'ai ajouter l'action history montrant la synchronisation
=> _test_api_ pas la peine d'ajouter l'action history car pas d'auteur dans les tests

Dans le backoffice, dans la page du compte,
lorsque l'on va sur le lieu qui a été synchronisé sur l'app pro ALORS
- on voit l'action history avec le nom de l'auteur, le logiciel, la date à laquelle la synchronisation a été effectué.


Dans le backoffice dans synchronisation à un pivot
lorsque l'on créer un pivot rattaché a un lieu ALORS
- un action history est effectué qui prendra l'auteur, le type du pivot ( allociné ou autres) , l'identifiant du cinéma. la date 

_test observé_ => class _CreatePivotTest_ contient _5 tests_ repertoriant chacun des différent pivot

Dans le backoffice dans la page du compte
lorsque l'on va sur le lieu dont le pivot a été crée ALORS
- on voir l'action history avec le nom de l'auteur, le type de pivot et l'identifiant cinéma

### Verification ticket

- nom du ticket conforme -> OK
- auteur du ticket -> OK
- nombre de commit -> OK
- nom du commit -> OK
- mettre le ticket en code-review -> OK

### Tache restante si WIP + AUTRE

- refresh de la page github -> OK
- Rien de visible
