### PR TITLE
(PC-31461)[API] fix: revert TEST_DEFAULT_PASSWORD to secrets

### DIFF
--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -266,7 +266,7 @@ DAYS_BEFORE_UBBLE_LONG_ACTION_REMINDER = 21 if IS_PROD else 0
 # EHP SANDBOX
 CAN_RUN_SANDBOX = bool(int(os.environ.get("CAN_RUN_SANDBOX", 0)))
 # Sandbox users and unit tests default password - overridden by a secret password on cloud environments
-TEST_DEFAULT_PASSWORD = os.environ.get("TEST_DEFAULT_PASSWORD", "user@AZERTY123")
+TEST_DEFAULT_PASSWORD = secrets_utils.get("TEST_DEFAULT_PASSWORD", "user@AZERTY123")
 ENABLE_LOCAL_DEV_MODE_FOR_STORAGE = bool(int(os.environ.get("ENABLE_LOCAL_DEV_MODE_FOR_STORAGE", 0)))
 ENABLE_UBBLE_E2E_TESTING = bool(int(os.environ.get("ENABLE_UBBLE_E2E_TESTING", 0)))
 


### PR DESCRIPTION
because it is a password.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31461

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
