### PR TITLE
(BSR)[BO] chore: run djlint after upgrade to 1.34.2

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/admin/feature_flipping.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/feature_flipping.html
@@ -51,8 +51,8 @@
                        aria-hidden="true">
                     <div class="modal-dialog modal-dialog-centered">
                       <div class="modal-content">
-                        <form action="{{ url_for(".disable_feature_flag", feature_flag_id=feature_flag.id) if feature_flag.isActive else url_for(".enable_feature_flag", feature_flag_id=feature_flag.id) }}"
-                              name="{{ url_for(".disable_feature_flag", feature_flag_id=feature_flag.id) if feature_flag.isActive else url_for(".enable_feature_flag", feature_flag_id=feature_flag.id) | action_to_name }}"
+                        <form action="{{ url_for('.disable_feature_flag', feature_flag_id=feature_flag.id) if feature_flag.isActive else url_for(".enable_feature_flag", feature_flag_id=feature_flag.id) }}"
+                              name="{{ url_for('.disable_feature_flag', feature_flag_id=feature_flag.id) if feature_flag.isActive else url_for(".enable_feature_flag", feature_flag_id=feature_flag.id) | action_to_name }}"
                               method="post"
                               data-turbo="false">
                           {{ csrf_token }}

--- a/api/src/pcapi/routes/backoffice/templates/admin/roles.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/roles.html
@@ -19,9 +19,9 @@
                    role="button">{{ form.name }}</div>
               <div class="collapse card-collapse p-3 shadow pc-collapse-{{ form.name }}">
                 <form class=".{{ form.name }}"
-                      action="{{ url_for(".update_role", role_id=form.id) }}"
+                      action="{{ url_for('.update_role', role_id=form.id) }}"
                       method="post"
-                      name="{{ url_for(".update_role", role_id=form.id) | action_to_name }}">
+                      name="{{ url_for('.update_role', role_id=form.id) | action_to_name }}">
                   <div class="card-body">
                     <div class="row">
                       {% for form_field in forms[form] %}{{ form_field }}{% endfor %}
@@ -40,7 +40,7 @@
         {% endcall %}
         {% call tabs.build_details_tab_content("history") %}
           <div class="mt-4">
-            <turbo-frame data-turbo="false" id="admin_roles_history_frame" src="{{ url_for("backoffice_web.get_roles_history") }}">
+            <turbo-frame data-turbo="false" id="admin_roles_history_frame" src="{{ url_for('backoffice_web.get_roles_history') }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           </div>

--- a/api/src/pcapi/routes/backoffice/templates/admin/users_deletion.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/users_deletion.html
@@ -3,8 +3,8 @@
   <div class="pt-3 px-5">
     <h2 class="fw-light">Suppression d'utilisateur de test</h2>
     <div class="col">
-      <form action="{{ url_for("backoffice_web.delete_user") }}"
-            name="{{ url_for("backoffice_web.delete_user") | action_to_name }}"
+      <form action="{{ url_for('backoffice_web.delete_user') }}"
+            name="{{ url_for('backoffice_web.delete_user') | action_to_name }}"
             method="post"
             data-turbo="false">
         {{ form.csrf_token }}

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
@@ -96,17 +96,17 @@
         {% endcall %}
         {% call build_details_tabs_content_wrapper() %}
           {% call build_details_tab_content("linked-venues", active_tab == 'linked_venues') %}
-            <turbo-frame data-turbo="false" id="bank_account_venues_frame" loading="lazy" src="{{ url_for("backoffice_web.bank_account.get_linked_venues", bank_account_id=bank_account.id) }}">
+            <turbo-frame data-turbo="false" id="bank_account_venues_frame" loading="lazy" src="{{ url_for('backoffice_web.bank_account.get_linked_venues', bank_account_id=bank_account.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}
           {% call build_details_tab_content("history", active_tab == 'history') %}
-            <turbo-frame data-turbo="false" id="bank_account_history_frame" loading="lazy" src="{{ url_for("backoffice_web.bank_account.get_history", bank_account_id=bank_account.id) }}">
+            <turbo-frame data-turbo="false" id="bank_account_history_frame" loading="lazy" src="{{ url_for('backoffice_web.bank_account.get_history', bank_account_id=bank_account.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}
           {% call build_details_tab_content("invoices", active_tab == 'invoices') %}
-            <turbo-frame data-turbo="false" id="bank_account_invoices_frame" loading="lazy" src="{{ url_for("backoffice_web.bank_account.get_invoices", bank_account_id=bank_account.id) }}">
+            <turbo-frame data-turbo="false" id="bank_account_invoices_frame" loading="lazy" src="{{ url_for('backoffice_web.bank_account.get_invoices', bank_account_id=bank_account.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get/invoices.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get/invoices.html
@@ -9,7 +9,7 @@
     <button disabled
             type="button"
             class="btn btn-outline-primary"
-            data-url="{{ url_for("backoffice_web.bank_account.download_reimbursement_details", bank_account_id=bank_account_id) }}"
+            data-url="{{ url_for('backoffice_web.bank_account.download_reimbursement_details', bank_account_id=bank_account_id) }}"
             data-use-confirmation-modal="false">Téléchargement des détails de remboursements</button>
   </div>
   <table class="table table-hover my-4"

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -33,12 +33,12 @@
             {% if form.is_single_venue_with_optional_dates %}
               <span class="mx-2 fs-3">
                 {% set from_to_date_formatted = (form.from_to_date.data[0].strftime("%d/%m/%Y") + ' - ' + form.from_to_date.data[1].strftime("%d/%m/%Y")) if form.from_to_date.data else None %}
-                <a href="{{ url_for("backoffice_web.collective_bookings.get_collective_booking_csv_download", venue=form.venue.data[0], from_to_date=from_to_date_formatted) }}"
+                <a href="{{ url_for('backoffice_web.collective_bookings.get_collective_booking_csv_download', venue=form.venue.data[0], from_to_date=from_to_date_formatted) }}"
                    class="mx-2"><i class="bi bi-filetype-csv"
    data-bs-toggle="tooltip"
    data-bs-placement="top"
    data-bs-title="Télécharger en CSV."></i></a>
-                <a href="{{ url_for("backoffice_web.collective_bookings.get_collective_booking_xlsx_download", venue=form.venue.data[0], from_to_date=from_to_date_formatted) }}"
+                <a href="{{ url_for('backoffice_web.collective_bookings.get_collective_booking_xlsx_download', venue=form.venue.data[0], from_to_date=from_to_date_formatted) }}"
                    class="mx-2"><i class="bi bi-filetype-xlsx"
    data-bs-toggle="tooltip"
    data-bs-placement="top"
@@ -116,8 +116,8 @@
                                aria-hidden="true">
                             <div class="modal-dialog modal-dialog-centered">
                               <div class="modal-content">
-                                <form action="{{ url_for("backoffice_web.collective_bookings.mark_booking_as_used", collective_booking_id=collective_booking.id) }}"
-                                      name="{{ url_for("backoffice_web.collective_bookings.mark_booking_as_used", collective_booking_id=collective_booking.id) | action_to_name }}"
+                                <form action="{{ url_for('backoffice_web.collective_bookings.mark_booking_as_used', collective_booking_id=collective_booking.id) }}"
+                                      name="{{ url_for('backoffice_web.collective_bookings.mark_booking_as_used', collective_booking_id=collective_booking.id) | action_to_name }}"
                                       method="post"
                                       data-turbo="false">
                                   <div class="modal-header"
@@ -143,8 +143,8 @@
                                aria-hidden="true">
                             <div class="modal-dialog modal-dialog-centered">
                               <div class="modal-content">
-                                <form action="{{ url_for("backoffice_web.collective_bookings.mark_booking_as_cancelled", collective_booking_id=collective_booking.id) }}"
-                                      name="{{ url_for("backoffice_web.collective_bookings.mark_booking_as_cancelled", collective_booking_id=collective_booking.id) | action_to_name }}"
+                                <form action="{{ url_for('backoffice_web.collective_bookings.mark_booking_as_cancelled', collective_booking_id=collective_booking.id) }}"
+                                      name="{{ url_for('backoffice_web.collective_bookings.mark_booking_as_cancelled', collective_booking_id=collective_booking.id) | action_to_name }}"
                                       method="post"
                                       data-turbo="false">
                                   <div class="modal-header"

--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -12,7 +12,7 @@
             class="d-none"
             target="_blank"
             rel="noopener"
-            action="{{ url_for("backoffice_web.pro.connect_as") }}"
+            action="{{ url_for('backoffice_web.pro.connect_as') }}"
             method="post">
         <input type="hidden"
                name="csrf_token"

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
@@ -23,7 +23,7 @@
     <div class="filters-container">{{ forms.build_filters_form(form, dst) }}</div>
     <div class="row">
       <div class="col-md-11 mb-4">
-        <turbo-frame id="reimbursement_stats" src="{{ url_for("backoffice_web.reimbursement_rules.get_stats") }}">
+        <turbo-frame id="reimbursement_stats" src="{{ url_for('backoffice_web.reimbursement_rules.get_stats') }}">
         {{ build_loading_spinner() }}
         </turbo-frame>
       </div>

--- a/api/src/pcapi/routes/backoffice/templates/fraud/blacklist_domain_name_summary.html
+++ b/api/src/pcapi/routes/backoffice/templates/fraud/blacklist_domain_name_summary.html
@@ -71,8 +71,8 @@
           </div>
         </div>
       {% endif %}
-      <form action="{{ url_for("backoffice_web.fraud.blacklist_domain_name") }}"
-            name="{{ url_for("backoffice_web.fraud.blacklist_domain_name") | action_to_name }}"
+      <form action="{{ url_for('backoffice_web.fraud.blacklist_domain_name') }}"
+            name="{{ url_for('backoffice_web.fraud.blacklist_domain_name') | action_to_name }}"
             method="post"
             class="my-4"
             data-turbo="true">
@@ -84,7 +84,7 @@
         {{ csrf_token() }}
         <div>
           <a class="text-decoration-none"
-             href="{{ url_for("backoffice_web.fraud.list_blacklisted_domain_names") }}">
+             href="{{ url_for('backoffice_web.fraud.list_blacklisted_domain_names') }}">
             <button type="button"
                     class="btn btn-outline-primary">Annuler</button>
           </a>

--- a/api/src/pcapi/routes/backoffice/templates/fraud/domain_names.html
+++ b/api/src/pcapi/routes/backoffice/templates/fraud/domain_names.html
@@ -24,8 +24,8 @@
     <div class="col">
       <h2 class="card-title text-primary">Noms de domaines</h2>
       <div class="my-4">
-        <form action="{{ url_for("backoffice_web.fraud.prepare_blacklist_domain_name") }}"
-              name="{{ url_for("backoffice_web.fraud.prepare_blacklist_domain_name") | action_to_name }}"
+        <form action="{{ url_for('backoffice_web.fraud.prepare_blacklist_domain_name') }}"
+              name="{{ url_for('backoffice_web.fraud.prepare_blacklist_domain_name') | action_to_name }}"
               method="get"
               data-turbo="false">
           <div class="col-8 row">

--- a/api/src/pcapi/routes/backoffice/templates/fraud/domain_names/blacklist.html
+++ b/api/src/pcapi/routes/backoffice/templates/fraud/domain_names/blacklist.html
@@ -26,8 +26,8 @@
                   </a>
                 </li>
                 <li class="dropdown-item p-0">
-                  <form action="{{ url_for("backoffice_web.fraud.remove_blacklisted_domain_name", domain=row.domain) }}"
-                        name="{{ url_for("backoffice_web.fraud.remove_blacklisted_domain_name", domain=row.domain) | action_to_name }}"
+                  <form action="{{ url_for('backoffice_web.fraud.remove_blacklisted_domain_name', domain=row.domain) }}"
+                        name="{{ url_for('backoffice_web.fraud.remove_blacklisted_domain_name', domain=row.domain) | action_to_name }}"
                         method="post"
                         data-turbo="false">
                     <div class="col-8 row">

--- a/api/src/pcapi/routes/backoffice/templates/home/login.html
+++ b/api/src/pcapi/routes/backoffice/templates/home/login.html
@@ -15,7 +15,7 @@
           <hr class="my-5" />
           <h1>Connexion au backoffice</h1>
           <div>
-            <a href="{{ url_for("backoffice_web.login") }}"
+            <a href="{{ url_for('backoffice_web.login') }}"
                class="btn mt-5 btn-primary">Se connecter via Google</a>
           </div>
         </div>

--- a/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
@@ -18,12 +18,12 @@
           {% if form.is_single_venue_with_optional_dates %}
             <span class="mx-2 fs-3">
               {% set from_to_date_formatted = (form.from_to_date.data[0].strftime("%d/%m/%Y") + ' - ' + form.from_to_date.data[1].strftime("%d/%m/%Y")) if form.from_to_date.data else None %}
-              <a href="{{ url_for("backoffice_web.individual_bookings.get_individual_booking_csv_download", venue=form.venue.data[0], from_to_date=from_to_date_formatted) }}"
+              <a href="{{ url_for('backoffice_web.individual_bookings.get_individual_booking_csv_download', venue=form.venue.data[0], from_to_date=from_to_date_formatted) }}"
                  class="mx-2"><i class="bi bi-filetype-csv"
    data-bs-toggle="tooltip"
    data-bs-placement="top"
    data-bs-title="Télécharger en CSV."></i></a>
-              <a href="{{ url_for("backoffice_web.individual_bookings.get_individual_booking_xlsx_download", venue=form.venue.data[0], from_to_date=from_to_date_formatted) }}"
+              <a href="{{ url_for('backoffice_web.individual_bookings.get_individual_booking_xlsx_download', venue=form.venue.data[0], from_to_date=from_to_date_formatted) }}"
                  class="mx-2"><i class="bi bi-filetype-xlsx"
    data-bs-toggle="tooltip"
    data-bs-placement="top"
@@ -62,14 +62,14 @@
                       class="btn btn-outline-primary"
                       data-modal-selector="#overpayment-creation-modal"
                       data-mode="fetch"
-                      data-fetch-url="{{ url_for("backoffice_web.finance_incidents.get_individual_bookings_overpayment_creation_form") }}"
+                      data-fetch-url="{{ url_for('backoffice_web.finance_incidents.get_individual_bookings_overpayment_creation_form') }}"
                       data-use-confirmation-modal="true">Créer un incident</button>
               <button disabled
                       type="button"
                       class="btn btn-outline-primary"
                       data-modal-selector="#commercial-gesture-creation-modal"
                       data-mode="fetch"
-                      data-fetch-url="{{ url_for("backoffice_web.finance_incidents.get_individual_bookings_commercial_gesture_creation_form") }}"
+                      data-fetch-url="{{ url_for('backoffice_web.finance_incidents.get_individual_bookings_commercial_gesture_creation_form') }}"
                       data-use-confirmation-modal="true">Créer un geste commercial</button>
             </div>
           {% endif %}
@@ -146,8 +146,8 @@
                                aria-hidden="true">
                             <div class="modal-dialog modal-dialog-centered">
                               <div class="modal-content">
-                                <form action="{{ url_for("backoffice_web.individual_bookings.mark_booking_as_used", booking_id=booking.id) }}"
-                                      name="{{ url_for("backoffice_web.individual_bookings.mark_booking_as_used", booking_id=booking.id) | action_to_name }}"
+                                <form action="{{ url_for('backoffice_web.individual_bookings.mark_booking_as_used', booking_id=booking.id) }}"
+                                      name="{{ url_for('backoffice_web.individual_bookings.mark_booking_as_used', booking_id=booking.id) | action_to_name }}"
                                       method="post"
                                       data-turbo="false">
                                   <div class="modal-header"
@@ -173,8 +173,8 @@
                                aria-hidden="true">
                             <div class="modal-dialog modal-dialog-centered">
                               <div class="modal-content">
-                                <form action="{{ url_for("backoffice_web.individual_bookings.mark_booking_as_cancelled", booking_id=booking.id) }}"
-                                      name="{{ url_for("backoffice_web.individual_bookings.mark_booking_as_cancelled", booking_id=booking.id) | action_to_name }}"
+                                <form action="{{ url_for('backoffice_web.individual_bookings.mark_booking_as_cancelled', booking_id=booking.id) }}"
+                                      name="{{ url_for('backoffice_web.individual_bookings.mark_booking_as_cancelled', booking_id=booking.id) | action_to_name }}"
                                       method="post"
                                       data-turbo="false">
                                   <div class="modal-header"

--- a/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
@@ -33,7 +33,7 @@
             aria-controls="{{ pc_collapse_menu_id }}">
       <i class="bi bi-list text-white h4"></i>
     </button>
-    <a href="{{ url_for("backoffice_web.home") }}"
+    <a href="{{ url_for('backoffice_web.home') }}"
        class="card-link">
       <p class="my-0 ms-5 navbar-brand text-white btn">
         <svg width="105.532"
@@ -44,8 +44,8 @@
         Back Office
       </p>
     </a>
-    <form action="{{ url_for("backoffice_web.logout") }}"
-          name="{{ url_for("backoffice_web.logout") | action_to_name }}"
+    <form action="{{ url_for('backoffice_web.logout') }}"
+          name="{{ url_for('backoffice_web.logout') | action_to_name }}"
           method="post">
       {{ csrf_token }}
       <button type="submit"

--- a/api/src/pcapi/routes/backoffice/templates/layouts/error.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/error.html
@@ -4,7 +4,7 @@
     <div class="text-center">
       {% block error %}
       {% endblock error %}
-      <a href="{{ url_for("backoffice_web.home") }}"
+      <a href="{{ url_for('backoffice_web.home') }}"
          class="btn btn-primary">Retour au
       backoffice</a>
     </div>

--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -246,14 +246,14 @@
             <div class="my-2 lead text-center">Exporter les réservations (choisir le format) :</div>
             <div class="d-flex justify-content-center align-items-center my-2">
               <div class="mx-2 fs-1">
-                <a href="{{ url_for("backoffice_web.offer.download_bookings_csv", offer_id=offer.id) }}"
+                <a href="{{ url_for('backoffice_web.offer.download_bookings_csv', offer_id=offer.id) }}"
                    class="mx-2"><i class="bi bi-filetype-csv"
    data-bs-toggle="tooltip"
    data-bs-placement="top"
    data-bs-title="Télécharger au format CSV"></i></a>
               </div>
               <div class="mx-2 fs-1">
-                <a href="{{ url_for("backoffice_web.offer.download_bookings_xlsx", offer_id=offer.id) }}"
+                <a href="{{ url_for('backoffice_web.offer.download_bookings_xlsx', offer_id=offer.id) }}"
                    class="mx-2"><i class="bi bi-filetype-xlsx"
    data-bs-toggle="tooltip"
    data-bs-placement="top"

--- a/api/src/pcapi/routes/backoffice/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/list.html
@@ -41,7 +41,7 @@
                     class="btn btn-outline-primary"
                     data-modal-selector="#batch-edit-offer-modal"
                     data-mode="fetch"
-                    data-fetch-url="{{ url_for("backoffice_web.offer.get_batch_edit_offer_form") }}"
+                    data-fetch-url="{{ url_for('backoffice_web.offer.get_batch_edit_offer_form') }}"
                     data-use-confirmation-modal="true">Éditer les offres</button>
           </div>
         </div>

--- a/api/src/pcapi/routes/backoffice/templates/offer_validation_rules/list_rules.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer_validation_rules/list_rules.html
@@ -74,7 +74,7 @@
           </div>
         {% endcall %}
         {% call tabs.build_details_tab_content("history", active_tab == 'history') %}
-          <turbo-frame data-turbo="false" id="rules_history_frame" loading="lazy" src="{{ url_for("backoffice_web.offer_validation_rules.get_rules_history") }}">
+          <turbo-frame data-turbo="false" id="rules_history_frame" loading="lazy" src="{{ url_for('backoffice_web.offer_validation_rules.get_rules_history') }}">
           {{ build_loading_spinner() }}
           </turbo-frame>
         {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -160,18 +160,18 @@
                             } %}
               <p class="mb-1">
                 <span class="fw-bold">Offres BO :</span>
-                <a href="{{ url_for("backoffice_web.offer.list_offers", **search_params) }}"
+                <a href="{{ url_for('backoffice_web.offer.list_offers', **search_params) }}"
                    class="link-primary">individuelles</a> |
-                <a href="{{ url_for("backoffice_web.collective_offer.list_collective_offers", **search_params) }}"
+                <a href="{{ url_for('backoffice_web.collective_offer.list_collective_offers', **search_params) }}"
                    class="link-primary">collectives</a> |
-                <a href="{{ url_for("backoffice_web.collective_offer_template.list_collective_offer_templates", offerer=offerer.id) }}"
+                <a href="{{ url_for('backoffice_web.collective_offer_template.list_collective_offer_templates', offerer=offerer.id) }}"
                    class="link-primary">vitrine</a>
               </p>
               <p class="mb-1">
                 <span class="fw-bold">Réservations BO :</span>
-                <a href="{{ url_for("backoffice_web.individual_bookings.list_individual_bookings", offerer=offerer.id) }}"
+                <a href="{{ url_for('backoffice_web.individual_bookings.list_individual_bookings', offerer=offerer.id) }}"
                    class="link-primary">individuelles</a> |
-                <a href="{{ url_for("backoffice_web.collective_bookings.list_collective_bookings", offerer=offerer.id) }}"
+                <a href="{{ url_for('backoffice_web.collective_bookings.list_collective_bookings', offerer=offerer.id) }}"
                    class="link-primary">collectives</a>
               </p>
               <div>
@@ -226,7 +226,7 @@
         </div>
       </div>
       <div class="mt-4">
-        <turbo-frame id="total_revenue_frame" src="{{ url_for("backoffice_web.offerer.get_stats", offerer_id=offerer.id) }}">
+        <turbo-frame id="total_revenue_frame" src="{{ url_for('backoffice_web.offerer.get_stats', offerer_id=offerer.id) }}">
         {{ build_loading_spinner() }}
         </turbo-frame>
       </div>
@@ -250,48 +250,48 @@
         {% endcall %}
         {% call build_details_tabs_content_wrapper() %}
           {% call build_details_tab_content("history", active_tab == 'history') %}
-            <turbo-frame data-turbo="false" id="offerer_history_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_history", offerer_id=offerer.id) }}">
+            <turbo-frame data-turbo="false" id="offerer_history_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_history', offerer_id=offerer.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}
           {% if show_subscription_tab %}
             {% call build_details_tab_content("subscription", active_tab == 'subscription') %}
-              <turbo-frame data-turbo="false" id="offerer_subscription_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_individual_subscription", offerer_id=offerer.id) }}">
+              <turbo-frame data-turbo="false" id="offerer_subscription_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_individual_subscription', offerer_id=offerer.id) }}">
               {{ build_loading_spinner() }}
               </turbo-frame>
             {% endcall %}
           {% endif %}
           {% if offerer.siren and has_permission("READ_PRO_ENTREPRISE_INFO") %}
             {% call build_details_tab_content("entreprise", active_tab == 'entreprise') %}
-              <turbo-frame data-turbo="false" id="offerer_entreprise_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_entreprise_info", offerer_id=offerer.id) }}">
+              <turbo-frame data-turbo="false" id="offerer_entreprise_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_entreprise_info', offerer_id=offerer.id) }}">
               {{ build_loading_spinner() }}
               </turbo-frame>
             {% endcall %}
           {% endif %}
           {% call build_details_tab_content("pro-users", active_tab == 'users') %}
-            <turbo-frame data-turbo="false" id="offerer_users_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_pro_users", offerer_id=offerer.id) }}">
+            <turbo-frame data-turbo="false" id="offerer_users_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_pro_users', offerer_id=offerer.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}
           {% call build_details_tab_content("managed-venues", active_tab == 'managed_venues') %}
-            <turbo-frame data-turbo="false" id="offerer_venues_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_managed_venues", offerer_id=offerer.id) }}">
+            <turbo-frame data-turbo="false" id="offerer_venues_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_managed_venues', offerer_id=offerer.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}
           {% if has_offerer_address %}
             {% call build_details_tab_content("addresses", active_tab == 'addresses') %}
-              <turbo-frame data-turbo="false" id="offerer_addresses_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_offerer_addresses", offerer_id=offerer.id) }}">
+              <turbo-frame data-turbo="false" id="offerer_addresses_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_offerer_addresses', offerer_id=offerer.id) }}">
               {{ build_loading_spinner() }}
               </turbo-frame>
             {% endcall %}
           {% endif %}
           {% call build_details_tab_content("dms-adage", active_tab == 'dms_adage') %}
-            <turbo-frame data-turbo="false" id="offerer_collective_dms_applications_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_collective_dms_applications", offerer_id=offerer.id) }}">
+            <turbo-frame data-turbo="false" id="offerer_collective_dms_applications_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_collective_dms_applications', offerer_id=offerer.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}
           {% call build_details_tab_content("bank-accounts", active_tab == 'bank_accounts') %}
-            <turbo-frame data-turbo="false" id="offerer_bank_accounts_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_bank_accounts", offerer_id=offerer.id) }}">
+            <turbo-frame data-turbo="false" id="offerer_bank_accounts_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_bank_accounts', offerer_id=offerer.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/addresses.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/addresses.html
@@ -26,7 +26,7 @@
                       "search-1-operator": "IN",
                       "search-1-address": offerer_address.address.id,
                     } %}
-          <a href="{{ url_for("backoffice_web.offer.list_offers", **search_params) }}"
+          <a href="{{ url_for('backoffice_web.offer.list_offers', **search_params) }}"
              class="link-primary">individuelles</a>
         </td>
       </tr>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/entreprise_info.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/entreprise_info.html
@@ -76,7 +76,7 @@
     <div class="card-body my-2">
       <h5 class="card-title">Données RCS (Infogreffe)</h5>
       <div class="card-body">
-        <turbo-frame data-turbo="false" id="offerer_rcs_frame" loading="lazy" src="{{ url_for("backoffice_web.offerer.get_entreprise_rcs_info", offerer_id=offerer.id) }}">
+        <turbo-frame data-turbo="false" id="offerer_rcs_frame" loading="lazy" src="{{ url_for('backoffice_web.offerer.get_entreprise_rcs_info', offerer_id=offerer.id) }}">
         {{ build_loading_spinner() }}
         </turbo-frame>
       </div>
@@ -86,7 +86,7 @@
         <h5 class="card-title">Données URSSAF</h5>
         <div class="card-body">
           <turbo-frame data-turbo="true" id="offerer_urssaf_frame">
-          <a href="{{ url_for("backoffice_web.offerer.get_entreprise_urssaf_info", offerer_id=offerer.id) }}"
+          <a href="{{ url_for('backoffice_web.offerer.get_entreprise_urssaf_info', offerer_id=offerer.id) }}"
              class="btn btn-md btn-outline-primary fw-bold pc-hide-on-click"><i class="bi bi-arrow-clockwise"></i> Vérifier</a>
           <div class="d-none pc-show-on-click">{{ build_loading_spinner() }}</div>
           </turbo-frame>
@@ -97,7 +97,7 @@
           <h5 class="card-title">Données DGFIP</h5>
           <div class="card-body">
             <turbo-frame data-turbo="true" id="offerer_dgfip_frame">
-            <a href="{{ url_for("backoffice_web.offerer.get_entreprise_dgfip_info", offerer_id=offerer.id) }}"
+            <a href="{{ url_for('backoffice_web.offerer.get_entreprise_dgfip_info', offerer_id=offerer.id) }}"
                class="btn btn-md btn-outline-primary fw-bold pc-hide-on-click"><i class="bi bi-arrow-clockwise"></i> Vérifier</a>
             <div class="d-none pc-show-on-click">{{ build_loading_spinner() }}</div>
             </turbo-frame>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/users.html
@@ -45,8 +45,8 @@
               <ul class="dropdown-menu">
                 {% if has_permission("VALIDATE_OFFERER") %}
                   <li class="dropdown-item p-0">
-                    <form action="{{ url_for("backoffice_web.validation.validate_user_offerer",user_offerer_id=user_offerer.id) }}"
-                          name="{{ url_for("backoffice_web.validation.validate_user_offerer",user_offerer_id=user_offerer.id) | action_to_name }}"
+                    <form action="{{ url_for('backoffice_web.validation.validate_user_offerer',user_offerer_id=user_offerer.id) }}"
+                          name="{{ url_for('backoffice_web.validation.validate_user_offerer',user_offerer_id=user_offerer.id) | action_to_name }}"
                           method="post">
                       {{ csrf_token }}
                       <button type="submit"

--- a/api/src/pcapi/routes/backoffice/templates/offerer/offerer_tag.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/offerer_tag.html
@@ -65,8 +65,8 @@
                                  aria-hidden="true">
                               <div class="modal-dialog modal-dialog-centered">
                                 <div class="modal-content">
-                                  <form action="{{ url_for("backoffice_web.offerer_tag.update_offerer_tag", offerer_tag_id=offerer_tag.id) }}"
-                                        name="{{ url_for("backoffice_web.offerer_tag.update_offerer_tag", offerer_tag_id=offerer_tag.id) | action_to_name }}"
+                                  <form action="{{ url_for('backoffice_web.offerer_tag.update_offerer_tag', offerer_tag_id=offerer_tag.id) }}"
+                                        name="{{ url_for('backoffice_web.offerer_tag.update_offerer_tag', offerer_tag_id=offerer_tag.id) | action_to_name }}"
                                         method="post"
                                         data-turbo="false">
                                     <div class="modal-header"
@@ -93,8 +93,8 @@
                                  aria-hidden="true">
                               <div class="modal-dialog modal-dialog-centered">
                                 <div class="modal-content">
-                                  <form action="{{ url_for("backoffice_web.offerer_tag.delete_offerer_tag", offerer_tag_id=offerer_tag.id) }}"
-                                        name="{{ url_for("backoffice_web.offerer_tag.delete_offerer_tag", offerer_tag_id=offerer_tag.id) | action_to_name }}"
+                                  <form action="{{ url_for('backoffice_web.offerer_tag.delete_offerer_tag', offerer_tag_id=offerer_tag.id) }}"
+                                        name="{{ url_for('backoffice_web.offerer_tag.delete_offerer_tag', offerer_tag_id=offerer_tag.id) | action_to_name }}"
                                         method="post"
                                         data-turbo="false">
                                     <div class="modal-header"

--- a/api/src/pcapi/routes/backoffice/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/user_offerer_validation.html
@@ -37,7 +37,7 @@
               <button disabled
                       type="button"
                       class="btn btn-outline-primary"
-                      data-url="{{ url_for("backoffice_web.validation.batch_validate_user_offerer") }}"
+                      data-url="{{ url_for('backoffice_web.validation.batch_validate_user_offerer') }}"
                       data-use-confirmation-modal="false">Valider</button>
               <button disabled
                       type="button"
@@ -105,8 +105,8 @@
                       </button>
                       <ul class="dropdown-menu">
                         <li class="dropdown-item p-0">
-                          <form action="{{ url_for("backoffice_web.validation.validate_user_offerer", offerer_id=offerer.id, user_offerer_id=user_offerer.id) }}"
-                                name="{{ url_for("backoffice_web.validation.validate_user_offerer", offerer_id=offerer.id, user_offerer_id=user_offerer.id) | action_to_name }}"
+                          <form action="{{ url_for('backoffice_web.validation.validate_user_offerer', offerer_id=offerer.id, user_offerer_id=user_offerer.id) }}"
+                                name="{{ url_for('backoffice_web.validation.validate_user_offerer', offerer_id=offerer.id, user_offerer_id=user_offerer.id) | action_to_name }}"
                                 method="post">
                             <button type="submit"
                                     class="btn btn-sm d-block w-100 text-start px-3">Valider</button>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/validation.html
@@ -56,14 +56,14 @@
               <button disabled
                       type="button"
                       class="btn btn-outline-primary"
-                      data-url="{{ url_for("backoffice_web.validation.batch_validate_offerer") }}"
+                      data-url="{{ url_for('backoffice_web.validation.batch_validate_offerer') }}"
                       data-use-confirmation-modal="false">Valider</button>
               <button disabled
                       type="button"
                       class="btn btn-outline-primary"
                       data-use-confirmation-modal="true"
                       data-mode="fetch"
-                      data-fetch-url="{{ url_for("backoffice_web.validation.get_batch_offerer_pending_form") }}"
+                      data-fetch-url="{{ url_for('backoffice_web.validation.get_batch_offerer_pending_form') }}"
                       data-modal-selector="#batch-pending-modal">Mettre en attente</button>
               <button disabled
                       type="button"
@@ -131,8 +131,8 @@
                         </button>
                         <ul class="dropdown-menu">
                           <li class="dropdown-item p-0">
-                            <form action="{{ url_for("backoffice_web.validation.validate_offerer", offerer_id=offerer.id) }}"
-                                  name="{{ url_for("backoffice_web.validation.validate_offerer", offerer_id=offerer.id) | action_to_name }}"
+                            <form action="{{ url_for('backoffice_web.validation.validate_offerer', offerer_id=offerer.id) }}"
+                                  name="{{ url_for('backoffice_web.validation.validate_offerer', offerer_id=offerer.id) | action_to_name }}"
                                   method="post">
                               {{ csrf_token }}
                               <button type="submit"
@@ -162,8 +162,8 @@
                   <td>
                     {% set top_actor_checked = "top-acteur" in item.tags | map(attribute="name") %}
                     <div class="form-check form-switch">
-                      <form action="{{ url_for("backoffice_web.validation.toggle_top_actor", offerer_id=offerer.id) }}"
-                            name="{{ url_for("backoffice_web.validation.toggle_top_actor", offerer_id=offerer.id) | action_to_name }}"
+                      <form action="{{ url_for('backoffice_web.validation.toggle_top_actor', offerer_id=offerer.id) }}"
+                            name="{{ url_for('backoffice_web.validation.toggle_top_actor', offerer_id=offerer.id) | action_to_name }}"
                             method="post">
                         {{ csrf_token }}
                         <input class="form-check-input" type="checkbox" role="switch" name="is_top_actor" id="top-switch-{{ offerer.id }}" aria-label="{{ top_actor_checked | format_bool }}" onChange="this.form.submit()" {{ "checked" if top_actor_checked else "" }} />

--- a/api/src/pcapi/routes/backoffice/templates/pivots/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/pivots/get.html
@@ -17,27 +17,27 @@
       {% endcall %}
       {% call build_details_tabs_content_wrapper() %}
         {% call build_details_tab_content("allocine", active_tab == 'allocine') %}
-          <turbo-frame data-turbo="true" id="allocine_frame" loading="lazy" src="{{ url_for("backoffice_web.pivots.list_pivots", name="allocine") }}">
+          <turbo-frame data-turbo="true" id="allocine_frame" loading="lazy" src="{{ url_for('backoffice_web.pivots.list_pivots', name='allocine') }}">
           {{ build_loading_spinner() }}
           </turbo-frame>
         {% endcall %}
         {% call build_details_tab_content("boost", active_tab == 'boost') %}
-          <turbo-frame data-turbo="true" id="boost_frame" loading="lazy" src="{{ url_for("backoffice_web.pivots.list_pivots", name="boost") }}">
+          <turbo-frame data-turbo="true" id="boost_frame" loading="lazy" src="{{ url_for('backoffice_web.pivots.list_pivots', name='boost') }}">
           {{ build_loading_spinner() }}
           </turbo-frame>
         {% endcall %}
         {% call build_details_tab_content("cgr", active_tab == 'cgr') %}
-          <turbo-frame data-turbo="true" id="cgr_frame" loading="lazy" src="{{ url_for("backoffice_web.pivots.list_pivots", name="cgr") }}">
+          <turbo-frame data-turbo="true" id="cgr_frame" loading="lazy" src="{{ url_for('backoffice_web.pivots.list_pivots', name='cgr') }}">
           {{ build_loading_spinner() }}
           </turbo-frame>
         {% endcall %}
         {% call build_details_tab_content("cineoffice", active_tab == 'cineoffice') %}
-          <turbo-frame data-turbo="true" id="cineoffice_frame" loading="lazy" src="{{ url_for("backoffice_web.pivots.list_pivots", name="cineoffice") }}">
+          <turbo-frame data-turbo="true" id="cineoffice_frame" loading="lazy" src="{{ url_for('backoffice_web.pivots.list_pivots', name='cineoffice') }}">
           {{ build_loading_spinner() }}
           </turbo-frame>
         {% endcall %}
         {% call build_details_tab_content("ems", active_tab == 'ems') %}
-          <turbo-frame data-turbo="true" id="ems_frame" loading="lazy" src="{{ url_for("backoffice_web.pivots.list_pivots", name="ems") }}">
+          <turbo-frame data-turbo="true" id="ems_frame" loading="lazy" src="{{ url_for('backoffice_web.pivots.list_pivots', name='ems') }}">
           {{ build_loading_spinner() }}
           </turbo-frame>
         {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/pro/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/get.html
@@ -4,6 +4,6 @@
   <p>{{ row.id }}</p>
   <p>{{ pro_type }}</p>
   <p>
-    <a href="{{ url_for("backoffice_web.pro.search_pro") }}">Page de recherche (pro)</a>
+    <a href="{{ url_for('backoffice_web.pro.search_pro') }}">Page de recherche (pro)</a>
   </p>
 {% endblock page %}

--- a/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
@@ -25,7 +25,7 @@
           {% endif %}
         </p>
       </div>
-      <a href="{{ url_for("backoffice_web.venue.get", venue_id=venue.id) }}"
+      <a href="{{ url_for('backoffice_web.venue.get', venue_id=venue.id) }}"
          target="_blank"
          class="card-link">
         <button class="btn lead px-0 fw-bold mt-1">CONSULTER LE PROFIL</button>
@@ -47,7 +47,7 @@
       </div>
     </div>
     <div class="d-flex justify-content-end py-4">
-      <a href="{{ url_for(".move_siret") }}"
+      <a href="{{ url_for('.move_siret') }}"
          class="btn btn-outline-primary mx-4"
          role="button">Annuler</a>
       <div>

--- a/api/src/pcapi/routes/backoffice/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro_user/get.html
@@ -93,7 +93,7 @@
         </div>
       </div>
       <div class="mt-4">
-        <turbo-frame data-turbo="false" id="pro_user_details_frame" src="{{ url_for("backoffice_web.pro_user.get_details", user_id=user.id, active_tab=request.args.get("active_tab", "history") ) }}">
+        <turbo-frame data-turbo="false" id="pro_user_details_frame" src="{{ url_for('backoffice_web.pro_user.get_details', user_id=user.id, active_tab=request.args.get('active_tab', 'history') ) }}">
         {{ build_loading_spinner() }}
         </turbo-frame>
       </div>

--- a/api/src/pcapi/routes/backoffice/templates/providers/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/providers/get.html
@@ -78,7 +78,7 @@
         </div>
       </div>
       <div class="mt-4">
-        <turbo-frame id="venue_providers_count_frame" src="{{ url_for("backoffice_web.providers.get_stats", provider_id=provider.id) }}">
+        <turbo-frame id="venue_providers_count_frame" src="{{ url_for('backoffice_web.providers.get_stats', provider_id=provider.id) }}">
         {{ build_loading_spinner() }}
         </turbo-frame>
       </div>
@@ -88,7 +88,7 @@
         {% endcall %}
         {% call build_details_tabs_content_wrapper() %}
           {% call build_details_tab_content("venues", active_tab == 'venues') %}
-            <turbo-frame data-turbo="false" id="provider_venues_frame" loading="lazy" src="{{ url_for("backoffice_web.providers.get_venues", provider_id=provider.id) }}">
+            <turbo-frame data-turbo="false" id="provider_venues_frame" loading="lazy" src="{{ url_for('backoffice_web.providers.get_venues', provider_id=provider.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/titelive/search_result.html
+++ b/api/src/pcapi/routes/backoffice/templates/titelive/search_result.html
@@ -104,7 +104,7 @@
                                 data-bs-target="#add-whitelist-confirmation">Ajouter le livre dans la whitelist</button>
                         {{ build_lazy_modal(url_for("backoffice_web.titelive.get_add_product_whitelist_confirmation_form", ean=json.ean, title=json.oeuvre.titre) , "add-whitelist-confirmation", "true") }}
                       {% else %}
-                        <a href="{{ url_for("backoffice_web.titelive.delete_product_whitelist", ean=json.ean) }}"
+                        <a href="{{ url_for('backoffice_web.titelive.delete_product_whitelist', ean=json.ean) }}"
                            class="btn btn-outline-primary">Retirer le livre de la whitelist</a>
                       {% endif %}
                     </div>

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -33,8 +33,8 @@
                      aria-hidden="true">
                   <div class="modal-dialog modal-dialog-centered">
                     <div class="modal-content">
-                      <form action="{{ url_for("backoffice_web.venue.fully_sync_venue", venue_id=venue.id) }}"
-                            name="{{ url_for("backoffice_web.venue.fully_sync_venue", venue_id=venue.id) | action_to_name }}"
+                      <form action="{{ url_for('backoffice_web.venue.fully_sync_venue', venue_id=venue.id) }}"
+                            name="{{ url_for('backoffice_web.venue.fully_sync_venue', venue_id=venue.id) | action_to_name }}"
                             method="post"
                             data-turbo="false">
                         <div class="modal-header"
@@ -276,18 +276,18 @@
                             } %}
               <p class="mb-1">
                 <span class="fw-bold">Offres BO :</span>
-                <a href="{{ url_for("backoffice_web.offer.list_offers", **search_params) }}"
+                <a href="{{ url_for('backoffice_web.offer.list_offers', **search_params) }}"
                    class="link-primary">individuelles</a> |
-                <a href="{{ url_for("backoffice_web.collective_offer.list_collective_offers", **search_params) }}"
+                <a href="{{ url_for('backoffice_web.collective_offer.list_collective_offers', **search_params) }}"
                    class="link-primary">collectives</a> |
-                <a href="{{ url_for("backoffice_web.collective_offer_template.list_collective_offer_templates", venue=venue.id) }}"
+                <a href="{{ url_for('backoffice_web.collective_offer_template.list_collective_offer_templates', venue=venue.id) }}"
                    class="link-primary">vitrine</a>
               </p>
               <p class="mb-1">
                 <span class="fw-bold">Réservations BO :</span>
-                <a href="{{ url_for("backoffice_web.individual_bookings.list_individual_bookings", venue=venue.id) }}"
+                <a href="{{ url_for('backoffice_web.individual_bookings.list_individual_bookings', venue=venue.id) }}"
                    class="link-primary">individuelles</a> |
-                <a href="{{ url_for("backoffice_web.collective_bookings.list_collective_bookings", venue=venue.id) }}"
+                <a href="{{ url_for('backoffice_web.collective_bookings.list_collective_bookings', venue=venue.id) }}"
                    class="link-primary">collectives</a>
               </p>
               <div>
@@ -342,7 +342,7 @@
         </div>
       </div>
       <div class="mt-4">
-        <turbo-frame data-turbo="false" id="venue_total_revenue_frame" src="{{ url_for("backoffice_web.venue.get_stats", venue_id=venue.id) }}">
+        <turbo-frame data-turbo="false" id="venue_total_revenue_frame" src="{{ url_for('backoffice_web.venue.get_stats', venue_id=venue.id) }}">
         {{ build_loading_spinner() }}
         </turbo-frame>
       </div>
@@ -356,20 +356,20 @@
         {% endcall %}
         {% call build_details_tabs_content_wrapper() %}
           {% call build_details_tab_content("history", active_tab == 'history') %}
-            <turbo-frame data-turbo="false" id="venue_history_frame" loading="lazy" src="{{ url_for("backoffice_web.venue.get_history", venue_id=venue.id) }}">
+            <turbo-frame data-turbo="false" id="venue_history_frame" loading="lazy" src="{{ url_for('backoffice_web.venue.get_history', venue_id=venue.id) }}">
             {{ build_loading_spinner() }}
             </turbo-frame>
           {% endcall %}
           {% if venue.siret and has_permission("READ_PRO_ENTREPRISE_INFO") %}
             {% call build_details_tab_content("entreprise", active_tab == 'entreprise') %}
-              <turbo-frame data-turbo="false" id="venue_entreprise_frame" loading="lazy" src="{{ url_for("backoffice_web.venue.get_entreprise_info", venue_id=venue.id) }}">
+              <turbo-frame data-turbo="false" id="venue_entreprise_frame" loading="lazy" src="{{ url_for('backoffice_web.venue.get_entreprise_info', venue_id=venue.id) }}">
               {{ build_loading_spinner() }}
               </turbo-frame>
             {% endcall %}
           {% endif %}
           {% if venue.siret %}
             {% call build_details_tab_content("dms-adage", active_tab == 'dms_adage') %}
-              <turbo-frame data-turbo="false" id="venue_collective_dms_applications_frame" loading="lazy" src="{{ url_for("backoffice_web.venue.get_collective_dms_applications", venue_id=venue.id) }}">
+              <turbo-frame data-turbo="false" id="venue_collective_dms_applications_frame" loading="lazy" src="{{ url_for('backoffice_web.venue.get_collective_dms_applications', venue_id=venue.id) }}">
               {{ build_loading_spinner() }}
               </turbo-frame>
             {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/venue/get/stats.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get/stats.html
@@ -109,7 +109,7 @@
             <span class="fw-bold">Point de valorisation :</span>
             {% if pricing_point %}
               {% if pricing_point.id != venue.id %}
-                <a href="{{ url_for("backoffice_web.venue.get", venue_id=pricing_point.id) }}"
+                <a href="{{ url_for('backoffice_web.venue.get', venue_id=pricing_point.id) }}"
                    class="link-primary">{{ pricing_point.common_name }}</a>
                 {% if has_permission("ADVANCED_PRO_SUPPORT") %}
                   <button class="btn btn-link lead fw-bold mx-0 my-0 py-0"

--- a/api/src/pcapi/routes/backoffice/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/list.html
@@ -25,7 +25,7 @@
                       class="btn btn-outline-primary"
                       data-modal-selector="#batch-edit-venues-modal"
                       data-mode="fetch"
-                      data-fetch-url="{{ url_for("backoffice_web.venue.get_batch_edit_venues_form") }}"
+                      data-fetch-url="{{ url_for('backoffice_web.venue.get_batch_edit_venues_form') }}"
                       data-use-confirmation-modal="true">Éditer les lieux</button>
             </div>
           {% endif %}


### PR DESCRIPTION
## But de la pull request

djlint a été mis à jour en version 1.34.2 par dependabot dans la PR #13868 .
Cette PR met à jour le code du backoffice avec cette nouvelle version.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
