### PR TITLE
(PC-31128)[PRO] feat: Remove FF WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION.

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 e9caf841c7d6 (pre) (head)
-943f189a4c71 (post) (head)
+7ed9516f7af7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240730T080948_7ed9516f7af7_remove_ff_collective_markdown.py
+++ b/api/src/pcapi/alembic/versions/20240730T080948_7ed9516f7af7_remove_ff_collective_markdown.py
@@ -1,0 +1,35 @@
+"""
+Remove the feature flag WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "7ed9516f7af7"
+down_revision = "943f189a4c71"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def get_flag():  # type: ignore[no-untyped-def]
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION",
+        isActive=True,
+        description="Activer la description des offres collectives en markdown.",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -117,7 +117,6 @@ class FeatureToggle(enum.Enum):
     ENABLE_PRO_NEW_NAV_MODIFICATION = "Activer la modification du statut de la navigation du portail pro"
     WIP_ENABLE_NEW_HASHING_ALGORITHM = "Activer le nouveau système de hachage des clés publiques d'API"
     WIP_BENEFICIARY_EXTRACT_TOOL = "Activer l'extraction de données personnelles (RGPD)"
-    WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION = "Activer la description des offres collectives en markdown."
     USE_END_DATE_FOR_COLLECTIVE_PRICING = "Utiliser la date de fin du stock collectif comme date de valorisation."
     WIP_ENABLE_OFFER_ADDRESS = "Activer l'association des offres à des adresses."
     WIP_SPLIT_OFFER = "Activer le nouveau parcours de création/édition d'offre individuelle"

--- a/pro/src/components/Markdown/Markdown.tsx
+++ b/pro/src/components/Markdown/Markdown.tsx
@@ -1,7 +1,5 @@
 import DOMPurify from 'dompurify'
 
-import { useActiveFeature } from 'hooks/useActiveFeature'
-
 const BOLD_REGEXP = /\*\*(.*?)\*\*/gim
 const ITALIC_REGEXP = /_(.*?)_/gim
 const URL_REGEXP = /((https?:\/\/)|(www\.))[^\s/$.?#].[^\s]*/gim
@@ -21,14 +19,6 @@ function markdownToHtml(markdown: string) {
 }
 
 export const Markdown = ({ markdownText }: { markdownText: string }) => {
-  const isMarkdownDescriptionEnabled = useActiveFeature(
-    'WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION'
-  )
-
-  if (!isMarkdownDescriptionEnabled) {
-    return markdownText
-  }
-
   const html = DOMPurify.sanitize(markdownToHtml(markdownText), {
     ALLOWED_TAGS: ['strong', 'em', 'a'],
     ALLOWED_ATTR: ['href', 'target', 'rel'],

--- a/pro/src/components/Markdown/__specs__/Markdown.spec.tsx
+++ b/pro/src/components/Markdown/__specs__/Markdown.spec.tsx
@@ -1,74 +1,58 @@
-import { renderWithProviders } from 'utils/renderWithProviders'
+import { render } from '@testing-library/react'
 
 import { Markdown } from '../Markdown'
 
+function renderMarkdown(text: string) {
+  return render(<Markdown markdownText={text} />)
+}
+
 describe('Markdown', () => {
-  describe('when feature flag WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION is on', () => {
-    it('should render bold text with <strong> tag', () => {
-      const component = renderMarkdown('**texte en gras**')
-      expect(component.container.innerHTML).toContain(
-        '<span><strong>texte en gras</strong></span>'
-      )
-    })
-
-    it('should render italic text with <em> tag', () => {
-      const component = renderMarkdown('_texte en italique_')
-      expect(component.container.innerHTML).toContain(
-        '<span><em>texte en italique</em></span>'
-      )
-    })
-
-    it('should render urls with <a> tag', () => {
-      const component = renderMarkdown('https://example.com')
-      expect(component.container.innerHTML).toContain(
-        '<span><a rel="noreferrer" href="https://example.com">https://example.com</a></span>'
-      )
-    })
-
-    it('should render urls without http prefix with <a> tag', () => {
-      const component = renderMarkdown('www.example.com')
-      expect(component.container.innerHTML).toContain(
-        '<span><a rel="noreferrer" href="https://www.example.com">www.example.com</a></span>'
-      )
-    })
-
-    it('should render email adress with <a> tag and mailto attribute', () => {
-      const component = renderMarkdown('test@example.com')
-      expect(component.container.innerHTML).toContain(
-        '<span><a href="mailto:test@example.com">test@example.com</a></span>'
-      )
-    })
-
-    it('should render multiple strong tags when multiple words are surrounded with double asterisks', () => {
-      const component = renderMarkdown('**texte** en **gras**')
-      expect(component.container.innerHTML).toContain(
-        '<span><strong>texte</strong> en <strong>gras</strong></span>'
-      )
-    })
-
-    it('should render multiple em tags when multiple words are surrounded with underscores', () => {
-      const component = renderMarkdown('_texte_ en _italique_')
-      expect(component.container.innerHTML).toContain(
-        '<span><em>texte</em> en <em>italique</em></span>'
-      )
-    })
+  it('should render bold text with <strong> tag', () => {
+    const component = renderMarkdown('**texte en gras**')
+    expect(component.container.innerHTML).toContain(
+      '<span><strong>texte en gras</strong></span>'
+    )
   })
 
-  it('should render unformatted text when feature flag WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION is off', () => {
-    const component = renderMarkdown(
-      '**texte en gras** _texte en italique_ https://example.com',
-      false
-    )
+  it('should render italic text with <em> tag', () => {
+    const component = renderMarkdown('_texte en italique_')
     expect(component.container.innerHTML).toContain(
-      '**texte en gras** _texte en italique_ https://example.com'
+      '<span><em>texte en italique</em></span>'
+    )
+  })
+
+  it('should render urls with <a> tag', () => {
+    const component = renderMarkdown('https://example.com')
+    expect(component.container.innerHTML).toContain(
+      '<span><a rel="noreferrer" href="https://example.com">https://example.com</a></span>'
+    )
+  })
+
+  it('should render urls without http prefix with <a> tag', () => {
+    const component = renderMarkdown('www.example.com')
+    expect(component.container.innerHTML).toContain(
+      '<span><a rel="noreferrer" href="https://www.example.com">www.example.com</a></span>'
+    )
+  })
+
+  it('should render email adress with <a> tag and mailto attribute', () => {
+    const component = renderMarkdown('test@example.com')
+    expect(component.container.innerHTML).toContain(
+      '<span><a href="mailto:test@example.com">test@example.com</a></span>'
+    )
+  })
+
+  it('should render multiple strong tags when multiple words are surrounded with double asterisks', () => {
+    const component = renderMarkdown('**texte** en **gras**')
+    expect(component.container.innerHTML).toContain(
+      '<span><strong>texte</strong> en <strong>gras</strong></span>'
+    )
+  })
+
+  it('should render multiple em tags when multiple words are surrounded with underscores', () => {
+    const component = renderMarkdown('_texte_ en _italique_')
+    expect(component.container.innerHTML).toContain(
+      '<span><em>texte</em> en <em>italique</em></span>'
     )
   })
 })
-
-function renderMarkdown(text: string, isFFEnabled: boolean = true) {
-  return renderWithProviders(<Markdown markdownText={text} />, {
-    features: isFFEnabled
-      ? ['WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION']
-      : undefined,
-  })
-}

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -5,7 +5,6 @@ import { FormLayout } from 'components/FormLayout/FormLayout'
 import { MAX_DETAILS_LENGTH } from 'core/OfferEducational/constants'
 import { OfferEducationalFormValues } from 'core/OfferEducational/types'
 import { SelectOption } from 'custom_types/form'
-import { useActiveFeature } from 'hooks/useActiveFeature'
 import { getNationalProgramsForDomains } from 'screens/OfferEducational/constants/getNationalProgramsForDomains'
 import { Select } from 'ui-kit/form/Select/Select'
 import { SelectAutocomplete } from 'ui-kit/form/SelectAutoComplete/SelectAutocomplete'
@@ -31,9 +30,6 @@ export const FormOfferType = ({
   disableForm,
 }: FormTypeProps): JSX.Element => {
   const { values } = useFormikContext<OfferEducationalFormValues>()
-  const isMarkdownDescriptionEnabled = useActiveFeature(
-    'WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION'
-  )
 
   const eacFormatOptions = Object.entries(EacFormat).map(([, value]) => ({
     value: value,
@@ -110,17 +106,15 @@ export const FormOfferType = ({
         </FormLayout.Row>
         <FormLayout.Row
           sideComponent={
-            isMarkdownDescriptionEnabled ? (
-              <InfoBox>
-                Vous pouvez modifier la mise en forme de votre texte.
-                <br />
-                Utilisez des doubles astérisques pour mettre en{' '}
-                <strong>gras</strong> : **exemple** et des tirets bas pour l’
-                <em>italique</em> : _exemple_
-                <br />
-                Vous pourrez vérifier l’affichage à l’étape "Aperçu".
-              </InfoBox>
-            ) : null
+            <InfoBox>
+              Vous pouvez modifier la mise en forme de votre texte.
+              <br />
+              Utilisez des doubles astérisques pour mettre en{' '}
+              <strong>gras</strong> : **exemple** et des tirets bas pour l’
+              <em>italique</em> : _exemple_
+              <br />
+              Vous pourrez vérifier l’affichage à l’étape "Aperçu".
+            </InfoBox>
           }
         >
           <TextArea


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31128

**Objectif**
Suppression du FF WIP_ENABLE_OFFER_MARKDOWN_DESCRIPTION responsable de l'affichage des instructions et du fonctionnement du markdown dans la description d'une offre collective.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
