### PR TITLE
(PC-31293)[API] feat: save failed job for a week

### DIFF
--- a/api/src/pcapi/workers/decorators.py
+++ b/api/src/pcapi/workers/decorators.py
@@ -14,6 +14,8 @@ from pcapi.workers.logger import job_extra_description
 
 logger = logging.getLogger(__name__)
 
+FAILED_JOB_TTL = 60 * 60 * 24 * 7  # 1 week
+
 
 def job(queue: Queue) -> typing.Callable:
     def decorator(func: typing.Callable) -> typing.Callable:
@@ -55,7 +57,7 @@ def job(queue: Queue) -> typing.Callable:
 
         @wraps(job_func)
         def delay(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
-            current_job = queue.enqueue(job_func, *args, **kwargs)
+            current_job = queue.enqueue(job_func, failure_ttl=FAILED_JOB_TTL, *args, **kwargs)
             logger.info(
                 "Enqueue job %s",
                 func.__name__,


### PR DESCRIPTION
## But de la pull request
Change failed job ttl to 1 week instead of 1 year to avoid flooding our redis with (sometimes big) useless data

> failure_ttl specifies how long (in seconds) failed jobs are kept (defaults to 1 year)

[link to rq doc](https://python-rq.org/docs/jobs/#failed-jobs)
A script will be used to clean old failed jobs
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31293

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
