### PR TITLE
(PC-31012)[PRO] fix(a11y): use descriptions instead of placeholders for TextInput / TextArea instructions

### DIFF
--- a/pro/src/components/BoxFormLayout/BoxFormLayout.stories.tsx
+++ b/pro/src/components/BoxFormLayout/BoxFormLayout.stories.tsx
@@ -42,7 +42,7 @@ const DefaultBoxFormLayout = (args: BoxFormLayoutProps) => {
                       <TextInput
                         label="Nouvelle adresse email"
                         name="email"
-                        placeholder="email@exemple.com"
+                        description="Format : email@exemple.com"
                       />
                     </FormLayout.Row>
                     <FormLayout.Row>

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop.tsx
@@ -188,7 +188,6 @@ export const ModalImageCrop = ({
               label="Crédit de l’image"
               maxLength={255}
               name="credit"
-              placeholder="Photographe..."
               required={false}
               type="text"
               isOptional

--- a/pro/src/components/IndividualOfferForm/ExternalLink/ExternalLink.tsx
+++ b/pro/src/components/IndividualOfferForm/ExternalLink/ExternalLink.tsx
@@ -24,7 +24,7 @@ export const ExternalLink = ({
           name="externalTicketOfficeUrl"
           isOptional
           type="text"
-          placeholder="https://exemple.com"
+          description="Format : https://exemple.com"
           disabled={readOnlyFields?.includes('externalTicketOfficeUrl')}
         />
       </FormLayout.Row>

--- a/pro/src/components/IndividualOfferForm/Notifications/Notifications.tsx
+++ b/pro/src/components/IndividualOfferForm/Notifications/Notifications.tsx
@@ -52,7 +52,7 @@ export const Notifications = ({
             label="Email auquel envoyer les notifications"
             maxLength={90}
             name="bookingEmail"
-            placeholder="email@exemple.com"
+            description="Format : email@exemple.com"
             disabled={readOnlyFields?.includes('bookingEmail')}
           />
         </FormLayout.Row>

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
@@ -97,7 +97,7 @@ export const UsefulInformations = ({
           name="withdrawalDetails"
           maxLength={500}
           disabled={readOnlyFields.includes('withdrawalDetails')}
-          placeholder={
+          description={
             isVenueVirtual
               ? 'Exemples : une création de compte, un code d’accès spécifique, une communication par email...'
               : 'Exemples : une autre adresse, un horaire d’accès, un délai de retrait, un guichet spécifique, un code d’accès, une communication par email...'
@@ -119,7 +119,7 @@ export const UsefulInformations = ({
             label="Email de contact"
             maxLength={90}
             name="bookingContact"
-            placeholder="email@exemple.com"
+            description="Format : email@exemple.com"
             disabled={readOnlyFields.includes('bookingContact')}
           />
         </FormLayout.Row>
@@ -138,7 +138,7 @@ export const UsefulInformations = ({
             label="URL d’accès à l’offre"
             name="url"
             type="text"
-            placeholder="https://exemple.com"
+            description="Format : https://exemple.com"
             disabled={readOnlyFields.includes('url')}
           />
         </FormLayout.Row>

--- a/pro/src/components/UserEmailForm/UserEmailForm.tsx
+++ b/pro/src/components/UserEmailForm/UserEmailForm.tsx
@@ -79,7 +79,7 @@ export const UserEmailForm = ({
                 <TextInput
                   label="Nouvelle adresse email"
                   name="email"
-                  placeholder="email@exemple.com"
+                  description="Format : email@exemple.com"
                 />
               </FormLayout.Row>
               <FormLayout.Row>

--- a/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
+++ b/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
@@ -69,18 +69,10 @@ export const UserIdentityForm = ({
           <Form onSubmit={formik.handleSubmit}>
             <FormLayout>
               <FormLayout.Row>
-                <TextInput
-                  label="Prénom"
-                  name="firstName"
-                  placeholder="Votre prénom"
-                />
+                <TextInput label="Prénom" name="firstName" />
               </FormLayout.Row>
               <FormLayout.Row>
-                <TextInput
-                  label="Nom"
-                  name="lastName"
-                  placeholder="Votre nom"
-                />
+                <TextInput label="Nom" name="lastName" />
               </FormLayout.Row>
             </FormLayout>
 

--- a/pro/src/components/UserPhoneForm/UserPhoneForm.tsx
+++ b/pro/src/components/UserPhoneForm/UserPhoneForm.tsx
@@ -71,11 +71,7 @@ export const UserPhoneForm = ({
         <Form onSubmit={formik.handleSubmit}>
           <FormLayout>
             <FormLayout.Row>
-              <TextInput
-                label="Téléphone"
-                name="phoneNumber"
-                placeholder="Votre téléphone"
-              />
+              <TextInput label="Téléphone" name="phoneNumber" />
             </FormLayout.Row>
           </FormLayout>
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/DefaultFormContact.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/DefaultFormContact.tsx
@@ -69,7 +69,7 @@ export const DefaultFormContact = ({
               label="Que souhaitez vous organiser ?"
               maxLength={1000}
               name="description"
-              placeholder="Décrivez le projet que vous souhaiteriez co-construire avec l’acteur culturel (Ex : Je souhaite organiser une visite que vous proposez dans votre théâtre pour un projet pédagogique autour du théâtre et de l’expression corporelle avec ma classe de 30 élèves entre janvier et mars. Je suis joignable par téléphone ou par mail.)"
+              description="Décrivez le projet que vous souhaiteriez co-construire avec l’acteur culturel (Ex : Je souhaite organiser une visite que vous proposez dans votre théâtre pour un projet pédagogique autour du théâtre et de l’expression corporelle avec ma classe de 30 élèves entre janvier et mars. Je suis joignable par téléphone ou par mail.)"
             />
           </FormLayout.Row>
           <div className={styles['buttons-container']}>

--- a/pro/src/pages/Collaborators/Collaborators.tsx
+++ b/pro/src/pages/Collaborators/Collaborators.tsx
@@ -187,7 +187,7 @@ export const Collaborators = (): JSX.Element | null => {
                   >
                     <EmailSpellCheckInput
                       name="email"
-                      placeholder="email@exemple.com"
+                      description="Format : email@exemple.com"
                       label="Adresse email"
                       className={styles['invitation-email-field']}
                     />

--- a/pro/src/pages/Desk/Desk.module.scss
+++ b/pro/src/pages/Desk/Desk.module.scss
@@ -12,6 +12,7 @@
   .desk-form-input {
     margin: rem.torem(10px) auto rem.torem(15px);
     max-width: rem.torem(328px);
+    text-align: left;
   }
 
   .desk-form-label {

--- a/pro/src/pages/Desk/Desk.tsx
+++ b/pro/src/pages/Desk/Desk.tsx
@@ -153,7 +153,7 @@ export const Desk = (): JSX.Element => {
             label="Contremarque"
             name="token"
             onChange={handleOnChangeToken}
-            placeholder="ex : AZE123"
+            description="Format : 6 caractères alphanumériques en majuscules. Par exemple : AZE123"
             value={token}
             classNameLabel={styles['desk-form-label']}
             className={styles['desk-form-input']}

--- a/pro/src/pages/LostPassword/ChangePasswordRequestForm/ChangePasswordRequestForm.tsx
+++ b/pro/src/pages/LostPassword/ChangePasswordRequestForm/ChangePasswordRequestForm.tsx
@@ -25,7 +25,7 @@ export const ChangePasswordRequestForm = (): JSX.Element => {
           <FormLayout.Row>
             <EmailSpellCheckInput
               name="email"
-              placeholder="email@exemple.com"
+              description="Format : email@exemple.com"
               label="Adresse email"
             />
           </FormLayout.Row>

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
@@ -123,7 +123,7 @@ export const CollectiveDataForm = ({
                   <TextArea
                     name="collectiveDescription"
                     label="Démarche d’éducation artistique et culturelle"
-                    placeholder="Présenter la démarche d’éducation artistique et culturelle : présentation du lieu, actions menées auprès du public scolaire..."
+                    description="Présenter la démarche d’éducation artistique et culturelle : présentation du lieu, actions menées auprès du public scolaire..."
                     maxLength={500}
                     countCharacters
                     isOptional
@@ -146,7 +146,7 @@ export const CollectiveDataForm = ({
                   <TextInput
                     name="collectiveWebsite"
                     label="URL de votre site web"
-                    placeholder="https://exemple.com"
+                    description="Format : https://exemple.com"
                     isOptional
                   />
                 </FormLayout.Row>
@@ -217,7 +217,7 @@ export const CollectiveDataForm = ({
                   <TextInput
                     name="collectiveEmail"
                     label="Email"
-                    placeholder="email@exemple.com"
+                    description="Format : email@exemple.com"
                     isOptional
                   />
                 </FormLayout.Row>

--- a/pro/src/pages/SignIn/SigninForm.tsx
+++ b/pro/src/pages/SignIn/SigninForm.tsx
@@ -37,7 +37,7 @@ export const SigninForm = (): JSX.Element => {
           <TextInput
             label="Adresse email"
             name="email"
-            placeholder="email@exemple.com"
+            description="Format : email@exemple.com"
           />
         </FormLayout.Row>
         <FormLayout.Row>

--- a/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
@@ -46,7 +46,7 @@ export const SignupForm = (): JSX.Element => {
         <FormLayout.Row>
           <EmailSpellCheckInput
             name="email"
-            placeholder="email@exemple.com"
+            description="Format : email@exemple.com"
             label="Adresse email"
           />
         </FormLayout.Row>

--- a/pro/src/pages/VenueCreation/SiretOrCommentFields/SiretOrCommentFields.tsx
+++ b/pro/src/pages/VenueCreation/SiretOrCommentFields/SiretOrCommentFields.tsx
@@ -126,7 +126,7 @@ export const SiretOrCommentFields = ({
         <TextArea
           label="Commentaire du lieu sans SIRET"
           name="comment"
-          placeholder="Par exemple : le lieu est un équipement culturel qui n’appartient pas à ma structure."
+          description="Par exemple : le lieu est un équipement culturel qui n’appartient pas à ma structure."
           isOptional={isSiretSelected}
           maxLength={500}
           countCharacters

--- a/pro/src/pages/VenueCreation/VenueCreationForm.tsx
+++ b/pro/src/pages/VenueCreation/VenueCreationForm.tsx
@@ -150,7 +150,7 @@ export const VenueCreationForm = ({
               name="bookingEmail"
               label="Adresse email"
               type="email"
-              placeholder="email@exemple.com"
+              description="Format : email@exemple.com"
             />
           </FormLayout.Row>
         </FormLayout.Section>

--- a/pro/src/pages/VenueCreation/WithdrawalDetails/WithdrawalDetails.tsx
+++ b/pro/src/pages/VenueCreation/WithdrawalDetails/WithdrawalDetails.tsx
@@ -28,7 +28,7 @@ export const WithdrawalDetails = () => {
           name="withdrawalDetails"
           label="Informations de retrait"
           maxLength={500}
-          placeholder="Par exemple : une autre adresse, un horaire d’accès, un délai de retrait, un guichet spécifique, un code d’accès, une communication par email..."
+          description="Par exemple : une autre adresse, un horaire d’accès, un délai de retrait, un guichet spécifique, un code d’accès, une communication par email..."
           countCharacters
           isOptional
         />

--- a/pro/src/pages/VenueEdition/VenueEditionForm.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionForm.tsx
@@ -122,7 +122,7 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
                 <TextArea
                   name="description"
                   label="Description"
-                  placeholder="Par exemple : mon établissement propose des spectacles, de l’improvisation..."
+                  description="Par exemple : mon établissement propose des spectacles, de l’improvisation..."
                   maxLength={1000}
                   countCharacters
                   isOptional
@@ -152,7 +152,7 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
                 <TextInput
                   name="email"
                   label="Adresse email"
-                  placeholder="email@exemple.com"
+                  description="Format : email@exemple.com"
                   isOptional
                 />
               </FormLayout.Row>
@@ -161,7 +161,7 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
                 <TextInput
                   name="webSite"
                   label="URL de votre site web"
-                  placeholder="https://exemple.com"
+                  description="Format : https://exemple.com"
                   isOptional
                 />
               </FormLayout.Row>

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.tsx
@@ -90,7 +90,7 @@ export const AllocineProviderForm = ({
               type="number"
               label="Prix de vente/place"
               min="0"
-              placeholder="Ex : 12€"
+              description="Le prix doit être indiqué en euros."
               step={0.01}
               className={styles['price-input']}
               required

--- a/pro/src/pages/VenueSettings/VenueSettingsForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueSettingsForm.tsx
@@ -150,7 +150,7 @@ export const VenueSettingsForm = ({
               name="bookingEmail"
               label="Adresse email"
               type="email"
-              placeholder="email@exemple.com"
+              description="Format : email@exemple.com"
               isOptional={venue.isVirtual}
               disabled={venue.isVirtual}
             />

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.module.scss
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.module.scss
@@ -9,6 +9,9 @@
 
 .price-input {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
 }
 
 .duo-section {
@@ -35,7 +38,6 @@
 }
 
 .form-layout-row-price-category {
-  padding: rem.torem(8px);
   border-radius: rem.torem(4px);
   padding-bottom: rem.torem(24px);
 }
@@ -59,8 +61,9 @@
 
   .form-row-actions {
     margin-top: calc(
-      #{forms.$label-small-space-before-input} + #{fonts.$caption-line-height}
+      #{forms.$label-small-space-before-input} + #{fonts.$caption-line-height}/2
     );
+    height: auto;
   }
 
   .form-layout-row-price-category {

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.tsx
@@ -141,7 +141,7 @@ export const PriceCategoriesForm = ({
                       smallLabel
                       name={`priceCategories[${index}].label`}
                       label="Intitulé du tarif"
-                      placeholder="Ex : catégorie 2, moins de 18 ans, pass 3 jours..."
+                      description="Par exemple : catégorie 2, moins de 18 ans, pass 3 jours..."
                       maxLength={PRICE_CATEGORY_LABEL_MAX_LENGTH}
                       countCharacters
                       className={styles['label-input']}

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationForm.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationForm.tsx
@@ -193,7 +193,7 @@ export const UsefulInformationForm = ({
             name="withdrawalDetails"
             maxLength={500}
             disabled={readOnlyFields.includes('withdrawalDetails')}
-            placeholder={
+            description={
               isVenueVirtual
                 ? 'Exemples : une création de compte, un code d’accès spécifique, une communication par email...'
                 : 'Exemples : une autre adresse, un horaire d’accès, un délai de retrait, un guichet spécifique, un code d’accès, une communication par email...'
@@ -215,7 +215,7 @@ export const UsefulInformationForm = ({
               label="Email de contact"
               maxLength={90}
               name="bookingContact"
-              placeholder="email@exemple.com"
+              description="Format : email@exemple.com"
               disabled={readOnlyFields.includes('bookingContact')}
             />
           </FormLayout.Row>
@@ -234,7 +234,7 @@ export const UsefulInformationForm = ({
               label="URL d’accès à l’offre"
               name="url"
               type="text"
-              placeholder="https://exemple.com"
+              description="Format : https://exemple.com"
               disabled={readOnlyFields.includes('url')}
             />
           </FormLayout.Row>
@@ -291,7 +291,7 @@ export const UsefulInformationForm = ({
               label="Email auquel envoyer les notifications"
               maxLength={90}
               name="bookingEmail"
-              placeholder="email@exemple.com"
+              description="Format : email@exemple.com"
               disabled={readOnlyFields.includes('bookingEmail')}
             />
           </FormLayout.Row>
@@ -311,7 +311,7 @@ export const UsefulInformationForm = ({
             name="externalTicketOfficeUrl"
             isOptional
             type="text"
-            placeholder="https://exemple.com"
+            description="Format : https://exemple.com"
             disabled={readOnlyFields.includes('externalTicketOfficeUrl')}
           />
         </FormLayout.Row>

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContact/FormContact.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContact/FormContact.tsx
@@ -29,7 +29,7 @@ export const FormContact = ({ disableForm }: FormContactProps): JSX.Element => {
           label={EMAIL_LABEL}
           name="email"
           disabled={disableForm}
-          placeholder="email@exemple.com"
+          description="Format : email@exemple.com"
         />
       </FormLayout.Row>
     </FormLayout.Section>

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplate.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplate.tsx
@@ -50,7 +50,7 @@ export const FormContactTemplate = ({
                 isOptional
                 name="email"
                 disabled={disableForm}
-                placeholder="email@exemple.com"
+                description="Format : email@exemple.com"
               />
             </div>
           )}

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
@@ -49,7 +49,7 @@ export const FormContactTemplateCustomForm = ({
           isOptional
           name="contactUrl"
           disabled={disableForm}
-          placeholder="https://exemple.com"
+          description="Format : https://exemple.com"
           className={styles['custom-form-radio-input-control']}
         />
       </div>

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/__specs__/FormContactTemplateCustomForm.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/__specs__/FormContactTemplateCustomForm.spec.tsx
@@ -49,8 +49,8 @@ describe('FormContactTemplateCustomForm', () => {
       })
     ).toBeChecked()
 
-    expect(screen.getByPlaceholderText('https://exemple.com')).toHaveValue(
-      'http://www.test-url.com'
-    )
+    expect(
+      screen.getByRole('textbox', { name: 'URL de mon formulaire de contact' })
+    ).toHaveValue('http://www.test-url.com')
   })
 })

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/__specs__/FormContactTemplate.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/__specs__/FormContactTemplate.spec.tsx
@@ -34,13 +34,19 @@ describe('FormContactTemplate', () => {
   it('should show the email form when the contact email checkbox is checked', async () => {
     renderFormContact({ isTemplate: true })
     expect(
-      screen.queryByPlaceholderText('email@exemple.com')
+      screen.queryByRole('textbox', {
+        name: 'Email de contact',
+      })
     ).not.toBeInTheDocument()
 
     const emailCheckbox = screen.getByRole('checkbox', { name: 'Par email' })
     await userEvent.click(emailCheckbox)
 
-    expect(screen.getByPlaceholderText('email@exemple.com')).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', {
+        name: 'Email de contact',
+      })
+    ).toBeInTheDocument()
   })
 
   it('should show the phone form when the contact phone checkbox is checked', async () => {

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -122,7 +122,7 @@ export const FormOfferType = ({
             label={DESCRIPTION_LABEL}
             maxLength={MAX_DETAILS_LENGTH}
             name="description"
-            placeholder="Détaillez ici votre projet et son interêt pédagogique."
+            description="Détaillez ici votre projet et son interêt pédagogique."
             disabled={disableForm}
           />
         </FormLayout.Row>
@@ -131,7 +131,7 @@ export const FormOfferType = ({
             isOptional
             label={DURATION_LABEL}
             name="duration"
-            placeholder="HH:MM"
+            description="Format : HH:MM"
             disabled={disableForm}
           />
         </FormLayout.Row>

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormPriceDetails/FormPriceDetails.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormPriceDetails/FormPriceDetails.tsx
@@ -23,7 +23,7 @@ export const FormPriceDetails = ({ disableForm }: FormPriceDetailsProps) => {
           label={PRICE_INFORMATION}
           maxLength={MAX_DETAILS_LENGTH}
           name="priceDetail"
-          placeholder="Par exemple : tarif par élève ou par groupe scolaire, politique tarifaire REP/REP+ et accompagnateurs... "
+          description="Par exemple : tarif par élève ou par groupe scolaire, politique tarifaire REP/REP+ et accompagnateurs... "
         />
       </FormLayout.Row>
     </FormLayout.Section>

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOfferTypeStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOfferTypeStep.spec.tsx
@@ -34,7 +34,10 @@ describe('screens | OfferEducational : creation offer type step', () => {
     const descriptionTextArea = await screen.findByLabelText(/Description */)
     expect(descriptionTextArea).toBeEnabled()
     expect(descriptionTextArea).toHaveValue('')
-    expect(descriptionTextArea.getAttribute('placeholder')).toBe(
+    const descriptionTextAreaDesc = screen.getByTestId(
+      'description-description'
+    )
+    expect(descriptionTextAreaDesc).toHaveTextContent(
       'Détaillez ici votre projet et son interêt pédagogique.'
     )
     expect(await screen.findByTestId('counter-description')).toHaveTextContent(
@@ -45,7 +48,8 @@ describe('screens | OfferEducational : creation offer type step', () => {
     expect(durationInput).toBeInTheDocument()
     expect(durationInput).toBeEnabled()
     expect(durationInput).toHaveValue('')
-    expect(durationInput.getAttribute('placeholder')).toBe('HH:MM')
+    const durationInputDesc = screen.getByTestId('description-duration')
+    expect(durationInputDesc).toHaveTextContent('Format : HH:MM')
   })
 
   describe('domains', () => {

--- a/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
@@ -94,7 +94,6 @@ export const FormStock = ({
         disabled={disablePriceAndParticipantInputs}
         label={NUMBER_OF_PLACES_LABEL}
         name="numberOfPlaces"
-        placeholder="Ex : 30"
         type="number"
         hasLabelLineBreak={false}
         rightIcon={strokeCollaborator}

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -179,7 +179,7 @@ export const OfferEducationalStock = <
                   label={DETAILS_PRICE_LABEL}
                   maxLength={MAX_DETAILS_LENGTH}
                   name="priceDetail"
-                  placeholder={PRICE_DETAIL_PLACEHOLDER}
+                  description={PRICE_DETAIL_PLACEHOLDER}
                 />
               </FormLayout.Row>
             </FormLayout.Section>

--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -13,7 +13,7 @@ import {
 import { FORMAT_HH_mm, FORMAT_ISO_DATE_ONLY } from 'utils/date'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
-import { PRICE_DETAIL_PLACEHOLDER } from '../constants/labels'
+import { DETAILS_PRICE_LABEL } from '../constants/labels'
 import {
   OfferEducationalStock,
   OfferEducationalStockProps,
@@ -104,9 +104,9 @@ describe('OfferEducationalStock', () => {
       }
       renderWithProviders(<OfferEducationalStock {...testProps} />)
 
-      const descriptionInput = screen.getByPlaceholderText(
-        PRICE_DETAIL_PLACEHOLDER
-      )
+      const descriptionInput = screen.getByRole('textbox', {
+        name: `${DETAILS_PRICE_LABEL} *`,
+      })
       const priceInput = screen.getByLabelText('Prix total TTC *')
       const placeInput = screen.getByLabelText('Nombre de participants *')
 
@@ -136,9 +136,9 @@ describe('OfferEducationalStock', () => {
       }
       renderWithProviders(<OfferEducationalStock {...testProps} />)
 
-      const descriptionInput = screen.getByPlaceholderText(
-        PRICE_DETAIL_PLACEHOLDER
-      )
+      const descriptionInput = screen.getByRole('textbox', {
+        name: `${DETAILS_PRICE_LABEL} *`,
+      })
       const priceInput = screen.getByLabelText('Prix total TTC *')
       const placeInput = screen.getByLabelText('Nombre de participants *')
       const saveButton = screen.getByText('Enregistrer les modifications')

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -62,7 +62,7 @@ export const ActivityForm = ({
                 <TextInput
                   name={`socialUrls[${index}]`}
                   label="Site internet, réseau social"
-                  placeholder="https://www.siteinternet.com"
+                  description="Format : https://www.siteinternet.com"
                   data-testid="activity-form-social-url"
                   type="url"
                   className={styles['url-input']}

--- a/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
@@ -147,7 +147,9 @@ describe('screens:SignupJourney::ActivityForm', () => {
 
     expect(await screen.findByText('Activité')).toBeInTheDocument()
     await userEvent.type(
-      screen.getByPlaceholderText('https://www.siteinternet.com'),
+      screen.getByRole('textbox', {
+        name: 'Site internet, réseau social',
+      }),
       'qsdsqd'
     )
     await userEvent.click(screen.getByText('Submit'))

--- a/pro/src/ui-kit/form/DurationInput/DurationInput.tsx
+++ b/pro/src/ui-kit/form/DurationInput/DurationInput.tsx
@@ -50,7 +50,7 @@ export const DurationInput = ({
       onBlur={onDurationBlur}
       className={className}
       isOptional={isOptional}
-      placeholder="HH:MM"
+      description="Format : HH:MM"
       disabled={disabled}
       {...props}
     />

--- a/pro/src/ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput.stories.tsx
+++ b/pro/src/ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput.stories.tsx
@@ -19,7 +19,7 @@ export const Default = {
   args: {
     name: 'email',
     label: 'Adresse email',
-    placeholder: 'email@exemple.com',
+    description: 'Format: email@exemple.com',
     overrideInitialTip: 'marie.dupont@gmail.com',
   },
 }

--- a/pro/src/ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput.tsx
+++ b/pro/src/ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput.tsx
@@ -14,7 +14,8 @@ import styles from './EmailSpellCheckInput.module.scss'
 type EmailSpellCheckInputProps<FormType> = FieldLayoutBaseProps & {
   // `Extract` needed so the key is a string. See https://stackoverflow.com/a/51808262
   name: Extract<keyof FormType, string>
-  placeholder: string
+  placeholder?: string
+  description: string
   label: string
   overrideInitialTip?: string | null
   maxLength?: number
@@ -23,6 +24,7 @@ type EmailSpellCheckInputProps<FormType> = FieldLayoutBaseProps & {
 export const EmailSpellCheckInput = <FormType,>({
   name,
   placeholder,
+  description,
   label,
   className,
   overrideInitialTip = null,
@@ -61,6 +63,7 @@ export const EmailSpellCheckInput = <FormType,>({
         label={label}
         name={name}
         placeholder={placeholder}
+        description={description}
         onBlur={handleEmailValidation}
         onFocus={resetEmailValidation}
         hideFooter={emailValidationTip !== null} // This is needed to hide the footer div that takes some space

--- a/pro/src/ui-kit/form/EmailSpellCheckInput/__specs__/EmailSpellCheckInput.spec.tsx
+++ b/pro/src/ui-kit/form/EmailSpellCheckInput/__specs__/EmailSpellCheckInput.spec.tsx
@@ -23,7 +23,7 @@ const renderEmailSpellCheckInput = () => {
       <EmailSpellCheckInput
         name="email"
         label="Email"
-        placeholder="mail@exemple.com"
+        description="Format : mail@exemple.com"
       />
     </Formik>
   )

--- a/pro/src/ui-kit/form/PasswordInput/PasswordInput.tsx
+++ b/pro/src/ui-kit/form/PasswordInput/PasswordInput.tsx
@@ -15,6 +15,7 @@ import { ValidationMessageList } from './ValidationMessageList/ValidationMessage
 interface PasswordInputProps {
   label: string
   name: string
+  description?: string
   placeholder?: string
   withErrorPreview?: boolean
   autoComplete?: string
@@ -23,6 +24,7 @@ interface PasswordInputProps {
 export const PasswordInput = ({
   label,
   name,
+  description,
   placeholder,
   withErrorPreview = false,
   autoComplete,
@@ -49,6 +51,7 @@ export const PasswordInput = ({
         label={label}
         name={name}
         placeholder={placeholder}
+        description={description}
         type={isPasswordHidden ? 'password' : 'text'}
         autoComplete={autoComplete}
         rightButton={() => (

--- a/pro/src/ui-kit/form/TextArea/TextArea.tsx
+++ b/pro/src/ui-kit/form/TextArea/TextArea.tsx
@@ -21,6 +21,7 @@ export const TextArea = ({
   name,
   className,
   disabled,
+  description,
   placeholder,
   label,
   maxLength = 1000,
@@ -42,9 +43,11 @@ export const TextArea = ({
       name={name}
       showError={meta.touched && !!meta.error}
       smallLabel={smallLabel}
+      description={description}
     >
       <Textarea
         aria-invalid={meta.touched && !!meta.error}
+        {...(description ? { 'aria-describedby': `description-${name}` } : {})}
         className={cn(styles['text-area'], {
           [styles['has-error']]: meta.touched && !!meta.error,
         })}

--- a/pro/src/ui-kit/form/TextArea/__specs__/TextArea.spec.tsx
+++ b/pro/src/ui-kit/form/TextArea/__specs__/TextArea.spec.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { Formik } from 'formik'
+
+import { TextArea } from '../TextArea'
+
+describe('TextArea', () => {
+  it('should link the input to its description when defined', () => {
+    const inputName = 'test'
+    const inputLabel = 'Ceci est un champ texte'
+    const descriptionContent = 'Instructions pour le remplissage du champ.'
+    const descriptionId = `description-${inputName}`
+
+    render(
+      <Formik initialValues={{ test1: '', test2: '' }} onSubmit={() => {}}>
+        <TextArea
+          label={inputLabel}
+          description={descriptionContent}
+          name={inputName}
+          isOptional={true}
+        />
+      </Formik>
+    )
+
+    const description = screen.queryByTestId(descriptionId)
+    expect(description).toBeInTheDocument()
+    expect(description).toHaveTextContent(descriptionContent)
+
+    const input = screen.getByRole('textbox', { name: inputLabel })
+    expect(input.getAttribute('aria-describedby')).toBe(descriptionId)
+  })
+})

--- a/pro/src/ui-kit/form/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/form/TextInput/TextInput.tsx
@@ -109,6 +109,9 @@ export const TextInput = ({
           rightIcon={rightIcon}
           leftIcon={leftIcon}
           aria-required={!isOptional}
+          {...(description
+            ? { 'aria-describedby': `description-${name}` }
+            : {})}
           onKeyDown={(event) => {
             if (type === 'number') {
               if (regexIsNavigationKey.test(event.key)) {

--- a/pro/src/ui-kit/form/TextInput/__specs__/TextInput.spec.tsx
+++ b/pro/src/ui-kit/form/TextInput/__specs__/TextInput.spec.tsx
@@ -34,4 +34,30 @@ describe('TextInput', () => {
       expect(screen.getByLabelText('Input 2 *')).toHaveFocus()
     }
   )
+
+  it('should link the input to its description when defined', () => {
+    const inputName = 'test'
+    const inputLabel = 'Ceci est un champ texte'
+    const descriptionContent = 'Instructions pour le remplissage du champ.'
+    const descriptionId = `description-${inputName}`
+
+    render(
+      <Formik initialValues={{ test1: '', test2: '' }} onSubmit={() => {}}>
+        <TextInput
+          type="text"
+          label={inputLabel}
+          description={descriptionContent}
+          name={inputName}
+          isOptional={true}
+        />
+      </Formik>
+    )
+
+    const description = screen.queryByTestId(descriptionId)
+    expect(description).toBeInTheDocument()
+    expect(description).toHaveTextContent(descriptionContent)
+
+    const input = screen.getByRole('textbox', { name: inputLabel })
+    expect(input.getAttribute('aria-describedby')).toBe(descriptionId)
+  })
 })

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.tsx
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.tsx
@@ -98,7 +98,11 @@ export const FieldLayout = ({
           {label} {!isOptional && '*'}
         </label>
         {description && (
-          <span className={styles['field-layout-input-description']}>
+          <span
+            id={`description-${name}`}
+            data-testid={`description-${name}`}
+            className={styles['field-layout-input-description']}
+          >
             {description}
           </span>
         )}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31012
- Préférer un champ description au placeholder pour les instructions d’input et exemples d’entrée qui constitueraient une véritable aide (pas de répétition vis à vis du label, pas d’exemple évident qui constituerait une pollution visuelle).
- Éviter les abbréviations dans les textes pour les screen readers (“ex pour exemple”).

## Descriptif des modifications
- TextInput.tsx : Un lien a été créé entre champ descriptif (instruction) & input via aria-describedby. aria-describedby est passé à BaseInput et pointe vers la description de FieldLayout (voir attribut id). En cas d’erreur aria-describedby pointe vers le message d’erreur.
- Même chose pour TextArea.tsx.
- Suppression de redondances : inutile d’avoir un rappel du label dans le placeholder. Cela engendre une répétition visuelle et/ou sonore intempestive. Voir UserIdentityForm & UserPhoneForm.
- Certains placeholders ont été supprimés car jugés non pertinents / inutiles / trop évidents : 
-- Mention “Illimité” sur certains inputs.
-- “Photographe” sur input avec le label “Crédit de l’image” (ModalImageCrop).
-- “Ex: 30” sur input avec le label “Nombre de participants” (FormStock).

## Notes for the future
Éviter de construire les tests à partir de …ByPlaceholder. La plupart du temps, ces query peuvent être faits à base de …ByRole. D’après la documentation cette fonction serait de toute façon à prioriser. Voir : https://testing-library.com/docs/queries/about

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
