### PR TITLE
Pc 31601 template offer date midnight

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferDateSection.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { GetCollectiveOfferTemplateResponseModel } from 'apiClient/v1'
 import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
 import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
@@ -18,7 +16,12 @@ export const CollectiveOfferDateSection = ({
     const startDateWithoutTz = toDateStrippedOfTimezone(offer.dates.start)
     const endDateWithoutTz = toDateStrippedOfTimezone(offer.dates.end)
 
-    description = getRangeToFrenchText(startDateWithoutTz, endDateWithoutTz)
+    description = getRangeToFrenchText(
+      startDateWithoutTz,
+      endDateWithoutTz,
+      startDateWithoutTz.getHours() !== 0 ||
+        startDateWithoutTz.getMinutes() !== 0
+    )
   }
 
   return (

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferDates.ts
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/utils/adageOfferDates.ts
@@ -15,14 +15,16 @@ export function getFormattedDatesForTemplateOffer(
 ) {
   // Template offer start & end dates timezone is to be ignored. A date entered in pro UI as "2024-01-25" at "15:15"
   //  is saved as "2024-01-25T15:15:00Z" and thus should be displayed as "Le 25 janvier 2024 à 15h15"
-  return (
-    (offer.dates?.start &&
-      offer.dates.end &&
-      getRangeToFrenchText(
-        toDateStrippedOfTimezone(offer.dates.start),
-        toDateStrippedOfTimezone(offer.dates.end)
-      )) ||
-    noDatesWording
+
+  if (!offer.dates?.start || !offer.dates.end) {
+    return noDatesWording
+  }
+  const start = toDateStrippedOfTimezone(offer.dates.start)
+  const end = toDateStrippedOfTimezone(offer.dates.end)
+  return getRangeToFrenchText(
+    start,
+    end,
+    start.getHours() !== 0 || start.getMinutes() !== 0
   )
 }
 
@@ -50,6 +52,7 @@ export function getFormattedDatesForBookableOffer(
     getLocalDepartementDateTimeFromUtc(
       offer.stock.endDatetime,
       offer.venue.departmentCode
-    )
+    ),
+    true
   )
 }

--- a/pro/src/pages/Offers/OffersTable/Cells/OfferEventDateCell/__specs__/OfferEventDateCell.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/OfferEventDateCell/__specs__/OfferEventDateCell.spec.tsx
@@ -38,7 +38,7 @@ describe('OfferNameCell', () => {
     })
 
     expect(screen.getByText('04/08/2024')).toBeInTheDocument()
-    expect(screen.getByText('13h00')).toBeInTheDocument()
+    expect(screen.getByText('15h00')).toBeInTheDocument()
   })
 
   it('should display both date and time when dates are not the same', () => {
@@ -46,8 +46,8 @@ describe('OfferNameCell', () => {
       isShowcase: false,
       name: 'Offre nom',
       dates: {
-        start: '2024-08-04T13:00:00Z',
-        end: '2024-09-04T13:00:00Z',
+        start: '2024-08-04T23:00:00Z',
+        end: '2024-09-05T23:00:00Z',
       },
     })
 
@@ -55,12 +55,12 @@ describe('OfferNameCell', () => {
       offer: eventOffer,
     })
 
-    expect(screen.getByText('du 04/08/2024')).toBeInTheDocument()
-    expect(screen.getByText('au 04/09/2024')).toBeInTheDocument()
-    expect(screen.getByText('13h00')).toBeInTheDocument()
+    expect(screen.getByText('du 05/08/2024')).toBeInTheDocument()
+    expect(screen.getByText('au 06/09/2024')).toBeInTheDocument()
+    expect(screen.getByText('01h00')).toBeInTheDocument()
   })
 
-  it('must display "Toute l’année scolaire" if dates are not defined', () => {
+  it('should display "Toute l’année scolaire" if dates are not defined', () => {
     const eventOffer = collectiveOfferFactory({
       isShowcase: true,
       name: 'Offre nom',
@@ -72,5 +72,58 @@ describe('OfferNameCell', () => {
     })
 
     expect(screen.getByText('Toute l’année scolaire')).toBeInTheDocument()
+  })
+
+  it('should not display the time for a template offer starting at midnight UTC', () => {
+    const eventOffer = collectiveOfferFactory({
+      isShowcase: true,
+      name: 'Offre nom',
+      dates: {
+        start: '2024-08-04T00:00:00Z',
+        end: '2024-09-04T00:00:00Z',
+      },
+    })
+
+    renderOfferNameCell({
+      offer: eventOffer,
+    })
+
+    expect(screen.getByText('du 04/08/2024')).toBeInTheDocument()
+    expect(screen.getByText('au 04/09/2024')).toBeInTheDocument()
+    expect(screen.queryByText('00h00')).not.toBeInTheDocument()
+  })
+
+  it('should display 1 date and time when dates are the same for a template offer', () => {
+    const eventOffer = collectiveOfferFactory({
+      isShowcase: true,
+      dates: {
+        start: '2024-08-04T23:00:00Z',
+        end: '2024-08-04T23:00:00Z',
+      },
+    })
+
+    renderOfferNameCell({
+      offer: eventOffer,
+    })
+
+    expect(screen.getByText('04/08/2024')).toBeInTheDocument()
+    expect(screen.getByText('23h00')).toBeInTheDocument()
+  })
+
+  it('should display 1 date and time when dates are the same for a template offer', () => {
+    const eventOffer = collectiveOfferFactory({
+      isShowcase: true,
+      dates: {
+        start: '2024-09-04T13:00:00Z',
+        end: '2024-09-04T13:00:00Z',
+      },
+    })
+
+    renderOfferNameCell({
+      offer: eventOffer,
+    })
+
+    expect(screen.getByText('04/09/2024')).toBeInTheDocument()
+    expect(screen.getByText('13h00')).toBeInTheDocument()
   })
 })

--- a/pro/src/utils/__specs__/date.spec.ts
+++ b/pro/src/utils/__specs__/date.spec.ts
@@ -65,7 +65,7 @@ describe('getRangeToFrenchText', () => {
     const from = new Date('2020-11-17T08:15:00Z')
     const to = new Date('2020-11-17T23:59:00Z')
 
-    const formattedRange = getRangeToFrenchText(from, to)
+    const formattedRange = getRangeToFrenchText(from, to, true)
 
     expect(formattedRange).toBe('Le mardi 17 novembre 2020 à 08h15')
   })
@@ -74,7 +74,7 @@ describe('getRangeToFrenchText', () => {
     const from = new Date('2020-11-17T08:15:00Z')
     const to = new Date('2020-12-10T23:59:00Z')
 
-    const formattedRange = getRangeToFrenchText(from, to)
+    const formattedRange = getRangeToFrenchText(from, to, true)
 
     expect(formattedRange).toBe('Du 17 novembre au 10 décembre 2020 à 08h15')
   })
@@ -83,7 +83,7 @@ describe('getRangeToFrenchText', () => {
     const from = new Date('2020-11-17T08:15:00Z')
     const to = new Date('2021-01-10T23:59:00Z')
 
-    const formattedRange = getRangeToFrenchText(from, to)
+    const formattedRange = getRangeToFrenchText(from, to, true)
 
     expect(formattedRange).toBe(
       'Du 17 novembre 2020 au 10 janvier 2021 à 08h15'
@@ -94,32 +94,45 @@ describe('getRangeToFrenchText', () => {
     const from = new Date('2020-11-17T00:00:00Z')
     const to = new Date('2021-01-10T23:59:00Z')
 
-    const formattedRange = getRangeToFrenchText(from, to)
+    const formattedRange = getRangeToFrenchText(from, to, true)
 
-    expect(formattedRange).toBe('Du 17 novembre 2020 au 10 janvier 2021')
+    expect(formattedRange).toBe('Du 17 novembre 2020 au 10 janvier 2021 à 00h')
   })
 
   it('should not display the time minutes when the starting date minutes are 00', () => {
     const from = new Date('2020-11-17T08:00:00Z')
     const to = new Date('2021-01-10T23:59:00Z')
 
-    const formattedRange = getRangeToFrenchText(from, to)
+    const formattedRange = getRangeToFrenchText(from, to, true)
 
     expect(formattedRange).toBe('Du 17 novembre 2020 au 10 janvier 2021 à 08h')
   })
 
+  it('should not display the time', () => {
+    const from = new Date('2020-11-17T08:00:00Z')
+    const to = new Date('2021-01-10T23:59:00Z')
+
+    const formattedRange = getRangeToFrenchText(from, to, false)
+
+    expect(formattedRange).toBe('Du 17 novembre 2020 au 10 janvier 2021')
+  })
+})
+
+describe('formatShortDateForInput', () => {
   it('should format a date with the right format for a HTML input', () => {
     const date = new Date('2020-11-17T08:00:00Z')
 
     expect(formatShortDateForInput(date)).toBe('2020-11-17')
   })
-
+})
+describe('formatTimeForInput', () => {
   it('should format a time with the right format for a HTML input', () => {
     const date = new Date('2020-11-17T23:10:00Z')
 
     expect(formatTimeForInput(date)).toBe('23:10')
   })
-
+})
+describe('getDateToFrenchText', () => {
   it('should not return a date when transforming an invalid date into French text', () => {
     expect(getDateToFrenchText('0024-01-15T23:59:59+00:09:21')).toEqual(null)
   })

--- a/pro/src/utils/date.ts
+++ b/pro/src/utils/date.ts
@@ -71,14 +71,15 @@ export function getDateTimeToFrenchText(
   return Intl.DateTimeFormat('fr-FR', options).format(date)
 }
 
-export function getRangeToFrenchText(from: Date, to: Date): string {
+export function getRangeToFrenchText(
+  from: Date,
+  to: Date,
+  shouldDisplayTime: boolean
+): string {
   //  The time displayed will be the one taken from the first date
-
   const isSameYear = from.getFullYear() === to.getFullYear()
   const isSameMonth = isSameYear && from.getMonth() === to.getMonth()
   const isSameDay = isSameYear && isSameMonth && from.getDate() === to.getDate()
-
-  const shouldDisplayTime = from.getHours() !== 0 || from.getMinutes() !== 0
 
   const timeToFrenchText = getDateTimeToFrenchText(from, {
     hour: '2-digit',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31601

**Objectif**
Corriger l'affichage de la date dans la colonne "date de l'évènement" de la table des offres collectives.
Il y a 2 problèmes :
- Jusqu'à maintenant on affiche l'heure de l'événement et la/les dates en faisant `new Date(startDate)` qui crée un formattage de date en UTC alors que les dates des offres réservables doivent être affichées dans la timezone de la venue.
- On a la possibilité de créer une offre vitrine avec des dates de début et de fin mais sans heure précise. Auquel cas, l'api enregistre la date à minuit. Et on n'a pas d'autre indication sur l'existence d'une heure de début pour l'offre. Donc on doit vérifier si c'est pas minuit UTC pour afficher ou non l'heure.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
