### PR TITLE
(PC-30914)[PRO] feat: make individual offer creation stepper dynamic regarding subcat (goods vs event)

### DIFF
--- a/pro/src/components/IndividualOfferNavigation/IndividualOfferNavigation.tsx
+++ b/pro/src/components/IndividualOfferNavigation/IndividualOfferNavigation.tsx
@@ -20,7 +20,7 @@ import { LabelBooking } from './LabelBooking/LabelBooking'
 
 export const IndividualOfferNavigation = () => {
   const isSplitOfferEnabled = useActiveFeature('WIP_SPLIT_OFFER')
-  const { offer } = useIndividualOfferContext()
+  const { offer, isEvent: isEventOfferContext } = useIndividualOfferContext()
   const activeStep = useActiveStep(Object.values(OFFER_WIZARD_STEP_IDS))
   const mode = useOfferWizardMode()
   const hasOffer = offer !== null
@@ -32,7 +32,8 @@ export const IndividualOfferNavigation = () => {
   const queryOfferType = queryParams.get('offer-type')
 
   const offerSubtype = getOfferSubtypeFromParam(queryOfferType)
-  const isEvent = offer?.isEvent || isOfferSubtypeEvent(offerSubtype)
+  const isEvent =
+    isEventOfferContext || offer?.isEvent || isOfferSubtypeEvent(offerSubtype)
 
   const steps: StepPattern[] = []
 

--- a/pro/src/context/IndividualOfferContext/IndividualOfferContext.tsx
+++ b/pro/src/context/IndividualOfferContext/IndividualOfferContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react'
+import React, { createContext, useContext, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import useSWR from 'swr'
 
@@ -18,6 +18,8 @@ export interface IndividualOfferContextValues {
   offer: GetIndividualOfferWithAddressResponseModel | null
   categories: CategoryResponseModel[]
   subCategories: SubcategoryResponseModel[]
+  isEvent: boolean | null
+  setIsEvent: (isEvent: boolean | null) => void
 }
 
 export const IndividualOfferContext =
@@ -25,6 +27,8 @@ export const IndividualOfferContext =
     offer: null,
     categories: [],
     subCategories: [],
+    isEvent: null,
+    setIsEvent: () => {},
   })
 
 export const useIndividualOfferContext = () => {
@@ -38,6 +42,7 @@ interface IndividualOfferContextProviderProps {
 export const IndividualOfferContextProvider = ({
   children,
 }: IndividualOfferContextProviderProps) => {
+  const [isEvent, setIsEvent] = useState<boolean | null>(null)
   const { offerId } = useParams<{
     offerId: string
   }>()
@@ -64,8 +69,10 @@ export const IndividualOfferContextProvider = ({
     <IndividualOfferContext.Provider
       value={{
         offer: offer ?? null,
+        isEvent,
         categories: categoriesQuery.data.categories,
         subCategories: categoriesQuery.data.subcategories,
+        setIsEvent,
       }}
     >
       {children}

--- a/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.spec.tsx
@@ -79,6 +79,8 @@ const contextValue: IndividualOfferContextValues = {
   categories: [],
   subCategories: SUB_CATEGORIES,
   offer: null,
+  isEvent: null,
+  setIsEvent: vi.fn(),
 }
 const SuggestedSubWrappedWithFormik = (
   props: SuggestedSubcategoriesProps

--- a/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.tsx
@@ -34,7 +34,7 @@ export function SuggestedSubcategories({
 }: SuggestedSubcategoriesProps) {
   const [prevSelectedSubCategory, setPrevSelectedFromPrevSuggestions] =
     useState<string | null>(null)
-  const { subCategories } = useIndividualOfferContext()
+  const { subCategories, setIsEvent } = useIndividualOfferContext()
   const {
     values: {
       categoryId,
@@ -88,6 +88,7 @@ export function SuggestedSubcategories({
         subcategories: subCategories,
         setFieldValue,
         subcategoryConditionalFields,
+        setIsEvent,
       })
     } else {
       const { categoryId, subcategoryId } = DEFAULT_DETAILS_FORM_VALUES
@@ -170,6 +171,7 @@ export function SuggestedSubcategories({
                   setFieldValue,
                   onSubcategoryChange,
                   subcategoryConditionalFields,
+                  setIsEvent,
                 })
                 handleChange(event)
               }}
@@ -193,6 +195,7 @@ export function SuggestedSubcategories({
                     subcategories: filteredSubcategories,
                     setFieldValue,
                     subcategoryConditionalFields,
+                    setIsEvent,
                   })
                   handleChange(event)
                 }}

--- a/pro/src/screens/IndividualOffer/DetailsScreen/utils.ts
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/utils.ts
@@ -86,6 +86,7 @@ type OnCategoryChangeProps = {
   ) => Promise<void | FormikErrors<DetailsFormValues>>
   onSubcategoryChange: (p: OnSubcategoryChangeProps) => Promise<void>
   subcategoryConditionalFields: string[]
+  setIsEvent?: (isEvent: boolean | null) => void
 }
 
 export const onCategoryChange = async ({
@@ -95,6 +96,7 @@ export const onCategoryChange = async ({
   setFieldValue,
   onSubcategoryChange,
   subcategoryConditionalFields,
+  setIsEvent,
 }: OnCategoryChangeProps) => {
   if (readOnlyFields.includes('subcategoryId')) {
     return
@@ -113,6 +115,7 @@ export const onCategoryChange = async ({
     subcategories,
     setFieldValue,
     subcategoryConditionalFields,
+    setIsEvent,
   })
 }
 
@@ -125,6 +128,7 @@ type OnSubcategoryChangeProps = {
     shouldValidate?: boolean | undefined
   ) => Promise<void | FormikErrors<DetailsFormValues>>
   subcategoryConditionalFields: string[]
+  setIsEvent?: (isEvent: boolean | null) => void
 }
 
 export const onSubcategoryChange = async ({
@@ -132,10 +136,15 @@ export const onSubcategoryChange = async ({
   subcategories,
   setFieldValue,
   subcategoryConditionalFields,
+  setIsEvent,
 }: OnSubcategoryChangeProps) => {
   const newSubcategory = subcategories.find(
     (subcategory) => subcategory.id === newSubCategoryId
   )
+
+  if (setIsEvent) {
+    setIsEvent(newSubcategory?.isEvent ?? null)
+  }
 
   const { subcategoryConditionalFields: newSubcategoryConditionalFields } =
     buildSubcategoryConditonalFields(newSubcategory)

--- a/pro/src/utils/individualApiFactories.ts
+++ b/pro/src/utils/individualApiFactories.ts
@@ -181,6 +181,8 @@ export const individualOfferContextValuesFactory = (
     offer,
     categories: [],
     subCategories: [],
+    isEvent: null,
+    setIsEvent: () => {},
     ...customIndividualOfferContextValues,
   }
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30914

## Descriptif des modifications.
- Sur la sélection des sous-catégories (suggéré ou sélectionné à postériori via "Autre"), le stepper change en fonction du type d'offre (good vs event). 
N.B: Bien vérifier que l'url en comporte pas de `?offer-type=`, puisque cela correspond à l'ancien parcours (voir a/b testing à mettre en place).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
