### PR TITLE
(BSR) chore: transform 'clean_database' decorator into a fixture

### DIFF
--- a/api/TESTS.md
+++ b/api/TESTS.md
@@ -4,11 +4,17 @@ Les tests automatisés sont écrits et exécutés avec pytest.
 
 ## Indépendance des tests
 
-Aujourd'hui, la plupart des tests ne sont pas réellement indépendants : ils dépendant des données générées par d'autres tests
+Aujourd'hui, la plupart des tests ne sont pas réellement indépendants : ils dépendent des données générées par d'autres tests
 exécutés plus tôt. Le souhait est de les rendre exécutable indépendamment des autres.
 
-* Pour ce faire, on peut décorer une fonction de test avec `@clean_database` qui va s'occuper de vider toutes les tables dans la base de donnée.
-Un test décoré de cette manière va donc devoir se préoccuper d'enregistrer les données dont il a besoin.
+* Pour ce faire, on peut utiliser la fixture `clean_database` qui va s'occuper de vider toutes les tables dans la base de donnée.
+Un test qui utilise cette fixture va donc devoir se préoccuper d'enregistrer les données dont il a besoin. exemple :
+
+```python
+@pytest.mark.usefixtures("clean_database")
+def test_regular():
+    …
+```
 
 ## Niveaux de tests
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,5 +1,4 @@
 import contextlib
-from functools import wraps
 import os
 from pathlib import Path
 from pprint import pprint
@@ -175,16 +174,10 @@ def clear_tests_invoices_bucket():
         object_storage_testing.reset_bucket()
 
 
-def clean_database(f: object) -> object:
-    @wraps(f)
-    def decorated_function(*args, **kwargs):
-        try:
-            return_value = f(*args, **kwargs)
-        finally:
-            clean_all_database()
-        return return_value
-
-    return decorated_function
+@pytest.fixture(scope="function")
+def clean_database():
+    yield
+    clean_all_database()
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -55,11 +55,9 @@ from pcapi.tasks.serialization.external_api_booking_notification_tasks import Bo
 from pcapi.utils import queue
 from pcapi.utils.requests import exceptions as requests_exception
 
-from tests.conftest import clean_database
-
 
 class BookOfferConcurrencyTest:
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_create_booking(self, app):
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         stock = offers_factories.StockFactory(price=10, dnBookedQuantity=5)
@@ -86,7 +84,7 @@ class BookOfferConcurrencyTest:
         assert models.Booking.query.count() == 0
         assert offers_models.Stock.query.filter_by(id=stock.id, dnBookedQuantity=5).count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_cancel_booking(self, app):
         booking = bookings_factories.BookingFactory(stock__dnBookedQuantity=1)
 
@@ -124,7 +122,7 @@ class BookOfferConcurrencyTest:
         api._cancel_booking(booking, BookingCancellationReasons.BENEFICIARY)
         assert booking.stock.dnBookedQuantity == dnBookedQuantity
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_cancel_all_bookings_from_stock(self, app):
         stock = offers_factories.StockFactory(dnBookedQuantity=1)
         bookings_factories.BookingFactory(stock=stock)

--- a/api/tests/core/bookings/test_api_race_condition.py
+++ b/api/tests/core/bookings/test_api_race_condition.py
@@ -4,6 +4,7 @@ import logging
 import threading
 from unittest.mock import patch
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
@@ -18,7 +19,6 @@ from pcapi.core.providers.models import Provider
 from pcapi.local_providers.cinema_providers.cds.cds_stocks import CDSStocks
 from pcapi.models import db
 
-from tests.conftest import clean_database
 import tests.local_providers.cinema_providers.cds.fixtures as cds_fixtures
 
 
@@ -118,7 +118,7 @@ class BookingRaceConditionTest:
             logger.warning("End of contextmanager, removing the session, session: %s", session)
             Session.remove()
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")
     @patch("pcapi.settings.CDS_API_URL", "fakeUrl/")
     def test_stock_race_condition_between_booking_and_synchronization(self, mock_get_venue_movies, requests_mock, app):

--- a/api/tests/core/bookings/test_commands.py
+++ b/api/tests/core/bookings/test_commands.py
@@ -8,12 +8,11 @@ import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offer_models
 
-from tests.conftest import clean_database
 from tests.test_utils import run_command
 
 
 class ArchiveOldBookingsTest:
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_basics(self, app):
         # given
         now = datetime.datetime.utcnow()
@@ -37,7 +36,7 @@ class ArchiveOldBookingsTest:
         assert old_booking.displayAsEnded
         assert not recent_booking.displayAsEnded
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     @pytest.mark.parametrize(
         "subcategoryId",
         offer_models.Stock.AUTOMATICALLY_USED_SUBCATEGORIES,
@@ -72,7 +71,7 @@ class ArchiveOldBookingsTest:
         assert not old_not_free_booking.displayAsEnded
         assert old_booking.displayAsEnded
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     @pytest.mark.parametrize(
         "subcategoryId",
         offer_models.Stock.AUTOMATICALLY_USED_SUBCATEGORIES,

--- a/api/tests/core/external/test_commands.py
+++ b/api/tests/core/external/test_commands.py
@@ -1,14 +1,15 @@
 from unittest.mock import patch
 
+import pytest
+
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import testing
 
-from tests.conftest import clean_database
 from tests.test_utils import run_command
 
 
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_update_sendinblue_batch_users(app):
     users_factories.BeneficiaryGrant18Factory.create_batch(2)
 
@@ -23,7 +24,7 @@ def test_update_sendinblue_batch_users(app):
     assert "Exception" not in result.stdout
 
 
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_update_sendinblue_pro(app):
     users_factories.UserFactory()  # excluded
     users_factories.AdminFactory()  # excluded

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -1,6 +1,8 @@
 import datetime
 from unittest.mock import patch
 
+import pytest
+
 import pcapi.core.categories.subcategories_v2 as subcategories
 import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.factories as finance_factories
@@ -12,12 +14,11 @@ from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
 
-from tests.conftest import clean_database
 from tests.test_utils import run_command
 
 
 class AddCustomOfferReimbursementRuleTest:
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_basics(self, app):
         stock = offers_factories.StockFactory(price=24.68)
         offer = stock.offer
@@ -40,7 +41,7 @@ class AddCustomOfferReimbursementRuleTest:
         assert rule.offer.id == offer_id
         assert rule.amount == 1234
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_warnings(self, app):
         stock = offers_factories.StockFactory(price=24.68)
         offer = stock.offer
@@ -61,7 +62,7 @@ class AddCustomOfferReimbursementRuleTest:
         assert "Mismatch on original amount" in result.output
         assert finance_models.CustomReimbursementRule.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_force_with_warnings(self, app):
         stock = offers_factories.StockFactory(price=24.68)
         offer = stock.offer
@@ -87,7 +88,7 @@ class AddCustomOfferReimbursementRuleTest:
 
 
 @override_settings(SLACK_GENERATE_INVOICES_FINISHED_CHANNEL="channel")
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_generate_invoices_internal_notification(app, css_font_http_request_mock):
     venue = offerers_factories.VenueFactory()
     batch = finance_factories.CashflowBatchFactory()
@@ -121,7 +122,7 @@ def test_generate_invoices_internal_notification(app, css_font_http_request_mock
 
 
 @override_features(WIP_ENABLE_FINANCE_INCIDENT=True)
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_when_there_is_a_debit_note_to_generate_on_total_incident(app, css_font_http_request_mock):
     sixteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=16)
     fifteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=15)
@@ -211,7 +212,7 @@ def test_when_there_is_a_debit_note_to_generate_on_total_incident(app, css_font_
 
 
 @override_features(WIP_ENABLE_FINANCE_INCIDENT=True)
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_when_there_is_a_debit_note_to_generate_on_partial_incident(app, css_font_http_request_mock):
     sixteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=16)
     fifteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=15)

--- a/api/tests/core/finance/test_siret_api.py
+++ b/api/tests/core/finance/test_siret_api.py
@@ -9,11 +9,9 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
 
-from tests.conftest import clean_database
-
 
 class DeleteSiretTest:
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_basics(self):
         venue = offerers_factories.VenueFactory(pricing_point="self")
         dependent_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer, pricing_point=venue)
@@ -44,7 +42,7 @@ class DeleteSiretTest:
             assert action.venueId in (venue.id, dependent_venue.id)
             assert action.extraData["modified_info"]["pricingPointSiret"] == {"old_info": old_siret, "new_info": None}
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_with_new_pricing_point(self):
         venue = offerers_factories.VenueFactory(pricing_point="self")
         dependent_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer, pricing_point=venue)
@@ -92,7 +90,7 @@ class DeleteSiretTest:
         assert actions[1].venueId == dependent_venue.id
         assert actions[1].extraData["modified_info"]["pricingPointSiret"] == {"old_info": old_siret, "new_info": None}
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_dry_run(self):
         venue = offerers_factories.VenueFactory(pricing_point="self")
 
@@ -101,7 +99,7 @@ class DeleteSiretTest:
         assert venue.siret is not None
         assert venue.comment is None
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_revenue_check(self):
         venue = offerers_factories.VenueFactory(pricing_point="self")
         user = users_factories.RichBeneficiaryFactory()
@@ -124,7 +122,7 @@ class DeleteSiretTest:
         )
         assert venue.siret is None
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_refuse_if_pricing_point_has_pending_pricings(self):
         venue = offerers_factories.VenueFactory(pricing_point="self")
         factories.PricingFactory(booking__stock__offer__venue=venue, status=models.PricingStatus.PENDING)
@@ -133,7 +131,7 @@ class DeleteSiretTest:
             siret_api.remove_siret(venue, comment="xxx", apply_changes=True)
         assert str(err.value) == "Ce lieu a des valorisations en attente"
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_refuse_if_new_pricing_point_does_not_exist(self):
         venue = offerers_factories.VenueFactory(pricing_point="self")
 
@@ -141,7 +139,7 @@ class DeleteSiretTest:
             siret_api.remove_siret(venue, comment="xxx", new_pricing_point_id=venue.id + 1000, apply_changes=True)
         assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même structure"
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_refuse_if_new_pricing_point_has_no_siret(self):
         venue = offerers_factories.VenueFactory(pricing_point="self")
         new_pricing_point = offerers_factories.VenueWithoutSiretFactory(managingOffererId=venue.managingOffererId)
@@ -150,7 +148,7 @@ class DeleteSiretTest:
             siret_api.remove_siret(venue, comment="xxx", new_pricing_point_id=new_pricing_point.id, apply_changes=True)
         assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même structure"
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_refuse_if_new_pricing_point_is_managed_by_another_offerer(self):
         venue = offerers_factories.VenueFactory(pricing_point="self")
         new_pricing_point = offerers_factories.VenueFactory(pricing_point="self")

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -53,7 +53,6 @@ from pcapi.notifications.push import testing as push_testing
 from pcapi.utils.human_ids import humanize
 
 import tests
-from tests import conftest
 from tests.connectors.cgr import soap_definitions
 from tests.connectors.titelive import fixtures
 from tests.local_providers.cinema_providers.boost import fixtures as boost_fixtures
@@ -1037,7 +1036,7 @@ class CreateMediationV2Test:
 
     @mock.patch("pcapi.core.object_storage.store_public_object", side_effect=Exception)
     @override_settings(LOCAL_STORAGE_DIR=BASE_THUMBS_DIR)
-    @conftest.clean_database
+    @pytest.mark.usefixtures("clean_database")
     # this test needs "clean_database" instead of "db_session" fixture because with the latter, the mediation would still be present in databse
     def test_rollback_if_exception(self, mock_store_public_object, clear_tests_assets_bucket):
         user = users_factories.ProFactory()

--- a/api/tests/core/reference/test_models.py
+++ b/api/tests/core/reference/test_models.py
@@ -7,8 +7,6 @@ from pcapi.core.reference import factories
 from pcapi.core.reference import models
 from pcapi.models import db
 
-from tests.conftest import clean_database
-
 
 class ReferenceSchemeTest:
     @pytest.mark.usefixtures("db_session")
@@ -46,7 +44,7 @@ class ReferenceSchemeTest:
         db.session.refresh(scheme)
         assert scheme.nextNumber == 2
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_usage_without_proper_lock(self, app):
         scheme = factories.ReferenceSchemeFactory()
         scheme.nextNumber = 1

--- a/api/tests/core/search/test_commands_indexation.py
+++ b/api/tests/core/search/test_commands_indexation.py
@@ -4,26 +4,20 @@ from unittest import mock
 import pytest
 
 from pcapi.core import search
-import pcapi.core.bookings.factories as bookings_factories
+from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.categories.subcategories_v2 import ALL_SUBCATEGORIES
-import pcapi.core.educational.factories as educational_factories
-import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.educational import factories as educational_factories
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
-import pcapi.core.offers.factories as offers_factories
 from pcapi.core.providers.titelive_gtl import GTLS
-import pcapi.core.search.testing as search_testing
+from pcapi.core.search import testing as search_testing
 from pcapi.repository import repository
 
-from tests.conftest import clean_database
+from tests.test_utils import run_command
 
 
-def run_command(app, command_name, *args):
-    runner = app.test_cli_runner()
-    args = (command_name, *args)
-    return runner.invoke(args=args)
-
-
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_partially_index_offers(app):
     _inactive_offer = offers_factories.StockFactory(offer__isActive=False)
     _unbookable_offer = offers_factories.OfferFactory()
@@ -49,7 +43,7 @@ def test_partially_index_offers(app):
     assert set(search_testing.search_store["offers"].keys()) == expected_to_be_reindexed
 
 
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 @mock.patch("pcapi.core.search.async_index_offer_ids")
 def test_update_products_booking_count_and_reindex_offers(mocked_async_index_offer_ids, app):
     ean = "1234567890123"
@@ -73,7 +67,7 @@ def test_update_products_booking_count_and_reindex_offers(mocked_async_index_off
     )
 
 
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 @mock.patch("pcapi.core.search.async_index_offer_ids")
 def test_update_products_booking_count_and_reindex_offers_if_same_ean(mocked_async_index_offer_ids, app):
     ean_1 = "1234567890123"
@@ -106,7 +100,7 @@ def test_update_products_booking_count_and_reindex_offers_if_same_ean(mocked_asy
     assert kwargs == {"reason": search.IndexationReason.BOOKING_COUNT_CHANGE}
 
 
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_partially_index_collective_offer_templates(app):
     _not_indexable_template = educational_factories.CollectiveOfferTemplateFactory(isActive=False)
     indexable_template1 = educational_factories.CollectiveOfferTemplateFactory()
@@ -129,7 +123,7 @@ def test_partially_index_collective_offer_templates(app):
     assert set(search_testing.search_store["collective-offers-templates"].keys()) == expected_to_be_reindexed
 
 
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_partially_index_venues(app):
     _not_indexable_venue = offerers_factories.VenueFactory(isPermanent=False)
     indexable_venue1 = offerers_factories.VenueFactory(isPermanent=True)
@@ -155,7 +149,7 @@ def test_partially_index_venues(app):
     assert set(search_testing.search_store["venues"].keys()) == expected_to_be_reindexed
 
 
-@clean_database
+@pytest.mark.usefixtures("clean_database")
 def test_partially_index_venues_removes_non_eligible_venues(app):
     future_not_indexable_venue = offerers_factories.VenueFactory(isPermanent=True)
     indexable_venue1 = offerers_factories.VenueFactory(isPermanent=True)

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -27,8 +27,6 @@ from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.repository import repository
 from pcapi.repository import transaction
 
-from tests.conftest import clean_database
-
 
 @pytest.mark.usefixtures("db_session")
 class UserTest:
@@ -606,7 +604,7 @@ class UserLoginTest:
     # Since we are testing a deferred trigger on the User table,
     # we cannot have the db_session fixture tampering with the
     # transaction lifecycle.
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_empty_password_update(self):
         with pytest.raises(sa_exc.InternalError) as exc:
             with transaction():
@@ -617,7 +615,7 @@ class UserLoginTest:
         assert "missingLoginMethod" in str(exc.value)
         assert user.password is not None
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_empty_password_insert(self):
         with pytest.raises(sa_exc.InternalError) as exc:
             with transaction():
@@ -627,7 +625,7 @@ class UserLoginTest:
         assert "missingLoginMethod" in str(exc.value)
         assert user_models.User.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_empty_password_update_with_sso(self):
         user = users_factories.UserFactory()
         users_factories.SingleSignOnFactory(user=user)
@@ -638,7 +636,7 @@ class UserLoginTest:
 
         assert user.password is None
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_empty_password_insert_with_sso(self):
         new_user = user_models.User(email="test@example.com")
         single_sign_on = user_models.SingleSignOn(user=new_user, ssoProvider="google", ssoUserId="user_id")

--- a/api/tests/repository/test_transaction.py
+++ b/api/tests/repository/test_transaction.py
@@ -8,11 +8,9 @@ from pcapi.repository import _manage_session
 from pcapi.repository import atomic
 from pcapi.repository import mark_transaction_as_invalid
 
-from tests.conftest import clean_database
-
 
 class AtomicTest:
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_atomic_commits_on_success(self):
         user_session = UserSession(userId=1, uuid=uuid.uuid4())
 
@@ -21,7 +19,7 @@ class AtomicTest:
 
         assert UserSession.query.count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_atomic_rolls_back_on_raise(self):
         user_session = UserSession(userId=1, uuid=uuid.uuid4())
 
@@ -32,7 +30,7 @@ class AtomicTest:
 
         assert UserSession.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_atomic_is_reentrant(self):
         user_session = UserSession(userId=1, uuid=uuid.uuid4())
 
@@ -47,7 +45,7 @@ class AtomicTest:
 
         assert UserSession.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_atomic_disables_autoflush(self):
         user_session = UserSession(userId=1, uuid=uuid.uuid4())
 
@@ -55,7 +53,7 @@ class AtomicTest:
             db.session.add(user_session)
             assert UserSession.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_atomic_decorator_commits_on_success(self):
         @atomic()
         def view():
@@ -66,7 +64,7 @@ class AtomicTest:
         _manage_session()
         assert UserSession.query.count() == 1
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_atomic_decorator_rollsback_on_exception(self):
         @atomic()
         def view():
@@ -78,7 +76,7 @@ class AtomicTest:
             view()
         assert UserSession.query.count() == 0
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_atomic_decorator_rollback_invalid_transaction(self):
         @atomic()
         def view():

--- a/api/tests/routes/pro/post_venue_provider_test.py
+++ b/api/tests/routes/pro/post_venue_provider_test.py
@@ -18,7 +18,6 @@ import pcapi.core.providers.repository as providers_repository
 from pcapi.core.users import factories as user_factories
 from pcapi.models.api_errors import ApiErrors
 
-from tests.conftest import clean_database
 from tests.local_providers.cinema_providers.cds import fixtures as cds_fixtures
 
 
@@ -353,7 +352,7 @@ class Returns400Test:
         assert response.json["venueId"] == ["Ce champ est obligatoire"]
         assert response.json["providerId"] == ["Ce champ est obligatoire"]
 
-    @clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_when_add_allocine_stocks_provider_with_wrong_format_price(self, client):
         # Given
         venue = offerers_factories.VenueFactory(managingOfferer__siren="775671464")

--- a/api/tests/routes/public/individual_offers/v1/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_test.py
@@ -16,7 +16,6 @@ from pcapi.utils import date as date_utils
 from pcapi.utils import human_ids
 
 import tests
-from tests import conftest
 from tests.routes import image_data
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 
@@ -39,12 +38,12 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         }
 
     @pytest.mark.usefixtures("db_session")
-    def test_should_raise_401_because_not_authenticated(self, client: conftest.TestClient):
+    def test_should_raise_401_because_not_authenticated(self, client):
         response = client.post(self.endpoint_url, json={})
         assert response.status_code == 401
 
     @pytest.mark.usefixtures("db_session")
-    def test_should_raise_404_because_has_no_access_to_venue(self, client: conftest.TestClient):
+    def test_should_raise_404_because_has_no_access_to_venue(self, client):
         plain_api_key, _ = self.setup_provider()
         venue = self.setup_venue()
         response = client.with_explicit_token(plain_api_key).post(
@@ -54,7 +53,7 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         assert response.status_code == 404
 
     @pytest.mark.usefixtures("db_session")
-    def test_should_raise_404_because_venue_provider_is_inactive(self, client: conftest.TestClient):
+    def test_should_raise_404_because_venue_provider_is_inactive(self, client):
         plain_api_key, venue_provider = self.setup_inactive_venue_provider()
         response = client.with_explicit_token(plain_api_key).post(
             self.endpoint_url,
@@ -448,7 +447,7 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         assert response.json == {"venueId": ["There is no venue with this id associated to your API key"]}
         assert offers_models.Offer.query.first() is None
 
-    @conftest.clean_database
+    @pytest.mark.usefixtures("clean_database")
     @mock.patch("pcapi.core.offers.api.create_thumb", side_effect=Exception)
     # this test needs "clean_database" instead of "db_session" fixture because with the latter, the mediation would still be present in databse
     def test_no_objects_saved_on_image_error(self, create_thumb_mock, client):
@@ -475,7 +474,7 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         assert offers_models.Offer.query.first() is None
         assert offers_models.Stock.query.first() is None
 
-    @conftest.clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_image_too_small(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
 
@@ -500,7 +499,7 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         assert offers_models.Offer.query.first() is None
         assert offers_models.Stock.query.first() is None
 
-    @conftest.clean_database
+    @pytest.mark.usefixtures("clean_database")
     def test_bad_image_ratio(self, client):
         venue, _ = utils.create_offerer_provider_linked_to_venue()
 


### PR DESCRIPTION
## But de la pull request

Refactor du décorateur "clean_database" pour le remplacer par une fixture

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
