### PR TITLE
(PC-31196)[API] feat: add `offer_id_at_provider` and `stock_id_at_provider` in message payload documentation

### DIFF
--- a/api/documentation/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system.md
+++ b/api/documentation/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system.md
@@ -46,11 +46,13 @@ We will be calling your booking URL with the following payload :
     "booking_quantity": 1,
     "offer_ean": "1234567890123",
     "offer_id": 1234,
+    "offer_id_at_provider": "your_offer_id",
     "offer_name": "Mon offre",
     "offer_price": 1000,
     "price_category_id": 1234,
     "price_category_label": "Ma cat de prix",
     "stock_id": 1234,
+    "stock_id_at_provider": "your_stock_id",
     "user_birth_date": "2007-01-01",
     "user_email": "test@test.com",
     "user_first_name": "john",
@@ -72,11 +74,13 @@ We will be calling your booking URL with the following payload :
 | **booking_quantity** | Integer | **`false`** | The number of tickets, either 1 or 2 (if you set **`enableDoubleBookings`** to `true` [**when creating the event**](/rest-api#tag/Event-offer/operation/PostEventOffer)) |
 | **offer_ean** | String | `true` | Offer EAN code (relevant for product) |
 | **offer_id** | Integer | **`false`** | Offer id |
+| **offer_id_at_provider** | String | `true` | You own offer id that you gave us using the [**creation**](/rest-api#tag/Event-offers/operation/PostEventOffer) or [**update**](/rest-api#tag/Event-offers/operation/EditEvent) endpoints |
 | **offer_name** | String | **`false`** | Offer name |
 | **offer_price** | Integer | **`false`** | Offer price in euro and in cents (*for instance 1000 = 10 €*) |
 | **price_category_id** | Integer | `true` | The price category id (cannot be null in the case of an event) |
 | **price_category_label** | String | `true` | The price category label (*for instance, "Catégorie Or"*) |
 | **stock_id** | Integer | **`false`** | The stock id on our side |
+| **stock_id_at_provider** | String | `true` | You own stock id that you gave us using the [**creation**](/rest-api#tag/Event-offer-stocks/operation/PostEventStocks) or [**update**](/rest-api#tag/Event-offer-stocks/operation/PatchEventStock) endpoints |
 | **user_birth_date** | Stringified date (format **`YYYY-MM-DD`**) | **`false`** | Beneficiary birth date |
 | **user_first_name** | String | **`false`** | Beneficiary first name |
 | **user_last_name** | String | **`false`** | Beneficiary last name |

--- a/api/documentation/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system.md
+++ b/api/documentation/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system.md
@@ -61,7 +61,7 @@ We will be calling your booking URL with the following payload :
     "venue_address": "1 boulevard Poissonniere",
     "venue_department_code": "75",
     "venue_id": 12345,
-    "venue_name": "Mon lieu trop cool",
+    "venue_name": "Mon lieu trop cool"
 }
 ```
 

--- a/api/documentation/docs/understanding-our-api/managing-bookings/countermarks-management.md
+++ b/api/documentation/docs/understanding-our-api/managing-bookings/countermarks-management.md
@@ -31,11 +31,13 @@ Each time a beneficiary books a product (or an event not linked to a ticketing s
     "booking_quantity": 1,
     "offer_ean": "9787547722909",
     "offer_id": 1234,
+    "offer_id_at_provider": "your_offer_id",
     "offer_name": "Le petit Prince",
     "offer_price": 1000,
     "price_category_id": 1234,
     "price_category_label": null,
     "stock_id": 1234,
+    "stock_id_at_provider": "your_stock_id",
     "user_birth_date": "2007-01-01",
     "user_email": "john.doe@test.com",
     "user_first_name": "john",
@@ -58,6 +60,7 @@ Each time a beneficiary books a product (or an event not linked to a ticketing s
 | **booking_quantity** | Integer | **`false`** | The number of items booked |
 | **offer_ean** | String | `true` | Offer EAN code |
 | **offer_id** | Integer | **`false`** | Offer id |
+| **offer_id_at_provider** | String | `true` | Your own offer id that you gave us using the [**creation**](/rest-api#tag/Product-offers/operation/PostProductOffer) or [**update**](/rest-api#tag/Product-offers/operation/EditProduct) endpoints |
 | **offer_name** | String | **`false`** | Offer name |
 | **offer_price** | Integer | **`false`** | Offer price in euro and in cents (*for instance 1000 = 10 €*) |
 | **price_category_id** | Integer | `true` | Not relevant for products (used for events) |

--- a/api/documentation/docs/understanding-our-api/managing-bookings/countermarks-management.md
+++ b/api/documentation/docs/understanding-our-api/managing-bookings/countermarks-management.md
@@ -46,7 +46,7 @@ Each time a beneficiary books a product (or an event not linked to a ticketing s
     "venue_address": "1 boulevard Poissonniere",
     "venue_department_code": "75",
     "venue_id": 12345,
-    "venue_name": "Your bookshop",
+    "venue_name": "Your bookshop"
 }
 ```
 

--- a/api/documentation/src/pages/change-logs.md
+++ b/api/documentation/src/pages/change-logs.md
@@ -21,7 +21,8 @@ title: Pass Culture API change logs
 
 ## June 2024
 
-- You can now specify your own id when you [create an individual event offer](/rest-api#tag/Event-offers/operation/PostEventOffer) and/or [create stock for this event](/rest-api#tag/Event-offer-stocks/operation/PostEventStocks). This id is called `idAtProvider` and will be send to your ticketing system when a beneficiary books a ticket.
+- You can now specify your own id when you [**create an individual event offe**r](/rest-api#tag/Event-offers/operation/PostEventOffer) and/or [**create stock for this event**](/rest-api#tag/Event-offer-stocks/operation/PostEventStocks). This id is called `idAtProvider` and will be sent to your ticketing system when a beneficiary books a ticket ; in the message payload, it is called `offer_id_at_provider`.
+- You can now specify you own id when you [**create stocks for an event offer**](/rest-api#tag/Event-offer-stocks/operation/PostEventStocks). This id called `idAtProvider` and will be sent to your ticketing system when a beneficiary books a ticket ; in the message payload, it is called `stock_id_at_provider`.
 
 ## March 2024
 


### PR DESCRIPTION
Update `change_logs.md` accordingly

## But de la pull request

Ticket Jira  : https://passculture.atlassian.net/browse/PC-31196

<img width="852" alt="image" src="https://github.com/user-attachments/assets/6ebbf9e9-fad9-44f3-b2e3-fefe7108ab41">
<img width="820" alt="image" src="https://github.com/user-attachments/assets/5c990009-5851-4112-ba97-bee43980e66e">
<img width="929" alt="image" src="https://github.com/user-attachments/assets/7821f8f3-a302-4319-af30-6c48ede4419a">

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
