### PR TITLE
(PC-31513)[API] fix: avoid flaky error on offer query

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -239,7 +239,6 @@ def get_offers_details(offer_ids: list[int]) -> BaseQuery:
             )
         )
         .options(sa_orm.joinedload(models.Offer.venue).joinedload(offerers_models.Venue.googlePlacesInfo))
-        .options(sa_orm.joinedload(models.Offer.venue).joinedload(offerers_models.Venue.venueProviders))
         .options(sa_orm.joinedload(models.Offer.mediations))
         .options(sa_orm.joinedload(models.Offer.reactions))
         .options(


### PR DESCRIPTION
This reverts commit 8ea47b13c888090c140bf3f75c2df6b5fdc6c98b.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31513
This fixes a [Sentry issue](https://sentry.passculture.team/organizations/sentry/issues/1617678/events/3af849c194234df1a8fee86ae68e5a89/?environment=production&project=5&query=is:unresolved+NoSuchColumnError&statsPeriod=14d&stream_index=0)