### PR TITLE
(PC-31510)[PRO] feat: add tracker on collective offer edit button

### DIFF
--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -13,6 +13,7 @@ export enum Events {
   CLICKED_DOWNLOAD_BOOKINGS_CSV = 'hasClickedDownloadBookingCsv',
   CLICKED_DOWNLOAD_BOOKINGS_XLS = 'hasClickedDownloadBookingXls',
   CLICKED_EDIT_PROFILE = 'hasClickedEditProfile',
+  CLICKED_EDIT_COLLECTIVE_OFFER = 'hasClickedEditCollectiveOffer',
   CLICKED_HOME_STATS_PENDING_OFFERS_FAQ = 'hasClickedHomeStatsPendingOffersFaq',
   CLICKED_FORGOTTEN_PASSWORD = 'hasClickedForgottenPassword',
   CLICKED_HELP_CENTER = 'hasClickedHelpCenter',

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -202,6 +202,12 @@ export const CollectiveActionsCells = ({
     }
   }
 
+  const handleEditOfferClick = () => {
+    logEvent(Events.CLICKED_EDIT_COLLECTIVE_OFFER, {
+      from: location.pathname,
+    })
+  }
+
   const canDuplicateOffer = offer.status !== CollectiveOfferStatus.DRAFT
 
   return (
@@ -301,6 +307,7 @@ export const CollectiveActionsCells = ({
                         to={editionOfferLink}
                         icon={fullPenIcon}
                         className={styles['button']}
+                        onClick={handleEditOfferClick}
                       >
                         Modifier
                       </ButtonLink>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31510

Ajout d'un tracker sur le bouton modifier depuis la liste des offres collectives

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
