### PR TITLE
(PC-31217)[API]feat: add new validation for post and patch offer regarding EAN code

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -204,6 +204,10 @@ class EanFormatException(OfferCreationBaseException):
     pass
 
 
+class ProductNotFoundForOfferCreation(OfferCreationBaseException):
+    pass
+
+
 class FutureOfferException(OfferCreationBaseException):
     pass
 

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -570,7 +570,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     lastValidationPrice: decimal.Decimal = sa.Column(sa.Numeric(10, 2), nullable=True)
     name: str = sa.Column(sa.String(140), nullable=False)
     priceCategories: sa_orm.Mapped[list["PriceCategory"]] = sa.orm.relationship("PriceCategory", back_populates="offer")
-    product: Product = sa.orm.relationship(Product, backref="offers")
+    product: sa_orm.Mapped["Product | None"] = sa.orm.relationship(Product, backref="offers")
     productId: int = sa.Column(sa.BigInteger, sa.ForeignKey("product.id"), index=True, nullable=True)
     rankingWeight = sa.Column(sa.Integer, nullable=True)
     subcategoryId: str = sa.Column(sa.Text, nullable=False, index=True)

--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -10,6 +10,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
+from pcapi.validation.routes.offers import check_offer_product_update
 
 
 class PostDraftOfferBodyModel(BaseModel):
@@ -19,6 +20,7 @@ class PostDraftOfferBodyModel(BaseModel):
     description: str | None = None
     extra_data: typing.Any = None
     duration_minutes: int | None = None
+    product_id: int | None
 
     @validator("name", pre=True)
     def validate_name(cls, name: str, values: dict) -> str:
@@ -41,6 +43,11 @@ class PatchDraftOfferBodyModel(BaseModel):
     def validate_name(cls, name: str, values: dict) -> str:
         check_offer_name_length_is_valid(name)
         return name
+
+    @validator("extra_data", pre=True)
+    def validate_extra_data(cls, extra_data: dict[str, typing.Any]) -> dict[str, typing.Any]:
+        check_offer_product_update(extra_data)
+        return extra_data
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -25,6 +25,7 @@ from pcapi.domain import music_types
 from pcapi.domain import show_types
 from pcapi.models import api_errors
 from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.routes.native.v1.serialization.offerers import VenueTypeCode
 from pcapi.routes.public.books_stocks import serialization
 from pcapi.utils import date
 
@@ -569,6 +570,26 @@ def check_offer_extra_data(
 
     if errors.errors:
         raise errors
+
+
+def check_product_for_venue_and_subcategory(
+    product: models.Product | None,
+    subcategory_id: str | None,
+    venue_type_code: VenueTypeCode,
+) -> None:
+    if venue_type_code != VenueTypeCode.RECORD_STORE:
+        return
+
+    if subcategory_id not in [
+        subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
+        subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id,
+    ]:
+        return
+    if product is not None:
+        return
+    raise exceptions.ProductNotFoundForOfferCreation(
+        ExtraDataFieldEnum.EAN.value, "EAN non reconnu. Assurez-vous qu'il n'y ait pas d'erreur de saisie."
+    )
 
 
 def check_ean_does_not_exist(ean: str | None, venue: offerers_models.Venue) -> None:

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -495,7 +495,9 @@ def get_last_x_days_booking_count_by_offer(offers: abc.Iterable[offers_models.Of
     default_dict = get_offers_booking_count_by_id([offer.id for offer in offers_without_product])
 
     for offer in offers_with_product:
-        default_dict[offer.id] = offer.product.last_30_days_booking if offer.product.last_30_days_booking else 0
+        default_dict[offer.id] = (
+            offer.product.last_30_days_booking if offer.product and offer.product.last_30_days_booking else 0
+        )
 
     return default_dict
 

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -440,6 +440,7 @@ class GetIndividualOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     name: str
     priceCategories: list[PriceCategoryResponseModel] | None
     subcategoryId: SubcategoryIdEnum
+    productId: int | None
     thumbUrl: str | None
     externalTicketOfficeUrl: str | None
     url: str | None

--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_event_occurrences.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_event_occurrences.py
@@ -41,7 +41,7 @@ def create_data_event_occurrences(event_offers_by_name: dict[str, offers_models.
         price_categories: dict[decimal.Decimal, offers_models.PriceCategory] = {}
         for index, beginning_datetime in enumerate(EVENT_OCCURRENCE_BEGINNING_DATETIMES, start=1):
             name = "{} / {} / {} ".format(
-                event_offer_with_occurrences.product.name,
+                event_offer_with_occurrences.product.name if event_offer_with_occurrences.product else "",
                 event_offer_with_occurrences.venue.name,
                 beginning_datetime.strftime(date_utils.DATE_ISO_FORMAT),
             )
@@ -52,7 +52,10 @@ def create_data_event_occurrences(event_offers_by_name: dict[str, offers_models.
             if price_counter > 2:
                 price = price + price_counter
 
-            if event_offer_with_occurrences.product.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES:
+            if (
+                event_offer_with_occurrences.product
+                and event_offer_with_occurrences.product.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES
+            ):
                 price = decimal.Decimal(0)
 
             if price in price_categories:

--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_event_stocks.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_event_stocks.py
@@ -33,7 +33,10 @@ def create_data_event_stocks(event_occurrences_by_name: dict[str, EventOccurrenc
             price = price + price_counter
         short_names_to_increase_price.append(short_name)
 
-        if event_occurrence_with_stocks.offer.product.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES:
+        if (
+            event_occurrence_with_stocks.offer.product
+            and event_occurrence_with_stocks.offer.product.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES
+        ):
             price = Decimal(0)
 
         name = event_occurrence_with_stocks_name + " / " + str(available) + " / " + str(price) + " / " + "DATA"

--- a/api/src/pcapi/sandboxes/scripts/creators/e2e/create_e2e_event_occurrences.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/e2e/create_e2e_event_occurrences.py
@@ -42,7 +42,7 @@ def create_e2e_event_occurrences(event_offers_by_name: dict[str, offers_models.O
         price_categories: dict[decimal.Decimal, offers_models.PriceCategory] = {}
         for index, beginning_datetime in enumerate(EVENT_OCCURRENCE_BEGINNING_DATETIMES, start=1):
             name = "{} / {} / {} ".format(
-                event_offer_with_occurrences.product.name,
+                event_offer_with_occurrences.product.name if event_offer_with_occurrences.product else "",
                 event_offer_with_occurrences.venue.name,
                 beginning_datetime.strftime(date_utils.DATE_ISO_FORMAT),
             )
@@ -53,7 +53,10 @@ def create_e2e_event_occurrences(event_offers_by_name: dict[str, offers_models.O
             if price_counter > 2:
                 price = price + price_counter
 
-            if event_offer_with_occurrences.product.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES:
+            if (
+                event_offer_with_occurrences.product
+                and event_offer_with_occurrences.product.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES
+            ):
                 price = decimal.Decimal(0)
 
             if price in price_categories:

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_occurrences.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_occurrences.py
@@ -44,7 +44,7 @@ def create_industrial_event_occurrences(
         price_categories: dict[decimal.Decimal, offers_models.PriceCategory] = {}
         for index, beginning_datetime in enumerate(EVENT_OCCURRENCE_BEGINNING_DATETIMES, start=1):
             name = "{} / {} / {} ".format(
-                event_offer_with_occurrences.product.name,
+                event_offer_with_occurrences.product.name if event_offer_with_occurrences.product else "",
                 event_offer_with_occurrences.venue.name,
                 beginning_datetime.strftime(date_utils.DATE_ISO_FORMAT),
             )
@@ -55,7 +55,10 @@ def create_industrial_event_occurrences(
             if price_counter > 2:
                 price = price + price_counter
 
-            if event_offer_with_occurrences.product.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES:
+            if (
+                event_offer_with_occurrences.product
+                and event_offer_with_occurrences.product.subcategoryId in subcategories.ACTIVATION_SUBCATEGORIES
+            ):
                 price = decimal.Decimal(0)
 
             if price in price_categories:

--- a/api/src/pcapi/validation/routes/offers.py
+++ b/api/src/pcapi/validation/routes/offers.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pcapi.models.api_errors import ApiErrors
 
 
@@ -14,4 +16,11 @@ def check_collective_offer_name_length_is_valid(offer_name: str) -> None:
     if len(offer_name) > max_offer_name_length:
         api_error = ApiErrors()
         api_error.add_error("name", "Le titre de l’offre doit faire au maximum 110 caractères.")
+        raise api_error
+
+
+def check_offer_product_update(extra_data: dict[str, Any]) -> None:
+    if extra_data.get("ean", False):
+        api_error = ApiErrors()
+        api_error.add_error("ean", "Vous ne pouvez pas changer cette information")
         raise api_error

--- a/api/tests/core/offers/test_schemas.py
+++ b/api/tests/core/offers/test_schemas.py
@@ -25,5 +25,5 @@ class PostDraftOfferBodyModelTest:
 class PatchDraftOfferBodyModelTest:
     def test_patch_draft_offer_body_model(self):
         _ = PatchDraftOfferBodyModel(
-            name="Name", description="description", extraData={"ean": "12345678910111"}, durationMinutes=12
+            name="Name", description="description", extraData={"artist": "An-2"}, durationMinutes=12
         )

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -175,6 +175,7 @@ class Returns200Test:
             "bookingsCount": 0,
             "bookingEmail": "offer.booking.email@example.com",
             "dateCreated": "2020-10-15T00:00:00Z",
+            "productId": None,
             "publicationDate": None,
             "description": "Tatort, but slower",
             "durationMinutes": 60,

--- a/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
@@ -37,6 +37,7 @@ export type GetIndividualOfferResponseModel = {
   motorDisabilityCompliant?: boolean | null;
   name: string;
   priceCategories?: Array<PriceCategoryResponseModel> | null;
+  productId?: number | null;
   publicationDate?: string | null;
   status: OfferStatus;
   subcategoryId: SubcategoryIdEnum;

--- a/pro/src/apiClient/v1/models/GetIndividualOfferWithAddressResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferWithAddressResponseModel.ts
@@ -40,6 +40,7 @@ export type GetIndividualOfferWithAddressResponseModel = {
   motorDisabilityCompliant?: boolean | null;
   name: string;
   priceCategories?: Array<PriceCategoryResponseModel> | null;
+  productId?: number | null;
   publicationDate?: string | null;
   status: OfferStatus;
   subcategoryId: SubcategoryIdEnum;

--- a/pro/src/apiClient/v1/models/PostDraftOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostDraftOfferBodyModel.ts
@@ -7,6 +7,7 @@ export type PostDraftOfferBodyModel = {
   durationMinutes?: number | null;
   extraData?: any;
   name: string;
+  productId?: number | null;
   subcategoryId: string;
   venueId: number;
 };


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31217

Ajout de validation lors de la création et mise à jour d'offre draft. Le code EAN devient obligatoire lorsque la venue est un disquaire et que le produit est un CD ou vinyle.

Il n'est pas possible de mettre à jour le produit d'une offre (et donc le code EAN dans les extra data non plus)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
