### PR TITLE
(BSR)[PRO] test: Do not open again offer list bc already displayed

### DIFF
--- a/pro/cypress/e2e/features/editEventIndividualOffer.feature
+++ b/pro/cypress/e2e/features/editEventIndividualOffer.feature
@@ -8,7 +8,6 @@ Feature: Modify a digital individual offer
     And I display Informations pratiques tab
     And I edit the offer displayed
     And I update the url link
-    And I go to the "Offres" page
     And I open the first offer in the list
     And I display Informations pratiques tab
     Then the url updated is retrieved in the details of the offer

--- a/pro/cypress/e2e/step-definitions/editEventIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/editEventIndividualOffer.cy.ts
@@ -31,6 +31,8 @@ When('I update the url link', () => {
   )
   cy.findByText('Retour à la liste des offres').click()
   cy.url().should('contain', '/offres')
+  cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
+  cy.contains('Offres individuelles')
 })
 
 Then('the url updated is retrieved in the details of the offer', function () {


### PR DESCRIPTION
## But de la pull request

Inutile d'ouvrir les offres individuelles car on est redirigé dessus. Passait parfois selon la vitesse d'exécution des tests...

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
