### PR TITLE
(BSR)[API] fix: flush the deposit manually after object creation

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -2605,6 +2605,7 @@ def create_deposit(
         expirationDate=granted_deposit.expiration_date,
     )
     db.session.add(deposit)
+    db.session.flush()
 
     # Edge-cases: Validation of the registration occurred over a birthday
     # Then we need to add recredit to compensate


### PR DESCRIPTION
A database object should be manually flushed if the business logic depends on a field that is populated by the server, like the creation date. Furthermore, relying on autoflush is a bad practice because some routes disable it in order to have more control on the SQLAlchemy session.

## But de la pull request

Fixes sentry issues : 
- https://sentry.passculture.team/organizations/sentry/issues/1617244/?project=5&referrer=slack
- https://sentry.passculture.team/organizations/sentry/issues/1617236/?project=5&referrer=slack