### PR TITLE
(PC-30542)[API] feat: using offer timezone instead of venue. Venue tz…

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -299,7 +299,17 @@ def book_offer(
     Return a booking or raise an exception if it's not possible.
     Update a user's credit information on Batch.
     """
-    stock = offers_models.Stock.query.filter_by(id=stock_id).one_or_none()
+    stock = (
+        offers_models.Stock.query.filter_by(id=stock_id)
+        .options(
+            joinedload(Stock.offer)
+            .joinedload(Offer.venue)
+            .joinedload(Venue.offererAddress)
+            .joinedload(OffererAddress.address),
+            joinedload(Stock.offer).joinedload(Offer.offererAddress).joinedload(OffererAddress.address),
+        )
+        .one_or_none()
+    )
     if not stock:
         raise offers_exceptions.StockDoesNotExist()
 

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -169,7 +169,7 @@ class BookOfferTest:
         # 1 - UPDATE dnBookedQuantity
         # 1 - INSERT the new booking
         # 1 - SELECT the user
-        # 7 - SELECT the stock, booking, external_booking, stock, venue, offerer, provider
+        # 5 - SELECT the stock, booking, external_booking, stock, venue, offerer, provider
         # 1 - SELECT venue with bank activation & bank account
         # 1 - SELECT activation code
         # 1 - SELECT criterion
@@ -182,7 +182,7 @@ class BookOfferTest:
         # 1 - SELECT from offer that I don't get
         # 1 - SELECT bookings for the venue ???
         # 1 - SELECT feature
-        with assert_num_queries(36):
+        with assert_num_queries(34):
             booking = api.book_offer(beneficiary=beneficiary, stock_id=stock_id, quantity=1)
 
         # One request should have been sent to Batch to trigger the event


### PR DESCRIPTION
… was kept as fallback option. It should only affect individual offer

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30542

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
