### PR TITLE
(PC-31234)[API] fix: truncate titles to 140 caracters

### DIFF
--- a/api/src/pcapi/core/providers/titelive_api.py
+++ b/api/src/pcapi/core/providers/titelive_api.py
@@ -284,6 +284,12 @@ class TiteliveSearch(abc.ABC, typing.Generic[TiteliveWorkType]):
         for product_mediation in product_mediations:
             db.session.delete(product_mediation)
 
+    def truncate_string(self, s: str) -> str:
+        max_length = 140
+        if len(s) > max_length:
+            return s[: max_length - 1] + "…"
+        return s
+
 
 def filter_recent_products(
     titelive_product_page: list[TiteliveWorkType],

--- a/api/src/pcapi/core/providers/titelive_book_search.py
+++ b/api/src/pcapi/core/providers/titelive_book_search.py
@@ -49,7 +49,7 @@ class TiteliveBookSearch(TiteliveSearch[TiteLiveBookWork]):
     def upsert_titelive_result_in_dict(
         self, titelive_search_result: TiteLiveBookWork, products_by_ean: dict[str, offers_models.Product]
     ) -> dict[str, offers_models.Product]:
-        title = titelive_search_result.titre
+        title = self.truncate_string(titelive_search_result.titre)
         authors = titelive_search_result.auteurs_multi
         for article in titelive_search_result.article:
             ean = article.gencod

--- a/api/src/pcapi/core/providers/titelive_music_search.py
+++ b/api/src/pcapi/core/providers/titelive_music_search.py
@@ -71,7 +71,7 @@ class TiteliveMusicSearch(TiteliveSearch[TiteliveMusicWork]):
             extraData=build_music_extra_data(article, common_article_fields),
             idAtProviders=article.gencod,
             lastProvider=self.provider,
-            name=common_article_fields["titre"],
+            name=self.truncate_string(common_article_fields["titre"]),
             subcategoryId=parse_titelive_music_codesupport(article.codesupport).id,
         )
 
@@ -86,7 +86,7 @@ class TiteliveMusicSearch(TiteliveSearch[TiteliveMusicWork]):
             product.extraData = offers_models.OfferExtraData()
         product.extraData.update(build_music_extra_data(article, common_article_fields))
         product.idAtProviders = article.gencod
-        product.name = common_article_fields["titre"]
+        product.name = self.truncate_string(common_article_fields["titre"])
         product.subcategoryId = parse_titelive_music_codesupport(article.codesupport).id
 
         activate_newly_eligible_product_and_offers(product)


### PR DESCRIPTION
This was the behavior of the old sync, the new one ignored the product with titles too long.
We can find the old behavior here : https://github.com/pass-culture/pass-culture-main/blob/199941a1a00cf611267fe136350832b50fd61334/api/src/pcapi/local_providers/titelive_things/titelive_things.py#L160

I'm not sure how but it also caused this update error : https://sentry.passculture.team/organizations/sentry/issues/1617601/?referrer=slack
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31234

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
