### PR TITLE
(PC-31345)[API] feat: add new endpoint in public API to check EANs availability for bulk upsert

### DIFF
--- a/api/documentation/src/pages/change-logs.md
+++ b/api/documentation/src/pages/change-logs.md
@@ -15,9 +15,13 @@ title: Pass Culture API change logs
 
 ## September 2024
 
+### `idAtProvider` in price category
 - You can now specify your own id when you [**create price categories**](/rest-api#tag/Event-offer-prices/operation/PostEventPriceCategories) or when you [**update a price category**](/rest-api#tag/Event-offer-prices/operation/PatchEventPriceCategory)
 - You can now access your event price categories using [**this endpoint**](/rest-api#tag/Event-offer-prices/operation/GetEventPriceCategories) and filter them using the `idsAtProvider` parameter
 - Your price category id is now sent in [**our ticket request message**](/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system#-our-request-payload)
+
+### EANs availability check
+- You can now check if your EANs are available for bulk upsert using [**this endpoint**](/rest-api#tag/Product-offer-bulk-operations/operation/CheckEansAvailability)
 
 ## July 2024
 

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -157,6 +157,25 @@ class _FIELDS:
         description="European Article Number (EAN-13)",
         example="3700551782888",
     )
+    EANS_AVAILABLE = Field(
+        description="List of EANs that are available for upsert",
+        example=["3700551782888", "9782895761792"],
+    )
+    EANS_REJECTED = Field(
+        description="List of EANs that are not available for upsert, sorted by their rejection reasons",
+    )
+    EANS_REJECTED_BECAUSE_NOT_FOUND = Field(
+        description="List of EANS not present in our database",
+        example=["3700551782888", "9782895761792"],
+    )
+    EANS_REJECTED_BECAUSE_NOT_COMPLIANT = Field(
+        description="List of EANS that do not comply with our CGU (General Terms and Conditions)",
+        example=["3700551782888", "9782895761792"],
+    )
+    EANS_REJECTED_BECAUSE_CATEGORY_NOT_ALLOWED = Field(
+        description="List of EANS that do not belong to an allowed category (only paper books, CDs, and vinyl records are permitted)",
+        example=["3700551782888", "9782895761792"],
+    )
 
     # Event fields
     PRICE_CATEGORY_ID = Field(description="Price category id", example=12)

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -865,6 +865,37 @@
                 "title": "AccessibilityResponse",
                 "type": "object"
             },
+            "AvailableEANsResponse": {
+                "properties": {
+                    "available": {
+                        "description": "List of EANs that are available for upsert",
+                        "example": [
+                            "3700551782888",
+                            "9782895761792"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Available",
+                        "type": "array"
+                    },
+                    "rejected": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RejectedEANsPartialResponse"
+                            }
+                        ],
+                        "description": "List of EANs that are not available for upsert, sorted by their rejection reasons",
+                        "title": "Rejected"
+                    }
+                },
+                "required": [
+                    "available",
+                    "rejected"
+                ],
+                "title": "AvailableEANsResponse",
+                "type": "object"
+            },
             "BON_ACHAT_INSTRUMENT_read": {
                 "description": "Bon d'achat instrument",
                 "properties": {
@@ -3502,6 +3533,21 @@
                     "category"
                 ],
                 "title": "FESTIVAL_SPECTACLE_read",
+                "type": "object"
+            },
+            "GetAvailableEANsListQuery": {
+                "properties": {
+                    "eans": {
+                        "description": "EANs list (max 100)",
+                        "example": "3700551782888,9782895761792",
+                        "title": "Eans",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "eans"
+                ],
+                "title": "GetAvailableEANsListQuery",
                 "type": "object"
             },
             "GetBookingResponse": {
@@ -7324,6 +7370,53 @@
                 "title": "RENCONTRE_read",
                 "type": "object"
             },
+            "RejectedEANsPartialResponse": {
+                "properties": {
+                    "notCompliantWithCgu": {
+                        "description": "List of EANS that do not comply with our CGU (General Terms and Conditions)",
+                        "example": [
+                            "3700551782888",
+                            "9782895761792"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Notcompliantwithcgu",
+                        "type": "array"
+                    },
+                    "notFound": {
+                        "description": "List of EANS not present in our database",
+                        "example": [
+                            "3700551782888",
+                            "9782895761792"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Notfound",
+                        "type": "array"
+                    },
+                    "subcategoryNotAllowed": {
+                        "description": "List of EANS that do not belong to an allowed category (only paper books, CDs, and vinyl records are permitted)",
+                        "example": [
+                            "3700551782888",
+                            "9782895761792"
+                        ],
+                        "items": {
+                            "type": "string"
+                        },
+                        "title": "Subcategorynotallowed",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "notFound",
+                    "subcategoryNotAllowed",
+                    "notCompliantWithCgu"
+                ],
+                "title": "RejectedEANsPartialResponse",
+                "type": "object"
+            },
             "SALON_create": {
                 "description": "Salon, Convention",
                 "properties": {
@@ -10571,7 +10664,7 @@
                 ]
             },
             "post": {
-                "description": "This endpoint allows for the batch upsert (update or insert) of product offers and their corresponding stock levels using the **European Article Number (EAN-13)**. It performs the following operations:\n\n1. **Create Offers:** If a venue does not have an existing offer for a product identified by its EAN, the endpoint creates a new offer.\n\n2. **Update Offer Stocks:** It updates the stock levels for the product offers. If the stock quantity is set to `0`, the product offer stock is deleted.\n\nThe upsert process is **asynchronous**, meaning the operation may take some time to complete. The success response from this endpoint indicates only that the upsert job has been successfully added to the queue.",
+                "description": "This endpoint allows for the batch upsert (update or insert) of product offers and their corresponding stock levels using the **European Article Number (EAN-13)**. It performs the following operations:\n\n1. **Create Offers:** If a venue does not have an existing offer for a product identified by its EAN, the endpoint creates a new offer.\n\n2. **Update Offer Stocks:** It updates the stock levels for the product offers. If the stock quantity is set to `0`, the product offer stock is deleted.\n\nThe upsert process is **asynchronous**, meaning the operation may take some time to complete. The success response from this endpoint indicates only that the upsert job has been successfully added to the queue.\n\n**WARNING:** As it is an asynchronous you won't be given any feedback if one or more EANs is rejected. To make sure that your EANs won't be rejected please use [**this endpoint**](/rest-api#tag/Product-offer-bulk-operations/operation/CheckEansAvailability)",
                 "operationId": "PostProductOfferByEan",
                 "parameters": [],
                 "requestBody": {
@@ -10616,6 +10709,63 @@
                     }
                 ],
                 "summary": "Batch Upsert Product Offers by EAN",
+                "tags": [
+                    "Product offer bulk operations"
+                ]
+            }
+        },
+        "/public/offers/v1/products/ean/check_availability": {
+            "get": {
+                "description": "This endpoint checks the availability of a list of EANs (European Article Numbers) for a bulk upsert operation. The response contains the EANs categorized by their availability status.\n\n**Response Structure**\n\n- `available`: A list of EANs that are available for upsert.\n\n- `rejected`: A list of EANs that are not available for upsert, sorted by their rejection reasons.\n\n**Rejection Reasons**\n\nAn EAN can be rejected for the following reasons:\n\n- `notFound`: The EAN is not present in our database.\n\n- `subcategoryNotAllowed`: The product identified by the EAN does not belong to an allowed category (only paper books, CDs, and vinyl records are permitted).\n\n- `notCompliantWithCgu`: The product identified by the EAN does not comply with our CGU (General Terms and Conditions).",
+                "operationId": "CheckEansAvailability",
+                "parameters": [
+                    {
+                        "description": "EANs list (max 100)",
+                        "in": "query",
+                        "name": "eans",
+                        "required": true,
+                        "schema": {
+                            "description": "EANs list (max 100)",
+                            "example": "3700551782888,9782895761792",
+                            "title": "Eans",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AvailableEANsResponse"
+                                }
+                            }
+                        },
+                        "description": "EANs by availability"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Check EAN Availability for Bulk Upsert",
                 "tags": [
                     "Product offer bulk operations"
                 ]

--- a/api/tests/routes/public/individual_offers/v1/get_eans_availability_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_eans_availability_test.py
@@ -1,0 +1,143 @@
+import pytest
+
+from pcapi.core import testing
+from pcapi.core.categories import subcategories_v2 as subcategories
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers import models as offers_models
+
+from tests.conftest import TestClient
+from tests.routes.public.helpers import PublicAPIEndpointBaseHelper
+
+
+@pytest.mark.usefixtures("db_session")
+class GetEANsAvailabilityTest(PublicAPIEndpointBaseHelper):
+    endpoint_url = "/public/offers/v1/products/ean/check_availability"
+    endpoint_method = "get"
+
+    expected_num_queries_success = 1  # 1. Select API key
+    expected_num_queries_success += 1  # 2. Select provider
+    expected_num_queries_success += 1  # 3. Select products
+
+    expected_num_queries_400 = 1  # 1. Select API key
+    expected_num_queries_400 += 1  # 2. Select provider
+
+    def test_should_return_eans_ordered_by_availability(self, client: TestClient):
+        plain_api_key, _ = self.setup_provider()
+        # Valid EAN
+        valid_ean = "1234567890123"
+        offers_factories.ProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            name="Vieux motard que jamais",
+            extraData={"ean": valid_ean, "subcategoryId": subcategories.LIVRE_PAPIER.id},
+        )
+
+        # Invalid EAN because of subcategory
+        invalid_ean_because_not_in_allowed_subcategory = "2234567890123"
+        offers_factories.ProductFactory(
+            subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
+            name="Les 3000 mousquetaires contre Goldorak (collection Art & Essai)",
+            extraData={
+                "ean": invalid_ean_because_not_in_allowed_subcategory,
+                "subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id,
+            },
+        )
+
+        # Invalid EAN because not compliant with CGU
+        invalid_ean_because_not_compliant_with_cgu = "3234567890123"
+        offers_factories.ProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            gcuCompatibilityType=offers_models.GcuCompatibilityType.FRAUD_INCOMPATIBLE,
+            name="Un livre un peu 'olé olé'",
+            extraData={
+                "ean": invalid_ean_because_not_compliant_with_cgu,
+                "subcategoryId": subcategories.LIVRE_PAPIER.id,
+            },
+        )
+        not_found_ean = "4234567890123"
+
+        with testing.assert_num_queries(self.expected_num_queries_success):
+            response = client.with_explicit_token(plain_api_key).get(
+                self.endpoint_url,
+                params={
+                    "eans": ",".join(
+                        [
+                            valid_ean,
+                            invalid_ean_because_not_compliant_with_cgu,
+                            invalid_ean_because_not_in_allowed_subcategory,
+                            not_found_ean,
+                        ]
+                    )
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json == {
+            "available": [valid_ean],
+            "rejected": {
+                "notCompliantWithCgu": [invalid_ean_because_not_compliant_with_cgu],
+                "notFound": [not_found_ean],
+                "subcategoryNotAllowed": [invalid_ean_because_not_in_allowed_subcategory],
+            },
+        }
+
+        # With one EAN
+        with testing.assert_num_queries(self.expected_num_queries_success):
+            response = client.with_explicit_token(plain_api_key).get(
+                self.endpoint_url,
+                params={"eans": valid_ean},
+            )
+
+        assert response.status_code == 200
+        assert response.json == {
+            "available": [valid_ean],
+            "rejected": {
+                "notCompliantWithCgu": [],
+                "notFound": [],
+                "subcategoryNotAllowed": [],
+            },
+        }
+
+        # With duplicate EAN
+        with testing.assert_num_queries(self.expected_num_queries_success):
+            response = client.with_explicit_token(plain_api_key).get(
+                self.endpoint_url,
+                params={
+                    "eans": ",".join(
+                        [
+                            invalid_ean_because_not_compliant_with_cgu,
+                            invalid_ean_because_not_compliant_with_cgu,
+                            invalid_ean_because_not_in_allowed_subcategory,
+                        ]
+                    )
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json == {
+            "available": [],
+            "rejected": {
+                "notCompliantWithCgu": [invalid_ean_because_not_compliant_with_cgu],
+                "notFound": [],
+                "subcategoryNotAllowed": [invalid_ean_because_not_in_allowed_subcategory],
+            },
+        }
+
+    @pytest.mark.parametrize(
+        "eans_list,expected_msg",
+        [
+            ([], "EAN list must not be empty"),
+            (["1234567890123" for _ in range(101)], "Too many EANs"),
+            (["1234567890123", "coucou"], "EAN must be an integer"),
+            (["1234567890123", "11111"], "Only 13 characters EAN are accepted"),
+        ],
+    )
+    def test_should_raise_400_because_eans_query_param_is_invalid(self, client: TestClient, eans_list, expected_msg):
+        plain_api_key, _ = self.setup_provider()
+
+        with testing.assert_num_queries(self.expected_num_queries_400):
+            response = client.with_explicit_token(plain_api_key).get(
+                self.endpoint_url,
+                params={"eans": ",".join(eans_list)},
+            )
+            assert response.status_code == 400
+            assert response.json == {"eans": [expected_msg]}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31345

### Modifications de la doc
- **Change logs**
![image](https://github.com/user-attachments/assets/e2431bcf-a438-41c1-9dca-ba41a4bcd5c5)
- **REST API**
   - New endpoint 
![image](https://github.com/user-attachments/assets/d1c99941-734f-445b-820d-94ba598e8cfd)
![image](https://github.com/user-attachments/assets/73da7019-1f09-49a4-8466-2217e5288c64)
   - Existing endpoint (in red)
<img width="908" alt="image" src="https://github.com/user-attachments/assets/65381433-8f4d-4324-b8dc-21bed07e9648">



## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
