### PR TITLE
(BSR)[API] fix: copy FF clean data to main repo

### DIFF
--- a/.github/workflows/templates/post-upgrade-job.yaml
+++ b/.github/workflows/templates/post-upgrade-job.yaml
@@ -32,4 +32,5 @@ spec:
           - |
             set -e
             alembic upgrade post@head
+            flask clean_data
       restartPolicy: Never


### PR DESCRIPTION
## But de la pull request

portage du clean data du repo infra vers le repo main.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
