### PR TITLE
(PC-30963)[API] Add CLI command to easily migrate existing `VenueProvider` to new permission system

### DIFF
--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -95,6 +95,13 @@ class VenueProviderExternalUrlsFactory(BaseFactory):
     notificationExternalUrl = factory.Sequence("https://{}.example.org/notification".format)
 
 
+class VenueProviderPermissionFactory(BaseFactory):
+    class Meta:
+        model = models.VenueProviderPermission
+
+    venueProvider = factory.SubFactory(VenueProviderFactory)
+
+
 class CinemaProviderPivotFactory(BaseFactory):
     class Meta:
         model = models.CinemaProviderPivot

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -17,6 +17,39 @@ from . import constants
 from . import models
 
 
+def add_all_permissions_for_venue_provider(venue_provider: models.VenueProvider) -> None:
+    for resource in models.ApiResourceEnum:
+        for permission in models.PermissionEnum:
+            venue_provider_permission = models.VenueProviderPermission(
+                venueProvider=venue_provider,
+                resource=resource,
+                permission=permission,
+            )
+            db.session.add(venue_provider_permission)
+
+
+def get_all_venue_providers_with_no_permission() -> BaseQuery:
+    return (
+        models.VenueProvider.query.outerjoin(models.VenueProviderPermission)
+        .filter(models.VenueProvider.permissions == None)
+        .filter(models.VenueProvider.isFromAllocineProvider == False)
+        .filter(models.VenueProvider.isFromCinemaProvider == False)
+    )
+
+
+def get_venue_provider_permission_or_none(
+    venue_provider_id: int,
+    resource: models.ApiResourceEnum,
+    permission: models.PermissionEnum,
+) -> models.VenueProviderPermission | None:
+    return (
+        models.VenueProviderPermission.query.filter(models.VenueProviderPermission.venueProviderId == venue_provider_id)
+        .filter(models.VenueProviderPermission.resource == resource)
+        .filter(models.VenueProviderPermission.permission == permission)
+        .one_or_none()
+    )
+
+
 def get_venue_provider_by_id(venue_provider_id: int) -> models.VenueProvider:
     return models.VenueProvider.query.filter_by(id=venue_provider_id).one()
 

--- a/api/src/pcapi/scripts/install.py
+++ b/api/src/pcapi/scripts/install.py
@@ -32,6 +32,7 @@ def install_commands(app: flask.Flask) -> None:
         "pcapi.scripts.install_data",
         "pcapi.scripts.generate_expected_openapi_json",
         "pcapi.scripts.provider.check_provider_api",
+        "pcapi.scripts.provider.migrate_venue_providers_to_permission_system",
         "pcapi.scripts.sandbox",
         "pcapi.scripts.ubble_archive_past_identifications",
         "pcapi.scripts.offer.fix_offer_data_titelive",

--- a/api/src/pcapi/scripts/provider/migrate_venue_providers_to_permission_system.py
+++ b/api/src/pcapi/scripts/provider/migrate_venue_providers_to_permission_system.py
@@ -1,0 +1,72 @@
+import click
+from sqlalchemy.exc import NoResultFound
+
+from pcapi.core.providers import models as providers_models
+from pcapi.core.providers import repository as providers_repository
+from pcapi.repository import transaction
+from pcapi.scripts.utils import PromptColors
+from pcapi.utils.blueprint import Blueprint
+
+
+blueprint = Blueprint(__name__, __name__)
+
+
+def _migrate_venue_provider(venue_provider: providers_models.VenueProvider) -> None:
+    if len(venue_provider.permissions) > 0:
+        print(
+            f"{PromptColors.YELLOW}`VenueProvider` id={venue_provider.id} has already been migrated!{PromptColors.END_COLOR}"
+        )
+        return
+
+    with transaction():
+        providers_repository.add_all_permissions_for_venue_provider(venue_provider=venue_provider)
+
+    print(
+        f"{PromptColors.GREEN}`VenueProvider` id={venue_provider.id} has been successfully migrated to the permission system! {PromptColors.END_COLOR}"
+    )
+    return
+
+
+@blueprint.cli.command("migrate_venue_providers_to_permission_system")
+@click.option("--venue_provider_id", type=int, required=False)
+@click.option("--all-venue-providers", type=bool, required=False)
+def migrate_venue_providers_to_permission_system(
+    venue_provider_id: int | None,
+    all_venue_providers: bool | None,
+) -> None:
+    """
+    Migrate existing `VenueProvider` to the new permission system, meaning it creates
+    all the `VenueProviderPermission` necessary to give full access to the existing
+    integration and prevent any regression.
+
+    If a `VenueProvider` already has at least one `VenueProviderPermission` we consider
+    that it has already been migrated.
+
+    :venue_provider_id: To migrate a specific `VenueProvider` using its id
+    :all: When set to `true`, migrate all the `VenueProviders` that do not have a `VenueProviderPermission`
+    """
+    if venue_provider_id is None and not all_venue_providers:
+        print(
+            f"{PromptColors.RED}You should pass a `venue_provider_id` or set `all_venue_providers` to `true`{PromptColors.END_COLOR}"
+        )
+        return
+
+    if venue_provider_id is not None and all_venue_providers:
+        print(
+            f"{PromptColors.RED}You cannot give a `venue_provider_id` and set `all_venue_providers` to `true`. Choose one of the two option.{PromptColors.END_COLOR}"
+        )
+        return
+
+    if venue_provider_id:
+        try:
+            venue_provider = providers_repository.get_venue_provider_by_id(venue_provider_id)
+            _migrate_venue_provider(venue_provider)
+        except NoResultFound:
+            print(f"{PromptColors.RED}`VenueProvider` id={venue_provider_id} does not exist!{PromptColors.END_COLOR}")
+
+        return
+
+    venue_providers = providers_repository.get_all_venue_providers_with_no_permission()
+
+    for venue_provider in venue_providers:
+        _migrate_venue_provider(venue_provider)

--- a/api/src/pcapi/scripts/utils.py
+++ b/api/src/pcapi/scripts/utils.py
@@ -1,0 +1,5 @@
+class PromptColors:
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    END_COLOR = "\033[0m"


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-30963

Résumé : Ajout d'une commande pour donner toutes les permissions aux `VenueProvider` existants et faciliter la mise en place du nouveau système de permission.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
