### PR TITLE
(PC-31509)[PRO] feat: Add tracker when archiving one or multiple coll…

### DIFF
--- a/pro/src/components/ArchiveConfirmationModal/ArchiveConfirmationModal.tsx
+++ b/pro/src/components/ArchiveConfirmationModal/ArchiveConfirmationModal.tsx
@@ -1,4 +1,8 @@
+import { useLocation } from 'react-router-dom'
+
+import { useAnalytics } from 'app/App/analytics/firebase'
 import { ConfirmDialog } from 'components/Dialog/ConfirmDialog/ConfirmDialog'
+import { Events } from 'core/FirebaseEvents/constants'
 import strokeThingIcon from 'icons/stroke-thing.svg'
 
 interface OfferEducationalModalProps {
@@ -12,10 +16,20 @@ export const ArchiveConfirmationModal = ({
   onValidate,
   hasMultipleOffers = false,
 }: OfferEducationalModalProps): JSX.Element => {
+  const location = useLocation()
+  const { logEvent } = useAnalytics()
+
+  function onConfirmArchive() {
+    logEvent(Events.CLICKED_ARCHIVE_COLLECTIVE_OFFER, {
+      from: location.pathname,
+    })
+    onValidate()
+  }
+
   return (
     <ConfirmDialog
       onCancel={onDismiss}
-      onConfirm={onValidate}
+      onConfirm={onConfirmArchive}
       cancelText="Annuler"
       confirmText={
         hasMultipleOffers ? 'Archiver les offres ' : 'Archiver l’offre'

--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -41,6 +41,7 @@ export enum Events {
   CLICKED_PAGINATION_NEXT_PAGE = 'hasClickedPaginationNextPage',
   CLICKED_PAGINATION_PREVIOUS_PAGE = 'hasClickedPaginationPreviousPage',
   CLICKED_CONTACT_OUR_TEAMS = 'hasClickedContactOurTeams',
+  CLICKED_ARCHIVE_COLLECTIVE_OFFER = 'hasClickedArchiveCollectiveOffer',
   FIRST_LOGIN = 'firstLogin',
   PAGE_VIEW = 'page_view',
   SIGNUP_FORM_ABORT = 'signupFormAbort',


### PR DESCRIPTION
…ective offers.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31509

**Objectif**
Ajouter un tracker quand on archive une offre collective (depuis les "..." des rows de la table collective, ou depuis le bulk edit. Les 2 utilisent le même dialog de validation).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
