### PR TITLE
(PC-31275)[API] feat: drop unique constraint on `stock.idAtProviders`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 869f0d3be788 (pre) (head)
-d8a0801f62e2 (post) (head)
+63fa42fd8352 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240902T142336_63fa42fd8352_drop_unique_constraint_on_stock_idatproviders.py
+++ b/api/src/pcapi/alembic/versions/20240902T142336_63fa42fd8352_drop_unique_constraint_on_stock_idatproviders.py
@@ -1,0 +1,32 @@
+"""
+Drop unique constraint on stock.idAtProviders
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "63fa42fd8352"
+down_revision = "d8a0801f62e2"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE "stock" DROP CONSTRAINT IF EXISTS "stock_idAtProviders_key";
+        """
+    )
+
+
+def downgrade() -> None:
+    # `COMMIT` and isolation of the `CREATE UNIQUE INDEX CONCURRENTLY` command necessary since it cannot run in a transaction block
+    op.execute("COMMIT;")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "stock_idAtProviders_key" ON stock ("idAtProviders");
+        """
+    )
+    op.execute("BEGIN;")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -263,7 +263,6 @@ class Stock(PcObject, Base, Model, SoftDeletableMixin):
             name="check_providable_with_provider_has_idatproviders",
         ),
         nullable=True,
-        unique=True,  # to be replaced by unique constraint on `offerId`/`idAtProviders`
     )
 
     dateModifiedAtLastProvider = sa.Column(sa.DateTime, nullable=True, default=datetime.datetime.utcnow)


### PR DESCRIPTION
`stock.idAtProviders` is now editable through the public API so `idAtProviders` cannot be unique anymore (two providers can have two stocks with the same id). The unique constraint is now on the pair (`idAtProviders`, `offerId`)

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31275

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
