### PR TITLE
(PC-31262)[API] fix: fix collective status filters

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -525,7 +525,10 @@ def _filter_collective_offers_by_statuses(query: BaseQuery, statuses: list[str] 
         # all displayedStatus with an offer that has expired
         allowed_expired_booking_status: set[educational_models.CollectiveBookingStatus | None] = set()
         if DisplayedStatus.ENDED.value in statuses:
-            allowed_expired_booking_status.add(educational_models.CollectiveBookingStatus.USED)
+            # TODO(anoukhello - 08/08/24) remove REIMBURSED status once it is handled in frontend filters
+            allowed_expired_booking_status.update(
+                {educational_models.CollectiveBookingStatus.USED, educational_models.CollectiveBookingStatus.REIMBURSED}
+            )
         if DisplayedStatus.REIMBURSED.value in statuses:
             allowed_expired_booking_status.add(educational_models.CollectiveBookingStatus.REIMBURSED)
         if DisplayedStatus.EXPIRED.value in statuses:

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -551,7 +551,7 @@ def _filter_collective_offers_by_statuses(query: BaseQuery, statuses: list[str] 
         on_booking_status_filter.append(
             and_(
                 offer_id_with_booking_status_subquery.c.status == None,
-                educational_models.CollectiveOffer.isActive == True,
+                educational_models.CollectiveOffer.status == offer_mixin.CollectiveOfferStatus.ACTIVE.name,
                 educational_models.CollectiveOffer.validation == offer_mixin.OfferValidationStatus.APPROVED,
                 educational_models.CollectiveOffer.isArchived == False,
             )
@@ -559,7 +559,7 @@ def _filter_collective_offers_by_statuses(query: BaseQuery, statuses: list[str] 
     if DisplayedStatus.INACTIVE.value in statuses:
         on_booking_status_filter.append(
             and_(
-                educational_models.CollectiveOffer.isActive == False,
+                educational_models.CollectiveOffer.status == offer_mixin.CollectiveOfferStatus.INACTIVE.name,
                 educational_models.CollectiveOffer.validation == offer_mixin.OfferValidationStatus.APPROVED,
                 educational_models.CollectiveOffer.isArchived == False,
             )

--- a/api/tests/core/educational/test_repository.py
+++ b/api/tests/core/educational/test_repository.py
@@ -569,10 +569,14 @@ class FilterCollectiveOfferByStatusesTest:
 
         filtered_query_status = {all_offers_status_by_id[offer.id] for offer in filtered_query}
 
-        assert filtered_query_status == {
-            offer_status for offer_status in all_offers_status_by_id.values() if status.value != offer_status
-        }
-        assert filtered_query.count() == len(self.ALL_STATUS) - 1
+        if status == CollectiveOfferDisplayedStatus.REIMBURSED:
+            assert filtered_query_status == {status.value for status in self.ALL_STATUS}
+            assert filtered_query.count() == len(self.ALL_STATUS)
+        else:
+            assert filtered_query_status == {
+                offer_status for offer_status in all_offers_status_by_id.values() if status.value != offer_status
+            }
+            assert filtered_query.count() == len(self.ALL_STATUS) - 1
 
     def test_filter_with_no_statuses(self, app):
         # Given

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1501,6 +1501,41 @@ class GetFilteredCollectiveOffersTest:
         with assert_num_queries(1):
             assert offers.one() == collective_offer_draft
 
+    def test_get_collective_offers_expired(self):
+        user_offerer = offerers_factories.UserOffererFactory()
+
+        # expired offer without booking
+        collective_offer_expired = educational_factories.CollectiveOfferFactory(
+            validation=offer_mixin.OfferValidationStatus.APPROVED.value, venue__managingOfferer=user_offerer.offerer
+        )
+
+        educational_factories.CollectiveStockFactory(
+            collectiveOffer=collective_offer_expired, beginningDatetime=datetime.datetime(year=2000, month=1, day=1)
+        )
+
+        # expired offer with pending booking
+        collective_offer_prebooked_expired = educational_factories.CollectiveOfferFactory(
+            validation=offer_mixin.OfferValidationStatus.APPROVED.value, venue__managingOfferer=user_offerer.offerer
+        )
+
+        collective_stock_prebooked_expired = educational_factories.CollectiveStockFactory(
+            collectiveOffer=collective_offer_prebooked_expired,
+            beginningDatetime=datetime.datetime(year=2000, month=1, day=1),
+        )
+
+        educational_factories.CollectiveBookingFactory(
+            collectiveStock=collective_stock_prebooked_expired,
+            confirmationLimitDate=datetime.datetime(year=2000, month=1, day=1),
+            status=educational_models.CollectiveBookingStatus.PENDING.value,
+        )
+
+        offers = repository.get_collective_offers_by_filters(
+            user_offerer.userId,
+            user_is_admin=False,
+            statuses=[educational_models.CollectiveOfferDisplayedStatus.EXPIRED.value],
+        )
+        assert offers.all() == [collective_offer_expired, collective_offer_prebooked_expired]
+
 
 @pytest.mark.usefixtures("db_session")
 class ExcludeOffersFromInactiveVenueProviderTest:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31262

Correction de ces 3 soucis identifiés :
- la sélection du statut "Publiée sur ADAGE" remonte les offres publiées, masquées et expirées
- la sélection du statut "Expirée" ne remonte aucune offre
- la sélection du statut “Terminée” ne prend pas en compte les offres remboursées (affichées comme terminées côté front)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
