### PR TITLE
(PC-31591)[PRO] fix: <fieldset> a11y improvements + indiv. offer creation "Stock" action buttons html

### DIFF
--- a/pro/src/pages/IndividualOfferWizard/Stocks/__specs__/Stocks.spec.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Stocks/__specs__/Stocks.spec.tsx
@@ -21,6 +21,15 @@ import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { Stocks } from '../Stocks'
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: () => ({
+    matches: false,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }),
+})
+
 const renderStocksScreen = (
   storeOverrides: Partial<RootState> = {},
   contextOverride: Partial<IndividualOfferContextValues>

--- a/pro/src/screens/IndividualOffer/StocksThing/StockThingFormActions/StockThingFormActions.module.scss
+++ b/pro/src/screens/IndividualOffer/StocksThing/StockThingFormActions/StockThingFormActions.module.scss
@@ -1,25 +1,10 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/variables/_size.scss" as size;
 
-.menu-item-icon {
-  width: rem.torem(20px);
-  height: rem.torem(20px);
-  flex-shrink: 0;
-  margin-right: rem.torem(8px);
-
-  path {
-    fill: var(--color-black);
-  }
-}
-
-.dropdown-actions {
-  display: none;
-}
-
 .button-actions {
   display: flex;
-  flex-direction: column;
   gap: rem.torem(16px);
+  flex-direction: column;
   margin-bottom: rem.torem(16px);
 }
 
@@ -28,13 +13,8 @@
 }
 
 @media (min-width: size.$tablet) {
-  .dropdown-actions {
-    align-self: flex-start;
-    display: flex;
-    margin-top: rem.torem(42px); // Vertically align with input field
-  }
-
   .button-actions {
-    display: none;
+    flex-direction: row;
+    margin-top: rem.torem(40px);
   }
 }

--- a/pro/src/screens/IndividualOffer/StocksThing/StockThingFormActions/StockThingFormActions.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/StockThingFormActions/StockThingFormActions.tsx
@@ -1,8 +1,6 @@
+import { useMediaQuery } from 'hooks/useMediaQuery'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import { DropdownItem } from 'ui-kit/DropdownMenuWrapper/DropdownItem'
-import { DropdownMenuWrapper } from 'ui-kit/DropdownMenuWrapper/DropdownMenuWrapper'
-import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './StockThingFormActions.module.scss'
 import { StockFormRowAction } from './types'
@@ -14,44 +12,22 @@ export interface StockThingFormActionsProps {
 export const StockThingFormActions = ({
   actions,
 }: StockThingFormActionsProps): JSX.Element => {
-  return (
-    <>
-      <DropdownMenuWrapper
-        title="Opérations sur le stock"
-        className={styles['dropdown-actions']}
-      >
-        {actions.map((action, i) => (
-          <DropdownItem
-            key={`action-${i}`}
-            disabled={action.disabled}
-            onSelect={action.callback}
-            title={action.label}
-          >
-            {action.icon && (
-              <SvgIcon
-                src={action.icon}
-                alt=""
-                className={styles['menu-item-icon']}
-              />
-            )}
-            <span>{action.label}</span>
-          </DropdownItem>
-        ))}
-      </DropdownMenuWrapper>
+  const isMobileScreen = useMediaQuery('(max-width: 46.5rem)')
 
-      {/* We only display this buttons on small screen */}
-      <div className={styles['button-actions']}>
-        {actions.map((action, i) => (
-          <Button
-            className={styles['button-action']}
-            key={`action-${i}`}
-            variant={ButtonVariant.TERNARY}
-            icon={action.icon}
-          >
-            {action.label}
-          </Button>
-        ))}
-      </div>
-    </>
+  return (
+    <div className={styles['button-actions']}>
+      {actions.map((action, i) => (
+        <Button
+          className={styles['button-action']}
+          key={`action-${i}`}
+          variant={ButtonVariant.TERNARY}
+          icon={action.icon}
+          onClick={action.callback}
+          hasTooltip={!isMobileScreen}
+        >
+          {action.label}
+        </Button>
+      ))}
+    </div>
   )
 }

--- a/pro/src/screens/IndividualOffer/StocksThing/StockThingFormActions/__specs__/StockThingFormActions.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/StockThingFormActions/__specs__/StockThingFormActions.spec.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import { userEvent } from '@testing-library/user-event'
 
 import FullTrashIcon from 'icons/full-trash.svg'
 
@@ -8,6 +7,15 @@ import {
   StockThingFormActionsProps,
 } from '../StockThingFormActions'
 import { StockFormRowAction } from '../types'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: () => ({
+    matches: false,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }),
+})
 
 const renderStockFormActions = (props: StockThingFormActionsProps) => {
   return render(<StockThingFormActions {...props} />)
@@ -26,20 +34,12 @@ describe('StockFormActions', () => {
     ]
   })
 
-  it('render actions button open', () => {
+  it('render actions button', () => {
     renderStockFormActions({
       actions,
     })
 
-    expect(screen.getByTestId('dropdown-menu-trigger')).toBeInTheDocument()
-    expect(screen.getAllByText('Action label')).toHaveLength(1)
-  })
-
-  it('render actions list', async () => {
-    renderStockFormActions({
-      actions,
-    })
-    await userEvent.click(screen.getByTestId('dropdown-menu-trigger'))
-    expect(screen.getAllByText('Action label')).toHaveLength(2)
+    const button = screen.getByRole('button', { name: 'Action label' })
+    expect(button).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
@@ -413,14 +413,12 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                   />
                 </>
               )}
-
               {actions.length > 0 && (
                 <StockThingFormActions actions={actions} />
               )}
             </div>
           </div>
         </FormLayout>
-
         {canBeDuo && (
           <FormLayout fullWidthActions>
             <FormLayout.Section

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -46,6 +46,15 @@ vi.mock('utils/date', async () => {
   }
 })
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: () => ({
+    matches: false,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }),
+})
+
 const renderStockThingScreen = () =>
   renderWithProviders(
     <>
@@ -198,8 +207,10 @@ describe('screens:StocksThing', () => {
     vi.spyOn(api, 'deleteStock').mockResolvedValue({ id: 1 })
     renderStockThingScreen()
     await screen.findByTestId('stock-thing-form')
-    await userEvent.click(screen.getByTestId('dropdown-menu-trigger'))
-    await userEvent.click(await screen.findByTitle('Supprimer le stock'))
+    const button = screen.getByRole('button', {
+      name: 'Supprimer le stock',
+    })
+    await userEvent.click(button)
     expect(
       screen.getByText('Voulez-vous supprimer ce stock ?')
     ).toBeInTheDocument()
@@ -232,9 +243,10 @@ describe('screens:StocksThing', () => {
     renderStockThingScreen()
     await screen.findByTestId('stock-thing-form')
 
-    await userEvent.click(screen.getAllByTestId('dropdown-menu-trigger')[1])
-    await userEvent.click(screen.getAllByTestId('dropdown-menu-trigger')[0])
-    await userEvent.click(await screen.findByTitle('Supprimer le stock'))
+    const button = screen.getByRole('button', {
+      name: 'Supprimer le stock',
+    })
+    await userEvent.click(button)
     expect(
       screen.getByText('Voulez-vous supprimer ce stock ?')
     ).toBeInTheDocument()
@@ -260,8 +272,10 @@ describe('screens:StocksThing', () => {
     renderStockThingScreen()
     await screen.findByTestId('stock-thing-form')
 
-    await userEvent.click(screen.getByTestId('dropdown-menu-trigger'))
-    await userEvent.click(await screen.findByTitle('Supprimer le stock'))
+    const button = screen.getByRole('button', {
+      name: 'Supprimer le stock',
+    })
+    await userEvent.click(button)
     await userEvent.click(
       await screen.findByText('Supprimer', { selector: 'button' })
     )
@@ -297,8 +311,10 @@ describe('screens:StocksThing', () => {
     })
     renderStockThingScreen()
     await screen.findByTestId('stock-thing-form')
-    await userEvent.click(screen.getByTestId('dropdown-menu-trigger'))
-    await userEvent.click(await screen.findByTitle('Supprimer le stock'))
+    const button = screen.getByRole('button', {
+      name: 'Supprimer le stock',
+    })
+    await userEvent.click(button)
     expect(
       screen.queryByText('Voulez-vous supprimer ce stock ?')
     ).not.toBeInTheDocument()

--- a/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
@@ -47,6 +47,15 @@ vi.mock('utils/date', async () => {
   }
 })
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: () => ({
+    matches: false,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }),
+})
+
 const renderStockThingScreen = async (
   stocks: GetOfferStockResponseModel[],
   props: StocksThingProps,
@@ -319,9 +328,10 @@ describe('screens:StocksThing', () => {
       }
       await renderStockThingScreen([], props, contextValue)
 
-      await userEvent.click(screen.getByTestId('dropdown-menu-trigger'))
-
-      await userEvent.click(screen.getByTitle("Ajouter des codes d'activation"))
+      const button = screen.getByRole('button', {
+        name: "Ajouter des codes d'activation",
+      })
+      await userEvent.click(button)
 
       const uploadButton = screen.getByText(
         'Importer un fichier .csv depuis l’ordinateur'
@@ -385,8 +395,10 @@ describe('screens:StocksThing', () => {
       }
       await renderStockThingScreen([], props, contextValue)
 
-      await userEvent.click(screen.getByTestId('dropdown-menu-trigger'))
-      await userEvent.click(screen.getByTitle("Ajouter des codes d'activation"))
+      const button = screen.getByRole('button', {
+        name: "Ajouter des codes d'activation",
+      })
+      await userEvent.click(button)
 
       const uploadButton = await screen.findByText(
         'Importer un fichier .csv depuis l’ordinateur'

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormAccessibility/FormAccessibility.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormAccessibility/FormAccessibility.tsx
@@ -7,12 +7,10 @@ import { useAccessibilityOptions } from 'hooks/useAccessibilityOptions'
 import { CheckboxGroup } from 'ui-kit/form/CheckboxGroup/CheckboxGroup'
 
 interface FormAccessibilityProps {
-  legend?: string
   disableForm: boolean
 }
 
 export const FormAccessibility = ({
-  legend = 'Cette offre est accessible au public en situation de handicap :',
   disableForm,
 }: FormAccessibilityProps): JSX.Element => {
   const { setFieldValue } = useFormikContext<OfferEducationalFormValues>()
@@ -23,7 +21,7 @@ export const FormAccessibility = ({
         <CheckboxGroup
           group={useAccessibilityOptions(setFieldValue)}
           groupName="accessibility"
-          legend={legend}
+          legend="Cette offre est accessible au public en situation de handicap :"
           disabled={disableForm}
         />
       </FormLayout.Row>

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplate.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplate.tsx
@@ -19,19 +19,17 @@ export const FormContactTemplate = ({
   disableForm,
 }: FormContactTemplateProps): JSX.Element => {
   const { values } = useFormikContext<OfferEducationalFormValues>()
-
   const [, contactOptionsMeta] = useField({ name: 'contactOptions' })
+  const hasError =
+    contactOptionsMeta.touched && Boolean(contactOptionsMeta.error)
+  const ariaDescribedBy = 'error-contactOptions'
 
   return (
     <FormLayout.Section title="Contact">
       <FieldSetLayout
         legend="Choisissez le ou les moyens par lesquels vous souhaitez être contacté par les enseignants au sujet de cette offre :"
         name="contactOptions"
-        error={
-          contactOptionsMeta.touched && Boolean(contactOptionsMeta.error)
-            ? contactOptionsMeta.error
-            : undefined
-        }
+        {...(hasError ? { error: contactOptionsMeta.error } : {})}
       >
         <div className={styles['contact-checkbox']}>
           <Checkbox
@@ -41,6 +39,7 @@ export const FormContactTemplate = ({
             hideFooter
             disabled={disableForm}
             aria-expanded={Boolean(values.contactOptions?.email)}
+            {...(hasError ? { ariaDescribedBy } : {})}
           />
           {values.contactOptions?.email && (
             <div className={styles['contact-checkbox-inner-control']}>
@@ -68,6 +67,7 @@ export const FormContactTemplate = ({
             hideFooter
             disabled={disableForm}
             aria-expanded={Boolean(values.contactOptions?.phone)}
+            {...(hasError ? { ariaDescribedBy } : {})}
           />
           {values.contactOptions?.phone && (
             <div className={styles['contact-checkbox-inner-control']}>
@@ -93,6 +93,7 @@ export const FormContactTemplate = ({
             hideFooter
             disabled={disableForm}
             aria-expanded={Boolean(values.contactOptions?.form)}
+            {...(hasError ? { ariaDescribedBy } : {})}
           />
           {values.contactOptions?.form && (
             <div className={styles['contact-checkbox-inner-control']}>

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
@@ -16,7 +16,6 @@ export const FormContactTemplateCustomForm = ({
   return (
     <FieldSetLayout
       name="contactForm"
-      legend="Test"
       className={styles['custom-form']}
       hideFooter
     >

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
@@ -16,6 +16,7 @@ export const FormContactTemplateCustomForm = ({
   return (
     <FieldSetLayout
       name="contactForm"
+      legend="Test"
       className={styles['custom-form']}
       hideFooter
     >

--- a/pro/src/ui-kit/form/Checkbox/Checkbox.tsx
+++ b/pro/src/ui-kit/form/Checkbox/Checkbox.tsx
@@ -19,6 +19,7 @@ interface CheckboxProps {
   disabled?: boolean
   withBorder?: boolean
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  ariaDescribedBy?: string
 }
 
 export const Checkbox = ({
@@ -30,6 +31,7 @@ export const Checkbox = ({
   hideFooter,
   disabled,
   withBorder,
+  ariaDescribedBy,
   ...props
 }: CheckboxProps): JSX.Element => {
   const [field, meta] = useField({ name, type: 'checkbox' })
@@ -43,6 +45,7 @@ export const Checkbox = ({
         value={value}
         disabled={disabled}
         withBorder={withBorder}
+        ariaDescribedBy={ariaDescribedBy}
         {...props}
       />
       {!hideFooter && (

--- a/pro/src/ui-kit/form/CheckboxGroup/CheckboxGroup.tsx
+++ b/pro/src/ui-kit/form/CheckboxGroup/CheckboxGroup.tsx
@@ -31,11 +31,12 @@ export const CheckboxGroup = ({
   isOptional,
 }: CheckboxGroupProps): JSX.Element => {
   const [, meta, helpers] = useField({ name: groupName })
+  const hasError = meta.touched && !!meta.error
 
   return (
     <FieldSetLayout
       className={cn(styles['checkbox-group'], className)}
-      error={meta.touched && !!meta.error ? meta.error : undefined}
+      error={hasError ? meta.error : undefined}
       legend={legend}
       name={groupName}
       isOptional={isOptional}
@@ -44,7 +45,7 @@ export const CheckboxGroup = ({
         <div className={styles['checkbox-group-item']} key={item.name}>
           <CheckboxGroupItem
             icon={item.icon}
-            hasError={meta.touched && !!meta.error}
+            hasError={hasError}
             label={item.label}
             name={item.name}
             setGroupTouched={() =>
@@ -52,6 +53,7 @@ export const CheckboxGroup = ({
             }
             disabled={disabled}
             onChange={item.onChange}
+            {...(hasError ? { ariaDescribedBy: `error-${groupName}` } : {})}
           />
         </div>
       ))}

--- a/pro/src/ui-kit/form/CheckboxGroup/CheckboxGroupItem.tsx
+++ b/pro/src/ui-kit/form/CheckboxGroup/CheckboxGroupItem.tsx
@@ -12,6 +12,7 @@ interface CheckboxGroupItemProps {
   hasError?: boolean
   disabled?: boolean
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  ariaDescribedBy?: string
 }
 
 export const CheckboxGroupItem = ({
@@ -22,6 +23,7 @@ export const CheckboxGroupItem = ({
   icon,
   disabled,
   onChange,
+  ariaDescribedBy,
 }: CheckboxGroupItemProps): JSX.Element => {
   const [field] = useField({ name, type: 'checkbox' })
 
@@ -41,6 +43,7 @@ export const CheckboxGroupItem = ({
       label={label}
       onChange={onCustomChange}
       disabled={disabled}
+      ariaDescribedBy={ariaDescribedBy}
     />
   )
 }

--- a/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
+++ b/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
@@ -12,6 +12,7 @@ interface RadioButtonProps
   withBorder?: boolean
   hasError?: boolean
   fullWidth?: boolean
+  ariaDescribedBy?: string
 }
 
 export const RadioButton = ({
@@ -24,6 +25,7 @@ export const RadioButton = ({
   className,
   hasError,
   onChange,
+  ariaDescribedBy,
 }: RadioButtonProps): JSX.Element => {
   const [field] = useField({ name, value, type: 'radio' })
 
@@ -50,6 +52,7 @@ export const RadioButton = ({
       withBorder={withBorder}
       fullWidth={fullWidth}
       onChange={(e) => onCustomChange(e)}
+      ariaDescribedBy={ariaDescribedBy}
     />
   )
 }

--- a/pro/src/ui-kit/form/RadioGroup/RadioGroup.tsx
+++ b/pro/src/ui-kit/form/RadioGroup/RadioGroup.tsx
@@ -37,6 +37,7 @@ export const RadioGroup = ({
   onChange,
 }: RadioGroupProps): JSX.Element => {
   const [, meta] = useField({ name })
+  const hasError = meta.touched && !!meta.error
 
   return (
     <FieldSetLayout
@@ -46,7 +47,7 @@ export const RadioGroup = ({
         className
       )}
       dataTestId={`wrapper-${name}`}
-      error={meta.touched && !!meta.error ? meta.error : undefined}
+      error={hasError ? meta.error : undefined}
       hideFooter={hideFooter}
       legend={legend}
       name={`radio-group-${name}`}
@@ -60,9 +61,10 @@ export const RadioGroup = ({
             name={name}
             value={item.value}
             withBorder={withBorder}
-            hasError={meta.touched && !!meta.error}
+            hasError={hasError}
             fullWidth
             onChange={onChange}
+            {...(hasError ? { ariaDescribedBy: `error-${name}` } : {})}
           />
         </div>
       ))}

--- a/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.tsx
+++ b/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.tsx
@@ -22,6 +22,7 @@ interface BaseCheckboxProps
   partialCheck?: boolean
   exceptionnallyHideLabelDespiteA11y?: boolean
   description?: string
+  ariaDescribedBy?: string
 }
 
 export const BaseCheckbox = ({
@@ -33,6 +34,7 @@ export const BaseCheckbox = ({
   partialCheck,
   exceptionnallyHideLabelDespiteA11y,
   description,
+  ariaDescribedBy,
   ...props
 }: BaseCheckboxProps): JSX.Element => {
   const checkboxRef = useRef<HTMLInputElement>(null)
@@ -66,6 +68,7 @@ export const BaseCheckbox = ({
         <input
           ref={checkboxRef}
           aria-invalid={hasError}
+          {...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {})}
           type="checkbox"
           {...props}
           className={styles['base-checkbox-input']}

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
@@ -10,6 +10,7 @@ interface BaseRadioProps
   className?: string
   withBorder?: boolean
   fullWidth?: boolean
+  ariaDescribedBy?: string
 }
 
 export const BaseRadio = ({
@@ -18,6 +19,7 @@ export const BaseRadio = ({
   className,
   withBorder = false,
   fullWidth = false,
+  ariaDescribedBy,
   ...props
 }: BaseRadioProps): JSX.Element => {
   const id = useId()
@@ -42,6 +44,7 @@ export const BaseRadio = ({
         className={cn(styles[`base-radio-input`], {
           [styles['has-error']]: hasError,
         })}
+        {...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {})}
         aria-invalid={hasError}
         id={id}
       />

--- a/pro/src/ui-kit/form/shared/FieldSetLayout/FieldSetLayout.tsx
+++ b/pro/src/ui-kit/form/shared/FieldSetLayout/FieldSetLayout.tsx
@@ -31,14 +31,9 @@ export const FieldSetLayout = ({
       className={cn(styles['fieldset-layout'], className)}
       data-testid={dataTestId}
       aria-required={!isOptional}
-      role="group"
-      aria-labelledby="checkboxes-error-legend"
     >
       {legend && (
-        <legend
-          className={styles['fieldset-layout-legend']}
-          id="checkboxes-error-legend"
-        >
+        <legend className={styles['fieldset-layout-legend']}>
           {legend}
           {!isOptional && ' *'}
         </legend>

--- a/pro/src/ui-kit/form/shared/FieldSetLayout/FieldSetLayout.tsx
+++ b/pro/src/ui-kit/form/shared/FieldSetLayout/FieldSetLayout.tsx
@@ -43,14 +43,10 @@ export const FieldSetLayout = ({
           {!isOptional && ' *'}
         </legend>
       )}
-
-      <div> {children} </div>
-
+      <div>{children}</div>
       {!hideFooter && (
-        <div aria-live="assertive">
-          <div className={styles['fieldset-layout-error']}>
-            {!!error && <FieldError name={name}>{error}</FieldError>}
-          </div>
+        <div className={styles['fieldset-layout-error']}>
+          {!!error && <FieldError name={name}>{error}</FieldError>}
         </div>
       )}
     </fieldset>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31591

## Descriptif des modifications
- Modification du composant `FieldSetLayout` de façon à faire sauter la déclaration `aria-live="assertive"` qui n’est pas très efficace pour relayer l’erreur au niveau des inputs entourés par le <fieldset>.
    - Avec le aria-live en assertive, l’erreur est annoncée 1 seule fois quand elle apparaît dans le DOM.
    - Il n’y a pas d’association avec les champs marqués en erreur.
    - Si l’erreur est levée une fois et que l’user se balade dans le formulaire avant de retourner sur les checkbox, alors l’erreur n’est pas rappelée.
    - Cette modification permet de corriger ces points en exploitant le `aria-describedby`.
- Doublon d’ids sur les <fieldset>. Voir FieldSetLayout, id / aria-labelledby inutile en présence de la balise <legend> (https://www.w3.org/WAI/tutorials/forms/grouping/#radio-buttons).
- L’élément <fieldset> possède un attribut aria-required non autorisé : https://dequeuniversity.com/rules/axe/4.10/aria-allowed-attr?application=AxeChrome

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
