### PR TITLE
(PC-31232)[PRO] feat: add hasOffers in Venue response

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -39,6 +39,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import Case
 import sqlalchemy.sql.functions as sqla_func
+from sqlalchemy.sql.selectable import Exists
 from sqlalchemy.sql.sqltypes import LargeBinary
 
 from pcapi import settings
@@ -479,6 +480,16 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     @bannerMeta.expression  # type: ignore[no-redef]
     def bannerMeta(cls):  # pylint: disable=no-self-argument
         return cls._bannerMeta
+
+    @hybrid_property
+    def hasOffers(self) -> bool:
+        return bool(self.offers)
+
+    @hasOffers.expression  # type: ignore[no-redef]
+    def hasOffers(cls) -> Exists:  # pylint: disable=no-self-argument
+        import pcapi.core.offers.models as offers_models
+
+        return sa.exists().where(offers_models.Offer.venuId == cls.id)
 
     @property
     def is_eligible_for_search(self) -> bool:

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -237,6 +237,7 @@ class GetVenueResponseModel(base.BaseVenueResponse, AccessibilityComplianceMixin
     adageInscriptionDate: datetime | None
     bankAccount: BankAccountResponseModel | None
     isVisibleInApp: bool = True
+    hasOffers: bool
 
     class Config:
         orm_mode = True

--- a/pro/src/apiClient/v1/models/GetVenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetVenueResponseModel.ts
@@ -45,6 +45,7 @@ export type GetVenueResponseModel = {
   externalAccessibilityId?: string | null;
   externalAccessibilityUrl?: string | null;
   hasAdageId: boolean;
+  hasOffers: boolean;
   id: number;
   isPermanent?: boolean | null;
   isVirtual: boolean;

--- a/pro/src/utils/collectiveApiFactories.ts
+++ b/pro/src/utils/collectiveApiFactories.ts
@@ -297,6 +297,7 @@ export const defaultGetVenue: GetVenueResponseModel = {
   dateCreated: new Date().toISOString(),
   dmsToken: 'fakeDmsToken',
   hasAdageId: true,
+  hasOffers: true,
   isVirtual: false,
   managingOfferer: {
     id: 1,


### PR DESCRIPTION
Will be used to figure out wether or not a Venue can be saftely relocated - its address changes - or if we need to warn the user that the associated offer's address may need to be updated - they will be kept on the old address.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31232

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
