### PR TITLE
(PC-31355)[API] fix: handle coexisting incomplete movie products

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -19,6 +19,7 @@ from pcapi.core.educational.models import CollectiveOfferDisplayedStatus as Disp
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import constants as providers_constants
 from pcapi.core.providers import models as providers_models
+from pcapi.core.reactions import models as reactions_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models import offer_mixin
@@ -1192,3 +1193,13 @@ def get_movie_product_by_allocine_id(allocine_id: str) -> models.Product | None:
 
 def get_movie_product_by_visa(visa: str) -> models.Product | None:
     return models.Product.query.filter(models.Product.extraData["visa"].astext == visa).one_or_none()
+
+
+def merge_products(to_keep: models.Product, to_delete: models.Product) -> models.Product:
+    models.Offer.query.filter(models.Offer.productId == to_delete.id).update({"productId": to_keep.id})
+    reactions_models.Reaction.query.filter(reactions_models.Reaction.productId == to_delete.id).update(
+        {"productId": to_keep.id}
+    )
+    db.session.delete(to_delete)
+
+    return to_keep


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31355

Le bug corrigé dans cette PR est le suivant :

Il est possible que des produits cinéma soient créés seulement avec un `visa` ou seulement avec un `allocineId`.
En voulant mettre à jour un produit qui n'a qu'un `allocineId` et pas de `visa`, avec des données contenant maintenant un `visa`, une erreur va survenir si un produit avec ce `visa` existait déjà.

La proposition est de supprimer ce dernier et donc d'effectuer le transfert des offres et des réactions associées. Quant aux médiations, elles sont aussi supprimées pour ne garder que celle(s) du produit que l'on met à jour.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
