### PR TITLE
[DRAFT] Ncanseco/bsr cypress automatic link venue with bank account

### DIFF
--- a/pro/cypress/e2e/features/financialManagement.feature
+++ b/pro/cypress/e2e/features/financialManagement.feature
@@ -1,20 +1,20 @@
 @P0
 Feature: Financial Management
 
-  # Scenario: Check messages, reimbursement details and offerer selection change
-  #   Given I am logged in with the new interface
-  #   When I go to the "Gestion financière" page
-  #   Then I can see information message about reimbursement
-  #   And I can see a link to the next reimbursement help page
-  #   And I can see a link to the terms and conditions of reimbursement help page
-  #   When I select offerer "1 - [CB] Structure avec des coordonnées bancaires dans différents états"
-  #   Then No receipt results should be displayed
-  #   When I select offerer "0 - Structure avec justificatif et compte bancaire"
-  #   Then These receipt results should be displayed
-  #     | Date du justificatif | Type de document | Compte bancaire | N° de virement                        | Montant remboursé | Actions |
-  #     |                      |                  | Remboursement   | Libellé des coordonnées bancaires n°0 | VIR1              |         |
-  #   When I download reimbursement details
-  #   Then I can see the reimbursement details
+  Scenario: Check messages, reimbursement details and offerer selection change
+    Given I am logged in with the new interface
+    When I go to the "Gestion financière" page
+    Then I can see information message about reimbursement
+    And I can see a link to the next reimbursement help page
+    And I can see a link to the terms and conditions of reimbursement help page
+    When I select offerer "1 - [CB] Structure avec des coordonnées bancaires dans différents états"
+    Then No receipt results should be displayed
+    When I select offerer "0 - Structure avec justificatif et compte bancaire"
+    Then These receipt results should be displayed
+      | Date du justificatif | Type de document | Compte bancaire | N° de virement                        | Montant remboursé | Actions |
+      |                      |                  | Remboursement   | Libellé des coordonnées bancaires n°0 | VIR1              |         |
+    When I download reimbursement details
+    Then I can see the reimbursement details
 
   # Scenario: I can download accounting receipt as pdf
   #   Then I can download accounting receipt as pdf

--- a/pro/cypress/e2e/features/financialManagement.feature
+++ b/pro/cypress/e2e/features/financialManagement.feature
@@ -1,19 +1,29 @@
 @P0
-Feature: Financial Management - messages, links to external help page, reimbursement details
+Feature: Financial Management
 
-  Scenario: Check messages, reimbursement details and offerer selection change
-    Given I am logged in with the new interface
-    When I go to the "Gestion financière" page
-    Then I can see information message about reimbursement
-    And I can see a link to the next reimbursement help page
-    And I can see a link to the terms and conditions of reimbursement help page
-    When I select offerer "1 - [CB] Structure avec des coordonnées bancaires dans différents états"
-    Then No receipt results should be displayed
-    When I select offerer "0 - Structure avec justificatif et compte bancaire"
-    Then These receipt results should be displayed
-      | Date du justificatif | Type de document | Compte bancaire | N° de virement                        | Montant remboursé | Actions |
-      |                      |                  | Remboursement   | Libellé des coordonnées bancaires n°0 | VIR1              |         |
-    When I download reimbursement details
-    Then I can see the reimbursement details
+  # Scenario: Check messages, reimbursement details and offerer selection change
+  #   Given I am logged in with the new interface
+  #   When I go to the "Gestion financière" page
+  #   Then I can see information message about reimbursement
+  #   And I can see a link to the next reimbursement help page
+  #   And I can see a link to the terms and conditions of reimbursement help page
+  #   When I select offerer "1 - [CB] Structure avec des coordonnées bancaires dans différents états"
+  #   Then No receipt results should be displayed
+  #   When I select offerer "0 - Structure avec justificatif et compte bancaire"
+  #   Then These receipt results should be displayed
+  #     | Date du justificatif | Type de document | Compte bancaire | N° de virement                        | Montant remboursé | Actions |
+  #     |                      |                  | Remboursement   | Libellé des coordonnées bancaires n°0 | VIR1              |         |
+  #   When I download reimbursement details
+  #   Then I can see the reimbursement details
+
   # Scenario: I can download accounting receipt as pdf
   #   Then I can download accounting receipt as pdf
+
+  Scenario: Automatic link venue with bank account
+    Given I am logged in
+    And I go to the "Gestion financière" page
+    And I go to "Informations bancaires" view
+    When I remove "Terrain vague" venue from my bank account
+    Then no venue should be linked to my account
+    When I add "Terrain vague" venue to my bank account
+    Then "Terrain vague" venue should be linked to my account

--- a/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
+++ b/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
@@ -34,6 +34,10 @@ Given('I am logged in with the new interface', () => {
   cy.findAllByTestId('spinner').should('not.exist')
 })
 
+Given('I go to {string} view', (tab: string) => {
+  cy.findByText(tab).click()
+})
+
 // créer un seul scénario createOffers avec son step-def
 When('I want to create {string} offer', (offerType: string) => {
   cy.findByText('Au grand public').click()

--- a/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
+++ b/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
@@ -14,6 +14,40 @@ When('I download reimbursement details', () => {
 //   })
 // })
 
+When('I remove {string} venue from my bank account', (venue: string) => {
+  cy.get('[class^=_linked-venues-section_]').within(() => {
+    cy.contains("Lieu(x) rattaché(s) à ce compte bancaire")
+    cy.contains("Certains de vos lieux ne sont pas rattachés.")
+    cy.contains(venue)
+
+    cy.findByText("Modifier").click()
+  })
+
+  cy.findByRole("dialog").within(() => {
+    cy.findByLabelText(venue).should('be.checked')
+    cy.findByLabelText(venue).uncheck()
+
+    cy.findByText("Enregistrer").click()
+    cy.findByText("Confirmer").click()  
+  })
+})
+
+When('I add {string} venue to my bank account', (venue: string) => {
+  cy.get('[class^=_linked-venues-section_]').within(() => {
+    cy.contains("Aucun lieu n’est rattaché à ce compte bancaire.")
+
+    cy.findByText("Rattacher un lieu").click()
+  })
+
+  cy.findByRole("dialog").within(() => {
+    cy.findByLabelText(venue).should('not.be.checked')
+    cy.findByLabelText(venue).check()
+
+    cy.findByText("Enregistrer").click()
+    //cy.findByText("Confirmer").click()  
+  })
+})
+
 Then('I can see the reimbursement details', () => {
   const filename = `${Cypress.config('downloadsFolder')}/remboursements_pass_culture.csv`
 
@@ -108,4 +142,19 @@ Then('No receipt results should be displayed', () => {
   cy.contains(
     'Vous n’avez pas encore de justificatifs de remboursement disponibles'
   )
+})
+
+Then('no venue should be linked to my account', () => {
+  cy.findAllByTestId('global-notification-success').should(
+    'contain',
+    'Vos modifications ont bien été prises en compte.'
+  )  
+})
+
+Then('{string} venue should be linked to my account', (venue: string) => {
+  cy.get('[class^=_linked-venues-section_]').within(() => {
+    cy.contains("Lieu(x) rattaché(s) à ce compte bancaire")
+    cy.contains("Certains de vos lieux ne sont pas rattachés.")
+    cy.contains(venue)
+  })
 })

--- a/pro/cypress/e2e/step-definitions/searchCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/searchCollectiveOffer.cy.ts
@@ -1,9 +1,5 @@
 import { Given, When } from '@badeball/cypress-cucumber-preprocessor'
 
-Given('I go to {string} view', (tab: string) => {
-  cy.findByText(tab).click()
-})
-
 Given('I go to Offres collectives view', () => {
   cy.intercept({ method: 'GET', url: '/collective/offers*', times: 1 }).as(
     'collectiveOffers'


### PR DESCRIPTION
## But de la pull request

Couvre la ligne 263 du référentiel de tests.

Comme sur le compte de test (retention_structures@example.com) on avait déjà un lieu rattaché et pas d'autre lieu physique dispo, il a fallu une étape pour "détacher" le lieu du compte pour pouvoir ensuite tester le rattachement. Donc ce test est flaky par design : le compte de test peut se retrouver dans un état mal géré si il échoue en cours de route, 
et échouer au retry par exemple. A voir si on peut l'améliorer par la suite.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
