### PR TITLE
(PC-31293)[API] script: to clean failed job registry

### DIFF
--- a/api/src/pcapi/scripts/delete_old_failed_jobs_rq/main.py
+++ b/api/src/pcapi/scripts/delete_old_failed_jobs_rq/main.py
@@ -1,0 +1,21 @@
+from rq.registry import FailedJobRegistry
+
+from pcapi.workers import worker
+
+
+def delete_old_failed_rq_jobs(registry: FailedJobRegistry) -> None:
+    # https://python-rq.org/docs/job_registries/#removing-jobs
+    print(f"Jobs in FailedJobRegistry: {registry.count}")
+    for job_id in registry.get_job_ids():
+        registry.remove(job_id, delete_job=True)
+
+
+if __name__ == "__main__":
+    dq_failed_registry = worker.default_queue.failed_job_registry
+    print("Start cleaning default queue failed job registry")
+    delete_old_failed_rq_jobs(dq_failed_registry)
+    print("Ending cleaning default queue failed job registry")
+    lq_failed_registry = worker.low_queue.failed_job_registry
+    print("Start cleaning low queue failed job registry")
+    delete_old_failed_rq_jobs(lq_failed_registry)
+    print("Ending cleaning low queue failed job registry")


### PR DESCRIPTION
## But de la pull request
Script to clean failed job registry. Inspired by https://python-rq.org/docs/job_registries/#removing-jobs

For prod there is around 70_000 failed jobs in default queue and 100_000 for low queue. 

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31293

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
