### PR TITLE
(BSR)[API] fix: number of query when booking an offer (flaky test_create_booking)

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -752,7 +752,13 @@ def get_and_lock_stock(stock_id: int) -> models.Stock:
     # This is required to prevent bugs due to concurrent access
     # Also call `populate_existing()` to make sure we don't use something
     # older from the SQLAlchemy's session.
-    stock = models.Stock.query.filter_by(id=stock_id).populate_existing().with_for_update().one_or_none()
+    stock = (
+        models.Stock.query.filter_by(id=stock_id)
+        .populate_existing()
+        .with_for_update()
+        .options(sa.orm.joinedload(models.Stock.offer, innerjoin=True))
+        .one_or_none()
+    )
     if not stock:
         raise exceptions.StockDoesNotExist()
     return stock

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -152,24 +152,26 @@ class BookOfferTest:
     def test_create_booking(self, mocked_async_index_offer_ids, app):
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         stock = offers_factories.StockFactory(price=10, dnBookedQuantity=5, offer__bookingEmail="offerer@example.com")
+        stock_id = stock.id
 
         # There is a different email for the first venue booking
         bookings_factories.BookingFactory(stock=stock)
 
-        # 2 - SELECT the stock (twice ??)
+        # 1 - SELECT the stock
         # 1 - SELECT the offer
         # 1 - SELECT the booking
+        # 1 - SELECT the stock FOR UPDATE (joined with offer)
         # 2 - SELECT the user + SELECT FOR UPDATE
         # 1 - SELECT COUNT reservations
         # 1 - SELECT the venue
-        # 1 - SELECT offerer address
+        # 1 - SELECT offerer
         # 1 - SELECT user's deposit
         # 1 - SELECT the bookings not cancelled
         # 1 - SELECT EXISTS on the booking's token
         # 1 - UPDATE dnBookedQuantity
         # 1 - INSERT the new booking
         # 1 - SELECT the user
-        # 8 - SELECT the stock, booking, external_booking, offer, stock, venue, offerer, provider
+        # 7 - SELECT the stock, booking, external_booking, stock, venue, offerer, provider
         # 1 - SELECT venue with bank activation & bank account
         # 1 - SELECT activation code
         # 1 - SELECT criterion
@@ -182,9 +184,8 @@ class BookOfferTest:
         # 1 - SELECT from offer that I don't get
         # 1 - SELECT bookings for the venue ???
         # 1 - SELECT feature
-        # 1 - one query I missed somewhere
-        with assert_num_queries(37):
-            booking = api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
+        with assert_num_queries(35):
+            booking = api.book_offer(beneficiary=beneficiary, stock_id=stock_id, quantity=1)
 
         # One request should have been sent to Batch to trigger the event
         # HAS_BOOKED_OFFER, and another one with the user's

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -957,7 +957,7 @@ class CancelBookingTest:
         booking = booking_factories.BookingFactory(user=user)
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(29):
+        with assert_num_queries(27):
             response = client.post(f"/native/v1/bookings/{booking.id}/cancel")
 
         assert response.status_code == 204
@@ -972,7 +972,7 @@ class CancelBookingTest:
         booking = booking_factories.BookingFactory(user=user)
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(29):
+        with assert_num_queries(27):
             response = client.post(f"/native/v1/bookings/{booking.id}/cancel")
 
         assert response.status_code == 204


### PR DESCRIPTION
## But de la pull request

Une requête supplémentaire sur `offer` est parfois faite lorsqu'on crée une réservation, au bon vouloir de sqlalchemy, ce qui rend le comptage des requêtes instables dans `test_create_booking`. Cette correction a pour but de précharger l'offre en `joinedload`, ce qui réduit d'une requête et lève l'incertitude.

Note : l'instabilité disparaissait si on retirait `populate_existing`, ce qui semble confirmer une origine dans sqlalchemy.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
