### PR TITLE
(PC-31438)[PRO] Corrections a11y

### DIFF
--- a/pro/src/components/IndividualOfferForm/Informations/Informations.tsx
+++ b/pro/src/components/IndividualOfferForm/Informations/Informations.tsx
@@ -41,7 +41,6 @@ export const Informations = ({
       </FormLayout.Row>
       <FormLayout.Row>
         <TextArea
-          countCharacters
           isOptional
           label="Description"
           maxLength={1000}

--- a/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
+++ b/pro/src/components/IndividualOfferForm/UsefulInformations/UsefulInformations.tsx
@@ -91,7 +91,6 @@ export const UsefulInformations = ({
         }
       >
         <TextArea
-          countCharacters
           isOptional
           label={'Informations de retrait'}
           name="withdrawalDetails"

--- a/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.tsx
+++ b/pro/src/components/NewNavReview/NewNavReviewDialog/NewNavReviewDialog.tsx
@@ -134,7 +134,6 @@ export const NewNavReviewDialog = () => {
                 'Souhaitez-vous préciser ? Nous lisons tous les commentaires. 🙂'
               }
               maxLength={500}
-              countCharacters
               isOptional
             />
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/DefaultFormContact.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/DefaultFormContact.tsx
@@ -65,7 +65,6 @@ export const DefaultFormContact = ({
           </div>
           <FormLayout.Row>
             <TextArea
-              countCharacters
               label="Que souhaitez vous organiser ?"
               maxLength={1000}
               name="description"

--- a/pro/src/pages/LostPassword/ChangePasswordRequestForm/ChangePasswordRequestForm.tsx
+++ b/pro/src/pages/LostPassword/ChangePasswordRequestForm/ChangePasswordRequestForm.tsx
@@ -27,6 +27,7 @@ export const ChangePasswordRequestForm = (): JSX.Element => {
               name="email"
               description="Format : email@exemple.com"
               label="Adresse email"
+              showMandatoryAsterisk={false}
             />
           </FormLayout.Row>
           <FormLayout.Row>

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
@@ -125,7 +125,6 @@ export const CollectiveDataForm = ({
                     label="Démarche d’éducation artistique et culturelle"
                     description="Présenter la démarche d’éducation artistique et culturelle : présentation du lieu, actions menées auprès du public scolaire..."
                     maxLength={500}
-                    countCharacters
                     isOptional
                   />
                 </FormLayout.Row>

--- a/pro/src/pages/VenueCreation/SiretOrCommentFields/SiretOrCommentFields.tsx
+++ b/pro/src/pages/VenueCreation/SiretOrCommentFields/SiretOrCommentFields.tsx
@@ -129,7 +129,6 @@ export const SiretOrCommentFields = ({
           description="Par exemple : le lieu est un équipement culturel qui n’appartient pas à ma structure."
           isOptional={isSiretSelected}
           maxLength={500}
-          countCharacters
           rows={6}
         />
       )}

--- a/pro/src/pages/VenueCreation/WithdrawalDetails/WithdrawalDetails.tsx
+++ b/pro/src/pages/VenueCreation/WithdrawalDetails/WithdrawalDetails.tsx
@@ -29,7 +29,6 @@ export const WithdrawalDetails = () => {
           label="Informations de retrait"
           maxLength={500}
           description="Par exemple : une autre adresse, un horaire d’accès, un délai de retrait, un guichet spécifique, un code d’accès, une communication par email..."
-          countCharacters
           isOptional
         />
       </FormLayout.Row>

--- a/pro/src/pages/VenueEdition/VenueEditionForm.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionForm.tsx
@@ -124,7 +124,6 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
                   label="Description"
                   description="Par exemple : mon établissement propose des spectacles, de l’improvisation..."
                   maxLength={1000}
-                  countCharacters
                   isOptional
                 />
               </FormLayout.Row>

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
@@ -140,6 +140,7 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
                 placeholder="Rechercher une offre vitrine"
                 className={styles['search-input']}
                 aria-labelledby="search-filter"
+                isOptional
               />
               <Button
                 type="submit"
@@ -160,6 +161,9 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
                     {showAll
                       ? 'Les dernières offres vitrines créées'
                       : `${pluralize(offers.length, 'offre')} vitrine`}
+                  </p>
+                  <p className="visually-hidden" role="status">
+                    {pluralize(offers.length, 'offre vitrine trouvée')}
                   </p>
                 </legend>
 

--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
@@ -190,7 +190,6 @@ export const DetailsForm = ({
         </FormLayout.Row>
         <FormLayout.Row>
           <TextArea
-            countCharacters
             isOptional
             label="Description"
             maxLength={1000}

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationForm.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationForm.tsx
@@ -196,7 +196,6 @@ export const UsefulInformationForm = ({
           }
         >
           <TextArea
-            countCharacters
             isOptional
             label={'Informations de retrait'}
             name="withdrawalDetails"

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -117,7 +117,6 @@ export const FormOfferType = ({
           }
         >
           <TextArea
-            countCharacters
             label={DESCRIPTION_LABEL}
             maxLength={MAX_DETAILS_LENGTH}
             name="description"

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
@@ -200,7 +200,6 @@ export const FormPracticalInformation = ({
       {values.eventAddress.addressType === OfferAddressType.OTHER && (
         <FormLayout.Row>
           <TextArea
-            countCharacters
             label={EVENT_ADDRESS_OTHER_ADDRESS_LABEL}
             maxLength={200}
             name="eventAddress.otherAddress"

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormPriceDetails/FormPriceDetails.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormPriceDetails/FormPriceDetails.tsx
@@ -17,7 +17,6 @@ export const FormPriceDetails = ({ disableForm }: FormPriceDetailsProps) => {
       <FormLayout.Row>
         <TextArea
           className={styles['price-details']}
-          countCharacters
           disabled={disableForm}
           isOptional
           label={PRICE_INFORMATION}

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -182,7 +182,6 @@ export const OfferEducationalStock = <
               <FormLayout.Row>
                 <TextArea
                   className={styles['price-details']}
-                  countCharacters
                   disabled={disablePriceAndParticipantInputs}
                   label={DETAILS_PRICE_LABEL}
                   maxLength={MAX_DETAILS_LENGTH}

--- a/pro/src/ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput.tsx
+++ b/pro/src/ui-kit/form/EmailSpellCheckInput/EmailSpellCheckInput.tsx
@@ -19,6 +19,7 @@ type EmailSpellCheckInputProps<FormType> = FieldLayoutBaseProps & {
   label: string
   overrideInitialTip?: string | null
   maxLength?: number
+  showMandatoryAsterisk?: boolean
 }
 
 export const EmailSpellCheckInput = <FormType,>({
@@ -29,6 +30,7 @@ export const EmailSpellCheckInput = <FormType,>({
   className,
   overrideInitialTip = null,
   maxLength = 255,
+  showMandatoryAsterisk,
 }: EmailSpellCheckInputProps<FormType>): JSX.Element => {
   const { setFieldValue, setFieldTouched } = useFormikContext<FormType>()
   const [field, meta] = useField<string>(name)
@@ -70,6 +72,7 @@ export const EmailSpellCheckInput = <FormType,>({
         autoComplete="email"
         className={className}
         maxLength={maxLength}
+        showMandatoryAsterisk={showMandatoryAsterisk}
         ErrorDetails={
           emailValidationTip ? (
             <div className={styles['email-validation-error']}>

--- a/pro/src/ui-kit/form/TextArea/TextArea.tsx
+++ b/pro/src/ui-kit/form/TextArea/TextArea.tsx
@@ -12,7 +12,6 @@ import styles from './TextArea.module.scss'
 type TextAreaProps = React.InputHTMLAttributes<HTMLTextAreaElement> &
   FieldLayoutBaseProps & {
     rows?: number
-    countCharacters?: boolean
     maxLength?: number
   }
 
@@ -24,7 +23,6 @@ export const TextArea = ({
   placeholder,
   label,
   maxLength = 1000,
-  countCharacters,
   isOptional,
   smallLabel,
   rows = 7,
@@ -49,10 +47,16 @@ export const TextArea = ({
     updateTextAreaHeight()
   }, [])
 
+  const describedBy = [`field-characters-count-description-${name}`]
+
+  if (description) {
+    describedBy.unshift(`description-${name}`)
+  }
+
   return (
     <FieldLayout
       className={className}
-      count={countCharacters ? field.value?.length : undefined}
+      count={field.value?.length}
       error={meta.error}
       isOptional={isOptional}
       label={label}
@@ -64,7 +68,7 @@ export const TextArea = ({
     >
       <textarea
         aria-invalid={meta.touched && !!meta.error}
-        {...(description ? { 'aria-describedby': `description-${name}` } : {})}
+        aria-describedby={describedBy.join(' ')}
         className={cn(styles['text-area'], {
           [styles['has-error']]: meta.touched && !!meta.error,
         })}

--- a/pro/src/ui-kit/form/TextArea/__specs__/TextArea.spec.tsx
+++ b/pro/src/ui-kit/form/TextArea/__specs__/TextArea.spec.tsx
@@ -26,6 +26,6 @@ describe('TextArea', () => {
     expect(description).toHaveTextContent(descriptionContent)
 
     const input = screen.getByRole('textbox', { name: inputLabel })
-    expect(input.getAttribute('aria-describedby')).toBe(descriptionId)
+    expect(input.getAttribute('aria-describedby')).toContain(descriptionId)
   })
 })

--- a/pro/src/ui-kit/form/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/form/TextInput/TextInput.tsx
@@ -67,6 +67,16 @@ export const TextInput = ({
   const regexIsNavigationKey = /Tab|Backspace|Enter/
   const showError = meta.touched && !!meta.error
 
+  const describedBy = []
+
+  if (description) {
+    describedBy.push(`description-${name}`)
+  }
+
+  if (countCharacters) {
+    describedBy.push(`field-characters-count-description-${name}`)
+  }
+
   return (
     <FieldLayout
       className={className}
@@ -112,9 +122,7 @@ export const TextInput = ({
           rightIcon={rightIcon}
           leftIcon={leftIcon}
           aria-required={!isOptional}
-          {...(description
-            ? { 'aria-describedby': `description-${name}` }
-            : {})}
+          aria-describedby={describedBy.join(' ') || undefined}
           onKeyDown={(event) => {
             if (type === 'number') {
               if (regexIsNavigationKey.test(event.key)) {

--- a/pro/src/ui-kit/form/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/form/TextInput/TextInput.tsx
@@ -22,6 +22,7 @@ type TextInputProps = React.InputHTMLAttributes<HTMLInputElement> &
     refForInput?: ForwardedRef<HTMLInputElement>
     ErrorDetails?: React.ReactNode
     maxLength?: number
+    showMandatoryAsterisk?: boolean
   }
 
 export const TextInput = ({
@@ -52,6 +53,7 @@ export const TextInput = ({
   clearButtonProps,
   hasLabelLineBreak = true,
   ErrorDetails,
+  showMandatoryAsterisk,
   ...props
 }: TextInputProps): JSX.Element => {
   const [field, meta] = useField({
@@ -74,6 +76,7 @@ export const TextInput = ({
       count={countCharacters ? field.value.length : undefined}
       error={meta.error}
       isOptional={isOptional}
+      showMandatoryAsterisk={showMandatoryAsterisk}
       label={label}
       isLabelHidden={isLabelHidden}
       maxLength={maxLength}

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
@@ -60,14 +60,6 @@
     }
   }
 
-  &-counter {
-    @include fonts.caption;
-
-    color: var(--color-grey-dark);
-    flex: initial;
-    justify-self: flex-end;
-  }
-
   &-input-description {
     @include fonts.caption;
 

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.tsx
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.tsx
@@ -8,6 +8,7 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 import { FieldError } from '../FieldError/FieldError'
 
 import styles from './FieldLayout.module.scss'
+import { FieldLayoutCharacterCount } from './FieldLayoutCharacterCount/FieldLayoutCharacterCount'
 
 export type FieldLayoutBaseProps = {
   // These props are display options that are applicable to all fields using FieldLayout
@@ -145,13 +146,11 @@ export const FieldLayout = ({
               )}
             </div>
             {hasCounter && (
-              <span
-                className={styles['field-layout-counter']}
-                data-testid={`counter-${name}`}
-                role="status"
-              >
-                {count}/{maxLength}
-              </span>
+              <FieldLayoutCharacterCount
+                count={count}
+                maxLength={maxLength}
+                name={name}
+              />
             )}
           </div>
         )}

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.tsx
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.tsx
@@ -18,6 +18,7 @@ export type FieldLayoutBaseProps = {
   isLabelHidden?: boolean
   hasLabelLineBreak?: boolean
   isOptional?: boolean
+  showMandatoryAsterisk?: boolean
   className?: string
   classNameLabel?: string
   classNameFooter?: string
@@ -53,6 +54,7 @@ export const FieldLayout = ({
   count = undefined,
   maxLength = undefined,
   isOptional = false,
+  showMandatoryAsterisk = true, //  Can be false only when it's the only field in a form and it's mandatory
   smallLabel,
   hideFooter = false,
   inline = false,
@@ -95,7 +97,7 @@ export const FieldLayout = ({
           )}
           htmlFor={name}
         >
-          {label} {!isOptional && '*'}
+          {label} {!isOptional && showMandatoryAsterisk && '*'}
         </label>
         {description && (
           <span

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.module.scss
@@ -1,0 +1,7 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.field-layout-character-count {
+  @include fonts.caption;
+
+  color: var(--color-grey-dark);
+}

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.spec.tsx
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.spec.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+
+import {
+  FieldLayoutCharacterCount,
+  FieldLayoutCharacterCountProps,
+} from './FieldLayoutCharacterCount'
+
+describe('FieldLayoutCharacterCount', () => {
+  const props: FieldLayoutCharacterCountProps = {
+    count: 10,
+    maxLength: 100,
+    name: 'field',
+  }
+  it('should show the count of characters typed', () => {
+    render(<FieldLayoutCharacterCount {...props} />)
+
+    expect(screen.getByText('10/100')).toBeInTheDocument()
+  })
+
+  it('should have a count of characters for assistive technologies taht is visually hidden', () => {
+    render(<FieldLayoutCharacterCount {...props} />)
+
+    const counter = screen.getByText('10 caractères sur 100')
+    expect(counter).toBeInTheDocument()
+    expect(counter).toHaveClass('visually-hidden')
+  })
+
+  it('should delay the change of the count for the hidden counter', () => {
+    const { rerender } = render(<FieldLayoutCharacterCount {...props} />)
+    expect(screen.getByText('10/100')).toBeInTheDocument()
+    expect(screen.getByText('10 caractères sur 100')).toBeInTheDocument()
+
+    rerender(<FieldLayoutCharacterCount {...props} count={11} />)
+
+    expect(screen.getByText('11/100')).toBeInTheDocument()
+    expect(screen.getByText('10 caractères sur 100')).toBeInTheDocument()
+  })
+})

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.tsx
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.tsx
@@ -1,0 +1,34 @@
+import { useDebounce } from 'use-debounce'
+
+import styles from './FieldLayoutCharacterCount.module.scss'
+
+export type FieldLayoutCharacterCountProps = {
+  count: number
+  maxLength: number
+  name: string
+}
+
+export function FieldLayoutCharacterCount({
+  count,
+  maxLength,
+  name,
+}: FieldLayoutCharacterCountProps) {
+  //  The real counter would be announced by assistive technologies after each character typed.
+  //  Therefore, we need a debounced counter that only changes when the user stops typing.
+  const [debouncedCount] = useDebounce(count, 1000)
+
+  return (
+    <>
+      <span role="status" className="visually-hidden">
+        {debouncedCount} caractères sur {maxLength}
+      </span>
+      <span
+        className={styles['field-layout-character-count']}
+        data-testid={`counter-${name}`}
+        aria-hidden
+      >
+        {count}/{maxLength}
+      </span>
+    </>
+  )
+}

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.tsx
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.tsx
@@ -19,7 +19,11 @@ export function FieldLayoutCharacterCount({
 
   return (
     <>
-      <span role="status" className="visually-hidden">
+      <span
+        role="status"
+        className="visually-hidden"
+        id={`field-characters-count-${name}`}
+      >
         {debouncedCount} caractères sur {maxLength}
       </span>
       <span


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31438

**Objectif**
1er commit : Ne pas afficher l'astérisque dans le form mdp oublié (et autoriser à ne pas l'afficher quand le formulaire ne contient qu'un champ, et qu'il est obligatoire).
2e commit : Ajouter un faux compteur de caractères aux champs de texte pour que les technos d'assistance n'annoncent pas le texte tapé après chaque changement.
3e commit : Rendre le champ de recherche de la création d'offre collective réservable à partir d'une offre vitrine optionnel (sinon on a un astérisque qui est lu aux technos d'assistance sans explications sur la signification). Et au passage, ajout d'une annonce pour le compte d'offres trouvées dans la recherche.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
