### PR TITLE
(BSR)[PRO] fix: Remove missing <DialogTitle> alert on modal display

### DIFF
--- a/pro/src/components/Dialog/Dialog/Dialog.tsx
+++ b/pro/src/components/Dialog/Dialog/Dialog.tsx
@@ -40,11 +40,11 @@ export const Dialog = ({
             className={styles['dialog-icon']}
           />
         )}
-        <RadixDialog.Title asChild>
-          <h1 className={styles['dialog-title']} id={titleId}>
+        <RadixDialog.Title>
+          <div className={styles['dialog-title']} id={titleId}>
             {title}
             <span>{secondTitle}</span>
-          </h1>
+          </div>
         </RadixDialog.Title>
         {explanation && (
           <div className={styles['dialog-explanation']}>{explanation}</div>


### PR DESCRIPTION
## But de la pull request

Afin de corriger l'erreur console survenant avec l'apparition d'une modale `<ConfirmDialog>`
![image](https://github.com/user-attachments/assets/14584fc9-43ef-4277-9741-c613b60de430)

PR ouverte aux discussions (cf. code) car cela implique d'utiliser un `<h2>` au lieu d'un `<h1>`
