### PR TITLE
(PC-31079)[PRO] style: `pointer-events` is set in mixin, so has to be…

### DIFF
--- a/pro/src/ui-kit/form/shared/BaseInput/BaseInput.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseInput/BaseInput.module.scss
@@ -62,9 +62,9 @@
   }
 
   &-right-button {
-    pointer-events: initial;
-
     @include forms.input-icon-wrapper(rem.torem(32px));
+
+    pointer-events: initial;
 
     button {
       background: none;


### PR DESCRIPTION
… set after.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31079

- Correction d'un bouton non cliquable

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
