### PR TITLE
(PC-31319)[API] fix: make allocine movie release date None when invalid

### DIFF
--- a/api/src/pcapi/connectors/serialization/allocine_serializers.py
+++ b/api/src/pcapi/connectors/serialization/allocine_serializers.py
@@ -217,7 +217,16 @@ class AllocineMoviePoster(pydantic.BaseModel):
 
 
 class AllocineReleaseDate(pydantic.BaseModel):
-    date: datetime.date
+    date: datetime.date | None
+
+    @pydantic.field_validator("date", mode="before")
+    def make_date_none_if_not_iso(cls, date: str) -> str | None:
+        try:
+            datetime.date.fromisoformat(date)
+        except ValueError:
+            return None
+
+        return date
 
 
 class AllocineReleaseDataTech(pydantic.BaseModel):

--- a/api/src/pcapi/core/providers/allocine.py
+++ b/api/src/pcapi/core/providers/allocine.py
@@ -131,7 +131,12 @@ def build_movie_id_at_providers(provider_id: int, allocine_id: int) -> str:
 
 def get_most_recent_release_date(releases: list[allocine_serializers.AllocineMovieRelease]) -> str | None:
     sorted_releases = sorted(
-        [release.releaseDate.date.isoformat() for release in releases if release.releaseDate], reverse=True
+        [
+            release.releaseDate.date.isoformat()
+            for release in releases
+            if release.releaseDate and release.releaseDate.date
+        ],
+        reverse=True,
     )
     return sorted_releases[0] if sorted_releases else None
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31319

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
