### PR TITLE
(BSR)[PRO] test: only intercept one create offer

### DIFF
--- a/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
@@ -92,9 +92,12 @@ When('I fill activity form without target audience', () => {
 })
 
 When('I validate the registration', () => {
-  cy.intercept({ method: 'POST', url: '/offerers/new' }).as('createOfferer')
   cy.wait(2000) // @todo: delete this when random failures fixed
+  cy.intercept({ method: 'POST', url: '/offerers/new', times: 1 }).as(
+    'createOfferer'
+  )
   cy.findByText('Valider et créer ma structure').click()
+  cy.wait('@createOfferer').its('response.statusCode').should('eq', 201)
 })
 
 When('I add a new offerer', () => {
@@ -164,9 +167,6 @@ Then('the attachment is in progress', () => {
 })
 
 Then('the offerer is created', () => {
-  cy.wait('@createOfferer', { timeout: 60000 })
-    .its('response.statusCode')
-    .should('eq', 201)
   cy.findAllByTestId('global-notification-success').should(
     'contain',
     'Votre structure a bien été créée'


### PR DESCRIPTION
## But de la pull request

Il arrive parfois qu'un test `signupJourney` échoue (6% d'échecs). Ici par exemple: https://cloud.cypress.io/projects/rit5sb/runs/646/test-results/7b41924c-5204-473b-a998-f6933c8b9fd7/replay

![CleanShot 2024-09-03 at 15 37 32@2x](https://github.com/user-attachments/assets/40fde8e0-7433-471f-b827-4b860ea5f742)

Après discussion/analyse avec les devs Back, on a un comportement inexpliqué qui fait qu'on peut avoir la même requête interceptée 2 fois par Cypress, alors qu'elle semble bien être envoyée qu'une seule fois!

Cette PR est là pour proposer une petite modification sans être assuré que ça résolve le problème. Au pire ça ne change rien, au mieux ça corrige! Donc tentons:

- ajout de `times: 1` pour n'intercepter qu'une seule requête
- `wait` juste après le `click()`et plus dans un autre bloc cucumber. Qui sait l'état de fraicheur du 🥒  ?

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
