### PR TITLE
Pc 31428 suppression font-legacy extra-bold

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscoveryBanner/AdageDiscoveryBanner.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscoveryBanner/AdageDiscoveryBanner.module.scss
@@ -10,11 +10,10 @@
   position: relative;
 
   &-title {
-    @include fonts.extra-bold;
+    @include fonts.title1;
 
     margin: 0;
     color: var(--color-white);
-    font-size: rem.torem(24px);
     text-align: center;
     line-height: normal;
     position: relative;
@@ -57,8 +56,6 @@
 @media (min-width: size.$tablet) {
   .discovery-banner {
     &-title {
-      font-size: rem.torem(32px);
-
       &-highlight {
         padding: rem.torem(4px);
       }

--- a/pro/src/pages/Home/WelcomeToTheNewBetaBanner/WelcomeToTheNewBetaBanner.module.scss
+++ b/pro/src/pages/Home/WelcomeToTheNewBetaBanner/WelcomeToTheNewBetaBanner.module.scss
@@ -7,7 +7,6 @@
 
   &-title {
     @include fonts.title3;
-    @include fonts.extra-bold;
 
     margin-top: rem.torem(62px);
   }

--- a/pro/src/styles/mixins/_fonts-legacy.scss
+++ b/pro/src/styles/mixins/_fonts-legacy.scss
@@ -1,10 +1,5 @@
 //  Legacy fonts to cover the typos weights and styles that do not fit in the new design system
 //  These should be progresively replaced with DS fonts
-@mixin extra-bold {
-  font-family: Montserrat-ExtraBold, system-ui, sans-serif;
-  font-weight: 800;
-  font-style: normal;
-}
 
 @mixin bold() {
   font-family: Montserrat-Bold, system-ui, sans-serif;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31428

**Objectif**
Remplacer les fonts "extra-bold" sauvages par des typos de titres normales.
Vu avec Marion pour le dialog de bienvenue, et avec Agathe pour la bannière d'ADAGE.

avant/après
<img width="969" alt="adage-banner-avant" src="https://github.com/user-attachments/assets/b0e27255-7073-467b-9be6-aa7e5a29419c">
<img width="979" alt="adage-banner-apres" src="https://github.com/user-attachments/assets/0d47e7be-7109-48a6-8ac0-c5f930633eec">

avant/après
<img width="654" alt="welcome-avant" src="https://github.com/user-attachments/assets/a0d91254-790a-48d2-93ed-79d0e9f61788">
<img width="653" alt="welcome-après" src="https://github.com/user-attachments/assets/db018ac4-eef9-4014-b421-3794c3d0d916">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
