### PR TITLE
(PC-31125)[API] fix: support empty fraud check in age at deposit calculation

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -2691,9 +2691,8 @@ def _get_known_age_at_deposit(user: users_models.User) -> int | None:
     identity_provider_birthday_checks = [
         fraud_check
         for fraud_check in user.beneficiaryFraudChecks
-        if fraud_check.type in fraud_models.IDENTITY_CHECK_TYPES
-        and fraud_check.status == fraud_models.FraudCheckStatus.OK
-        and fraud_check.source_data().get_birth_date() is not None
+        if fraud_check.status == fraud_models.FraudCheckStatus.OK
+        and fraud_check.get_identity_check_birth_date() is not None
         and fraud_check.dateCreated < deposit_date
     ]
     last_identity_provider_birthday_check = max(
@@ -2717,7 +2716,7 @@ def _get_known_age_at_deposit(user: users_models.User) -> int | None:
 
         case check, None:
             assert check is not None
-            known_birthday_at_deposit = check.source_data().get_birth_date()
+            known_birthday_at_deposit = check.get_identity_check_birth_date()
 
         case None, action:
             assert action is not None
@@ -2733,7 +2732,7 @@ def _get_known_age_at_deposit(user: users_models.User) -> int | None:
                     action.extraData["modified_info"]["validatedBirthDate"]["new_info"], "%Y-%m-%d"
                 ).date()
             else:
-                known_birthday_at_deposit = check.source_data().get_birth_date()
+                known_birthday_at_deposit = check.get_identity_check_birth_date()
 
         case _:
             raise ValueError(

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -569,6 +569,11 @@ class BeneficiaryFraudCheck(PcObject, Base, Model):
             return min(self.dateCreated, registration_datetime)
         return self.dateCreated
 
+    def get_identity_check_birth_date(self) -> datetime.date | None:
+        if self.type not in IDENTITY_CHECK_TYPES or not self.resultContent:
+            return None
+        return self.source_data().get_birth_date()
+
     def source_data(self) -> FraudCheckContent:  # type: ignore[type-var]
         cls = FRAUD_CHECK_CONTENT_MAPPING[self.type]
         if not cls:

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -3949,6 +3949,18 @@ class UserRecreditTest:
         with time_machine.travel("2020-05-02"):
             assert api._can_be_recredited(user) is False
 
+    def test_can_be_recredited_legacy_educonnect_fraud_check(self):
+        user = users_factories.BeneficiaryFactory(age=15)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            dateCreated=datetime.datetime(2020, 5, 2),
+            user=user,
+            type=fraud_models.FraudCheckType.EDUCONNECT,
+            status=fraud_models.FraudCheckStatus.OK,
+            resultContent=None,
+            eligibilityType=users_models.EligibilityType.UNDERAGE,
+        )
+        assert api._has_been_recredited(user)
+
     @mock.patch("pcapi.core.finance.api._has_been_recredited")
     def should_not_check_recredits_on_age_18(self, mock_has_been_recredited):
         user = users_factories.BeneficiaryFactory(age=18)


### PR DESCRIPTION
The legacy Educonnect fraud checks do not have any associated source data, so we return None as the known birth date instead of raising an exception.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31125

## Vérifications

- [X] J'ai écrit les tests nécessaires