### PR TITLE
(BSR) ci: Fix missing env when calling prepare cache

### DIFF
--- a/.github/workflows/dev_on_schedule_prepare_cache_weekly.yml
+++ b/.github/workflows/dev_on_schedule_prepare_cache_weekly.yml
@@ -15,6 +15,8 @@ jobs:
       TRIGGER_ONLY_ON_API_CHANGE: false
       TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: false
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+      api-changed: false
+      dependencies-changed: false
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
## But de la pull request

Fix de https://github.com/pass-culture/pass-culture-main/actions/runs/10542588807 suite à https://github.com/pass-culture/pass-culture-main/commit/3087d4bce2854d03c558f901542d974b009fe114 