### PR TITLE
(PC-31565)[PRO] fix: Show the bulk edit notification when the offers …

### DIFF
--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveOffersActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveOffersActionsBar.spec.tsx
@@ -208,6 +208,50 @@ describe('ActionsBar', () => {
     expect(screen.getByText('Une erreur est survenue'))
   })
 
+  it('should show an error message when an error occurs after clicking on "Masquer" button when some offers are selected', async () => {
+    vi.spyOn(api, 'patchCollectiveOffersActiveStatus').mockRejectedValueOnce(
+      null
+    )
+    renderActionsBar({
+      ...props,
+      selectedOffers: [
+        collectiveOfferFactory({ id: 1, status: CollectiveOfferStatus.ACTIVE }),
+      ],
+    })
+
+    const inactiveButton = screen.getByText('Masquer')
+    await userEvent.click(inactiveButton)
+
+    const modalInactiveButton = screen.getByTestId(
+      'confirm-dialog-button-confirm'
+    )
+    await userEvent.click(modalInactiveButton)
+
+    expect(screen.getByText('Une erreur est survenue'))
+  })
+
+  it('should show an error message when an error occurs after clicking on "Archiver" button when some offers are selected', async () => {
+    vi.spyOn(api, 'patchCollectiveOffersArchive').mockRejectedValueOnce(null)
+    renderActionsBar({
+      ...props,
+      selectedOffers: [
+        collectiveOfferFactory({ id: 1, status: CollectiveOfferStatus.ACTIVE }),
+      ],
+    })
+
+    const archiveButton = screen.getByText('Archiver')
+    await userEvent.click(archiveButton)
+
+    const modalArchiveButton = screen.getByTestId(
+      'confirm-dialog-button-confirm'
+    )
+    await userEvent.click(modalArchiveButton)
+
+    expect(
+      screen.getByText('Une erreur est survenue lors de l’archivage de l’offre')
+    )
+  })
+
   it('should not deactivate offers on click on "Masquer" when at least one offer is not published or expired', async () => {
     renderActionsBar({
       ...props,


### PR DESCRIPTION
…list is refreshed.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31565

**Objectif**
Dans l'édition des offres collectives via le bulk edit, quand on fait une action (Archiver/Masquer/Publier) synchroniser l'apparition de la notification de succès avec le changement de tag statut et avec le dé-cochage de la case. Pour ça il a fallu revoir un peu la structure des appels.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
