### PR TITLE
(BSR)[PRO] fix: format_datetime for non europe timezones

### DIFF
--- a/api/src/pcapi/utils/date.py
+++ b/api/src/pcapi/utils/date.py
@@ -83,7 +83,7 @@ class FrenchParserInfo(parserinfo):
 
 
 def format_datetime(date_time: datetime) -> str:
-    return babel_format_datetime(date_time, format="long", locale="fr")[:-9]
+    return babel_format_datetime(date_time, format="d MMMM y, HH:mm", locale="fr")
 
 
 def get_postal_code_timezone(postal_code: str) -> str:

--- a/api/tests/utils/date_test.py
+++ b/api/tests/utils/date_test.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 import dateutil
 import pytest
 
+import pcapi.utils.date as utils_date
 from pcapi.utils.date import CUSTOM_TIMEZONES
 from pcapi.utils.date import FrenchParserInfo
 from pcapi.utils.date import METROPOLE_TIMEZONE
@@ -188,3 +189,18 @@ class FormatDatetimeFromUtcTimezoneToLocalTimezoneTest:
 
         # Then
         assert result == datetime.datetime(2022, 6, 24, 12, 0, tzinfo=ZoneInfo(METROPOLE_TIMEZONE))
+
+
+class FormatDatetimeTest:
+    @pytest.mark.parametrize(
+        "tz_str",
+        [
+            "America/Martinique",
+            "Europe/Paris",
+        ],
+        ids=["Martinique", "metropole"],
+    )
+    def test_tz_conversion(self, tz_str):
+        dt = datetime.datetime(2022, 6, 24, 14, 0, tzinfo=ZoneInfo(tz_str))
+        result = utils_date.format_datetime(dt)
+        assert result == "24 juin 2022, 14:00"


### PR DESCRIPTION
babel.dates.format_datetime(datetime, format="long", locale="fr") gives inconsistent results on the TZ displayed.
For "Europe/Paris" it gives:
'20 juillet 2019, 08:00:00 +0200'
but for "America/Martinique" it gives:
'20 juillet 2019, 08:00:00 HNA'
which will fails the [:-9] to discard the TZ.

Let's switch to more explicit datetime format without TZ.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
