### PR TITLE
(PC-31161)[BO] feat: FRAUD button to unvalidate user password

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -45,6 +45,7 @@ class ActionType(enum.Enum):
     USER_EMAIL_VALIDATED = "Validation manuelle de l'email"
     USER_EXTRACT_DATA = "Génération d'un extrait des données du compte"
     CONNECT_AS_USER = "Connexion d'un admin"
+    USER_PASSWORD_INVALIDATED = "Invalidation du mot de passe de l'utilisateur"
     # Fraud and compliance actions:
     BLACKLIST_DOMAIN_NAME = "Blacklist d'un nom de domaine"
     REMOVE_BLACKLISTED_DOMAIN_NAME = "Suppression d'un nom de domaine banni"

--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
@@ -146,6 +146,11 @@
                 {% endif %}
               {% endif %}
             </div>
+            {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
+              <div>
+                {{ build_modal_form("invalidate-account-password", password_invalidation_dst, password_invalidation_form, "Invalider le mot de passe", "Invalider le mot de passe", "Confirmer l'invalidation") }}
+              </div>
+            {% endif %}
             {% if suspension_form %}
               {% if user.isActive %}
                 <div>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31161

## Vérifications

### verification front 

Un bouton est accessible au utilisateur possédant les droit MANAGE USER ACCOUNT
<img width="1480" alt="Capture d’écran 2024-08-13 à 11 48 31" src="https://github.com/user-attachments/assets/daf72ca4-f5e8-4388-810e-2bb535aff6db">

au click sur le bouton un formulaire apparait, le formulaire n'est présent que pour une raison de sécurité ( éviter les missclick ) 
<img width="920" alt="Capture d’écran 2024-08-13 à 11 49 40" src="https://github.com/user-attachments/assets/b5487e24-18cd-402f-85c5-007b3ed9515b">

Lorsque l'on confirme un message flash est envoyé et le mot de passe de l'utilisateur en question est modifié par un mot de passe aléatoire et hashé ( afin de le forcer a reinitialiser son mot de passe )
<img width="1500" alt="Capture d’écran 2024-08-13 à 11 50 45" src="https://github.com/user-attachments/assets/a42ccbd3-580b-477b-8467-4d22a0b00a4b">

un exemple de changement de mot de passe aleatoire
<img width="640" alt="Capture d’écran 2024-08-13 à 11 51 25" src="https://github.com/user-attachments/assets/069c97bd-24ca-4f0e-a845-7fef9b4804ed">
<img width="1010" alt="Capture d’écran 2024-08-13 à 11 51 55" src="https://github.com/user-attachments/assets/1c70609a-7a5f-4c11-8dc8-f1cfff851272">

un action history est envoyé : 
<img width="1367" alt="Capture d’écran 2024-08-13 à 15 02 17" src="https://github.com/user-attachments/assets/67d9dc6f-4030-4960-96ec-744201b8736c">

### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 

CAS 0 : test du bouton avec les bon droits

CAS 1 : 
LORSQUE
je suis sur la page d'un utilisateur et j'ai les droits MANAGE_ACCOUNT, un bouton Invalider le mot de passe est visible, si je clique sur le bouton un formulaire sans question apparait ( pour la confirmation), si je confirme 
ALORS
- le mot de passe de l'utilisateur est modifié par un mot de passe random
- un log horodaté avec l'auteur est crée concernant l'invalidation du mot de passe de l'utilisateur en question 
- un message flash explique que le bouton a fonctionné
- une redirection est faite vers la page de l'utilisateur. 

CAS 2 : 
LORSQUE 
je fais joujoue avec l'id de l'utilisateur dans l'URL pour trigger le lien du bouton, 
ALORS
erreur 404

CAS 3 : 
LORSQUE
L'utilisateur ciblé n'est pas bénéficiaire alors qu'on utilise le bouton
ALORS 
message flash disant que ce n'est pas un bénéficiaire, redirection


### Verification ticket

- nom du ticket conforme -> OK
- auteur du ticket -> OK
- nombre de commit -> OK
- nom du commit -> OK
- mettre le ticket en code-review -> OK

### Tache restante si WIP + AUTRE

- refresh de la page github -> OK
- Rien de visible
