### PR TITLE
(BSR)[API] fix: number of queries when canceling an offer (flaky test_cancel_booking)

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -455,6 +455,18 @@ def _cancel_booking(
         if raise_if_error:
             raise error
 
+    # After UPDATE query, objet is refreshed when accessed.
+    # Force refresh with joinedload to avoid N+1 queries below.
+    booking = (
+        Booking.query.filter_by(id=booking.id)
+        .options(
+            sa.orm.joinedload(Booking.externalBookings),
+            sa.orm.joinedload(Booking.stock, innerjoin=True).joinedload(Stock.offer, innerjoin=True),
+            sa.orm.joinedload(Booking.user, innerjoin=True).joinedload(User.deposits),
+        )
+        .one()
+    )
+
     logger.info(
         "Booking has been cancelled",
         extra={

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -957,7 +957,7 @@ class CancelBookingTest:
         booking = booking_factories.BookingFactory(user=user)
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(27):
+        with assert_num_queries(24):
             response = client.post(f"/native/v1/bookings/{booking.id}/cancel")
 
         assert response.status_code == 204
@@ -972,7 +972,7 @@ class CancelBookingTest:
         booking = booking_factories.BookingFactory(user=user)
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(27):
+        with assert_num_queries(24):
             response = client.post(f"/native/v1/bookings/{booking.id}/cancel")
 
         assert response.status_code == 204


### PR DESCRIPTION
## But de la pull request

`test_cancel_booking` est instable sur le nombre de requêtes : https://github.com/pass-culture/pass-culture-main/actions/runs/10315189393/job/28555285561
Rendre ce test plus stable est l'occasion de réduire le nombre de requêtes à l'annulation d'une réservation.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
