### PR TITLE
(PC-31511)[PRO] fix: Open the help link file in the topmost frame.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -74,6 +74,7 @@ export const AdageHeader = () => {
             isExternal
             download
             icon={fullDownloadIcon}
+            target="_top"
           >
             Télécharger l’aide
           </ButtonLink>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31511

**Objectif**
Le bouton "Télécharger l'aide" ne télécharge pas le fichier pptx dans le header de la page de recherche ADAGE. Cette PR corrige ça en s'assurant que quand on est dans l'iframe, le bouton se télécharge dans la page parente (ADAGE) et pas dans l'iframe.

A tester dans une iframe ADAGE (et pas en standalone sinon l'url ne peut pas être construite).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
