### PR TITLE
(PC-29137)[PRO] fix: Fix tutorial accessibility - empty buttons.

### DIFF
--- a/pro/src/components/Tutorial/Tutorial.module.scss
+++ b/pro/src/components/Tutorial/Tutorial.module.scss
@@ -1,5 +1,6 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_a11y.scss" as a11y;
 @use "styles/variables/_size.scss" as size;
 
 .tutorial-box {
@@ -94,4 +95,8 @@
     width: rem.torem(560px);
     flex-direction: row;
   }
+}
+
+.visually-hidden {
+  @include a11y.visually-hidden;
 }

--- a/pro/src/components/Tutorial/Tutorial.tsx
+++ b/pro/src/components/Tutorial/Tutorial.tsx
@@ -92,9 +92,12 @@ export const Tutorial = ({ onFinish }: TutorialProps): JSX.Element => {
                 key={step.position}
                 onClick={goToStep(step.position)}
                 type="button"
-                aria-current={isActiveStep ? 'page' : false}
-                aria-label={`Étape du tutoriel ${step.position} sur ${stepsToShow.length}`}
-              />
+              >
+                <span className={styles['visually-hidden']}>
+                  Étape du tutoriel {step.position} sur {stepsToShow.length}{' '}
+                  {isActiveStep && '(en cours)'}
+                </span>
+              </button>
             )
           })}
         </div>

--- a/pro/src/components/TutorialDialog/__specs__/TutorialDialog.spec.tsx
+++ b/pro/src/components/TutorialDialog/__specs__/TutorialDialog.spec.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
+import { axe } from 'vitest-axe'
 
 import { api } from 'apiClient/api'
 import * as useAnalytics from 'app/App/analytics/firebase'
@@ -24,12 +24,20 @@ const stepTitles = [
   'Suivez et gérez vos réservations',
 ]
 
-const renderTutorialDialog = (options?: RenderWithProvidersOptions) =>
+const renderTutorialDialog = (options: RenderWithProvidersOptions) =>
   renderWithProviders(<TutorialDialog />, options)
 
 const mockLogEvent = vi.fn()
 
 describe('tutorial modal', () => {
+  it('should check content for accessibility', async () => {
+    const { container } = renderTutorialDialog({
+      user: sharedCurrentUserFactory({ hasSeenProTutorials: false }),
+    })
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
   it('should trigger an event when the user arrive on /accueil for the first time', async () => {
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
       logEvent: mockLogEvent,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29137

**Objectif**
Corriger un pb d'accessibilité du tutorial - les boutons du stepper n'ont pas de contenu.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
