### PR TITLE
(PC-30842)[API] feat: modfify the offererAddress during offer update

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -338,6 +338,7 @@ def update_offer(
     shouldSendMail: bool = False,
     is_from_private_api: bool = False,
     idAtProvider: str | None | T_UNCHANGED = UNCHANGED,
+    offererAddress: offerers_models.OffererAddress | None | T_UNCHANGED = UNCHANGED,
 ) -> models.Offer:
     modifications = {
         field: new_value

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -83,6 +83,9 @@ class PostOfferOffererAddressBodyModel(BaseModel):
     street: base_serializers.VenueAddress
 
 
+class PatchOfferOffererAddressBodyModel(PostOfferOffererAddressBodyModel): ...
+
+
 class PostOfferBodyModel(BaseModel):
     audio_disability_compliant: bool
     booking_contact: EmailStr | None
@@ -143,6 +146,7 @@ class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     isDuo: bool | None
     durationMinutes: int | None
     shouldSendMail: bool | None
+    address: PatchOfferOffererAddressBodyModel | None
 
     @validator("name", pre=True, allow_reuse=True)
     def validate_name(cls, name: str) -> str:

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -21,6 +21,7 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.finance import factories as finance_factories
 from pcapi.core.finance import models as finance_models
+from pcapi.core.geography import factories as geography_factories
 from pcapi.core.geography import models as geography_models
 from pcapi.core.history import models as history_models
 import pcapi.core.mails.testing as mails_testing
@@ -2825,3 +2826,55 @@ class GetOffererConfidenceLevelTest:
 
         assert caplog.records[0].message == "Incompatible offerer rule detected"
         assert caplog.records[0].extra == {"offerer_id": venue.managingOffererId, "venue_id": venue.id}
+
+
+class GetOffererAddressTest:
+    @pytest.mark.parametrize("same_label,same_address", [[True, False], [False, True], [True, True], [False, False]])
+    def test_get_or_create_offerer_address(self, same_label, same_address):
+        offerer = offerers_factories.OffererFactory()
+        oa_1 = offerers_factories.OffererAddressFactory(offerer=offerer)
+        other_addresss = geography_factories.AddressFactory(
+            street="1 rue de la paix",
+        )
+
+        oa_return = offerers_api.get_or_create_offerer_address(
+            offerer_id=offerer.id,
+            address_id=oa_1.address.id if same_address else other_addresss.id,
+            label=oa_1.label if same_label else "somethingdifferent",
+        )
+        if same_label and same_address:
+            assert oa_return == oa_1
+        else:
+            assert oa_return.offerer == offerer
+            assert oa_return != oa_1
+
+    @pytest.mark.parametrize("existant_address", [True, False])
+    def test_get_or_create_address(self, existant_address):
+        if existant_address:
+            old_address = geography_factories.AddressFactory(
+                street="1 rue de la paix",
+                city="Paris",
+                postalCode="75103",
+                latitude=40.8566,
+                longitude=1.3522,
+                banId="75103_7560_00001",
+            )
+        location_data = offerers_api.LocationData(
+            street="1 rue de la paix",
+            city="Paris",
+            postal_code="75103",
+            latitude=40.8566,
+            longitude=1.3522,
+            insee_code="75103",
+            ban_id="75103_7560_00001",
+        )
+        address = offerers_api.get_or_create_address(location_data=location_data, is_manual_edition=False)
+        assert len(geography_models.Address.query.all()) == 1
+        if existant_address:
+            assert address == old_address
+        else:
+            assert address.street == "1 rue de la paix"
+            assert address.city == "Paris"
+            assert address.postalCode == "75103"
+            assert address.latitude == 40.8566
+            assert address.longitude == 1.3522

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -193,6 +193,7 @@ export type { PatchDraftOfferDetailsBodyModel } from './models/PatchDraftOfferDe
 export type { PatchOfferActiveStatusBodyModel } from './models/PatchOfferActiveStatusBodyModel';
 export type { PatchOfferBodyModel } from './models/PatchOfferBodyModel';
 export type { PatchOffererAddressRequest } from './models/PatchOffererAddressRequest';
+export type { PatchOfferOffererAddressBodyModel } from './models/PatchOfferOffererAddressBodyModel';
 export type { PatchOfferPublishBodyModel } from './models/PatchOfferPublishBodyModel';
 export { PhoneValidationStatusType } from './models/PhoneValidationStatusType';
 export type { PostCollectiveOfferBodyModel } from './models/PostCollectiveOfferBodyModel';

--- a/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
@@ -2,8 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { PatchOfferOffererAddressBodyModel } from './PatchOfferOffererAddressBodyModel';
 import type { WithdrawalTypeEnum } from './WithdrawalTypeEnum';
 export type PatchOfferBodyModel = {
+  address?: PatchOfferOffererAddressBodyModel | null;
   audioDisabilityCompliant?: boolean | null;
   bookingContact?: string | null;
   bookingEmail?: string | null;

--- a/pro/src/apiClient/v1/models/PatchOfferOffererAddressBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferOffererAddressBodyModel.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type PatchOfferOffererAddressBodyModel = {
+  city: string;
+  label?: string | null;
+  latitude: (number | string);
+  longitude: (number | string);
+  postalCode: string;
+  street: string;
+};
+


### PR DESCRIPTION
## But de la pull request
modifier l'adresse de l'offre par l'offererAddress
+ petite refacto pour rendre le code plus maintenable.

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30842

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
