### PR TITLE
Pc 31157 fix template offers

### DIFF
--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -2,6 +2,10 @@ import cn from 'classnames'
 import React from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
+import {
+  GetCollectiveOfferResponseModel,
+  GetCollectiveOfferTemplateResponseModel,
+} from 'apiClient/v1'
 import { CollectiveOfferNavigation } from 'components/CollectiveOfferNavigation/CollectiveOfferNavigation'
 import { HelpLink } from 'components/HelpLink/HelpLink'
 import { getActiveStep } from 'pages/CollectiveOfferRoutes/utils/getActiveStep'
@@ -17,6 +21,9 @@ export interface CollectiveOfferLayoutProps {
   isFromTemplate?: boolean
   requestId?: string | null
   isArchivable?: boolean | null
+  offer?:
+    | GetCollectiveOfferResponseModel
+    | GetCollectiveOfferTemplateResponseModel
 }
 
 export const CollectiveOfferLayout = ({
@@ -27,6 +34,7 @@ export const CollectiveOfferLayout = ({
   isTemplate = false,
   requestId = null,
   isArchivable,
+  offer,
 }: CollectiveOfferLayoutProps): JSX.Element => {
   const location = useLocation()
   const isSummaryPage = location.pathname.includes('recapitulatif')
@@ -85,6 +93,7 @@ export const CollectiveOfferLayout = ({
         isTemplate={isTemplate}
         requestId={requestId}
         isArchivable={isArchivable}
+        offer={offer}
       />
 
       {children}

--- a/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
@@ -5,6 +5,11 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'
+import {
+  CollectiveOfferStatus,
+  GetCollectiveOfferResponseModel,
+  GetCollectiveOfferTemplateResponseModel,
+} from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { ArchiveConfirmationModal } from 'components/ArchiveConfirmationModal/ArchiveConfirmationModal'
 import { Step, Stepper } from 'components/Stepper/Stepper'
@@ -50,6 +55,9 @@ export interface CollectiveOfferNavigationProps {
   isTemplate: boolean
   requestId?: string | null
   isArchivable?: boolean | null
+  offer?:
+    | GetCollectiveOfferResponseModel
+    | GetCollectiveOfferTemplateResponseModel
 }
 
 export const CollectiveOfferNavigation = ({
@@ -61,6 +69,7 @@ export const CollectiveOfferNavigation = ({
   className,
   requestId = null,
   isArchivable,
+  offer,
 }: CollectiveOfferNavigationProps): JSX.Element => {
   const { logEvent } = useAnalytics()
   const notify = useNotification()
@@ -87,10 +96,14 @@ export const CollectiveOfferNavigation = ({
 
   const stepList: { [key in CollectiveOfferStep]?: Step } = {}
 
+  const canEditOffer =
+    offer?.status !== CollectiveOfferStatus.ARCHIVED &&
+    !location.pathname.includes('edition')
+
   const requestIdUrl = requestId ? `?requete=${requestId}` : ''
 
   if (isEditingExistingOffer) {
-    if (!isTemplate) {
+    if (!isTemplate && canEditOffer) {
       stepList[CollectiveOfferStep.DETAILS] = {
         id: CollectiveOfferStep.DETAILS,
         label: 'Détails de l’offre',
@@ -214,7 +227,7 @@ export const CollectiveOfferNavigation = ({
   return isEditingExistingOffer ? (
     <>
       <div className={styles['duplicate-offer']}>
-        {!location.pathname.includes('edition') && (
+        {canEditOffer && (
           <ButtonLink to={offerEditLink} icon={fullEditIcon}>
             Modifier l’offre
           </ButtonLink>

--- a/pro/src/components/CollectiveOfferNavigation/__specs__/CollectiveOfferNavigation.spec.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/__specs__/CollectiveOfferNavigation.spec.tsx
@@ -8,6 +8,7 @@ import { api } from 'apiClient/api'
 import {
   ApiError,
   CollectiveOfferResponseIdModel,
+  CollectiveOfferStatus,
   GetCollectiveOfferResponseModel,
   GetCollectiveOfferTemplateResponseModel,
 } from 'apiClient/v1'
@@ -20,6 +21,7 @@ import { SENT_DATA_ERROR_MESSAGE } from 'core/shared/constants'
 import * as useNotification from 'hooks/useNotification'
 import {
   defaultGetVenue,
+  getCollectiveOfferFactory,
   getCollectiveOfferTemplateFactory,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -436,5 +438,35 @@ describe('CollectiveOfferNavigation', () => {
         duration: 8000,
       }
     )
+  })
+
+  it('should not display the edition button for archived collective offers', () => {
+    renderCollectiveOfferNavigation({
+      ...props,
+      offerId: 1,
+      isCreatingOffer: false,
+      isTemplate: false,
+      offer: getCollectiveOfferFactory({
+        status: CollectiveOfferStatus.ARCHIVED,
+      }),
+    })
+
+    expect(
+      screen.queryByRole('link', { name: 'Modifier l’offre' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not display the navigation for archived collective offers', () => {
+    renderCollectiveOfferNavigation({
+      ...props,
+      offerId: 1,
+      isCreatingOffer: false,
+      isTemplate: false,
+      offer: getCollectiveOfferFactory({
+        status: CollectiveOfferStatus.ARCHIVED,
+      }),
+    })
+
+    expect(screen.queryByTestId('stepper')).not.toBeInTheDocument()
   })
 })

--- a/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
+++ b/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import {
+  CollectiveOfferStatus,
   GetCollectiveOfferResponseModel,
   GetCollectiveOfferTemplateResponseModel,
 } from 'apiClient/v1'
@@ -44,6 +45,8 @@ export const CollectiveOfferSummary = ({
   const offerManuallyCreated = isCollectiveOffer(offer) && !offer.isPublicApi
 
   const isOfferTemplate = isCollectiveOfferTemplate(offer)
+
+  const canEditOffer = offer.status !== CollectiveOfferStatus.ARCHIVED
   return (
     <>
       <SummaryLayout>
@@ -56,7 +59,9 @@ export const CollectiveOfferSummary = ({
           <SummarySection
             title="Détails de l’offre"
             editLink={
-              offerManuallyCreated || offer.isTemplate ? offerEditLink : null
+              canEditOffer && (offerManuallyCreated || offer.isTemplate)
+                ? offerEditLink
+                : null
             }
           >
             <CollectiveOfferVenueSection venue={offer.venue} />
@@ -82,7 +87,9 @@ export const CollectiveOfferSummary = ({
             <SummarySection
               title="Dates & Prix"
               editLink={
-                offerManuallyCreated || offer.isTemplate ? stockEditLink : null
+                canEditOffer && (offerManuallyCreated || offer.isTemplate)
+                  ? stockEditLink
+                  : null
               }
             >
               <CollectiveOfferStockSection
@@ -96,7 +103,7 @@ export const CollectiveOfferSummary = ({
             <SummarySection
               title={'Établissement et enseignant'}
               editLink={
-                offerManuallyCreated || offer.isTemplate
+                canEditOffer && (offerManuallyCreated || offer.isTemplate)
                   ? visibilityEditLink
                   : null
               }

--- a/pro/src/components/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
@@ -146,4 +146,14 @@ describe('CollectiveOfferSummary', () => {
 
     expect(screen.getByText('http://www.form.com')).toBeInTheDocument()
   })
+
+  it('should not display the edition button when there is no edition link', async () => {
+    renderCollectiveOfferSummary({ ...props, offerEditLink: undefined })
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(
+      screen.queryByRole('link', { name: 'Modifier' })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/pro/src/components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/components/SummaryLayout/SummaryLayout.module.scss
@@ -90,5 +90,8 @@
   @include fonts.title3;
 
   padding-right: rem.torem(16px);
-  border-right: rem.torem(1px) solid var(--color-grey-medium);
+
+  &.section-title-editable {
+    border-right: rem.torem(1px) solid var(--color-grey-medium);
+  }
 }

--- a/pro/src/components/SummaryLayout/SummarySection.tsx
+++ b/pro/src/components/SummaryLayout/SummarySection.tsx
@@ -23,7 +23,13 @@ export const SummarySection = ({
 }: SummaryLayoutSectionProps): JSX.Element => (
   <div className={cn(style['summary-layout-section'], className)}>
     <div className={style['summary-layout-section-header']}>
-      <h2 className={style['section-title']}>{title}</h2>
+      <h2
+        className={cn(style['section-title'], {
+          [style['section-title-editable']]: Boolean(editLink),
+        })}
+      >
+        {title}
+      </h2>
 
       {typeof editLink === 'string' ? (
         <ButtonLink

--- a/pro/src/pages/CollectiveOfferEdition/CollectiveOfferEdition.tsx
+++ b/pro/src/pages/CollectiveOfferEdition/CollectiveOfferEdition.tsx
@@ -27,7 +27,11 @@ const CollectiveOfferEdition = ({
       {!isReady ? (
         <Spinner />
       ) : (
-        <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+        <CollectiveOfferLayout
+          subTitle={offer.name}
+          isTemplate={isTemplate}
+          offer={offer}
+        >
           <OfferEducational
             userOfferers={offerEducationalFormData.offerers}
             domainsOptions={offerEducationalFormData.domains}

--- a/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -21,6 +21,7 @@ export const CollectiveOfferSummaryCreation = ({
         isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
         isTemplate={isTemplate}
         isCreation={true}
+        offer={offer}
       >
         <CollectiveOfferSummaryCreationScreen offer={offer} />
         <RouteLeavingGuardCollectiveOfferCreation />

--- a/pro/src/pages/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -17,6 +17,7 @@ const CollectiveOfferSummaryEdition = ({
       <CollectiveOfferLayout
         subTitle={offer.name}
         isTemplate={isTemplate}
+        offer={offer}
         isArchivable={canArchiveCollectiveOfferFromSummary(offer)}
       >
         <CollectiveOfferSummaryEditionScreen

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -89,14 +89,12 @@ export const CollectiveActionsCells = ({
 
   const isMarseilleActive = useActiveFeature('WIP_ENABLE_MARSEILLE')
 
-  if (!isDateValid(offer.stocks[0].beginningDatetime)) {
-    return null
-  }
-
-  const eventDateFormated = formatBrowserTimezonedDateAsUTC(
-    new Date(offer.stocks[0].beginningDatetime),
-    FORMAT_ISO_DATE_ONLY
-  )
+  const eventDateFormated = isDateValid(offer.stocks[0].beginningDatetime)
+    ? formatBrowserTimezonedDateAsUTC(
+        new Date(offer.stocks[0].beginningDatetime),
+        FORMAT_ISO_DATE_ONLY
+      )
+    : ''
   const bookingLink = `/reservations/collectives?page=1&offerEventDate=${eventDateFormated}&bookingStatusFilter=booked&offerType=all&offerVenueId=all&bookingId=${offer.booking?.id}`
 
   const onDialogConfirm = async (shouldNotDisplayModalAgain: boolean) => {

--- a/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
@@ -2,7 +2,6 @@ import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { api } from 'apiClient/api'
-import { CollectiveOfferStatus } from 'apiClient/v1'
 import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -75,21 +74,6 @@ describe('CollectiveActionsCells', () => {
     )
 
     expect(api.patchCollectiveOffersArchive).toHaveBeenCalledTimes(1)
-  })
-
-  it('should not show action button', () => {
-    renderCollectiveActionsCell({
-      offer: collectiveOfferFactory({
-        isShowcase: true,
-        status: CollectiveOfferStatus.ARCHIVED,
-      }),
-      editionOfferLink: '',
-      urlSearchFilters: DEFAULT_SEARCH_FILTERS,
-      isSelected: false,
-      deselectOffer: vi.fn(),
-    })
-
-    expect(screen.queryByTitle('Action')).not.toBeInTheDocument()
   })
 
   it('should deselect an offer selected when the offer has just been archived', async () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31157

**Objectif**
- Correction: les offres vitrine n'avaient plus de bouton d'action dans la liste des offres collectives
- Correction: les offres collectives archivées étaient modifiables depuis la page de récapitulatif

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
