### PR TITLE
(PC-31454)[API] feat: script: deactivate batch offers

### DIFF
--- a/api/src/pcapi/scripts/batch_offers_deactivation/main.py
+++ b/api/src/pcapi/scripts/batch_offers_deactivation/main.py
@@ -1,0 +1,74 @@
+import argparse
+import logging
+import os
+import sys
+
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.api import batch_update_offers
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.repository import get_synchronized_offers_with_provider_for_venue
+from pcapi.core.providers.models import Provider
+from pcapi.flask_app import app
+from pcapi.utils.chunks import get_chunks
+from pcapi.workers.update_all_offers_active_status_job import update_venue_synchronized_offers_active_status_job
+
+
+logger = logging.getLogger(__name__)
+
+
+def usage() -> None:
+    print("Usage:")
+    print(f"{os.path.relpath(__file__)} <venue_id> <provider_id>")
+    print("")
+
+
+def check_resources_exists(venue_id: int, provider_id: int) -> None:
+    if not Venue.query.get(venue_id):
+        logger.info("venue #%d does not exist", venue_id)
+        sys.exit(-1)
+
+    if not Provider.query.get(provider_id):
+        logger.info("provider #%d does not exist", provider_id)
+        sys.exit(-1)
+
+
+def push_async_job(venue_id: int, provider_id: int) -> None:
+    logger.info("starting deactivation job for venue #%d and provider #%d", venue_id, provider_id)
+
+    update_venue_synchronized_offers_active_status_job.delay(venue_id, provider_id, False)
+
+    logger.info("deactivation job for venue #%d and provider #%d registered", venue_id, provider_id)
+
+
+def run_task(venue_id: int, provider_id: int) -> None:
+    base_query = get_synchronized_offers_with_provider_for_venue(venue_id, provider_id)
+
+    total_ids = [row[0] for row in base_query.with_entities(Offer.id).yield_per(10_000)]
+    logger.info("script: batch deactivation: all ids have been loaded (total %d)", len(total_ids))
+
+    for idx, ids in enumerate(get_chunks(total_ids, 500), start=1):
+        query = base_query.filter(Offer.id.in_(ids))
+
+        batch_update_offers(query, {"isActive": False})
+
+        logger.info(
+            "script: batch deactivation: round %d, %d offers deactivated for venue #%d", idx, len(ids), venue_id
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--runner", choices=["sync", "async"], required=True)
+    parser.add_argument("venue_id", type=int)
+    parser.add_argument("provider_id", type=int)
+
+    args = parser.parse_args()
+
+    with app.app_context():
+        check_resources_exists(args.venue_id, args.provider_id)
+
+        if args.runner == "async":
+            push_async_job(args.venue_id, args.provider_id)
+        else:
+            run_task(args.venue_id, args.provider_id)

--- a/api/tests/scripts/batch_offers_deactivation/test_main.py
+++ b/api/tests/scripts/batch_offers_deactivation/test_main.py
@@ -1,0 +1,36 @@
+import pytest
+
+from pcapi.core.offerers.factories import VenueFactory
+from pcapi.core.offers.factories import OfferFactory
+from pcapi.core.offers.models import Offer
+from pcapi.core.providers.factories import ProviderFactory
+from pcapi.scripts.batch_offers_deactivation.main import run_task
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def test_run(caplog):
+    provider = ProviderFactory()
+    other_provider = ProviderFactory()
+
+    venue = VenueFactory()
+    other_venue = VenueFactory()
+
+    offers = OfferFactory.create_batch(3, venue=venue, lastProvider=provider, isActive=True)
+
+    other_offers = OfferFactory.create_batch(
+        3, venue=venue, lastProvider=other_provider, isActive=True
+    ) + OfferFactory.create_batch(3, venue=other_venue, isActive=True)
+
+    run_task(venue.id, provider.id)
+
+    offer_ids = {o.id for o in offers}
+    target_offers = Offer.query.filter(Offer.id.in_(offer_ids))
+
+    assert all(not o.isActive for o in target_offers)
+
+    other_offer_ids = {o.id for o in other_offers}
+    other_target_offers = Offer.query.filter(Offer.id.in_(other_offer_ids))
+
+    assert all(o.isActive for o in other_target_offers)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31454

Simple script qui permet de lancer le job `update_venue_synchronized_offers_active_status_job` pour un lieu et un provider donnés, lorsque l'opération ne peut être réalisée via le portail pro. Par exemple si la ligne dans `venue_provider` a été supprimée et que la tâche n'a pas s'exécuter ou que la page ne se charge pas.
