### PR TITLE
(PC-31395)[API] feat: add `idAtProvider` in `PriceCategory`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-869f0d3be788 (pre) (head)
-63fa42fd8352 (post) (head)
+8523f3e2d7d6 (pre) (head)
+404b3075d1a4 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240903T113527_8523f3e2d7d6_add_idatprovider_in_price_category.py
+++ b/api/src/pcapi/alembic/versions/20240903T113527_8523f3e2d7d6_add_idatprovider_in_price_category.py
@@ -1,0 +1,21 @@
+"""Add idAtProvider in `price_category`
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "8523f3e2d7d6"
+down_revision = "869f0d3be788"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("price_category", sa.Column("idAtProvider", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("price_category", "idAtProvider")

--- a/api/src/pcapi/alembic/versions/20240903T114208_404b3075d1a4_add_unique_index_on_price_category_idatprovider.py
+++ b/api/src/pcapi/alembic/versions/20240903T114208_404b3075d1a4_add_unique_index_on_price_category_idatprovider.py
@@ -1,0 +1,34 @@
+"""Add unique index on (`idAProvider`, `offerId`) in `price_category` table
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "404b3075d1a4"
+down_revision = "63fa42fd8352"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "unique_ix_offer_id_id_at_provider",
+            "price_category",
+            ["offerId", "idAtProvider"],
+            unique=True,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "unique_ix_offer_id_id_at_provider",
+            table_name="price_category",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -1243,6 +1243,11 @@ class PriceCategory(PcObject, Base, Model):
         "PriceCategoryLabel", back_populates="priceCategory"
     )
     stocks: sa_orm.Mapped[list["Stock"]] = relationship("Stock", back_populates="priceCategory", cascade="all")
+    idAtProvider = sa.Column(sa.Text, nullable=True)
+
+    # First step : Create a unique index on offerId/idAtProvider
+    # Next step : (TO DO) Create a unique constraint based on this index
+    sa.Index("unique_ix_offer_id_id_at_provider", offerId, idAtProvider, unique=True)
 
     @property
     def label(self) -> str:


### PR DESCRIPTION
Add unique index on `PriceCategory` values couple (`idAtProvider`, `offerId`). This index will be transformed into a unique constraint in a later migration

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31395

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
