### PR TITLE
(PC-31418)[API] fix: prevent sentry sampling crash

### DIFF
--- a/api/src/pcapi/utils/sentry.py
+++ b/api/src/pcapi/utils/sentry.py
@@ -48,6 +48,10 @@ def custom_traces_sampler(sampling_context: dict) -> float:
     """
     path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
 
+    # for instance : worker requests
+    if not path or not isinstance(path, str):
+        return LOWEST_SAMPLE_RATE
+
     match path:
         # monitoring endpoints
         case "/health/api":


### PR DESCRIPTION
## But de la pull request

https://passculture.atlassian.net/browse/PC-31418

Eviter le crash du SDK sentry si aucun path n'est renseigné par exemple lors du traitement de tâches aynchrones