### PR TITLE
(PC-31238)[PRO] feat: Restitute collective offer draft status.

### DIFF
--- a/pro/src/components/ActionsBarSticky/ActionsBarStickyRight.tsx
+++ b/pro/src/components/ActionsBarSticky/ActionsBarStickyRight.tsx
@@ -25,24 +25,26 @@ export const Right = ({
         [style['right-inverse']]: inverseWhenSmallerThanTablet,
       })}
     >
-      {dirtyForm !== undefined && mode === Mode.CREATION ? (
-        !dirtyForm ? (
-          <span className={style['draft-indicator']}>
-            <SvgIcon
-              src={fullValidateIcon}
-              alt=""
-              width="16"
-              className={style['draft-saved-icon']}
-            />
-            Brouillon enregistré
-          </span>
-        ) : (
-          <span className={style['draft-indicator']}>
-            <div className={style['draft-not-saved-icon']} />
-            Brouillon non enregistré
-          </span>
-        )
-      ) : null}
+      <div role="status">
+        {dirtyForm !== undefined && mode === Mode.CREATION ? (
+          !dirtyForm ? (
+            <span className={style['draft-indicator']}>
+              <SvgIcon
+                src={fullValidateIcon}
+                alt=""
+                width="16"
+                className={style['draft-saved-icon']}
+              />
+              Brouillon enregistré
+            </span>
+          ) : (
+            <span className={style['draft-indicator']}>
+              <div className={style['draft-not-saved-icon']} />
+              Brouillon non enregistré
+            </span>
+          )
+        ) : null}
+      </div>
       {children}
     </div>
   ) : null


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31238

**Objectif**
Restituer le changement de statut d'offre (Brouillon enregistré/Brouillon non enregistré) dans le formulaire des offres collectives.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
