### PR TITLE
(PC-26149)[PRO] feat: use offererAddress for Algolia index

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -762,7 +762,14 @@ def get_offer_coordinates(offer: AnyCollectiveOffer) -> tuple[float | Decimal, f
 
     # we should return a coherent value: either latitude AND
     # longitude or empty coordinates.
-    latitude, longitude = venue.latitude, venue.longitude
+    if feature.FeatureToggle.WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE.is_active():
+        if venue.offererAddress is not None:
+            latitude = venue.offererAddress.address.latitude
+            longitude = venue.offererAddress.address.longitude
+        else:
+            latitude, longitude = None, None
+    else:
+        latitude, longitude = venue.latitude, venue.longitude
     if not latitude or not longitude:
         return (None, None)
 

--- a/api/src/pcapi/core/geography/factories.py
+++ b/api/src/pcapi/core/geography/factories.py
@@ -7,6 +7,11 @@ from pcapi.utils.regions import get_department_code_from_city_code
 from . import models
 
 
+DEFAULT_LATITUDE = 48.87055
+DEFAULT_LONGITUDE = 2.3476515
+DEFAULT_TRUNCATED_LONGITUDE = 2.34765
+
+
 class IrisFranceFactory(factory.Factory):
     class Meta:
         model = models.IrisFrance
@@ -22,8 +27,8 @@ class AddressFactory(BaseFactory):
     street = factory.Sequence("1{} boulevard Poissonnière".format)  # sequence avoids UniqueViolation (street+inseeCode)
     postalCode = "75002"
     city = "Paris"
-    latitude: float | None = 48.87055
-    longitude: float | None = 2.3476515
+    latitude: float | None = DEFAULT_LATITUDE
+    longitude: float | None = DEFAULT_LONGITUDE
     departmentCode = factory.LazyAttribute(
         lambda address: (
             get_department_code_from_city_code(address.inseeCode or address.postalCode)

--- a/api/tests/core/search/test_backend_algolia.py
+++ b/api/tests/core/search/test_backend_algolia.py
@@ -9,6 +9,7 @@ import pcapi.core.educational.factories as educational_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.search.backends import algolia
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 
 
@@ -199,7 +200,54 @@ def test_unindex_all_collective_offer_templates():
         assert posted.called
 
 
+@override_features(WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE=True)
 def test_index_collective_offers_templates():
+    backend = get_backend()
+    collective_offer_template = educational_factories.CollectiveOfferTemplateFactory.build()
+    # Unfortunatly had to create explicit OffererAddress because
+    # venue__offererAddress__address__postalCode did not work on the CollectiveOfferTemplateFactory
+    offerer_address_north_corsica = offerers_factories.OffererAddressFactory(
+        address__departmentCode=20,
+        address__postalCode="20213",
+    )
+    offerer_address_south_corsica = offerers_factories.OffererAddressFactory(
+        address__departmentCode=20,
+        address__postalCode="20113",
+    )
+    collective_offer_template_north_corsica = educational_factories.CollectiveOfferTemplateFactory(
+        venue__departementCode=20,
+        venue__postalCode="20213",
+        venue__offererAddress=offerer_address_north_corsica,
+    )
+    collective_offer_template_south_corsica = educational_factories.CollectiveOfferTemplateFactory(
+        venue__departementCode=20,
+        venue__postalCode="20113",
+        venue__offererAddress=offerer_address_south_corsica,
+    )
+
+    with requests_mock.Mocker() as mock:
+        posted = mock.post("https://dummy-app-id.algolia.net/1/indexes/testing-collective-offers/batch", json={})
+        backend.index_collective_offer_templates(
+            [
+                collective_offer_template,
+                collective_offer_template_north_corsica,
+                collective_offer_template_south_corsica,
+            ]
+        )
+        posted_json = posted.last_request.json()
+        assert posted_json["requests"][0]["action"] == "updateObject"
+        assert posted_json["requests"][0]["body"]["objectID"] == f"T-{collective_offer_template.id}"
+        assert (
+            posted_json["requests"][0]["body"]["venue"]["departmentCode"]
+            == collective_offer_template.venue.offererAddress.address.departmentCode
+        )
+        assert posted_json["requests"][1]["body"]["venue"]["departmentCode"] == "2B"
+        assert posted_json["requests"][2]["body"]["venue"]["departmentCode"] == "2A"
+
+
+@override_features(WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE=False)
+def test_index_collective_offers_templates_legacy():
+    # Same as test_index_collective_offers_templates
     backend = get_backend()
     collective_offer_template = educational_factories.CollectiveOfferTemplateFactory.build()
     collective_offer_template_north_corsica = educational_factories.CollectiveOfferTemplateFactory(

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -7,11 +7,13 @@ from pcapi.core.categories import subcategories_v2 as subcategories
 import pcapi.core.criteria.factories as criteria_factories
 import pcapi.core.educational.factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
+import pcapi.core.geography.factories as geography_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
 from pcapi.core.search.backends import algolia
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 from pcapi.routes.adage_iframe.serialization.offers import OfferAddressType
 from pcapi.routes.native.v1.serialization.offerers import VenueTypeCode
@@ -22,7 +24,105 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 
 @override_settings(ALGOLIA_LAST_30_DAYS_BOOKINGS_RANGE_THRESHOLDS=[1, 2, 3, 4])
+@override_features(WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE=True)
 def test_serialize_offer():
+    rayon = "Policier / Thriller format poche"  # fetched from provider
+
+    # known values (inserted using a migration)
+    # note: some might contain trailing whitespaces. Also sections are
+    # usually lowercase whilst sections from providers might be
+    # capitalized.
+    book_macro_section = offers_models.BookMacroSection.query.filter_by(
+        section="policier / thriller format poche"
+    ).one()
+    macro_section = book_macro_section.macroSection.strip()
+
+    offerer_address = offerers_factories.OffererAddressFactory(
+        address__departmentCode="86",
+        address__postalCode="86140",
+    )
+
+    offer = offers_factories.OfferFactory(
+        dateCreated=datetime.datetime(2022, 1, 1, 10, 0, 0),
+        name="Titre formidable",
+        description="Un LIVRE qu'il est bien pour le lire",
+        extraData={
+            "author": "Author",
+            "ean": "2221001648",
+            "performer": "Performer",
+            "speaker": "Speaker",
+            "stageDirector": "Stage Director",
+            "rayon": rayon,
+        },
+        rankingWeight=2,
+        subcategoryId=subcategories.LIVRE_PAPIER.id,
+        venue__id=127,
+        venue__offererAddress=offerer_address,
+        venue__name="La Moyenne Librairie SA",
+        venue__publicName="La Moyenne Librairie",
+        venue__venueTypeCode=VenueTypeCode.LIBRARY,
+        venue__managingOfferer__name="Les Librairies Associées",
+    )
+    offers_factories.StockFactory(offer=offer, price=10)
+    serialized = algolia.AlgoliaBackend().serialize_offer(offer, 0)
+    assert serialized == {
+        "distinct": "2221001648",
+        "objectID": offer.id,
+        "offer": {
+            "artist": "Author Performer Speaker Stage Director",
+            "bookMacroSection": macro_section,
+            "dateCreated": offer.dateCreated.timestamp(),
+            "dates": [],
+            "description": "livre bien lire",
+            "ean": "2221001648",
+            "isDigital": False,
+            "isDuo": False,
+            "isEducational": False,
+            "isEvent": False,
+            "isForbiddenToUnderage": offer.is_forbidden_to_underage,
+            "isPermanent": offer.isPermanent,
+            "isThing": True,
+            "last30DaysBookings": 0,
+            "last30DaysBookingsRange": algolia.Last30DaysBookingsRange.VERY_LOW.value,
+            "name": "Titre formidable",
+            "nativeCategoryId": offer.subcategory.native_category_id,
+            "prices": [decimal.Decimal("10.00")],
+            "rankingWeight": 2,
+            "searchGroupName": "LIVRES",
+            "searchGroupNamev2": "LIVRES",
+            "students": [],
+            "subcategoryId": offer.subcategory.id,
+            "tags": [],
+            "times": [],
+        },
+        "offerer": {
+            "name": "Les Librairies Associées",
+        },
+        "venue": {
+            "banner_url": offer.venue.bannerUrl,
+            "address": offer.venue.offererAddress.address.street,
+            "city": offer.venue.offererAddress.address.city,
+            "departmentCode": "86",
+            "postalCode": offer.venue.offererAddress.address.postalCode,
+            "id": offer.venueId,
+            "isAudioDisabilityCompliant": False,
+            "isMentalDisabilityCompliant": False,
+            "isMotorDisabilityCompliant": False,
+            "isVisualDisabilityCompliant": False,
+            "name": "La Moyenne Librairie SA",
+            "publicName": "La Moyenne Librairie",
+            "venue_type": VenueTypeCode.LIBRARY.name,
+        },
+        "_geoloc": {
+            "lat": geography_factories.DEFAULT_LATITUDE,
+            "lng": geography_factories.DEFAULT_TRUNCATED_LONGITUDE,
+        },
+    }
+
+
+@override_settings(ALGOLIA_LAST_30_DAYS_BOOKINGS_RANGE_THRESHOLDS=[1, 2, 3, 4])
+@override_features(WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE=False)
+def test_serialize_offer_legacy():
     rayon = "Policier / Thriller format poche"  # fetched from provider
 
     # known values (inserted using a migration)
@@ -282,7 +382,7 @@ def test_serialize_venue():
     serialized = algolia.AlgoliaBackend().serialize_venue(venue)
     assert serialized == {
         "objectID": venue.id,
-        "city": venue.city,
+        "city": venue.offererAddress.address.city,
         "name": venue.name,
         "offerer_name": venue.managingOfferer.name,
         "venue_type": venue.venueTypeCode.name,
@@ -300,11 +400,14 @@ def test_serialize_venue():
         "twitter": "https://twitter.com/my.venue",
         "tags": [],
         "banner_url": venue.bannerUrl,
-        "_geoloc": {"lng": float(venue.longitude), "lat": float(venue.latitude)},
+        "_geoloc": {
+            "lng": float(venue.offererAddress.address.longitude),
+            "lat": float(venue.offererAddress.address.latitude),
+        },
         "has_at_least_one_bookable_offer": False,
         "date_created": venue.dateCreated.timestamp(),
-        "postalCode": venue.postalCode,
-        "adress": venue.street,
+        "postalCode": venue.offererAddress.address.postalCode,
+        "adress": venue.offererAddress.address.street,
     }
 
 
@@ -319,7 +422,75 @@ def test_serialize_venue_with_one_bookable_offer():
     assert serialized["has_at_least_one_bookable_offer"]
 
 
+@override_features(WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE=True)
 def test_serialize_collective_offer_template():
+    domain1 = educational_factories.EducationalDomainFactory(name="Danse")
+    domain2 = educational_factories.EducationalDomainFactory(name="Architecture")
+    offer_venue_offerer_address = offerers_factories.OffererAddressFactory(
+        address__latitude=algolia.DEFAULT_LATITUDE,
+        address__longitude=algolia.DEFAULT_LONGITUDE,
+    )
+    offer_venue = offerers_factories.VenueFactory(offererAddress=offer_venue_offerer_address)
+    venue_offerer_address = offerers_factories.OffererAddressFactory(
+        address__postalCode="86140",
+        address__departmentCode="86",
+    )
+
+    collective_offer_template = educational_factories.CollectiveOfferTemplateFactory(
+        dateCreated=datetime.datetime(2022, 1, 1, 10, 0, 0),
+        name="Titre formidable",
+        description="description formidable",
+        students=[StudentLevels.CAP1, StudentLevels.CAP2],
+        subcategoryId=subcategories.CONCERT.id,
+        venue__offererAddress=venue_offerer_address,
+        venue__name="La Moyenne Librairie SA",
+        venue__publicName="La Moyenne Librairie",
+        venue__managingOfferer__name="Les Librairies Associées",
+        venue__adageId="123456",
+        educational_domains=[domain1, domain2],
+        interventionArea=None,
+        offerVenue={"addressType": OfferAddressType.OFFERER_VENUE, "venueId": offer_venue.id, "otherAddress": ""},
+    )
+
+    serialized = algolia.AlgoliaBackend().serialize_collective_offer_template(collective_offer_template)
+    assert serialized == {
+        "objectID": f"T-{collective_offer_template.id}",
+        "offer": {
+            "dateCreated": 1641031200.0,
+            "name": "Titre formidable",
+            "students": ["CAP - 1re année", "CAP - 2e année"],
+            "subcategoryId": subcategories.CONCERT.id,
+            "domains": [domain1.id, domain2.id],
+            "educationalInstitutionUAICode": "all",
+            "interventionArea": [],
+            "schoolInterventionArea": None,
+            "eventAddressType": OfferAddressType.OFFERER_VENUE.value,
+            "beginningDatetime": 1641031200.0,
+            "description": collective_offer_template.description,
+        },
+        "offerer": {
+            "name": "Les Librairies Associées",
+        },
+        "venue": {
+            "academy": "Poitiers",
+            "departmentCode": "86",
+            "id": collective_offer_template.venue.id,
+            "name": "La Moyenne Librairie SA",
+            "publicName": "La Moyenne Librairie",
+            "adageId": collective_offer_template.venue.adageId,
+        },
+        "_geoloc": {
+            "lat": 47.15846,
+            "lng": 2.40929,
+        },
+        "isTemplate": True,
+        "formats": [fmt.value for fmt in subcategories.CONCERT.formats],
+    }
+
+
+@override_features(WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE=False)
+def test_serialize_collective_offer_template_legacy():
+    # Same as test_serialize_collective_offer_template
     domain1 = educational_factories.EducationalDomainFactory(name="Danse")
     domain2 = educational_factories.EducationalDomainFactory(name="Architecture")
     venue = offerers_factories.VenueFactory(latitude=algolia.DEFAULT_LATITUDE, longitude=algolia.DEFAULT_LONGITUDE)


### PR DESCRIPTION
Depending on WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE either it uses legacy address data in Venue if false or gets the Venue's offererAddress if true

## But de la pull request

Ticket Jira: https://passculture.atlassian.net/browse/PC-26149

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
