### PR TITLE
(BSR) chore: refactor 'clean_temporary_files fixture used in finance api tests

### DIFF
--- a/api/tests/core/testing/tests.py
+++ b/api/tests/core/testing/tests.py
@@ -1,12 +1,8 @@
-import pathlib
-import tempfile
-
 import pytest
 
 from pcapi import settings
 import pcapi.core.bookings.models as bookings_models
 from pcapi.core.testing import assert_no_duplicated_queries
-from pcapi.core.testing import clean_temporary_files
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 from pcapi.models.feature import FeatureToggle
@@ -70,26 +66,3 @@ class OverrideFeaturesOnClassTest:
     @override_features(ENABLE_NATIVE_APP_RECAPTCHA=False)
     def test_method_level_override(self):
         assert not FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA.is_active()
-
-
-def test_clean_temporary_files():
-    created = []
-
-    @clean_temporary_files
-    def func():
-        file1 = pathlib.Path(tempfile.mkstemp()[1])
-        created.append(file1)
-        dir1 = pathlib.Path(tempfile.mkdtemp())
-        created.append(dir1)
-        file2 = dir1 / "marker.txt"
-        file2.touch()  # make `dir1` non empty
-        created.append(file2)
-        # Make sure that files are cleaned even if there is an error.
-        raise ValueError()
-
-    with pytest.raises(ValueError):
-        func()
-
-    assert len(created) == 3
-    for path in created:
-        assert not path.exists()


### PR DESCRIPTION
## But de la pull request

Refactor du décorateur "clean_temporary_files" pour le remplacer par une fixture

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
