### PR TITLE
(PC-31614)[PRO] feat: Remove Titles use to fix ci.

### DIFF
--- a/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.module.scss
+++ b/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.module.scss
@@ -14,3 +14,9 @@
     }
   }
 }
+
+.title {
+  @include fonts.title1;
+
+  margin-bottom: rem.torem(32px);
+}

--- a/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.tsx
+++ b/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.tsx
@@ -21,7 +21,6 @@ import { SelectOption } from 'custom_types/form'
 import { CollectiveOffersActionsBar } from 'pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar'
 import { CollectiveOffersTable } from 'pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTable'
 import { isSameOffer } from 'pages/Offers/utils/isSameOffer'
-import { Titles } from 'ui-kit/Titles/Titles'
 
 import styles from './TemplateCollectiveOffersScreen.module.scss'
 import { TemplateOffersSearchFilters } from './TemplateOffersSearchFilters/TemplateOffersSearchFilters'
@@ -158,7 +157,7 @@ export const TemplateCollectiveOffersScreen = ({
 
   return (
     <div>
-      <Titles title="Offres vitrines" />
+      <h1 className={styles['title']}>Offres vitrines</h1>
       <TemplateOffersSearchFilters
         applyFilters={applyFilters}
         categories={categories}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31614

**Objectif**
Corriger la ci. La suppression du composant `Titles` était basé sur le master d'avant l'ajout de la page des offres vitrines qui contient un `<Titles>` et j'ai pas relancé la ci de la PR avant de merge 😢 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
