### PR TITLE
(PC-31142)[PRO] feat: Add the draft badge to the collective offers st…

### DIFF
--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveOfferStatusCell/CollectiveOfferStatusCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveOfferStatusCell/CollectiveOfferStatusCell.tsx
@@ -153,6 +153,23 @@ export const getCollectiveStatusLabel = (
           label="archivée"
         />
       )
+    case CollectiveOfferStatus.DRAFT:
+      return (
+        <CollectiveStatusLabel
+          className={style['status-draft']}
+          icon={
+            <SvgIcon
+              alt=""
+              src={strokeThing}
+              className={cn(
+                style['status-label-icon'],
+                style['status-draft-icon']
+              )}
+            />
+          }
+          label="brouillon"
+        />
+      )
     default:
       throw Error('Le statut de l’offre n’est pas valide')
   }

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveOfferStatusCell/__specs__/CollectiveOfferStatusCell.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveOfferStatusCell/__specs__/CollectiveOfferStatusCell.spec.tsx
@@ -52,6 +52,7 @@ describe('CollectiveStatusLabel', () => {
     },
     { offerStatus: CollectiveOfferStatus.EXPIRED, expectedLabel: 'expirée' },
     { offerStatus: CollectiveOfferStatus.ARCHIVED, expectedLabel: 'archivée' },
+    { offerStatus: CollectiveOfferStatus.DRAFT, expectedLabel: 'brouillon' },
   ]
 
   it.each(testCases)(


### PR DESCRIPTION
…atus

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31142

**Objectif**
Ajouter le badge "brouillon" dans les badges possibles des offres collectives.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
