### PR TITLE
(PC-31642)[PRO] fix: Allow to lower a price when editing USED bookings

### DIFF
--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -151,7 +151,10 @@ def edit_collective_stock(
         and "bookingLimitDatetime" not in stock_data
     ):
         price = updatable_fields.get("price")
-        if current_booking and current_booking.status == CollectiveBookingStatus.CONFIRMED:
+        if current_booking and current_booking.status in {
+            CollectiveBookingStatus.CONFIRMED,
+            CollectiveBookingStatus.USED,
+        }:
             if price is not None:
                 validation.check_if_edition_lower_price_possible(stock, price)
         else:


### PR DESCRIPTION

Erreur sentry -> https://sentry.passculture.team/organizations/sentry/issues/1618230/?project=5&referrer=slack

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31642

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
