### PR TITLE
(BSR)[PRO] test: add fail-fast plugin

### DIFF
--- a/pro/cypress/cypress.config.ts
+++ b/pro/cypress/cypress.config.ts
@@ -2,6 +2,7 @@ import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-prepro
 import { createEsbuildPlugin } from '@badeball/cypress-cucumber-preprocessor/esbuild'
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor'
 import { defineConfig } from 'cypress'
+import cypressFailFast = require('cypress-fail-fast/plugin')
 
 async function setupNodeEvents(
   on: Cypress.PluginEvents,
@@ -16,7 +17,7 @@ async function setupNodeEvents(
       plugins: [createEsbuildPlugin(config)],
     })
   )
-
+  cypressFailFast(on, config)
   // Make sure to return the config object as it might have been modified by the plugin.
   return config
 }
@@ -42,4 +43,9 @@ export default defineConfig({
   video: true,
   videoCompression: true,
   watchForFileChanges: false,
+  env: {
+    FAIL_FAST_STRATEGY: 'run',
+    FAIL_FAST_ENABLED: true,
+    FAIL_FAST_BAIL: 3,
+  },
 })

--- a/pro/cypress/support/e2e.ts
+++ b/pro/cypress/support/e2e.ts
@@ -16,6 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 import { configure } from '@testing-library/react'
+import 'cypress-fail-fast'
 
 // Set to `defaultCommandTimeout` to match the cypress default timeout
 configure({ asyncUtilTimeout: 4000 })

--- a/pro/package.json
+++ b/pro/package.json
@@ -105,6 +105,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/coverage-v8": "^2.0.4",
     "cypress": "^13.14.2",
+    "cypress-fail-fast": "^7.1.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.30.0",

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -4690,6 +4690,13 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
+cypress-fail-fast@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/cypress-fail-fast/-/cypress-fail-fast-7.1.1.tgz#4be6ddbed8c284358faf488c73b6bd87f69cda49"
+  integrity sha512-9qPXikVY20OWdc97DO2++0AS4IF9kB+vuPhP8/0wXchcnFIsiCiwvQhOEBSdVHr1mZi87h0Z8jYEB4VLPzNkGg==
+  dependencies:
+    chalk "4.1.2"
+
 cypress@^13.14.2:
   version "13.14.2"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.14.2.tgz#4237eb7b26de2baeaa1f01e585f965d88fca7f39"


### PR DESCRIPTION
## But de la pull request

Ajout du plugin fail-fast. Avec celui-ci, dès que 3 scénarios auront échoué alors tous les tests suivants seront skipper. Cela évite d'avoir des runs de tests e2e tous pétés qui tournent pendant 30 minutes (et des jobs bloquant les autres) [comme ici par exemple](https://github.com/pass-culture/pass-culture-main/actions/runs/10703065721/job/29673789279)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
