### PR TITLE
(BSR)[PRO] test: Step renamed in another PR

### DIFF
--- a/pro/cypress/e2e/features/editEventIndividualOffer.feature
+++ b/pro/cypress/e2e/features/editEventIndividualOffer.feature
@@ -2,7 +2,7 @@
 Feature: Modify a digital individual offer
 
   Scenario: I should be able to modify the url of a digital offer
-    Given I am logged in with the new interface
+    Given I am logged in with account 2
     When I go to the "Offres" page
     And I open the first offer in the list
     And I display Informations pratiques tab


### PR DESCRIPTION
## But de la pull request

Corriger une étape qui a été renommée dans une [PR](https://github.com/pass-culture/pass-culture-main/pull/13779) et pas reportée dans une autre [PR](https://github.com/pass-culture/pass-culture-main/pull/13794) créée en même temps (my fault)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
