### PR TITLE
(PC-31528)[API] feat: use virtual venue on online offer creation

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -315,6 +315,15 @@ class ForbiddenDestinationVenue(MoveOfferBaseException):
         super().__init__("Ce lieu n'est pas éligible au transfert de l'offre")
 
 
+class OffererVirtualVenueNotFound(Exception):
+    def __init__(self) -> None:
+        super().__init__("Votre structure ne possède aucun lieu numérique")
+
+
+class OfferVenueShouldNotBeVirtual(Exception):
+    pass
+
+
 class BookingsHaveOtherPricingPoint(MoveOfferBaseException):
     def __init__(self) -> None:
         super().__init__(


### PR DESCRIPTION
## But de la pull request

règles métier : 
lorsque le FF WIP_SUGGESTED_SUBCATEGORIES est activé
- si on choisi une sous-catégorie numérique, on doit utiliser la venue virtuelle associée à l'offerer 
- si aucune venue numérique n'est associée au lieu -> pas traité car 3 cas en prod
- si on n'a pas de venue physique et qu'on choisi une sous-catégorie numérique -> géré côté front, pas de back à faire


Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31528

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
