### PR TITLE
(PC-31600)[PRO] feat: filter out integrated providers from venue settings options when the venue is already linked to a integrated provider

### DIFF
--- a/pro/src/pages/VenueSettings/VenueProvidersManager/OffersSynchronization.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/OffersSynchronization.tsx
@@ -39,9 +39,7 @@ export const OffersSynchronization = ({
         <FormLayout.Row>
           <AddVenueProviderButton
             venue={venue}
-            linkedProvidersIds={venueProviders.map(
-              ({ provider }) => provider.id
-            )}
+            linkedProviders={venueProviders.map(({ provider }) => provider)}
           />
         </FormLayout.Row>
       </FormLayout.Section>

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/__specs__/AddVenueProviderButton.spec.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/__specs__/AddVenueProviderButton.spec.tsx
@@ -25,7 +25,7 @@ describe('AddVenueProviderButton', () => {
   beforeEach(() => {
     props = {
       venue: defaultGetVenue,
-      linkedProvidersIds: [],
+      linkedProviders: [],
     }
 
     vi.spyOn(api, 'getProvidersByVenue').mockResolvedValue([
@@ -47,6 +47,12 @@ describe('AddVenueProviderButton', () => {
         hasOffererProvider: true,
         isActive: true,
       },
+      {
+        name: 'Ticket Ultra Mega Buster',
+        id: 15,
+        hasOffererProvider: true,
+        isActive: true,
+      },
     ])
   })
 
@@ -64,7 +70,7 @@ describe('AddVenueProviderButton', () => {
     expect(addVenueProviderButton).toBeInTheDocument()
     await userEvent.click(addVenueProviderButton)
     const options = screen.getAllByRole('option')
-    expect(options.length).toBe(4)
+    expect(options.length).toBe(5)
 
     expect(screen.getByRole('option', { name: 'Allociné' })).toBeInTheDocument()
     expect(
@@ -73,20 +79,63 @@ describe('AddVenueProviderButton', () => {
     expect(
       screen.getByRole('option', { name: 'Ciné Office' })
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'Ticket Ultra Mega Buster' })
+    ).toBeInTheDocument()
   })
 
   it('should hide linked providers', async () => {
     await renderAddVenueProviderButton({
       ...props,
-      linkedProvidersIds: [12, 14],
+      linkedProviders: [
+        {
+          name: 'Ticket Buster',
+          id: 14,
+          hasOffererProvider: true,
+          isActive: true,
+        },
+      ],
     })
 
     const addVenueProviderButton = screen.getByText('Sélectionner un logiciel')
     expect(addVenueProviderButton).toBeInTheDocument()
     await userEvent.click(addVenueProviderButton)
     const options = screen.getAllByRole('option')
-    expect(options.length).toBe(2)
+    expect(options.length).toBe(4)
 
     expect(screen.getByRole('option', { name: 'Allociné' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'Ciné Office' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'Ticket Ultra Mega Buster' })
+    ).toBeInTheDocument()
+  })
+
+  it('should hide other integrated providers if venue is already linked to an integrated provider', async () => {
+    await renderAddVenueProviderButton({
+      ...props,
+      linkedProviders: [
+        {
+          name: 'Allociné',
+          id: 13,
+          hasOffererProvider: false,
+          isActive: true,
+        },
+      ],
+    })
+
+    const addVenueProviderButton = screen.getByText('Sélectionner un logiciel')
+    expect(addVenueProviderButton).toBeInTheDocument()
+    await userEvent.click(addVenueProviderButton)
+    const options = screen.getAllByRole('option')
+    expect(options.length).toBe(3)
+
+    expect(
+      screen.getByRole('option', { name: 'Ticket Buster' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'Ticket Ultra Mega Buster' })
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
To prevent concurrent synchronisations from different providers

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31600

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
