### PR TITLE
(BSR)[API] revert: types-redis to ^4.6.0.20240806

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -5221,13 +5221,13 @@ files = [
 
 [[package]]
 name = "types-redis"
-version = "4.6.0.20240425"
+version = "4.6.0.20240819"
 description = "Typing stubs for redis"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-redis-4.6.0.20240425.tar.gz", hash = "sha256:9402a10ee931d241fdfcc04592ebf7a661d7bb92a8dea631279f0d8acbcf3a22"},
-    {file = "types_redis-4.6.0.20240425-py3-none-any.whl", hash = "sha256:ac5bc19e8f5997b9e76ad5d9cf15d0392d9f28cf5fc7746ea4a64b989c45c6a8"},
+    {file = "types-redis-4.6.0.20240819.tar.gz", hash = "sha256:08f51f550ad41d0152bd98d77ac9d6d8f761369121710a213642f6036b9a7183"},
+    {file = "types_redis-4.6.0.20240819-py3-none-any.whl", hash = "sha256:86db9af6f0033154e12bc22c77236cef0907b995fda8c9f0f0eacd59943ed2fc"},
 ]
 
 [package.dependencies]
@@ -5650,4 +5650,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "d40e4efd222ca3a943235c7dd8089bfcd96c9479130fb6396f2d51a36b02661e"
+content-hash = "d47e6b49e0a05fa71396493faf3912a1788b6d59f92572922936e3813b4f53b5"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -99,7 +99,7 @@ types-protobuf = "^5.27.0.20240626"
 types-python-dateutil = "^2.9.0.20240316"
 types-pytz = "^2024.1.0.20240417"
 types-pyyaml = "^6.0.12.20240808"
-types-redis = "4.6.0.20240425"
+types-redis = "^4.6.0.20240806"
 types-requests = "<2.33.0"
 types-urllib3 = "^1.26.25.14"
 


### PR DESCRIPTION
## But de la pull request
Revert le downgrade de types-redis

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
