### PR TITLE
(PC-31132)[BO] refactor: remove unused EPN autotagging feature

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -869,9 +869,6 @@ def auto_tag_new_offerer(
         if not siren_info.diffusible:
             tag_names_to_apply.add("non-diffusible")
 
-        if siren_info.siren in settings.EPN_SIREN:
-            tag_names_to_apply.add("ecosysteme-epn")
-
     if user.email.split("@")[-1] in set(settings.NATIONAL_PARTNERS_EMAIL_DOMAINS.split(",")):
         tag_names_to_apply.add("partenaire-national")
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerer_tags.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerer_tags.py
@@ -30,4 +30,3 @@ def create_industrial_offerer_tags() -> None:
     offerers_factories.OffererTagFactory(name="adage", label="Adage", categories=[homologation])
     offerers_factories.OffererTagFactory(name="siren-caduc", label="SIREN caduc", categories=[homologation])
     offerers_factories.OffererTagFactory(name="non-diffusible", label="Non-diffusible", categories=[homologation])
-    offerers_factories.OffererTagFactory(name="ecosysteme-epn", label="Ecosystème EPN", categories=[homologation])

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -530,8 +530,6 @@ METABASE_DASHBOARD_ID = int(os.environ.get("METABASE_DASHBOARD_ID", 438))
 # NATIONAL PARTNERS
 NATIONAL_PARTNERS_EMAIL_DOMAINS = secrets_utils.get("NATIONAL_PARTNERS_EMAIL_DOMAINS", "impossible_email_domain.fr")
 
-# EPN
-EPN_SIREN = utils.parse_str_to_list(secrets_utils.get("EPN_SIREN", ""))
 
 # NAME CHECKING
 ENABLE_PERMISSIVE_NAME_VALIDATION = bool(int(os.environ.get("ENABLE_PERMISSIVE_NAME_VALIDATION", 0)))

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -888,37 +888,6 @@ class CreateOffererTest:
         assert national_partner_tag not in created_offerer_not_partner.tags
         assert national_partner_tag in created_offerer_partner.tags
 
-    @override_settings(EPN_SIREN="222222223,222222227")
-    def test_create_offerer_epn_autotagging(self):
-        # Given
-        epn_tag = offerers_factories.OffererTagFactory(name="ecosysteme-epn", label="Ecosystème EPN")
-        user = users_factories.UserFactory()
-        not_an_epn_offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer Not EPN",
-            siren="222222225",
-            address="123 rue de Paris",
-            postalCode="93100",
-            city="Montreuil",
-        )
-        epn_offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer EPN",
-            siren="222222223",
-            address="123 rue de Paname",
-            postalCode="93100",
-            city="Montreuil",
-        )
-
-        # When
-        created_user_offerer_not_epn = offerers_api.create_offerer(user, not_an_epn_offerer_informations)
-        created_user_offerer_epn = offerers_api.create_offerer(user, epn_offerer_informations)
-
-        # Then
-        created_offerer_not_epn = created_user_offerer_not_epn.offerer
-        created_offerer_epn = created_user_offerer_epn.offerer
-
-        assert epn_tag not in created_offerer_not_epn.tags
-        assert epn_tag in created_offerer_epn.tags
-
 
 class UpdateOffererTest:
     def test_update_offerer(self):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31132
Suppression d'une feature qui n'allait jamais marcher et qui impliquait l'utilisation d'un secret qui aurait été pénible, et duquel on ne nous a jamais donné la valeur.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
