### PR TITLE
(PC-31274)[API] feat: create index on `stock.idAtProviders`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 869f0d3be788 (pre) (head)
-2a3cbc3aa996 (post) (head)
+d8a0801f62e2 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240827T091759_d8a0801f62e2_create_index_on_stock_idatproviders.py
+++ b/api/src/pcapi/alembic/versions/20240827T091759_d8a0801f62e2_create_index_on_stock_idatproviders.py
@@ -1,0 +1,34 @@
+"""Create index on stock.idAtProviders
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "d8a0801f62e2"
+down_revision = "2a3cbc3aa996"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_stock_idAtProviders",
+            "stock",
+            ["idAtProviders"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_stock_idAtProviders",
+            table_name="stock",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -275,6 +275,7 @@ class Stock(PcObject, Base, Model, SoftDeletableMixin):
     # First step : Create a unique index on offerId/idAtProviders
     # Next step : Create a unicity constraint based on this index and to drop the unicity constraint on idAtProviders
     sa.Index("unique_ix_offer_id_id_at_providers", offerId, idAtProviders, unique=True)
+    sa.Index("ix_stock_idAtProviders", idAtProviders)
 
     __table_args__ = (
         sa.Index(


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31274

La création de l'index sur `stock.idAtProviders` a pour but de pouvoir enlever la contrainte d'unicité sur ce champ sans pour autant perdre en performance sur la recherche sur cet index.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
