### PR TITLE
(PC-29690) multiselect status filter

### DIFF
--- a/pro/src/app/App/hook/useLogNavigation.ts
+++ b/pro/src/app/App/hook/useLogNavigation.ts
@@ -3,6 +3,7 @@ import { useLocation, useParams } from 'react-router-dom'
 
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { Events } from 'core/FirebaseEvents/constants'
+import { parseUrlParams } from 'utils/parseUrlParams'
 
 export const useLogNavigation = (): void => {
   const location = useLocation()
@@ -11,14 +12,15 @@ export const useLogNavigation = (): void => {
   const [previousPage, setPreviousPage] = useState<string>()
 
   useEffect(() => {
-    const queryParams = Object.fromEntries(new URLSearchParams(location.search))
+    const urlSearchParams = new URLSearchParams(location.search)
+    const queryParams = parseUrlParams(urlSearchParams)
+
     const urlParams = { ...params }
 
     // useParams exposes a * key with the end of the path
     // when the end was not explicitely specified in the path
     // we do not want to log it
     delete urlParams['*']
-
     logEvent(Events.PAGE_VIEW, {
       ...urlParams,
       ...queryParams,

--- a/pro/src/core/Offers/constants.ts
+++ b/pro/src/core/Offers/constants.ts
@@ -79,6 +79,11 @@ export const DEFAULT_SEARCH_FILTERS: SearchFiltersParams = {
   offererAddressId: 'all',
 }
 
+export const DEFAULT_COLLECTIVE_SEARCH_FILTERS: SearchFiltersParams = {
+  ...DEFAULT_SEARCH_FILTERS,
+  status: [],
+}
+
 export const ALL_VENUES_OPTION: SelectOption = {
   label: 'Tous les lieux',
   value: ALL_VENUES,

--- a/pro/src/core/Offers/hooks/useQuerySearchFilters.ts
+++ b/pro/src/core/Offers/hooks/useQuerySearchFilters.ts
@@ -1,23 +1,45 @@
 import { useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
-import { parse } from 'utils/query-string'
+import {
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+  DEFAULT_SEARCH_FILTERS,
+} from 'core/Offers/constants'
+import { Audience } from 'core/shared/types'
 import { translateQueryParamsToApiParams } from 'utils/translate'
 
 import { SearchFiltersParams } from '../types'
 
-export const useQuerySearchFilters = (): SearchFiltersParams => {
+export const useQuerySearchFilters = (
+  audience: Audience
+): SearchFiltersParams => {
   const { search } = useLocation()
 
   const urlSearchFilters: SearchFiltersParams = useMemo(() => {
-    const queryParams = parse(search)
-    const translatedQuery = translateQueryParamsToApiParams({
-      ...queryParams,
+    const urlParams = new URLSearchParams(search)
+    const queryParams: Record<string, string | string[]> = {}
+    urlParams.forEach((value, key) => {
+      if (queryParams[key]) {
+        if (!Array.isArray(queryParams[key])) {
+          queryParams[key] = [queryParams[key]]
+        }
+        queryParams[key].push(value)
+      } else {
+        queryParams[key] = value
+      }
     })
 
+    const translatedQuery = translateQueryParamsToApiParams(
+      {
+        ...queryParams,
+      },
+      audience
+    )
+
     const urlFilters = {
-      ...DEFAULT_SEARCH_FILTERS,
+      ...(audience === Audience.INDIVIDUAL
+        ? DEFAULT_SEARCH_FILTERS
+        : DEFAULT_COLLECTIVE_SEARCH_FILTERS),
       ...translatedQuery,
     }
 

--- a/pro/src/core/Offers/hooks/useQuerySearchFilters.ts
+++ b/pro/src/core/Offers/hooks/useQuerySearchFilters.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_SEARCH_FILTERS,
 } from 'core/Offers/constants'
 import { Audience } from 'core/shared/types'
+import { parseUrlParams } from 'utils/parseUrlParams'
 import { translateQueryParamsToApiParams } from 'utils/translate'
 
 import { SearchFiltersParams } from '../types'
@@ -17,17 +18,7 @@ export const useQuerySearchFilters = (
 
   const urlSearchFilters: SearchFiltersParams = useMemo(() => {
     const urlParams = new URLSearchParams(search)
-    const queryParams: Record<string, string | string[]> = {}
-    urlParams.forEach((value, key) => {
-      if (queryParams[key]) {
-        if (!Array.isArray(queryParams[key])) {
-          queryParams[key] = [queryParams[key]]
-        }
-        queryParams[key].push(value)
-      } else {
-        queryParams[key] = value
-      }
-    })
+    const queryParams = parseUrlParams(urlParams)
 
     const translatedQuery = translateQueryParamsToApiParams(
       {

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -13,7 +13,7 @@ export type SearchFiltersParams = {
   venueId: string
   categoryId: string
   format: EacFormat | typeof ALL_FORMATS
-  status: OfferStatus | CollectiveOfferDisplayedStatus | typeof ALL_STATUS
+  status: OfferStatus | CollectiveOfferDisplayedStatus[] | typeof ALL_STATUS
   creationMode: string
   collectiveOfferType: string
   periodBeginningDate: string

--- a/pro/src/core/Offers/utils/__specs__/computeOffersUrl.spec.ts
+++ b/pro/src/core/Offers/utils/__specs__/computeOffersUrl.spec.ts
@@ -1,6 +1,9 @@
-import { OfferStatus } from 'apiClient/v1'
+import { CollectiveOfferDisplayedStatus, OfferStatus } from 'apiClient/v1'
 
-import { computeOffersUrl } from '../computeOffersUrl'
+import {
+  computeCollectiveOffersUrl,
+  computeOffersUrl,
+} from '../computeOffersUrl'
 
 describe('computeOffersUrl', () => {
   it('should return simple query for offers page when no search filters', () => {
@@ -28,6 +31,31 @@ describe('computeOffersUrl', () => {
 
     expect(value).toBe(
       '/offres?page=2&nom=test&structure=AY&lieu=EQ&categorie=CINEMA&statut=active&creation=manuelle&periode-evenement-debut=2020-11-30T00%3A00%3A00%2B01%3A00&periode-evenement-fin=2021-01-07T23%3A59%3A59%2B01%3A00'
+    )
+  })
+})
+
+describe('computeCollectiveOffersUrl', () => {
+  it('should build proper query given collective offers filters', () => {
+    const offersSearchFilters = {
+      name: 'test',
+      offererId: 'AY',
+      venueId: 'EQ',
+      categoryId: 'CINEMA',
+      status: [
+        CollectiveOfferDisplayedStatus.ACTIVE,
+        CollectiveOfferDisplayedStatus.EXPIRED,
+      ],
+      creationMode: 'manual',
+      periodBeginningDate: '2020-11-30T00:00:00+01:00',
+      periodEndingDate: '2021-01-07T23:59:59+01:00',
+      page: 2,
+    }
+
+    const value = computeCollectiveOffersUrl(offersSearchFilters)
+
+    expect(value).toBe(
+      '/offres/collectives?page=2&nom=test&structure=AY&lieu=EQ&categorie=CINEMA&statut=active&statut=expiree&creation=manuelle&periode-evenement-debut=2020-11-30T00%3A00%3A00%2B01%3A00&periode-evenement-fin=2021-01-07T23%3A59%3A59%2B01%3A00'
     )
   })
 })

--- a/pro/src/core/Offers/utils/computeOffersUrl.ts
+++ b/pro/src/core/Offers/utils/computeOffersUrl.ts
@@ -13,28 +13,43 @@ const computeOffersUrlForGivenAudience = (
   offersSearchFilters: Partial<SearchFiltersParams>
 ): string => {
   const emptyNewFilters: Partial<SearchFiltersParams> = {}
-  const newFilters = Object.entries(offersSearchFilters).reduce(
-    (accumulator, [filter, filterValue]) => {
-      if (
-        filterValue !==
-        DEFAULT_SEARCH_FILTERS[filter as keyof SearchFiltersParams]
-      ) {
-        return {
-          ...accumulator,
-          [filter]: filterValue,
-        }
+  const newFilters: Partial<SearchFiltersParams> = Object.entries(
+    offersSearchFilters
+  ).reduce((accumulator, [filter, filterValue]) => {
+    if (
+      filterValue !==
+      DEFAULT_SEARCH_FILTERS[filter as keyof SearchFiltersParams]
+    ) {
+      return {
+        ...accumulator,
+        [filter]: filterValue,
       }
-      return accumulator
-    },
-    emptyNewFilters
-  )
+    }
+    return accumulator
+  }, emptyNewFilters)
 
-  const queryString = stringify(translateApiParamsToQueryParams(newFilters))
-  const baseUrl =
-    audience === Audience.INDIVIDUAL
-      ? INDIVIDUAL_OFFERS_URL
+  if (audience === Audience.COLLECTIVE) {
+    const queryString = Object.entries(
+      translateApiParamsToQueryParams(newFilters, audience)
+    )
+      .flatMap(([key, value]) =>
+        Array.isArray(value)
+          ? value.map((v) => `${key}=${encodeURIComponent(v)}`)
+          : `${key}=${encodeURIComponent(value as string)}`
+      )
+      .join('&')
+
+    return queryString
+      ? `${COLLECTIVE_OFFERS_URL}?${queryString}`
       : COLLECTIVE_OFFERS_URL
-  return queryString ? `${baseUrl}?${queryString}` : baseUrl
+  }
+
+  const queryString = stringify(
+    translateApiParamsToQueryParams(newFilters, audience)
+  )
+  return queryString
+    ? `${INDIVIDUAL_OFFERS_URL}?${queryString}`
+    : INDIVIDUAL_OFFERS_URL
 }
 
 export const computeOffersUrl = (

--- a/pro/src/core/Offers/utils/serializer.ts
+++ b/pro/src/core/Offers/utils/serializer.ts
@@ -2,12 +2,17 @@ import {
   ListCollectiveOffersQueryModel,
   ListOffersQueryModel,
 } from 'apiClient/v1'
+import { Audience } from 'core/shared/types'
 
-import { DEFAULT_SEARCH_FILTERS } from '../constants'
+import {
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+  DEFAULT_SEARCH_FILTERS,
+} from '../constants'
 import { SearchFiltersParams } from '../types'
 
 export const serializeApiFilters = (
-  searchFilters: Partial<SearchFiltersParams>
+  searchFilters: Partial<SearchFiltersParams>,
+  audience: Audience
 ): ListOffersQueryModel & ListCollectiveOffersQueryModel => {
   const listOffersQueryKeys: (
     | keyof ListOffersQueryModel
@@ -26,9 +31,13 @@ export const serializeApiFilters = (
   ]
 
   const body: ListOffersQueryModel & ListCollectiveOffersQueryModel = {}
+  const defaultFilters =
+    audience === Audience.INDIVIDUAL
+      ? DEFAULT_SEARCH_FILTERS
+      : DEFAULT_COLLECTIVE_SEARCH_FILTERS
   return listOffersQueryKeys.reduce((accumulator, field) => {
     const filterValue = searchFilters[field]
-    if (filterValue && filterValue !== DEFAULT_SEARCH_FILTERS[field]) {
+    if (filterValue && filterValue !== defaultFilters[field]) {
       return {
         ...accumulator,
         [field]: filterValue,

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -14,9 +14,8 @@ import {
   GET_VENUES_QUERY_KEY,
 } from 'config/swrQueryKeys'
 import {
-  ALL_STATUS,
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
   DEFAULT_PAGE,
-  DEFAULT_SEARCH_FILTERS,
 } from 'core/Offers/constants'
 import { useQuerySearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
 import { SearchFiltersParams } from 'core/Offers/types'
@@ -33,7 +32,7 @@ import { selectCurrentOffererId } from 'store/user/selectors'
 import { Spinner } from 'ui-kit/Spinner/Spinner'
 
 export const CollectiveOffers = (): JSX.Element => {
-  const urlSearchFilters = useQuerySearchFilters()
+  const urlSearchFilters = useQuerySearchFilters(Audience.COLLECTIVE)
   const currentPageNumber = urlSearchFilters.page ?? DEFAULT_PAGE
   const navigate = useNavigate()
   const { currentUser } = useCurrentUser()

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -110,7 +110,7 @@ export const CollectiveOffers = (): JSX.Element => {
         periodEndingDate,
         collectiveOfferType,
         format,
-      } = serializeApiFilters(apiFilters)
+      } = serializeApiFilters(apiFilters, Audience.COLLECTIVE)
 
       return api.getCollectiveOffers(
         nameOrIsbn,

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -50,7 +50,7 @@ export const CollectiveOffers = (): JSX.Element => {
   const offererQuery = useSWR(
     [GET_OFFERER_QUERY_KEY, offererId],
     ([, offererIdParam]) =>
-      offererId === DEFAULT_SEARCH_FILTERS.offererId
+      offererId === DEFAULT_COLLECTIVE_SEARCH_FILTERS.offererId
         ? null
         : api.getOfferer(Number(offererIdParam)),
     { fallbackData: null }
@@ -78,9 +78,9 @@ export const CollectiveOffers = (): JSX.Element => {
   const isRestrictedAsAdmin = currentUser.isAdmin && !isFilterByVenueOrOfferer
 
   const apiFilters: SearchFiltersParams = {
-    ...DEFAULT_SEARCH_FILTERS,
+    ...DEFAULT_COLLECTIVE_SEARCH_FILTERS,
     ...urlSearchFilters,
-    ...(isRestrictedAsAdmin ? { status: ALL_STATUS } : {}),
+    ...(isRestrictedAsAdmin ? { status: [] } : {}),
     ...(isNewInterfaceActive
       ? { offererId: selectedOffererId?.toString() ?? '' }
       : {}),
@@ -116,7 +116,7 @@ export const CollectiveOffers = (): JSX.Element => {
       return api.getCollectiveOffers(
         nameOrIsbn,
         offererId,
-        status as CollectiveOfferDisplayedStatus,
+        status as CollectiveOfferDisplayedStatus[],
         venueId,
         categoryId,
         creationMode,

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -3,10 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
-import {
-  CollectiveOfferDisplayedStatus,
-  CollectiveOfferStatus,
-} from 'apiClient/v1'
+import { CollectiveOfferStatus } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import {
   GET_COLLECTIVE_OFFERS_QUERY_KEY,
@@ -115,7 +112,7 @@ export const CollectiveOffers = (): JSX.Element => {
       return api.getCollectiveOffers(
         nameOrIsbn,
         offererId,
-        status as CollectiveOfferDisplayedStatus[],
+        status,
         venueId,
         categoryId,
         creationMode,

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.admin.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.admin.spec.tsx
@@ -11,7 +11,10 @@ import {
   CollectiveOffersStockResponseModel,
   OfferStatus,
 } from 'apiClient/v1'
-import { ALL_VENUES, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import {
+  ALL_VENUES,
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+} from 'core/Offers/constants'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { computeCollectiveOffersUrl } from 'core/Offers/utils/computeOffersUrl'
 import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
@@ -40,7 +43,7 @@ const proVenues = [
 ]
 
 const renderOffers = async (
-  filters: Partial<SearchFiltersParams> = DEFAULT_SEARCH_FILTERS
+  filters: Partial<SearchFiltersParams> = DEFAULT_COLLECTIVE_SEARCH_FILTERS
 ) => {
   const route = computeCollectiveOffersUrl(filters)
 
@@ -87,7 +90,7 @@ describe('route CollectiveOffers when user is admin', () => {
       expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
         undefined,
         undefined,
-        undefined,
+        [],
         undefined,
         undefined,
         undefined,
@@ -153,7 +156,7 @@ describe('route CollectiveOffers when user is admin', () => {
       expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
         undefined,
         undefined,
-        undefined,
+        [],
         undefined,
         undefined,
         undefined,

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -2,6 +2,7 @@ import {
   screen,
   waitFor,
   waitForElementToBeRemoved,
+  within,
 } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
@@ -74,12 +75,16 @@ describe('route CollectiveOffers', () => {
   describe('filters', () => {
     describe('status filters', () => {
       it('should filter offers given status filter when clicking on "Appliquer"', async () => {
+        vi.spyOn(api, 'getCollectiveOffers').mockResolvedValueOnce(offersRecap)
         await renderOffers()
 
-        const statusSelect = screen.getByRole('combobox', {
-          name: 'Statut Nouveau',
-        })
-        await userEvent.selectOptions(statusSelect, 'Expirée')
+        await userEvent.click(
+          screen.getByText('Statut', {
+            selector: 'span',
+          })
+        )
+        const list = screen.getByTestId('list')
+        await userEvent.click(within(list).getByText('Expirée'))
 
         await userEvent.click(
           screen.getByRole('button', { name: 'Rechercher' })
@@ -101,16 +106,53 @@ describe('route CollectiveOffers', () => {
         })
       })
 
+      it('should filter offers given multiple status filter when clicking on "Appliquer"', async () => {
+        vi.spyOn(api, 'getCollectiveOffers').mockResolvedValueOnce(offersRecap)
+        await renderOffers()
+
+        await userEvent.click(
+          screen.getByText('Statut', {
+            selector: 'span',
+          })
+        )
+        const list = screen.getByTestId('list')
+        await userEvent.click(within(list).getByText('Expirée'))
+        await userEvent.click(within(list).getByText('Préréservée'))
+        await userEvent.click(within(list).getByText('Réservée'))
+
+        await userEvent.click(
+          screen.getByRole('button', { name: 'Rechercher' })
+        )
+
+        await waitFor(() => {
+          expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+            undefined,
+            undefined,
+            ['EXPIRED', 'PREBOOKED', 'BOOKED'],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined
+          )
+        })
+      })
+
       it('should indicate that no offers match selected filters', async () => {
         vi.spyOn(api, 'getCollectiveOffers')
           .mockResolvedValueOnce(offersRecap)
           .mockResolvedValueOnce([])
         await renderOffers()
 
-        const statusSelect = screen.getByRole('combobox', {
-          name: 'Statut Nouveau',
-        })
-        await userEvent.selectOptions(statusSelect, 'Expirée')
+        await userEvent.click(
+          screen.getByText('Statut', {
+            selector: 'span',
+          })
+        )
+        const list = screen.getByTestId('list')
+        await userEvent.click(within(list).getByText('Expirée'))
 
         await userEvent.click(
           screen.getByRole('button', { name: 'Rechercher' })

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -13,7 +13,7 @@ import {
 } from 'apiClient/v1'
 import {
   ALL_VENUES_OPTION,
-  DEFAULT_SEARCH_FILTERS,
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
 } from 'core/Offers/constants'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { computeCollectiveOffersUrl } from 'core/Offers/utils/computeOffersUrl'
@@ -40,7 +40,7 @@ const proVenues = [
 ]
 
 const renderOffers = async (
-  filters: Partial<SearchFiltersParams> = DEFAULT_SEARCH_FILTERS,
+  filters: Partial<SearchFiltersParams> = DEFAULT_COLLECTIVE_SEARCH_FILTERS,
   features: string[] = []
 ) => {
   const route = computeCollectiveOffersUrl(filters)
@@ -497,7 +497,7 @@ describe('route CollectiveOffers', () => {
       collectiveOfferFactory({ status: CollectiveOfferStatus.ACTIVE }),
       collectiveOfferFactory({ status: CollectiveOfferStatus.DRAFT }),
     ])
-    await renderOffers(DEFAULT_SEARCH_FILTERS, [
+    await renderOffers(DEFAULT_COLLECTIVE_SEARCH_FILTERS, [
       'WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS',
     ])
 
@@ -509,7 +509,7 @@ describe('route CollectiveOffers', () => {
       collectiveOfferFactory({ status: CollectiveOfferStatus.ACTIVE }),
       collectiveOfferFactory({ status: CollectiveOfferStatus.DRAFT }),
     ])
-    await renderOffers(DEFAULT_SEARCH_FILTERS)
+    await renderOffers(DEFAULT_COLLECTIVE_SEARCH_FILTERS)
 
     expect(screen.getByText('1 offre')).toBeInTheDocument()
   })

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
@@ -1,6 +1,5 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 import * as router from 'react-router-dom'
 
 import { api } from 'apiClient/api'
@@ -9,7 +8,7 @@ import {
   CollectiveOffersStockResponseModel,
   OfferStatus,
 } from 'apiClient/v1'
-import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { computeCollectiveOffersUrl } from 'core/Offers/utils/computeOffersUrl'
 import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
@@ -30,7 +29,7 @@ vi.mock('react-router-dom', async () => ({
 }))
 
 const renderOffers = async (
-  filters: Partial<SearchFiltersParams> = DEFAULT_SEARCH_FILTERS
+  filters: Partial<SearchFiltersParams> = DEFAULT_COLLECTIVE_SEARCH_FILTERS
 ) => {
   const route = computeCollectiveOffersUrl(filters)
   renderWithProviders(

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -117,7 +117,7 @@ export const OffersRoute = (): JSX.Element => {
       creationMode,
       periodBeginningDate,
       periodEndingDate,
-    } = serializeApiFilters(apiFilters)
+    } = serializeApiFilters(apiFilters, Audience.INDIVIDUAL)
 
     return api.listOffers(
       nameOrIsbn,

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -31,7 +31,7 @@ import { sortByLabel } from 'utils/strings'
 export const GET_OFFERS_QUERY_KEY = 'listOffers'
 
 export const OffersRoute = (): JSX.Element => {
-  const urlSearchFilters = useQuerySearchFilters()
+  const urlSearchFilters = useQuerySearchFilters(Audience.INDIVIDUAL)
   const currentPageNumber = urlSearchFilters.page ?? DEFAULT_PAGE
   const navigate = useNavigate()
   const { currentUser } = useCurrentUser()

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -25,7 +25,7 @@ import {
 import { NOTIFICATION_LONG_SHOW_DURATION } from 'core/Notification/constants'
 import { createOfferFromBookableOffer } from 'core/OfferEducational/utils/createOfferFromBookableOffer'
 import { createOfferFromTemplate } from 'core/OfferEducational/utils/createOfferFromTemplate'
-import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useNotification } from 'hooks/useNotification'
@@ -140,7 +140,7 @@ export const CollectiveActionsCells = ({
   }
 
   const apiFilters = {
-    ...DEFAULT_SEARCH_FILTERS,
+    ...DEFAULT_COLLECTIVE_SEARCH_FILTERS,
     ...urlSearchFilters,
   }
   delete apiFilters.page

--- a/pro/src/pages/Offers/OffersTable/Cells/DeleteDraftCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/DeleteDraftCell.tsx
@@ -12,6 +12,7 @@ import {
 } from 'core/FirebaseEvents/constants'
 import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQuerySearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
+import { Audience } from 'core/shared/types'
 import { useNotification } from 'hooks/useNotification'
 import fullTrashIcon from 'icons/full-trash.svg'
 import strokeTrashIcon from 'icons/stroke-trash.svg'
@@ -27,7 +28,7 @@ interface DeleteDraftOffersProps {
 }
 
 export const DeleteDraftCell = ({ offer }: DeleteDraftOffersProps) => {
-  const urlSearchFilters = useQuerySearchFilters()
+  const urlSearchFilters = useQuerySearchFilters(Audience.INDIVIDUAL)
   const { mutate } = useSWRConfig()
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false)
   const { logEvent } = useAnalytics()

--- a/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { api } from 'apiClient/api'
-import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -54,7 +54,7 @@ describe('CollectiveActionsCells', () => {
         ],
       }),
       editionOfferLink: '',
-      urlSearchFilters: DEFAULT_SEARCH_FILTERS,
+      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
       isSelected: false,
       deselectOffer: vi.fn(),
     })
@@ -89,7 +89,7 @@ describe('CollectiveActionsCells', () => {
         ],
       }),
       editionOfferLink: '',
-      urlSearchFilters: DEFAULT_SEARCH_FILTERS,
+      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
       isSelected: true,
       deselectOffer: mockDeselectOffer,
     })

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
@@ -14,7 +14,7 @@ import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import * as useAnalytics from 'app/App/analytics/firebase'
 import { Notification } from 'components/Notification/Notification'
 import { CollectiveBookingsEvents } from 'core/FirebaseEvents/constants'
-import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import {
   collectiveOfferFactory,
   listOffersVenueFactory,
@@ -78,7 +78,7 @@ describe('ollectiveOfferRow', () => {
       offer,
       selectOffer: vi.fn(),
       isSelected: false,
-      urlSearchFilters: DEFAULT_SEARCH_FILTERS,
+      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
       isFirstRow: true,
     }
   })

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -16,6 +16,7 @@ import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQuerySearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { serializeApiFilters } from 'core/Offers/utils/serializer'
+import { Audience } from 'core/shared/types'
 import { useNotification } from 'hooks/useNotification'
 import fullHideIcon from 'icons/full-hide.svg'
 import fullValidateIcon from 'icons/full-validate.svg'
@@ -159,7 +160,7 @@ export function CollectiveOffersActionsBar({
   areAllOffersSelected,
   getUpdateOffersStatusMessage,
 }: CollectiveOffersActionsBarProps) {
-  const urlSearchFilters = useQuerySearchFilters()
+  const urlSearchFilters = useQuerySearchFilters(Audience.COLLECTIVE)
 
   const notify = useNotification()
   const [isDeactivationDialogOpen, setIsDeactivationDialogOpen] =

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -65,7 +65,7 @@ const updateCollectiveOffersStatus = async (
   notify: ReturnType<typeof useNotification>,
   apiFilters: SearchFiltersParams
 ) => {
-  const payload = serializeApiFilters(apiFilters)
+  const payload = serializeApiFilters(apiFilters, Audience.COLLECTIVE)
   if (areAllOffersSelected) {
     //  Bulk edit if all editable offers are selected
     try {

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -12,7 +12,7 @@ import { ArchiveConfirmationModal } from 'components/ArchiveConfirmationModal/Ar
 import { canArchiveCollectiveOffer } from 'components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer'
 import { GET_COLLECTIVE_OFFERS_QUERY_KEY } from 'config/swrQueryKeys'
 import { NOTIFICATION_LONG_SHOW_DURATION } from 'core/Notification/constants'
-import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQuerySearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { serializeApiFilters } from 'core/Offers/utils/serializer'
@@ -167,7 +167,7 @@ export function CollectiveOffersActionsBar({
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false)
 
   const apiFilters = {
-    ...DEFAULT_SEARCH_FILTERS,
+    ...DEFAULT_COLLECTIVE_SEARCH_FILTERS,
     ...urlSearchFilters,
   }
   delete apiFilters.page

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQuerySearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { serializeApiFilters } from 'core/Offers/utils/serializer'
+import { Audience } from 'core/shared/types'
 import { useNotification } from 'hooks/useNotification'
 import fullHideIcon from 'icons/full-hide.svg'
 import fullTrashIcon from 'icons/full-trash.svg'
@@ -111,7 +112,7 @@ export const IndividualOffersActionsBar = ({
   getUpdateOffersStatusMessage,
   canDeleteOffers,
 }: IndividualOffersActionsBarProps): JSX.Element => {
-  const urlSearchFilters = useQuerySearchFilters()
+  const urlSearchFilters = useQuerySearchFilters(Audience.INDIVIDUAL)
   const { mutate } = useSWRConfig()
 
   const notify = useNotification()

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
@@ -61,7 +61,7 @@ const updateIndividualOffersStatus = async (
   notify: ReturnType<typeof useNotification>,
   apiFilters: SearchFiltersParams
 ) => {
-  const payload = serializeApiFilters(apiFilters)
+  const payload = serializeApiFilters(apiFilters, Audience.INDIVIDUAL)
   if (areAllOffersSelected) {
     //  Bulk edit if all editable offers are selected
     try {

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
@@ -15,6 +15,7 @@ import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { computeOffersUrl } from 'core/Offers/utils/computeOffersUrl'
 import { serializeApiFilters } from 'core/Offers/utils/serializer'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared/constants'
+import { Audience } from 'core/shared/types'
 import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useNotification } from 'hooks/useNotification'
 import strokeSearchIcon from 'icons/stroke-search.svg'
@@ -64,13 +65,16 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
         periodEndingDate,
         collectiveOfferType,
         format,
-      } = serializeApiFilters({
-        ...DEFAULT_COLLECTIVE_SEARCH_FILTERS,
-        nameOrIsbn: offerName,
-        collectiveOfferType: 'template',
-        offererId: queryOffererId ? queryOffererId : 'all',
-        venueId: queryVenueId ? queryVenueId : 'all',
-      })
+      } = serializeApiFilters(
+        {
+          ...DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+          nameOrIsbn: offerName,
+          collectiveOfferType: 'template',
+          offererId: queryOffererId ? queryOffererId : 'all',
+          venueId: queryVenueId ? queryVenueId : 'all',
+        },
+        Audience.COLLECTIVE
+      )
 
       try {
         const offers = await api.getCollectiveOffers(

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
@@ -11,7 +11,7 @@ import {
 import { AppLayout } from 'app/AppLayout'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { createOfferFromTemplate } from 'core/OfferEducational/utils/createOfferFromTemplate'
-import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { computeOffersUrl } from 'core/Offers/utils/computeOffersUrl'
 import { serializeApiFilters } from 'core/Offers/utils/serializer'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared/constants'
@@ -65,7 +65,7 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
         collectiveOfferType,
         format,
       } = serializeApiFilters({
-        ...DEFAULT_SEARCH_FILTERS,
+        ...DEFAULT_COLLECTIVE_SEARCH_FILTERS,
         nameOrIsbn: offerName,
         collectiveOfferType: 'template',
         offererId: queryOffererId ? queryOffererId : 'all',

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
@@ -4,10 +4,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import {
-  CollectiveOfferDisplayedStatus,
-  CollectiveOfferResponseModel,
-} from 'apiClient/v1'
+import { CollectiveOfferResponseModel } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { createOfferFromTemplate } from 'core/OfferEducational/utils/createOfferFromTemplate'
@@ -80,7 +77,7 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
         const offers = await api.getCollectiveOffers(
           nameOrIsbn,
           offererId,
-          status as CollectiveOfferDisplayedStatus,
+          status,
           venueId,
           categoryId,
           creationMode,

--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -23,6 +23,7 @@ import {
 } from 'core/Offers/constants'
 import { getIndividualOfferUrl } from 'core/Offers/utils/getIndividualOfferUrl'
 import { serializeApiFilters } from 'core/Offers/utils/serializer'
+import { Audience } from 'core/shared/types'
 import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useIsNewInterfaceActive } from 'hooks/useIsNewInterfaceActive'
 import { useNotification } from 'hooks/useNotification'
@@ -139,7 +140,7 @@ export const OfferTypeScreen = (): JSX.Element => {
         periodEndingDate,
         collectiveOfferType,
         format,
-      } = serializeApiFilters(apiFilters)
+      } = serializeApiFilters(apiFilters, Audience.COLLECTIVE)
 
       const templateOffersOnSelectedVenue = await api.getCollectiveOffers(
         nameOrIsbn,

--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -17,7 +17,7 @@ import {
 import {
   COLLECTIVE_OFFER_SUBTYPE,
   COLLECTIVE_OFFER_SUBTYPE_DUPLICATE,
-  DEFAULT_SEARCH_FILTERS,
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
   OFFER_TYPES,
   OFFER_WIZARD_MODE,
 } from 'core/Offers/constants'
@@ -123,7 +123,7 @@ export const OfferTypeScreen = (): JSX.Element => {
       COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.DUPLICATE
     ) {
       const apiFilters = {
-        ...DEFAULT_SEARCH_FILTERS,
+        ...DEFAULT_COLLECTIVE_SEARCH_FILTERS,
         collectiveOfferType: COLLECTIVE_OFFER_SUBTYPE.TEMPLATE.toLowerCase(),
         offererId: queryOffererId ? queryOffererId : 'all',
         venueId: queryVenueId ? queryVenueId : 'all',

--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
-import { CollectiveOfferDisplayedStatus } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
@@ -145,7 +144,7 @@ export const OfferTypeScreen = (): JSX.Element => {
       const templateOffersOnSelectedVenue = await api.getCollectiveOffers(
         nameOrIsbn,
         offererId,
-        status as CollectiveOfferDisplayedStatus,
+        status,
         venueId,
         categoryId,
         creationMode,

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -227,7 +227,7 @@ export const Offers = ({
 
   const isNewInterfaceActive = useIsNewInterfaceActive()
   const title = isNewInterfaceActive
-    ? audience === Audience.COLLECTIVE
+    ? isCollective
       ? 'Offres collectives'
       : 'Offres individuelles'
     : 'Offres'
@@ -294,8 +294,8 @@ export const Offers = ({
         />
       )}
 
-      {audience === Audience.INDIVIDUAL ? (
-        <IndividualSearchFilters
+      {isCollective ? (
+        <CollectiveSearchFilters
           applyFilters={applyFilters}
           categories={categories}
           disableAllFilters={userHasNoOffers}
@@ -308,7 +308,7 @@ export const Offers = ({
           isRestrictedAsAdmin={isRestrictedAsAdmin}
         />
       ) : (
-        <CollectiveSearchFilters
+        <IndividualSearchFilters
           applyFilters={applyFilters}
           categories={categories}
           disableAllFilters={userHasNoOffers}
@@ -322,7 +322,7 @@ export const Offers = ({
         />
       )}
 
-      {Audience.COLLECTIVE === audience && (
+      {isCollective && (
         <Callout
           className={styles['banner']}
           variant={CalloutVariant.INFO}

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -48,7 +48,7 @@ import { Titles } from 'ui-kit/Titles/Titles'
 
 import styles from './Offers.module.scss'
 import { CollectiveSearchFilters } from './SearchFilters/CollectiveSearchFilters'
-import { SearchFilters } from './SearchFilters/SearchFilters'
+import { IndividualSearchFilters } from './SearchFilters/IndividualSearchFilters'
 
 export type OffersProps = {
   currentPageNumber: number
@@ -295,7 +295,7 @@ export const Offers = ({
       )}
 
       {audience === Audience.INDIVIDUAL ? (
-        <SearchFilters
+        <IndividualSearchFilters
           applyFilters={applyFilters}
           categories={categories}
           disableAllFilters={userHasNoOffers}

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -16,6 +16,7 @@ import { NoData } from 'components/NoData/NoData'
 import { GET_VALIDATED_OFFERERS_NAMES_QUERY_KEY } from 'config/swrQueryKeys'
 import { isOfferEducational } from 'core/OfferEducational/types'
 import {
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
   DEFAULT_PAGE,
   DEFAULT_SEARCH_FILTERS,
   MAX_TOTAL_PAGES,
@@ -283,7 +284,7 @@ export const Offers = ({
               label: 'Offres collectives',
               url: computeCollectiveOffersUrl({
                 ...initialSearchFilters,
-                status: DEFAULT_SEARCH_FILTERS.status,
+                status: DEFAULT_COLLECTIVE_SEARCH_FILTERS.status,
                 page: currentPageNumber,
               }),
               key: 'collective',

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -46,6 +46,7 @@ import { Tabs } from 'ui-kit/Tabs/Tabs'
 import { Titles } from 'ui-kit/Titles/Titles'
 
 import styles from './Offers.module.scss'
+import { CollectiveSearchFilters } from './SearchFilters/CollectiveSearchFilters'
 import { SearchFilters } from './SearchFilters/SearchFilters'
 
 export type OffersProps = {
@@ -292,19 +293,34 @@ export const Offers = ({
         />
       )}
 
-      <SearchFilters
-        applyFilters={applyFilters}
-        audience={audience}
-        categories={categories}
-        disableAllFilters={userHasNoOffers}
-        offerer={offerer}
-        removeOfferer={removeOfferer}
-        resetFilters={resetFilters}
-        selectedFilters={selectedFilters}
-        setSelectedFilters={setSelectedFilters}
-        venues={venues}
-        isRestrictedAsAdmin={isRestrictedAsAdmin}
-      />
+      {audience === Audience.INDIVIDUAL ? (
+        <SearchFilters
+          applyFilters={applyFilters}
+          categories={categories}
+          disableAllFilters={userHasNoOffers}
+          offerer={offerer}
+          removeOfferer={removeOfferer}
+          resetFilters={resetFilters}
+          selectedFilters={selectedFilters}
+          setSelectedFilters={setSelectedFilters}
+          venues={venues}
+          isRestrictedAsAdmin={isRestrictedAsAdmin}
+        />
+      ) : (
+        <CollectiveSearchFilters
+          applyFilters={applyFilters}
+          categories={categories}
+          disableAllFilters={userHasNoOffers}
+          offerer={offerer}
+          removeOfferer={removeOfferer}
+          resetFilters={resetFilters}
+          selectedFilters={selectedFilters}
+          setSelectedFilters={setSelectedFilters}
+          venues={venues}
+          isRestrictedAsAdmin={isRestrictedAsAdmin}
+        />
+      )}
+
       {Audience.COLLECTIVE === audience && (
         <Callout
           className={styles['banner']}

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -172,9 +172,13 @@ export const Offers = ({
   }
 
   const resetFilters = () => {
-    setSelectedFilters(DEFAULT_SEARCH_FILTERS)
+    const defaultFilters = isCollective
+      ? DEFAULT_COLLECTIVE_SEARCH_FILTERS
+      : DEFAULT_SEARCH_FILTERS
+
+    setSelectedFilters(defaultFilters)
     applyUrlFiltersAndRedirect({
-      ...DEFAULT_SEARCH_FILTERS,
+      ...defaultFilters,
     })
   }
 

--- a/pro/src/screens/Offers/SearchFilters/CollectiveSearchFilters.tsx
+++ b/pro/src/screens/Offers/SearchFilters/CollectiveSearchFilters.tsx
@@ -162,6 +162,14 @@ export const CollectiveSearchFilters = ({
     applyFilters(selectedFilters)
   }
 
+  const resetCollectiveFilters = async () => {
+    await formik.setFieldValue(
+      'status',
+      DEFAULT_COLLECTIVE_SEARCH_FILTERS.status
+    )
+    resetFilters()
+  }
+
   const searchByOfferNameLabel = 'Nom de l’offre'
   const searchByOfferNamePlaceholder = 'Rechercher par nom d’offre'
 
@@ -267,7 +275,7 @@ export const CollectiveSearchFilters = ({
           <Button
             icon={fullRefreshIcon}
             disabled={!hasSearchFilters(selectedFilters)}
-            onClick={resetFilters}
+            onClick={resetCollectiveFilters}
             variant={ButtonVariant.TERNARY}
           >
             Réinitialiser les filtres

--- a/pro/src/screens/Offers/SearchFilters/CollectiveSearchFilters.tsx
+++ b/pro/src/screens/Offers/SearchFilters/CollectiveSearchFilters.tsx
@@ -11,7 +11,7 @@ import {
   ALL_FORMATS_OPTION,
   ALL_VENUES_OPTION,
   COLLECTIVE_OFFER_TYPES_OPTIONS,
-  DEFAULT_SEARCH_FILTERS,
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
 } from 'core/Offers/constants'
 import { SearchFiltersParams } from 'core/Offers/types'
 import { hasSearchFilters } from 'core/Offers/utils/hasSearchFilters'
@@ -145,7 +145,7 @@ export const CollectiveSearchFilters = ({
     const dateToFilter =
       periodBeginningDate !== ''
         ? periodBeginningDate
-        : DEFAULT_SEARCH_FILTERS.periodBeginningDate
+        : DEFAULT_COLLECTIVE_SEARCH_FILTERS.periodBeginningDate
     updateSearchFilters({ periodBeginningDate: dateToFilter })
   }
 
@@ -153,7 +153,7 @@ export const CollectiveSearchFilters = ({
     const dateToFilter =
       periodEndingDate !== ''
         ? periodEndingDate
-        : DEFAULT_SEARCH_FILTERS.periodEndingDate
+        : DEFAULT_COLLECTIVE_SEARCH_FILTERS.periodEndingDate
     updateSearchFilters({ periodEndingDate: dateToFilter })
   }
 

--- a/pro/src/screens/Offers/SearchFilters/IndividualSearchFilters.tsx
+++ b/pro/src/screens/Offers/SearchFilters/IndividualSearchFilters.tsx
@@ -26,7 +26,7 @@ import { Tag, TagVariant } from 'ui-kit/Tag/Tag'
 
 import styles from './SearchFilters.module.scss'
 
-interface SearchFiltersProps {
+interface IndividualSearchFiltersProps {
   applyFilters: (filters: SearchFiltersParams) => void
   offerer: GetOffererResponseModel | null
   removeOfferer: () => void
@@ -50,7 +50,7 @@ const individualFilterStatus = [
   { label: 'Refusée', value: OfferStatus.REJECTED },
 ]
 
-export const SearchFilters = ({
+export const IndividualSearchFilters = ({
   applyFilters,
   selectedFilters,
   setSelectedFilters,
@@ -61,7 +61,7 @@ export const SearchFilters = ({
   venues,
   categories,
   isRestrictedAsAdmin = false,
-}: SearchFiltersProps): JSX.Element => {
+}: IndividualSearchFiltersProps): JSX.Element => {
   const isNewInterfaceActive = useIsNewInterfaceActive()
 
   const updateSearchFilters = (

--- a/pro/src/screens/Offers/SearchFilters/SearchFilters.module.scss
+++ b/pro/src/screens/Offers/SearchFilters/SearchFilters.module.scss
@@ -63,11 +63,11 @@ $status-filter-margin-top: rem.torem(24px);
 
 .status-filter {
   width: fit-content;
-  margin-top: $status-filter-margin-top;
   margin-bottom: 0;
 }
 
 .status-filter-label {
+  margin-top: $status-filter-margin-top;
   display: flex;
   align-items: center;
   gap: rem.torem(8px);

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -411,7 +411,7 @@ describe('screen Offers', () => {
     expect(screen.queryByLabelText(offers[2].name)).toBeEnabled()
   })
 
-  it('should not have "Tout Sélectionner" checked when there is no offer to be checked', () => {
+  it('should not have "Tout Sélectionner" checked when there is no offer to be checked', async () => {
     const offers = [
       collectiveOfferFactory({
         isActive: false,
@@ -425,7 +425,7 @@ describe('screen Offers', () => {
       collectiveOffers: offers,
     })
 
-    expect(screen.getByLabelText('Tout sélectionner')).not.toBeChecked()
+    expect(await screen.findByLabelText('Tout sélectionner')).not.toBeChecked()
   })
 
   it('should display the button to create an offer when user is not an admin', async () => {
@@ -587,13 +587,13 @@ describe('screen Offers', () => {
     })
   })
 
-  it('should display the collective offers format', () => {
+  it('should display the collective offers format', async () => {
     renderOffers({
       ...props,
       collectiveOffers: [collectiveOfferFactory()],
       audience: Audience.COLLECTIVE,
     })
-    expect(screen.getByRole('combobox', { name: 'Format' }))
+    expect(await screen.findByRole('combobox', { name: 'Format' }))
   })
 
   it('should filter on the format', async () => {
@@ -645,7 +645,7 @@ describe('screen Offers', () => {
     expect(screen.queryByText(/Créer une offre/)).not.toBeInTheDocument()
   })
 
-  it('should display onboarding banner for archivage only in collective offer list', () => {
+  it('should display onboarding banner for archivage only in collective offer list', async () => {
     renderOffers({
       ...props,
       audience: Audience.COLLECTIVE,
@@ -653,7 +653,7 @@ describe('screen Offers', () => {
     })
 
     expect(
-      screen.getByText(
+      await screen.findByText(
         'C’est nouveau ! Vous pouvez désormais archiver vos offres collectives.'
       )
     ).toBeInTheDocument()
@@ -686,7 +686,7 @@ describe('screen Offers', () => {
     )
   })
 
-  it('should delete aniway even with active status', async () => {
+  it('should delete anyway even with active status', async () => {
     vi.spyOn(api, 'deleteDraftOffers').mockResolvedValueOnce()
 
     renderOffers({
@@ -711,7 +711,7 @@ describe('screen Offers', () => {
     )
   })
 
-  it('should display a new column "Date de l’évènement" if FF is enabled', () => {
+  it('should display a new column "Date de l’évènement" if FF is enabled', async () => {
     const featureOverrides = {
       features: ['ENABLE_COLLECTIVE_OFFERS_EXPIRATION'],
     }
@@ -725,7 +725,7 @@ describe('screen Offers', () => {
       featureOverrides
     )
 
-    expect(screen.getByText('Date de l’évènement'))
+    expect(await screen.findByText('Date de l’évènement'))
   })
 
   it('should filter new column "Date de l’évènement"', async () => {

--- a/pro/src/utils/parseUrlParams.ts
+++ b/pro/src/utils/parseUrlParams.ts
@@ -1,0 +1,14 @@
+export function parseUrlParams(urlParams: URLSearchParams) {
+  const queryParams: Record<string, string | string[]> = {}
+  urlParams.forEach((value, key) => {
+    if (queryParams[key]) {
+      if (!Array.isArray(queryParams[key])) {
+        queryParams[key] = [queryParams[key]]
+      }
+      queryParams[key].push(value)
+    } else {
+      queryParams[key] = value
+    }
+  })
+  return queryParams
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-29690

- séparation des filtres collectifs et individuels
- ajout du SelectAutocomplete sur les filtres collectifs pour remplacer le filtre à choix unique par un filtre à choix multiples
- modifications sur la serialisation des filtres sélectionnés en paramètres d'url et inversement pour prendre en compte les listes
- réutilisation de ces modifs pour les trackers


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
