### PR TITLE
(PC-31342)[PRO] fix: cache previously selected subcat until suggestion change

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.spec.tsx
@@ -1,0 +1,219 @@
+import { screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { FormikProvider, useFormik } from 'formik'
+
+import { CategoryResponseModel, SubcategoryResponseModel } from 'apiClient/v1'
+import {
+  IndividualOfferContext,
+  IndividualOfferContextValues,
+} from 'context/IndividualOfferContext/IndividualOfferContext'
+import { subcategoryFactory } from 'utils/individualApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import {
+  SuggestedSubcategories,
+  SuggestedSubcategoriesProps,
+} from './SuggestedSubcategories'
+
+const CATEGORIES: CategoryResponseModel[] = [
+  {
+    id: 'LIVRE',
+    isSelectable: true,
+    proLabel: 'Livre',
+  },
+  {
+    id: 'SPECTACLE',
+    isSelectable: true,
+    proLabel: 'Spectacle',
+  },
+  {
+    id: 'FILM',
+    isSelectable: true,
+    proLabel: 'Film',
+  },
+  {
+    id: 'INSTRUMENT',
+    isSelectable: true,
+    proLabel: 'Instrument',
+  },
+]
+
+const SUB_CATEGORIES: SubcategoryResponseModel[] = [
+  subcategoryFactory({
+    id: 'LIVRE_PAPIER',
+    categoryId: 'LIVRE',
+    proLabel: 'Livre papier',
+    conditionalFields: ['author', 'ean', 'gtl_id'],
+  }),
+  subcategoryFactory({
+    id: 'SPECTACLE_REPRESENTATION',
+    categoryId: 'SPECTACLE',
+    proLabel: 'Spectacle, représentation',
+    conditionalFields: [
+      'author',
+      'showSubType',
+      'showType',
+      'stageDirector',
+      'performer',
+    ],
+  }),
+  subcategoryFactory({
+    id: 'ABO_PLATEFORME_VIDEO',
+    categoryId: 'FILM',
+    proLabel: 'Abonnement plateforme streaming',
+    conditionalFields: [],
+  }),
+  subcategoryFactory({
+    id: 'BON_ACHAT_INSTRUMENT',
+    categoryId: 'INSTRUMENT',
+    proLabel: "Bon d'achat instrument",
+    conditionalFields: [],
+  }),
+]
+
+const suggestedSubcategories = SUB_CATEGORIES.map((subcat) => subcat.id)
+const firstSuggestedSubcategories = suggestedSubcategories.slice(0, 2)
+const otherSuggestedSubcategories = suggestedSubcategories.slice(2)
+
+const contextValue: IndividualOfferContextValues = {
+  categories: [],
+  subCategories: SUB_CATEGORIES,
+  offer: null,
+}
+const SuggestedSubWrappedWithFormik = (
+  props: SuggestedSubcategoriesProps
+): JSX.Element => {
+  const formik = useFormik({
+    initialValues: {
+      categoryId: '',
+      subcategoryConditionalFields: [],
+      suggestedSubcategory: '',
+    },
+    onSubmit: vi.fn(),
+  })
+
+  return (
+    <FormikProvider value={formik}>
+      <SuggestedSubcategories {...props} />
+    </FormikProvider>
+  )
+}
+
+const renderSuggestedSubcategories = (props: SuggestedSubcategoriesProps) => {
+  return renderWithProviders(
+    <IndividualOfferContext.Provider value={contextValue}>
+      <SuggestedSubWrappedWithFormik {...props} />
+    </IndividualOfferContext.Provider>,
+    {}
+  )
+}
+
+describe('SuggestedSubcategories', () => {
+  it('should render suggested subcategories as radio buttons', () => {
+    renderSuggestedSubcategories({
+      suggestedSubcategories,
+      filteredCategories: [],
+      filteredSubcategories: [],
+      readOnlyFields: [],
+    })
+
+    suggestedSubcategories.forEach((subcategoryId, index) => {
+      const label = SUB_CATEGORIES[index].proLabel
+      const radioButton = screen.queryByRole('radio', { name: label })
+      expect(radioButton).toBeInTheDocument()
+    })
+  })
+
+  it('should always render an "Autre" radio button', () => {
+    renderSuggestedSubcategories({
+      suggestedSubcategories,
+      filteredCategories: [],
+      filteredSubcategories: [],
+      readOnlyFields: [],
+    })
+
+    const radioButton = screen.queryByRole('radio', { name: 'Autre' })
+    expect(radioButton).toBeInTheDocument()
+  })
+
+  it('should keep previously selected subcategory as radio button even if it is not in the suggested subcategories', async () => {
+    const { rerender } = renderSuggestedSubcategories({
+      suggestedSubcategories: firstSuggestedSubcategories,
+      filteredCategories: [],
+      filteredSubcategories: [],
+      readOnlyFields: [],
+    })
+
+    const selectedIndex = 0
+    const selectedName = SUB_CATEGORIES[selectedIndex].proLabel
+    const queryParams = { name: selectedName }
+
+    const selected = screen.getByRole('radio', queryParams)
+    await userEvent.click(selected)
+
+    rerender(
+      <IndividualOfferContext.Provider value={{ ...contextValue }}>
+        <SuggestedSubWrappedWithFormik
+          suggestedSubcategories={otherSuggestedSubcategories}
+          filteredCategories={[]}
+          filteredSubcategories={[]}
+          readOnlyFields={[]}
+        />
+      </IndividualOfferContext.Provider>
+    )
+
+    // Previous suggested subcategories are no longer rendered
+    // except previously selected.
+    firstSuggestedSubcategories.forEach((subcategoryId, index) => {
+      const label = SUB_CATEGORIES[index].proLabel
+      const radioButton = screen.queryByRole('radio', { name: label })
+
+      if (index === selectedIndex) {
+        expect(radioButton).toBeInTheDocument()
+      } else {
+        expect(radioButton).not.toBeInTheDocument()
+      }
+    })
+  })
+
+  describe('when the "Autre" radio button is selected', () => {
+    it('should render a category select', async () => {
+      renderSuggestedSubcategories({
+        suggestedSubcategories,
+        filteredCategories: [],
+        filteredSubcategories: [],
+        readOnlyFields: [],
+      })
+
+      const otherRadioButton = screen.getByRole('radio', { name: 'Autre' })
+      await userEvent.click(otherRadioButton)
+
+      const categorySelect = screen.getByRole('combobox', {
+        name: 'Catégorie *',
+      })
+      expect(categorySelect).toBeInTheDocument()
+    })
+
+    it('should render a subcategory select when a category is selected', async () => {
+      renderSuggestedSubcategories({
+        suggestedSubcategories,
+        filteredCategories: CATEGORIES,
+        filteredSubcategories: SUB_CATEGORIES,
+        readOnlyFields: [],
+      })
+
+      const otherRadioButton = screen.getByRole('radio', { name: 'Autre' })
+      await userEvent.click(otherRadioButton)
+
+      const categorySelect = screen.getByRole('combobox', {
+        name: 'Catégorie *',
+      })
+      await userEvent.selectOptions(categorySelect, 'LIVRE')
+
+      const subcategorySelect = screen.getByRole('combobox', {
+        name: 'Sous-catégorie *',
+      })
+      expect(subcategorySelect).toBeInTheDocument()
+    })
+  })
+})

--- a/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.tsx
@@ -1,4 +1,5 @@
 import { useFormikContext } from 'formik'
+import { useEffect, useState } from 'react'
 
 import { CategoryResponseModel, SubcategoryResponseModel } from 'apiClient/v1'
 import { FormLayout } from 'components/FormLayout/FormLayout'
@@ -10,7 +11,6 @@ import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 import { DEFAULT_DETAILS_FORM_VALUES } from '../constants'
 import { DetailsFormValues } from '../types'
 import {
-  onSuggestedSubcategoriesChange,
   onSubcategoryChange,
   onCategoryChange,
   buildCategoryOptions,
@@ -19,7 +19,7 @@ import {
 
 import styles from './SuggestedSubcategories.module.scss'
 
-type SuggestedSubcategoriesProps = {
+export type SuggestedSubcategoriesProps = {
   suggestedSubcategories: string[]
   readOnlyFields: string[]
   filteredCategories: CategoryResponseModel[]
@@ -32,15 +32,90 @@ export function SuggestedSubcategories({
   filteredCategories,
   filteredSubcategories,
 }: SuggestedSubcategoriesProps) {
+  const [prevSelectedSubCategory, setPrevSelectedFromPrevSuggestions] =
+    useState<string | null>(null)
   const { subCategories } = useIndividualOfferContext()
   const {
-    values: { categoryId, subcategoryConditionalFields, suggestedSubcategory },
+    values: {
+      categoryId,
+      subcategoryConditionalFields,
+      suggestedSubcategory: selectedSubCategory,
+    },
     handleChange,
     setFieldValue,
   } = useFormikContext<DetailsFormValues>()
 
   const categoryOptions = buildCategoryOptions(filteredCategories)
   const subcategoryOptions = buildSubcategoryOptions(subCategories, categoryId)
+
+  // Suggested subcategories have changed and current selection
+  // is not in this list anymore. Yet, we'd like to
+  // display it as a selected radio button.
+  const isSelectedFromPrevSuggestions =
+    selectedSubCategory &&
+    selectedSubCategory !== 'OTHER' &&
+    !suggestedSubcategories.includes(selectedSubCategory)
+  const wasSelectedFromPrevSuggestions = prevSelectedSubCategory !== null
+
+  // Clean start: on suggested subcategories change,
+  // only the suggested subcategories list and current selection
+  // are to be displayed.
+  useEffect(() => {
+    setPrevSelectedFromPrevSuggestions(null)
+  }, [suggestedSubcategories])
+
+  const onRadioButtonChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ): Promise<void> => {
+    const id = event.target.value
+    const isSubcategoryId = id !== 'OTHER'
+    const subCategory: SubcategoryResponseModel | null = isSubcategoryId
+      ? subCategories.find((subcategory) => subcategory.id === id) || null
+      : null
+
+    if (isSelectedFromPrevSuggestions) {
+      // If previous selection belongs to a previous list of suggested subcategories,
+      // it will be stored to be displayed as an unselected radio button
+      // so it doesn't disappear onSuggestedSubcategoriesChange.
+      setPrevSelectedFromPrevSuggestions(selectedSubCategory)
+    }
+
+    if (subCategory) {
+      await setFieldValue('categoryId', subCategory.categoryId)
+      await setFieldValue('subcategoryId', id)
+      await onSubcategoryChange({
+        newSubCategoryId: id,
+        subcategories: subCategories,
+        setFieldValue,
+        subcategoryConditionalFields,
+      })
+    } else {
+      const { categoryId, subcategoryId } = DEFAULT_DETAILS_FORM_VALUES
+      await setFieldValue('categoryId', categoryId)
+      await setFieldValue('subcategoryId', subcategoryId)
+    }
+
+    handleChange(event)
+  }
+
+  const renderRadioButton = (id: string) => {
+    const isSubcategoryId = id !== 'OTHER'
+    const label = isSubcategoryId
+      ? subCategories.find((subcat) => subcat.id === id)?.proLabel || ''
+      : 'Autre'
+
+    return (
+      <RadioButton
+        label={label}
+        className={styles['suggested-subcategory']}
+        name="suggestedSubcategory"
+        value={id}
+        key={id}
+        withBorder
+        onChange={onRadioButtonChange}
+      />
+    )
+  }
 
   return (
     <FormLayout.Section title={'Type d’offre'}>
@@ -50,117 +125,86 @@ export function SuggestedSubcategories({
             Catégories suggérées pour votre offre&nbsp;:
           </p>
           <div className={styles['items']}>
-            {suggestedSubcategories.map((suggestedSubcategoryId) => (
-              <RadioButton
-                label={
-                  subCategories.find(
-                    (subcategory) => subcategory.id === suggestedSubcategoryId
-                  )?.proLabel ?? ''
-                }
-                className={styles['suggested-subcategory']}
-                name="suggestedSubcategory"
-                value={suggestedSubcategoryId}
-                key={suggestedSubcategoryId}
-                withBorder
-                onChange={async (event) => {
-                  await onSuggestedSubcategoriesChange({
-                    event,
-                    setFieldValue,
-                    subcategoryConditionalFields,
-                    subcategories: subCategories,
-                    onSubcategoryChange,
-                  })
-                  handleChange(event)
-                }}
-              />
-            ))}
-            <RadioButton
-              label="Autre"
-              name="suggestedSubcategory"
-              className={styles['suggested-subcategory']}
-              value="OTHER"
-              withBorder
-              onChange={async (event) => {
-                await onSuggestedSubcategoriesChange({
-                  event,
-                  setFieldValue,
-                  subcategoryConditionalFields,
-                  subcategories: subCategories,
-                  onSubcategoryChange,
-                })
-                handleChange(event)
-              }}
-            />
+            {suggestedSubcategories.map(renderRadioButton)}
+            {isSelectedFromPrevSuggestions &&
+              renderRadioButton(selectedSubCategory)}
+            {wasSelectedFromPrevSuggestions &&
+              prevSelectedSubCategory !== selectedSubCategory &&
+              renderRadioButton(prevSelectedSubCategory)}
+            {renderRadioButton('OTHER')}
           </div>
         </div>
       </FormLayout.Row>
-      {suggestedSubcategory === 'OTHER' && (
-        <FormLayout.Row
-          sideComponent={
-            <InfoBox
-              link={{
-                isExternal: true,
-                to: 'https://aide.passculture.app/hc/fr/articles/4411999013265--Acteurs-Culturels-Quelle-cat%C3%A9gorie-et-sous-cat%C3%A9gorie-choisir-lors-de-la-cr%C3%A9ation-d-offres-',
-                text: 'Quelles catégories choisir ?',
-                opensInNewTab: true,
-              }}
-            >
-              Une sélection précise de vos catégories permettra au grand public
-              de facilement trouver votre offre. Une fois validées, vous ne
-              pourrez pas les modifier.
-            </InfoBox>
-          }
-        >
-          <Select
-            label="Catégorie"
-            name="categoryId"
-            options={categoryOptions}
-            defaultOption={{
-              label: 'Choisir une catégorie',
-              value: DEFAULT_DETAILS_FORM_VALUES.categoryId,
-            }}
-            disabled={readOnlyFields.includes('categoryId')}
-            onChange={async (event: React.ChangeEvent<HTMLSelectElement>) => {
-              await onCategoryChange({
-                categoryId: event.target.value,
-                readOnlyFields,
-                subcategories: filteredSubcategories,
-                setFieldValue,
-                onSubcategoryChange,
-                subcategoryConditionalFields,
-              })
-              handleChange(event)
-            }}
-          />
-        </FormLayout.Row>
-      )}
-      {categoryId !== DEFAULT_DETAILS_FORM_VALUES.categoryId &&
-        suggestedSubcategory === 'OTHER' && (
-          <FormLayout.Row>
+      {selectedSubCategory === 'OTHER' && (
+        <>
+          <FormLayout.Row
+            sideComponent={
+              <InfoBox
+                link={{
+                  isExternal: true,
+                  to: 'https://aide.passculture.app/hc/fr/articles/4411999013265--Acteurs-Culturels-Quelle-cat%C3%A9gorie-et-sous-cat%C3%A9gorie-choisir-lors-de-la-cr%C3%A9ation-d-offres-',
+                  text: 'Quelles catégories choisir ?',
+                  opensInNewTab: true,
+                }}
+              >
+                Une sélection précise de vos catégories permettra au grand
+                public de facilement trouver votre offre. Une fois validées,
+                vous ne pourrez pas les modifier.
+              </InfoBox>
+            }
+          >
             <Select
-              label="Sous-catégorie"
-              name="subcategoryId"
-              options={subcategoryOptions}
+              label="Catégorie"
+              name="categoryId"
+              options={categoryOptions}
               defaultOption={{
-                label: 'Choisir une sous-catégorie',
-                value: DEFAULT_DETAILS_FORM_VALUES.subcategoryId,
+                label: 'Choisir une catégorie',
+                value: DEFAULT_DETAILS_FORM_VALUES.categoryId,
               }}
+              disabled={readOnlyFields.includes('categoryId')}
               onChange={async (event: React.ChangeEvent<HTMLSelectElement>) => {
-                await onSubcategoryChange({
-                  newSubCategoryId: event.target.value,
+                await onCategoryChange({
+                  categoryId: event.target.value,
+                  readOnlyFields,
                   subcategories: filteredSubcategories,
                   setFieldValue,
+                  onSubcategoryChange,
                   subcategoryConditionalFields,
                 })
                 handleChange(event)
               }}
-              disabled={
-                readOnlyFields.includes('subcategoryId') ||
-                subcategoryOptions.length === 1
-              }
             />
           </FormLayout.Row>
-        )}
+          {categoryId !== DEFAULT_DETAILS_FORM_VALUES.categoryId && (
+            <FormLayout.Row>
+              <Select
+                label="Sous-catégorie"
+                name="subcategoryId"
+                options={subcategoryOptions}
+                defaultOption={{
+                  label: 'Choisir une sous-catégorie',
+                  value: DEFAULT_DETAILS_FORM_VALUES.subcategoryId,
+                }}
+                onChange={async (
+                  event: React.ChangeEvent<HTMLSelectElement>
+                ) => {
+                  await onSubcategoryChange({
+                    newSubCategoryId: event.target.value,
+                    subcategories: filteredSubcategories,
+                    setFieldValue,
+                    subcategoryConditionalFields,
+                  })
+                  handleChange(event)
+                }}
+                disabled={
+                  readOnlyFields.includes('subcategoryId') ||
+                  subcategoryOptions.length === 1
+                }
+              />
+            </FormLayout.Row>
+          )}
+        </>
+      )}
     </FormLayout.Section>
   )
 }

--- a/pro/src/screens/IndividualOffer/DetailsScreen/utils.ts
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/utils.ts
@@ -1,5 +1,4 @@
 import { FormikErrors } from 'formik'
-import { ChangeEvent } from 'react'
 
 import {
   CategoryResponseModel,
@@ -162,50 +161,6 @@ export const onSubcategoryChange = async ({
       )
     }
   })
-}
-
-type OnSuggestedSubcategoriesChange = {
-  event: ChangeEvent<HTMLInputElement>
-  setFieldValue: (
-    field: string,
-    value: any,
-    shouldValidate?: boolean | undefined
-  ) => Promise<void | FormikErrors<DetailsFormValues>>
-  subcategories: SubcategoryResponseModel[]
-  subcategoryConditionalFields: string[]
-  onSubcategoryChange: (p: OnSubcategoryChangeProps) => Promise<void>
-}
-
-export async function onSuggestedSubcategoriesChange({
-  event,
-  setFieldValue,
-  subcategories,
-  subcategoryConditionalFields,
-  onSubcategoryChange,
-}: OnSuggestedSubcategoriesChange) {
-  const suggestedSubcategory = event.target.value
-  if (suggestedSubcategory === 'OTHER') {
-    await setFieldValue('categoryId', DEFAULT_DETAILS_FORM_VALUES.categoryId)
-    await setFieldValue(
-      'subcategoryId',
-      DEFAULT_DETAILS_FORM_VALUES.subcategoryId
-    )
-  } else {
-    const subcategory = subcategories.find(
-      (subcategory) => subcategory.id === suggestedSubcategory
-    )
-    if (subcategory) {
-      await setFieldValue('categoryId', subcategory.categoryId)
-      await setFieldValue('subcategoryId', suggestedSubcategory)
-
-      await onSubcategoryChange({
-        newSubCategoryId: suggestedSubcategory,
-        subcategories,
-        setFieldValue,
-        subcategoryConditionalFields,
-      })
-    }
-  }
 }
 
 export const buildVenueOptions = (venues: VenueListItemResponseModel[]) => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31342

## Objectifs
- Si un user sélectionne une sous-catégorie suggérée et que les suggestions changent, on souhaite conserver la sélection parmi la suite de radio buttons proposés même si la sélection est issue d'une liste de suggestions différente.
- Si alors, l'user sélectionne une autre sous-catégorie de cette nouvelle liste de suggestions, le radio button précédemment sélectionné ne disparaît pas de liste pour autant.
- tldr; on affiche toujours la liste des suggestions ce sous catégories telle quelle, la sélection courante (si existante, qu'importe si elle appartient à une liste précédente de suggestions), et l'options "Autre".

## Descriptif des modifications
- Clean / réécriture DRY du composant.
- Rajouts artificiels de radio buttons en suppléments de la liste de suggestion, en fonction des cas (voir state).
- Ajout de tests unitaires au niveau du composant pour contrôler le rerender.

## Questions 
- L'ajout des tests unitaires niveau composant fait-il sauter ou réduit-il le test suivant : "screens:IndividualOffer::Informations > should render suggested subcategories" ?

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
