### PR TITLE
(BSR)[PRO] test: check url modification in a digital offer

### DIFF
--- a/pro/cypress/e2e/features/editEventIndividualOffer.feature
+++ b/pro/cypress/e2e/features/editEventIndividualOffer.feature
@@ -1,0 +1,14 @@
+@P0
+Feature: Modify a digital individual offer
+
+  Scenario: I should be able to modify the url of a digital offer
+    Given I am logged in with the new interface
+    When I go to the "Offres" page
+    And I open the first offer in the list
+    And I display Informations pratiques tab
+    And I edit the offer displayed
+    And I update the url link
+    And I go to the "Offres" page
+    And I open the first offer in the list
+    And I display Informations pratiques tab
+    Then the url updated is retrieved in the details of the offer

--- a/pro/cypress/e2e/step-definitions/editEventIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/editEventIndividualOffer.cy.ts
@@ -1,0 +1,38 @@
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor'
+
+When('I open the first offer in the list', () => {
+  cy.setFeatureFlags([{ name: 'WIP_SPLIT_OFFER', isActive: true }])
+  cy.findAllByTestId('offer-item-row')
+    .first()
+    .within(() => {
+      cy.get('[class^=_button-icon_]').eq(1).click()
+    })
+  cy.url().should('contain', '/recapitulatif/details')
+})
+
+When('I display Informations pratiques tab', () => {
+  cy.findByText('Informations pratiques').click()
+  cy.url().should('contain', '/pratiques')
+})
+
+When('I edit the offer displayed', () => {
+  cy.get('a[aria-label^="Modifier les détails de l’offre"]').click()
+  cy.url().should('contain', '/edition/pratiques')
+})
+
+When('I update the url link', () => {
+  const randomUrl = `http://myrandomurl${Math.random().toString().substring(2, 5)}.fr/`
+  cy.wrap(randomUrl).as('urlModified')
+  cy.get('input#url').clear().type(randomUrl)
+  cy.findByText('Enregistrer les modifications').click()
+  cy.findAllByTestId('global-notification-success').should(
+    'contain',
+    'Vos modifications ont bien été enregistrées'
+  )
+  cy.findByText('Retour à la liste des offres').click()
+  cy.url().should('contain', '/offres')
+})
+
+Then('the url updated is retrieved in the details of the offer', function () {
+  cy.contains('URL d’accès à l’offre : ' + this.urlModified)
+})

--- a/pro/cypress/e2e/step-definitions/editEventIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/editEventIndividualOffer.cy.ts
@@ -5,9 +5,9 @@ When('I open the first offer in the list', () => {
   cy.findAllByTestId('offer-item-row')
     .first()
     .within(() => {
-      cy.get('[class^=_button-icon_]').eq(1).click()
+      cy.findByRole('link', { name: 'Modifier' }).click()
     })
-  cy.url().should('contain', '/recapitulatif/details')
+  cy.url().should('contain', '/recapitulatif')
 })
 
 When('I display Informations pratiques tab', () => {


### PR DESCRIPTION
## But de la pull request

Ligne 108 référentiel des tests. Vérifie la modification d'url dans le détail d'une offre numérique

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
