### PR TITLE
(PC-31295)[PRO] style: Fix base input right button warning.

### DIFF
--- a/pro/src/ui-kit/form/shared/BaseInput/BaseInput.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseInput/BaseInput.module.scss
@@ -62,9 +62,14 @@
   }
 
   &-right-button {
-    @include forms.input-icon-wrapper(rem.torem(32px));
-
-    pointer-events: initial;
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 100%;
+    width: rem.torem(48px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     button {
       background: none;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31295

**Objectif**
Corriger le warning sur le scss qui invite à [ne pas déclarer une propriété CSS après avoir définit les propriétés "nested"](https://sass-lang.com/documentation/breaking-changes/mixed-decls/).

Pour ça, la mixin appliquée au button-right étant utilisée une seule fois pour un button dans PasswordInput, j'ai dupliqué les styles qui nous intéressent de la mixin de l'icon-left/right. Et on n'a plus besoin du `pointer-events: none` ce qui règle le pb.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
