### PR TITLE
(PC-31595)[PRO] fix: ignore label if matching the venue's

### DIFF
--- a/api/src/pcapi/connectors/api_adresse.py
+++ b/api/src/pcapi/connectors/api_adresse.py
@@ -50,7 +50,7 @@ class RateLimitExceeded(AdresseApiException):
 
 class AddressInfo(pydantic_v1.BaseModel):
     id: str
-    label: str
+    label: str | None
     postcode: str
     citycode: str  # inseeCode
     latitude: float

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -309,6 +309,8 @@ def create_offer(
 def get_offerer_address_from_address(
     venue: offerers_models.Venue, address: offerers_schemas.AddressBodyModel
 ) -> offerers_models.OffererAddress:
+    if not address.label or address.label == venue.common_name:
+        address.label = None
     address_from_api = offerers_api.create_offerer_address_from_address_api(
         street=address.street,
         postal_code=address.postalCode,
@@ -316,7 +318,11 @@ def get_offerer_address_from_address(
         latitude=float(address.latitude),
         longitude=float(address.longitude),
     )
-    return offerers_api.get_or_create_offerer_address(venue.managingOffererId, address_from_api.id, label=address.label)
+    return offerers_api.get_or_create_offerer_address(
+        venue.managingOffererId,
+        address_from_api.id,
+        label=address.label,
+    )
 
 
 def update_offer(


### PR DESCRIPTION
This works around a weird issue if selecting the venue's offerer address as the front will send us the venue common name as label but the OA expects a NULL/None value.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31595

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
