### PR TITLE
(PC-31590)[PRO] feat: Fix storybook dialog theme.

### DIFF
--- a/pro/.storybook/preview-body.html
+++ b/pro/.storybook/preview-body.html
@@ -4,3 +4,11 @@
     max-width: 960px;
   }
 </style>
+
+<script>
+  //  Storybook lets you add a div root inside the body, but since Dialog portals are sent to the body
+  //  children, we need to apply the theme on the body tag itself.
+  document.body.onload = function () {
+    document.body.setAttribute('data-theme-storybook', 'blue')
+  }
+</script>

--- a/pro/.storybook/preview.tsx
+++ b/pro/.storybook/preview.tsx
@@ -1,19 +1,4 @@
 import '../src/styles/index.scss'
-import React from 'react'
-
-import { Preview } from '@storybook/react'
-
-const preview: Preview = {
-  decorators: [
-    (Story) => (
-      <div data-theme-storybook="blue">
-        <Story />
-      </div>
-    ),
-  ],
-}
-
-export default preview
 
 export const parameters = {
   backgrounds: {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31590

**Objectif**
Corriger le style des dialogs dans le storybook.

Le pb est que le `preview-body.html` ne laisse pas vraiment modifier les attributs du body, mais ajoute une div dans le body de la preview. Les Portals des dialogs étant envoyés directement sous le body, ils sont siblings de la div root ajoutée. On dirait qu'on est obligés de modifier les attributs du body en JS.

Le avant/après :
<img width="901" alt="Capture d’écran 2024-09-02 à 11 49 30" src="https://github.com/user-attachments/assets/b4acfbc8-44b0-4af5-a426-3f5cc3e917d8">
<img width="927" alt="Capture d’écran 2024-09-02 à 11 49 56" src="https://github.com/user-attachments/assets/bbda5251-6faa-4dab-b469-a098d721b98a">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
