### PR TITLE
(PC-31299)[API] fix: prevent the creation of collective offer when `startDatetime` > `endDatetime`

### DIFF
--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -466,6 +466,16 @@ class PostCollectiveOfferBodyModel(BaseModel):
 
         return values
 
+    @validator("end_datetime", pre=False)
+    def validate_end_datetime_vs_start_datetime(
+        cls, end_datetime: datetime | None, values: dict[str, Any]
+    ) -> datetime | None:
+        start_datetime = values.get("start_datetime")
+
+        if start_datetime and end_datetime < start_datetime:
+            raise ValueError("La date de fin de l'évènement ne peut précéder la date de début.")
+        return end_datetime
+
     class Config:
         alias_generator = to_camel
         extra = "forbid"


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31299

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
