### PR TITLE
(PC-31348)[API] fix: user offerer attachment was NEW instead of VALIDATED in case of double API call

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -949,14 +949,14 @@ def create_offerer(
         user_offerer = grant_user_offerer_access(offerer, user)
         db.session.add_all([offerer, digital_venue, user_offerer])
 
-    assert offerer.siren  # helps mypy until Offerer.siren is set as NOT NULL
-    try:
-        siren_info = sirene.get_siren(offerer.siren, raise_if_non_public=False)
-    except sirene_exceptions.SireneException as exc:
-        logger.info("Could not fetch info from Sirene API", extra={"exc": exc})
-        siren_info = None
-
     if is_new:
+        assert offerer.siren  # helps mypy until Offerer.siren is set as NOT NULL
+        try:
+            siren_info = sirene.get_siren(offerer.siren, raise_if_non_public=False)
+        except sirene_exceptions.SireneException as exc:
+            logger.info("Could not fetch info from Sirene API", extra={"exc": exc})
+            siren_info = None
+
         auto_tag_new_offerer(offerer, siren_info, user)
 
         extra_data = {}

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -918,7 +918,8 @@ def create_offerer(
         # in this case it is passed to NEW if the structure is not rejected
         user_offerer = offerers_models.UserOfferer.query.filter_by(userId=user.id, offererId=offerer.id).one_or_none()
         if not user_offerer:
-            user_offerer = grant_user_offerer_access(offerer, user)
+            user_offerer = models.UserOfferer(offerer=offerer, user=user, validationStatus=ValidationStatus.NEW)
+            db.session.add(user_offerer)
 
         if offerer.isRejected:
             # When offerer was rejected, it is considered as a new offerer in validation process;
@@ -927,7 +928,7 @@ def create_offerer(
             _fill_in_offerer(offerer, offerer_informations)
             comment = (comment + "\n" if comment else "") + "Nouvelle demande sur un SIREN précédemment rejeté"
             user_offerer.validationStatus = ValidationStatus.VALIDATED
-        else:
+        elif not user_offerer.isValidated:
             user_offerer.validationStatus = ValidationStatus.NEW
             user_offerer.dateCreated = datetime.utcnow()
             extra_data: dict[str, typing.Any] = {}

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -814,6 +814,33 @@ class CreateOffererTest:
         assert actions_list[1].user == user
         assert actions_list[1].offerer == created_offerer
 
+    def test_create_new_offerer_twice(self):
+        # Given
+        user = users_factories.NonAttachedProFactory()
+        offerer_informations = offerers_serialize.CreateOffererQueryModel(
+            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+        )
+
+        # When
+        offerers_api.create_offerer(user, offerer_informations)
+        user_offerer = offerers_api.create_offerer(user, offerer_informations)
+
+        # Then
+        created_offerer = user_offerer.offerer
+        assert created_offerer.validationStatus == ValidationStatus.NEW
+        assert user_offerer.validationStatus == ValidationStatus.VALIDATED
+        assert user_offerer.dateCreated is not None
+
+        assert not user.has_pro_role
+        assert user.has_non_attached_pro_role
+
+        actions_list = user.action_history
+        assert len(actions_list) == 1
+        assert actions_list[0].actionType == history_models.ActionType.OFFERER_NEW
+        assert actions_list[0].authorUser == user
+        assert actions_list[0].user == user
+        assert actions_list[0].offerer == created_offerer
+
     def test_create_new_offerer_on_known_offerer_by_user_deleted(self):
         # Given
         user = users_factories.UserFactory()


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31348

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
