### PR TITLE
(PC-31275)[API] chore: rebuild `ix_stock_idAtProviders` index

### DIFF
--- a/api/src/pcapi/scripts/rebuild_indexes/main.py
+++ b/api/src/pcapi/scripts/rebuild_indexes/main.py
@@ -1,0 +1,19 @@
+from sqlalchemy import text
+
+from pcapi import settings
+from pcapi.app import app
+from pcapi.models import db
+
+
+def rebuild_concurrent_index() -> None:
+    with app.app_context():
+        db.session.execute("SET statement_timeout = 0;")  # disable, as we can't know how much it will take
+        # Below concurrent queries won't run inside a transaction
+        db.session.execute("COMMIT")
+        # https://www.postgresql.org/docs/15/sql-reindex.html
+        db.session.execute(text("""REINDEX INDEX CONCURRENTLY "ix_stock_idAtProviders" """))
+        db.session.execute(f"SET statement_timeout = {settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+if __name__ == "__main__":
+    rebuild_concurrent_index()


### PR DESCRIPTION
## But de la pull request

Rebuild de l'index invalide `ix_stock_idAtProviders` qui avait été ajouté par [cette PR](https://github.com/pass-culture/pass-culture-main/pull/13707). Ce rebuild est nécessaire pour éviter que le retrait de la contrainte d'unicité ([PR](https://github.com/pass-culture/pass-culture-main/pull/13926)) sur `stock.idAtProviders` ne provoquent le timeout des synchronisations provider.

Job:

- Staging ✅ ([job](https://github.com/pass-culture/infrastructure/actions/runs/10736246101/job/29775279338))
- Prod ✅ ([job](https://github.com/pass-culture/infrastructure/actions/runs/10737100671))

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
