### PR TITLE
(PC-30982)[PRO] feat: Make collective form date inputs wider and more…

### DIFF
--- a/pro/src/screens/OfferEducationalStock/FormStock/FormStock.module.scss
+++ b/pro/src/screens/OfferEducationalStock/FormStock/FormStock.module.scss
@@ -1,9 +1,21 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .input-date svg {
-    width: rem.torem(20px);
+  width: rem.torem(20px);
 }
 
 .input-custom-width {
-    width: rem.torem(110px);
+  width: rem.torem(110px);
+}
+
+.input-date {
+  min-width: rem.torem(192px);
+}
+
+.custom-field-layout {
+  width: unset;
+}
+
+.layout-row {
+  flex-wrap: wrap;
 }

--- a/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { useFormikContext } from 'formik'
 import React from 'react'
 
@@ -61,26 +62,33 @@ export const FormStock = ({
   }
 
   return (
-    <FormLayout.Row inline>
+    <FormLayout.Row inline className={styles['layout-row']}>
       <DatePicker
         disabled={mode === Mode.READ_ONLY}
         label={START_DATE_LABEL}
         minDate={new Date()}
         name="startDatetime"
         onChange={handleStartDatetimeChange}
-        className={styles['input-date']}
+        className={classNames(
+          styles['input-date'],
+          styles['custom-field-layout']
+        )}
       />
       <DatePicker
         disabled={mode === Mode.READ_ONLY}
         label={END_DATE_LABEL}
         minDate={minEndDatetime}
         name="endDatetime"
-        className={styles['input-date']}
+        className={classNames(
+          styles['input-date'],
+          styles['custom-field-layout']
+        )}
       />
       <TimePicker
         disabled={mode === Mode.READ_ONLY}
         label={EVENT_TIME_LABEL}
         name="eventTime"
+        className={styles['custom-field-layout']}
       />
       <TextInput
         disabled={disablePriceAndParticipantInputs}
@@ -90,6 +98,7 @@ export const FormStock = ({
         type="number"
         hasLabelLineBreak={false}
         rightIcon={strokeCollaborator}
+        className={styles['custom-field-layout']}
         classNameInput={styles['input-custom-width']}
       />
       <TextInput
@@ -99,6 +108,7 @@ export const FormStock = ({
         step={0.01} // allow user to enter a price with cents
         type="number"
         rightIcon={strokeEuroIcon}
+        className={styles['custom-field-layout']}
         classNameInput={styles['input-custom-width']}
       />
     </FormLayout.Row>

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.module.scss
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.module.scss
@@ -30,5 +30,5 @@
 }
 
 .input-date {
-  width: rem.torem(150px);
+  width: rem.torem(192px);
 }


### PR DESCRIPTION
… responsive.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30982

**Objectif**
Rendre l'affichage du formulaire dates & prix des offres collectives + responsive et accessible.
- Agrandissement des inputs date du form pour que le letter-spacing de 1.8px ne rende pas une partie de la date invisible
- Responsive de la liste des inputs du formulaire pour que ça passe à la ligne petit à petit (sinon ça passait plus avec les inputs date agrandis)

<img width="628" alt="Capture d’écran 2024-07-29 à 09 22 35" src="https://github.com/user-attachments/assets/81a209ee-854e-4114-b6cd-673e338a7284">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
