### PR TITLE
(BSR) docs: add a comment about the mysterious `deploy` environment

### DIFF
--- a/.github/workflows/dev_on_dispatch_release_deploy.yml
+++ b/.github/workflows/dev_on_dispatch_release_deploy.yml
@@ -68,6 +68,7 @@ jobs:
   version:
     name: "Version"
     needs: check-worflow-ref
+    # `deploy` is an artificial environment with protection rules, which allows a single required review instead of many
     environment:  ${{ fromJSON('["deploy", "testing"]')[github.event.inputs.target_environment == 'testing'] }}
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## But de la pull request

Expliquer le mystère de l'environnement `deploy`

La PR introduisant cet usage était https://github.com/pass-culture/pass-culture-main/pull/4853