### PR TITLE
(PC-31332)[PRO] feat: If the new offers split FF is enabled, only fet…

### DIFF
--- a/pro/src/config/swrQueryKeys.ts
+++ b/pro/src/config/swrQueryKeys.ts
@@ -10,11 +10,13 @@ export const GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY =
   'getCollectiveOfferTemplate'
 export const GET_COLLECTIVE_OFFER_TEMPLATES_QUERY_KEY =
   'getCollectiveOfferTemplates'
+export const GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY =
+  'getCollectiveOffersBookable'
 export const GET_COLLECTIVE_OFFERS_FOR_INSTITUTION_QUERY_KEY =
   'getCollectiveOffersForMyInstitution'
+export const GET_COLLECTIVE_OFFERS_QUERY_KEY = 'getCollectiveOffers'
 export const GET_COLLECTIVE_REQUEST_INFORMATIONS_QUERY_KEY =
   'getCollectiveOfferRequestInformations'
-export const GET_COLLECTIVE_OFFERS_QUERY_KEY = 'getCollectiveOffers'
 export const GET_CULTURAL_PARTNERS_QUERY_KEY = 'getEducationalPartners'
 export const GET_EDUCATIONAL_DOMAINS_QUERY_KEY = 'listEducationalDomains'
 export const GET_EDUCATIONAL_OFFERERS_QUERY_KEY = 'listEducationalOfferers'

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -3,9 +3,10 @@ import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
-import { CollectiveOfferStatus } from 'apiClient/v1'
+import { CollectiveOfferStatus, CollectiveOfferType } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import {
+  GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY,
   GET_COLLECTIVE_OFFERS_QUERY_KEY,
   GET_OFFERER_QUERY_KEY,
   GET_VENUES_QUERY_KEY,
@@ -40,6 +41,10 @@ export const CollectiveOffers = (): JSX.Element => {
 
   const isDraftCollectiveOffersEnabled = useActiveFeature(
     'WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS'
+  )
+
+  const isNewOffersAndBookingsActive = useActiveFeature(
+    'WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE'
   )
 
   const offererQuery = useSWR(
@@ -91,7 +96,12 @@ export const CollectiveOffers = (): JSX.Element => {
   }
 
   const offersQuery = useSWR(
-    [GET_COLLECTIVE_OFFERS_QUERY_KEY, apiFilters],
+    [
+      isNewOffersAndBookingsActive
+        ? GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY
+        : GET_COLLECTIVE_OFFERS_QUERY_KEY,
+      apiFilters,
+    ],
     () => {
       const {
         nameOrIsbn,
@@ -115,7 +125,9 @@ export const CollectiveOffers = (): JSX.Element => {
         creationMode,
         periodBeginningDate,
         periodEndingDate,
-        collectiveOfferType,
+        isNewOffersAndBookingsActive
+          ? CollectiveOfferType.OFFER
+          : collectiveOfferType,
         format
       )
     },

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -298,7 +298,7 @@ describe('route CollectiveOffers', () => {
         })
       })
 
-      it('should load offers with selected offer type', async () => {
+      it('should load offers with selected offer type if the WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE FF is not active', async () => {
         await renderOffers()
         const offerTypeSelect = screen.getByLabelText('Type de l’offre')
         await userEvent.selectOptions(offerTypeSelect, 'template')
@@ -554,5 +554,27 @@ describe('route CollectiveOffers', () => {
     await renderOffers(DEFAULT_COLLECTIVE_SEARCH_FILTERS)
 
     expect(screen.getByText('1 offre')).toBeInTheDocument()
+  })
+
+  it('should fetch only bookable offers when the WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE FF is active', async () => {
+    vi.spyOn(api, 'getCollectiveOffers').mockResolvedValueOnce(offersRecap)
+    await renderOffers({}, [
+      'WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE',
+    ])
+
+    await waitFor(() => {
+      expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'offer',
+        undefined
+      )
+    })
   })
 })

--- a/pro/src/screens/CollectiveOffersScreen/CollectiveOffersSearchFilters/CollectiveOffersSearchFilters.tsx
+++ b/pro/src/screens/CollectiveOffersScreen/CollectiveOffersSearchFilters/CollectiveOffersSearchFilters.tsx
@@ -89,6 +89,9 @@ export const CollectiveOffersSearchFilters = ({
   isRestrictedAsAdmin = false,
 }: CollectiveOffersSearchFiltersProps): JSX.Element => {
   const isNewInterfaceActive = useIsNewInterfaceActive()
+  const isNewOffersAndBookingsActive = useActiveFeature(
+    'WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE'
+  )
   const formats: SelectOption[] = Object.values(EacFormat).map((format) => ({
     value: format,
     label: format,
@@ -182,6 +185,12 @@ export const CollectiveOffersSearchFilters = ({
       })
     : collectiveFilterStatus
 
+  const filteredStatusOptions = statusOptions.filter(
+    (status) =>
+      !isNewOffersAndBookingsActive ||
+      status.value !== CollectiveOfferDisplayedStatus.INACTIVE
+  )
+
   return (
     <>
       {!isNewInterfaceActive && offerer && (
@@ -237,19 +246,21 @@ export const CollectiveOffersSearchFilters = ({
             />
           </FieldLayout>
 
-          <FieldLayout
-            label="Type de l’offre"
-            name="collectiveOfferType"
-            isOptional
-          >
-            <SelectInput
-              onChange={storeCollectiveOfferType}
-              disabled={disableAllFilters}
+          {!isNewOffersAndBookingsActive && (
+            <FieldLayout
+              label="Type de l’offre"
               name="collectiveOfferType"
-              options={COLLECTIVE_OFFER_TYPES_OPTIONS}
-              value={selectedFilters.collectiveOfferType}
-            />
-          </FieldLayout>
+              isOptional
+            >
+              <SelectInput
+                onChange={storeCollectiveOfferType}
+                disabled={disableAllFilters}
+                name="collectiveOfferType"
+                options={COLLECTIVE_OFFER_TYPES_OPTIONS}
+                value={selectedFilters.collectiveOfferType}
+              />
+            </FieldLayout>
+          )}
           <fieldset>
             <legend>Période de l’évènement</legend>
 
@@ -272,7 +283,7 @@ export const CollectiveOffersSearchFilters = ({
                 Statut<Tag variant={TagVariant.BLUE}>Nouveau</Tag>
               </span>
             }
-            options={statusOptions}
+            options={filteredStatusOptions}
             placeholder="Statuts"
             isOptional
             className={styles['status-filter']}

--- a/pro/src/screens/CollectiveOffersScreen/__specs__/CollectiveOffersScreen.spec.tsx
+++ b/pro/src/screens/CollectiveOffersScreen/__specs__/CollectiveOffersScreen.spec.tsx
@@ -494,4 +494,35 @@ describe('CollectiveOffersScreen', () => {
 
     expect(newFirstOfferEventDate).toEqual('30/06/2024')
   })
+
+  it('should not display the offer type filter if the WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE FF is active', () => {
+    renderOffers(
+      {
+        ...props,
+      },
+      { features: ['WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE'] }
+    )
+    expect(
+      screen.queryByRole('combobox', { name: 'Type de l’offre' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not show the inactive status option if the WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE FF is active', async () => {
+    renderOffers(
+      {
+        ...props,
+      },
+      { features: ['WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE'] }
+    )
+
+    await userEvent.click(
+      screen.getByRole('combobox', {
+        name: 'Statut Nouveau',
+      })
+    )
+
+    expect(
+      screen.queryByRole('option', { name: 'Masquée sur ADAGE' })
+    ).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
…ch bookable offers in collective offers list.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31332

**Objectif**
Dans le cadre de la séparation de la page offres vitrines / offres réservables :

Avec le nouveau FF `WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE` actif, on ne doit voir que les offres réservables dans la liste des offres collectives. On ne doit aussi plus voir le filtre sur le type de l'offre. Et le filtre de statut ne doit plus contenir "Masquée sur ADAGE" qui n'a pas de sens pour une offre réservable.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
