### PR TITLE
(PC-31534)[PRO] fix: In collective stock form don't block limitation …

### DIFF
--- a/pro/src/screens/OfferEducationalStock/FormStock/__specs__/FormStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/__specs__/FormStock.spec.tsx
@@ -30,7 +30,8 @@ const renderFormStock = ({
       onSubmit={onSubmit}
       validationSchema={generateValidationSchema(
         props.preventPriceIncrease,
-        initialValues.totalPrice
+        initialValues.totalPrice,
+        false
       )}
     >
       <Form>

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -109,7 +109,8 @@ export const OfferEducationalStock = <
         ? showcaseOfferValidationSchema
         : generateValidationSchema(
             preventPriceIncrease,
-            initialValues.totalPrice
+            initialValues.totalPrice,
+            mode === Mode.READ_ONLY
           )
     }),
   })

--- a/pro/src/screens/OfferEducationalStock/__specs__/validationSchema.spec.ts
+++ b/pro/src/screens/OfferEducationalStock/__specs__/validationSchema.spec.ts
@@ -29,6 +29,7 @@ describe('validationSchema', () => {
     description: string
     formValues: Partial<OfferEducationalStockFormValues>
     expectedErrors: string[]
+    isReadOnly?: boolean
   }[] = [
     {
       description: 'start and end date should be on same school year',
@@ -111,15 +112,27 @@ describe('validationSchema', () => {
         'La date limite de réservation doit être égale ou postérieure à la date actuelle',
       ],
     },
+    {
+      description:
+        'booking limit date can be in the past if the form is read only',
+      formValues: {
+        ...values,
+        bookingLimitDatetime: sub(new Date(), { days: 1 }).toISOString(),
+      },
+      expectedErrors: [],
+      isReadOnly: true,
+    },
   ]
 
-  cases.forEach(({ description, formValues, expectedErrors }) => {
-    it(`should validate the form for case: ${description}`, async () => {
-      const errors = await getYupValidationSchemaErrors(
-        generateValidationSchema(false, 0),
-        formValues
-      )
-      expect(errors).toEqual(expectedErrors)
-    })
-  })
+  cases.forEach(
+    ({ description, formValues, expectedErrors, isReadOnly = false }) => {
+      it(`should validate the form for case: ${description}`, async () => {
+        const errors = await getYupValidationSchemaErrors(
+          generateValidationSchema(false, 0, isReadOnly),
+          formValues
+        )
+        expect(errors).toEqual(expectedErrors)
+      })
+    }
+  )
 })

--- a/pro/src/screens/OfferEducationalStock/validationSchema.ts
+++ b/pro/src/screens/OfferEducationalStock/validationSchema.ts
@@ -39,7 +39,8 @@ function isBookingDateAfterNow(bookingLimitDatetime: Date | null | undefined) {
 
 export const generateValidationSchema = (
   preventPriceIncrease: boolean,
-  initialPrice: number | ''
+  initialPrice: number | '',
+  isReadOnly: boolean
 ) => {
   let totalPriceValidation = yup
     .number()
@@ -126,7 +127,7 @@ export const generateValidationSchema = (
       .test({
         message:
           'La date limite de réservation doit être égale ou postérieure à la date actuelle',
-        test: isBookingDateAfterNow,
+        test: (value) => isBookingDateAfterNow(value) || isReadOnly,
       }),
     priceDetail: yup
       .string()


### PR DESCRIPTION
…date when the mode is read only.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31534

**Objectif**
Laisser les utilisateurs mettre à jour le prix (à la baisse) et le nombre d'élèves d'un stock collectif même lorsque la date limite de réservation est dans le passé. Dans ce cas on est en read only sur le formulaire, auquel cas on ne doit pas faire la validation dur la date limite de réservation.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
