### PR TITLE
(PC-30572)[PRO] feat: Implement default sort order for collective offers

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -510,7 +510,7 @@ def get_collective_offers_for_filters(
         formats=formats,
     )
 
-    query = query.order_by(educational_models.CollectiveOffer.id.desc())
+    query = query.order_by(educational_models.CollectiveOffer.dateCreated.desc())
     offers = (
         query.options(
             sa.orm.joinedload(educational_models.CollectiveOffer.venue).joinedload(
@@ -558,7 +558,7 @@ def get_collective_offers_template_for_filters(
     if query is None:
         return []
 
-    query = query.order_by(educational_models.CollectiveOfferTemplate.id.desc())
+    query = query.order_by(educational_models.CollectiveOfferTemplate.dateCreated.desc())
 
     offers = (
         query.options(


### PR DESCRIPTION
## But de la pull request

L'objectif est de mettre en avant les offres collectives sur le point d'expirer afin que le pro fasse le nécessaire que l'offre soit validé.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30572

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
