### PR TITLE
(PC-30719)[BO] feat: coll. booking: update status (integration only)

### DIFF
--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -507,3 +507,7 @@ def notify_redactor_that_booking_has_been_cancelled(booking: educational_models.
 
 def notify_pro_that_booking_has_been_cancelled(booking: educational_models.CollectiveBooking) -> None:
     transactional_mails.send_collective_booking_cancellation_confirmation_by_pro_email(booking)
+
+
+def update_collective_booking_status(booking: educational_models.CollectiveBooking) -> None:
+    pass

--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -220,6 +220,16 @@ class CancelCollectiveBookingForm(FlaskForm):
     )
 
 
+class UpdateCollectiveBookingStatusForm(FlaskForm):
+    status = fields.PCSelectWithPlaceholderValueField(
+        "Statut",
+        choices=utils.choices_from_enum(
+            educational_models.CollectiveBookingStatus,
+            formatter=filters.format_collective_booking_status_enum,
+        ),
+    )
+
+
 class CancelIndividualBookingForm(FlaskForm):
     reason = fields.PCSelectWithPlaceholderValueField(
         "Raison",

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -309,6 +309,20 @@ def format_booking_status(
     return "Réservée"
 
 
+def format_collective_booking_status_enum(status: educational_models.CollectiveBookingStatus) -> str:
+    match status:
+        case educational_models.CollectiveBookingStatus.PENDING:
+            return "Pré-réservée"
+        case educational_models.CollectiveBookingStatus.CONFIRMED:
+            return "Confirmée"
+        case educational_models.CollectiveBookingStatus.USED:
+            return "Validée"
+        case educational_models.CollectiveBookingStatus.CANCELLED:
+            return "Annulée"
+        case educational_models.CollectiveBookingStatus.REIMBURSED:
+            return "Remboursée"
+
+
 def format_validation_status(status: validation_status_mixin.ValidationStatus) -> str:
     match status:
         case validation_status_mixin.ValidationStatus.NEW:

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -7,6 +7,7 @@
 {% extends "layouts/connected.html" %}
 {% set pc_validate_booking_modal_id = random_hash() %}
 {% set pc_cancel_booking_modal_id = random_hash() %}
+{% set pc_integration_update_booking_status_modal_id = random_hash() %}
 {% block page %}
   <div class="pt-3 px-5"
        data-toggle="filters"
@@ -108,6 +109,13 @@
                                  data-bs-target="#overpayment-creation-modal-{{ collective_booking.id }}">Créer un incident</a>
                             </li>
                           {% endif %}
+                          {% if is_integration %}
+                            <li class="dropdown-item p-0">
+                              <a class="btn btn-sm d-block w-100 text-start px-3"
+                                 data-bs-toggle="modal"
+                                 data-bs-target=".pc-integration-update-status-modal-{{ collective_booking.id }}">Modifier le statut de la réservation</a>
+                            </li>
+                          {% endif %}
                         </ul>
                         {% if collective_booking.isCancelled %}
                           <div class="modal modal-lg fade pc-validate-booking-modal-{{ collective_booking.id }}"
@@ -164,6 +172,34 @@
                             </div>
                           </div>
                         {% endif %}
+                            {% if is_integration %}
+                              <div class="modal modal-lg fade pc-integration-update-status-modal-{{ collective_booking.id }}"
+                                   tabindex="-1"
+                                   aria-labelledby="{{ pc_integration_update_booking_status_modal_id }}"
+                                   aria-hidden="true">
+                                <div class="modal-dialog modal-dialog-centered">
+                                  <div class="modal-content">
+                                    <form action="{{ url_for("backoffice_web.collective_bookings.update_collective_booking_status", collective_booking_id=collective_booking.id) }}"
+                                          name="{{ url_for("backoffice_web.collective_bookings.update_collective_booking_status", collective_booking_id=collective_booking.id) | action_to_name }}"
+                                          method="post"
+                                          data-turbo="false">
+                                      <div class="modal-header"
+                                           id="{{ pc_integration_update_booking_status_modal_id }}">
+                                        <h5 class="modal-title">Modifier le statut de la réservation {{ collective_booking.id }}</h5>
+                                      </div>
+                                      <div class="modal-body row">{{ forms.build_form_fields_group(update_booking_status_form) }}</div>
+                                      <div class="modal-footer">
+                                        <button type="button"
+                                                class="btn btn-outline-primary"
+                                                data-bs-dismiss="modal">Annuler</button>
+                                        <button type="submit"
+                                                class="btn btn-primary">Confirmer</button>
+                                      </div>
+                                    </form>
+                                  </div>
+                                </div>
+                              </div>
+                            {% endif %}
                       {% endif %}
                     </div>
                   </div>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30719

Backoffice -> réservations collectives -> permettre de changer le statut d'une réservation collective... en intégration (et en local) uniquement.
Le but est de permettre de mimer certaines étapes d'une réservation collective qui ne sont pas accessibles dans l'environnement d'intégration.

### Notes

La fonction chargée de mettre à jour le statut reprend des méthodes existantes dans certains cas et se contente de mettre à jour le statut dans d'autres. J'espère ne pas avoir raté de méthodes ou fonctions existantes pour ces cas.
