### PR TITLE
(PC-31734)[PRO] fix: only add aria-controls=suggested-subcat when component exists in dom

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
@@ -179,6 +179,8 @@ export const DetailsForm = ({
 
   const showAddVenueBanner =
     !areSuggestedSubcategoriesUsed && venueOptions.length === 0
+  const isSuggestedSubcategoryDisplayed =
+    areSuggestedSubcategoriesUsed && !offer
 
   return (
     <>
@@ -216,7 +218,9 @@ export const DetailsForm = ({
                     readOnlyFields.includes('venueId') ||
                     venueOptions.length === 1
                   }
-                  aria-controls="suggested-subcategories"
+                  {...(isSuggestedSubcategoryDisplayed && {
+                    'aria-controls': 'suggested-subcategories',
+                  })}
                 />
               </FormLayout.Row>
             )}
@@ -228,7 +232,9 @@ export const DetailsForm = ({
                 name="name"
                 onChange={onChangeGetSuggestedSubcategories}
                 disabled={readOnlyFields.includes('name')}
-                aria-controls="suggested-subcategories"
+                {...(isSuggestedSubcategoryDisplayed && {
+                  'aria-controls': 'suggested-subcategories',
+                })}
               />
             </FormLayout.Row>
             <FormLayout.Row>
@@ -239,13 +245,15 @@ export const DetailsForm = ({
                 name="description"
                 onChange={onChangeGetSuggestedSubcategories}
                 disabled={readOnlyFields.includes('description')}
-                aria-controls="suggested-subcategories"
+                {...(isSuggestedSubcategoryDisplayed && {
+                  'aria-controls': 'suggested-subcategories',
+                })}
               />
             </FormLayout.Row>
           </>
         )}
       </FormLayout.Section>
-      {areSuggestedSubcategoriesUsed && !offer ? (
+      {isSuggestedSubcategoryDisplayed ? (
         <SuggestedSubcategories
           hasApiBeenCalled={hasSuggestionsApiBeenCalled}
           suggestedSubcategories={suggestedSubcategories}

--- a/pro/src/ui-kit/form/TextArea/TextArea.tsx
+++ b/pro/src/ui-kit/form/TextArea/TextArea.tsx
@@ -78,6 +78,7 @@ export const TextArea = ({
         maxLength={maxLength}
         placeholder={placeholder}
         aria-required={!isOptional}
+        aria-controls={props['aria-controls']}
         ref={textAreaRef}
         {...field}
         onChange={(event) => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31734

## Objectifs : 

- Les inputs “Lieu” + “Titre” + “Description” doivent avoir un aria-controls uniquement si le composant est présent dans le dom. Autrement on a l’erreur suivante : https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value?application=AxeChrome
- “aria-controls” n’était de toute façon pas bien passé dans le textarea “Description”.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
