### PR TITLE
(PC-31262)[API] fix: update `endDatetime` validator `pre` param

### DIFF
--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -573,7 +573,7 @@ class PatchCollectiveOfferBodyModel(BaseModel):
             raise ValueError("La date de début de l'évènement ne peut pas être vide.")
         return startDatetime
 
-    @validator("endDatetime", pre=True)
+    @validator("endDatetime", pre=False)
     def validate_end_limit_datetime(cls, endDatetime: datetime | None, values: dict[str, Any]) -> datetime | None:
         start_datetime = values.get("startDatetime")
         if not endDatetime:


### PR DESCRIPTION
Set `pre` to `False` to be able to compare `endDatime`and `startDatime` as dates

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31248

Fix d'un bug remonté par UGC dû au fait que l'on essayait de comparer un string avec un datetime (`startDatime` n'était pas castée comme une date)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
