### PR TITLE
(PC-31604)[BO] fix: when user is already anonymized button to anonymize should not appear

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -406,9 +406,11 @@ def render_public_account_details(
         if not user.isEmailValidated:
             kwargs["resend_email_validation_form"] = empty_forms.EmptyForm()
 
-    if utils.has_current_user_permission(
-        perm_models.Permissions.ANONYMIZE_PUBLIC_ACCOUNT
-    ) and not _has_user_pending_anonymization(user_id):
+    if (
+        utils.has_current_user_permission(perm_models.Permissions.ANONYMIZE_PUBLIC_ACCOUNT)
+        and not _has_user_pending_anonymization(user_id)
+        and users_models.UserRole.ANONYMIZED not in user.roles
+    ):
         kwargs["anonymize_form"] = empty_forms.EmptyForm()
         kwargs["anonymize_public_accounts_dst"] = url_for(".anonymize_public_account", user_id=user.id)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31604

### verification front 

A présent lorsque l'on a deja anonymisé un utilisateur de plus de 21 ans, le bouton anonymisé aura disparu pour des raisons évidente de clarté: 
<img width="1003" alt="Capture d’écran 2024-09-02 à 18 06 10" src="https://github.com/user-attachments/assets/deeb6830-d525-4f9b-9fd1-24c1185d0a1b">


### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 

c'est du front aucun test ( voir image) 

### Verification ticket

- nom du ticket conforme -> OK
- auteur du ticket -> Ok
- nombre de commit -> Ok 
- nom du commit -> OK
- mettre le ticket en code-review -> OK

### Tache restante si WIP + AUTRE

- refresh de la page github ->  OK
- Rien de visible

<img width="1125" alt="Capture d’écran 2024-09-03 à 10 09 53" src="https://github.com/user-attachments/assets/9edc30d8-0ad4-418d-8d4d-e9af772bb10c">


