### PR TITLE
Pc 31546 collective bulk edit uncheck

### DIFF
--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -127,7 +127,7 @@ export function CollectiveOffersActionsBar({
   }
   delete apiFilters.page
 
-  async function onOffersStatusChanged(
+  async function updateOfferStatus(
     newSatus:
       | CollectiveOfferDisplayedStatus.ARCHIVED
       | CollectiveOfferDisplayedStatus.INACTIVE
@@ -262,7 +262,7 @@ export function CollectiveOffersActionsBar({
           areAllOffersSelected={areAllOffersSelected}
           nbSelectedOffers={selectedOffers.length}
           onConfirm={() =>
-            onOffersStatusChanged(CollectiveOfferDisplayedStatus.INACTIVE)
+            updateOfferStatus(CollectiveOfferDisplayedStatus.INACTIVE)
           }
           onCancel={() => setIsDeactivationDialogOpen(false)}
         />
@@ -272,7 +272,7 @@ export function CollectiveOffersActionsBar({
         <ArchiveConfirmationModal
           onDismiss={() => setIsArchiveDialogOpen(false)}
           onValidate={() =>
-            onOffersStatusChanged(CollectiveOfferDisplayedStatus.ARCHIVED)
+            updateOfferStatus(CollectiveOfferDisplayedStatus.ARCHIVED)
           }
           hasMultipleOffers={selectedOffers.length > 1}
         />
@@ -305,7 +305,7 @@ export function CollectiveOffersActionsBar({
           </Button>
           <Button
             onClick={() =>
-              onOffersStatusChanged(CollectiveOfferDisplayedStatus.ACTIVE)
+              updateOfferStatus(CollectiveOfferDisplayedStatus.ACTIVE)
             }
             icon={fullValidateIcon}
             variant={ButtonVariant.SECONDARY}

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -4,6 +4,7 @@ import { mutate } from 'swr'
 import { api } from 'apiClient/api'
 import {
   CollectiveBookingStatus,
+  CollectiveOfferDisplayedStatus,
   CollectiveOfferResponseModel,
   CollectiveOfferStatus,
 } from 'apiClient/v1'
@@ -14,7 +15,6 @@ import { GET_COLLECTIVE_OFFERS_QUERY_KEY } from 'config/swrQueryKeys'
 import { NOTIFICATION_LONG_SHOW_DURATION } from 'core/Notification/constants'
 import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQueryCollectiveSearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
-import { CollectiveSearchFiltersParams } from 'core/Offers/types'
 import { useNotification } from 'hooks/useNotification'
 import fullHideIcon from 'icons/full-hide.svg'
 import fullValidateIcon from 'icons/full-validate.svg'
@@ -32,7 +32,6 @@ export type CollectiveOffersActionsBarProps = {
   clearSelectedOfferIds: () => void
   selectedOffers: CollectiveOfferResponseModel[]
   toggleSelectAllCheckboxes: () => void
-  getUpdateOffersStatusMessage: (selectedOfferIds: number[]) => string
 }
 
 const computeDeactivationSuccessMessage = (nbSelectedOffers: number) => {
@@ -43,22 +42,37 @@ const computeDeactivationSuccessMessage = (nbSelectedOffers: number) => {
   return `${nbSelectedOffers} ${successMessage}`
 }
 
-const updateCollectiveOffersStatus = async (
-  isActive: boolean,
+function canDeactivateCollectiveOffers(offers: CollectiveOfferResponseModel[]) {
+  return offers.every((offer) => {
+    //  Check that all the offers are published or expired
+    return (
+      offer.status === CollectiveOfferStatus.ACTIVE ||
+      (offer.status === CollectiveOfferStatus.EXPIRED &&
+        (!offer.booking?.booking_status ||
+          offer.booking.booking_status === CollectiveBookingStatus.CANCELLED))
+    )
+  })
+}
+
+const toggleCollectiveOffersActiveInactiveStatus = async (
+  newStatus:
+    | CollectiveOfferDisplayedStatus.ACTIVE
+    | CollectiveOfferDisplayedStatus.INACTIVE,
   selectedOffers: CollectiveOfferResponseModel[],
-  notify: ReturnType<typeof useNotification>,
-  apiFilters: CollectiveSearchFiltersParams
+  notify: ReturnType<typeof useNotification>
 ) => {
   try {
     //  Differenciate template and bookable selected offers so that there can be two separarate api status update calls
     const collectiveOfferIds = []
     const collectiveOfferTemplateIds = []
 
-    if (!canPublishCollectiveOffersArchived(selectedOffers)) {
+    if (
+      selectedOffers.some(
+        (offer) => offer.status === CollectiveOfferStatus.ARCHIVED
+      )
+    ) {
       notify.error(
-        `Une erreur est survenue lors de ${
-          isActive ? 'l’activation' : 'la désactivation'
-        } des offres sélectionnées`
+        `Une erreur est survenue lors de ${newStatus === CollectiveOfferDisplayedStatus.ACTIVE ? 'la publication' : 'la désactivation'} des offres sélectionnées`
       )
       return
     }
@@ -74,56 +88,31 @@ const updateCollectiveOffersStatus = async (
     if (collectiveOfferIds.length > 0) {
       await api.patchCollectiveOffersActiveStatus({
         ids: collectiveOfferIds.map((id) => Number(id)),
-        isActive,
+        isActive: newStatus === CollectiveOfferDisplayedStatus.ACTIVE,
       })
     }
 
     if (collectiveOfferTemplateIds.length > 0) {
       await api.patchCollectiveOffersTemplateActiveStatus({
         ids: collectiveOfferTemplateIds.map((ids) => Number(ids)),
-        isActive,
+        isActive: newStatus === CollectiveOfferDisplayedStatus.ACTIVE,
       })
     }
 
-    notify.information(
-      isActive
+    notify.success(
+      newStatus === CollectiveOfferDisplayedStatus.ACTIVE
         ? computeActivationSuccessMessage(selectedOffers.length)
         : computeDeactivationSuccessMessage(selectedOffers.length)
     )
   } catch {
     notify.error('Une erreur est survenue')
   }
-
-  await mutate([GET_COLLECTIVE_OFFERS_QUERY_KEY, apiFilters])
-}
-
-function canDeactivateCollectiveOffers(offers: CollectiveOfferResponseModel[]) {
-  return offers.every((offer) => {
-    //  Check that all the offers are published or expired
-    return (
-      offer.status === CollectiveOfferStatus.ACTIVE ||
-      (offer.status === CollectiveOfferStatus.EXPIRED &&
-        (!offer.booking?.booking_status ||
-          offer.booking.booking_status === CollectiveBookingStatus.CANCELLED))
-    )
-  })
-}
-
-function canPublishCollectiveOffersArchived(
-  offers: CollectiveOfferResponseModel[]
-) {
-  return offers.every((offer) => {
-    //  Check that all the offers are published or expired
-    return offer.status !== CollectiveOfferStatus.ARCHIVED
-  })
 }
 
 export function CollectiveOffersActionsBar({
   selectedOffers,
   clearSelectedOfferIds,
-  toggleSelectAllCheckboxes,
   areAllOffersSelected,
-  getUpdateOffersStatusMessage,
 }: CollectiveOffersActionsBarProps) {
   const urlSearchFilters = useQueryCollectiveSearchFilters()
 
@@ -138,54 +127,54 @@ export function CollectiveOffersActionsBar({
   }
   delete apiFilters.page
 
-  const handleClose = () => {
+  async function onOffersStatusChanged(
+    newSatus:
+      | CollectiveOfferDisplayedStatus.ARCHIVED
+      | CollectiveOfferDisplayedStatus.INACTIVE
+      | CollectiveOfferDisplayedStatus.ACTIVE
+  ) {
+    switch (newSatus) {
+      case CollectiveOfferDisplayedStatus.ACTIVE: {
+        const updateOfferStatusMessage = getPublishOffersErrorMessage()
+        if (!updateOfferStatusMessage) {
+          await toggleCollectiveOffersActiveInactiveStatus(
+            CollectiveOfferDisplayedStatus.ACTIVE,
+            selectedOffers,
+            notify
+          )
+        } else {
+          notify.error(updateOfferStatusMessage)
+          return
+        }
+        break
+      }
+      case CollectiveOfferDisplayedStatus.INACTIVE: {
+        setIsDeactivationDialogOpen(false)
+        await toggleCollectiveOffersActiveInactiveStatus(
+          CollectiveOfferDisplayedStatus.INACTIVE,
+          selectedOffers,
+          notify
+        )
+        break
+      }
+      case CollectiveOfferDisplayedStatus.ARCHIVED: {
+        setIsArchiveDialogOpen(false)
+        await onArchiveOffers()
+        break
+      }
+    }
+
     clearSelectedOfferIds()
-    areAllOffersSelected && toggleSelectAllCheckboxes()
+    await mutate([GET_COLLECTIVE_OFFERS_QUERY_KEY, apiFilters])
   }
 
-  function onDeactivateOffersClicked() {
-    if (!canDeactivateCollectiveOffers(selectedOffers)) {
-      notify.error(
-        'Seules les offres au statut publié ou expiré peuvent être masquées.'
-      )
-      return
-    }
-    setIsDeactivationDialogOpen(true)
-  }
-
-  const handleUpdateOffersStatus = async (isActivating: boolean) => {
-    await updateCollectiveOffersStatus(
-      isActivating,
-      selectedOffers,
-      notify,
-      apiFilters
-    )
-
-    handleClose()
-  }
-
-  const handleActivate = async () => {
-    const updateOfferStatusMessage = getUpdateOffersStatusMessage(
-      selectedOffers.map((offer) => offer.id)
-    )
-    if (!updateOfferStatusMessage) {
-      await handleUpdateOffersStatus(true)
-    } else {
-      notify.error(updateOfferStatusMessage)
-    }
-  }
-
-  const handleDeactivateOffers = async () => {
-    await handleUpdateOffersStatus(false)
-    setIsDeactivationDialogOpen(false)
-  }
-
-  const onArchiveOffersClicked = () => {
+  function openArchiveOffersDialog() {
     const shouldOpenArchiveDialog = selectedOffers.every((offer) => {
       if (!canArchiveCollectiveOffer(offer)) {
         notify.error(
           'Les offres liées à des réservations en cours ne peuvent pas être archivées'
         )
+        clearSelectedOfferIds()
         return false
       }
       return true
@@ -193,7 +182,18 @@ export function CollectiveOffersActionsBar({
     setIsArchiveDialogOpen(shouldOpenArchiveDialog)
   }
 
-  const archiveOffer = async () => {
+  function openDeactivateOffersDialog() {
+    if (!canDeactivateCollectiveOffers(selectedOffers)) {
+      notify.error(
+        'Seules les offres au statut publié ou expiré peuvent être masquées.'
+      )
+      clearSelectedOfferIds()
+      return
+    }
+    setIsDeactivationDialogOpen(true)
+  }
+
+  const onArchiveOffers = async () => {
     try {
       const collectiveOfferIds = []
       const collectiveOfferTemplateIds = []
@@ -216,22 +216,43 @@ export function CollectiveOffersActionsBar({
         await api.patchCollectiveOffersArchive({ ids: [...collectiveOfferIds] })
       }
 
-      await mutate([GET_COLLECTIVE_OFFERS_QUERY_KEY, apiFilters])
-
       notify.success(
         selectedOffers.length > 1
-          ? `${selectedOffers.length} offres ont bien été archivée`
+          ? `${selectedOffers.length} offres ont bien été archivées`
           : 'Une offre a bien été archivée',
         {
           duration: NOTIFICATION_LONG_SHOW_DURATION,
         }
       )
-      setIsArchiveDialogOpen(false)
     } catch (error) {
       notify.error('Une erreur est survenue lors de l’archivage de l’offre', {
         duration: NOTIFICATION_LONG_SHOW_DURATION,
       })
     }
+  }
+
+  function getPublishOffersErrorMessage() {
+    if (
+      selectedOffers.some(
+        (offer) => offer.status === CollectiveOfferStatus.ARCHIVED
+      )
+    ) {
+      notify.error(
+        `Une erreur est survenue lors de la publication des offres sélectionnées`
+      )
+      return
+    }
+    if (
+      selectedOffers.some(
+        (offer) => offer.status === CollectiveOfferStatus.DRAFT
+      )
+    ) {
+      return 'Vous ne pouvez pas publier des brouillons depuis cette liste'
+    }
+    if (selectedOffers.some((offer) => offer.hasBookingLimitDatetimesPassed)) {
+      return 'Vous ne pouvez pas publier des offres collectives dont la date de réservation est passée'
+    }
+    return ''
   }
 
   return (
@@ -240,7 +261,9 @@ export function CollectiveOffersActionsBar({
         <CollectiveDeactivationConfirmDialog
           areAllOffersSelected={areAllOffersSelected}
           nbSelectedOffers={selectedOffers.length}
-          onConfirm={handleDeactivateOffers}
+          onConfirm={() =>
+            onOffersStatusChanged(CollectiveOfferDisplayedStatus.INACTIVE)
+          }
           onCancel={() => setIsDeactivationDialogOpen(false)}
         />
       )}
@@ -248,7 +271,9 @@ export function CollectiveOffersActionsBar({
       {isArchiveDialogOpen && (
         <ArchiveConfirmationModal
           onDismiss={() => setIsArchiveDialogOpen(false)}
-          onValidate={archiveOffer}
+          onValidate={() =>
+            onOffersStatusChanged(CollectiveOfferDisplayedStatus.ARCHIVED)
+          }
           hasMultipleOffers={selectedOffers.length > 1}
         />
       )}
@@ -258,25 +283,30 @@ export function CollectiveOffersActionsBar({
           {computeSelectedOffersLabel(selectedOffers.length)}
         </ActionsBarSticky.Left>
         <ActionsBarSticky.Right>
-          <Button onClick={handleClose} variant={ButtonVariant.SECONDARY}>
+          <Button
+            onClick={clearSelectedOfferIds}
+            variant={ButtonVariant.SECONDARY}
+          >
             Annuler
           </Button>
           <Button
-            onClick={onArchiveOffersClicked}
+            onClick={openArchiveOffersDialog}
             icon={strokeThingIcon}
             variant={ButtonVariant.SECONDARY}
           >
             Archiver
           </Button>
           <Button
-            onClick={onDeactivateOffersClicked}
+            onClick={openDeactivateOffersDialog}
             icon={fullHideIcon}
             variant={ButtonVariant.SECONDARY}
           >
             Masquer
           </Button>
           <Button
-            onClick={handleActivate}
+            onClick={() =>
+              onOffersStatusChanged(CollectiveOfferDisplayedStatus.ACTIVE)
+            }
             icon={fullValidateIcon}
             variant={ButtonVariant.SECONDARY}
           >

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
@@ -86,7 +86,7 @@ const updateIndividualOffersStatus = async (
         ids: selectedOfferIds.map((id) => Number(id)),
         isActive,
       })
-      notify.information(
+      notify.error(
         isActive
           ? computeActivationSuccessMessage(selectedOfferIds.length)
           : computeDeactivationSuccessMessage(selectedOfferIds.length)

--- a/pro/src/screens/CollectiveOffersScreen/CollectiveOffersScreen.tsx
+++ b/pro/src/screens/CollectiveOffersScreen/CollectiveOffersScreen.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 
 import {
   CollectiveOfferResponseModel,
-  CollectiveOfferStatus,
   GetOffererResponseModel,
   UserRole,
 } from 'apiClient/v1'
@@ -122,23 +121,6 @@ export const CollectiveOffersScreen = ({
     applyUrlFiltersAndRedirect(updatedFilters)
   }
 
-  const getUpdateOffersStatusMessage = (tmpSelectedOfferIds: number[]) => {
-    const selectedOffers = offers.filter((offer) =>
-      tmpSelectedOfferIds.includes(offer.id)
-    )
-    if (
-      selectedOffers.some(
-        (offer) => offer.status === CollectiveOfferStatus.DRAFT
-      )
-    ) {
-      return 'Vous ne pouvez pas publier des brouillons depuis cette liste'
-    }
-    if (selectedOffers.some((offer) => offer.hasBookingLimitDatetimesPassed)) {
-      return 'Vous ne pouvez pas publier des offres collectives dont la date de réservation est passée'
-    }
-    return ''
-  }
-
   function onSetSelectedOffer(offer: CollectiveOfferResponseModel) {
     const matchingOffer = selectedOffers.find((selectedOffer) =>
       isSameOffer(offer, selectedOffer)
@@ -221,7 +203,6 @@ export const CollectiveOffersScreen = ({
                 clearSelectedOfferIds={clearSelectedOfferIds}
                 selectedOffers={selectedOffers}
                 toggleSelectAllCheckboxes={toggleSelectAllCheckboxes}
-                getUpdateOffersStatusMessage={getUpdateOffersStatusMessage}
               />
             )}
           </div>

--- a/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.tsx
+++ b/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 
 import {
   CollectiveOfferResponseModel,
-  CollectiveOfferStatus,
   GetOffererResponseModel,
   UserRole,
 } from 'apiClient/v1'
@@ -122,23 +121,6 @@ export const TemplateCollectiveOffersScreen = ({
     applyUrlFiltersAndRedirect(updatedFilters)
   }
 
-  const getUpdateOffersStatusMessage = (tmpSelectedOfferIds: number[]) => {
-    const selectedOffers = offers.filter((offer) =>
-      tmpSelectedOfferIds.includes(offer.id)
-    )
-    if (
-      selectedOffers.some(
-        (offer) => offer.status === CollectiveOfferStatus.DRAFT
-      )
-    ) {
-      return 'Vous ne pouvez pas publier des brouillons depuis cette liste'
-    }
-    if (selectedOffers.some((offer) => offer.hasBookingLimitDatetimesPassed)) {
-      return 'Vous ne pouvez pas publier des offres collectives dont la date de réservation est passée'
-    }
-    return ''
-  }
-
   function onSetSelectedOffer(offer: CollectiveOfferResponseModel) {
     const matchingOffer = selectedOffers.find((selectedOffer) =>
       isSameOffer(offer, selectedOffer)
@@ -221,7 +203,6 @@ export const TemplateCollectiveOffersScreen = ({
                 clearSelectedOfferIds={clearSelectedOfferIds}
                 selectedOffers={selectedOffers}
                 toggleSelectAllCheckboxes={toggleSelectAllCheckboxes}
-                getUpdateOffersStatusMessage={getUpdateOffersStatusMessage}
               />
             )}
           </div>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31546

**Objectif**
- N'utiliser que des toaster de notif success dans la liste des offres à la place des "information".
- Aligner tous les fonctionnements de bulk edit collectifs pour que quand on applique une action, les offres sont désélectionnées 
- Aligner tous les fonctionnements de bulk edit collectifs pour que quand on applique une action, les statuts des offres modifiées changent en temps réel
- Corriger un message d'erreur "offres archivée" -> "offres archivées"

Et au passage Agathe a demandé de passer les statuts de notif à succès aussi pour les offres indiv (voir 2e commit)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
