### PR TITLE
(BSR)[PRO] test: may fix random list of offers modulo-ed

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/e2e/create_e2e_event_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/e2e/create_e2e_event_offers.py
@@ -8,8 +8,6 @@ from pcapi.repository import repository
 
 logger = logging.getLogger(__name__)
 
-
-DEACTIVATED_OFFERS_PICK_MODULO = 3
 EVENTS_PER_OFFERER_WITH_PHYSICAL_VENUE = 5
 
 
@@ -40,14 +38,8 @@ def create_e2e_event_offers(
             (event_name, event) = event_items[rest_event_index]
 
             name = "{} / {}".format(event_name, event_venue.name)
-            if offer_index % DEACTIVATED_OFFERS_PICK_MODULO == 0:
-                is_active = False
-            else:
-                is_active = True
-            if offer_index % DEACTIVATED_OFFERS_PICK_MODULO == 0:
-                is_duo = False
-            else:
-                is_duo = True
+            is_active = True
+            is_duo = True
             event_offers_by_name[name] = offers_factories.OfferFactory(
                 venue=event_venue,
                 product=event,

--- a/api/src/pcapi/sandboxes/scripts/creators/e2e/create_e2e_thing_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/e2e/create_e2e_thing_offers.py
@@ -9,7 +9,6 @@ from pcapi.repository import repository
 logger = logging.getLogger(__name__)
 
 
-DEACTIVATED_OFFERS_PICK_MODULO = 3
 THINGS_PER_OFFERER = 5
 
 
@@ -47,10 +46,7 @@ def create_e2e_thing_offers(
                 thing_index += 1
 
             name = "{} / {}".format(thing_name, thing_venue.name)
-            if offer_index % DEACTIVATED_OFFERS_PICK_MODULO == 0:
-                is_active = False
-            else:
-                is_active = True
+            is_active = True
             thing_offers_by_name[name] = offers_factories.OfferFactory(
                 venue=thing_venue,
                 subcategoryId=thing_product.subcategoryId,

--- a/pro/cypress/e2e/features/searchIndividualOffer.feature
+++ b/pro/cypress/e2e/features/searchIndividualOffer.feature
@@ -77,12 +77,12 @@ Feature: Search individual offers
       |  |  | Mon offre brouillon            | Terrain vague                  |      0 | brouillon  |
       |  |  | Offer                          | Terrain vague                  |     16 | expirée    |
       |  |  | Offer                          | Terrain vague                  |     20 | publiée    |
-      |  |  | Offer                          | Terrain vague                  |      0 | désactivée |
+      |  |  | Offer                          | Terrain vague                  |      0 | épuisée    |
       |  |  | Offer                          | Bar des amis - Offre numérique |     20 | publiée    |
       |  |  | Offer                          | Terrain vague                  |     16 | expirée    |
       |  |  | Offer                          | Terrain vague                  |     40 | publiée    |
       |  |  | Offer                          | Terrain vague                  |     40 | publiée    |
-      |  |  | Offer                          | Terrain vague                  |      0 | désactivée |
+      |  |  | Offer                          | Terrain vague                  |      0 | épuisée    |
   # comme tout est "Manuel" dans la sandbox, automatiser ce test en l'état n'aurait pas beaucoup de sens
   # Scenario: A search by creation mode should display expected results
   #   When I select "Manuel" in "Mode de création"


### PR DESCRIPTION
## But de la pull request

Pour éviter certains échecs avec la sandbox qui ne génère pas exactement les mêmes données, on simplifie ici la création des offres pour (peut-être) éviter les échecs sur searchIndividualOffer comme [ici](https://cloud.cypress.io/projects/rit5sb/runs/637)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
