### PR TITLE
(PC-31372)[PRO] fix: Dont transform invalid date values when getting …

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.tsx
@@ -227,14 +227,16 @@ export const CollectiveTimeLine = ({
         <div className={styles['timeline-step-title']}>
           Réservation en cours de confirmation
         </div>
-        <div>
-          À partir du {cancellationLimitDate.toString()}, la réservation ne sera
-          plus annulable par l’établissement scolaire. <br />
-          <br />
-          30 jours avant la date de l’évènement, l’établissement scolaire ne
-          peut plus annuler. De votre côté, vous pouvez annuler la réservation
-          jusqu’à 48 heures après la date de l’évènement.
-        </div>
+        {cancellationLimitDate && (
+          <div>
+            À partir du {cancellationLimitDate.toString()}, la réservation ne
+            sera plus annulable par l’établissement scolaire. <br />
+            <br />
+            30 jours avant la date de l’évènement, l’établissement scolaire ne
+            peut plus annuler. De votre côté, vous pouvez annuler la réservation
+            jusqu’à 48 heures après la date de l’évènement.
+          </div>
+        )}
       </>
     ),
   }

--- a/pro/src/utils/__specs__/date.spec.ts
+++ b/pro/src/utils/__specs__/date.spec.ts
@@ -3,6 +3,7 @@ import {
   formatBrowserTimezonedDateAsUTC,
   formatShortDateForInput,
   formatTimeForInput,
+  getDateToFrenchText,
   getRangeToFrenchText,
   toDateStrippedOfTimezone,
   toISOStringWithoutMilliseconds,
@@ -117,5 +118,9 @@ describe('getRangeToFrenchText', () => {
     const date = new Date('2020-11-17T23:10:00Z')
 
     expect(formatTimeForInput(date)).toBe('23:10')
+  })
+
+  it('should not return a date when transforming an invalid date into French text', () => {
+    expect(getDateToFrenchText('0024-01-15T23:59:59+00:09:21')).toEqual(null)
   })
 })

--- a/pro/src/utils/date.ts
+++ b/pro/src/utils/date.ts
@@ -53,6 +53,9 @@ export const toDateStrippedOfTimezone = (dateIsoString: string) => {
 }
 
 export const getDateToFrenchText = (dateIsoString: string) => {
+  if (!isValid(new Date(dateIsoString))) {
+    return null
+  }
   const noTimeZoneDate = toDateStrippedOfTimezone(dateIsoString)
   return format(noTimeZoneDate, FORMAT_DD_MMMM_YYYY, { locale: fr })
 }


### PR DESCRIPTION
…the French text version of a date.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31372

**Objectif**
Ne pas considérer les dates invalides quand on transforme une date en "French text". Pour corriger un bug Sentry en prod sur une date qui a une coquille (?) `"bookingConfirmationLimitDate": "0024-01-15T23:59:59+00:09:21"`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
