### PR TITLE
(BSR)[API] feat: add api-documentation-build-checks in CI

### DIFF
--- a/.github/workflows/dev_on_pull_request_workflow.yml
+++ b/.github/workflows/dev_on_pull_request_workflow.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api-changed: ${{ steps.check-api-changes.outputs.any_modified }}
+      api-documentation-changed: ${{ steps.check-api-documentation-changes.outputs.any_modified }}
       pro-changed: ${{ steps.check-pro-changes.outputs.any_modified }}
       dependencies-changed: ${{ steps.check-dependencies-changes.outputs.any_modified }}
       push-tags: ${{ steps.pcapi-tags.outputs.push-tags }}
@@ -37,8 +38,14 @@ jobs:
         with:
           files: |
             api/**
+            !api/documentation/**
             !api/src/pcapi/scripts/**/main.py
             !api/src/pcapi/scripts/**/main.sql
+      - name: "Check api documentation folder changes"
+        id: check-api-documentation-changes
+        uses: tj-actions/changed-files@v44
+        with:
+          files: api/documentation/**
       - name: "Check pro folder changes"
         id: check-pro-changes
         uses: tj-actions/changed-files@v44
@@ -110,6 +117,7 @@ jobs:
       - name: "Summary"
         run: |
           echo "[api] folder changed : ${{ steps.check-api-changes.outputs.any_modified }}"
+          echo "[api-documentation] folder changed : ${{ steps.check-api-documentation-changes.outputs.any_modified }}"
           echo "[pro] folder changed : ${{ steps.check-pro-changes.outputs.any_modified }}"
           echo "[dependencies] changed : ${{ steps.check-dependencies-changes.outputs.any_modified }}"
           echo "[pcapi] push-tags : ${{ steps.pcapi-tags.outputs.push-tags }}"
@@ -189,6 +197,15 @@ jobs:
     uses: ./.github/workflows/dev_on_workflow_tests_api.yml
     with:
       tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+    secrets:
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+
+  test-api-documentation:
+    name: "Tests API documentation"
+    needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.api-documentation-changed == 'true'
+    uses: ./.github/workflows/dev_on_workflow_tests_api_documentation.yml
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api-changed: ${{ steps.check-api-changes.outputs.any_modified }}
+      api-documentation-changed: ${{ steps.check-api-documentation-changes.outputs.any_modified }}
       pro-changed: ${{ steps.check-pro-changes.outputs.any_modified }}
       dependencies-changed: ${{ steps.check-dependencies-changes.outputs.any_modified }}
       push-tags: ${{ steps.pcapi-tags.outputs.push-tags }}
@@ -31,8 +32,14 @@ jobs:
         with:
           files: |
             api/**
+            !api/documentation/**
             !api/src/pcapi/scripts/**/main.py
             !api/src/pcapi/scripts/**/main.sql
+      - name: "Check api documentation folder changes"
+        id: check-api-documentation-changes
+        uses: tj-actions/changed-files@v44
+        with:
+          files: api/documentation/**
       - name: "Check pro folder changes"
         id: check-pro-changes
         uses: tj-actions/changed-files@v44
@@ -193,6 +200,15 @@ jobs:
     uses: ./.github/workflows/dev_on_workflow_tests_api.yml
     with:
       tag: ${{ needs.build-pcapi-tests.result == 'skipped' && 'latest' || needs.pcapi-init-job.outputs.checksum-tag }}
+    secrets:
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+
+  test-api-documentation:
+    name: "Tests API documentation"
+    needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.api-documentation-changed == 'true'
+    uses: ./.github/workflows/dev_on_workflow_tests_api_documentation.yml
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/dev_on_workflow_tests_api_documentation.yml
+++ b/.github/workflows/dev_on_workflow_tests_api_documentation.yml
@@ -1,0 +1,79 @@
+name: "3 [on_workflow/API] Tests"
+
+on:
+  workflow_call:
+    inputs:
+      doc-api-entrypoint:
+        type: string
+        required: false
+        default: 'api/documentation'
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      GCP_EHP_SERVICE_ACCOUNT:
+        required: true
+
+env:
+  registry: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry
+
+defaults:
+  run:
+    working-directory: api
+
+jobs:
+  api-documentation-build-checks:
+    name: "Check API documentation can be built"
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '${{ inputs.doc-api-entrypoint }}/.nvmrc'
+      - name: "Build documentation"
+        run: |
+            set -e
+            npm install
+            npm run build
+        env:
+          ENV: ci-tests
+        working-directory: '${{ inputs.doc-api-entrypoint }}'
+      - name: "Authentification to Google"
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      - name: "Get Secret"
+        id: secrets
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
+        with:
+          secrets: |-
+            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+      - name: "Slack Notification"
+        if: ${{ failure() && github.ref == 'refs/heads/master'  }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # channel #dev
+          channel-id: "CPZ7U1CNP"
+          payload: |
+            {
+            "attachments": [
+              {
+                "mrkdwn_in": ["text"],
+                "color": "#A30002",
+                "author_name": "${{github.actor}}",
+                "author_link": "https://github.com/${{github.actor}}",
+                "author_icon": "https://github.com/${{github.actor}}.png",
+                "title": "Api tests",
+                "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+                "text": "Les tests api-documentation-build-checks échouent sur `master` :boom:"
+              }
+            ],
+            "unfurl_links": false,
+            "unfurl_media": false
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}

--- a/api/documentation/docusaurus.config.ts
+++ b/api/documentation/docusaurus.config.ts
@@ -4,6 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 import type * as Redocusaurus from 'redocusaurus';
 
 const env = process.env['ENV'];
+const EXPECTED_OPEN_API_JSON_PATH = './../tests/routes/public/expected_openapi.json';
 
 const getOpenAPIJsonUrlFromEnv = (): string => {
   if (env === 'testing' || env === 'staging') {
@@ -11,6 +12,9 @@ const getOpenAPIJsonUrlFromEnv = (): string => {
   }
   if (env === 'production') {
     return 'https://backend.passculture.pro/openapi.json';
+  }
+  if (env === 'ci-tests') {
+    return EXPECTED_OPEN_API_JSON_PATH;
   }
   return 'http://localhost:5001/openapi.json';
 }


### PR DESCRIPTION
## But de la pull request

Le but de cette PR est d'ajouter un check pour vérifier que les modifications apportées à la documentation API ne cassent pas sa génération.

**⚠️ Le deuxième commit est en erreur pour montrer que le test de la CI fonctionne comme convenu. Il sera retiré une fois que la PR est validée.**

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
