### PR TITLE
(PC-31228) Fix 500 caused by duplicate (`idAtProvider`, `venueId`)

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -305,6 +305,7 @@ def create_offer(
     subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
     validation.check_is_duo_compliance(is_duo, subcategory)
     validation.check_can_input_id_at_provider(provider, id_at_provider)
+    validation.check_can_input_id_at_provider_for_this_venue(venue.id, id_at_provider)
 
     is_national = True if url else bool(is_national)
 
@@ -395,6 +396,7 @@ def update_offer(
 
     if idAtProvider is not UNCHANGED:
         validation.check_can_input_id_at_provider(offer.lastProvider, idAtProvider)
+        validation.check_can_input_id_at_provider_for_this_venue(offer.venueId, idAtProvider, offer.id)
 
     withdrawal_updated = not (
         withdrawalType is UNCHANGED

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -141,6 +141,14 @@ class CannotSetIdAtProviderWithoutAProvider(OfferCreationBaseException):
         )
 
 
+class IdAtProviderAlreadyTaken(OfferCreationBaseException):
+    def __init__(self, id_at_provider: str) -> None:
+        super().__init__(
+            "idAtProvider",
+            f"`{id_at_provider}` is already taken by another venue offer",
+        )
+
+
 class NoDelayWhenEventWithdrawalTypeHasNoTicket(OfferCreationBaseException):
     def __init__(self) -> None:
         super().__init__(

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -700,6 +700,21 @@ def get_stocks_by_id_at_providers(id_at_providers: list[str]) -> dict:
     }
 
 
+def is_id_at_provider_taken_by_another_venue_offer(venue_id: int, id_at_provider: str, offer_id: int | None) -> bool:
+    """
+    Return `True` if `id_at_provider` is already used to identify another venue offer.
+    """
+    base_query = models.Offer.query.filter(
+        models.Offer.venueId == venue_id,
+        models.Offer.idAtProvider == id_at_provider,
+    )
+
+    if offer_id:
+        base_query = base_query.filter(models.Offer.id != offer_id)
+
+    return db.session.query(base_query.exists()).scalar()
+
+
 def get_active_offers_count_for_venue(venue_id: int) -> int:
     active_offers_query = models.Offer.query.filter(models.Offer.venueId == venue_id)
     active_offers_query = _filter_by_status(active_offers_query, offer_mixin.OfferStatus.ACTIVE.name)

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -280,6 +280,27 @@ def check_can_input_id_at_provider(provider: providers_models.Provider | None, i
         raise exceptions.CannotSetIdAtProviderWithoutAProvider()
 
 
+def check_can_input_id_at_provider_for_this_venue(
+    venue_id: int,
+    id_at_provider: str | None,
+    offer_id: int | None = None,
+) -> None:
+    """
+    Raise a validation error if `id_at_provider` is already used to identify another venue offer.
+    """
+    if not id_at_provider:
+        return
+
+    id_at_provider_is_taken = repository.is_id_at_provider_taken_by_another_venue_offer(
+        venue_id=venue_id,
+        id_at_provider=id_at_provider,
+        offer_id=offer_id,
+    )
+
+    if id_at_provider_is_taken:
+        raise exceptions.IdAtProviderAlreadyTaken(id_at_provider)
+
+
 def check_update_only_allowed_stock_fields_for_allocine_offer(updated_fields: set) -> None:
     if not updated_fields.issubset(EDITABLE_FIELDS_FOR_ALLOCINE_STOCK):
         errors = api_errors.ApiErrors()


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31228

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
