### PR TITLE
(BSR) fix: flaky 'test_get_collective_offers_expired'

### DIFF
--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1467,7 +1467,9 @@ class GetFilteredCollectiveOffersTest:
             user_is_admin=False,
             statuses=[educational_models.CollectiveOfferDisplayedStatus.EXPIRED.value],
         )
-        assert offers.all() == [collective_offer_expired, collective_offer_prebooked_expired]
+        offers_list = offers.all()
+        assert len(offers_list) == 2
+        assert set(offers_list) == {collective_offer_expired, collective_offer_prebooked_expired}
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
## But de la pull request

Fix: flaky 'test_get_collective_offers_expired'

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
