### PR TITLE
(PC-31682)[PRO] fix: Use the correct query key for FF-protected new c…

### DIFF
--- a/pro/src/config/swrQueryKeys.ts
+++ b/pro/src/config/swrQueryKeys.ts
@@ -12,6 +12,8 @@ export const GET_COLLECTIVE_OFFER_TEMPLATES_QUERY_KEY =
   'getCollectiveOfferTemplates'
 export const GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY =
   'getCollectiveOffersBookable'
+export const GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY =
+  'getTemplateCollectiveOffers'
 export const GET_COLLECTIVE_OFFERS_FOR_INSTITUTION_QUERY_KEY =
   'getCollectiveOffersForMyInstitution'
 export const GET_COLLECTIVE_OFFERS_QUERY_KEY = 'getCollectiveOffers'
@@ -42,8 +44,6 @@ export const GET_OFFERER_BANK_ACCOUNTS_AND_ATTACHED_VENUES_QUERY_KEY =
 export const GET_OFFERER_QUERY_KEY = 'getOfferer'
 export const GET_OFFERER_NAMES_QUERY_KEY = 'getOffererNames'
 export const GET_PROVIDERS_QUERY_KEY = 'getProviders'
-export const GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY =
-  'getTemplateCollectiveOffers'
 export const GET_VALIDATED_OFFERERS_NAMES_QUERY_KEY = 'listOfferersNames'
 export const GET_VENUE_QUERY_KEY = 'getVenue'
 export const GET_VENUE_LABELS_QUERY_KEY = 'getVenueLabels'

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -16,7 +16,11 @@ import { useAnalytics } from 'app/App/analytics/firebase'
 import { ArchiveConfirmationModal } from 'components/ArchiveConfirmationModal/ArchiveConfirmationModal'
 import { canArchiveCollectiveOffer } from 'components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer'
 import { CancelCollectiveBookingModal } from 'components/CancelCollectiveBookingModal/CancelCollectiveBookingModal'
-import { GET_COLLECTIVE_OFFERS_QUERY_KEY } from 'config/swrQueryKeys'
+import {
+  GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY,
+  GET_COLLECTIVE_OFFERS_QUERY_KEY,
+  GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY,
+} from 'config/swrQueryKeys'
 import {
   CollectiveBookingsEvents,
   Events,
@@ -85,6 +89,17 @@ export const CollectiveActionsCells = ({
   const shouldDisplayModal =
     !isLocalStorageAvailable ||
     localStorage.getItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY) !== 'true'
+
+  const isNewOffersAndBookingsActive = useActiveFeature(
+    'WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE'
+  )
+
+  const offersQueryKey = isNewOffersAndBookingsActive
+    ? offer.isShowcase
+      ? GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY
+      : GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY
+    : GET_COLLECTIVE_OFFERS_QUERY_KEY
+
   const { mutate } = useSWRConfig()
 
   const isMarseilleActive = useActiveFeature('WIP_ENABLE_MARSEILLE')
@@ -152,7 +167,7 @@ export const CollectiveActionsCells = ({
     }
     try {
       await api.cancelCollectiveOfferBooking(offer.id)
-      await mutate([GET_COLLECTIVE_OFFERS_QUERY_KEY, apiFilters])
+      await mutate([offersQueryKey, apiFilters])
       isSelected && deselectOffer(offer)
       setIsCancelledBookingModalOpen(false)
       notify.success(
@@ -189,7 +204,7 @@ export const CollectiveActionsCells = ({
         await api.patchCollectiveOffersArchive({ ids: [offer.id] })
       }
 
-      await mutate([GET_COLLECTIVE_OFFERS_QUERY_KEY, apiFilters])
+      await mutate([offersQueryKey, apiFilters])
       isSelected && deselectOffer(offer)
       setIsArchivedModalOpen(false)
       notify.success('Une offre a bien été archivée', {

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -19,7 +19,7 @@ import { CancelCollectiveBookingModal } from 'components/CancelCollectiveBooking
 import {
   GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY,
   GET_COLLECTIVE_OFFERS_QUERY_KEY,
-  GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY,
+  GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY,
 } from 'config/swrQueryKeys'
 import {
   CollectiveBookingsEvents,
@@ -96,7 +96,7 @@ export const CollectiveActionsCells = ({
 
   const offersQueryKey = isNewOffersAndBookingsActive
     ? offer.isShowcase
-      ? GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY
+      ? GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY
       : GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY
     : GET_COLLECTIVE_OFFERS_QUERY_KEY
 

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { mutate } from 'swr'
+import { useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'
 import {
@@ -14,7 +14,7 @@ import { canArchiveCollectiveOffer } from 'components/ArchiveConfirmationModal/u
 import {
   GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY,
   GET_COLLECTIVE_OFFERS_QUERY_KEY,
-  GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY,
+  GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY,
 } from 'config/swrQueryKeys'
 import { NOTIFICATION_LONG_SHOW_DURATION } from 'core/Notification/constants'
 import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
@@ -131,9 +131,11 @@ export function CollectiveOffersActionsBar({
     'WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE'
   )
 
+  const { mutate } = useSWRConfig()
+
   const offersQueryKey = isNewOffersAndBookingsActive
     ? areTemplateOffers
-      ? GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY
+      ? GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY
       : GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY
     : GET_COLLECTIVE_OFFERS_QUERY_KEY
 

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -11,10 +11,15 @@ import {
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { ArchiveConfirmationModal } from 'components/ArchiveConfirmationModal/ArchiveConfirmationModal'
 import { canArchiveCollectiveOffer } from 'components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer'
-import { GET_COLLECTIVE_OFFERS_QUERY_KEY } from 'config/swrQueryKeys'
+import {
+  GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY,
+  GET_COLLECTIVE_OFFERS_QUERY_KEY,
+  GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY,
+} from 'config/swrQueryKeys'
 import { NOTIFICATION_LONG_SHOW_DURATION } from 'core/Notification/constants'
 import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
 import { useQueryCollectiveSearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useNotification } from 'hooks/useNotification'
 import fullHideIcon from 'icons/full-hide.svg'
 import fullValidateIcon from 'icons/full-validate.svg'
@@ -31,7 +36,7 @@ export type CollectiveOffersActionsBarProps = {
   areAllOffersSelected: boolean
   clearSelectedOfferIds: () => void
   selectedOffers: CollectiveOfferResponseModel[]
-  toggleSelectAllCheckboxes: () => void
+  areTemplateOffers: boolean
 }
 
 const computeDeactivationSuccessMessage = (nbSelectedOffers: number) => {
@@ -113,6 +118,7 @@ export function CollectiveOffersActionsBar({
   selectedOffers,
   clearSelectedOfferIds,
   areAllOffersSelected,
+  areTemplateOffers,
 }: CollectiveOffersActionsBarProps) {
   const urlSearchFilters = useQueryCollectiveSearchFilters()
 
@@ -120,6 +126,16 @@ export function CollectiveOffersActionsBar({
   const [isDeactivationDialogOpen, setIsDeactivationDialogOpen] =
     useState(false)
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false)
+
+  const isNewOffersAndBookingsActive = useActiveFeature(
+    'WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE'
+  )
+
+  const offersQueryKey = isNewOffersAndBookingsActive
+    ? areTemplateOffers
+      ? GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY
+      : GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY
+    : GET_COLLECTIVE_OFFERS_QUERY_KEY
 
   const apiFilters = {
     ...DEFAULT_COLLECTIVE_SEARCH_FILTERS,
@@ -165,7 +181,7 @@ export function CollectiveOffersActionsBar({
     }
 
     clearSelectedOfferIds()
-    await mutate([GET_COLLECTIVE_OFFERS_QUERY_KEY, apiFilters])
+    await mutate([offersQueryKey, apiFilters])
   }
 
   function openArchiveOffersDialog() {

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveOffersActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveOffersActionsBar.spec.tsx
@@ -58,7 +58,7 @@ describe('ActionsBar', () => {
         id: offerId,
       })),
       clearSelectedOfferIds: vi.fn(),
-      toggleSelectAllCheckboxes: vi.fn(),
+      areTemplateOffers: false,
       areAllOffersSelected: false,
     }
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({

--- a/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffers.tsx
+++ b/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffers.tsx
@@ -7,7 +7,7 @@ import { CollectiveOfferStatus, CollectiveOfferType } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import {
   GET_OFFERER_QUERY_KEY,
-  GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY,
+  GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY,
   GET_VENUES_QUERY_KEY,
 } from 'config/swrQueryKeys'
 import {
@@ -91,7 +91,7 @@ export const TemplateCollectiveOffers = (): JSX.Element => {
   }
 
   const offersQuery = useSWR(
-    [GET_TEMPLATE_COLLECTIVE_OFFERS_QUERY_KEY, apiFilters],
+    [GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY, apiFilters],
     () => {
       const {
         nameOrIsbn,

--- a/pro/src/screens/CollectiveOffersScreen/CollectiveOffersScreen.tsx
+++ b/pro/src/screens/CollectiveOffersScreen/CollectiveOffersScreen.tsx
@@ -199,10 +199,10 @@ export const CollectiveOffersScreen = ({
           <div role="status">
             {selectedOffers.length > 0 && (
               <CollectiveOffersActionsBar
+                areTemplateOffers={false}
                 areAllOffersSelected={areAllOffersSelected}
                 clearSelectedOfferIds={clearSelectedOfferIds}
                 selectedOffers={selectedOffers}
-                toggleSelectAllCheckboxes={toggleSelectAllCheckboxes}
               />
             )}
           </div>

--- a/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.tsx
+++ b/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.tsx
@@ -199,10 +199,10 @@ export const TemplateCollectiveOffersScreen = ({
           <div role="status">
             {selectedOffers.length > 0 && (
               <CollectiveOffersActionsBar
+                areTemplateOffers
                 areAllOffersSelected={areAllOffersSelected}
                 clearSelectedOfferIds={clearSelectedOfferIds}
                 selectedOffers={selectedOffers}
-                toggleSelectAllCheckboxes={toggleSelectAllCheckboxes}
               />
             )}
           </div>


### PR DESCRIPTION
…ollective offers pages.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31682

**Objectif**
Corriger la queryKey swr utilisée dans les sous-composants des offres collectives quand on a le FF `WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE` activé. Puisque dans ce cas là les offres sont chargées avec des keys différentes, actuellement le mutate après avoir updaté une offre ne fonctionne pas.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
