### PR TITLE
(PC-31354)[PRO] fix: Use the right swr cache key for updating the off…

### DIFF
--- a/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
@@ -13,7 +13,10 @@ import {
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { ArchiveConfirmationModal } from 'components/ArchiveConfirmationModal/ArchiveConfirmationModal'
 import { Step, Stepper } from 'components/Stepper/Stepper'
-import { GET_COLLECTIVE_OFFER_QUERY_KEY } from 'config/swrQueryKeys'
+import {
+  GET_COLLECTIVE_OFFER_QUERY_KEY,
+  GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY,
+} from 'config/swrQueryKeys'
 import {
   Events,
   OFFER_FROM_TEMPLATE_ENTRIES,
@@ -212,7 +215,11 @@ export const CollectiveOfferNavigation = ({
         await api.patchCollectiveOffersArchive({ ids: [offerId] })
       }
 
-      await mutate([GET_COLLECTIVE_OFFER_QUERY_KEY, offerId])
+      if (isTemplate) {
+        await mutate([GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY, offerId])
+      } else {
+        await mutate([GET_COLLECTIVE_OFFER_QUERY_KEY, offerId])
+      }
       setIsArchiveModalOpen(false)
       notify.success('Une offre a bien été archivée', {
         duration: NOTIFICATION_LONG_SHOW_DURATION,


### PR DESCRIPTION
…er after archiving it.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31354

**Objectif**
Corriger le fait que quand on archive une offre collective vitrine depuis la page récap, le statut de l'offre affiché en haut a droite ne change pas immédiatement. (c'est parce qu'on `mutate` la key de l'offre collective réservable et pas vitrine)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
