### PR TITLE
(BSR)[PRO] ci: Make testing library timeout the same as cypress.

### DIFF
--- a/pro/cypress/support/e2e.ts
+++ b/pro/cypress/support/e2e.ts
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import { configure } from '@testing-library/react'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
+// Set to `defaultCommandTimeout` to match the cypress default timeout
+configure({ asyncUtilTimeout: 4000 })


### PR DESCRIPTION
## But de la pull request


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
