### PR TITLE
(PC-31225)[API] Drop `venu_provider_permission` table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 35d67a2cddcd (pre) (head)
-227228152465 (post) (head)
+03013c06a0ac (post) (head)

--- a/api/src/pcapi/alembic/versions/20240807T090456_03013c06a0ac_drop_venue_provider_permission_table.py
+++ b/api/src/pcapi/alembic/versions/20240807T090456_03013c06a0ac_drop_venue_provider_permission_table.py
@@ -1,0 +1,46 @@
+"""Drop `venue_provider_permission` table
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "03013c06a0ac"
+down_revision = "227228152465"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute('DROP TABLE IF EXISTS "venue_provider_permission"')
+    op.execute("DROP TYPE IF EXISTS permissionenum")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "venue_provider_permission",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("venueProviderId", sa.BigInteger(), nullable=False),
+        sa.Column("resource", sa.Text(), nullable=False),
+        sa.Column("permission", sa.Enum("READ", "WRITE", name="permissionenum"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "venueProviderId", "resource", "permission", name="unique_venue_provider_resource_permission"
+        ),
+    )
+    op.create_foreign_key(
+        "venue_provider_permission_venueProviderId_fkey",
+        "venue_provider_permission",
+        "venue_provider",
+        ["venueProviderId"],
+        ["id"],
+        ondelete="CASCADE",
+        postgresql_not_valid=True,
+    )
+    op.execute("COMMIT")
+    op.execute("BEGIN")
+    op.execute(
+        'ALTER TABLE "venue_provider_permission" VALIDATE CONSTRAINT "venue_provider_permission_venueProviderId_fkey"'
+    )

--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -95,13 +95,6 @@ class VenueProviderExternalUrlsFactory(BaseFactory):
     notificationExternalUrl = factory.Sequence("https://{}.example.org/notification".format)
 
 
-class VenueProviderPermissionFactory(BaseFactory):
-    class Meta:
-        model = models.VenueProviderPermission
-
-    venueProvider = factory.SubFactory(VenueProviderFactory)
-
-
 class CinemaProviderPivotFactory(BaseFactory):
     class Meta:
         model = models.CinemaProviderPivot

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -108,44 +108,6 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
         return sa.and_(cls.isActive.is_(True), cls.apiUrl.is_not(None), cls.name.not_ilike("%praxiel%"))
 
 
-class PermissionEnum(enum.Enum):
-    READ = "READ"
-    WRITE = "WRITE"
-
-
-class ApiResourceEnum(enum.Enum):
-    products = "products"
-    events = "events"
-    bookings = "bookings"
-    collective_events = "collective_events"
-    collective_bookings = "collective_bookings"
-
-
-class VenueProviderPermission(PcObject, Base, Model):
-    """
-    Stores the permission given by the Venue Owner to the provider
-    """
-
-    venueProviderId: int = sa.Column(
-        sa.BigInteger, sa.ForeignKey("venue_provider.id", ondelete="CASCADE"), nullable=False
-    )
-    venueProvider: sa_orm.Mapped["VenueProvider"] = sa_orm.relationship(
-        "VenueProvider", foreign_keys=[venueProviderId], back_populates="permissions"
-    )
-
-    resource: ApiResourceEnum = sa.Column(sa.Enum(ApiResourceEnum, create_constraint=False), nullable=False)
-    permission: PermissionEnum = sa.Column(sa.Enum(PermissionEnum), nullable=False)
-
-    __table_args__ = (
-        sa.UniqueConstraint(
-            "venueProviderId",
-            "resource",
-            "permission",
-            name="unique_venue_provider_resource_permission",
-        ),
-    )
-
-
 class VenueProviderExternalUrls(PcObject, Base, Model, DeactivableMixin):
     """
     Stores external Urls specific for a Venue. It will be set by providers via API.
@@ -194,10 +156,6 @@ class VenueProvider(PcObject, Base, Model, DeactivableMixin):
     # external URLs
     externalUrls: sa_orm.Mapped["VenueProviderExternalUrls"] = sa_orm.relationship(
         "VenueProviderExternalUrls", uselist=False, back_populates="venueProvider", cascade="all,delete"
-    )
-    # permissions
-    permissions: sa_orm.Mapped["VenueProviderPermission"] = sa_orm.relationship(
-        "VenueProviderPermission", uselist=True, back_populates="venueProvider", cascade="all,delete"
     )
 
     # This column is unused by our code but by the data team

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -16,19 +16,6 @@ from . import constants
 from . import models
 
 
-def get_venue_provider_permission_or_none(
-    venue_provider_id: int,
-    resource: models.ApiResourceEnum,
-    permission: models.PermissionEnum,
-) -> models.VenueProviderPermission | None:
-    return (
-        models.VenueProviderPermission.query.filter(models.VenueProviderPermission.venueProviderId == venue_provider_id)
-        .filter(models.VenueProviderPermission.resource == resource)
-        .filter(models.VenueProviderPermission.permission == permission)
-        .one_or_none()
-    )
-
-
 def get_venue_provider_by_id(venue_provider_id: int) -> models.VenueProvider:
     return models.VenueProvider.query.filter_by(id=venue_provider_id).one()
 

--- a/api/tests/routes/pro/post_venue_provider_test.py
+++ b/api/tests/routes/pro/post_venue_provider_test.py
@@ -92,7 +92,6 @@ class Returns201Test:
         assert response.json["quantity"] == 50
         venue_provider = VenueProvider.query.one()
         mock_synchronize_venue_provider.assert_called_once_with(venue_provider)
-        assert len(venue_provider.permissions) == 0
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.synchronize_venue_provider")
@@ -123,7 +122,6 @@ class Returns201Test:
         assert response.json["quantity"] == 50
         venue_provider = VenueProvider.query.one()
         mock_synchronize_venue_provider.assert_called_once_with(venue_provider)
-        assert len(venue_provider.permissions) == 0
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.venue_provider_job.delay")
@@ -315,8 +313,6 @@ class Returns201Test:
         assert response.json["provider"]["id"] == provider.id
         assert response.json["venueId"] == venue.id
         assert response.json["venueIdAtOfferProvider"] == cds_pivot.idAtProvider
-        venue_provider = VenueProvider.query.one()
-        assert len(venue_provider.permissions) == 0
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.synchronize_ems_venue_provider")
@@ -339,7 +335,6 @@ class Returns201Test:
         venue_provider = VenueProvider.query.one()
         mocked_synchronize_ems_venue_provider.assert_called_once_with(venue_provider)
         venue_provider = VenueProvider.query.one()
-        assert len(venue_provider.permissions) == 0
 
 
 class Returns400Test:

--- a/api/tests/routes/public/individual_offers/v1/get_events_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_events_test.py
@@ -6,7 +6,6 @@ from pcapi.core import testing
 from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
-from pcapi.core.providers import models as providers_models
 from pcapi.core.testing import assert_no_duplicated_queries
 
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
@@ -14,7 +13,6 @@ from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 
 @pytest.mark.usefixtures("db_session")
 class GetEventsTest(PublicAPIVenueEndpointHelper):
-    needed_permission = (providers_models.ApiResourceEnum.events, providers_models.PermissionEnum.READ)
     endpoint_url = "/public/offers/v1/events"
 
     def test_should_raise_401_because_not_authenticated(self, client):

--- a/api/tests/routes/public/individual_offers/v1/utils.py
+++ b/api/tests/routes/public/individual_offers/v1/utils.py
@@ -39,10 +39,8 @@ def create_offerer_provider_linked_to_venue(
     with_ticketing_service_at_provider_level=False,
     with_ticketing_service_at_venue_level=False,
     is_venue_provider_active=True,
-    venue_provider_permissions=None,
 ):
     venue_params = venue_params if venue_params else {}
-    venue_provider_permissions = venue_provider_permissions or []
     provider, api_key = create_offerer_provider(with_ticketing_service_at_provider_level)
     if is_virtual:
         venue = offerers_factories.VirtualVenueFactory(**venue_params)
@@ -55,9 +53,4 @@ def create_offerer_provider_linked_to_venue(
     if with_ticketing_service_at_venue_level:
         providers_factories.VenueProviderExternalUrlsFactory(venueProvider=venue_provider)
 
-    for permission_tuple in venue_provider_permissions:
-        permission, resource = permission_tuple
-        providers_factories.VenueProviderPermissionFactory(
-            venueProvider=venue_provider, resource=resource, permission=permission
-        )
     return venue, api_key


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31225

Deuxième étape de la suppression du système de permission pour l'API publique.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
