### PR TITLE
(BSR)[API] perf: reduce memory allocation when sampling staging offers to index

### DIFF
--- a/api/src/pcapi/core/search/staging_indexation.py
+++ b/api/src/pcapi/core/search/staging_indexation.py
@@ -24,9 +24,9 @@ def get_relevant_offers_to_index() -> set[int]:
 
 
 def get_offers_for_each_subcategory(size_per_subcategory: int) -> set[int]:
-    query = offers_models.Offer.query.join(offers_models.Stock).filter(False).with_entities(offers_models.Offer.id)
+    result = set()
     for subcategory in ALL_SUBCATEGORIES:
-        query = query.union(
+        query = (
             offers_models.Offer.query.join(offers_models.Stock)
             .join(offerer_models.Venue)
             .join(offerer_models.Offerer)
@@ -37,9 +37,8 @@ def get_offers_for_each_subcategory(size_per_subcategory: int) -> set[int]:
             .with_entities(offers_models.Offer.id)
             .limit(size_per_subcategory)
         )
-
-    with log_elapsed(logger, "offers for each categories"):
-        result = {offer_id for offer_id, in query}
+        with log_elapsed(logger, f"offers for subcategory {subcategory.id}"):
+            result.update({offer_id for offer_id, in query})
     return result
 
 
@@ -59,9 +58,9 @@ def get_offers_with_gtl(size: int) -> set[int]:
 
 
 def get_offers_for_each_gtl_level_1(size_per_gtl: int) -> set[int]:
-    query = offers_models.Offer.query.join(offers_models.Stock).filter(False).with_entities(offers_models.Offer.id)
+    result = set()
     for i in range(1, 14):
-        query = query.union(
+        query = (
             offers_models.Offer.query.join(offers_models.Stock)
             .filter(
                 offers_models.Offer.extraData["gtl_id"].astext.startswith(str(i).zfill(2)),
@@ -70,8 +69,8 @@ def get_offers_for_each_gtl_level_1(size_per_gtl: int) -> set[int]:
             .with_entities(offers_models.Offer.id)
             .limit(size_per_gtl)
         )
-    with log_elapsed(logger, "offers for each GTL level 1"):
-        result = {offer_id for offer_id, in query}
+        with log_elapsed(logger, "offers for each GTL level 1"):
+            result.update({offer_id for offer_id, in query})
     return result
 
 


### PR DESCRIPTION
## But de la pull request

Améliorer la mémoire allouée lors des queries
La PR divise par 10 la mémoire nécessaire pour la même opération, en n'augmentant que peu le temps d'exécution (quelques secondes)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
