### PR TITLE
(PC-31424)[PRO] fix: Remove collective offers bulk edit to fix multip…

### DIFF
--- a/pro/src/screens/IndividualOffersScreen/__specs__/IndividualOffersScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffersScreen/__specs__/IndividualOffersScreen.spec.tsx
@@ -91,7 +91,6 @@ vi.mock('utils/date', async () => {
 vi.mock('apiClient/api', () => ({
   api: {
     listOfferersNames: vi.fn().mockReturnValue({}),
-    patchAllCollectiveOffersActiveStatus: vi.fn(),
     deleteDraftOffers: vi.fn(),
   },
 }))


### PR DESCRIPTION
…le statuses update.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31424

**Objectif**
Corriger le bug suivant : quand on filtre sur plusieurs status dans la recherche d'offres collectives, puis qu'on sélectionne toutes les offres, dans le bulk edit, si on effectue une action autorisée il y a une erreur "Une erreur est survenue".

Pour corriger on se passe de l'api d'édition de toutes les offres en même temps qui n'a pas d'utilité puisqu'on n'a pas de vraie pagination, et qui ne fonctionne pas quand on a plusieurs statuts.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
