### PR TITLE
(BSR)[API] Add `@provider_api_key_required` decorator to prevent user using old API keys to access the new public API

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/providers.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/providers.py
@@ -10,12 +10,12 @@ from pcapi.routes.public.serialization import providers as providers_serializati
 from pcapi.routes.public.serialization import venues as venues_serialization
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/public/providers/v1/provider", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PROVIDERS],
@@ -38,7 +38,7 @@ def get_provider() -> providers_serialization.ProviderResponse:
 
 
 @blueprints.public_api.route("/public/providers/v1/provider", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PROVIDERS],
@@ -86,7 +86,7 @@ def update_provider(body: providers_serialization.ProviderUpdate) -> providers_s
 
 
 @blueprints.public_api.route("/public/providers/v1/venues/<int:venue_id>", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     on_success_status=204,
     api=spectree_schemas.public_api_schema,

--- a/api/tests/routes/public/helpers.py
+++ b/api/tests/routes/public/helpers.py
@@ -31,6 +31,25 @@ class PublicAPIEndpointBaseHelper(abc.ABC):
     def test_should_raise_401_because_not_authenticated(self, client: TestClient):
         raise NotImplementedError()
 
+    def _setup_api_key(self, offerer, provider=None) -> str:
+        secret = str(uuid.uuid4())
+        env = "test"
+        prefix_id = str(uuid.uuid1())
+
+        offerers_factories.ApiKeyFactory(
+            offerer=offerer, provider=provider, secret=secret, prefix="%s_%s" % (env, prefix_id)
+        )
+        plain_api_key = "%s_%s_%s" % (env, prefix_id, secret)
+
+        return plain_api_key
+
+    def setup_old_api_key(self) -> str:
+        """
+        Setup old api key not linked to a provider
+        """
+        offerer = offerers_factories.OffererFactory(name="Technical provider")
+        return self._setup_api_key(offerer=offerer)
+
     def setup_provider(self, has_ticketing_urls=True) -> tuple[str, providers_models.Provider]:
         if has_ticketing_urls:
             provider = providers_factories.PublicApiProviderFactory()
@@ -42,14 +61,7 @@ class PublicAPIEndpointBaseHelper(abc.ABC):
             provider=provider,
         )
 
-        secret = str(uuid.uuid4())
-        env = "test"
-        prefix_id = str(uuid.uuid1())
-
-        offerers_factories.ApiKeyFactory(
-            offerer=offerer, provider=provider, secret=secret, prefix="%s_%s" % (env, prefix_id)
-        )
-        plain_api_key = "%s_%s_%s" % (env, prefix_id, secret)
+        plain_api_key = self._setup_api_key(offerer=offerer, provider=provider)
 
         return plain_api_key, provider
 

--- a/api/tests/routes/public/individual_offers/v1/get_provider_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_provider_test.py
@@ -1,12 +1,19 @@
+from tests.conftest import TestClient
 from tests.routes.public.helpers import PublicAPIEndpointBaseHelper
 
 
 class GetProviderTest(PublicAPIEndpointBaseHelper):
     endpoint_url = "/public/providers/v1/provider"
 
-    def test_should_raise_401_because_not_authenticated(self, client):
+    def test_should_raise_401_because_not_authenticated(self, client: TestClient):
         response = client.get(self.endpoint_url)
         assert response.status_code == 401
+
+    def test_should_raise_401_because_api_key_is_not_linked_to_provider(self, client: TestClient):
+        old_api_key = self.setup_old_api_key()
+        response = client.with_explicit_token(old_api_key).get(self.endpoint_url)
+        assert response.status_code == 401
+        assert response.json == {"auth": "Deprecated API key. Please contact provider support to get a new API key"}
 
     def test_return_provider_information(self, client):
         plain_api_key, provider = self.setup_provider()

--- a/api/tests/routes/public/individual_offers/v1/patch_provider_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_provider_test.py
@@ -5,6 +5,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.providers import factories as providers_factories
 
+from tests.conftest import TestClient
 from tests.routes.public.helpers import PublicAPIEndpointBaseHelper
 
 
@@ -17,6 +18,12 @@ class PatchProviderTest(PublicAPIEndpointBaseHelper):
     def test_should_raise_401_because_not_authenticated(self, client):
         response = client.patch(self.endpoint_url, json={})
         assert response.status_code == 401
+
+    def test_should_raise_401_because_api_key_is_not_linked_to_provider(self, client: TestClient):
+        old_api_key = self.setup_old_api_key()
+        response = client.with_explicit_token(old_api_key).patch(self.endpoint_url)
+        assert response.status_code == 401
+        assert response.json == {"auth": "Deprecated API key. Please contact provider support to get a new API key"}
 
     def test_should_update_notification_url(self, client):
         plain_api_key, provider = self.setup_provider()

--- a/api/tests/routes/public/individual_offers/v1/patch_venue_provider_external_urls.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_venue_provider_external_urls.py
@@ -11,13 +11,20 @@ from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-class PatchProviderTest(PublicAPIVenueEndpointHelper):
+class PatchVenueProviderExternalUrlsTest(PublicAPIVenueEndpointHelper):
     endpoint_url = "/public/providers/v1/venues/{venue_id}"
 
     def test_should_raise_401_because_not_authenticated(self, client: TestClient):
         venue = self.setup_venue()
         response = client.patch(self.endpoint_url.format(venue_id=venue.id))
         assert response.status_code == 401
+
+    def test_should_raise_401_because_api_key_is_not_linked_to_provider(self, client: TestClient):
+        old_api_key = self.setup_old_api_key()
+        venue = self.setup_venue()
+        response = client.with_explicit_token(old_api_key).patch(self.endpoint_url.format(venue_id=venue.id))
+        assert response.status_code == 401
+        assert response.json == {"auth": "Deprecated API key. Please contact provider support to get a new API key"}
 
     def test_should_raise_404_because_venue_provider_is_inactive(self, client: TestClient):
         plain_api_key, venue_provider = self.setup_inactive_venue_provider()


### PR DESCRIPTION
## But de la pull request

Cette PR vise à prévenir ce genre de bug:https://sentry.passculture.team/organizations/sentry/issues/1617472/?project=5&referrer=slack

Dans cette PR :
- Ajout du décorateur `@provider_api_key_required`
- Mise en place du décorateur sur les routes provider de l'API publique : 
   - [GET Provider](https://developers.passculture.pro/rest-api#tag/Providers/operation/GetProvider)
   - [PATCH Provider](https://developers.passculture.pro/rest-api#tag/Providers/operation/UpdateProvider)
   - [PATCH External Urls](https://developers.passculture.pro/rest-api#tag/Providers/operation/UpdateVenueExternalUrls)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
