### PR TITLE
(PC-31738)[API] chore: delete unused enums

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 8523f3e2d7d6 (pre) (head)
-d0a81150dd8d (post) (head)
+294d3a0492f7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20240909T130532_294d3a0492f7_delete_unused_enums.py
+++ b/api/src/pcapi/alembic/versions/20240909T130532_294d3a0492f7_delete_unused_enums.py
@@ -1,0 +1,118 @@
+"""Delete unused enums : eventtype, featuretoggle, studentlevels, thingtype"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "294d3a0492f7"
+down_revision = "d0a81150dd8d"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TYPE IF EXISTS eventtype;")
+    op.execute("DROP TYPE IF EXISTS featuretoggle;")
+    op.execute("DROP TYPE IF EXISTS thingtype;")
+
+
+def downgrade() -> None:
+    # Theses commands has been copied from schema_init.sql
+    op.execute(
+        """
+        CREATE TYPE public.eventtype AS ENUM (
+            'Workshop',
+            'MovieScreening',
+            'Meeting',
+            'Game',
+            'SchoolHelp',
+            'StreetPerformance',
+            'Other',
+            'BookReading',
+            'CircusAndMagic',
+            'DancePerformance',
+            'Comedy',
+            'Concert',
+            'Combo',
+            'Youth',
+            'Musical',
+            'Theater',
+            'GuidedVisit',
+            'FreeVisit'
+        );"""
+    )
+    op.execute(
+        """
+        CREATE TYPE public.featuretoggle AS ENUM (
+            'SEARCH_ALGOLIA',
+            'SYNCHRONIZE_ALGOLIA',
+            'SYNCHRONIZE_ALLOCINE',
+            'SYNCHRONIZE_TITELIVE_PRODUCTS',
+            'SYNCHRONIZE_TITELIVE_PRODUCTS_DESCRIPTION',
+            'SYNCHRONIZE_TITELIVE_PRODUCTS_THUMBS',
+            'UPDATE_BOOKING_USED',
+            'BOOKINGS_V2',
+            'API_SIRENE_AVAILABLE'
+        );"""
+    )
+    op.execute(
+        """
+        CREATE TYPE public.thingtype as ENUM (
+            'Article',
+            'AudioObject',
+            'Blog',
+            'Book',
+            'BookSeries',
+            'BroadcastService',
+            'BusTrip',
+            'CableOrSatelliteService',
+            'Clip',
+            'Course',
+            'CreativeWorkSeason',
+            'CreativeWorkSeries',
+            'DataDownload',
+            'Episode',
+            'FoodService',
+            'Game',
+            'ImageObject',
+            'Map',
+            'MediaObject',
+            'Movie',
+            'MovieClip',
+            'MovieSeries',
+            'MusicAlbum',
+            'MusicComposition',
+            'MusicRecording',
+            'MusicVideoObject',
+            'NewsArticle',
+            'Painting',
+            'PaymentCard',
+            'Periodical',
+            'Photograph',
+            'Product',
+            'ProgramMembership',
+            'PublicationIssue',
+            'PublicationVolume',
+            'RadioClip',
+            'RadioEpisode',
+            'RadioSeason',
+            'RadioSeries',
+            'Report',
+            'ScholarlyArticle',
+            'Sculpture',
+            'Service',
+            'TaxiService',
+            'TechArticle',
+            'Ticket',
+            'TVClip',
+            'TVEpisode',
+            'TVSeason',
+            'TVSeries',
+            'VideoGame',
+            'VideoGameClip',
+            'VideoGameSeries',
+            'VideoObject',
+            'VisualArtwork'
+        );"""
+    )


### PR DESCRIPTION
## But de la pull request
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31738
Delete unused postgresql types. 
To find unused types : 
```
WITH enums AS (
     SELECT n.nspname AS schema_name,
            t.typname AS enum_name,
            t.typarray AS array_type_oid
     FROM pg_type t
     JOIN pg_enum e ON t.oid = e.enumtypid
     JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
     GROUP BY schema_name, enum_name, array_type_oid
 )

 SELECT e.schema_name,
        e.enum_name
 FROM enums e
 WHERE NOT EXISTS (
     SELECT 1
     FROM information_schema.columns c
     WHERE c.udt_name = e.enum_name //check if type is used
        OR c.udt_name = ( // Check if array of type is used
            SELECT typname 
            FROM pg_type 
            WHERE oid = e.array_type_oid
        )
 )
 ORDER BY e.schema_name, e.enum_name;
```

```
+-------------+---------------+
| schema_name | enum_name     |
|-------------+---------------|
| public      | eventtype     |
| public      | featuretoggle |
| public      | thingtype     |
+-------------+---------------+
```
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
