### PR TITLE
(PC-31170)[API] feat: check the offer<>oa association accordingly to …

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -335,7 +335,6 @@ def create_offer(
     validation.check_is_duo_compliance(is_duo, subcategory)
     validation.check_can_input_id_at_provider(provider, id_at_provider)
     validation.check_can_input_id_at_provider_for_this_venue(venue.id, id_at_provider)
-
     is_national = True if url else bool(is_national)
 
     offer = models.Offer(
@@ -365,6 +364,7 @@ def create_offer(
         offererAddress=offerer_address or venue.offererAddress,
         idAtProvider=id_at_provider,
     )
+    validation.check_digital_offer_fields(offer)
     repository.add_to_session(offer)
     db.session.flush()
 
@@ -452,9 +452,10 @@ def update_offer(
 
     if offer.is_soft_deleted():
         raise pc_object.DeletedRecordException()
-
     for key, value in modifications.items():
         setattr(offer, key, value)
+    with db.session.no_autoflush:
+        validation.check_digital_offer_fields(offer)
     if offer.isFromAllocine:
         offer.fieldsUpdated = list(set(offer.fieldsUpdated) | set(modifications))
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -391,12 +391,18 @@ def check_digital_offer_fields(offer: models.Offer) -> None:
             errors.add_error(
                 "url", f"Une offre de sous-catégorie {offer.subcategory.pro_label} ne peut pas être numérique"
             )
+            raise errors
+        if offer.offererAddress is not None:
+            errors.add_error("offererAddress", "Une offre numérique ne peut pas avoir d'adresse")
+            raise errors
     else:
         if venue.isVirtual:
             errors.add_error("venue", 'Une offre physique ne peut être associée au lieu "Offre numérique"')
 
         if offer.subcategory.is_online_only:
             errors.add_error("url", f'Une offre de catégorie {offer.subcategory.id} doit contenir un champ "url"')
+        if offer.offererAddress is None:
+            errors.add_error("offererAddress", "Une offre physique doit avoir une adresse")
 
     if errors.errors:
         raise errors

--- a/api/tests/routes/pro/patch_offer_test.py
+++ b/api/tests/routes/pro/patch_offer_test.py
@@ -70,15 +70,14 @@ class Returns200Test:
     def test_patch_offer_with_address(self, get_address_mock, label, offer_has_oa, address_update_exist, client):
         # Given
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
-        venue = offerers_factories.VirtualVenueFactory(managingOfferer=user_offerer.offerer)
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
         oa = None
         if offer_has_oa:
             oa = offerers_factories.OffererAddressFactory(offerer=user_offerer.offerer)
         offer = offers_factories.OfferFactory(
-            subcategoryId=subcategories.ABO_PLATEFORME_VIDEO.id,
+            subcategoryId=subcategories.ABO_MEDIATHEQUE.id,
             venue=venue,
             name="New name",
-            url="test@test.com",
             description="description",
             offererAddress=oa,
         )
@@ -120,6 +119,7 @@ class Returns200Test:
             label=label if label else "",
         )
         response = client.with_session_auth("user@example.com").patch(f"/offers/{offer.id}", json=data)
+
         assert response.status_code == 200
         assert response.json["id"] == offer.id
         updated_offer = Offer.query.get(offer.id)

--- a/api/tests/routes/public/individual_offers/v1/patch_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_product_test.py
@@ -367,10 +367,11 @@ class PatchProductTest(PublicAPIVenueEndpointHelper, ProductEndpointHelper):
         # 1. get api key
         # 2. check FF
         # 3. get offer and related data
-        # 4. update offer
-        # 5. reload provider
-        # 6. reload offer and related data (before serialization)
-        with assert_num_queries(6):
+        # 4. select oa
+        # 5. update offer
+        # 6. reload provider
+        # 7. reload offer and related data (before serialization)
+        with assert_num_queries(7):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 url_for("public_api.edit_product"),
                 json={"offerId": offer_id, "name": new_name, "description": new_desc},

--- a/api/tests/routes/public/individual_offers/v1/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_test.py
@@ -402,7 +402,10 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         )
 
         assert response.status_code == 400
-        assert response.json == {"venue": ['Une offre physique ne peut être associée au lieu "Offre numérique"']}
+        assert response.json == {
+            "venue": ['Une offre physique ne peut être associée au lieu "Offre numérique"'],
+            "offererAddress": ["Une offre physique doit avoir une adresse"],
+        }
         assert offers_models.Offer.query.first() is None
 
     @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
…virtual venue and digital offer
S'assurer qu'une offre a une oa apres mise a jour dans le cas ou elle n'est pas une offre digital.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
