### PR TITLE
(BSR)[PRO] script: Zsh completion script for `pc` script

### DIFF
--- a/scripts/pc-completion.sh
+++ b/scripts/pc-completion.sh
@@ -1,0 +1,39 @@
+# Completion script for the `pc` command
+# To install this script:
+# 1. Add the following line to your `~/.zshrc` file:
+#    source /path/to/pc-completion.sh
+#    (replace `/path/to/pc-completion.sh` with the actual path to your script)
+# 2. Reload your `.zshrc` configuration with (or start a new terminal):
+#    source ~/.zshrc
+#
+
+_pc_completions()
+{
+    local cur prev commands opts
+
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    
+    # List of possible options
+    opts="-h -e -b -f -t"
+    
+    # List of available commands
+    commands="access-db-logs alembic bash diff-schema dump-db install install-hooks logs pgcli psql psql-file psql-test python rebuild-backend reset-all-db reset-db-no-docker reset-db-test-no-docker reset-all-storage restart-backend restart-api-no-docker restore-db restore-db-intact set-git-config setup-no-docker start-backend start-api-no-docker start-backoffice-no-docker start-pro symlink test-backend test-backoffice"
+
+    # Completion for options
+    if [[ ${cur} == -* ]] ; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+
+    # Completion for commands
+    if [[ ${prev} == "pc" ]] ; then
+        COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
+        return 0
+    fi
+
+    return 0
+}
+complete -F _pc_completions pc
+


### PR DESCRIPTION
## But de la pull request

Pour bénéficier de la completion pour le script `pc` dans zsh.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
