### PR TITLE
(PC-31733)[API] fix: patch draft offer must not fail with ean without FF

### DIFF
--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -7,6 +7,7 @@ from pydantic.v1 import validator
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import schemas as offerers_schemas
 from pcapi.core.offers import models as offers_models
+from pcapi.models import feature
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
@@ -46,7 +47,8 @@ class PatchDraftOfferBodyModel(BaseModel):
 
     @validator("extra_data", pre=True)
     def validate_extra_data(cls, extra_data: dict[str, typing.Any]) -> dict[str, typing.Any]:
-        check_offer_product_update(extra_data)
+        if feature.FeatureToggle.WIP_EAN_CREATION.is_active():
+            check_offer_product_update(extra_data)
         return extra_data
 
     class Config:


### PR DESCRIPTION
## But de la pull request

Sans le FF `WIP_EAN_CREATION`, il doit être possible d'éditer l'EAN d'une offre

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31733

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
