### PR TITLE
(PC-31735)[PRO] feat: display api errors in DetailsForm

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsScreen.tsx
@@ -143,6 +143,9 @@ export const DetailsScreen = ({ venues }: DetailsScreenProps): JSX.Element => {
       if (!isErrorAPIError(error)) {
         return
       }
+      for (const field in error.body) {
+        formik.setFieldError(field, error.body[field])
+      }
       // This is used from scroll to error
       formik.setStatus('apiError')
     }

--- a/pro/src/screens/IndividualOffer/DetailsScreen/__specs__/DetailsScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/__specs__/DetailsScreen.spec.tsx
@@ -269,6 +269,65 @@ describe('screens:IndividualOffer::Informations', () => {
     ).toBeInTheDocument()
   })
 
+  it('should display error from api on fields', async () => {
+    vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
+      logEvent: mockLogEvent,
+    }))
+    vi.spyOn(api, 'postDraftOffer').mockRejectedValue({
+      message: 'oups',
+      name: 'ApiError',
+      body: { ean: 'broken ean from api' },
+    })
+    vi.spyOn(api, 'getMusicTypes').mockResolvedValue([
+      { canBeEvent: true, label: 'Pop', gtl_id: 'pop' },
+    ])
+    props.venues = [
+      venueListItemFactory({ id: 189 }),
+      venueListItemFactory({ id: 190 }),
+    ]
+
+    renderDetailsScreen(props, contextValue)
+
+    await userEvent.type(
+      screen.getByLabelText(/Titre de l’offre/),
+      'My super offer'
+    )
+    await userEvent.type(
+      screen.getByLabelText(/Description/),
+      'My super description'
+    )
+
+    await userEvent.selectOptions(await screen.findByLabelText(/Lieu/), '189')
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText('Catégorie *'),
+      'A'
+    )
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText('Sous-catégorie *'),
+      'physical'
+    )
+
+    await userEvent.type(screen.getByLabelText(/EAN/), '1234567891234')
+    await userEvent.selectOptions(
+      await screen.findByLabelText(/Type de spectacle/),
+      'Cirque'
+    )
+    await userEvent.selectOptions(
+      await screen.findByLabelText(/Sous-type/),
+      'Clown'
+    )
+    await userEvent.selectOptions(
+      await screen.findByLabelText(/Genre musical/),
+      'Pop'
+    )
+
+    await userEvent.click(screen.getByText(DEFAULTS.submitButtonLabel))
+
+    expect(screen.getByText('broken ean from api')).toBeInTheDocument()
+  })
+
   it('should submit the form with correct payload', async () => {
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
       logEvent: mockLogEvent,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31735

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
