### PR TITLE
(PC-31257)[PRO] bump: Install an up to date version of @types/react.

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -94,6 +94,7 @@
     "@types/node": "^20.14.14",
     "@types/papaparse": "^5.3.14",
     "@types/query-string": "^6.3.0",
+    "@types/react": "^18.3.3",
     "@types/react-avatar-editor": "^13.0.2",
     "@types/react-dom": "^18.3.0",
     "@types/react-instantsearch-dom": "^6.12.8",

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
@@ -185,7 +185,6 @@ export const CollectiveDataForm = ({
                     ]}
                     name="collectiveLegalStatus"
                     label="Statut"
-                    placeholder="Association, établissement public..."
                     isOptional
                   />
                 </FormLayout.Row>

--- a/pro/src/pages/Reimbursements/BankInformations/PricingPointDialog/PricingPointDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/PricingPointDialog/PricingPointDialog.tsx
@@ -93,7 +93,6 @@ export const PricingPointDialog = ({
             label={
               'Lieu avec SIRET utilisé pour le calcul de votre barème de remboursement'
             }
-            placeholder="Sélectionnez le SIRET dans la liste"
             options={venuesOptions}
             className={styles['venues-select']}
           />

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/AddVenueProviderButton.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/AddVenueProviderButton.tsx
@@ -93,7 +93,6 @@ export const AddVenueProviderButton = ({
           name="provider"
           options={providersOptions}
           value={String(selectedProviderId)}
-          placeholder="Choix du logiciel"
         />
       </FieldLayout>
 

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -88,7 +88,6 @@ export const FormOfferType = ({
             ]}
             label="Dispositif national"
             name="nationalProgramId"
-            placeholder="Séléctionner un dispositif national"
             isOptional
             disabled={disableForm}
           />

--- a/pro/src/ui-kit/form/TextArea/TextArea.tsx
+++ b/pro/src/ui-kit/form/TextArea/TextArea.tsx
@@ -1,6 +1,10 @@
 import cn from 'classnames'
-import { useField } from 'formik'
-import React from 'react'
+import {
+  FieldHelperProps,
+  FieldInputProps,
+  FieldMetaProps,
+  useField,
+} from 'formik'
 import Textarea from 'react-autosize-textarea'
 
 import {
@@ -30,7 +34,16 @@ export const TextArea = ({
   smallLabel,
   rows = 7,
 }: TextAreaProps): JSX.Element => {
-  const [field, meta] = useField({ name })
+  //  Temporary type fix while react-autosoze-textarea types are not in sync with the latest React types
+  //  see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68984
+  const [field, meta] = useField({ name }) as [
+    FieldInputProps<string | undefined> & {
+      onPointerEnterCapture: any
+      onPointerLeaveCapture: any
+    },
+    FieldMetaProps<string>,
+    FieldHelperProps<string>,
+  ]
 
   return (
     <FieldLayout

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -3196,24 +3196,18 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.2.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
-  integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
+"@types/react@*", "@types/react@^18.3.3":
+  version "18.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
+  integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/resolve@^1.20.2":
   version "1.20.4"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.4.tgz#d2df996a35695c843dbf180e26bc2c7a0f1a3e12"
   integrity sha512-BKGK0T1VgB1zD+PwQR4RRf0ais3NyvH1qjLUrHI5SEiccYaJrhLstLuoXFWJ+2Op9whGizSPUMGPJY/Qtb/A2w==
-
-"@types/scheduler@*":
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
-  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
 "@types/semver@^7.3.4":
   version "7.5.1"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31257

**Objectif**
Ajouter @types/react aux dev dependencies pour s'assurer qu'elle est tenue à jour car actuellement cette dépendance a une version de retard et il semble qu'elle n'est pas mise à jour par dependabot.

Quelques erreurs de types sont corrigées dans cette PR : 
- L'attribut "placeholder" n'existe pas sur les balises selects (et n'ont donc jamais eu d'effet), maintenant le type est plus stricte et nous empêche de les ajouter
- Il y a un conflit de types des attributs du `<textarea>` avec la librairie `react-autosize-textarea` qui n'est plus maintenue à jour

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
