### PR TITLE
(BSR)[PRO] test: activate FF at the beginning and not during test

### DIFF
--- a/pro/cypress/e2e/features/createEventIndividualOffer.feature
+++ b/pro/cypress/e2e/features/createEventIndividualOffer.feature
@@ -1,9 +1,10 @@
 @P0
 Feature: Create an individual offer (event)
-
   # Plante si l'offerer a plusieurs venues
+
   Scenario: It should create an individual offer (event)
-    Given I am logged in with account 1
+    Given I activate a feature flag "WIP_SPLIT_OFFER"
+    And I am logged in with account 1
     And I select offerer "Club Dorothy"
     When I go to the "Créer une offre" page
     And I want to create "Un évènement physique daté" offer

--- a/pro/cypress/e2e/features/createThingIndividualOffer.feature
+++ b/pro/cypress/e2e/features/createThingIndividualOffer.feature
@@ -2,7 +2,8 @@
 Feature: Create an individual offer (thing)
 
   Scenario: It should create an individual offer (thing)
-    Given I am logged in with account 1
+    Given I activate a feature flag "WIP_SPLIT_OFFER"
+    And I am logged in with account 1
     When I select offerer "Club Dorothy"
     And I go to the "Créer une offre" page
     And I want to create "Un bien physique" offer

--- a/pro/cypress/e2e/features/editEventIndividualOffer.feature
+++ b/pro/cypress/e2e/features/editEventIndividualOffer.feature
@@ -2,7 +2,8 @@
 Feature: Modify a digital individual offer
 
   Scenario: I should be able to modify the url of a digital offer
-    Given I am logged in with account 2
+    Given I activate a feature flag "WIP_SPLIT_OFFER"
+    And I am logged in with account 2
     When I go to the "Offres" page
     And I open the first offer in the list
     And I display Informations pratiques tab

--- a/pro/cypress/e2e/step-definitions/adage.cy.ts
+++ b/pro/cypress/e2e/step-definitions/adage.cy.ts
@@ -42,9 +42,7 @@ When('I open adage iframe with venue', () => {
 
 When('I open adage iframe with search page', () => {
   const adageToken = Cypress.env('adageToken')
-  cy.setFeatureFlags([
-    { name: 'WIP_ENABLE_ADAGE_VISUALIZATION', isActive: true },
-  ])
+
   cy.intercept({
     method: 'GET',
     url: '/adage-iframe/collective/offers-template/**',

--- a/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
+++ b/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
@@ -9,6 +9,10 @@ Given('I open the {string} page', (page: string) => {
   cy.visit('/' + page)
 })
 
+Given('I activate a feature flag {string}', (FF: string) => {
+  cy.setFeatureFlags([{ name: FF, isActive: true }])
+})
+
 When('I go to the {string} page', (page: string) => {
   cy.url().then((urlSource) => {
     cy.findAllByText(page).first().click()

--- a/pro/cypress/e2e/step-definitions/createEventIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/createEventIndividualOffer.cy.ts
@@ -1,7 +1,6 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor'
 
 When('I fill in event details', () => {
-  cy.setFeatureFlags([{ name: 'WIP_SPLIT_OFFER', isActive: true }])
   cy.findByLabelText('Titre de l’offre *').type('Le Diner de Devs')
   cy.findByLabelText('Description').type(
     'Une PO invite des développeurs à dîner...'

--- a/pro/cypress/e2e/step-definitions/createThingIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/createThingIndividualOffer.cy.ts
@@ -4,7 +4,6 @@ const offerDesc =
   'Une quête pour obtenir la question ultime sur la vie, l’univers et tout le reste.'
 
 When('I fill in details for physical offer', () => {
-  cy.setFeatureFlags([{ name: 'WIP_SPLIT_OFFER', isActive: true }])
   cy.findByLabelText('Titre de l’offre *').type(offerTitle)
   cy.findByLabelText('Description').type(offerDesc)
 

--- a/pro/cypress/e2e/step-definitions/editEventIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/editEventIndividualOffer.cy.ts
@@ -1,7 +1,6 @@
 import { Then, When } from '@badeball/cypress-cucumber-preprocessor'
 
 When('I open the first offer in the list', () => {
-  cy.setFeatureFlags([{ name: 'WIP_SPLIT_OFFER', isActive: true }])
   cy.findAllByTestId('offer-item-row')
     .first()
     .within(() => {

--- a/pro/cypress/support/commands.ts
+++ b/pro/cypress/support/commands.ts
@@ -78,6 +78,8 @@ Cypress.Commands.add('setFeatureFlags', (features: Feature[]) => {
     body: JSON.stringify({
       features,
     }),
+  }).then((response) => {
+    expect(response.status).to.equal(204)
   })
 })
 


### PR DESCRIPTION
## But de la pull request

Activation du FF au début du scénario (le cas createEventIndividualOffer était flaky car FF pas activé à la première exécution)
Suppression de l'activation d'un FF adage qui n'existe plus, donc devenu inutile.
Attente de la réponse du PATCH FF en 204.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
