### PR TITLE
(PC-31199)[PRO] fix: default a11y values in UsefulInformations

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -164,6 +164,10 @@ def create_draft_offer(body: schemas.PostDraftOfferBodyModel, venue: offerers_mo
     offer = models.Offer(
         **fields,
         venue=venue,
+        audioDisabilityCompliant=venue.audioDisabilityCompliant,
+        mentalDisabilityCompliant=venue.mentalDisabilityCompliant,
+        motorDisabilityCompliant=venue.motorDisabilityCompliant,
+        visualDisabilityCompliant=venue.audioDisabilityCompliant,
         offererAddress=venue.offererAddress,
         isActive=False,
         validation=models.OfferValidationStatus.DRAFT,

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
@@ -182,6 +182,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
     const expectedValues = {
       isEvent: false,
       isNational: true,
+      isVenueVirtual: false,
       withdrawalDetails:
         DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['withdrawalDetails'],
       withdrawalDelay: undefined,

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
@@ -169,6 +169,45 @@ describe('setDefaultInitialValuesFromOffer', () => {
     expect(result).toEqual(expectedValues)
   })
 
+  it('should handle accessibility not set', () => {
+    const mockOfferWithMissingProperties = getIndividualOfferFactory({
+      isEvent: false,
+      isNational: true,
+      visualDisabilityCompliant: undefined,
+      mentalDisabilityCompliant: undefined,
+      audioDisabilityCompliant: undefined,
+      motorDisabilityCompliant: undefined,
+    })
+
+    const expectedValues = {
+      isEvent: false,
+      isNational: true,
+      withdrawalDetails:
+        DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['withdrawalDetails'],
+      withdrawalDelay: undefined,
+      withdrawalType: undefined,
+      accessibility: {
+        [AccessibilityEnum.VISUAL]: false,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: false,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: false,
+      },
+      bookingEmail: '',
+      bookingContact: undefined,
+      receiveNotificationEmails: false,
+      url: DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['url'],
+      externalTicketOfficeUrl:
+        DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['externalTicketOfficeUrl'],
+    }
+
+    const result = setDefaultInitialValuesFromOffer(
+      mockOfferWithMissingProperties
+    )
+
+    expect(result).toEqual(expectedValues)
+  })
+
   it('should handle null withdrawalDelay correctly', () => {
     const mockOfferWithNullWithdrawalDelay = getIndividualOfferFactory({
       ...mockOffer,

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/utils.ts
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/utils.ts
@@ -38,11 +38,16 @@ export function setDefaultInitialValuesFromOffer(
   offer: GetIndividualOfferResponseModel
 ): UsefulInformationFormValues {
   const baseAccessibility = {
-    [AccessibilityEnum.VISUAL]: offer.visualDisabilityCompliant || false,
-    [AccessibilityEnum.MENTAL]: offer.mentalDisabilityCompliant || false,
-    [AccessibilityEnum.AUDIO]: offer.audioDisabilityCompliant || false,
-    [AccessibilityEnum.MOTOR]: offer.motorDisabilityCompliant || false,
+    [AccessibilityEnum.VISUAL]: offer.visualDisabilityCompliant,
+    [AccessibilityEnum.MENTAL]: offer.mentalDisabilityCompliant,
+    [AccessibilityEnum.AUDIO]: offer.audioDisabilityCompliant,
+    [AccessibilityEnum.MOTOR]: offer.motorDisabilityCompliant,
   }
+
+  const notAccessible = Object.values(baseAccessibility).every(
+    (value) => value === false
+  )
+
   return {
     isEvent: offer.isEvent,
     isNational: offer.isNational,
@@ -53,9 +58,11 @@ export function setDefaultInitialValuesFromOffer(
       offer.withdrawalDelay === null ? undefined : offer.withdrawalDelay,
     withdrawalType: offer.withdrawalType || undefined,
     accessibility: {
-      ...baseAccessibility,
-      [AccessibilityEnum.NONE]:
-        !Object.values(baseAccessibility).includes(true),
+      [AccessibilityEnum.VISUAL]: offer.visualDisabilityCompliant || false,
+      [AccessibilityEnum.MENTAL]: offer.mentalDisabilityCompliant || false,
+      [AccessibilityEnum.AUDIO]: offer.audioDisabilityCompliant || false,
+      [AccessibilityEnum.MOTOR]: offer.motorDisabilityCompliant || false,
+      [AccessibilityEnum.NONE]: notAccessible,
     },
     bookingEmail: offer.bookingEmail || '',
     bookingContact: offer.bookingContact || undefined,


### PR DESCRIPTION
## But de la pull request

⚠️ Attention, côté back cette PR entraîne ce changement de comportement dans la création d'offre:

Lorsque je créé une offre brouillon (`POST` `draft_offer`), on lui donne les données d'accessibilité de la `Venue` associée. Si toutes les données sont nulles on recopie aussi les valeurs `None`. Les champs sur les critère d'accessibilité sont par contre rendus obligatoires sur la 2nd partie de la création d'offre (`PATCH` `draft_offer`)

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31199

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
