### PR TITLE
(PC-31459)[BO] script to re-generate invoices csv file

### DIFF
--- a/api/src/pcapi/scripts/generate_invoices_csv/main.py
+++ b/api/src/pcapi/scripts/generate_invoices_csv/main.py
@@ -1,0 +1,31 @@
+import argparse
+import logging
+
+from pcapi.core.finance import api as finance_api
+from pcapi.core.finance import models as finance_models
+from pcapi.core.logging import log_elapsed
+from pcapi.flask_app import app
+
+
+logger = logging.getLogger(__name__)
+
+
+def generate_invoices_csv(batch_id: int) -> None:
+    batch = finance_models.CashflowBatch.query.get(batch_id)
+
+    with log_elapsed(logger, "Generated CSV invoices file"):
+        path = finance_api.generate_invoice_file(batch)
+    drive_folder_name = finance_api._get_drive_folder_name(batch)
+    with log_elapsed(logger, "Uploaded CSV invoices file to Google Drive"):
+        finance_api._upload_files_to_google_drive(drive_folder_name, [path])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--batch-id", type=int, required=True)
+
+    args = parser.parse_args()
+
+    with app.app_context():
+        generate_invoices_csv(args.batch_id)

--- a/api/tests/scripts/generate_invoices_csv/test_main.py
+++ b/api/tests/scripts/generate_invoices_csv/test_main.py
@@ -1,0 +1,43 @@
+import logging
+from unittest.mock import patch
+
+from pcapi.core.finance import factories as finance_factories
+from pcapi.core.finance import models as finance_models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.testing import override_settings
+from pcapi.scripts.generate_invoices_csv.main import generate_invoices_csv
+
+from tests.conftest import clean_database
+from tests.test_utils import run_command
+
+
+@override_settings(SLACK_GENERATE_INVOICES_FINISHED_CHANNEL="channel")
+@clean_database
+def test_run(caplog, app, css_font_http_request_mock):
+    venue = offerers_factories.VenueFactory()
+    batch = finance_factories.CashflowBatchFactory()
+    bank_account = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
+    finance_factories.CashflowFactory.create_batch(
+        size=3,
+        batch=batch,
+        bankAccount=bank_account,
+        status=finance_models.CashflowStatus.UNDER_REVIEW,
+    )
+    offerers_factories.VenueBankAccountLinkFactory(venue=venue, bankAccount=bank_account)
+
+    with patch("pcapi.core.finance.commands.send_internal_message") as mock_send_internal_message:
+        run_command(
+            app,
+            "generate_invoices",
+            "--batch-id",
+            str(batch.id),
+        )
+
+    assert mock_send_internal_message.call_count == 1
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        generate_invoices_csv(batch.id)
+        assert "Generated CSV invoices file" in caplog.text
+        assert "Finance file has been uploaded to Google Drive" in caplog.text
+        assert "Uploaded CSV invoices file to Google Drive" in caplog.text


### PR DESCRIPTION
## But de la pull request

Script permettant de forcer la re-génération de l'export csv des invoices

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31459

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
