### PR TITLE
(PC-30897)[PRO] fix: suggested subcategories

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
@@ -13,6 +13,7 @@ import { FormLayout } from 'components/FormLayout/FormLayout'
 import { OnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageEdit'
 import { ImageUploaderOffer } from 'components/IndividualOfferForm/ImageUploaderOffer/ImageUploaderOffer'
 import { GET_MUSIC_TYPES_QUERY_KEY } from 'config/swrQueryKeys'
+import { useIndividualOfferContext } from 'context/IndividualOfferContext/IndividualOfferContext'
 import { showOptionsTree } from 'core/Offers/categoriesSubTypes'
 import { IndividualOfferImage } from 'core/Offers/types'
 import { useActiveFeature } from 'hooks/useActiveFeature'
@@ -66,6 +67,7 @@ export const DetailsForm = ({
     },
     handleChange,
   } = useFormikContext<DetailsFormValues>()
+  const { offer } = useIndividualOfferContext()
 
   const musicTypesQuery = useSWR(
     GET_MUSIC_TYPES_QUERY_KEY,
@@ -113,7 +115,7 @@ export const DetailsForm = ({
       : subcategoryConditionalFields.includes('musicType')
 
   async function getSuggestedSubcategories() {
-    if (!areSuggestedCategoriesEnabled) {
+    if (!areSuggestedCategoriesEnabled && !offer) {
       return
     }
     const response = await api.getSuggestedSubcategories(
@@ -192,7 +194,7 @@ export const DetailsForm = ({
           </FormLayout.Row>
         )}
       </FormLayout.Section>
-      {areSuggestedCategoriesEnabled ? (
+      {areSuggestedCategoriesEnabled && !offer ? (
         suggestedSubcategories.length > 0 && (
           <SuggestedSubcategories
             suggestedSubcategories={suggestedSubcategories}

--- a/pro/src/screens/IndividualOffer/DetailsScreen/Subcategories/Subcategories.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/Subcategories/Subcategories.tsx
@@ -2,7 +2,6 @@ import { useFormikContext } from 'formik'
 
 import { CategoryResponseModel, SubcategoryResponseModel } from 'apiClient/v1'
 import { FormLayout } from 'components/FormLayout/FormLayout'
-import { useIndividualOfferContext } from 'context/IndividualOfferContext/IndividualOfferContext'
 import { Select } from 'ui-kit/form/Select/Select'
 import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 
@@ -26,7 +25,6 @@ export function Subcategories({
   filteredCategories,
   filteredSubcategories,
 }: SuggestedSubcategoriesProps) {
-  const { subCategories } = useIndividualOfferContext()
   const {
     values: { categoryId, subcategoryConditionalFields },
     handleChange,
@@ -34,7 +32,10 @@ export function Subcategories({
   } = useFormikContext<DetailsFormValues>()
 
   const categoryOptions = buildCategoryOptions(filteredCategories)
-  const subcategoryOptions = buildSubcategoryOptions(subCategories, categoryId)
+  const subcategoryOptions = buildSubcategoryOptions(
+    filteredSubcategories,
+    categoryId
+  )
 
   return (
     <FormLayout.Section title={'Type d’offre'}>

--- a/pro/src/screens/IndividualOffer/DetailsScreen/__specs__/DetailsScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/__specs__/DetailsScreen.spec.tsx
@@ -3,6 +3,11 @@ import { userEvent } from '@testing-library/user-event'
 
 import { api } from 'apiClient/api'
 import {
+  CategoryResponseModel,
+  SubcategoryIdEnum,
+  SubcategoryResponseModel,
+} from 'apiClient/v1'
+import {
   IndividualOfferContext,
   IndividualOfferContextValues,
 } from 'context/IndividualOfferContext/IndividualOfferContext'
@@ -51,17 +56,19 @@ const renderDetailsScreen = (
 describe('screens:IndividualOffer::Informations', () => {
   let props: DetailsScreenProps
   let contextValue: IndividualOfferContextValues
+  let categories: CategoryResponseModel[]
+  let subCategories: SubcategoryResponseModel[]
 
   beforeEach(() => {
     Element.prototype.scrollIntoView = scrollIntoViewMock
-    const categories = [
+    categories = [
       categoryFactory({
         id: 'A',
         proLabel: 'Catégorie A',
         isSelectable: true,
       }),
     ]
-    const subCategories = [
+    subCategories = [
       subcategoryFactory({
         id: 'virtual',
         categoryId: 'A',
@@ -277,5 +284,25 @@ describe('screens:IndividualOffer::Informations', () => {
     expect(screen.queryByText('Auteur')).not.toBeInTheDocument()
     expect(screen.queryByText(/EAN/)).not.toBeInTheDocument()
     expect(screen.getByLabelText(/Catégorie/)).toBeInTheDocument()
+  })
+
+  it('should not render suggested subcategories in edition', () => {
+    const context = individualOfferContextValuesFactory({
+      categories,
+      subCategories,
+      offer: getIndividualOfferFactory({
+        subcategoryId: 'physical' as SubcategoryIdEnum,
+      }),
+    })
+
+    renderDetailsScreen(props, context, {
+      features: ['WIP_SUGGESTED_SUBCATEGORIES'],
+    })
+
+    expect(
+      screen.queryByText(/Catégories suggérées pour votre offre/)
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('Type d’offre')).toBeInTheDocument()
+    expect(screen.getByText('Sous catégorie offline de A')).toBeInTheDocument()
   })
 })

--- a/pro/src/ui-kit/form/TextArea/TextArea.tsx
+++ b/pro/src/ui-kit/form/TextArea/TextArea.tsx
@@ -33,6 +33,7 @@ export const TextArea = ({
   isOptional,
   smallLabel,
   rows = 7,
+  ...props
 }: TextAreaProps): JSX.Element => {
   //  Temporary type fix while react-autosoze-textarea types are not in sync with the latest React types
   //  see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68984
@@ -71,6 +72,7 @@ export const TextArea = ({
         placeholder={placeholder}
         aria-required={!isOptional}
         {...field}
+        {...(props.onChange ? { onChange: props.onChange } : {})}
       />
     </FieldLayout>
   )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30897

3 commit trois fix 
- une fois l'offre crée on ne voyait plus les sous catégories
- le onChange du textArea ne fonctionnait pas
- les sous-catégorie n'étaient plus filtrées


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
