### PR TITLE
(PC-30496)[API][doc] Add warnings to hazardous booking endpoints

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
@@ -179,7 +179,7 @@ def get_booking_by_token(token: str) -> serialization.GetBookingResponse:
 @api_key_required
 def validate_booking_by_token(token: str) -> None:
     """
-    Validate a booking
+    Validate booking
 
     Confirm that the booking has been used by the beneficiary.
     """
@@ -220,9 +220,15 @@ def validate_booking_by_token(token: str) -> None:
 @api_key_required
 def cancel_booking_validation_by_token(token: str) -> None:
     """
-    Cancel a booking validation
+    Revert booking validation
 
-    Mark a booking as `unused`.
+    This operation reverses the status of a booking from `USED` back to `CONFIRMED`.
+    As a result, the pass Culture application will treat the booking as if the beneficiary has not retrieved it,
+    and the cultural partner will not receive a refund.
+
+    **⚠️ Warning:**
+    Before using this endpoint, **ensure that the cultural partner has manually confirmed their desire to revert the booking validation**.
+    Failure to do so may result in the cultural partner expecting a refund that will not be issued, due to the booking validation being reverted without their knowledge.
     """
     booking = _get_booking_by_token(token)
     if booking is None:

--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
@@ -262,12 +262,12 @@ def cancel_booking_validation_by_token(token: str) -> None:
 @api_key_required
 def cancel_booking_by_token(token: str) -> None:
     """
-    Cancel a booking
+    Delete a booking
 
-    Cancel a booking that has not been used or refunded.
+    Delete a booking that has not been used or refunded. For events, a booking can only be deleted if it is in a pending state.
 
-    For events, a booking can only be cancelled if it is pending.
-    Once it is confirmed, you cannot cancel it (for booking confirmation see [this page](/docs/understanding-our-api/resources/individual-offers#general-description-2)).
+    **⚠️ Warning:**
+    This operation is irreversible. Once a booking is deleted, the beneficiary cannot retrieve it and will need to create a new booking. **Use this endpoint only if you are certain that the order cannot be fulfilled.**
     """
     booking = _get_booking_by_token(token)
     if booking is None:

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -8896,7 +8896,7 @@
         },
         "/public/bookings/v1/cancel/token/{token}": {
             "patch": {
-                "description": "Cancel a booking that has not been used or refunded.\n\nFor events, a booking can only be cancelled if it is pending. Once it is confirmed, you cannot cancel it (for booking confirmation see [this page](/docs/understanding-our-api/resources/individual-offers#general-description-2)).",
+                "description": "Delete a booking that has not been used or refunded. For events, a booking can only be deleted if it is in a pending state.\n\n**\u26a0\ufe0f Warning:** This operation is irreversible. Once a booking is deleted, the beneficiary cannot retrieve it and will need to create a new booking. **Use this endpoint only if you are certain that the order cannot be fulfilled.**",
                 "operationId": "CancelBookingByToken",
                 "parameters": [
                     {
@@ -8947,7 +8947,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "summary": "Cancel a booking",
+                "summary": "Delete a booking",
                 "tags": [
                     "Bookings"
                 ]

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -8955,7 +8955,7 @@
         },
         "/public/bookings/v1/keep/token/{token}": {
             "patch": {
-                "description": "Mark a booking as `unused`.",
+                "description": "This operation reverses the status of a booking from `USED` back to `CONFIRMED`. As a result, the pass Culture application will treat the booking as if the beneficiary has not retrieved it, and the cultural partner will not receive a refund.\n\n**\u26a0\ufe0f Warning:** Before using this endpoint, **ensure that the cultural partner has manually confirmed their desire to revert the booking validation**. Failure to do so may result in the cultural partner expecting a refund that will not be issued, due to the booking validation being reverted without their knowledge.",
                 "operationId": "CancelBookingValidationByToken",
                 "parameters": [
                     {
@@ -9003,7 +9003,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "summary": "Cancel a booking validation",
+                "summary": "Revert booking validation",
                 "tags": [
                     "Bookings"
                 ]
@@ -9122,7 +9122,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "summary": "Validate a booking",
+                "summary": "Validate booking",
                 "tags": [
                     "Bookings"
                 ]


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30496

<img width="644" alt="image" src="https://github.com/user-attachments/assets/8a35c6e5-c76b-4d8c-8a4e-8afca3139ac4">
<img width="1105" alt="image" src="https://github.com/user-attachments/assets/494fe211-9ef0-417d-9dc6-ca4462de6616">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
