### PR TITLE
(PC-31459)[BO] fix: include debit notes in exported invoices csv

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1739,6 +1739,11 @@ def generate_debit_notes(batch: models.CashflowBatch) -> None:
                     "exc": str(exc),
                 },
             )
+    with log_elapsed(logger, "Generated CSV invoices file"):
+        path = generate_invoice_file(batch)
+    drive_folder_name = _get_drive_folder_name(batch)
+    with log_elapsed(logger, "Uploaded CSV invoices file to Google Drive"):
+        _upload_files_to_google_drive(drive_folder_name, [path])
 
 
 def _get_cashflows_by_bank_accounts(batch: models.CashflowBatch, only_debit_notes: bool = False) -> list:
@@ -1784,11 +1789,6 @@ def generate_invoices(batch: models.CashflowBatch) -> None:
                     "exc": str(exc),
                 },
             )
-    with log_elapsed(logger, "Generated CSV invoices file"):
-        path = generate_invoice_file(batch)
-    drive_folder_name = _get_drive_folder_name(batch)
-    with log_elapsed(logger, "Uploaded CSV invoices file to Google Drive"):
-        _upload_files_to_google_drive(drive_folder_name, [path])
 
 
 def async_generate_invoices(batch: models.CashflowBatch) -> None:

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -1,18 +1,26 @@
+import csv
 import datetime
+from decimal import Decimal
+import io
 from unittest.mock import patch
+import zipfile
 
 import pytest
 
-import pcapi.core.categories.subcategories_v2 as subcategories
-import pcapi.core.finance.api as finance_api
-import pcapi.core.finance.factories as finance_factories
-import pcapi.core.finance.models as finance_models
-import pcapi.core.offerers.factories as offerers_factories
-import pcapi.core.offers.factories as offers_factories
+from pcapi.core.bookings import api as bookings_api
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.bookings import models as bookings_models
+from pcapi.core.categories import subcategories_v2 as subcategories
+from pcapi.core.finance import api as finance_api
+from pcapi.core.finance import factories as finance_factories
+from pcapi.core.finance import models as finance_models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
-import pcapi.core.users.factories as users_factories
+from pcapi.core.users import factories as users_factories
 from pcapi.models import db
+from pcapi.utils import human_ids
 
 from tests.test_utils import run_command
 
@@ -299,3 +307,200 @@ def test_when_there_is_a_debit_note_to_generate_on_partial_incident(app, css_fon
     assert len(invoices[1].lines) == 1
     assert invoices[1].amount == -invoices[0].amount / 2
     assert invoices[1].amount == 1500
+
+
+@pytest.mark.usefixtures("clean_database")
+def test_generate_invoice_file_with_debit_note(app, tmp_path, monkeypatch, css_font_http_request_mock):
+    _paths = []
+
+    def _upload_files_to_google_drive(folder_name, paths) -> None:
+        nonlocal _paths
+        _paths = paths
+
+    monkeypatch.setattr(finance_api, "_upload_files_to_google_drive", _upload_files_to_google_drive)
+    monkeypatch.setattr(finance_api.tempfile, "mkdtemp", lambda: tmp_path)
+
+    offerer1 = offerers_factories.OffererFactory(name="Association de coiffeurs", siren="853318459")
+    bank_account1 = finance_factories.BankAccountFactory(offerer=offerer1)
+    venue1 = offerers_factories.VenueFactory(pricing_point="self", managingOfferer=offerer1, bank_account=bank_account1)
+    author_user = users_factories.UserFactory()
+
+    user1 = users_factories.BeneficiaryGrant18Factory()
+    ############################################################################
+    # Create an offer, book it, invoice it and reimburse it for bank_account 1 #
+    ############################################################################
+    booking1 = bookings_factories.BookingFactory(
+        user=user1,
+        quantity=13,
+        stock__price=Decimal("5.0"),
+        stock__offer__venue=venue1,
+    )  # 65€
+    bookings_api.mark_as_used(
+        booking=booking1,
+        validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+    )
+    finance_events = finance_models.FinanceEvent.query.all()
+    assert len(finance_events) == 1
+
+    initial_finance_event = finance_events[0]
+    finance_api.price_event(initial_finance_event)
+
+    cashflow_batch1 = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    run_command(
+        app,
+        "generate_invoices",
+        "--batch-id",
+        str(cashflow_batch1.id),
+    )
+    db.session.add_all([cashflow_batch1, booking1, bank_account1, author_user, initial_finance_event])
+    assert len(cashflow_batch1.cashflows) == 1
+    cashflow1 = cashflow_batch1.cashflows[0]
+    assert len(cashflow1.invoices) == 1
+    invoice1 = cashflow1.invoices[0]
+    assert booking1.status == bookings_models.BookingStatus.REIMBURSED
+
+    assert len(_paths) == 1
+    path = _paths[0]
+    with zipfile.ZipFile(path) as zfile:
+        invoices_files = [
+            file_name for file_name in zfile.namelist() if file_name.startswith(f"invoices_{cashflow_batch1.label}")
+        ]
+        assert len(invoices_files) == 1
+        with zfile.open(invoices_files[0]) as csv_bytefile:
+            csv_textfile = io.TextIOWrapper(csv_bytefile)
+            reader = csv.DictReader(csv_textfile, quoting=csv.QUOTE_NONNUMERIC)
+            rows = list(reader)
+
+    assert len(rows) == 2
+    assert {"offerer contribution", "offerer revenue"} == {row["Type de ticket de facturation"] for row in rows}
+    row_revenue1 = [row for row in rows if row["Type de ticket de facturation"] == "offerer revenue"][0]
+    assert row_revenue1["Identifiant des coordonnées bancaires"] == human_ids.humanize(bank_account1.id)
+    assert row_revenue1["Référence du justificatif"] == invoice1.reference
+    assert row_revenue1["Somme des tickets de facturation"] == Decimal("-6500.0")
+
+    row_contribution1 = [row for row in rows if row["Type de ticket de facturation"] == "offerer contribution"][0]
+    assert row_contribution1["Identifiant des coordonnées bancaires"] == human_ids.humanize(bank_account1.id)
+    assert row_contribution1["Référence du justificatif"] == invoice1.reference
+    assert row_contribution1["Somme des tickets de facturation"] == Decimal("0")
+
+    #################################################
+    # Create an overpayment incident for debit note #
+    #################################################
+    incident = finance_api.create_overpayment_finance_incident(
+        bookings=[booking1],
+        author=author_user,
+        origin="BO",
+        amount=Decimal("30"),
+    )
+
+    finance_api.validate_finance_overpayment_incident(
+        finance_incident=incident,
+        force_debit_note=True,
+        author=author_user,
+    )
+
+    finance_events = finance_models.FinanceEvent.query.filter(
+        finance_models.FinanceEvent.id != initial_finance_event.id
+    ).all()
+    assert len(finance_events) == 2
+    assert {finance_event.motive for finance_event in finance_events} == {
+        finance_models.FinanceEventMotive.INCIDENT_REVERSAL_OF_ORIGINAL_EVENT,
+        finance_models.FinanceEventMotive.INCIDENT_NEW_PRICE,
+    }
+    for finance_event in finance_events:
+        finance_api.price_event(finance_event)
+
+    ###########################################################################
+    # Create a second booking to reimburse and include it in the invoices csv #
+    ###########################################################################
+
+    offerer2 = offerers_factories.OffererFactory(name="Association de coiffeurs", siren="853318460")
+    bank_account2 = finance_factories.BankAccountFactory(offerer=offerer2)
+    venue2 = offerers_factories.VenueFactory(pricing_point="self", managingOfferer=offerer2, bank_account=bank_account2)
+
+    user2 = users_factories.BeneficiaryGrant18Factory()
+    booking2 = bookings_factories.BookingFactory(
+        user=user2,
+        quantity=4,
+        stock__price=Decimal("5.0"),
+        stock__offer__venue=venue2,
+    )  # 20€
+    bookings_api.mark_as_used(
+        booking=booking2,
+        validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
+    )
+    finance_events = booking2.finance_events
+    assert len(finance_events) == 1
+
+    finance_event = finance_events[0]
+    finance_api.price_event(finance_event)
+
+    ####################################################################################################
+    # Generate the cashflows and the invoice csv that should include both lines for income and outcome #
+    ####################################################################################################
+    cashflow_batch2 = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    run_command(
+        app,
+        "generate_invoices",
+        "--batch-id",
+        str(cashflow_batch2.id),
+    )
+    db.session.add_all([cashflow_batch2, booking2, bank_account1, bank_account2])
+    assert len(cashflow_batch2.cashflows) == 2
+    assert {cashflow.bankAccountId for cashflow in cashflow_batch2.cashflows} == {bank_account1.id, bank_account2.id}
+    cashflow2 = [c for c in cashflow_batch2.cashflows if c.bankAccountId == bank_account1.id][0]
+    assert len(cashflow2.invoices) == 1
+    invoice2 = cashflow2.invoices[0]
+    cashflow3 = [c for c in cashflow_batch2.cashflows if c.bankAccountId == bank_account2.id][0]
+    assert len(cashflow3.invoices) == 1
+    invoice3 = cashflow3.invoices[0]
+    assert booking2.status == bookings_models.BookingStatus.REIMBURSED
+
+    assert len(_paths) == 1
+    path = _paths[0]
+    with zipfile.ZipFile(path) as zfile:
+        invoices_files = [
+            file_name for file_name in zfile.namelist() if file_name.startswith(f"invoices_{cashflow_batch2.label}")
+        ]
+        assert len(invoices_files) == 1
+        with zfile.open(invoices_files[0]) as csv_bytefile:
+            csv_textfile = io.TextIOWrapper(csv_bytefile)
+            reader = csv.DictReader(csv_textfile, quoting=csv.QUOTE_NONNUMERIC)
+            rows = list(reader)
+
+    assert len(rows) == 4
+    assert {r["Référence du justificatif"] for r in rows} == {invoice2.reference, invoice3.reference}
+    assert invoice2.reference.startswith("A")  # →  debit note
+    invoice2_rows = [row for row in rows if row["Référence du justificatif"] == invoice2.reference]
+    assert len(invoice2_rows) == 2
+
+    assert {"offerer contribution", "offerer revenue"} == {
+        row["Type de ticket de facturation"] for row in invoice2_rows
+    }
+    row_revenue2 = [row for row in invoice2_rows if row["Type de ticket de facturation"] == "offerer revenue"][0]
+    assert row_revenue2["Identifiant des coordonnées bancaires"] == human_ids.humanize(bank_account1.id)
+    assert row_revenue2["Somme des tickets de facturation"] == Decimal("3000.0")
+    assert row_revenue2["Type de réservation"] == "PC"
+
+    row_contribution2 = [
+        row for row in invoice2_rows if row["Type de ticket de facturation"] == "offerer contribution"
+    ][0]
+    assert row_contribution2["Identifiant des coordonnées bancaires"] == human_ids.humanize(bank_account1.id)
+    assert row_contribution2["Somme des tickets de facturation"] == Decimal("0")
+    assert row_contribution2["Type de réservation"] == "PC"
+
+    invoice3_rows = [row for row in rows if row["Référence du justificatif"] == invoice3.reference]
+    assert len(invoice3_rows) == 2
+
+    assert {"offerer contribution", "offerer revenue"} == {
+        row["Type de ticket de facturation"] for row in invoice3_rows
+    }
+    row_revenue3 = [row for row in invoice3_rows if row["Type de ticket de facturation"] == "offerer revenue"][0]
+    assert row_revenue3["Identifiant des coordonnées bancaires"] == human_ids.humanize(bank_account2.id)
+    assert row_revenue3["Somme des tickets de facturation"] == Decimal("-2000.0")
+
+    row_contribution3 = [
+        row for row in invoice3_rows if row["Type de ticket de facturation"] == "offerer contribution"
+    ][0]
+    assert row_contribution3["Identifiant des coordonnées bancaires"] == human_ids.humanize(bank_account2.id)
+    assert row_contribution3["Somme des tickets de facturation"] == Decimal("0")


### PR DESCRIPTION
## But de la pull request

Ajout des lignes des notes de débit dans l'export invoices csv

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31459

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
