### PR TITLE
(PC-31691)[API]fix: modification spécifique aux offres musicales sous conditions

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -134,19 +134,23 @@ def build_new_offer_from_product(
     )
 
 
-def deserialize_extra_data(initial_extra_data: typing.Any) -> typing.Any:
+def deserialize_extra_data(initial_extra_data: typing.Any, subcategoryId: str) -> typing.Any:
     extra_data: dict = initial_extra_data
     if not extra_data:
         return None
-    # FIXME (ghaliela, 2024-02-16): If gtl id is sent in the extra data, musicType and musicSubType are not sent
-    if extra_data.get("gtl_id"):
-        extra_data["musicType"] = str(music_types.MUSIC_TYPES_BY_SLUG[MUSIC_SLUG_BY_GTL_ID[extra_data["gtl_id"]]].code)
-        extra_data["musicSubType"] = str(
-            music_types.MUSIC_SUB_TYPES_BY_SLUG[MUSIC_SLUG_BY_GTL_ID[extra_data["gtl_id"]]].code
-        )
-    # FIXME (ghaliela, 2024-02-16): If musicType is sent in the extra data, gtl id is not sent
-    elif extra_data.get("musicType"):
-        extra_data["gtl_id"] = GTL_IDS_BY_MUSIC_GENRE_CODE[int(extra_data["musicType"])]
+
+    if subcategoryId in subcategories.MUSIC_SUBCATEGORIES:
+        # FIXME (ghaliela, 2024-02-16): If gtl id is sent in the extra data, musicType and musicSubType are not sent
+        if extra_data.get("gtl_id"):
+            extra_data["musicType"] = str(
+                music_types.MUSIC_TYPES_BY_SLUG[MUSIC_SLUG_BY_GTL_ID[extra_data["gtl_id"]]].code
+            )
+            extra_data["musicSubType"] = str(
+                music_types.MUSIC_SUB_TYPES_BY_SLUG[MUSIC_SLUG_BY_GTL_ID[extra_data["gtl_id"]]].code
+            )
+        # FIXME (ghaliela, 2024-02-16): If musicType is sent in the extra data, gtl id is not sent
+        elif extra_data.get("musicType"):
+            extra_data["gtl_id"] = GTL_IDS_BY_MUSIC_GENRE_CODE[int(extra_data["musicType"])]
     return extra_data
 
 
@@ -325,7 +329,7 @@ def update_offer(
     aliases = set(body.dict(by_alias=True))
     fields = body.dict(by_alias=True, exclude_unset=True)
 
-    _extra_data = deserialize_extra_data(fields.get("extraData", offer.extraData))
+    _extra_data = deserialize_extra_data(fields.get("extraData", offer.extraData), offer.subcategoryId)
     fields["extraData"] = _format_extra_data(offer.subcategoryId, _extra_data) or {}
 
     if body.address:

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -313,7 +313,8 @@ def post_offer(body: offers_serialize.PostOfferBodyModel) -> offers_serialize.Ge
             fields = body.dict(by_alias=True)
             fields.pop("venueId")
             fields.pop("address")
-            fields["extraData"] = offers_api.deserialize_extra_data(fields["extraData"])
+            fields["extraData"] = offers_api.deserialize_extra_data(fields["extraData"], fields["subcategoryId"])
+
             offer_body = offers_schemas.CreateOffer(**fields)
             offer = offers_api.create_offer(offer_body, venue, offerer_address, is_from_private_api=True)
     except exceptions.OfferCreationBaseException as error:
@@ -419,7 +420,6 @@ def patch_offer(
     try:
         with repository.transaction():
             updates = body.dict(by_alias=True, exclude_unset=True)
-            updates["extraData"] = offers_api.deserialize_extra_data(updates.get("extraData", offer.extraData))
 
             offer_body = offers_schemas.UpdateOffer(**updates)
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1566,7 +1566,41 @@ class UpdateOfferTest:
             visualDisabilityCompliant=False,
             motorDisabilityCompliant=False,
             mentalDisabilityCompliant=True,
-            extraData={"ean": "1234567890124"},
+        )
+        body = offers_schemas.UpdateOffer(
+            name="Old name",
+            audioDisabilityCompliant=False,
+            visualDisabilityCompliant=True,
+            motorDisabilityCompliant=True,
+            mentalDisabilityCompliant=False,
+        )
+        api.update_offer(offer, body)
+
+        offer = models.Offer.query.one()
+        assert offer.name == "Old name"
+        assert offer.audioDisabilityCompliant is False
+        assert offer.visualDisabilityCompliant is True
+        assert offer.motorDisabilityCompliant is True
+        assert offer.mentalDisabilityCompliant is False
+
+    def test_success_on_imported_offer_with_product_not_music_related_with_gtl_id(self):
+        provider = providers_factories.AllocineProviderFactory()
+        product = factories.ProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            lastProvider=providers_factories.PublicApiProviderFactory(name="BookProvider"),
+            idAtProviders="1234567890123",
+            extraData={"gtl_id": "01020602", "author": "Asimov", "ean": "1234567890123"},
+        )
+        offer = factories.OfferFactory(
+            product=product,
+            lastProvider=provider,
+            name="Old name",
+            audioDisabilityCompliant=True,
+            visualDisabilityCompliant=False,
+            motorDisabilityCompliant=False,
+            mentalDisabilityCompliant=True,
+            extraData={"gtl_id": "01020602", "author": "Asimov", "ean": "1234567890123"},
+            subcategoryId=product.subcategoryId,
         )
         body = offers_schemas.UpdateOffer(
             name="Old name",


### PR DESCRIPTION
Correction d'un bug lors de la mise à jour d'une offre non musical avec gtl_id (pour les offres livres par exemple). Des actions spécifiques aux offres musicales sont faites lors de la mise à jour d'offre sur condition de présence du gtl_id dans les extra_data. Ajout d'une condition pour ne pas faire cette action lorsque l'offre n'est pas concernée. 

## But de la pull request

Ticket Jira: https://passculture.atlassian.net/browse/PC-31691

Fix bug sentry https://sentry.passculture.team/organizations/sentry/issues/1618207/?project=5&referrer=jira_integration

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
