### PR TITLE
(PC-31554)[API]docs: updated API documentation. externalTicketOfficeUrl field of offer model is now deprecated

### DIFF
--- a/api/documentation/src/pages/change-logs.md
+++ b/api/documentation/src/pages/change-logs.md
@@ -5,6 +5,10 @@ title: Pass Culture API change logs
 # Change logs
 
 :::warning
+  Offer field `externalTicketOfficeUrl` is now deprecated and is going to be removed in the coming months.
+:::
+
+:::warning
 💡 Important notice some old resources are going to be removed in the coming months.
 
 - If you were using `/v2/venue/<venue_id>/stocks` to manage stocks, you will have to migrate to this endpoint : [/public/offers/v1/products/ean](/rest-api#tag/Product-offer-bulk-operations/operation/PostProductOfferByEan). The endpoint `/v2/stock` will not be available anymore starting from September, the 31st 2024.

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -150,6 +150,10 @@ class _FIELDS:
         example=True,
         default=True,
     )
+    EXTERNAL_TICKET_OFFICE_URL_FIELD = Field(
+        description="**(deprecated)** Link displayed to users wishing to book the offer but who do not have credit.",
+        example="https://example.com",
+    )
 
     # Products fields
     EANS_FILTER = Field(description="EANs list (max 100)", example="3700551782888,9782895761792")

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -144,11 +144,6 @@ CATEGORY_RELATED_FIELD_DESCRIPTION = (
     "Cultural category the offer belongs to. According to the category, some fields may or must be specified."
 )
 CATEGORY_RELATED_FIELD = pydantic_v1.Field(..., description=CATEGORY_RELATED_FIELD_DESCRIPTION)
-EXTERNAL_TICKET_OFFICE_URL_FIELD = pydantic_v1.Field(
-    None,
-    description="Link displayed to users wishing to book the offer but who do not have credit.",
-    example="https://example.com",
-)
 WITHDRAWAL_DETAILS_FIELD = pydantic_v1.Field(
     None,
     description="Further information that will be provided to attendees to ease the offer collection.",
@@ -182,7 +177,7 @@ class OfferCreationBase(serialization.ConfiguredBaseModel):
     booking_email: pydantic_v1.EmailStr | None = fields.OFFER_BOOKING_EMAIL
     category_related_fields: CategoryRelatedFields = CATEGORY_RELATED_FIELD
     description: str | None = fields.OFFER_DESCRIPTION_WITH_MAX_LENGTH
-    external_ticket_office_url: pydantic_v1.HttpUrl | None = EXTERNAL_TICKET_OFFICE_URL_FIELD
+    external_ticket_office_url: pydantic_v1.HttpUrl | None = fields.EXTERNAL_TICKET_OFFICE_URL_FIELD
     image: ImageBody | None
     enable_double_bookings: bool | None = fields.OFFER_ENABLE_DOUBLE_BOOKINGS_WITH_DEFAULT
     name: str = fields.OFFER_NAME_WITH_MAX_LENGTH
@@ -663,7 +658,7 @@ class OfferResponse(serialization.ConfiguredBaseModel):
     booking_contact: str | None = fields.OFFER_BOOKING_CONTACT
     booking_email: str | None = fields.OFFER_BOOKING_EMAIL
     description: str | None = fields.OFFER_DESCRIPTION
-    external_ticket_office_url: str | None = EXTERNAL_TICKET_OFFICE_URL_FIELD
+    external_ticket_office_url: str | None = fields.EXTERNAL_TICKET_OFFICE_URL_FIELD
     image: ImageResponse | None
     enable_double_bookings: bool | None = fields.OFFER_ENABLE_DOUBLE_BOOKINGS_WITH_DEFAULT
     location: PhysicalLocation | DigitalLocation = LOCATION_FIELD

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -2537,7 +2537,7 @@
                         "type": "integer"
                     },
                     "externalTicketOfficeUrl": {
-                        "description": "Link displayed to users wishing to book the offer but who do not have credit.",
+                        "description": "**(deprecated)** Link displayed to users wishing to book the offer but who do not have credit.",
                         "example": "https://example.com",
                         "format": "uri",
                         "maxLength": 2083,
@@ -2966,7 +2966,7 @@
                         "type": "integer"
                     },
                     "externalTicketOfficeUrl": {
-                        "description": "Link displayed to users wishing to book the offer but who do not have credit.",
+                        "description": "**(deprecated)** Link displayed to users wishing to book the offer but who do not have credit.",
                         "example": "https://example.com",
                         "nullable": true,
                         "title": "Externalticketofficeurl",
@@ -6308,7 +6308,7 @@
                         "type": "boolean"
                     },
                     "externalTicketOfficeUrl": {
-                        "description": "Link displayed to users wishing to book the offer but who do not have credit.",
+                        "description": "**(deprecated)** Link displayed to users wishing to book the offer but who do not have credit.",
                         "example": "https://example.com",
                         "format": "uri",
                         "maxLength": 2083,
@@ -6804,7 +6804,7 @@
                         "type": "boolean"
                     },
                     "externalTicketOfficeUrl": {
-                        "description": "Link displayed to users wishing to book the offer but who do not have credit.",
+                        "description": "**(deprecated)** Link displayed to users wishing to book the offer but who do not have credit.",
                         "example": "https://example.com",
                         "nullable": true,
                         "title": "Externalticketofficeurl",


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31554

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

![image](https://github.com/user-attachments/assets/9e409419-9ce7-4501-97e7-a16450e297c1)
