### PR TITLE
(PC-31668)[BO] fix: timeout in bank accounts details when DMS timeouts

### DIFF
--- a/api/src/pcapi/connectors/dms/api.py
+++ b/api/src/pcapi/connectors/dms/api.py
@@ -19,6 +19,7 @@ from . import exceptions
 
 logger = logging.getLogger(__name__)
 GRAPHQL_DIRECTORY = pathlib.Path(os.path.dirname(__file__)) / "graphql"
+DEFAULT_RETRIES = 3
 
 ARCHIVE_APPLICATION_QUERY_NAME = "archive_application"
 GET_BANK_INFO_STATUS_QUERY_NAME = "pro/get_bank_info_status"
@@ -41,11 +42,11 @@ class DmsStats(BaseModel):
 
 
 class DMSGraphQLClient:
-    def __init__(self) -> None:
+    def __init__(self, retries: int = DEFAULT_RETRIES) -> None:
         transport = requests.CustomGqlTransport(
             url="https://www.demarches-simplifiees.fr/api/v2/graphql",
             headers={"Authorization": f"Bearer {settings.DMS_TOKEN}"},
-            retries=3,
+            retries=retries,
         )
         self.client = gql.Client(transport=transport)
 
@@ -286,7 +287,7 @@ def get_dms_stats(dms_application_id: int | None, api_v4: bool = False) -> DmsSt
         return None
 
     try:
-        dms_stats = DMSGraphQLClient().get_bank_info_status(dms_application_id)
+        dms_stats = DMSGraphQLClient(retries=1).get_bank_info_status(dms_application_id)
     except (
         gql_exceptions.TransportError,
         gql_exceptions.TransportQueryError,


### PR DESCRIPTION
## But de la pull request

https://passculture.atlassian.net/browse/PC-31668

Pas besoin de 3 tentatives d'appel à DMS pour afficher la page dans le BO.
Croisons les doigts pour que ça suffise à afficher la page, lorsque DMS ne répond pas.

Testé en console sur staging, mais il faut attendre le déploiement sur staging pour tester dans le BO.

Ça reste un « quick fix » !

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
