### PR TITLE
(BSR)[PRO] test: Add tests for sorting collective bookings columns

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingOfferCell.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingOfferCell.tsx
@@ -61,6 +61,7 @@ export const BookingOfferCell = ({
         href={editionUrl}
         title={booking.stock.offerName}
         className={styles['booking-offer-name']}
+        data-testid="booking-offer-name"
       >
         {booking.stock.offerName}
       </a>

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveBookingsTable.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveBookingsTable.tsx
@@ -128,6 +128,7 @@ export const CollectiveBookingsTable = ({
 
             <th
               scope="col"
+              data-testid="institution-column"
               className={cn(
                 styles['column-institution'],
                 styles['table-header-cell']

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTableRow.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTableRow.tsx
@@ -97,7 +97,9 @@ export const CollectiveTableRow = ({
         >
           <div className={styles['cell-item-wrapper']}>
             <div>
-              <span>{institutionName}</span>
+              <span data-testid="booking-offer-institution">
+                {institutionName}
+              </span>
               <br />
             </div>
             <span className={styles['institution-cell-subtitle']}>

--- a/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
@@ -1,6 +1,7 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React, { ComponentProps } from 'react'
+import { expect } from 'vitest'
 
 import { api } from 'apiClient/api'
 import * as useAnalytics from 'app/App/analytics/firebase'
@@ -9,6 +10,7 @@ import { Audience } from 'core/shared/types'
 import * as filterBookingsRecap from 'screens/Bookings/BookingsRecapTable/utils/filterBookingsRecap'
 import {
   collectiveBookingByIdFactory,
+  collectiveBookingCollectiveStockFactory,
   collectiveBookingFactory,
 } from 'utils/collectiveApiFactories'
 import { bookingRecapFactory } from 'utils/individualApiFactories'
@@ -159,6 +161,177 @@ describe('components | BookingsRecapTable', () => {
         selectedOmniSearchCriteria: 'booking_id',
       })
     )
+  })
+
+  it('should sort by offer name', async () => {
+    const props: Props = {
+      ...defaultProps,
+      audience: Audience.COLLECTIVE,
+      bookingsRecap: [
+        collectiveBookingFactory({
+          bookingId: '123',
+          stock: collectiveBookingCollectiveStockFactory({
+            offerName: 'Offre de test 2',
+          }),
+        }),
+        collectiveBookingFactory({
+          bookingId: '456',
+          stock: collectiveBookingCollectiveStockFactory({
+            offerName: 'Offre de test 1',
+          }),
+        }),
+        collectiveBookingFactory({
+          bookingId: '789',
+          stock: collectiveBookingCollectiveStockFactory({
+            offerName: 'Offre de test 3',
+          }),
+        }),
+      ],
+      locationState: {
+        statuses: ['booked', 'cancelled'],
+      },
+    }
+
+    renderBookingRecap(props)
+
+    expect(screen.getAllByTestId('booking-offer-name')[0]).toHaveTextContent(
+      /Offre de test 2/
+    )
+    expect(screen.getAllByTestId('booking-offer-name')[1]).toHaveTextContent(
+      /Offre de test 1/
+    )
+    expect(screen.getAllByTestId('booking-offer-name')[2]).toHaveTextContent(
+      /Offre de test 3/
+    )
+
+    await userEvent.click(
+      within(screen.getByText('Nom de l’offre').closest('th')!).getByRole(
+        'button'
+      )
+    )
+
+    expect(screen.getAllByTestId('booking-offer-name')[0]).toHaveTextContent(
+      /Offre de test 1/
+    )
+    expect(screen.getAllByTestId('booking-offer-name')[1]).toHaveTextContent(
+      /Offre de test 2/
+    )
+    expect(screen.getAllByTestId('booking-offer-name')[2]).toHaveTextContent(
+      /Offre de test 3/
+    )
+
+    await userEvent.click(
+      within(screen.getByText('Nom de l’offre').closest('th')!).getByRole(
+        'button'
+      )
+    )
+
+    expect(screen.getAllByTestId('booking-offer-name')[0]).toHaveTextContent(
+      /Offre de test 3/
+    )
+    expect(screen.getAllByTestId('booking-offer-name')[1]).toHaveTextContent(
+      /Offre de test 2/
+    )
+    expect(screen.getAllByTestId('booking-offer-name')[2]).toHaveTextContent(
+      /Offre de test 1/
+    )
+  })
+
+  it('should sort by institution name', async () => {
+    const props: Props = {
+      ...defaultProps,
+      audience: Audience.COLLECTIVE,
+      bookingsRecap: [
+        collectiveBookingFactory({
+          bookingId: '123',
+          institution: {
+            id: 1,
+            name: 'Collège 2',
+            city: 'City',
+            postalCode: '11111',
+            institutionId: 'ABCDEF',
+            institutionType: 'COLLEGE',
+            phoneNumber: '0102030405',
+          },
+          stock: collectiveBookingCollectiveStockFactory({
+            offerName: 'Offre de test 2',
+          }),
+        }),
+        collectiveBookingFactory({
+          bookingId: '456',
+          institution: {
+            id: 2,
+            name: 'Collège 1',
+            city: 'City',
+            postalCode: '11111',
+            institutionId: 'ABCDEF',
+            institutionType: 'COLLEGE',
+            phoneNumber: '0102030405',
+          },
+          stock: collectiveBookingCollectiveStockFactory({
+            offerName: 'Offre de test 1',
+          }),
+        }),
+        collectiveBookingFactory({
+          bookingId: '789',
+          institution: {
+            id: 3,
+            name: 'Collège 3',
+            city: 'City',
+            postalCode: '11111',
+            institutionId: 'ABCDEF',
+            institutionType: 'COLLEGE',
+            phoneNumber: '0102030405',
+          },
+          stock: collectiveBookingCollectiveStockFactory({
+            offerName: 'Offre de test 3',
+          }),
+        }),
+      ],
+      locationState: {
+        statuses: ['booked', 'cancelled'],
+      },
+    }
+
+    renderBookingRecap(props)
+
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[0]
+    ).toHaveTextContent(/Collège 2/)
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[1]
+    ).toHaveTextContent(/Collège 1/)
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[2]
+    ).toHaveTextContent(/Collège 3/)
+
+    await userEvent.click(
+      within(screen.getByTestId('institution-column')).getByRole('button')
+    )
+
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[0]
+    ).toHaveTextContent(/Collège 1/)
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[1]
+    ).toHaveTextContent(/Collège 2/)
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[2]
+    ).toHaveTextContent(/Collège 3/)
+
+    await userEvent.click(
+      within(screen.getByTestId('institution-column')).getByRole('button')
+    )
+
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[0]
+    ).toHaveTextContent(/Collège 3/)
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[1]
+    ).toHaveTextContent(/Collège 2/)
+    expect(
+      screen.getAllByTestId('booking-offer-institution')[2]
+    ).toHaveTextContent(/Collège 1/)
   })
 
   it('should render the expected table with max given number of hits per page', () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : Ajout de tests sur les tris des colonnes pour les resa collectives

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
