### PR TITLE
(PC-31577)[PRO] fix: Dont translate searched text in offers search in…

### DIFF
--- a/pro/src/utils/__specs__/translate.spec.ts
+++ b/pro/src/utils/__specs__/translate.spec.ts
@@ -1,0 +1,137 @@
+import {
+  CollectiveOfferDisplayedStatus,
+  EacFormat,
+  OfferStatus,
+} from 'apiClient/v1'
+import { Audience } from 'core/shared/types'
+import {
+  translateApiParamsToQueryParams,
+  translateQueryParamsToApiParams,
+} from 'utils/translate'
+
+describe('translate', () => {
+  it('should translate between query params to api params for collective offers', () => {
+    expect(
+      translateQueryParamsToApiParams(
+        {
+          'nom-ou-isbn': 'input de recherche',
+          structure: '883',
+          lieu: '891',
+          format: 'Concert',
+          'periode-evenement-debut': '2024-08-08',
+          'periode-evenement-fin': '2024-08-24',
+          statut: ['en-attente', 'active'],
+        },
+        Audience.COLLECTIVE
+      )
+    ).toEqual(
+      expect.objectContaining({
+        nameOrIsbn: 'input de recherche',
+        offererId: '883',
+        venueId: '891',
+        format: 'Concert',
+        periodBeginningDate: '2024-08-08',
+        periodEndingDate: '2024-08-24',
+        status: ['PENDING', 'ACTIVE'],
+      })
+    )
+
+    expect(
+      translateApiParamsToQueryParams(
+        {
+          nameOrIsbn: 'input de recherche',
+          offererId: '883',
+          venueId: '891',
+          format: EacFormat.CONCERT,
+          periodBeginningDate: '2024-08-08',
+          periodEndingDate: '2024-08-24',
+          status: [
+            CollectiveOfferDisplayedStatus.PENDING,
+            CollectiveOfferDisplayedStatus.ACTIVE,
+          ],
+        },
+        Audience.COLLECTIVE
+      )
+    ).toEqual(
+      expect.objectContaining({
+        'nom-ou-isbn': 'input de recherche',
+        structure: '883',
+        lieu: '891',
+        format: 'Concert',
+        'periode-evenement-debut': '2024-08-08',
+        'periode-evenement-fin': '2024-08-24',
+        statut: ['en-attente', 'active'],
+      })
+    )
+  })
+
+  it('should translate query params to api params for individual offers', () => {
+    expect(
+      translateQueryParamsToApiParams(
+        {
+          'nom-ou-isbn': 'input de recherche',
+          structure: '883',
+          lieu: '891',
+          'periode-evenement-debut': '2024-08-08',
+          'periode-evenement-fin': '2024-08-24',
+          statut: 'draft',
+        },
+        Audience.INDIVIDUAL
+      )
+    ).toEqual(
+      expect.objectContaining({
+        nameOrIsbn: 'input de recherche',
+        offererId: '883',
+        venueId: '891',
+        periodBeginningDate: '2024-08-08',
+        periodEndingDate: '2024-08-24',
+        status: 'DRAFT',
+      })
+    )
+
+    expect(
+      translateApiParamsToQueryParams(
+        {
+          nameOrIsbn: 'input de recherche',
+          offererId: '883',
+          venueId: '891',
+          periodBeginningDate: '2024-08-08',
+          periodEndingDate: '2024-08-24',
+          status: OfferStatus.DRAFT,
+        },
+        Audience.INDIVIDUAL
+      )
+    ).toEqual(
+      expect.objectContaining({
+        'nom-ou-isbn': 'input de recherche',
+        structure: '883',
+        lieu: '891',
+        'periode-evenement-debut': '2024-08-08',
+        'periode-evenement-fin': '2024-08-24',
+        statut: 'draft',
+      })
+    )
+  })
+
+  it('should not translate user inputs for collective offers', () => {
+    expect(
+      translateQueryParamsToApiParams(
+        {
+          'nom-ou-isbn': 'en-attente',
+        },
+        Audience.COLLECTIVE
+      )
+    ).toEqual(expect.objectContaining({ nameOrIsbn: 'en-attente' }))
+  })
+
+  it('should not translate user inputs for individual offers', () => {
+    expect(
+      translateQueryParamsToApiParams(
+        {
+          'nom-ou-isbn': 'remboursements',
+        },
+        Audience.INDIVIDUAL
+      )
+    ).toEqual(expect.objectContaining({ nameOrIsbn: 'remboursements' }))
+  })
+})

--- a/pro/src/utils/translate.ts
+++ b/pro/src/utils/translate.ts
@@ -8,13 +8,17 @@ const translateObjectKeysAndValues = (
   originalObject: Record<string, any>,
   translationsMap: Record<string, string>
 ) => {
+  const nonTranlatedKeys = ['nom-ou-isbn', 'nameOrIsbn'] //  These keys should not have their values translated since it's user inputs
+
   const result: Record<string, string> = {}
   Object.entries(originalObject).forEach(([originalKey, originalValue]) => {
     const translatedKey = translationsMap[originalKey] ?? originalKey
 
-    const translatedValue = Object.keys(translationsMap).includes(originalValue)
-      ? translationsMap[originalValue]
-      : originalValue
+    const translatedValue =
+      Object.keys(translationsMap).includes(originalValue) &&
+      !nonTranlatedKeys.includes(originalKey)
+        ? translationsMap[originalValue]
+        : originalValue
 
     result[translatedKey] = Array.isArray(translatedValue)
       ? translatedValue.map((value) => translationsMap[value])


### PR DESCRIPTION
…put.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31577

**Objectif**
Corriger le fate que les keys et values des paramètres des recherches d'offres collectives et indiv sont traduites pour matcher à l'api. 
Ce qui fait que un mot-clé correspondant à un champ tapé dans la rcherche d'offre est traduit automatiquement. Ex : rechercher une offre collective avec le mot clé "brouillon" fait une recherche sur "DRAFT", ou faire une recherche d'offre indiv sur "remboursements" fait une recherche sur "reimbursments".

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
