### PR TITLE
(BSR)[PRO] test: increase timeout for homepage url loading

### DIFF
--- a/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
@@ -153,7 +153,7 @@ When('I chose to join the space', () => {
 })
 
 When('I am redirected to homepage', () => {
-  cy.url().should('contain', '/accueil')
+  cy.url({ timeout: 10000 }).should('contain', '/accueil')
   cy.findByLabelText('Structure').select(offererName)
 })
 
@@ -171,7 +171,7 @@ Then('the offerer is created', () => {
     'contain',
     'Votre structure a bien été créée'
   )
-  cy.url().should('contain', '/accueil')
+  cy.url({ timeout: 10000 }).should('contain', '/accueil')
   cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
 
   cy.findByTestId('offerer-details-offerId').select(offererName)


### PR DESCRIPTION
## But de la pull request

Augmentation de 2 timeouts qui pourraint expliquer cet échec: https://cloud.cypress.io/projects/rit5sb/runs/461/test-results/0cb853d5-4950-4233-892d-a4c01a5ffac4/replay

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
