### PR TITLE
(PC-31508)[PRO] fix collective offers duplication bug

### DIFF
--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -202,6 +202,8 @@ export const CollectiveActionsCells = ({
     }
   }
 
+  const canDuplicateOffer = offer.status !== CollectiveOfferStatus.DRAFT
+
   return (
     <td
       className={cn(styles['offers-table-cell'], styles['actions-column'])}
@@ -274,34 +276,23 @@ export const CollectiveActionsCells = ({
                       />
                     </>
                   )}
-                {!offer.isShowcase ||
-                  (offer.status !== CollectiveOfferStatus.DRAFT && (
-                    <DropdownMenu.Item
-                      className={styles['menu-item']}
-                      onSelect={handleCreateOfferClick}
+
+                {canDuplicateOffer && (
+                  <DropdownMenu.Item
+                    className={styles['menu-item']}
+                    onSelect={handleCreateOfferClick}
+                  >
+                    <Button
+                      icon={offer.isShowcase ? fullPlusIcon : fullCopyIcon}
+                      variant={ButtonVariant.TERNARY}
                     >
-                      <Button
-                        icon={fullCopyIcon}
-                        variant={ButtonVariant.TERNARY}
-                      >
-                        Dupliquer
-                      </Button>
-                    </DropdownMenu.Item>
-                  ))}
-                {offer.isShowcase &&
-                  offer.status !== CollectiveOfferStatus.ARCHIVED && (
-                    <DropdownMenu.Item
-                      className={styles['menu-item']}
-                      onSelect={handleCreateOfferClick}
-                    >
-                      <Button
-                        icon={fullPlusIcon}
-                        variant={ButtonVariant.TERNARY}
-                      >
-                        Créer une offre réservable
-                      </Button>
-                    </DropdownMenu.Item>
-                  )}
+                      {offer.isShowcase
+                        ? 'Créer une offre réservable'
+                        : 'Dupliquer'}
+                    </Button>
+                  </DropdownMenu.Item>
+                )}
+
                 {offer.isEditable &&
                   !offer.isPublicApi &&
                   offer.status !== CollectiveOfferStatus.ARCHIVED && (
@@ -343,7 +334,6 @@ export const CollectiveActionsCells = ({
                       </DropdownMenu.Item>
                     </>
                   )}
-
                 {offer.status !== CollectiveOfferStatus.ARCHIVED &&
                   canArchiveCollectiveOffer(offer) && (
                     <>

--- a/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
@@ -12,24 +12,24 @@ import {
   CollectiveActionsCellsProps,
 } from '../CollectiveActionsCells'
 
-const renderCollectiveActionsCell = ({
-  offer,
-  editionOfferLink,
-  urlSearchFilters,
-  isSelected,
-  deselectOffer,
-}: CollectiveActionsCellsProps) => {
+const mockDeselectOffer = vi.fn()
+const renderCollectiveActionsCell = (
+  props: Partial<CollectiveActionsCellsProps> = {}
+) => {
+  const defaultProps: CollectiveActionsCellsProps = {
+    offer: collectiveOfferFactory(),
+    editionOfferLink: '',
+    urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+    isSelected: false,
+    deselectOffer: mockDeselectOffer,
+    ...props,
+  }
+
   return renderWithProviders(
     <table>
       <tbody>
         <tr>
-          <CollectiveActionsCells
-            offer={offer}
-            editionOfferLink={editionOfferLink}
-            urlSearchFilters={urlSearchFilters}
-            isSelected={isSelected}
-            deselectOffer={deselectOffer}
-          />
+          <CollectiveActionsCells {...defaultProps} />
         </tr>
       </tbody>
     </table>
@@ -54,10 +54,6 @@ describe('CollectiveActionsCells', () => {
           },
         ],
       }),
-      editionOfferLink: '',
-      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
-      isSelected: false,
-      deselectOffer: vi.fn(),
     })
 
     await userEvent.click(screen.getByTitle('Action'))
@@ -78,7 +74,6 @@ describe('CollectiveActionsCells', () => {
   })
 
   it('should deselect an offer selected when the offer has just been archived', async () => {
-    const mockDeselectOffer = vi.fn()
     renderCollectiveActionsCell({
       offer: collectiveOfferFactory({
         stocks: [
@@ -89,10 +84,7 @@ describe('CollectiveActionsCells', () => {
           },
         ],
       }),
-      editionOfferLink: '',
-      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
       isSelected: true,
-      deselectOffer: mockDeselectOffer,
     })
 
     await userEvent.click(screen.getByTitle('Action'))
@@ -118,10 +110,6 @@ describe('CollectiveActionsCells', () => {
         isShowcase: true,
         status: CollectiveOfferStatus.DRAFT,
       }),
-      editionOfferLink: '',
-      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
-      isSelected: false,
-      deselectOffer: vi.fn(),
     })
 
     await userEvent.click(screen.getByTitle('Action'))
@@ -136,10 +124,6 @@ describe('CollectiveActionsCells', () => {
       offer: collectiveOfferFactory({
         status: CollectiveOfferStatus.DRAFT,
       }),
-      editionOfferLink: '',
-      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
-      isSelected: false,
-      deselectOffer: vi.fn(),
     })
 
     await userEvent.click(screen.getByTitle('Action'))
@@ -152,10 +136,6 @@ describe('CollectiveActionsCells', () => {
       offer: collectiveOfferFactory({
         isShowcase: true,
       }),
-      editionOfferLink: '',
-      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
-      isSelected: false,
-      deselectOffer: vi.fn(),
     })
 
     await userEvent.click(screen.getByTitle('Action'))
@@ -164,13 +144,7 @@ describe('CollectiveActionsCells', () => {
   })
 
   it('should display duplicate button for draft bookable offer', async () => {
-    renderCollectiveActionsCell({
-      offer: collectiveOfferFactory(),
-      editionOfferLink: '',
-      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
-      isSelected: false,
-      deselectOffer: vi.fn(),
-    })
+    renderCollectiveActionsCell()
 
     await userEvent.click(screen.getByTitle('Action'))
 

--- a/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { api } from 'apiClient/api'
+import { CollectiveOfferStatus } from 'apiClient/v1'
 import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
@@ -109,5 +110,70 @@ describe('CollectiveActionsCells', () => {
     )
 
     expect(mockDeselectOffer).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not display duplicate button for draft template offer', async () => {
+    renderCollectiveActionsCell({
+      offer: collectiveOfferFactory({
+        isShowcase: true,
+        status: CollectiveOfferStatus.DRAFT,
+      }),
+      editionOfferLink: '',
+      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+      isSelected: false,
+      deselectOffer: vi.fn(),
+    })
+
+    await userEvent.click(screen.getByTitle('Action'))
+
+    expect(
+      screen.queryByText('Créer une offre réservable')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not display duplicate button for draft bookable offer', async () => {
+    renderCollectiveActionsCell({
+      offer: collectiveOfferFactory({
+        status: CollectiveOfferStatus.DRAFT,
+      }),
+      editionOfferLink: '',
+      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+      isSelected: false,
+      deselectOffer: vi.fn(),
+    })
+
+    await userEvent.click(screen.getByTitle('Action'))
+
+    expect(screen.queryByText('Dupliquer')).not.toBeInTheDocument()
+  })
+
+  it('should display duplicate button for template offer', async () => {
+    renderCollectiveActionsCell({
+      offer: collectiveOfferFactory({
+        isShowcase: true,
+      }),
+      editionOfferLink: '',
+      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+      isSelected: false,
+      deselectOffer: vi.fn(),
+    })
+
+    await userEvent.click(screen.getByTitle('Action'))
+
+    expect(screen.getByText('Créer une offre réservable')).toBeInTheDocument()
+  })
+
+  it('should display duplicate button for draft bookable offer', async () => {
+    renderCollectiveActionsCell({
+      offer: collectiveOfferFactory(),
+      editionOfferLink: '',
+      urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+      isSelected: false,
+      deselectOffer: vi.fn(),
+    })
+
+    await userEvent.click(screen.getByTitle('Action'))
+
+    expect(screen.getByText('Dupliquer')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31508

Bug: on ne peut plus dupliquer les offres réservables et le bouton de duplication apparaît 2 fois pour les offres vitrines (dupliquer + créer une offre réservable)
Fix: on peut dupliquer n'importe quelle offre tant qu'elle n'est pas au statut brouillon.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
