### PR TITLE
(BSR)[PRO] test: be sure to have homepage loaded

### DIFF
--- a/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
+++ b/pro/cypress/e2e/step-definitions/commonSteps.cy.ts
@@ -5,6 +5,13 @@ import {
   When,
 } from '@badeball/cypress-cucumber-preprocessor'
 
+function homePageLoaded(): void {
+  cy.findByText('Bienvenue dans l’espace acteurs culturels')
+  cy.findByText('Vos adresses')
+  cy.findByText('Ajouter un lieu')
+  cy.findAllByTestId('spinner').should('not.exist')
+}
+
 Given('I open the {string} page', (page: string) => {
   cy.visit('/' + page)
 })
@@ -18,7 +25,6 @@ When('I go to the {string} page', (page: string) => {
     cy.findAllByText(page).first().click()
     cy.url().should('not.equal', urlSource)
   })
-  cy.findAllByTestId('spinner').should('not.exist')
 })
 
 Given('I am logged in with account 1', () => {
@@ -26,7 +32,7 @@ Given('I am logged in with account 1', () => {
     email: 'retention_structures@example.com',
     password: 'user@AZERTY123',
   })
-  cy.findAllByTestId('spinner').should('not.exist')
+  homePageLoaded()
 })
 
 Given('I am logged in with account 2', () => {
@@ -34,7 +40,7 @@ Given('I am logged in with account 2', () => {
     email: 'activation@example.com',
     password: 'user@AZERTY123',
   })
-  cy.findAllByTestId('spinner').should('not.exist')
+  homePageLoaded()
 })
 
 Given('I am logged in with account 2 and no cookie selection', () => {
@@ -43,7 +49,6 @@ Given('I am logged in with account 2 and no cookie selection', () => {
     password: 'user@AZERTY123',
     refusePopupCookies: false,
   })
-  cy.findAllByTestId('spinner').should('not.exist')
 })
 
 // créer un seul scénario createOffers avec son step-def


### PR DESCRIPTION
## But de la pull request

Après connexion, on attend que la page d'accueil soit bien complètement chargée. On a eu un cas de test flaky qui changeait de structure quand la page n'était pas encore chargée, et le changement de structure n'était pas pris en compte.
On reproduit en ralentissant le réseau (`network throttling`)

Voir [ici sur Cypress Cloud](https://cloud.cypress.io/projects/rit5sb/runs/704/test-results/ddabb1bc-9da5-4998-98f4-cf8795a38879/replay)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
