### PR TITLE
(BSR)[PRO] test: search other data in offer list of an offerer

### DIFF
--- a/pro/cypress/e2e/features/searchIndividualOffer.feature
+++ b/pro/cypress/e2e/features/searchIndividualOffer.feature
@@ -39,15 +39,21 @@ Feature: Search individual offers
       |  |  | Offer | Terrain vague |     16 | expirée |
 
   Scenario: A search by offer status should display expected results
+    When I select offerer "Réseau de librairies" in offer page
     And I select "Publiée" in offer status
     And I validate my filters
-    Then These 5 results should be displayed
-      |  |  | Titre | Lieu                           | Stocks | Status  |
-      |  |  | Offer | Terrain vague                  |     20 | publiée |
-      |  |  | Offer | Bar des amis - Offre numérique |     20 | publiée |
-      |  |  | Offer | Terrain vague                  |     40 | publiée |
-      |  |  | Offer | Terrain vague                  |     40 | publiée |
-      |  |  | Offer | Terrain vague                  |     40 | publiée |
+    Then These 28 results should be displayed
+      |  |  | Titre            | Lieu         | Stocks | Status  |
+      |  |  | Livre 4 avec EAN | Librairie 10 |     10 | publiée |
+      |  |  | Livre 3 avec EAN | Librairie 10 |     10 | publiée |
+      |  |  | Livre 2 avec EAN | Librairie 10 |     10 | publiée |
+      |  |  | Livre 1 avec EAN | Librairie 10 |     10 | publiée |
+      |  |  | Livre 4 avec EAN | Librairie 8  |     10 | publiée |
+      |  |  | Livre 3 avec EAN | Librairie 8  |     10 | publiée |
+      |  |  | Livre 2 avec EAN | Librairie 8  |     10 | publiée |
+      |  |  | Livre 1 avec EAN | Librairie 8  |     10 | publiée |
+      |  |  | Livre 4 avec EAN | Librairie 7  |     10 | publiée |
+      |  |  | Livre 3 avec EAN | Librairie 7  |     10 | publiée |
 
   Scenario: A search by date should display expected results
     When I select offerer "Michel Léon" in offer page
@@ -58,31 +64,33 @@ Feature: Search individual offers
       |  |  | Un concert d'electro inoubliable | Michel et son accordéon |  1 000 | publiée |
 
   Scenario: A search combining several filters should display expected results
-    When I search with the text "Offer"
+    When I select offerer "Réseau de librairies" in offer page
+    And I search with the text "Livre"
     And I validate my filters
-    And I select "Films, vidéos" in "Catégories"
-    And I select "Terrain vague" in "Lieu"
+    And I select "Livre" in "Catégories"
+    And I select "Librairie 10" in "Lieu"
     And I select "Publiée" in offer status
     And I validate my filters
-    Then These 3 results should be displayed
-      |  |  | Titre | Lieu          | Stocks | Status  |
-      |  |  | Offer | Terrain vague |     40 | publiée |
-      |  |  | Offer | Terrain vague |     40 | publiée |
-      |  |  | Offer | Terrain vague |     40 | publiée |
+    Then These 4 results should be displayed
+      |  |  | Titre            | Lieu         | Stocks | Status  |
+      |  |  | Livre 4 avec EAN | Librairie 10 |     10 | publiée |
+      |  |  | Livre 3 avec EAN | Librairie 10 |     10 | publiée |
+      |  |  | Livre 2 avec EAN | Librairie 10 |     10 | publiée |
+      |  |  | Livre 1 avec EAN | Librairie 10 |     10 | publiée |
     When I reset all filters
     Then All filters are empty
-    And These 12 results should be displayed
-      |  |  | Titre                          | Lieu                           | Stocks | Status     |
-      |  |  | Mon offre brouillon avec stock | Terrain vague                  |  1 000 | brouillon  |
-      |  |  | Mon offre brouillon            | Terrain vague                  |      0 | brouillon  |
-      |  |  | Offer                          | Terrain vague                  |     16 | expirée    |
-      |  |  | Offer                          | Terrain vague                  |     20 | publiée    |
-      |  |  | Offer                          | Terrain vague                  |      0 | épuisée    |
-      |  |  | Offer                          | Bar des amis - Offre numérique |     20 | publiée    |
-      |  |  | Offer                          | Terrain vague                  |     16 | expirée    |
-      |  |  | Offer                          | Terrain vague                  |     40 | publiée    |
-      |  |  | Offer                          | Terrain vague                  |     40 | publiée    |
-      |  |  | Offer                          | Terrain vague                  |      0 | épuisée    |
+    And These 40 results should be displayed
+      |  |  | Titre            | Lieu         | Stocks | Status     |
+      |  |  | Livre 4 avec EAN | Librairie 10 |     10 | publiée    |
+      |  |  | Livre 3 avec EAN | Librairie 10 |     10 | publiée    |
+      |  |  | Livre 2 avec EAN | Librairie 10 |     10 | publiée    |
+      |  |  | Livre 1 avec EAN | Librairie 10 |     10 | publiée    |
+      |  |  | Livre 4 avec EAN | Librairie 9  |     10 | désactivée |
+      |  |  | Livre 3 avec EAN | Librairie 9  |     10 | désactivée |
+      |  |  | Livre 2 avec EAN | Librairie 9  |     10 | désactivée |
+      |  |  | Livre 1 avec EAN | Librairie 9  |     10 | désactivée |
+      |  |  | Livre 4 avec EAN | Librairie 8  |     10 | publiée    |
+      |  |  | Livre 3 avec EAN | Librairie 8  |     10 | publiée    |
   # comme tout est "Manuel" dans la sandbox, automatiser ce test en l'état n'aurait pas beaucoup de sens
   # Scenario: A search by creation mode should display expected results
   #   When I select "Manuel" in "Mode de création"


### PR DESCRIPTION
## But de la pull request

Ma précédente tentative de tacler le problème de sandbox ayant ou pas une "Offer 1922" n'a pas été concluant puisqu'on a encore eu un échec récemment. Voir sur [Cypress Cloud](https://cloud.cypress.io/projects/rit5sb/runs/675/test-results/c89649d8-7a6e-4ce9-886f-bc978466e252?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%7B%22label%22%3A%22features%2FsearchIndividualOffer.feature%22%2C%22value%22%3A%22%5B%5C%2222ae16bd-6ad2-4feb-b40b-06bf2728559c%5C%22%5D%22%7D%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D)

Cette fois je propose de chercher avec une autre structure, donc une autre liste d'offres en croisant les doigts que ça passe (toujours en attendant la solution ultime de création de données avec factory)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
