### PR TITLE
(PC-30892)[PRO] style: Delete FF WIP_MANDATORY_BOOKING_CONTACT 2

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 59d02d648922 (pre) (head)
-08b944954eba (post) (head)
+943f189a4c71 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240725T093357_943f189a4c71_drop_wip_mandatory_booking_contact.py
+++ b/api/src/pcapi/alembic/versions/20240725T093357_943f189a4c71_drop_wip_mandatory_booking_contact.py
@@ -1,0 +1,35 @@
+"""
+Delete WIP_MANDATORY_BOOKING_CONTACT Feature Flag
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "943f189a4c71"
+down_revision = "08b944954eba"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def get_flag():  # type:ignore[no-untyped-def]
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="WIP_MANDATORY_BOOKING_CONTACT",
+        isActive=True,
+        description="Rend obligatoire offer.bookingContact pour les offres retirables",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -23,7 +23,6 @@ from pcapi.core.providers import models as providers_models
 from pcapi.domain import music_types
 from pcapi.domain import show_types
 from pcapi.models import api_errors
-from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.routes.public.books_stocks import serialization
 from pcapi.utils import date
@@ -419,7 +418,7 @@ def check_offer_withdrawal(
     if is_offer_withdrawable and withdrawal_type is None:
         raise exceptions.WithdrawableEventOfferMustHaveWithdrawal()
 
-    if FeatureToggle.WIP_MANDATORY_BOOKING_CONTACT.is_active() and is_offer_withdrawable and not booking_contact:
+    if is_offer_withdrawable and not booking_contact:
         raise exceptions.WithdrawableEventOfferMustHaveBookingContact()
 
     if withdrawal_type == models.WithdrawalTypeEnum.NO_TICKET and withdrawal_delay is not None:

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -102,7 +102,6 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY = "Changer le template d'email de confirmation de réservation"
     WIP_ENABLE_TRUSTED_DEVICE = "Active la fonctionnalité d'appareil de confiance"
     WIP_ENABLE_SUSPICIOUS_EMAIL_SEND = "Active l'envoie d'email lors de la détection d'une connexion suspicieuse"
-    WIP_MANDATORY_BOOKING_CONTACT = "Rend obligatoire offer.bookingContact pour les offres retirables"
     WIP_ENABLE_NEW_BANK_DETAILS_JOURNEY = "Activer le nouveau parcours de dépôt de coordonnées bancaires"
     WIP_ENABLE_MOCK_UBBLE = "Utiliser le mock Ubble à la place du vrai Ubble"
     WIP_ENABLE_GOOGLE_SSO = "Activer la connexion SSO pour les jeunes"

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -14,7 +14,6 @@ from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.offers.models import WithdrawalTypeEnum
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.providers.repository import get_provider_by_local_class
-from pcapi.core.testing import override_features
 from pcapi.models.api_errors import ApiErrors
 
 import tests
@@ -524,16 +523,6 @@ class CheckOfferWithdrawalTest:
                 booking_contact=None,
                 provider=None,
             )
-
-    @override_features(WIP_MANDATORY_BOOKING_CONTACT=False)
-    def test_withdrawable_event_offer_can_have_no_booking_contact(self):
-        assert not validation.check_offer_withdrawal(
-            withdrawal_type=WithdrawalTypeEnum.NO_TICKET,
-            withdrawal_delay=None,
-            subcategory_id=subcategories.FESTIVAL_MUSIQUE.id,
-            booking_contact=None,
-            provider=None,
-        )
 
     def test_withdrawable_event_offer_with_provider_can_be_in_app(self):
         provider = providers_factories.ProviderFactory(

--- a/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
+++ b/pro/src/components/IndividualOfferForm/Categories/Categories.tsx
@@ -11,7 +11,6 @@ import { Callout } from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { INDIVIDUAL_OFFER_SUBTYPE } from 'core/Offers/constants'
-import { useActiveFeature } from 'hooks/useActiveFeature'
 import fullMoreIcon from 'icons/full-more.svg'
 import {
   buildCategoryOptions,
@@ -56,9 +55,6 @@ export const Categories = ({
     setFieldValue,
     handleChange,
   } = useFormikContext<IndividualOfferFormValues>()
-  const isBookingContactEnabled = useActiveFeature(
-    'WIP_MANDATORY_BOOKING_CONTACT'
-  )
   const categoryOptions = buildCategoryOptions(categories)
   const subcategoryOptions = buildSubcategoryOptions(subCategories, categoryId)
 
@@ -68,7 +64,7 @@ export const Categories = ({
     )
 
     const { subcategoryFields: newSubcategoryFields } = buildSubcategoryFields(
-      isBookingContactEnabled,
+      true,
       newSubcategory
     )
     await setFieldValue('subCategoryFields', newSubcategoryFields)

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
@@ -10,7 +10,6 @@ import { OfferRefundWarning } from 'components/Banner/OfferRefundWarning'
 import { WithdrawalReminder } from 'components/Banner/WithdrawalReminder'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { REIMBURSEMENT_RULES } from 'core/Finances/constants'
-import { useActiveFeature } from 'hooks/useActiveFeature'
 import { Checkbox } from 'ui-kit/form/Checkbox/Checkbox'
 import { TextArea } from 'ui-kit/form/TextArea/TextArea'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
@@ -42,9 +41,6 @@ export const UsefulInformations = ({
   const {
     values: { subCategoryFields, withdrawalType },
   } = useFormikContext<IndividualOfferFormValues>()
-  const isBookingContactEnabled = useActiveFeature(
-    'WIP_MANDATORY_BOOKING_CONTACT'
-  )
 
   const displayNoRefundWarning =
     offerSubCategory?.reimbursementRule === REIMBURSEMENT_RULES.NOT_REIMBURSED
@@ -52,8 +48,7 @@ export const UsefulInformations = ({
   const displayWithdrawalReminder =
     !offerSubCategory?.isEvent && !isVenueVirtual
 
-  const displayBookingContact =
-    isBookingContactEnabled && offerSubCategory?.canBeWithdrawable
+  const displayBookingContact = offerSubCategory?.canBeWithdrawable
 
   return (
     <FormLayout.Section title="Informations pratiques">

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
@@ -47,8 +47,7 @@ const renderUsefulInformations = ({
           Submit
         </Button>
       </Form>
-    </Formik>,
-    { features: ['WIP_MANDATORY_BOOKING_CONTACT'] }
+    </Formik>
   )
 }
 

--- a/pro/src/components/IndividualOfferForm/utils/buildSubCategoryFields.ts
+++ b/pro/src/components/IndividualOfferForm/utils/buildSubCategoryFields.ts
@@ -20,7 +20,6 @@ export const buildSubcategoryFields = (
   if (subcategory?.canBeWithdrawable) {
     subcategoryFields.push('withdrawalType')
     subcategoryFields.push('withdrawalDelay')
-
     if (isBookingContactEnabled) {
       subcategoryFields.push('bookingContact')
     }

--- a/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
@@ -32,7 +32,6 @@ import { OFFER_WIZARD_MODE } from 'core/Offers/constants'
 import { getIndividualOfferUrl } from 'core/Offers/utils/getIndividualOfferUrl'
 import { isOfferDisabled } from 'core/Offers/utils/isOfferDisabled'
 import { PATCH_SUCCESS_MESSAGE } from 'core/shared/constants'
-import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useCurrentUser } from 'hooks/useCurrentUser'
 import { useNotification } from 'hooks/useNotification'
 import { useOfferWizardMode } from 'hooks/useOfferWizardMode'
@@ -76,10 +75,6 @@ export const InformationsScreen = ({
     useIndividualOfferImageUpload()
   const selectedOffererId = useSelector(selectCurrentOffererId)
 
-  const isBookingContactEnabled = useActiveFeature(
-    'WIP_MANDATORY_BOOKING_CONTACT'
-  )
-
   const queryParams = new URLSearchParams(location.search)
   const queryOfferType = queryParams.get('offer-type')
 
@@ -105,9 +100,9 @@ export const InformationsScreen = ({
           offererId,
           venueId,
           filteredVenueList,
-          isBookingContactEnabled
+          true
         )
-      : setInitialFormValues(offer, subCategories, isBookingContactEnabled)
+      : setInitialFormValues(offer, subCategories, true)
 
   const [isWithdrawalMailDialogOpen, setIsWithdrawalMailDialogOpen] =
     useState<boolean>(false)

--- a/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
@@ -46,9 +46,6 @@ export const OfferSection = ({
   )
   const musicTypes = musicTypesQuery.data
 
-  const isBookingContactEnabled = useActiveFeature(
-    'WIP_MANDATORY_BOOKING_CONTACT'
-  )
   const isSplitOfferEnabled = useActiveFeature('WIP_SPLIT_OFFER')
 
   const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
@@ -175,7 +172,7 @@ export const OfferSection = ({
       text: `${humanizeDelay(offerData.withdrawalDelay)} avant le début de l’évènement`,
     })
   }
-  if (isBookingContactEnabled && offerData.bookingContact) {
+  if (offerData.bookingContact) {
     practicalInfoDescriptions.push({
       title: 'Email de contact',
       text:


### PR DESCRIPTION
## Delete FF WIP_MANDATORY_BOOKING_CONTACT

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30892

Si on garde pas isBookingContactEnabled, et si on passe pas par un 'true' alors il faut modifier encore plusieurs fichiers, testes ne passent pas.

Elle provient de buildSubcategoryFields.ts :

```
export const buildSubcategoryFields = (
  isBookingContactEnabled: boolean,
  subcategory?: SubcategoryResponseModel
): {
```
Categories.txs:

```
if (isBookingContactEnabled) {
      subcategoryFields.push('bookingContact')
    }
```
 
<img width="1155" alt="Capture d’écran 2024-07-24 à 16 59 57" src="https://github.com/user-attachments/assets/ab73fbd1-69d1-495e-b3db-b2ae779ac95f">
