### PR TITLE
(PC-31473)[ADAGE] fix: use new values for rural level

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 8523f3e2d7d6 (pre) (head)
-294d3a0492f7 (post) (head)
+4a4fb0253a9b (post) (head)

--- a/api/src/pcapi/alembic/versions/20240912T082546_4a4fb0253a9b_update_rural_level.py
+++ b/api/src/pcapi/alembic/versions/20240912T082546_4a4fb0253a9b_update_rural_level.py
@@ -1,0 +1,46 @@
+"""Update rural level on EducationalInstitution
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4a4fb0253a9b"
+down_revision = "294d3a0492f7"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+UPDATE educational_institution
+SET "ruralLevel" = CASE 
+    WHEN "ruralLevel" = 'urbain dense' THEN 'Grands centres urbains'
+    WHEN "ruralLevel" = 'urbain densité intermédiaire' THEN 'Centres urbains intermédiaires'
+    WHEN "ruralLevel" = 'rural sous forte influence d''un pôle' THEN 'Petites villes'
+    WHEN "ruralLevel" = 'rural sous faible influence d''un pôle' THEN 'Bourgs ruraux'
+    WHEN "ruralLevel" = 'rural autonome peu dense' THEN 'Rural à habitat dispersé'
+    WHEN "ruralLevel" = 'rural autonome très peu dense' THEN 'Rural à habitat très dispersé'
+    ELSE "ruralLevel"
+END;
+               """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+UPDATE educational_institution
+SET "ruralLevel" = CASE 
+    WHEN "ruralLevel" = 'Grands centres urbains' THEN 'urbain dense'
+    WHEN "ruralLevel" = 'Centres urbains intermédiaires' THEN 'urbain densité intermédiaire'
+    WHEN "ruralLevel" = 'Petites villes' THEN 'rural sous forte influence d''un pôle'
+    WHEN "ruralLevel" = 'Bourgs ruraux' THEN 'rural sous faible influence d''un pôle'
+    WHEN "ruralLevel" = 'Rural à habitat dispersé' THEN 'rural autonome peu dense'
+    WHEN "ruralLevel" = 'Rural à habitat très dispersé' THEN 'rural autonome très peu dense'
+    ELSE "ruralLevel"
+END;
+               """
+    )

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -141,22 +141,24 @@ class CollectiveBookingStatusFilter(enum.Enum):
 
 
 class InstitutionRuralLevel(enum.Enum):
-    URBAIN_DENSITE_INTERMEDIAIRE = "urbain densité intermédiaire"
-    RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE = "rural sous forte influence d'un pôle"
-    URBAIN_DENSE = "urbain dense"
-    RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE = "rural sous faible influence d'un pôle"
-    RURAL_AUTONOME_TRES_PEU_DENSE = "rural autonome très peu dense"
-    RURAL_AUTONOME_PEU_DENSE = "rural autonome peu dense"
+    GRANDS_CENTRES_URBAINS = "Grands centres urbains"  # URBAIN_DENSE
+    CEINTURES_URBAINES = "Ceintures urbaines"  # URBAIN_DENSE
+    CENTRES_URBAINS_INTERMEDIAIRES = "Centres urbains intermédiaires"  # URBAIN_DENSITE_INTERMEDIAIRE
+    PETITES_VILLES = "Petites villes"  # RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE
+    BOURGS_RURAUX = "Bourgs ruraux"  # RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE
+    RURAL_A_HABITAT_DISPERSE = "Rural à habitat dispersé"  # RURAL_AUTONOME_PEU_DENSE
+    RURAL_A_HABITAT_TRES_DISPERSE = "Rural à habitat très dispersé"  # RURAL_AUTONOME_TRES_PEU_DENSE
 
 
 # Mapping from rurality level to distance in km
 PLAYLIST_RURALITY_MAX_DISTANCE_MAPPING = {
-    InstitutionRuralLevel.URBAIN_DENSE: 3,
-    InstitutionRuralLevel.URBAIN_DENSITE_INTERMEDIAIRE: 10,
-    InstitutionRuralLevel.RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE: 15,
-    InstitutionRuralLevel.RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE: 60,
-    InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE: 60,
-    InstitutionRuralLevel.RURAL_AUTONOME_TRES_PEU_DENSE: 60,
+    InstitutionRuralLevel.GRANDS_CENTRES_URBAINS: 3,
+    InstitutionRuralLevel.CEINTURES_URBAINES: 3,
+    InstitutionRuralLevel.CENTRES_URBAINS_INTERMEDIAIRES: 10,
+    InstitutionRuralLevel.PETITES_VILLES: 15,
+    InstitutionRuralLevel.BOURGS_RURAUX: 60,
+    InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE: 60,
+    InstitutionRuralLevel.RURAL_A_HABITAT_TRES_DISPERSE: 60,
 }
 
 

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -629,10 +629,10 @@ class SynchroniseRuralityLevelTest:
     def test_should_update_rurality_level(self):
         et1 = educational_factories.EducationalInstitutionFactory(ruralLevel=None)
         et2 = educational_factories.EducationalInstitutionFactory(
-            ruralLevel=educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE
+            ruralLevel=educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE
         )
         et3 = educational_factories.EducationalInstitutionFactory(
-            ruralLevel=educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE
+            ruralLevel=educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE
         )
 
         mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
@@ -640,15 +640,15 @@ class SynchroniseRuralityLevelTest:
             mock_run_query.return_value = [
                 {
                     "institution_id": str(et1.id),
-                    "institution_rural_level": educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE.value,
+                    "institution_rural_level": educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE.value,
                 },
                 {
                     "institution_id": str(et2.id),
-                    "institution_rural_level": educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE.value,
+                    "institution_rural_level": educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE.value,
                 },
                 {
                     "institution_id": str(et3.id),
-                    "institution_rural_level": educational_models.InstitutionRuralLevel.URBAIN_DENSE.value,
+                    "institution_rural_level": educational_models.InstitutionRuralLevel.GRANDS_CENTRES_URBAINS.value,
                 },
             ]
             institution_api.synchronise_rurality_level()
@@ -657,6 +657,6 @@ class SynchroniseRuralityLevelTest:
             educational_models.EducationalInstitution.id
         ).all()
         assert [i.id for i in institutions] == [et1.id, et2.id, et3.id]
-        assert institutions[0].ruralLevel == educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE
-        assert institutions[1].ruralLevel == educational_models.InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE
-        assert institutions[2].ruralLevel == educational_models.InstitutionRuralLevel.URBAIN_DENSE
+        assert institutions[0].ruralLevel == educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE
+        assert institutions[1].ruralLevel == educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE
+        assert institutions[2].ruralLevel == educational_models.InstitutionRuralLevel.GRANDS_CENTRES_URBAINS

--- a/api/tests/routes/adage_iframe/get_authenticate_test.py
+++ b/api/tests/routes/adage_iframe/get_authenticate_test.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 
 DEFAULT_UAI = "EAU123"
-DEFAULT_RURAL_LEVEL = models.InstitutionRuralLevel.URBAIN_DENSE
+DEFAULT_RURAL_LEVEL = models.InstitutionRuralLevel.GRANDS_CENTRES_URBAINS
 
 
 @pytest.fixture(name="valid_user", scope="module")

--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -224,7 +224,7 @@ class SharedOfferersPlaylistTests:
         IMAGE_URL = "http://localhost/image.png"
 
         institution = educational_factories.EducationalInstitutionFactory(
-            ruralLevel=educational_models.InstitutionRuralLevel.URBAIN_DENSE
+            ruralLevel=educational_models.InstitutionRuralLevel.GRANDS_CENTRES_URBAINS
         )
 
         expected_distance = 2.5
@@ -271,7 +271,7 @@ class SharedOfferersPlaylistTests:
         offerers_factories.VenueFactory()
 
         institution = educational_factories.EducationalInstitutionFactory(
-            ruralLevel=educational_models.InstitutionRuralLevel.URBAIN_DENSE
+            ruralLevel=educational_models.InstitutionRuralLevel.GRANDS_CENTRES_URBAINS
         )
 
         expected_distance = 2.5
@@ -333,7 +333,7 @@ class SharedOfferersPlaylistTests:
         offerers_factories.VenueFactory()
 
         institution = educational_factories.EducationalInstitutionFactory(
-            ruralLevel=educational_models.InstitutionRuralLevel.URBAIN_DENSE
+            ruralLevel=educational_models.InstitutionRuralLevel.GRANDS_CENTRES_URBAINS
         )
 
         for venue in playlist_venues:

--- a/pro/src/apiClient/adage/models/InstitutionRuralLevel.ts
+++ b/pro/src/apiClient/adage/models/InstitutionRuralLevel.ts
@@ -6,10 +6,11 @@
  * An enumeration.
  */
 export enum InstitutionRuralLevel {
-  URBAIN_DENSIT_INTERM_DIAIRE = 'urbain densité intermédiaire',
-  RURAL_SOUS_FORTE_INFLUENCE_D_UN_P_LE = 'rural sous forte influence d\'un pôle',
-  URBAIN_DENSE = 'urbain dense',
-  RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_P_LE = 'rural sous faible influence d\'un pôle',
-  RURAL_AUTONOME_TR_S_PEU_DENSE = 'rural autonome très peu dense',
-  RURAL_AUTONOME_PEU_DENSE = 'rural autonome peu dense',
+  GRANDS_CENTRES_URBAINS = 'Grands centres urbains',
+  CEINTURES_URBAINES = 'Ceintures urbaines',
+  CENTRES_URBAINS_INTERM_DIAIRES = 'Centres urbains intermédiaires',
+  PETITES_VILLES = 'Petites villes',
+  BOURGS_RURAUX = 'Bourgs ruraux',
+  RURAL_HABITAT_DISPERS_ = 'Rural à habitat dispersé',
+  RURAL_HABITAT_TR_S_DISPERS_ = 'Rural à habitat très dispersé',
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31473

Le but de cette PR est de fixer la commande CRON -> `synchronise-rurality-level` 

Pour plus de contexte voir:
* https://passcultureteam.slack.com/archives/C01DXAW6YFJ/p1722253684823239
* https://passcultureteam.slack.com/archives/CQAMXPQSZ/p1722257245484799

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
