### PR TITLE
(BSR)[PRO] test: check cookie selection not linked to account

### DIFF
--- a/pro/cypress/e2e/features/collectiveBooking.feature
+++ b/pro/cypress/e2e/features/collectiveBooking.feature
@@ -2,7 +2,7 @@
 Feature: Search for collective bookings
 
   Background:
-    Given I am logged in
+    Given I am logged in with account 1
     And I select offerer "eac_2_lieu [BON EAC]"
     And I open the "reservations/collectives" page
 

--- a/pro/cypress/e2e/features/cookieBanner.feature
+++ b/pro/cypress/e2e/features/cookieBanner.feature
@@ -1,16 +1,15 @@
 @P0
 Feature: Cookie management
 
-  Background:
-    Given I open the "connexion" page
-
   Scenario: The cookie banner should remain displayed when opening a new page
+    Given I open the "connexion" page
     When I decline all cookies
     And I clear all cookies in Browser
     And I click on the "Accessibilité : non conforme" link
     Then The cookie banner should be displayed
 
   Scenario: The user can accept all, and all the cookies are checked in the dialog
+    Given I open the "connexion" page
     Then The cookie banner should be displayed
     When I accept all cookies
     Then The cookie banner should not be displayed
@@ -18,12 +17,14 @@ Feature: Cookie management
     Then I should have 4 items checked
 
   Scenario: The user can refuse all, and no cookie is checked in the dialog, except the required
+    Given I open the "connexion" page
     When I decline all cookies
     Then The cookie banner should not be displayed
     When I open the cookie management option
     Then I should have 1 items checked
 
   Scenario: The user can choose a specific cookie, save and the status should be the same on modal re display
+    Given I open the "connexion" page
     When I open the choose cookies option
     And I select the "Beamer" cookie
     And I save my choices
@@ -31,6 +32,7 @@ Feature: Cookie management
     Then The Beamer cookie should be checked
 
   Scenario: The user can choose a specific cookie, reload the page and the status should not have been changed
+    Given I open the "connexion" page
     When I open the choose cookies option
     And I select the "Beamer" cookie
     And I open the "connexion" page
@@ -38,8 +40,34 @@ Feature: Cookie management
     Then The Beamer cookie should not be checked
 
   Scenario: The user can choose a specific cookie, close the modal and the status should not have been changed
+    Given I open the "connexion" page
     When I open the choose cookies option
     And I select the "Beamer" cookie
     And I close the cookie option
     And I open the choose cookies option
     Then The Beamer cookie should be checked
+
+  Scenario: The user can choose a specific cookie, log in with another account and check that specific cookie is checked
+    Given I clear all cookies in Browser
+    And I am logged in with account 1
+    When I open the cookie management option
+    And I select the "Beamer" cookie
+    And I save my choices
+    When I disconnect of my account
+    And I am logged in with account 2 and no cookie selection
+    And I open the cookie management option
+    Then The Beamer cookie should be checked
+
+  Scenario: The user log in, choose a specific cookie, open another browser, log in again and check that specific cookie not checked
+    # Cypress cannot deal with 2 browsers or a tab. So we log out, and log in again with a clean browser
+    # See https://docs.cypress.io/guides/references/trade-offs#Multiple-browsers-open-at-the-same-time
+    Given I clear all cookies in Browser
+    And I am logged in with account 1
+    When I open the cookie management option
+    And I select the "Beamer" cookie
+    And I save my choices
+    When I disconnect of my account
+    And I clear all cookies and storage
+    And I am logged in with account 1
+    And I open the cookie management option
+    Then The Beamer cookie should not be checked

--- a/pro/cypress/e2e/features/createEventIndividualOffer.feature
+++ b/pro/cypress/e2e/features/createEventIndividualOffer.feature
@@ -3,7 +3,7 @@ Feature: Create an individual offer (event)
 
   # Plante si l'offerer a plusieurs venues
   Scenario: It should create an individual offer (event)
-    Given I am logged in
+    Given I am logged in with account 1
     And I select offerer "Club Dorothy"
     When I go to the "Créer une offre" page
     And I want to create "Un évènement physique daté" offer

--- a/pro/cypress/e2e/features/createThingIndividualOffer.feature
+++ b/pro/cypress/e2e/features/createThingIndividualOffer.feature
@@ -2,7 +2,7 @@
 Feature: Create an individual offer (thing)
 
   Scenario: It should create an individual offer (thing)
-    Given I am logged in
+    Given I am logged in with account 1
     When I select offerer "Club Dorothy"
     And I go to the "Créer une offre" page
     And I want to create "Un bien physique" offer

--- a/pro/cypress/e2e/features/desk.feature
+++ b/pro/cypress/e2e/features/desk.feature
@@ -2,7 +2,7 @@
 Feature: Desk (Guichet) feature
 
   Background:
-    Given I am logged in with the new interface
+    Given I am logged in with account 2
     And I go to the "Guichet" page
 
   Scenario: It should display identity check message

--- a/pro/cypress/e2e/features/financialManagement.feature
+++ b/pro/cypress/e2e/features/financialManagement.feature
@@ -2,7 +2,7 @@
 Feature: Financial Management - messages, links to external help page, reimbursement details
 
   Scenario: Check messages, reimbursement details and offerer selection change
-    Given I am logged in with the new interface
+    Given I am logged in with account 2
     When I go to the "Gestion financière" page
     Then I can see information message about reimbursement
     And I can see a link to the next reimbursement help page

--- a/pro/cypress/e2e/features/navigation.feature
+++ b/pro/cypress/e2e/features/navigation.feature
@@ -2,7 +2,7 @@
 Feature: User navigation
 
   Scenario: I should see the top of the page when changing page
-    Given I am logged in
+    Given I am logged in with account 1
     And I select offerer "Cinéma du coin"
     When I scroll to my venue
     And I want to update that venue

--- a/pro/cypress/e2e/features/searchCollectiveOffer.feature
+++ b/pro/cypress/e2e/features/searchCollectiveOffer.feature
@@ -2,7 +2,7 @@
 Feature: Search collective offers
 
   Scenario: A search with several filters should display expected results
-    Given I am logged in
+    Given I am logged in with account 1
     And I select offerer "eac_2_lieu [BON EAC]"
     When I go to Offres collectives view
     And I select "real_venue 1 eac_2_lieu [BON EAC]" in "Lieu"

--- a/pro/cypress/e2e/features/searchIndividualOffer.feature
+++ b/pro/cypress/e2e/features/searchIndividualOffer.feature
@@ -2,7 +2,7 @@
 Feature: Search individual offers
 
   Background:
-    Given I am logged in
+    Given I am logged in with account 1
     And I go to the "Offres" page
 
   Scenario: A search with a name should display expected results

--- a/pro/cypress/e2e/features/venue.feature
+++ b/pro/cypress/e2e/features/venue.feature
@@ -2,7 +2,7 @@
 Feature: Create and update venue
 
   Scenario: A pro user can add a venue without SIRET
-    Given I am logged in
+    Given I am logged in with account 1
     And I select offerer "Bar des amis"
     When I want to add a venue
     And I choose a venue which already has a Siret
@@ -14,7 +14,7 @@ Feature: Create and update venue
     Then I should see details of my venue
 
   Scenario: A pro user can add a venue with SIRET
-    Given I am logged in
+    Given I am logged in with account 1
     And I select offerer "Bar des amis"
     When I want to add a venue
     And I add a valid Siret
@@ -24,7 +24,7 @@ Feature: Create and update venue
     Then I should see my venue with Siret resume
 
   Scenario: It should update a venue
-    Given I am logged in
+    Given I am logged in with account 1
     And I select offerer "Bar des amis"
     When I go to the venue page in Individual section
     And I update Individual section data
@@ -35,7 +35,7 @@ Feature: Create and update venue
     Then Paramètres généraux data should be updated
 
   Scenario: It should display venues of selected offerer
-    Given I am logged in with the new interface
+    Given I am logged in with account 2
     When I select offerer "0 - Structure avec justificatif copié"
     Then I should only see these venues
       | Offres numériques | Lieu avec justificatif copié |

--- a/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
+++ b/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
@@ -17,8 +17,7 @@ When('I go to the {string} page', (page: string) => {
   cy.findAllByTestId('spinner').should('not.exist')
 })
 
-// this account is also in the new interface now
-Given('I am logged in', () => {
+Given('I am logged in with account 1', () => {
   cy.login({
     email: 'retention_structures@example.com',
     password: 'user@AZERTY123',
@@ -26,10 +25,19 @@ Given('I am logged in', () => {
   cy.findAllByTestId('spinner').should('not.exist')
 })
 
-Given('I am logged in with the new interface', () => {
+Given('I am logged in with account 2', () => {
   cy.login({
     email: 'activation_new_nav@example.com',
     password: 'user@AZERTY123',
+  })
+  cy.findAllByTestId('spinner').should('not.exist')
+})
+
+Given('I am logged in with account 2 and no cookie selection', () => {
+  cy.login({
+    email: 'activation_new_nav@example.com',
+    password: 'user@AZERTY123',
+    refusePopupCookies: false,
   })
   cy.findAllByTestId('spinner').should('not.exist')
 })

--- a/pro/cypress/e2e/step-definitions/cookieBanner.cy.ts
+++ b/pro/cypress/e2e/step-definitions/cookieBanner.cy.ts
@@ -58,3 +58,16 @@ When('I clear all cookies in Browser', () => {
 When('I click on the {string} link', (link: string) => {
   cy.findByText(link).click()
 })
+
+When('I disconnect of my account', () => {
+  cy.findByTestId('offerer-select').click()
+  cy.findByTestId('header-dropdown-menu-div').should('exist')
+  cy.contains('Se déconnecter').click()
+  cy.url().should('contain', '/connexion')
+})
+
+When('I clear all cookies and storage', () => {
+  cy.clearAllCookies()
+  cy.clearAllLocalStorage()
+  cy.clearAllSessionStorage()
+})

--- a/pro/cypress/support/commands.ts
+++ b/pro/cypress/support/commands.ts
@@ -43,20 +43,25 @@ Cypress.on('uncaught:exception', () => {
   return false
 })
 
-Cypress.Commands.add('login', ({ email, password, redirectUrl }) => {
-  cy.intercept({ method: 'POST', url: '/users/signin' }).as('signinUser')
+Cypress.Commands.add(
+  'login',
+  ({ email, password, redirectUrl, refusePopupCookies = true }) => {
+    cy.intercept({ method: 'POST', url: '/users/signin' }).as('signinUser')
 
-  cy.visit('/connexion')
-  cy.refuseCookies()
+    cy.visit('/connexion')
+    if (refusePopupCookies) {
+      cy.refuseCookies()
+    }
 
-  cy.get('#email').type(email)
-  cy.get('#password').type(password)
-  cy.get('button[type=submit]').click()
-  cy.wait('@signinUser')
+    cy.get('#email').type(email)
+    cy.get('#password').type(password)
+    cy.get('button[type=submit]').click()
+    cy.wait('@signinUser')
 
-  cy.url().should('contain', redirectUrl ?? '/accueil')
-  cy.findAllByTestId('spinner').should('not.exist')
-})
+    cy.url().should('contain', redirectUrl ?? '/accueil')
+    cy.findAllByTestId('spinner').should('not.exist')
+  }
+)
 
 Cypress.Commands.add('refuseCookies', () => {
   cy.findByText('Tout refuser', { timeout: 30000 }).click()

--- a/pro/cypress/support/index.d.ts
+++ b/pro/cypress/support/index.d.ts
@@ -4,7 +4,7 @@ declare namespace Cypress {
       email: string
       password: string
       redirectUrl?: string
-      acceptCookies?: boolean
+      refusePopupCookies?: boolean
     }): Chainable
 
     setFeatureFlags(features: Feature[]): Chainable


### PR DESCRIPTION
## But de la pull request

Ligne 38 du référentiel de test, 2 nouveaux cas de test:
- vérifie que la sélection de cookie (beamer) est conservée dans le même browser si on se log avec un second compte
- vérifie que la sélection de cookie (beamer) n'est pas conservée si on se log avec le même compte dans une autre fenêtre*
*: Cypress ne sait pas gérer plusieurs fenêtre ou tab de browser. Donc dans le même j'ai réinitialisé les cookies; local et session storage pour me reconnecter au même compte.
Voir https://docs.cypress.io/guides/references/trade-offs#Multiple-browsers-open-at-the-same-time

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
