### PR TITLE
(BSR)[API] feat: remove test-pro-e2e from blocking deployments

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -231,7 +231,7 @@ jobs:
 
   push-pcapi:
     name: "Push pcapi docker image to registry"
-    needs: [build-pcapi, pcapi-init-job, test-api, test-pro-e2e]
+    needs: [build-pcapi, pcapi-init-job, test-api]
     uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
     with:
       image: pcapi
@@ -244,7 +244,7 @@ jobs:
 
   push-pcapi-console:
     name: "Push pcapi-console docker image to registry"
-    needs: [build-pcapi-console, pcapi-init-job, test-api, test-pro-e2e]
+    needs: [build-pcapi-console, pcapi-init-job, test-api]
     uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
     with:
       image: pcapi-console


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : les tests E2E ne doivent pas bloquer les déploiements

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
