### PR TITLE
(PC-31216)[API]feat: endpoint get product by EAN, update error code and message

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -711,15 +711,15 @@ def get_product_by_ean(ean: str) -> offers_serialize.GetProductInformations:
     if product is None:
         raise api_errors.ApiErrors(
             errors={
-                "global": ["Aucun produit ne correspond à ce code EAN dans notre base de données"],
+                "ean": ["EAN non reconnu. Assurez-vous qu'il n'y ait pas d'erreur de saisie."],
             },
             status_code=404,
         )
     if not product.isGcuCompatible:
         raise api_errors.ApiErrors(
             errors={
-                "global": ["Ce product n'est pas compatible avec les CGU"],
+                "ean": ["EAN invalide. Ce produit n'est pas conforme à nos CGU."],
             },
-            status_code=200,
+            status_code=422,
         )
     return offers_serialize.GetProductInformations.from_orm(product=product)

--- a/api/tests/routes/pro/get_product_by_ean_test.py
+++ b/api/tests/routes/pro/get_product_by_ean_test.py
@@ -73,8 +73,8 @@ class Returns200Test:
             response = test_client.get(f"/get_product_by_ean/{product.extraData.get('ean')}")
 
             # Then
-            assert response.status_code == 200
-            assert response.json == {"global": ["Ce product n'est pas compatible avec les CGU"]}
+            assert response.status_code == 422
+            assert response.json == {"ean": ["EAN invalide. Ce produit n'est pas conforme à nos CGU."]}
 
 
 @pytest.mark.usefixtures("db_session")
@@ -92,3 +92,4 @@ class Returns404Test:
             response = test_client.get("/get_product_by_ean/UNKNOWN")
 
             assert response.status_code == 404
+            assert response.json == {"ean": ["EAN non reconnu. Assurez-vous qu'il n'y ait pas d'erreur de saisie."]}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31216
Mise à jour des messages d'erreurs avec les information fournies par les designer/euse/s. Modification du status code de la réponse lorsqu'on trouve un produit avec l'EAN fourni mais que celui-ci est non compatible avec les CGU : utilisation du code 422 : https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
