### PR TITLE
(PC-31223)[PRO] feat: do not autocomplete bookinglimitdatetime

### DIFF
--- a/pro/src/components/ScrollToFirstErrorAfterSubmit/ScrollToFirstErrorAfterSubmit.tsx
+++ b/pro/src/components/ScrollToFirstErrorAfterSubmit/ScrollToFirstErrorAfterSubmit.tsx
@@ -12,13 +12,13 @@ const scrollToFirstError = () => {
   // Without the setTimeout, the smooth behavior isn't working
   // cf https://github.com/iamdustan/smoothscroll/issues/28#issuecomment-630722825
   setTimeout(() => {
+    firstErrorElement?.focus()
     firstErrorElement?.scrollIntoView({
       behavior: scrollBehavior,
       block: 'center',
       inline: 'center',
     })
-    firstErrorElement?.focus()
-  }, 0)
+  })
 }
 
 export const ScrollToFirstErrorAfterSubmit = () => {

--- a/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
@@ -51,13 +51,6 @@ export const FormStock = ({
       ) {
         await setFieldValue('endDatetime', event.target.value)
       }
-
-      if (
-        !isDateValid(values.bookingLimitDatetime) ||
-        values.bookingLimitDatetime > event.target.value
-      ) {
-        await setFieldValue('bookingLimitDatetime', event.target.value)
-      }
     }
   }
 

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -16,6 +16,7 @@ import { CalloutVariant } from 'components/Callout/types'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { OfferEducationalActions } from 'components/OfferEducationalActions/OfferEducationalActions'
 import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
+import { ScrollToFirstErrorAfterSubmit } from 'components/ScrollToFirstErrorAfterSubmit/ScrollToFirstErrorAfterSubmit'
 import { MAX_DETAILS_LENGTH } from 'core/OfferEducational/constants'
 import {
   OfferEducationalStockFormValues,
@@ -133,6 +134,8 @@ export const OfferEducationalStock = <
       />
       <FormikProvider value={{ ...formik, resetForm, dirty }}>
         <form onSubmit={formik.handleSubmit} noValidate>
+          <ScrollToFirstErrorAfterSubmit />
+
           <FormLayout className={styles['offer-educational-stock-form-layout']}>
             {isCollectiveOffer(offer) && offer.isPublicApi && (
               <BannerPublicApi className={styles['banner-space']}>

--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { addDays, addMinutes, format, subDays } from 'date-fns'
 import * as router from 'react-router-dom'
@@ -180,25 +180,6 @@ describe('OfferEducationalStock', () => {
       screen.queryByRole('button', { name: 'Annuler et quitter' })
     ).not.toBeInTheDocument()
   })
-})
-
-it('should automatically update bookingLimitDatetime when the user edits the start date', async () => {
-  const testProps: OfferEducationalStockProps = {
-    ...defaultProps,
-    mode: Mode.CREATION,
-  }
-
-  renderWithProviders(<OfferEducationalStock {...testProps} />)
-
-  const userDateInput = format(addDays(new Date(), 1), FORMAT_ISO_DATE_ONLY)
-  const dateInput = screen.getByLabelText('Date de début *')
-  await userEvent.click(dateInput)
-  await userEvent.clear(dateInput)
-  await waitFor(() => userEvent.type(dateInput, userDateInput))
-  const bookingLimitDatetimeInput = screen.getByLabelText(
-    'Date limite de réservation *'
-  )
-  expect(bookingLimitDatetimeInput).toHaveValue(userDateInput)
 })
 
 it('should disable booking limit datetime when form access is read only', () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31223

On ne veut plus pré-remplir le champs de la date limite de réservation sur la page de stock lors d'une création d'une offre collective

