### PR TITLE
(PC-31273)[PRO] style: Replace preview-text with body-xs.

### DIFF
--- a/pro/src/components/OfferAppPreview/OfferAppPreview.module.scss
+++ b/pro/src/components/OfferAppPreview/OfferAppPreview.module.scss
@@ -50,7 +50,7 @@
   }
 
   .offer-description {
-    @include fonts.preview-text;
+    @include fonts.body-xs;
 
     padding: rem.torem(0) rem.torem(15px) rem.torem(15px);
     word-break: break-word;

--- a/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.module.scss
+++ b/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.module.scss
@@ -31,7 +31,7 @@
 }
 
 .text {
-  @include fonts.preview-text;
+  @include fonts.body-xs;
 
   margin-bottom: rem.torem(16px);
   word-break: break-word;

--- a/pro/src/pages/Home/StatisticsDashboard/MostViewedOffers.module.scss
+++ b/pro/src/pages/Home/StatisticsDashboard/MostViewedOffers.module.scss
@@ -41,7 +41,7 @@
   }
 
   &-details {
-    @include fonts.preview-text;
+    @include fonts.body-xs;
 
     flex-grow: 1;
   }

--- a/pro/src/pages/Home/StatisticsDashboard/OfferStats.module.scss
+++ b/pro/src/pages/Home/StatisticsDashboard/OfferStats.module.scss
@@ -48,8 +48,6 @@
   padding: rem.torem(16px) rem.torem(8px);
   border-radius: rem.torem(8px);
 
-  @include fonts.preview-text;
-
   &-icon {
     width: rem.torem(48px);
     height: rem.torem(48px);
@@ -63,10 +61,6 @@
     font-size: rem.torem(24px);
     line-height: rem.torem(22px);
   }
-}
-
-.pending-description {
-  @include fonts.preview-text;
 }
 
 .pending-offers {

--- a/pro/src/styles/index.scss
+++ b/pro/src/styles/index.scss
@@ -3,6 +3,7 @@
 @import "orejime/dist/orejime";
 @import "global/index";
 @import "components/index";
+@import "design-system/build/css/variables.css";
 
 // Components scoped imports.
 @import "src/components/DialogBox/DialogBox.module";

--- a/pro/src/styles/mixins/_fonts.scss
+++ b/pro/src/styles/mixins/_fonts.scss
@@ -75,12 +75,11 @@ $caption-line-height: rem.torem(16px);
   line-height: $caption-line-height;
 }
 
-@mixin preview-text() {
-  font-family: Montserrat-Regular, system-ui, sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: rem.torem(12px);
-  line-height: rem.torem(16px);
+@mixin body-xs() {
+  font-family: var(--typography-body-xs-font-family), system-ui, sans-serif;
+  font-weight: var(--typography-body-xs-font-weight);
+  font-size: var(--typography-body-xs-font-size);
+  line-height: var(--typography-body-xs-line-height);
 }
 
 @mixin highlight() {

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
@@ -32,12 +32,6 @@ $input-phone-number-padding-left: calc(
       justify-content: space-between;
     }
 
-    &-optional {
-      @include fonts.highlight;
-
-      color: var(--color-grey-dark);
-    }
-
     &-footer {
       @include formsM.field-layout-footer;
     }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31273

**Objectif**
La typo "preview-text" n'existe pas dans le figma PRO, mais elle semble quand même avoir une utilité, et le DS prévoit l'introduction d'une typo du même type (avec quelques petites diff) appelée "body-xs" pour compenser ce manque.

*Avant*
<img width="216" alt="Capture d’écran 2024-08-12 à 10 27 12" src="https://github.com/user-attachments/assets/67c1a801-b18b-456a-9557-1f6c5f24ef28">

*Après*
<img width="199" alt="Capture d’écran 2024-08-12 à 10 26 15" src="https://github.com/user-attachments/assets/571b65ac-1f40-45b6-8fc7-dfa75c3cfcc6">


## Vérifications


- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
