### PR TITLE
(PC-31235)[PRO] fix: use 15-min interval for duration-like BaseTimePickers

### DIFF
--- a/pro/src/ui-kit/form/TimePicker/BaseTimePicker.tsx
+++ b/pro/src/ui-kit/form/TimePicker/BaseTimePicker.tsx
@@ -16,7 +16,7 @@ const getTimeOptions = (suggestedTimeList?: SuggestedTimeList) => {
     return []
   }
 
-  const { interval = 1, min = '00:00', max = '23:59' } = suggestedTimeList
+  const { interval = 15, min = '00:00', max = '23:59' } = suggestedTimeList
   const [minHours, minMinutes] = min.split(':').map(Number)
   const [maxHours, maxMinutes] = max.split(':').map(Number)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31235

## Objectifs
- Simplement remettre une granularité de 15min pour les temps suggérés sur les inputs de type "Durée".

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
