### PR TITLE
(BSR)[API] fix: poetry.lock

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -5654,4 +5654,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f3441b6e5ce5aa35eb9f66f83c70c9812a9d46e9ab3ae04971fcfc97ad4a01ab"
+content-hash = "34a1db9f08078349ff82ce0bdb20b408e3b798d2094f9564b4d65ed33a6bcb49"


### PR DESCRIPTION
## But de la pull request

Corriger poetry.lock après re-re-re-re-rebase loupé.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
