### PR TITLE
(PC-31276)[PRO] style: Remplace highlight typo with caption.

### DIFF
--- a/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.module.scss
+++ b/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.module.scss
@@ -27,7 +27,7 @@
 }
 
 .sub-title {
-  @include fonts.highlight;
+  @include fonts.caption;
 }
 
 .text {

--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.module.scss
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.module.scss
@@ -68,7 +68,7 @@
   }
 
   .issue-text {
-    @include fonts.highlight;
+    @include fonts.caption;
 
     color: var(--color-error);
     margin-bottom: rem.torem(16px);

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
@@ -113,11 +113,11 @@ $offer-image-width: rem.torem(216px);
   margin-bottom: rem.torem(8px);
 
   &-name {
-    @include fonts.highlight;
+    @include fonts.caption;
   }
 
   &-distance {
-    @include fonts.highlight;
+    @include fonts.caption;
 
     color: var(--color-grey-dark);
     text-transform: uppercase;

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.module.scss
@@ -74,7 +74,7 @@ $venue-image-width: rem.torem(276px);
   }
 
   &-distance {
-    @include fonts.highlight;
+    @include fonts.caption;
 
     color: var(--color-grey-dark);
     text-transform: uppercase;

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.module.scss
@@ -9,7 +9,7 @@
   width: 100%;
 
   &-link {
-    @include fonts.highlight;
+    @include fonts.caption;
 
     display: block;
     margin-bottom: rem.torem(4px);

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
@@ -55,20 +55,6 @@
   }
 }
 
-.offers-load-more {
-  text-align: center;
-  width: fit-content;
-  margin: 0 auto rem.torem(24px);
-  font-size: rem.torem(12px);
-  height: rem.torem(50px);
-
-  &-text {
-    @include fonts.highlight;
-
-    margin-bottom: rem.torem(10px);
-  }
-}
-
 .back-to-top-button {
   @include fonts.button;
 

--- a/pro/src/pages/Offers/OffersTable/Cells/ExpirationCell/ExpirationCell.module.scss
+++ b/pro/src/pages/Offers/OffersTable/Cells/ExpirationCell/ExpirationCell.module.scss
@@ -27,7 +27,7 @@
     flex-wrap: wrap;
 
     &-waiting {
-      @include fonts.highlight;
+      @include fonts.caption;
 
       display: flex;
       align-items: center;
@@ -35,7 +35,7 @@
     }
 
     &-days-badge {
-      @include fonts.highlight;
+      @include fonts.caption;
 
       background-color: var(--color-alert-dark);
       display: flex;
@@ -52,7 +52,6 @@
     gap: rem.torem(16px);
   }
 }
-
 
 @media (max-width: size.$laptop) {
   .expiration-cell {

--- a/pro/src/pages/VenueEdition/AccesLibreSection/AccesLibreSection.module.scss
+++ b/pro/src/pages/VenueEdition/AccesLibreSection/AccesLibreSection.module.scss
@@ -31,7 +31,7 @@
 }
 
 .details-label {
-  @include fonts.highlight;
+  @include fonts.caption;
 
   margin-bottom: rem.torem(8px);
   display: block;

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/VenueProviderItem.module.scss
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/VenueProviderItem.module.scss
@@ -72,7 +72,7 @@
 .last-synchronisation {
   color: var(--color-grey-dark);
 
-  @include fonts.highlight;
+  @include fonts.caption;
 
   &::before {
     background-color: var(--color-valid);

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.module.scss
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.module.scss
@@ -25,7 +25,7 @@
 }
 
 .offer-info {
-  @include fonts.highlight;
+  @include fonts.caption;
 }
 
 .offer-selection {

--- a/pro/src/screens/IndividualOffer/BookingsSummary/DownloadBookingsModal/DownloadBookingsModal.module.scss
+++ b/pro/src/screens/IndividualOffer/BookingsSummary/DownloadBookingsModal/DownloadBookingsModal.module.scss
@@ -47,7 +47,7 @@
 .bookings-date-count {
   margin: rem.torem(16px) 0;
 
-  @include fonts.highlight;
+  @include fonts.caption;
 }
 
 .date-select-table {
@@ -58,7 +58,7 @@
   overflow: scroll;
 
   &-header {
-    @include fonts.highlight;
+    @include fonts.caption;
   }
 }
 

--- a/pro/src/styles/mixins/_fonts.scss
+++ b/pro/src/styles/mixins/_fonts.scss
@@ -83,13 +83,6 @@ $caption-line-height: rem.torem(16px);
   line-height: rem.torem(16px);
 }
 
-@mixin highlight() {
-  font-family: Montserrat-SemiBold, system-ui, sans-serif;
-  font-weight: 600;
-  font-style: normal;
-  font-size: rem.torem(12px);
-}
-
 @mixin mini-highlight() {
   font-family: Montserrat-SemiBold, system-ui, sans-serif;
   font-weight: 600;

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
@@ -32,12 +32,6 @@ $input-phone-number-padding-left: calc(
       justify-content: space-between;
     }
 
-    &-optional {
-      @include fonts.highlight;
-
-      color: var(--color-grey-dark);
-    }
-
     &-footer {
       @include formsM.field-layout-footer;
     }

--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectedValuesTags/SelectedValuesTags.module.scss
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectedValuesTags/SelectedValuesTags.module.scss
@@ -9,7 +9,7 @@
 }
 
 .tag {
-  @include fonts.highlight;
+  @include fonts.caption;
 
   white-space: nowrap;
   justify-content: center;
@@ -26,7 +26,7 @@
   }
 
   &-close-button {
-    @include fonts.highlight;
+    @include fonts.caption;
 
     line-height: rem.torem(16px);
     background: none;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31276

**Objectif**
La typo "highlight" qu'on a dans le code n'existe pas dans la lib figma des designers PRO. Par ailleurs on prévoit dans le DS de n'avoir qu'one typo de ce type (càd grasse et à 12px). On peut donc simplifier notre liste de typos dev en enlevant highlight et en l'alignant sur caption (seule diff la line-height)

1. le titre des sections Avant/après
<img width="213" alt="1_avant" src="https://github.com/user-attachments/assets/9c35ff05-01f1-438e-8746-beb313e56b01">
<img width="220" alt="1_après" src="https://github.com/user-attachments/assets/c0a38664-d116-43fc-b51a-c27c98d862fc">

2. la message d'erreur Avant/après
<img width="426" alt="2_avant" src="https://github.com/user-attachments/assets/a3c646b9-1da7-4098-9b90-0afc929515da">
<img width="427" alt="2_après" src="https://github.com/user-attachments/assets/df73bf6e-c085-4569-85b1-11bbbdf21b38">

3. les sous-titres Avant/après
<img width="189" alt="3_avant" src="https://github.com/user-attachments/assets/23869c75-d8b2-4a32-9482-6f2b23e6d7b0">
<img width="207" alt="3_après" src="https://github.com/user-attachments/assets/4fc76587-4536-4f21-84eb-c92827f9a896">

4. le message de statut Avant/après
<img width="283" alt="4_avant" src="https://github.com/user-attachments/assets/a7c1b0a7-2c16-45d7-81ff-7d3ffd8f5d89">
<img width="297" alt="4_après" src="https://github.com/user-attachments/assets/84937344-0117-497c-84e5-f7a18f3263bc">

5. le compte + les titres de colonne Avant/après
<img width="589" alt="5_avant" src="https://github.com/user-attachments/assets/62fc867b-1cc7-4e22-8aa9-067d8247537e">
<img width="591" alt="5_après" src="https://github.com/user-attachments/assets/21efd0d3-9899-4e47-a4d0-74e276e323ca">

6. le texte des tags Avant/après
<img width="416" alt="6_avant" src="https://github.com/user-attachments/assets/49bcef38-dd26-4b1f-bf43-34eedac0c3f2">
<img width="420" alt="6_après" src="https://github.com/user-attachments/assets/9ac8072e-5abf-4ff7-8e38-c957126a5b99">

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
