### PR TITLE
(PC-31616)[BO] fix: fix 500 when searching by event_from_date 01-01-0001 in booking and collective booking

### DIFF
--- a/api/src/pcapi/routes/backoffice/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice/forms/fields.py
@@ -8,6 +8,7 @@ import email_validator
 from flask import render_template
 from flask import url_for
 import wtforms
+from wtforms import ValidationError
 from wtforms import validators
 import wtforms_sqlalchemy.fields
 
@@ -277,6 +278,11 @@ class PCDateField(wtforms.DateField):
                 return "Date invalide"
             case _:
                 return string
+
+    def pre_validate(self, form: wtforms.Form) -> None:
+        if self.data and self.data < datetime.date(1900, 1, 1):
+            super().pre_validate(form)
+            raise ValidationError("La date doit être après le 01/01/1900.")
 
 
 class PCOptDateField(PCDateField):

--- a/api/src/pcapi/routes/backoffice/templates/components/forms/date_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/date_field.html
@@ -5,6 +5,8 @@
          name="{{ field.name }}"
          data-original-name="{{ field.name }}"
          class="form-control value-element-form"
+         min="1900-01-01"
+         max="2100-01-01"
          {% if field.flags.readonly %}readonly {% endif +%}
          value="{{ field.data if field.data else "" }}" />
   <label class="label-element-form"

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -368,6 +368,21 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data)
         assert set(int(row["ID résa"]) for row in rows) == {collective_bookings[1].id, collective_bookings[2].id}
 
+    def test_list_bookings_with_event_date_before_1900(
+        self,
+        authenticated_client,
+        collective_bookings,
+    ):
+        with assert_num_queries(2):  # user_session + user
+            response = authenticated_client.get(
+                url_for(
+                    self.endpoint,
+                    event_from_date=datetime.date(1, 1, 1),
+                    event_to_date=None,
+                )
+            )
+            assert response.status_code == 400
+
     @pytest.mark.parametrize(
         "from_date, to_date, expected_offers_name",
         [


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31616

à présent pour collective booking ET individual booking, mettre en date 01-01-0001 devrait mettre un message flash au lieu d'une 500.
<img width="1512" alt="Capture d’écran 2024-09-04 à 14 59 26" src="https://github.com/user-attachments/assets/65246a23-17b2-4750-b524-0c8921948c32">

