### PR TITLE
(PC-31140)[PRO] feat: eac actionbar draft offer

### DIFF
--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -118,3 +118,27 @@
     }
   }
 }
+
+.draft-saved-icon {
+  color: var(--color-valid);
+  vertical-align: middle;
+  margin-right: rem.torem(4px);
+}
+
+$not-saved-size: rem.torem(16px);
+
+.draft-not-saved-icon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: rem.torem(4px);
+  width: $not-saved-size;
+  height: $not-saved-size;
+  border-radius: 50%;
+  background-color: var(--color-alert-dark);
+}
+
+@media (min-width: size.$tablet) {
+  .draft-indicator {
+    margin-right: rem.torem(32px);
+  }
+}

--- a/pro/src/components/ActionsBarSticky/ActionsBarStickyRight.tsx
+++ b/pro/src/components/ActionsBarSticky/ActionsBarStickyRight.tsx
@@ -1,15 +1,23 @@
 import cn from 'classnames'
 
+import { Mode } from 'core/OfferEducational/types'
+import fullValidateIcon from 'icons/full-validate.svg'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+
 import style from './ActionsBarSticky.module.scss'
 
 interface ActionsBarStickyRightProps {
   children: React.ReactNode
   inverseWhenSmallerThanTablet?: boolean
+  dirtyForm?: boolean
+  mode?: Mode
 }
 
 export const Right = ({
   children,
   inverseWhenSmallerThanTablet = false,
+  dirtyForm,
+  mode,
 }: ActionsBarStickyRightProps): JSX.Element | null => {
   return children ? (
     <div
@@ -17,6 +25,24 @@ export const Right = ({
         [style['right-inverse']]: inverseWhenSmallerThanTablet,
       })}
     >
+      {dirtyForm !== undefined && mode === Mode.CREATION ? (
+        !dirtyForm ? (
+          <span className={style['draft-indicator']}>
+            <SvgIcon
+              src={fullValidateIcon}
+              alt=""
+              width="16"
+              className={style['draft-saved-icon']}
+            />
+            Brouillon enregistré
+          </span>
+        ) : (
+          <span className={style['draft-indicator']}>
+            <div className={style['draft-not-saved-icon']} />
+            Brouillon non enregistré
+          </span>
+        )
+      ) : null}
       {children}
     </div>
   ) : null

--- a/pro/src/components/ActionsBarSticky/__specs__/ActionsBarSticky.spec.tsx
+++ b/pro/src/components/ActionsBarSticky/__specs__/ActionsBarSticky.spec.tsx
@@ -1,18 +1,24 @@
 import { screen } from '@testing-library/react'
-import React from 'react'
 
+import { Mode } from 'core/OfferEducational/types'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { ActionsBarSticky } from '../ActionsBarSticky'
 
-const renderActionsBar = () =>
+const renderActionsBar = ({
+  dirtyForm,
+  mode,
+}: {
+  dirtyForm?: boolean
+  mode: Mode
+}) =>
   renderWithProviders(
     <ActionsBarSticky>
       <ActionsBarSticky.Left>
         <div>left content</div>
       </ActionsBarSticky.Left>
 
-      <ActionsBarSticky.Right>
+      <ActionsBarSticky.Right dirtyForm={dirtyForm} mode={mode}>
         <div>right content</div>
       </ActionsBarSticky.Right>
     </ActionsBarSticky>
@@ -20,9 +26,21 @@ const renderActionsBar = () =>
 
 describe('ActionsBarSticky', () => {
   it('should render contents', () => {
-    renderActionsBar()
+    renderActionsBar({ dirtyForm: undefined, mode: Mode.EDITION })
 
     expect(screen.queryByText('left content')).toBeInTheDocument()
     expect(screen.queryByText('right content')).toBeInTheDocument()
+  })
+
+  it('should display the saved draft message', () => {
+    renderActionsBar({ dirtyForm: false, mode: Mode.CREATION })
+
+    expect(screen.queryByText('Brouillon enregistré')).toBeInTheDocument()
+  })
+
+  it('should display draft unsaved information message', () => {
+    renderActionsBar({ dirtyForm: true, mode: Mode.CREATION })
+
+    expect(screen.queryByText('Brouillon non enregistré')).toBeInTheDocument()
   })
 })

--- a/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation.tsx
+++ b/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation.tsx
@@ -1,10 +1,20 @@
-import React from 'react'
+import {
+  BlockerFunction,
+  RouteLeavingGuard,
+} from 'components/RouteLeavingGuard/RouteLeavingGuard'
 
-import { RouteLeavingGuard } from 'components/RouteLeavingGuard/RouteLeavingGuard'
+interface RouteLeavingGuardCollectiveOffer {
+  when: boolean
+}
 
-import { shouldBlockNavigation } from './utils'
+export const RouteLeavingGuardCollectiveOfferCreation = ({
+  when,
+}: RouteLeavingGuardCollectiveOffer): JSX.Element => {
+  const shouldBlockNavigation: BlockerFunction = ({
+    currentLocation,
+    nextLocation,
+  }) => when && currentLocation.pathname !== nextLocation.pathname
 
-export const RouteLeavingGuardCollectiveOfferCreation = (): JSX.Element => {
   return (
     <RouteLeavingGuard
       shouldBlockNavigation={shouldBlockNavigation}

--- a/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation.tsx
+++ b/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation.tsx
@@ -8,12 +8,10 @@ export const RouteLeavingGuardCollectiveOfferCreation = (): JSX.Element => {
   return (
     <RouteLeavingGuard
       shouldBlockNavigation={shouldBlockNavigation}
-      dialogTitle="Voulez-vous quitter la création d’offre ?"
-    >
-      <p>
-        Votre offre ne sera pas sauvegardée et toutes les informations seront
-        perdues.
-      </p>
-    </RouteLeavingGuard>
+      dialogTitle="Les informations non enregistrées seront perdues"
+      leftButton="Quitter la page"
+      rightButton="Rester sur la page"
+      closeModalOnRightButton
+    />
   )
 }

--- a/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/utils.ts
+++ b/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/utils.ts
@@ -63,10 +63,12 @@ export const shouldBlockNavigation: BlockerFunction = ({
   ) {
     return false
   }
-  // going from confirmation to stock
-  if (from === STEP_CONFIRMATION) {
+
+  //  no leaving guard for confirmation or preview
+  if (from === STEP_CONFIRMATION || from === STEP_PREVIEW) {
     return false
   }
+
   if (
     // going to stocks
     to === STEP_STOCKS ||

--- a/pro/src/pages/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
+++ b/pro/src/pages/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
@@ -34,7 +34,7 @@ const CollectiveOfferConfirmation = ({
         offererId={offer.venue.managingOfferer.id}
         institutionDisplayName={getInstitutionDisplayName()}
       />
-      <RouteLeavingGuardCollectiveOfferCreation />
+      <RouteLeavingGuardCollectiveOfferCreation when={false} />
     </AppLayout>
   )
 }

--- a/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
+++ b/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
@@ -3,7 +3,6 @@ import { useLocation } from 'react-router-dom'
 
 import { AppLayout } from 'app/AppLayout'
 import { CollectiveOfferLayout } from 'components/CollectiveOfferLayout/CollectiveOfferLayout'
-import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
 import { isCollectiveOffer, Mode } from 'core/OfferEducational/types'
 import { useIsNewInterfaceActive } from 'hooks/useIsNewInterfaceActive'
 import { queryParamsFromOfferer } from 'pages/Offers/utils/queryParamsFromOfferer'
@@ -52,7 +51,6 @@ export const CollectiveOfferCreation = ({
             mode={Mode.CREATION}
             isTemplate={isTemplate}
           />
-          <RouteLeavingGuardCollectiveOfferCreation />
         </CollectiveOfferLayout>
       )}
     </AppLayout>

--- a/pro/src/pages/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -22,7 +22,7 @@ export const CollectiveOfferPreviewCreation = ({
         isCreation
       >
         <CollectiveOfferPreviewCreationScreen offer={offer} offerer={offerer} />
-        <RouteLeavingGuardCollectiveOfferCreation />
+        <RouteLeavingGuardCollectiveOfferCreation when={false} />
       </CollectiveOfferLayout>
     </AppLayout>
   )

--- a/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -9,7 +9,6 @@ import {
 } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import { CollectiveOfferLayout } from 'components/CollectiveOfferLayout/CollectiveOfferLayout'
-import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
 import {
   GET_COLLECTIVE_OFFER_QUERY_KEY,
   GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY,
@@ -184,7 +183,6 @@ export const CollectiveOfferStockCreation = ({
           onSubmit={handleSubmitStock}
           requestId={requestId}
         />
-        <RouteLeavingGuardCollectiveOfferCreation />
       </CollectiveOfferLayout>
     </AppLayout>
   )

--- a/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -23,7 +23,7 @@ export const CollectiveOfferSummaryCreation = ({
         isCreation={true}
       >
         <CollectiveOfferSummaryCreationScreen offer={offer} />
-        <RouteLeavingGuardCollectiveOfferCreation />
+        <RouteLeavingGuardCollectiveOfferCreation when={false} />
       </CollectiveOfferLayout>
     </AppLayout>
   )

--- a/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
@@ -76,4 +76,18 @@ describe('CollectiveOfferSummaryCreation', () => {
       '/offre/1/collectif/visibilite?requete=1'
     )
   })
+
+  it('should display the saved information in the action bar', async () => {
+    await renderCollectiveOfferSummaryCreation(
+      '/offre/A1/collectif/creation/recapitulatif',
+      defaultProps,
+      {
+        features: ['WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'],
+      }
+    )
+
+    expect(screen.getByText('Brouillon enregistré')).toBeInTheDocument()
+
+    expect(screen.getByText('Enregistrer et continuer')).toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
@@ -1,11 +1,9 @@
-import React from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import useSWR, { useSWRConfig } from 'swr'
 
 import { GetCollectiveOfferResponseModel } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import { CollectiveOfferLayout } from 'components/CollectiveOfferLayout/CollectiveOfferLayout'
-import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
 import {
   GET_COLLECTIVE_OFFER_QUERY_KEY,
   GET_EDUCATIONAL_INSTITUTIONS_QUERY_KEY,
@@ -81,7 +79,6 @@ export const CollectiveOfferVisibility = ({
           offer={offer}
           requestId={requestId}
         />
-        <RouteLeavingGuardCollectiveOfferCreation />
       </CollectiveOfferLayout>
     </AppLayout>
   )

--- a/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -13,6 +13,7 @@ import {
   GET_COLLECTIVE_OFFER_QUERY_KEY,
   GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY,
 } from 'config/swrQueryKeys'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useNotification } from 'hooks/useNotification'
 import { AdagePreviewLayout } from 'pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout'
 import { RedirectToBankAccountDialog } from 'screens/Offers/RedirectToBankAccountDialog'
@@ -35,6 +36,10 @@ export const CollectiveOfferPreviewCreationScreen = ({
   const navigate = useNavigate()
   const { mutate } = useSWRConfig()
   const [displayRedirectDialog, setDisplayRedirectDialog] = useState(false)
+
+  const isCollectiveOfferDraftEnabled = useActiveFeature(
+    'WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'
+  )
 
   const backRedirectionUrl = offer.isTemplate
     ? `/offre/${offer.id}/collectif/vitrine/creation/recapitulatif`
@@ -99,10 +104,21 @@ export const CollectiveOfferPreviewCreationScreen = ({
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
           <ButtonLink variant={ButtonVariant.SECONDARY} to={backRedirectionUrl}>
-            Étape précédente
+            Retour
           </ButtonLink>
         </ActionsBarSticky.Left>
-        <ActionsBarSticky.Right>
+        <ActionsBarSticky.Right dirtyForm={false}>
+          {isCollectiveOfferDraftEnabled && (
+            <ButtonLink
+              to="/offres/collectives"
+              variant={ButtonVariant.PRIMARY}
+              onClick={() => {
+                notify.success('Brouillon sauvegardé dans la liste des offres')
+              }}
+            >
+              Sauvegarder le brouillon et quitter
+            </ButtonLink>
+          )}
           <Button onClick={publishOffer}>Publier l’offre</Button>
         </ActionsBarSticky.Right>
       </ActionsBarSticky>

--- a/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -13,6 +13,7 @@ import {
   GET_COLLECTIVE_OFFER_QUERY_KEY,
   GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY,
 } from 'config/swrQueryKeys'
+import { Mode } from 'core/OfferEducational/types'
 import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useNotification } from 'hooks/useNotification'
 import { AdagePreviewLayout } from 'pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/AdagePreviewLayout'
@@ -107,11 +108,11 @@ export const CollectiveOfferPreviewCreationScreen = ({
             Retour
           </ButtonLink>
         </ActionsBarSticky.Left>
-        <ActionsBarSticky.Right dirtyForm={false}>
+        <ActionsBarSticky.Right dirtyForm={false} mode={Mode.CREATION}>
           {isCollectiveOfferDraftEnabled && (
             <ButtonLink
               to="/offres/collectives"
-              variant={ButtonVariant.PRIMARY}
+              variant={ButtonVariant.SECONDARY}
               onClick={() => {
                 notify.success('Brouillon sauvegardé dans la liste des offres')
               }}

--- a/pro/src/screens/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
@@ -39,6 +39,7 @@ const defaultProps = {
 
 describe('CollectiveOfferConfirmation', () => {
   const mockNotifyError = vi.fn()
+  const mockNotifySuccess = vi.fn()
 
   beforeEach(async () => {
     const notifsImport = (await vi.importActual(
@@ -47,6 +48,7 @@ describe('CollectiveOfferConfirmation', () => {
     vi.spyOn(useNotification, 'useNotification').mockImplementation(() => ({
       ...notifsImport,
       error: mockNotifyError,
+      success: mockNotifySuccess,
     }))
 
     vi.spyOn(api, 'getVenue').mockResolvedValue(defaultGetVenue)
@@ -104,6 +106,24 @@ describe('CollectiveOfferConfirmation', () => {
 
     expect(previewStep.getAttribute('href')).toBe(
       `/offre/${defaultProps.offer.id}/collectif/vitrine/creation/recapitulatif`
+    )
+  })
+
+  it('should redirect to list offer with success notification', async () => {
+    renderCollectiveOfferPreviewCreation(defaultProps, {
+      features: ['WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'],
+    })
+
+    const saveAndQuitButton = screen.getByText(
+      'Sauvegarder le brouillon et quitter'
+    )
+
+    expect(saveAndQuitButton.getAttribute('href')).toBe('/offres/collectives')
+
+    await userEvent.click(saveAndQuitButton)
+
+    expect(mockNotifySuccess).toHaveBeenCalledWith(
+      'Brouillon sauvegardé dans la liste des offres'
     )
   })
 })

--- a/pro/src/screens/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
@@ -98,7 +98,7 @@ describe('CollectiveOfferConfirmation', () => {
   it('should redirect to preview step on click', async () => {
     renderCollectiveOfferPreviewCreation(defaultProps)
 
-    const previewStep = screen.getByText('Étape précédente')
+    const previewStep = screen.getByText('Retour')
 
     await userEvent.click(previewStep)
 

--- a/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -6,6 +6,7 @@ import {
 } from 'apiClient/v1'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { CollectiveOfferSummary } from 'components/CollectiveOfferSummary/CollectiveOfferSummary'
+import { Mode } from 'core/OfferEducational/types'
 import { useActiveFeature } from 'hooks/useActiveFeature'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -58,7 +59,7 @@ export const CollectiveOfferSummaryCreationScreen = ({
           )}
         </ActionsBarSticky.Left>
         {isCollectiveOfferDraftEnabled && (
-          <ActionsBarSticky.Right dirtyForm={false}>
+          <ActionsBarSticky.Right dirtyForm={false} mode={Mode.CREATION}>
             <ButtonLink variant={ButtonVariant.PRIMARY} to={nextRedirectionUrl}>
               Enregistrer et continuer
             </ButtonLink>

--- a/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -6,6 +6,7 @@ import {
 } from 'apiClient/v1'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { CollectiveOfferSummary } from 'components/CollectiveOfferSummary/CollectiveOfferSummary'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -21,6 +22,9 @@ export const CollectiveOfferSummaryCreationScreen = ({
   offer,
 }: CollectiveOfferSummaryCreationProps) => {
   const { requete: requestId } = useParams()
+  const isCollectiveOfferDraftEnabled = useActiveFeature(
+    'WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'
+  )
 
   const nextRedirectionUrl = offer.isTemplate
     ? `/offre/${offer.id}/collectif/vitrine/creation/apercu`
@@ -45,12 +49,21 @@ export const CollectiveOfferSummaryCreationScreen = ({
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
           <ButtonLink variant={ButtonVariant.SECONDARY} to={backRedirectionUrl}>
-            Étape précédente
+            {isCollectiveOfferDraftEnabled ? 'Retour' : 'Étape précédente'}
           </ButtonLink>
-          <ButtonLink variant={ButtonVariant.PRIMARY} to={nextRedirectionUrl}>
-            Étape suivante
-          </ButtonLink>
+          {!isCollectiveOfferDraftEnabled && (
+            <ButtonLink variant={ButtonVariant.PRIMARY} to={nextRedirectionUrl}>
+              Étape suivante
+            </ButtonLink>
+          )}
         </ActionsBarSticky.Left>
+        {isCollectiveOfferDraftEnabled && (
+          <ActionsBarSticky.Right dirtyForm={false}>
+            <ButtonLink variant={ButtonVariant.PRIMARY} to={nextRedirectionUrl}>
+              Enregistrer et continuer
+            </ButtonLink>
+          </ActionsBarSticky.Right>
+        )}
       </ActionsBarSticky>
     </div>
   )

--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -27,6 +27,7 @@ import {
   SENT_DATA_ERROR_MESSAGE,
 } from 'core/shared/constants'
 import { SelectOption } from 'custom_types/form'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useNotification } from 'hooks/useNotification'
 import strokeSearch from 'icons/stroke-search.svg'
 import { Button } from 'ui-kit/Button/Button'
@@ -85,6 +86,9 @@ export const CollectiveOfferVisibilityScreen = ({
   requestId = '',
 }: CollectiveOfferVisibilityProps) => {
   const notify = useNotification()
+  const isCollectiveOfferDraftEnabled = useActiveFeature(
+    'WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'
+  )
 
   const [teachersOptions, setTeachersOptions] = useState<TeacherOption[]>([])
   const [buttonPressed, setButtonPressed] = useState(false)
@@ -314,24 +318,38 @@ export const CollectiveOfferVisibilityScreen = ({
                       : '/offres/collectives'
                   }
                 >
-                  {mode === Mode.CREATION
-                    ? 'Étape précédente'
-                    : 'Annuler et quitter'}
+                  {mode === Mode.CREATION ? 'Retour' : 'Annuler et quitter'}
                 </ButtonLink>
-                <Button
-                  type="submit"
-                  disabled={
-                    buttonPressed ||
-                    !formik.values.institution ||
-                    mode === Mode.READ_ONLY
-                  }
-                  isLoading={false}
-                >
-                  {mode === Mode.CREATION
-                    ? 'Étape suivante'
-                    : 'Enregistrer les modifications'}
-                </Button>
+                {!isCollectiveOfferDraftEnabled && (
+                  <Button
+                    type="submit"
+                    disabled={
+                      buttonPressed ||
+                      !formik.values.institution ||
+                      mode === Mode.READ_ONLY
+                    }
+                    isLoading={false}
+                  >
+                    {mode === Mode.CREATION
+                      ? 'Étape suivante'
+                      : 'Enregistrer les modifications'}
+                  </Button>
+                )}
               </ActionsBarSticky.Left>
+              {isCollectiveOfferDraftEnabled && (
+                <ActionsBarSticky.Right dirtyForm={formik.dirty} mode={mode}>
+                  <Button
+                    type="submit"
+                    disabled={
+                      buttonPressed ||
+                      !formik.values.institution ||
+                      mode === Mode.READ_ONLY
+                    }
+                  >
+                    Enregistrer et continuer
+                  </Button>
+                </ActionsBarSticky.Right>
+              )}
             </ActionsBarSticky>
           </FormLayout>
         </form>

--- a/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -12,6 +12,7 @@ import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { BannerPublicApi } from 'components/Banner/BannerPublicApi'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { OfferEducationalActions } from 'components/OfferEducationalActions/OfferEducationalActions'
+import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
 import { GET_COLLECTIVE_REQUEST_INFORMATIONS_QUERY_KEY } from 'config/swrQueryKeys'
 import {
   VisibilityFormValues,
@@ -354,6 +355,9 @@ export const CollectiveOfferVisibilityScreen = ({
           </FormLayout>
         </form>
       </FormikProvider>
+      <RouteLeavingGuardCollectiveOfferCreation
+        when={formik.dirty && !formik.isSubmitting}
+      />
     </>
   )
 }

--- a/pro/src/screens/OfferEducational/OfferEducational.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducational.tsx
@@ -11,6 +11,7 @@ import {
   GetEducationalOffererResponseModel,
 } from 'apiClient/v1'
 import { OfferEducationalActions } from 'components/OfferEducationalActions/OfferEducationalActions'
+import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
 import {
   GET_COLLECTIVE_OFFER_QUERY_KEY,
   GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY,
@@ -203,7 +204,12 @@ export const OfferEducational = ({
           mode={mode}
         />
       )}
-      <FormikProvider value={{ ...formik, resetForm }}>
+      <FormikProvider
+        value={{
+          ...formik,
+          resetForm,
+        }}
+      >
         <form onSubmit={formik.handleSubmit}>
           <OfferEducationalForm
             mode={mode}
@@ -219,6 +225,9 @@ export const OfferEducational = ({
           />
         </form>
       </FormikProvider>
+      <RouteLeavingGuardCollectiveOfferCreation
+        when={formik.dirty && !formik.isSubmitting}
+      />
     </>
   )
 }

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -17,6 +17,7 @@ import {
 } from 'core/OfferEducational/types'
 import { computeCollectiveOffersUrl } from 'core/Offers/utils/computeOffersUrl'
 import { SelectOption } from 'custom_types/form'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useNotification } from 'hooks/useNotification'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
@@ -73,13 +74,16 @@ export const OfferEducationalForm = ({
   offer,
 }: OfferEducationalFormProps): JSX.Element => {
   const notify = useNotification()
+  const isCollectiveOfferDraftEnabled = useActiveFeature(
+    'WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'
+  )
 
   const [venuesOptions, setVenuesOptions] = useState<SelectOption[]>([])
   const [currentOfferer, setCurrentOfferer] =
     useState<GetEducationalOffererResponseModel | null>(null)
   const [isEligible, setIsEligible] = useState<boolean>()
 
-  const { values, setFieldValue, initialValues } =
+  const { values, setFieldValue, initialValues, dirty } =
     useFormikContext<OfferEducationalFormValues>()
 
   const onOffererChange = useCallback(
@@ -201,15 +205,27 @@ export const OfferEducationalForm = ({
           >
             Annuler et quitter
           </ButtonLink>
-          <Button
-            type="submit"
-            disabled={!isEligible || mode === Mode.READ_ONLY}
-          >
-            {mode === Mode.CREATION
-              ? 'Étape suivante'
-              : 'Enregistrer les modifications'}
-          </Button>
+          {!isCollectiveOfferDraftEnabled && (
+            <Button
+              type="submit"
+              disabled={!isEligible || mode === Mode.READ_ONLY}
+            >
+              {mode === Mode.CREATION
+                ? 'Étape suivante'
+                : 'Enregistrer les modifications'}
+            </Button>
+          )}
         </ActionsBarSticky.Left>
+        {isCollectiveOfferDraftEnabled && (
+          <ActionsBarSticky.Right dirtyForm={dirty} mode={mode}>
+            <Button
+              type="submit"
+              disabled={!isEligible || mode === Mode.READ_ONLY}
+            >
+              Enregistrer et continuer
+            </Button>
+          </ActionsBarSticky.Right>
+        )}
       </ActionsBarSticky>
     </>
   )

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -217,7 +217,7 @@ export const OfferEducationalForm = ({
           )}
         </ActionsBarSticky.Left>
         {isCollectiveOfferDraftEnabled && (
-          <ActionsBarSticky.Right dirtyForm={dirty} mode={mode}>
+          <ActionsBarSticky.Right dirtyForm={dirty || !offer} mode={mode}>
             <Button
               type="submit"
               disabled={!isEligible || mode === Mode.READ_ONLY}

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/__specs__/OfferEducationalForm.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/__specs__/OfferEducationalForm.spec.tsx
@@ -112,4 +112,16 @@ describe('OfferEducationalForm', () => {
     const saveButton = screen.getByText('Enregistrer les modifications')
     expect(saveButton).toBeDisabled()
   })
+
+  it('should display unsaved information in the action bar when the value is not the default value', async () => {
+    renderOfferEducationalForm(defaultProps, {
+      features: ['WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'],
+    })
+
+    expect(screen.getByText('Brouillon non enregistré')).toBeInTheDocument()
+
+    expect(
+      await screen.findByRole('button', { name: 'Enregistrer et continuer' })
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -15,6 +15,7 @@ import { Callout } from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { OfferEducationalActions } from 'components/OfferEducationalActions/OfferEducationalActions'
+import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
 import { MAX_DETAILS_LENGTH } from 'core/OfferEducational/constants'
 import {
   OfferEducationalStockFormValues,
@@ -258,6 +259,9 @@ export const OfferEducationalStock = <
           </FormLayout>
         </form>
       </FormikProvider>
+      <RouteLeavingGuardCollectiveOfferCreation
+        when={dirty && !formik.isSubmitting}
+      />
     </>
   )
 }

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -24,6 +24,7 @@ import {
   isCollectiveOfferTemplate,
 } from 'core/OfferEducational/types'
 import { NBSP } from 'core/shared/constants'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -67,6 +68,9 @@ export const OfferEducationalStock = <
   const [isLoading, setIsLoading] = useState(false)
   const startDatetime =
     isCollectiveOffer(offer) && offer.collectiveStock?.startDatetime
+  const isCollectiveOfferDraftEnabled = useActiveFeature(
+    'WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'
+  )
 
   const preventPriceIncrease = Boolean(
     isCollectiveOffer(offer) &&
@@ -92,7 +96,7 @@ export const OfferEducationalStock = <
     setIsLoading(false)
   }
 
-  const { resetForm, ...formik } = useFormik({
+  const { dirty, resetForm, ...formik } = useFormik({
     initialValues,
     onSubmit: postForm,
     validationSchema: yup.lazy((values: OfferEducationalStockFormValues) => {
@@ -126,7 +130,7 @@ export const OfferEducationalStock = <
         offer={offer}
         mode={mode}
       />
-      <FormikProvider value={{ ...formik, resetForm }}>
+      <FormikProvider value={{ ...formik, resetForm, dirty }}>
         <form onSubmit={formik.handleSubmit} noValidate>
           <FormLayout className={styles['offer-educational-stock-form-layout']}>
             {isCollectiveOffer(offer) && offer.isPublicApi && (
@@ -219,23 +223,37 @@ export const OfferEducationalStock = <
                       : '/offres/collectives'
                   }
                 >
-                  {mode === Mode.CREATION
-                    ? 'Étape précédente'
-                    : 'Annuler et quitter'}
+                  {mode === Mode.CREATION ? 'Retour' : 'Annuler et quitter'}
                 </ButtonLink>
-                <Button
-                  type="submit"
-                  className=""
-                  disabled={
-                    mode === Mode.READ_ONLY && disablePriceAndParticipantInputs
-                  }
-                  isLoading={isLoading}
-                >
-                  {mode !== Mode.CREATION
-                    ? 'Enregistrer les modifications'
-                    : 'Étape suivante'}
-                </Button>
+                {!isCollectiveOfferDraftEnabled && (
+                  <Button
+                    type="submit"
+                    className=""
+                    disabled={
+                      mode === Mode.READ_ONLY &&
+                      disablePriceAndParticipantInputs
+                    }
+                    isLoading={isLoading}
+                  >
+                    {mode !== Mode.CREATION
+                      ? 'Enregistrer les modifications'
+                      : 'Étape suivante'}
+                  </Button>
+                )}
               </ActionsBarSticky.Left>
+              {isCollectiveOfferDraftEnabled && (
+                <ActionsBarSticky.Right dirtyForm={dirty} mode={mode}>
+                  <Button
+                    type="submit"
+                    disabled={
+                      mode === Mode.READ_ONLY &&
+                      disablePriceAndParticipantInputs
+                    }
+                  >
+                    Enregistrer et continuer
+                  </Button>
+                </ActionsBarSticky.Right>
+              )}
             </ActionsBarSticky>
           </FormLayout>
         </form>

--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -215,3 +215,18 @@ it('should disable booking limit datetime when form access is read only', () => 
 
   expect(bookingLimitDatetimeInput).toBeDisabled()
 })
+
+it('should display saved information in the action bar', () => {
+  const testProps: OfferEducationalStockProps = {
+    ...defaultProps,
+    mode: Mode.CREATION,
+  }
+
+  renderWithProviders(<OfferEducationalStock {...testProps} />, {
+    features: ['WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'],
+  })
+
+  expect(screen.getByText('Brouillon enregistré')).toBeInTheDocument()
+
+  expect(screen.getByText('Enregistrer et continuer')).toBeInTheDocument()
+})


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31140

SOUS FF : WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS

Ajouter le message de brouillon non sauvegardé ou sauvegardé lors de la création d'une offre collective
Toaster au moment de la sauvegarde et au retour sur la liste des offres
RouteLeavingGuard adapté pour la création en brouillon

## Vérifications

- [x] J'ai écrit les tests nécessaires
