### PR TITLE
(BSR)[PRO] test: fix new financialManagement test that fails

### DIFF
--- a/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
+++ b/pro/cypress/e2e/step-definitions/financialManagement.cy.ts
@@ -26,16 +26,15 @@ When('I remove {string} venue from my bank account', (venue: string) => {
   cy.findByRole('dialog').within(() => {
     cy.findByLabelText(venue).should('be.checked')
     cy.findByLabelText(venue).uncheck()
-
     cy.findByText('Enregistrer').click()
+    cy.intercept({ method: 'GET', url: '/offerers/*' }).as('getOfferers')
     cy.findByText('Confirmer').click()
+    cy.wait('@getOfferers').its('response.statusCode').should('equal', 200)
   })
 })
 
 When('I add {string} venue to my bank account', (venue: string) => {
   cy.findByTestId('reimbursement-bank-account-linked-venues').within(() => {
-    cy.contains('Aucun lieu n’est rattaché à ce compte bancaire.')
-
     cy.findByText('Rattacher un lieu').click()
   })
 
@@ -154,9 +153,20 @@ Then('no venue should be linked to my account', () => {
     'contain',
     'Vos modifications ont bien été prises en compte.'
   )
+  cy.reload()
+  cy.findAllByTestId('spinner').should('not.exist')
+  cy.findByTestId('reimbursement-bank-account-linked-venues').within(() => {
+    cy.contains('Aucun lieu n’est rattaché à ce compte bancaire.')
+  })
 })
 
 Then('{string} venue should be linked to my account', (venue: string) => {
+  cy.findAllByTestId('global-notification-success').should(
+    'contain',
+    'Vos modifications ont bien été prises en compte.'
+  )
+  cy.reload()
+  cy.findAllByTestId('spinner').should('not.exist')
   cy.findByTestId('reimbursement-bank-account-linked-venues').within(() => {
     cy.contains('Lieu(x) rattaché(s) à ce compte bancaire')
     cy.contains('Certains de vos lieux ne sont pas rattachés.')


### PR DESCRIPTION
## But de la pull request

Ajout d'attentes et étapes de vérifications pour que le nouveau test `financialManagement` ajouté dans cette [PR](https://github.com/pass-culture/pass-culture-main/pull/13982)  n'échoue plus

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
