### PR TITLE
(PC-31129)[PRO] fix: Wording of the colective offers table expiration…

### DIFF
--- a/pro/src/pages/Offers/OffersTable/Cells/ExpirationCell/ExpirationCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/ExpirationCell/ExpirationCell.tsx
@@ -51,9 +51,8 @@ export function ExpirationCell({
           <div className={styles['banner-expiration-waiting']}>
             <SvgIcon alt="" src={fullWaitIcon} width="16" /> En attente de{' '}
             {offer.status === CollectiveOfferStatus.ACTIVE
-              ? 'préréservation'
-              : 'réservation'}{' '}
-            par l’enseignant
+              ? 'préréservation par l’enseignant'
+              : 'réservation par le chef d’établissement'}
           </div>
         </div>
         <div className={styles['banner-booking-date']}>

--- a/pro/src/pages/Offers/OffersTable/Cells/ExpirationCell/__specs__/ExpirationCell.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/ExpirationCell/__specs__/ExpirationCell.spec.tsx
@@ -72,7 +72,7 @@ describe('ExpirationCell', () => {
     renderExpirationCell(offerExpiring, today.toISOString())
 
     expect(
-      screen.getByText('En attente de réservation par l’enseignant')
+      screen.getByText('En attente de réservation par le chef d’établissement')
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
@@ -476,7 +476,7 @@ describe('ollectiveOfferRow', () => {
     })
 
     expect(
-      screen.getByText('En attente de réservation par l’enseignant')
+      screen.getByText('En attente de réservation par le chef d’établissement')
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
… baner.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31129

**Objectif**
Correction de la formulation dans la bannière d'expiration. FF à activer : ENABLE_COLLECTIVE_OFFERS_EXPIRATION

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
