### PR TITLE
(PC-30880)[BO] feat: Include cashflow batch's info in finance incident/commercial gesture page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general_commercial_gesture.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general_commercial_gesture.html
@@ -57,7 +57,21 @@
             </p>
             {% if incident.author_full_name %}
               <p class="mb-1">
-                <span class="fw-bold">Incident créé par :</span> {{ incident.author_full_name }}
+                <span class="fw-bold">Geste commercial créé par :</span> {{ incident.author_full_name }}
+              </p>
+            {% endif %}
+            {% if incident.cashflow_batch_label %}
+              <p class="mb-1">
+                <span class="fw-bold">Batch :</span> {{ incident.cashflow_batch_label }}
+              </p>
+            {% endif %}
+            {% if incident.invoice_url %}
+              <p class="mb-1">
+                <span class="fw-bold">Justificatif de remboursement :</span>
+                <a class="link-primary"
+                   download
+                   href="{{ incident.invoice_url }}">
+                  <i class="bi bi-cloud-download-fill"></i> PDF</a>
               </p>
             {% endif %}
           </div>

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general_overpayment.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general_overpayment.html
@@ -72,6 +72,20 @@
                 <span class="fw-bold">Incident créé par :</span> {{ incident.author_full_name }}
               </p>
             {% endif %}
+            {% if incident.cashflow_batch_label %}
+              <p class="mb-1">
+                <span class="fw-bold">Batch :</span> {{ incident.cashflow_batch_label }}
+              </p>
+            {% endif %}
+            {% if incident.invoice_url %}
+              <p class="mb-1">
+                <span class="fw-bold">Justificatif de remboursement :</span>
+                <a class="link-primary"
+                   download
+                   href="{{ incident.invoice_url }}">
+                  <i class="bi bi-cloud-download-fill"></i> PDF</a>
+              </p>
+            {% endif %}
           </div>
         </div>
       </div>

--- a/api/tests/routes/backoffice/helpers/html_parser.py
+++ b/api/tests/routes/backoffice/helpers/html_parser.py
@@ -1,4 +1,5 @@
 import re
+import typing
 
 from bs4 import BeautifulSoup
 
@@ -139,18 +140,18 @@ def extract_alert(html_content: str) -> str:
     return _filter_whitespaces(alert.text)
 
 
-def get_tag(html_content: str, class_: str, tag: str = "div") -> list[str]:
+def get_tag(html_content: str, class_: str, tag: str = "div", **attrs: typing.Any) -> str:
     """
     Find a tag given its class
     """
     soup = get_soup(html_content)
-    tag = soup.find(tag, class_=class_)
-    assert tag is not None
+    found_tag = soup.find(tag, class_=class_, **attrs)
+    assert found_tag is not None
 
-    return tag.encode("utf-8")
+    return found_tag.encode("utf-8")
 
 
-def extract_alerts(html_content: str) -> str:
+def extract_alerts(html_content: str) -> list[str]:
     """
     Extract all flash messages
     """
@@ -162,7 +163,7 @@ def extract_alerts(html_content: str) -> str:
     return [_filter_whitespaces(alert.text) for alert in alerts]
 
 
-def assert_no_alert(html_content: str) -> str:
+def assert_no_alert(html_content: str) -> None:
     soup = get_soup(html_content)
 
     alert = soup.find("div", class_="alert")


### PR DESCRIPTION
## But de la pull request

Ajout des infos batch et justificatif de remboursement dans la page incident finance

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30880

<img width="980" alt="Capture d’écran 2024-08-13 à 17 22 46" src="https://github.com/user-attachments/assets/1b77a536-d0a1-4d60-9138-c190515e42fa">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
