### PR TITLE
(PC-31571)[API] fix: improve discord login by moving the main logic in a success page

### DIFF
--- a/api/src/pcapi/routes/auth/templates/discord_retry.html
+++ b/api/src/pcapi/routes/auth/templates/discord_retry.html
@@ -1,0 +1,45 @@
+{% extends "layouts/base.html" %}
+{% block content %}
+    <div class="container pc-login-container">
+        <div class="row">
+            <div class="col-md-8 col-lg-6 offset-lg-2">
+                <div class="card p-5">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <img src="{{ url_for('static', filename='backoffice/icons/passculture.svg') }}"
+                             class="pass-culture-logo"
+                             alt="Logo du pass Culture" />
+                    </div>
+                    <hr class="my-5" />
+                    <h1>Associe ton compte Discord au pass Culture</h1>
+                    <h3 class="text-muted">Pour accéder au serveur Discord du pass Culture</h3>
+                    {% if error %}
+                        <div class="alert alert-danger mt-4" role="alert">{{ error }}: réessaye en cliquant sur le bouton ci-dessous</div>
+                    {% endif %}
+                    <button class="btn btn-primary btn-lg mt-5"
+                            onclick="window.location.href = '{{ url }}'">Rejoindre le Discord pass Culture</button>
+                </div>
+            </div>
+        </div>
+        {# spacer #}
+        <div class="row">
+            <div class="col-12">
+                <div class="mt-5"></div>
+            </div>
+        </div>
+        {# terms of service #}
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <div class="text-center">
+                        En liant ton compte Discord et accédant au serveur Discord du pass Culture, nos services sont susceptibles d'utiliser tes données personnelles notamment à des fins de modération. Pour plus d'informations, tu peux te rendre sur notre
+                        <a href="https://pass.culture.fr/donnees-personnelles/"
+                           class="text-muted">"charte des données personnelles"</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <img src="{{ url_for('static', filename='backoffice/login/background.svg') }}"
+         class="pc-login-background"
+         alt="fond d'écran pass Culture" />
+{% endblock content %}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31571

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

Screen video de succès (réseau lent, mais tout ok):
https://github.com/user-attachments/assets/af29b767-1aa6-4d71-8952-6eca856b43ef

Screen vidéo de comment on gère une erreur (ajout d'un raise à la main dans le code)
https://github.com/user-attachments/assets/02259ad5-4f09-448a-8ce9-12156ca87b9e


