### PR TITLE
(PC-30587)[PRO] feat: sort column event date

### DIFF
--- a/pro/src/hooks/usePagination.ts
+++ b/pro/src/hooks/usePagination.ts
@@ -1,8 +1,12 @@
 import { useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
-export const usePagination = <T>(items: T[], itemsPerPage: number) => {
-  const [page, setPage] = useState(1)
+export const usePagination = <T>(
+  items: T[],
+  itemsPerPage: number,
+  pageFromFilter?: number
+) => {
+  const [page, setPage] = useState(pageFromFilter ?? 1)
 
   const previousPage = () => setPage((page) => page - 1)
   const nextPage = () => setPage((page) => page + 1)

--- a/pro/src/pages/Offers/OffersTable/Cells/Cells.module.scss
+++ b/pro/src/pages/Offers/OffersTable/Cells/Cells.module.scss
@@ -302,7 +302,7 @@
 }
 
 .offer-event {
-  min-width: rem.torem(150px);
+  min-width: rem.torem(170px);
   display: flex;
   flex-direction: column;
 

--- a/pro/src/pages/Offers/OffersTable/Cells/ExpirationCell/ExpirationCell.module.scss
+++ b/pro/src/pages/Offers/OffersTable/Cells/ExpirationCell/ExpirationCell.module.scss
@@ -52,3 +52,10 @@
     gap: rem.torem(16px);
   }
 }
+
+
+@media (max-width: size.$laptop) {
+  .expiration-cell {
+    display: block;
+  }
+}

--- a/pro/src/pages/Offers/OffersTable/Cells/OfferEventDateCell/OfferEventDateCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/OfferEventDateCell/OfferEventDateCell.tsx
@@ -66,7 +66,9 @@ export const OfferEventDateCell = ({
     <td headers={headers} className={styles['offers-table-cell']}>
       <div className={styles['offer-event']}>
         {getFormattedDatesForOffer(offer).map((date) => (
-          <span key={date}>{date}</span>
+          <span key={date} data-testid="offer-event-date">
+            {date}
+          </span>
         ))}
         <span className={styles['offer-event-hours']}>
           {formattedTime(offer.dates?.start)}

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableHead/CollectiveOffersTableHead.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableHead/CollectiveOffersTableHead.tsx
@@ -1,10 +1,26 @@
 import classNames from 'classnames'
 
+import { SortArrow } from 'components/StocksEventList/SortArrow'
 import { useActiveFeature } from 'hooks/useActiveFeature'
+import { SortingMode } from 'hooks/useColumnSorting'
+
+import { CollectiveOffersSortingColumn } from '../CollectiveOffersTable'
 
 import styles from './CollectiveOffersTableHead.module.scss'
 
-export const CollectiveOffersTableHead = (): JSX.Element => {
+type CollectiveOffersTableHeadProps = {
+  onColumnHeaderClick: (
+    headersName: CollectiveOffersSortingColumn
+  ) => SortingMode
+  currentSortingColumn: CollectiveOffersSortingColumn | null
+  currentSortingMode: SortingMode
+}
+
+export const CollectiveOffersTableHead = ({
+  onColumnHeaderClick,
+  currentSortingColumn,
+  currentSortingMode,
+}: CollectiveOffersTableHeadProps): JSX.Element => {
   const isCollectiveOffersExpirationEnabled = useActiveFeature(
     'ENABLE_COLLECTIVE_OFFERS_EXPIRATION'
   )
@@ -37,15 +53,26 @@ export const CollectiveOffersTableHead = (): JSX.Element => {
         >
           <span className="visually-hidden">Nom</span>
         </th>
-
         {isCollectiveOffersExpirationEnabled && (
           <th
             id="collective-offer-head-event-date"
             className={styles['collective-th']}
           >
-            Date de l’évènement
+            Date de l’évènement{' '}
+            <SortArrow
+              onClick={() => {
+                onColumnHeaderClick(CollectiveOffersSortingColumn.EVENT_DATE)
+              }}
+              sortingMode={
+                currentSortingColumn ===
+                CollectiveOffersSortingColumn.EVENT_DATE
+                  ? currentSortingMode
+                  : SortingMode.NONE
+              }
+            />
           </th>
         )}
+
         <th
           id="collective-offer-head-venue"
           className={classNames(

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -337,8 +337,6 @@ export const Offers = ({
           <CollectiveOffersTable
             applyUrlFiltersAndRedirect={applyUrlFiltersAndRedirect}
             areAllOffersSelected={areAllCollectiveOffersSelected}
-            currentPageNumber={currentPageNumber}
-            currentPageOffersSubset={currentPageCollectiveOffersSubset}
             hasOffers={hasOffers}
             isLoading={isLoading}
             offersCount={offers.length}
@@ -350,6 +348,7 @@ export const Offers = ({
             urlSearchFilters={urlSearchFilters}
             isAtLeastOneOfferChecked={selectedCollectiveOffers.length > 1}
             isRestrictedAsAdmin={isRestrictedAsAdmin}
+            offers={collectiveOffers}
           />
           {selectedCollectiveOffers.length > 0 && (
             <CollectiveOffersActionsBar

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -727,4 +727,48 @@ describe('screen Offers', () => {
 
     expect(screen.getByText('Date de l’évènement'))
   })
+
+  it('should filter new column "Date de l’évènement"', async () => {
+    const featureOverrides = {
+      features: ['ENABLE_COLLECTIVE_OFFERS_EXPIRATION'],
+    }
+
+    renderOffers(
+      {
+        ...props,
+        collectiveOffers: [
+          collectiveOfferFactory({
+            dates: {
+              start: '2024-07-31T09:11:00Z',
+              end: '2024-07-31T09:11:00Z',
+            },
+          }),
+          collectiveOfferFactory({
+            dates: {
+              start: '2024-06-30T09:11:00Z',
+              end: '2024-06-30T09:11:00Z',
+            },
+          }),
+        ],
+        audience: Audience.COLLECTIVE,
+      },
+      featureOverrides
+    )
+
+    const firstOfferEventDate =
+      screen.getAllByTestId('offer-event-date')[0].textContent
+
+    expect(firstOfferEventDate).toEqual('31/07/2024')
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Trier par ordre croissant',
+      })
+    )
+
+    const newFirstOfferEventDate =
+      screen.getAllByTestId('offer-event-date')[0].textContent
+
+    expect(newFirstOfferEventDate).toEqual('30/06/2024')
+  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30587

SOUS FF : ENABLE_COLLECTIVE_OFFERS_EXPIRATION

Ajouter la possibilité de trier la colonne des dates de l'évènement

<img width="174" alt="Capture d’écran 2024-07-29 à 17 02 07" src="https://github.com/user-attachments/assets/1528efa6-8b26-46db-a6b8-d46b910ee9e0">

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
