### PR TITLE
(PC-31081)[API] fix: enable creation of event with tickets when ticketing urls are defined at venue level

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -249,7 +249,7 @@ def _book_offer(
             offers_validation.check_offer_is_from_current_cinema_provider(stock.offer)
             _book_cinema_external_ticket(booking, stock, beneficiary)
 
-        if providers_repository.is_event_external_ticket_applicable(stock.offer):
+        if stock.offer.isEventLinkedToTicketingService:
             remaining_quantity = _book_event_external_ticket(booking, stock, beneficiary)
             if remaining_quantity is None:
                 stock.quantity = None
@@ -543,7 +543,9 @@ def _cancel_external_booking(booking: Booking, stock: Stock) -> None:
     if not booking.isExternal:
         return None
 
-    if offer.lastProvider and offer.lastProvider.hasProviderEnableCharlie:
+    if offer.lastProvider and (
+        offer.isEventLinkedToTicketingService or offer.lastProvider.hasProviderEnableCharlie
+    ):  # FIXME: `offer.lastProvider.hasProviderEnableCharlie` is legacy to support old public API
         sentry_sdk.set_tag("external-provider", offer.lastProvider.name)
         barcodes = [external_booking.barcode for external_booking in booking.externalBookings]
         venue_provider = providers_repository.get_venue_provider_by_venue_and_provider_ids(

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -30,6 +30,7 @@ from pcapi.utils.queue import add_to_queue
 
 from . import exceptions
 from . import serialize
+from . import validation
 
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,8 @@ def book_event_ticket(
     provider: providers_models.Provider,
     venue_provider: providers_models.VenueProvider | None,
 ) -> tuple[list[external_bookings_models.Ticket], int | None]:
+    validation.check_ticketing_service_is_correctly_set(provider=provider, venue_provider=venue_provider)
+
     payload = serialize.ExternalEventBookingRequest.build_external_booking(stock, booking, beneficiary)
     json_payload = payload.json()
     hmac_signature = generate_hmac_signature(provider.hmacKey, json_payload)
@@ -197,6 +200,8 @@ def cancel_event_ticket(
     is_booking_saved: bool,
     venue_provider: providers_models.VenueProvider | None,
 ) -> None:
+    validation.check_ticketing_service_is_correctly_set(provider=provider, venue_provider=venue_provider)
+
     payload = serialize.ExternalEventCancelBookingRequest.build_external_cancel_booking(barcodes)
     json_payload = payload.json()
     hmac_signature = generate_hmac_signature(provider.hmacKey, json_payload)

--- a/api/src/pcapi/core/external_bookings/validation.py
+++ b/api/src/pcapi/core/external_bookings/validation.py
@@ -1,0 +1,10 @@
+from pcapi.core.providers import models as providers_models
+
+from . import exceptions
+
+
+def check_ticketing_service_is_correctly_set(
+    provider: providers_models.Provider, venue_provider: providers_models.VenueProvider | None
+) -> None:
+    if not (provider.hasProviderEnableCharlie or venue_provider and venue_provider.hasTicketingService):
+        raise exceptions.ExternalBookingException("Ticketing system is not correctly set")

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -290,8 +290,11 @@ def create_offer(
     withdrawal_type: models.WithdrawalTypeEnum | None = None,
     is_from_private_api: bool = False,
     id_at_provider: str | None = None,
+    venue_provider: providers_models.VenueProvider | None = None,
 ) -> models.Offer:
-    validation.check_offer_withdrawal(withdrawal_type, withdrawal_delay, subcategory_id, booking_contact, provider)
+    validation.check_offer_withdrawal(
+        withdrawal_type, withdrawal_delay, subcategory_id, booking_contact, provider, venue_provider
+    )
     validation.check_offer_subcategory_is_valid(subcategory_id)
     formatted_extra_data = _format_extra_data(subcategory_id, extra_data)
     validation.check_offer_extra_data(subcategory_id, formatted_extra_data, venue, is_from_private_api)

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -684,6 +684,10 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         return cls.subcategoryId.in_(subcategories_v2.EVENT_SUBCATEGORIES)
 
     @property
+    def isEventLinkedToTicketingService(self) -> bool:
+        return self.isEvent and self.withdrawalType == WithdrawalTypeEnum.IN_APP
+
+    @property
     def isThing(self) -> bool:
         return not self.subcategory.is_event
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -443,6 +443,7 @@ def check_offer_withdrawal(
     subcategory_id: str,
     booking_contact: str | None,
     provider: providers_models.Provider | None,
+    venue_provider: providers_models.VenueProvider | None = None,
 ) -> None:
     is_offer_withdrawable = subcategory_id in subcategories.WITHDRAWABLE_SUBCATEGORIES
     if is_offer_withdrawable and withdrawal_type is None:
@@ -460,9 +461,12 @@ def check_offer_withdrawal(
     ):
         raise exceptions.EventWithTicketMustHaveDelay()
 
-    # Only providers that activated the charlie api can create offer with IN_APP withdrawal type
+    # Only providers that have set a ticketing system at provider level or at venue level
+    # can create offers with in app Withdrawal
     if withdrawal_type == models.WithdrawalTypeEnum.IN_APP:
-        if not provider or not provider.hasProviderEnableCharlie:
+        has_ticketing_system_at_provider_level = provider and provider.hasProviderEnableCharlie
+        has_ticketing_system_at_venue_level = venue_provider and venue_provider.hasTicketingService
+        if not (has_ticketing_system_at_provider_level or has_ticketing_system_at_venue_level):
             raise exceptions.NonLinkedProviderCannotHaveInAppTicket()
 
 

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -259,6 +259,10 @@ class VenueProvider(PcObject, Base, Model, DeactivableMixin):
             return ("global", "Votre lieu est déjà lié à cette source")
         return PcObject.restize_integrity_error(error)
 
+    @property
+    def hasTicketingService(self) -> bool:
+        return bool(self.externalUrls and self.externalUrls.bookingExternalUrl and self.externalUrls.cancelExternalUrl)
+
 
 class CinemaProviderPivot(PcObject, Base, Model):
     """Stores whether a Venue has requested to be synced with a Provider"""

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -8,7 +8,6 @@ from sqlalchemy import or_
 import sqlalchemy.orm as sqla_orm
 
 from pcapi.core.categories import subcategories_v2 as subcategories
-from pcapi.core.external_bookings import exceptions as external_bookings_exceptions
 from pcapi.core.offerers.models import Venue
 import pcapi.core.offers.models as offers_models
 from pcapi.models import db
@@ -225,20 +224,6 @@ def is_cinema_external_ticket_applicable(offer: offers_models.Offer) -> bool:
         and offer.lastProviderId
         and db.session.query(get_cinema_venue_provider_query(offer.venueId).exists()).scalar()
     )
-
-
-def is_event_external_ticket_applicable(offer: offers_models.Offer) -> bool:
-    if offer.isEvent and offer.withdrawalType == offers_models.WithdrawalTypeEnum.IN_APP:
-        if not (
-            offer.lastProvider is not None
-            and offer.lastProvider.isActive
-            and offer.lastProvider.hasProviderEnableCharlie
-        ):
-            raise external_bookings_exceptions.ExternalBookingException(
-                "Offer provider is inactive or not charlie enabled"
-            )
-        return True
-    return False
 
 
 def get_providers_venues(provider_id: int) -> BaseQuery:

--- a/api/src/pcapi/routes/public/individual_offers/v1/utils.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/utils.py
@@ -17,6 +17,14 @@ from . import constants
 from . import serialization
 
 
+def get_venue_with_offerer_address(venue_id: int) -> offerers_models.Venue:
+    return (
+        offerers_models.Venue.query.filter(offerers_models.Venue.id == venue_id)
+        .options(sqla.orm.joinedload(offerers_models.Venue.offererAddress))
+        .one()
+    )
+
+
 def retrieve_venue_from_location(
     location: serialization.DigitalLocation | serialization.PhysicalLocation,
 ) -> offerers_models.Venue:

--- a/api/src/pcapi/routes/public/services/authorization.py
+++ b/api/src/pcapi/routes/public/services/authorization.py
@@ -4,27 +4,24 @@ from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
 from pcapi.models import api_errors
 from pcapi.models.feature import FeatureToggle
+from pcapi.validation.routes.users_authentifications import current_api_key
 
 
 logger = logging.getLogger(__name__)
 
 
 def check_is_allowed_to_perform_action(
-    provider_id: int,
-    venue_id: int,
+    venue_provider: providers_models.VenueProvider,
+    *,
     resource: providers_models.ApiResourceEnum,
     permission: providers_models.PermissionEnum,
 ) -> None:
     """
-    Check with 2 steps:
-        1. Check that there is an active `VenueProvider` that links the venue to the provider.
-        If not, raise a `ResourceNotFoundError` (HTTP 404)
+    Check the permissions defined in `venue_provider` allow provider
+    to perform given action on given resource.
 
-        2. Check that the `VenueProvider` has given permission on given resource.
-        If not, raise a `ForbiddenError` (HTTP 403)
+    Raise `ForbiddenError` if permissions are insufficient.
     """
-    # Check if provider is actively linked to the venue
-    venue_provider = _get_venue_provider_or_raise_404(provider_id=provider_id, venue_id=venue_id)
 
     # Check if provider has permission to perform this action
     venue_provider_permission = providers_repository.get_venue_provider_permission_or_none(
@@ -46,9 +43,15 @@ def check_is_allowed_to_perform_action(
         )
 
 
-def _get_venue_provider_or_raise_404(provider_id: int, venue_id: int) -> providers_models.VenueProvider:
+def get_venue_provider_or_raise_404(venue_id: int) -> providers_models.VenueProvider:
+    """
+    Return active `VenueProvider` linking the venue to the current provider
+
+    Raise `ResourceNotFoundError` if no active `VenueProvider` is found because it means
+    provider should have access to the venue.
+    """
     venue_provider = providers_repository.get_venue_provider_by_venue_and_provider_ids(
-        venue_id=venue_id, provider_id=provider_id
+        venue_id=venue_id, provider_id=current_api_key.providerId
     )
 
     if not venue_provider or not venue_provider.isActive:

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -524,16 +524,29 @@ class CheckOfferWithdrawalTest:
                 provider=None,
             )
 
-    def test_withdrawable_event_offer_with_provider_can_be_in_app(self):
-        provider = providers_factories.ProviderFactory(
-            name="Technical provider", localClass=None, bookingExternalUrl="url", cancelExternalUrl="url"
-        )
+    def test_withdrawable_event_offer_with_ticketing_service_at_provider_level_can_be_in_app(self):
+        provider = providers_factories.PublicApiProviderFactory(name="Technical provider")
+
         assert not validation.check_offer_withdrawal(
             withdrawal_type=WithdrawalTypeEnum.IN_APP,
             withdrawal_delay=None,
             subcategory_id=subcategories.FESTIVAL_MUSIQUE.id,
             booking_contact="booking@conta.ct",
             provider=provider,
+        )
+
+    def test_withdrawable_event_offer_with_ticketing_service_at_venue_level_can_be_in_app(self):
+        provider = providers_factories.ProviderFactory(name="Technical provider")
+        venue_provider = providers_factories.VenueProviderFactory(provider=provider)
+        providers_factories.VenueProviderExternalUrlsFactory(venueProvider=venue_provider)
+
+        validation.check_offer_withdrawal(
+            withdrawal_type=WithdrawalTypeEnum.IN_APP,
+            withdrawal_delay=None,
+            subcategory_id=subcategories.FESTIVAL_MUSIQUE.id,
+            booking_contact="booking@conta.ct",
+            provider=provider,
+            venue_provider=venue_provider,
         )
 
     def test_withdrawable_event_offer_without_provider_cannot_be_in_app(self):
@@ -546,7 +559,7 @@ class CheckOfferWithdrawalTest:
                 provider=None,
             )
 
-    def test_withdrawable_event_offer_with_provider_without_charlie_implementation_cannot_be_in_app(self):
+    def test_withdrawable_event_offer_with_provider_without_a_ticketing_service_implementation_cannot_be_in_app(self):
         # A provider without bookingExternalUrl or cancelExternalUrl
         provider = providers_factories.ProviderFactory(name="Technical provider", localClass=None)
         with pytest.raises(exceptions.NonLinkedProviderCannotHaveInAppTicket):

--- a/api/tests/core/providers/test_repository.py
+++ b/api/tests/core/providers/test_repository.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from pcapi.core.external_bookings import exceptions as external_bookings_exceptions
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
@@ -74,41 +73,6 @@ class GetAvailableProvidersTest:
 
         providers = list(repository.get_available_providers(venue))
         assert providers == [provider_cds, provider_other]
-
-
-class IsEventExternalTicketApplicableTest:
-    def test_external_ticket_applicable(self):
-        provider = factories.PublicApiProviderFactory(name="Music party")
-        offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
-        assert repository.is_event_external_ticket_applicable(offer) is True
-
-    def test_external_ticket_not_applicable_if_offer_not_event(self):
-        provider = factories.PublicApiProviderFactory(name="Music party", isActive=False)
-        offer = offers_factories.OfferFactory(lastProvider=provider)
-        assert repository.is_event_external_ticket_applicable(offer) is False
-
-    def test_external_not_applicable_if_offer_not_in_app(self):
-        provider = factories.PublicApiProviderFactory(name="Music party")
-        offer = offers_factories.EventOfferFactory(lastProvider=provider)
-        assert repository.is_event_external_ticket_applicable(offer) is False
-
-    def test_raises_error_if_offer_in_app_and_provider_inactive(self):
-        provider = factories.PublicApiProviderFactory(name="Music party", isActive=False)
-        offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
-        with pytest.raises(external_bookings_exceptions.ExternalBookingException):
-            repository.is_event_external_ticket_applicable(offer)
-
-    def test_raises_error_if_offer_in_app_and_provider_has_not_enabled_charlie(self):
-        provider = factories.PublicApiProviderFactory(name="Music party", bookingExternalUrl=None)
-        offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
-        with pytest.raises(external_bookings_exceptions.ExternalBookingException):
-            repository.is_event_external_ticket_applicable(offer)
 
 
 def test_get_allocine_theater():

--- a/api/tests/routes/public/individual_offers/v1/delete_date_test.py
+++ b/api/tests/routes/public/individual_offers/v1/delete_date_test.py
@@ -28,7 +28,7 @@ class DeleteDateTest:
         assert stock_to_delete.isSoftDeleted is True
 
     def test_delete_unbooked_date_with_ticket(self, client):
-        venue, api_key = utils.create_offerer_provider_linked_to_venue(with_charlie=True)
+        venue, api_key = utils.create_offerer_provider_linked_to_venue(with_ticketing_service_at_provider_level=True)
         event_offer = offers_factories.EventOfferFactory(
             venue=venue,
             lastProvider=api_key.provider,
@@ -45,7 +45,7 @@ class DeleteDateTest:
         assert stock_to_delete.isSoftDeleted is True
 
     def test_400_if_event_stock_beginning_date_was_more_than_two_days_ago(self, client):
-        venue, api_key = utils.create_offerer_provider_linked_to_venue(with_charlie=True)
+        venue, api_key = utils.create_offerer_provider_linked_to_venue(with_ticketing_service_at_provider_level=True)
         event_offer = offers_factories.EventOfferFactory(
             venue=venue,
             lastProvider=api_key.provider,

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -117,7 +117,7 @@ class PatchEventTest:
         }
 
     def test_patch_all_fields(self, client):
-        venue, api_key = utils.create_offerer_provider_linked_to_venue(with_charlie=True)
+        venue, api_key = utils.create_offerer_provider_linked_to_venue(with_ticketing_service_at_provider_level=True)
         event_offer = offers_factories.EventOfferFactory(
             venue=venue,
             bookingContact="contact@example.com",

--- a/api/tests/routes/public/individual_offers/v1/patch_provider_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_provider_test.py
@@ -43,6 +43,7 @@ class PatchProviderTest(PublicAPIEndpointBaseHelper):
 
     def test_should_update_booking_url(self, client):
         plain_api_key, provider = self.setup_provider()
+
         previous_cancel_url = provider.cancelExternalUrl
         previous_notification_url = provider.notificationExternalUrl
 
@@ -66,6 +67,7 @@ class PatchProviderTest(PublicAPIEndpointBaseHelper):
 
     def test_should_update_cancel_url(self, client):
         plain_api_key, provider = self.setup_provider()
+
         previous_booking_url = provider.bookingExternalUrl
         previous_notification_url = provider.notificationExternalUrl
 
@@ -139,6 +141,7 @@ class PatchProviderTest(PublicAPIEndpointBaseHelper):
 
     def test_should_return_400_because_of_incoherent_ticketing_urls(self, client):
         plain_api_key, provider = self.setup_provider()
+
         previous_booking_url = provider.bookingExternalUrl
         previous_cancel_url = provider.cancelExternalUrl
         previous_notification_url = provider.notificationExternalUrl

--- a/api/tests/routes/public/individual_offers/v1/patch_venue_provider_external_urls.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_venue_provider_external_urls.py
@@ -15,7 +15,7 @@ class PatchProviderTest:
     VENUE_PROVIDER_URL = "/public/providers/v1/venues"
 
     def test_should_update_notification_url(self, client):
-        provider, _ = utils.create_offerer_provider(with_charlie=False)
+        provider, _ = utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
         venue_provider = providers_factories.VenueProviderFactory(provider=provider, venue=venue)
         venue_provider_external_urls = providers_factories.VenueProviderExternalUrlsFactory(
@@ -36,7 +36,7 @@ class PatchProviderTest:
         assert venue_provider_external_urls.cancelExternalUrl == previous_cancel_url
 
     def test_should_update_booking_url(self, client):
-        provider, _ = utils.create_offerer_provider(with_charlie=False)
+        provider, _ = utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
         venue_provider = providers_factories.VenueProviderFactory(provider=provider, venue=venue)
         venue_provider_external_urls = providers_factories.VenueProviderExternalUrlsFactory(
@@ -57,7 +57,7 @@ class PatchProviderTest:
         assert venue_provider_external_urls.cancelExternalUrl == previous_cancel_url
 
     def test_should_update_cancel_url(self, client):
-        provider, _ = utils.create_offerer_provider(with_charlie=False)
+        provider, _ = utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
         venue_provider = providers_factories.VenueProviderFactory(provider=provider, venue=venue)
         venue_provider_external_urls = providers_factories.VenueProviderExternalUrlsFactory(
@@ -78,7 +78,7 @@ class PatchProviderTest:
         assert venue_provider_external_urls.cancelExternalUrl == "https://cancelmoi.baby"
 
     def test_should_delete_venue_provider_external_urls(self, client):
-        provider, _ = utils.create_offerer_provider(with_charlie=False)
+        provider, _ = utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
         venue_provider = providers_factories.VenueProviderFactory(provider=provider, venue=venue)
         venue_provider_external_urls = providers_factories.VenueProviderExternalUrlsFactory(
@@ -95,7 +95,7 @@ class PatchProviderTest:
         assert venue_provider.externalUrls == None
 
     def test_should_create_venue_provider_external_urls(self, client):
-        provider, _ = utils.create_offerer_provider(with_charlie=False)
+        provider, _ = utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
         venue_provider = providers_factories.VenueProviderFactory(provider=provider, venue=venue)
 
@@ -129,7 +129,7 @@ class PatchProviderTest:
         assert response.status_code == 401
 
     def test_should_raise_404_because_venue_does_not_exists(self, client):
-        utils.create_offerer_provider(with_charlie=False)
+        utils.create_offerer_provider(with_ticketing_service=False)
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
             f"{self.VENUE_PROVIDER_URL}/123456789",
@@ -139,7 +139,7 @@ class PatchProviderTest:
         assert response.status_code == 404
 
     def test_should_raise_404_because_venue_not_linked_to_provider(self, client):
-        utils.create_offerer_provider(with_charlie=False)
+        utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
@@ -150,7 +150,7 @@ class PatchProviderTest:
         assert response.status_code == 404
 
     def test_should_raise_400_because_ticketing_urls_cannot_be_unset(self, client):
-        provider_without_ticketing_urls, _ = utils.create_offerer_provider(with_charlie=False)
+        provider_without_ticketing_urls, _ = utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
         venue_provider = providers_factories.VenueProviderFactory(provider=provider_without_ticketing_urls, venue=venue)
         venue_provider_external_urls = providers_factories.VenueProviderExternalUrlsFactory(
@@ -182,7 +182,7 @@ class PatchProviderTest:
         assert venue_provider_external_urls.cancelExternalUrl == previous_cancel_url
 
     def test_should_raise_400_because_try_to_set_booking_url_only(self, client):
-        provider_without_ticketing_urls, _ = utils.create_offerer_provider(with_charlie=False)
+        provider_without_ticketing_urls, _ = utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
         venue_provider = providers_factories.VenueProviderFactory(provider=provider_without_ticketing_urls, venue=venue)
 
@@ -201,7 +201,7 @@ class PatchProviderTest:
         assert venue_provider.externalUrls == None
 
     def test_should_raise_400_because_try_to_unset_only_cancel_url(self, client):
-        provider_without_ticketing_urls, _ = utils.create_offerer_provider(with_charlie=False)
+        provider_without_ticketing_urls, _ = utils.create_offerer_provider(with_ticketing_service=False)
         venue = offerers_factories.VenueFactory()
         venue_provider = providers_factories.VenueProviderFactory(provider=provider_without_ticketing_urls, venue=venue)
         venue_provider_external_urls = providers_factories.VenueProviderExternalUrlsFactory(

--- a/api/tests/routes/public/individual_offers/v1/utils.py
+++ b/api/tests/routes/public/individual_offers/v1/utils.py
@@ -10,9 +10,9 @@ ACCESSIBILITY_FIELDS = {
 }
 
 
-def create_offerer_provider(with_charlie=False):
-    booking_url = "http://example.com/booking" if with_charlie else None
-    cancellation_url = "http://example.com/cancellation" if with_charlie else None
+def create_offerer_provider(with_ticketing_service=False):
+    booking_url = "http://example.com/booking" if with_ticketing_service else None
+    cancellation_url = "http://example.com/cancellation" if with_ticketing_service else None
     offerer = offerers_factories.OffererFactory(name="Technical provider")
     provider = providers_factories.ProviderFactory(
         name="Technical provider",
@@ -36,20 +36,25 @@ def create_offerer_provider(with_charlie=False):
 def create_offerer_provider_linked_to_venue(
     venue_params=None,
     is_virtual=False,
-    with_charlie=False,
+    with_ticketing_service_at_provider_level=False,
+    with_ticketing_service_at_venue_level=False,
     is_venue_provider_active=True,
     venue_provider_permissions=None,
 ):
     venue_params = venue_params if venue_params else {}
     venue_provider_permissions = venue_provider_permissions or []
-    provider, api_key = create_offerer_provider(with_charlie)
+    provider, api_key = create_offerer_provider(with_ticketing_service_at_provider_level)
     if is_virtual:
         venue = offerers_factories.VirtualVenueFactory(**venue_params)
     else:
         venue = offerers_factories.VenueFactory(**venue_params)
+
     venue_provider = providers_factories.VenueProviderFactory(
         venue=venue, provider=provider, venueIdAtOfferProvider="Test", isActive=is_venue_provider_active
     )
+    if with_ticketing_service_at_venue_level:
+        providers_factories.VenueProviderExternalUrlsFactory(venueProvider=venue_provider)
+
     for permission_tuple in venue_provider_permissions:
         permission, resource = permission_tuple
         providers_factories.VenueProviderPermissionFactory(

--- a/api/tests/routes/public/services/test_authorization.py
+++ b/api/tests/routes/public/services/test_authorization.py
@@ -1,3 +1,4 @@
+from flask import g
 import pytest
 
 from pcapi.core.offerers import factories as offerers_factories
@@ -12,49 +13,12 @@ from pcapi.routes.public.services import authorization
 class CheckIsAllowedToPerformActionTest:
 
     @override_features(WIP_ENABLE_PUBLIC_API_PERMISSION_SYSTEM=True)
-    def should_raise_resource_not_found_error_when_no_venue_provider(self):
-        venue = offerers_factories.VenueFactory()
-        provider = providers_factories.ProviderFactory()
-
-        with pytest.raises(api_errors.ResourceNotFoundError) as exc_info:
-            authorization.check_is_allowed_to_perform_action(
-                provider_id=provider.id,
-                venue_id=venue.id,
-                resource=providers_models.ApiResourceEnum.bookings,
-                permission=providers_models.PermissionEnum.READ,
-            )
-
-        assert exc_info.value.errors == {"global": "Venue cannot be found"}
-
-    @override_features(WIP_ENABLE_PUBLIC_API_PERMISSION_SYSTEM=True)
-    def should_raise_resource_not_found_error_when_venue_provider_is_not_active(self):
-        venue = offerers_factories.VenueFactory()
-        provider = providers_factories.ProviderFactory()
-        providers_factories.VenueProviderFactory(venue=venue, provider=provider, isActive=False)
-
-        with pytest.raises(api_errors.ResourceNotFoundError) as exc_info:
-            authorization.check_is_allowed_to_perform_action(
-                provider_id=provider.id,
-                venue_id=venue.id,
-                resource=providers_models.ApiResourceEnum.bookings,
-                permission=providers_models.PermissionEnum.READ,
-            )
-
-        assert exc_info.value.errors == {"global": "Venue cannot be found"}
-
-    @override_features(WIP_ENABLE_PUBLIC_API_PERMISSION_SYSTEM=True)
     def should_raise_forbidden_error_when_no_permission(self):
-        venue = offerers_factories.VenueFactory()
-        provider = providers_factories.ProviderFactory()
-        providers_factories.VenueProviderFactory(
-            venue=venue,
-            provider=provider,
-        )
+        venue_provider = providers_factories.VenueProviderFactory()
 
         with pytest.raises(api_errors.ForbiddenError) as exc_info:
             authorization.check_is_allowed_to_perform_action(
-                provider_id=provider.id,
-                venue_id=venue.id,
+                venue_provider,
                 resource=providers_models.ApiResourceEnum.bookings,
                 permission=providers_models.PermissionEnum.READ,
             )
@@ -63,12 +27,7 @@ class CheckIsAllowedToPerformActionTest:
 
     @override_features(WIP_ENABLE_PUBLIC_API_PERMISSION_SYSTEM=True)
     def should_raise_forbidden_error_when_wrong_permissions(self):
-        venue = offerers_factories.VenueFactory()
-        provider = providers_factories.ProviderFactory()
-        venue_provider = providers_factories.VenueProviderFactory(
-            venue=venue,
-            provider=provider,
-        )
+        venue_provider = providers_factories.VenueProviderFactory()
 
         providers_factories.VenueProviderPermissionFactory(
             venueProvider=venue_provider,
@@ -83,8 +42,7 @@ class CheckIsAllowedToPerformActionTest:
 
         with pytest.raises(api_errors.ForbiddenError) as exc_info:
             authorization.check_is_allowed_to_perform_action(
-                provider_id=provider.id,
-                venue_id=venue.id,
+                venue_provider,
                 resource=providers_models.ApiResourceEnum.bookings,
                 permission=providers_models.PermissionEnum.READ,
             )
@@ -93,12 +51,7 @@ class CheckIsAllowedToPerformActionTest:
 
     @override_features(WIP_ENABLE_PUBLIC_API_PERMISSION_SYSTEM=True)
     def should_not_raise(self):
-        venue = offerers_factories.VenueFactory()
-        provider = providers_factories.ProviderFactory()
-        venue_provider = providers_factories.VenueProviderFactory(
-            venue=venue,
-            provider=provider,
-        )
+        venue_provider = providers_factories.VenueProviderFactory()
         providers_factories.VenueProviderPermissionFactory(
             venueProvider=venue_provider,
             resource=providers_models.ApiResourceEnum.bookings,
@@ -106,8 +59,34 @@ class CheckIsAllowedToPerformActionTest:
         )
 
         authorization.check_is_allowed_to_perform_action(
-            provider_id=provider.id,
-            venue_id=venue.id,
+            venue_provider,
             resource=providers_models.ApiResourceEnum.bookings,
             permission=providers_models.PermissionEnum.READ,
         )
+
+
+@pytest.mark.usefixtures("db_session")
+class GetVenueProviderOrRaise404Test:
+
+    def should_raise_resource_not_found_error_when_no_venue_provider(self):
+        venue = offerers_factories.VenueFactory()
+        provider = providers_factories.ProviderFactory()
+        api_key = offerers_factories.ApiKeyFactory(provider=provider)
+        g.current_api_key = api_key
+
+        with pytest.raises(api_errors.ResourceNotFoundError) as exc_info:
+            authorization.get_venue_provider_or_raise_404(venue_id=venue.id)
+
+        assert exc_info.value.errors == {"global": "Venue cannot be found"}
+
+    def should_raise_resource_not_found_error_when_venue_provider_is_not_active(self):
+        venue = offerers_factories.VenueFactory()
+        provider = providers_factories.ProviderFactory()
+        providers_factories.VenueProviderFactory(venue=venue, provider=provider, isActive=False)
+        api_key = offerers_factories.ApiKeyFactory(provider=provider)
+        g.current_api_key = api_key
+
+        with pytest.raises(api_errors.ResourceNotFoundError) as exc_info:
+            authorization.get_venue_provider_or_raise_404(venue_id=venue.id)
+
+        assert exc_info.value.errors == {"global": "Venue cannot be found"}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31081

Cette PR permet :
- à un provider de créer un event avec ticket ...
- à un jeune de prendre des place pour cet event...

... quand les urls de ticketing sont définies au niveau de la venue et qu'il n'y a rien au niveau du provider.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
