### PR TITLE
(PC-31390)[API] feat: public api: adage mock: cancel booking

### DIFF
--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -402,6 +402,7 @@ def cancel_collective_booking(
     _from: str | None = None,
     author_id: int | None = None,
 ) -> None:
+    collective_booking_id = collective_booking.id
     with transaction():
         educational_repository.get_and_lock_collective_stock(stock_id=collective_booking.collectiveStock.id)
         db.session.refresh(collective_booking)
@@ -420,7 +421,7 @@ def cancel_collective_booking(
         reason.value.lower(),
         f"from {_from}" if _from else "",
         extra={
-            "collective_booking": collective_booking.id,
+            "collective_booking": collective_booking_id,
             "reason": str(educational_models.CollectiveBookingCancellationReasons.OFFERER),
         },
     )

--- a/api/tests/routes/public/collective/endpoints/simulate_adage_steps/test_bookings.py
+++ b/api/tests/routes/public/collective/endpoints/simulate_adage_steps/test_bookings.py
@@ -1,82 +1,109 @@
-import contextlib
 import datetime
+from unittest.mock import patch
 
 import pytest
 
 from pcapi.core.educational import factories
 from pcapi.core.educational import models
+import pcapi.core.offerers.models as offerers_models
+import pcapi.core.providers.factories as providers_factories
+from pcapi.core.testing import assert_num_queries
 from pcapi.core.testing import override_features
-from pcapi.models import db
 from pcapi.routes.adage.v1.serialization import constants
 
 from tests.routes.public.helpers import PublicAPIRestrictedEnvEndpointHelper
+from tests.routes.public.helpers import assert_attribute_does_not_change
+from tests.routes.public.helpers import assert_attribute_value_changes_to
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-@pytest.fixture(name="current_year")
-def current_year_fixture():
+def _get_offerer(provider):
+    offerer = offerers_models.OffererProvider.query.filter_by(provider=provider).first().offerer
+
+    if not offerer:
+        offerer = providers_factories.OffererProviderFactory(
+            provider=provider,
+        ).offerer
+
+    return offerer
+
+
+def _build_current_year():
     return factories.EducationalYearFactory(
         beginningDate=datetime.datetime(factories._get_current_educational_year(), 9, 1),
         expirationDate=datetime.datetime(factories._get_current_educational_year() + 1, 8, 31, 23, 59),
     )
 
 
-@pytest.fixture(name="institution")
-def institution_fixture(current_year):
-    return factories.EducationalDepositFactory(educationalYear=current_year).educationalInstitution
+def _build_booking(factory, provider, venue=None, year=None, institution=None):
+    if not year:
+        year = _build_current_year()
 
+    if not institution:
+        institution = factories.EducationalDepositFactory(educationalYear=year).educationalInstitution
 
-@pytest.fixture(name="pending_booking")
-def pending_booking_fixture(current_year, institution):
-    return factories.PendingCollectiveBookingFactory(educationalYear=current_year, educationalInstitution=institution)
+    if not venue:
+        offerer = _get_offerer(provider)
+        venue = providers_factories.VenueProviderFactory(venue__managingOfferer=offerer, provider=provider).venue
 
-
-@pytest.fixture(name="confirmed_booking")
-def confirmed_booking_fixture(current_year, institution):
-    return factories.ConfirmedCollectiveBookingFactory(educationalYear=current_year, educationalInstitution=institution)
-
-
-@pytest.fixture(name="used_booking")
-def used_booking_fixture(current_year, institution):
-    return factories.UsedCollectiveBookingFactory(
-        educationalYear=current_year,
+    return factory(
+        educationalYear=year,
         educationalInstitution=institution,
+        collectiveStock__collectiveOffer__provider=provider,
+        collectiveStock__collectiveOffer__venue=venue,
     )
 
 
-@pytest.fixture(name="reimbursed_booking")
-def reimbursed_booking_fixture(current_year, institution):
-    return factories.ReimbursedCollectiveBookingFactory(
-        educationalYear=current_year, educationalInstitution=institution
+def build_pending_booking(provider, venue=None, institution=None, year=None):
+    return _build_booking(
+        factory=factories.PendingCollectiveBookingFactory,
+        provider=provider,
+        venue=venue,
+        institution=institution,
+        year=year,
     )
 
 
-@pytest.fixture(name="cancelled_booking")
-def cancelled_booking_fixture(current_year, institution):
-    return factories.CancelledCollectiveBookingFactory(educationalYear=current_year, educationalInstitution=institution)
+def build_confirmed_booking(provider, venue=None, institution=None, year=None):
+    return _build_booking(
+        factory=factories.ConfirmedCollectiveBookingFactory,
+        provider=provider,
+        venue=venue,
+        institution=institution,
+        year=year,
+    )
 
 
-@contextlib.contextmanager
-def assert_status_changes_to(booking, expected_status):
-    previous_status = booking.status
+def build_used_booking(provider, venue=None, institution=None, year=None):
+    return _build_booking(
+        factory=factories.UsedCollectiveBookingFactory,
+        provider=provider,
+        venue=venue,
+        institution=institution,
+        year=year,
+    )
 
-    yield
 
-    db.session.refresh(booking)
-    assert booking.status != previous_status
-    assert booking.status == expected_status
+def build_reimbursed_booking(provider, venue=None, institution=None, year=None):
+    return _build_booking(
+        factory=factories.ReimbursedCollectiveBookingFactory,
+        provider=provider,
+        venue=venue,
+        institution=institution,
+        year=year,
+    )
 
 
-@contextlib.contextmanager
-def assert_status_does_not_change(booking):
-    previous_status = booking.status
-
-    yield
-
-    db.session.refresh(booking)
-    assert booking.status == previous_status
+def build_cancelled_booking(provider, venue=None, institution=None, year=None):
+    return _build_booking(
+        factory=factories.CancelledCollectiveBookingFactory,
+        provider=provider,
+        venue=venue,
+        institution=institution,
+        year=year,
+    )
 
 
 class ConfirmCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
@@ -84,50 +111,78 @@ class ConfirmCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
     endpoint_method = "post"
     default_path_params = {"booking_id": 1}
 
-    def setup_method(self):
-        self.plain_api_key, _ = self.setup_provider()
+    def test_confirm_pending_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        pending_booking = build_pending_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
 
-    def get_authenticated_client(self, client):
-        if not hasattr(self, "_authenticated_client"):
-            self._authenticated_client = client.with_explicit_token(self.plain_api_key)
-        return self._authenticated_client
+        with assert_attribute_value_changes_to(pending_booking, "status", models.CollectiveBookingStatus.CONFIRMED):
+            self.confirm_booking(auth_client, pending_booking.id, status_code=204)
 
-    def test_confirm_pending_booking(self, client, pending_booking):
-        with assert_status_changes_to(pending_booking, models.CollectiveBookingStatus.CONFIRMED):
-            self.confirm_booking(client, pending_booking.id, status_code=204)
+    def test_confirm_confirmed_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        confirmed_booking = build_confirmed_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
 
-    def test_confirm_confirmed_booking(self, client, confirmed_booking):
-        with assert_status_does_not_change(confirmed_booking):
-            self.confirm_booking(client, confirmed_booking.id, status_code=204)
+        with assert_attribute_does_not_change(confirmed_booking, "status"):
+            self.confirm_booking(auth_client, confirmed_booking.id, status_code=204)
 
-    def test_confirm_used_booking(self, client, used_booking):
+    def test_confirm_used_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        used_booking = build_used_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
         error = {"code": "CONFIRMATION_LIMIT_DATE_HAS_PASSED"}
 
-        with assert_status_does_not_change(used_booking):
-            self.confirm_booking(client, used_booking.id, status_code=403, json_error=error)
+        with assert_attribute_does_not_change(used_booking, "status"):
+            self.confirm_booking(auth_client, used_booking.id, status_code=403, json_error=error)
 
-    def test_confirm_reimbursed_booking(self, client, reimbursed_booking):
+    def test_confirm_reimbursed_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        reimbursed_booking = build_reimbursed_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
         error = {"code": "CONFIRMATION_LIMIT_DATE_HAS_PASSED"}
 
-        with assert_status_does_not_change(reimbursed_booking):
-            self.confirm_booking(client, reimbursed_booking.id, status_code=403, json_error=error)
+        with assert_attribute_does_not_change(reimbursed_booking, "status"):
+            self.confirm_booking(auth_client, reimbursed_booking.id, status_code=403, json_error=error)
 
-    def test_confirm_cancelled_booking(self, client, cancelled_booking):
+    def test_confirm_cancelled_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        cancelled_booking = build_cancelled_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
         error = {"code": "EDUCATIONAL_BOOKING_IS_CANCELLED"}
 
-        with assert_status_does_not_change(cancelled_booking):
-            self.confirm_booking(client, cancelled_booking.id, status_code=403, json_error=error)
+        with assert_attribute_does_not_change(cancelled_booking, "status"):
+            self.confirm_booking(auth_client, cancelled_booking.id, status_code=403, json_error=error)
 
-    def test_confirm_when_insufficient_fund(self, client, institution, pending_booking):
-        for deposit in institution.deposits:
+    def test_confirm_when_insufficient_fund(self, client):
+        plain_api_key, provider = self.setup_provider()
+        pending_booking = build_pending_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        for deposit in pending_booking.educationalInstitution.deposits:
             deposit.amount = 0
 
         error = {"code": "INSUFFICIENT_FUND"}
-        with assert_status_does_not_change(pending_booking):
-            self.confirm_booking(client, pending_booking.id, status_code=403, json_error=error)
+        with assert_attribute_does_not_change(pending_booking, "status"):
+            self.confirm_booking(auth_client, pending_booking.id, status_code=403, json_error=error)
 
     @override_features(ENABLE_EAC_FINANCIAL_PROTECTION=True)
-    def test_confirm_when_insufficient_ministry_fund(self, client, used_booking, pending_booking):
+    def test_confirm_when_insufficient_ministry_fund(self, client):
+        plain_api_key, provider = self.setup_provider()
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        current_year = _build_current_year()
+
+        pending_booking = build_pending_booking(provider, year=current_year)
+
+        venue = pending_booking.collectiveStock.collectiveOffer.venue
+        institution = pending_booking.educationalInstitution
+
+        used_booking = build_used_booking(provider, venue=venue, institution=institution, year=current_year)
+
         # ensure offer's stock start between september and december
         # because this validation is not ran after and before that.
         start = pending_booking.collectiveStock.startDatetime.replace(month=10)
@@ -142,32 +197,183 @@ class ConfirmCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
         used_booking.collectiveStock.price = deposit_amount / 3
 
         error = {"code": "INSUFFICIENT_MINISTRY_FUND"}
-        with assert_status_does_not_change(pending_booking):
-            self.confirm_booking(client, pending_booking.id, status_code=403, json_error=error)
+        with assert_attribute_does_not_change(pending_booking, "status"):
+            self.confirm_booking(auth_client, pending_booking.id, status_code=403, json_error=error)
 
-    def test_confirm_when_insufficient_temporary_fund(self, client, institution, pending_booking):
-        for deposit in institution.deposits:
+    def test_confirm_when_insufficient_temporary_fund(self, client):
+        plain_api_key, provider = self.setup_provider()
+        pending_booking = build_pending_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        for deposit in pending_booking.educationalInstitution.deposits:
             deposit.amount = 0
             deposit.isFinal = False
 
         error = {"code": "INSUFFICIENT_FUND_DEPOSIT_NOT_FINAL"}
-        with assert_status_does_not_change(pending_booking):
-            self.confirm_booking(client, pending_booking.id, status_code=403, json_error=error)
+        with assert_attribute_does_not_change(pending_booking, "status"):
+            self.confirm_booking(auth_client, pending_booking.id, status_code=403, json_error=error)
 
     def test_confirm_unknown_booking(self, client):
-        error = {"code": constants.EDUCATIONAL_BOOKING_NOT_FOUND}
-        self.confirm_booking(client, 0, status_code=404, json_error=error)
+        plain_api_key, _ = self.setup_provider()
+        auth_client = client.with_explicit_token(plain_api_key)
 
-    def test_confirm_unknown_deposit(self, client, institution, pending_booking):
-        for deposit in institution.deposits:
+        error = {"code": constants.EDUCATIONAL_BOOKING_NOT_FOUND}
+        self.confirm_booking(auth_client, 0, status_code=404, json_error=error)
+
+    def test_confirm_unknown_deposit(self, client):
+        plain_api_key, provider = self.setup_provider()
+        pending_booking = build_pending_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        for deposit in pending_booking.educationalInstitution.deposits:
             deposit.educationalYear = factories.EducationalYearFactory()
 
         error = {"code": "DEPOSIT_NOT_FOUND"}
-        with assert_status_does_not_change(pending_booking):
-            self.confirm_booking(client, pending_booking.id, status_code=404, json_error=error)
+        with assert_attribute_does_not_change(pending_booking, "status"):
+            self.confirm_booking(auth_client, pending_booking.id, status_code=404, json_error=error)
 
     def confirm_booking(self, client, booking_id, status_code, json_error=None):
-        response = self.send_request(self.get_authenticated_client(client), url_params={"booking_id": booking_id})
+        response = self.send_request(client, url_params={"booking_id": booking_id})
+
+        assert response.status_code == status_code
+        if json_error:
+            for key, msg in json_error.items():
+                assert response.json.get(key) == msg
+
+
+class CancelCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
+    endpoint_url = "/v2/collective/adage_mock/bookings/{booking_id}/cancel"
+    endpoint_method = "post"
+    default_path_params = {"booking_id": 1}
+
+    # 1. get api key
+    # 2. get FF
+    # 3. get collective booking
+    # 4. get collective stock (lock for update)
+    # 5. get collective booking (refresh)
+    # 6. does pricing exists for collective booking?
+    # 7. get finance events for booking
+    # 8. update booking
+    on_success_num_queries = 8
+
+    def test_can_cancel_confirmed_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        confirmed_booking = build_confirmed_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_value_changes_to(confirmed_booking, "status", models.CollectiveBookingStatus.CANCELLED):
+            booking_id = confirmed_booking.id
+            with assert_num_queries(self.on_success_num_queries):
+                self.cancel_booking(auth_client, booking_id, status_code=204)
+
+    def test_can_cancel_pending_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        pending_booking = build_pending_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_value_changes_to(pending_booking, "status", models.CollectiveBookingStatus.CANCELLED):
+            booking_id = pending_booking.id
+            with assert_num_queries(self.on_success_num_queries):
+                self.cancel_booking(auth_client, booking_id, status_code=204)
+
+    def test_can_cancel_used_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        used_booking = build_used_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_value_changes_to(used_booking, "status", models.CollectiveBookingStatus.CANCELLED):
+            booking_id = used_booking.id
+            with assert_num_queries(self.on_success_num_queries):
+                self.cancel_booking(auth_client, booking_id, status_code=204)
+
+    def test_cannot_cancel_cancelled_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        cancelled_booking = build_cancelled_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        error = {"code": "ALREADY_CANCELLED_BOOKING"}
+        with assert_attribute_does_not_change(cancelled_booking, "status"):
+            booking_id = cancelled_booking.id
+            # 1. get api key
+            # 2. get FF
+            # 3. get collective booking
+            # 4. get collective stock (lock for update)
+            # 5. get collective booking (refresh)
+            # 6. does pricing exists for collective booking?
+            # 7. get finance events for booking
+            # 8. rollback
+            with assert_num_queries(8):
+                self.cancel_booking(auth_client, booking_id, status_code=403, json_error=error)
+
+    def test_cannot_cancel_reimbursed_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        reimbursed_booking = build_reimbursed_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        error = {"code": "BOOKING_IS_REIMBURSED"}
+        with assert_attribute_does_not_change(reimbursed_booking, "status"):
+            booking_id = reimbursed_booking.id
+            # 1. get api key
+            # 2. get FF
+            # 3. get collective booking
+            # 4. get collective stock (lock for update)
+            # 5. get collective booking (refresh)
+            # 6. rollback
+            with assert_num_queries(6):
+                self.cancel_booking(auth_client, booking_id, status_code=403, json_error=error)
+
+    def test_cannot_cancel_unknown_booking(self, client):
+        plain_api_key, _ = self.setup_provider()
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        error = {"code": "BOOKING_NOT_FOUND"}
+
+        # 1. get api key
+        # 2. get FF
+        # 3. get collective booking
+        with assert_num_queries(3):
+            self.cancel_booking(auth_client, 0, status_code=404, json_error=error)
+
+    def test_cannot_cancel_booking_not_linked_to_key(self, client):
+        plain_api_key, _ = self.setup_provider()
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        booking = factories.CollectiveBookingFactory()
+        error = {"code": "BOOKING_NOT_FOUND"}
+
+        with assert_attribute_does_not_change(booking, "status"):
+            booking_id = booking.id
+            # 1. get api key
+            # 2. get FF
+            # 3. get collective booking
+            with assert_num_queries(3):
+                self.cancel_booking(auth_client, booking_id, status_code=404, json_error=error)
+
+    @patch("pcapi.core.educational.api.booking.finance_api")
+    def test_unexpected_error_is_handled(self, mock_finance_api, client):
+        plain_api_key, provider = self.setup_provider()
+        confirmed_booking = build_confirmed_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        mock_finance_api.cancel_latest_event.side_effect = [RuntimeError("test")]
+
+        error = {"code": "FAILED_TO_CANCEL_BOOKING_TRY_AGAIN"}
+
+        with assert_attribute_does_not_change(confirmed_booking, "status"):
+            booking_id = confirmed_booking.id
+            # 1. get api key
+            # 2. get FF
+            # 3. get collective booking
+            # 4. get collective stock (lock for update)
+            # 5. get collective booking (refresh)
+            # 6. does pricing exists for collective booking?
+            # 7. get finance events for booking
+            # 8. rollback
+            with assert_num_queries(8):
+                self.cancel_booking(auth_client, booking_id, status_code=500, json_error=error)
+
+    def cancel_booking(self, client, booking_id, status_code, json_error=None):
+        response = self.send_request(client, url_params={"booking_id": booking_id})
 
         assert response.status_code == status_code
         if json_error:

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -11091,6 +11091,60 @@
                 ]
             }
         },
+        "/v2/collective/adage_mock/bookings/{booking_id}/cancel": {
+            "post": {
+                "description": "Like this could happen within the Adage platform.\n\nWarning: not available for production nor integration environments",
+                "operationId": "AdageMockCancelCollectiveBooking",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "booking_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "This collective booking's status has been successfully updated"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API."
+                    },
+                    "403": {
+                        "description": "Collective booking status updated has been refused"
+                    },
+                    "404": {
+                        "description": "The collective offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Mock collective booking cancellation",
+                "tags": [
+                    "Collective bookings Adage mock"
+                ]
+            }
+        },
         "/v2/collective/adage_mock/bookings/{booking_id}/confirm": {
             "post": {
                 "description": "Like this could happen within the Adage platform.\n\nWarning: not available for production nor integration environments",

--- a/api/tests/routes/public/helpers.py
+++ b/api/tests/routes/public/helpers.py
@@ -1,4 +1,5 @@
 import abc
+import contextlib
 import uuid
 
 import pytest
@@ -11,6 +12,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.providers import models as providers_models
+from pcapi.models import db
 
 from tests.conftest import TestClient
 
@@ -174,3 +176,24 @@ class ProductEndpointHelper:
             name="Vieux motard que jamais",
             extraData={"ean": "1234567890123"},
         )
+
+
+@contextlib.contextmanager
+def assert_attribute_value_changes_to(model, attribute_name, expected_value):
+    previous_value = getattr(model, attribute_name)
+
+    yield
+
+    db.session.refresh(model)
+    assert getattr(model, attribute_name) != previous_value
+    assert getattr(model, attribute_name) == expected_value
+
+
+@contextlib.contextmanager
+def assert_attribute_does_not_change(model, attribute_name):
+    previous_value = getattr(model, attribute_name)
+
+    yield
+
+    db.session.refresh(model)
+    assert getattr(model, attribute_name) == previous_value


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31390

Ajout d'une route qui permet d'annuler une réservation collective, à destination de l'environnement d'intégration qui n'a pas d'équivalent Adage - ce qui empêche d'aller au-delà de la création d'une offre.

### Au passage

1. Ajout de quelques __fixtures__.
2. fonctions déplacées dans des modules plus appropriés (`conftest`, nouveau, pour les __fixtures__, `helpers` pour les deux __context managers__).
