### PR TITLE
(PC-30926)[PRO] feat: responsive for offer list collective

### DIFF
--- a/pro/src/pages/Offers/OffersTable/Cells/Cells.module.scss
+++ b/pro/src/pages/Offers/OffersTable/Cells/Cells.module.scss
@@ -302,7 +302,7 @@
 }
 
 .offer-event {
-  min-width: rem.torem(220px);
+  min-width: rem.torem(150px);
   display: flex;
   flex-direction: column;
 

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOfferRow/CollectiveOfferRow.module.scss
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOfferRow/CollectiveOfferRow.module.scss
@@ -5,14 +5,6 @@
   border-bottom: rem.torem(1px) solid var(--color-grey-medium);
 
   &.collective-row-with-expiration {
-    display: grid;
-    grid-template-columns: rem.torem(22px) repeat(3, 1fr);
-    grid-template-areas:
-      "check thumb   head    head"
-      ".     thumb   desc    desc"
-      ".     desc2   desc3   desc3"
-      ".     desc4   desc4   desc4"
-      ".     actions actions status";
     border-bottom: none;
   }
 

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableBody/CollectiveOffersTableBody.module.scss
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableBody/CollectiveOffersTableBody.module.scss
@@ -1,10 +1,10 @@
 @use "styles/variables/_size.scss" as size;
 
 .collective-tbody {
-  display: block;
+  display: grid;
 }
 
-@media (min-width: size.$tablet) {
+@media (min-width: size.$laptop) {
   .collective-tbody {
     display: table-row-group;
   }

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableHead/CollectiveOffersTableHead.module.scss
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableHead/CollectiveOffersTableHead.module.scss
@@ -24,7 +24,11 @@
   padding-right: 0;
 }
 
-@media (min-width: size.$tablet) {
+.collective-th-width {
+  min-width: rem.torem(120px);
+}
+
+@media (min-width: size.$laptop) {
   .collective-offers-thead {
     display: table-header-group;
   }

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableHead/CollectiveOffersTableHead.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableHead/CollectiveOffersTableHead.tsx
@@ -31,7 +31,10 @@ export const CollectiveOffersTableHead = (): JSX.Element => {
         <th id="collective-offer-head-image">
           <span className="visually-hidden">Image</span>
         </th>
-        <th id="collective-offer-head-name">
+        <th
+          id="collective-offer-head-name"
+          className={classNames(styles['collective-th-width'])}
+        >
           <span className="visually-hidden">Nom</span>
         </th>
 
@@ -45,7 +48,10 @@ export const CollectiveOffersTableHead = (): JSX.Element => {
         )}
         <th
           id="collective-offer-head-venue"
-          className={styles['collective-th']}
+          className={classNames(
+            styles['collective-th'],
+            styles['collective-th-width']
+          )}
         >
           Lieu
         </th>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30926

FF : ENABLE_COLLECTIVE_OFFERS_EXPIRATION

Adapter le responsive de la liste des offres collectives

<img width="1128" alt="Capture d’écran 2024-07-31 à 16 46 45" src="https://github.com/user-attachments/assets/7ddbdbdf-3cb8-4f91-9f9d-91fd09a603f6">

Mobile :
<img width="306" alt="Capture d’écran 2024-07-31 à 16 47 02" src="https://github.com/user-attachments/assets/3f02b220-f91a-4589-92bb-dcfa122b34eb">

Tablette : 
<img width="752" alt="Capture d’écran 2024-07-31 à 16 47 21" src="https://github.com/user-attachments/assets/ce1c1e8b-0ee4-4308-bd31-f1ae2fd0eb29">

Laptop (scrollable pour voir les actions) : 
<img width="680" alt="Capture d’écran 2024-07-31 à 16 49 59" src="https://github.com/user-attachments/assets/e5d35682-fc1b-4675-98c3-56da6a56b485">


## Vérifications

- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
