### PR TITLE
(PC-31126)[API]feat: remove time from publication date info send to Brevo

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/offer_validation_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/offer_validation_to_pro.py
@@ -11,7 +11,7 @@ def retrieve_data_for_offer_approval_email(
     offer: Offer | educational_models.CollectiveOffer | educational_models.CollectiveOfferTemplate,
 ) -> models.TransactionalEmailData:
     if isinstance(offer, Offer) and offer.publicationDate:
-        publication_date = offer.publicationDate.strftime("%d/%m/%Y %H:%M:%S")
+        publication_date = offer.publicationDate.strftime("%d/%m/%Y")
     else:
         publication_date = None
     return models.TransactionalEmailData(

--- a/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
@@ -38,7 +38,7 @@ class SendinblueSendOfferValidationTest:
     def test_get_validation_approval_correct_email_metadata_when_future_offer(self):
         # Given
         offer = offers_factories.OfferFactory(name="Ma petite offre", venue__name="Mon stade")
-        publication_date = datetime.utcnow().replace(minute=0, second=0, microsecond=0) + timedelta(days=30)
+        publication_date = datetime.utcnow() + timedelta(days=30)
         offers_factories.FutureOfferFactory(offerId=offer.id, publicationDate=publication_date)
 
         # When
@@ -48,7 +48,7 @@ class SendinblueSendOfferValidationTest:
         assert new_offer_validation_email.template == TransactionalEmail.OFFER_APPROVAL_TO_PRO.value
         assert new_offer_validation_email.params == {
             "OFFER_NAME": "Ma petite offre",
-            "PUBLICATION_DATE": publication_date.strftime("%d/%m/%Y %H:%M:%S"),
+            "PUBLICATION_DATE": publication_date.strftime("%d/%m/%Y"),
             "VENUE_NAME": "Mon stade",
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
         }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31126

Suppression de l'information "heure de publication" dans les informations envoyées à Brevo lors de la validation d'une offre

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
