### PR TITLE
(PC-30915)[PRO] fix: support subcat suggestion API error

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
@@ -133,6 +133,11 @@ export const DetailsForm = ({
         description,
         Number(venueId)
       )
+
+      if (response.subcategoryIds.length === 0) {
+        throw new Error('No suggested subcategories')
+      }
+
       setSuggestedSubcategories(response.subcategoryIds)
     } catch (err) {
       if (!suggestedSubcategory) {

--- a/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.module.scss
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.module.scss
@@ -2,11 +2,11 @@
 @use "styles/variables/_size.scss" as size;
 
 .suggested-subcategories {
-    margin-bottom: rem.torem(24px);
+  margin-bottom: rem.torem(24px);
 }
 
 .description{
-    margin-bottom: rem.torem(16px);
+  margin-bottom: rem.torem(8px);
 }
 
 .items {

--- a/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.spec.tsx
@@ -113,6 +113,7 @@ const renderSuggestedSubcategories = (props: SuggestedSubcategoriesProps) => {
 describe('SuggestedSubcategories', () => {
   it('should render suggested subcategories as radio buttons', () => {
     renderSuggestedSubcategories({
+      hasApiBeenCalled: true,
       suggestedSubcategories,
       filteredCategories: [],
       filteredSubcategories: [],
@@ -128,6 +129,7 @@ describe('SuggestedSubcategories', () => {
 
   it('should always render an "Autre" radio button', () => {
     renderSuggestedSubcategories({
+      hasApiBeenCalled: true,
       suggestedSubcategories,
       filteredCategories: [],
       filteredSubcategories: [],
@@ -140,6 +142,7 @@ describe('SuggestedSubcategories', () => {
 
   it('should keep previously selected subcategory as radio button even if it is not in the suggested subcategories', async () => {
     const { rerender } = renderSuggestedSubcategories({
+      hasApiBeenCalled: true,
       suggestedSubcategories: firstSuggestedSubcategories,
       filteredCategories: [],
       filteredSubcategories: [],
@@ -156,6 +159,7 @@ describe('SuggestedSubcategories', () => {
     rerender(
       <IndividualOfferContext.Provider value={{ ...contextValue }}>
         <SuggestedSubWrappedWithFormik
+          hasApiBeenCalled={true}
           suggestedSubcategories={otherSuggestedSubcategories}
           filteredCategories={[]}
           filteredSubcategories={[]}
@@ -181,6 +185,7 @@ describe('SuggestedSubcategories', () => {
   describe('when the "Autre" radio button is selected', () => {
     it('should render a category select', async () => {
       renderSuggestedSubcategories({
+        hasApiBeenCalled: true,
         suggestedSubcategories,
         filteredCategories: [],
         filteredSubcategories: [],
@@ -198,6 +203,7 @@ describe('SuggestedSubcategories', () => {
 
     it('should render a subcategory select when a category is selected', async () => {
       renderSuggestedSubcategories({
+        hasApiBeenCalled: true,
         suggestedSubcategories,
         filteredCategories: CATEGORIES,
         filteredSubcategories: SUB_CATEGORIES,

--- a/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.tsx
@@ -20,6 +20,7 @@ import {
 import styles from './SuggestedSubcategories.module.scss'
 
 export type SuggestedSubcategoriesProps = {
+  hasApiBeenCalled: boolean
   suggestedSubcategories: string[]
   readOnlyFields: string[]
   filteredCategories: CategoryResponseModel[]
@@ -27,6 +28,7 @@ export type SuggestedSubcategoriesProps = {
 }
 
 export function SuggestedSubcategories({
+  hasApiBeenCalled,
   suggestedSubcategories,
   readOnlyFields,
   filteredCategories,
@@ -125,17 +127,32 @@ export function SuggestedSubcategories({
     <FormLayout.Section title={'Type d’offre'}>
       <FormLayout.Row>
         <div className={styles['suggested-subcategories']}>
-          <p className={styles['description']}>
-            Catégories suggérées pour votre offre&nbsp;:
+          <p
+            id="suggested-subcategories-title"
+            className={styles['description']}
+          >
+            Catégories suggérées pour votre offre :
           </p>
-          <div className={styles['items']}>
-            {suggestedSubcategories.map(renderRadioButton)}
-            {isSelectedFromPrevSuggestions &&
-              renderRadioButton(selectedSubCategory)}
-            {wasSelectedFromPrevSuggestions &&
-              prevSelectedSubCategory !== selectedSubCategory &&
-              renderRadioButton(prevSelectedSubCategory)}
-            {renderRadioButton('OTHER')}
+          <div
+            className={styles['items']}
+            id="suggested-subcategories"
+            aria-labelledby="suggested-subcategories-title"
+            aria-live="polite"
+            aria-atomic
+          >
+            {hasApiBeenCalled ? (
+              <>
+                {suggestedSubcategories.map(renderRadioButton)}
+                {isSelectedFromPrevSuggestions &&
+                  renderRadioButton(selectedSubCategory)}
+                {wasSelectedFromPrevSuggestions &&
+                  prevSelectedSubCategory !== selectedSubCategory &&
+                  renderRadioButton(prevSelectedSubCategory)}
+                {renderRadioButton('OTHER')}
+              </>
+            ) : (
+              <span>Veuillez renseigner un titre ou une description.</span>
+            )}
           </div>
         </div>
       </FormLayout.Row>

--- a/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/SuggestedSubcategories/SuggestedSubcategories.tsx
@@ -137,8 +137,7 @@ export function SuggestedSubcategories({
             className={styles['items']}
             id="suggested-subcategories"
             aria-labelledby="suggested-subcategories-title"
-            aria-live="polite"
-            aria-atomic
+            role="status"
           >
             {hasApiBeenCalled ? (
               <>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30915

## Descriptif des modifications
- Désormais si la feature "Suggestions de sous-catégories" est activée, alors on affiche toujours le composant et son titre "Catégories suggérées pour votre offre :" en état EMPTY, avec un message complémentaire "Veuillez renseigner un titre ou une description".
- Si au premier appel, l'API est en erreur alors on affiche seulement le radio button "Autre" préselectionné. Sur les futurs appels, les suggestions pourraient apparaître en complément si l'API répond à nouveau.
- Si l'API retombe en erreur, alors les suggestions correspondent au dernier appel OK.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
