### PR TITLE
(BSR)[BO] fix: Set default placeholder to avoid dummys decryption errors

### DIFF
--- a/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
+++ b/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
@@ -121,7 +121,7 @@ SET
   "tokenExpirationDate" = NULL
 ;
 
-UPDATE cgr_cinema_details SET password = '';
+UPDATE cgr_cinema_details SET password = 'gAAAAABm2qszKkneEsL_r-9YvryFCFCav-TedCnnHIY3RHizU8ijE6hg-C46JchXd7flfFXTMlpc9ybW_r8oIPGm55y6xK79e8m8zMN2PILTx1vjQQ4foSaCVeUiwsezkP9h9138lj8f'; -- encrypt("PLACEHOLDER-TO-AVOID-DECRYPTION-ERRORS")
 
 UPDATE cds_cinema_details
 SET "cinemaApiToken" = 'anonymized, you may have to set it if you want to use this provider'


### PR DESCRIPTION
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
