### PR TITLE
(PC-31618)[API]fix: isDuo of offer event that can be duo are set to True by default

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -229,6 +229,9 @@ def create_draft_offer(
     fields.update(_get_accessibility_compliance_fields(venue))
     fields.update({"withdrawalDetails": venue.withdrawalDetails})
 
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT.get(fields.get("subcategoryId", None))
+    fields.update({"isDuo": bool(subcategory and subcategory.is_event and subcategory.can_be_duo)})
+
     offer = models.Offer(
         **fields,
         venue=venue,

--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -35,6 +35,27 @@ class Returns201Test:
         assert response_dict["id"] == offer.id
         assert response_dict["productId"] == None
         assert response_dict["extraData"] == {"gtl_id": "07000000"}
+        assert response_dict["isDuo"] == False
+        assert not offer.product
+
+    def test_created_offer_should_have_is_duo_set_to_true_if_subcategory_is_event_and_can_be_duo(self, client):
+        venue = offerers_factories.VenueFactory()
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
+
+        data = {
+            "name": "Celeste",
+            "subcategoryId": subcategories.CONFERENCE.id,
+            "venueId": venue.id,
+        }
+        response = client.with_session_auth("user@example.com").post("/offers/draft", json=data)
+
+        assert response.status_code == 201
+
+        response_dict = response.json
+        offer_id = response_dict["id"]
+        offer = Offer.query.get(offer_id)
+        assert response_dict["isDuo"] == True
         assert not offer.product
 
     def test_created_offer_from_product_should_return_product_id(self, client):

--- a/pro/cypress/e2e/step-definitions/createEventIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/createEventIndividualOffer.cy.ts
@@ -60,7 +60,7 @@ When('I fill in prices', () => {
   // manque un data-testid ou un accessibility label
   cy.get('[name="priceCategories[2].free"]').click()
 
-  cy.findByText('Accepter les réservations “Duo“').should('exist').click()
+  cy.findByText('Accepter les réservations “Duo“').should('exist')
 })
 
 When('I validate prices step', () => {


### PR DESCRIPTION
This was done in the front before the FF WIP_SUGGESTED_SUBCATEGORIES, fixed it by doing it in the back with the FF WIP_SUGGESTED_SUBCATEGORIES activated.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31618

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
