### PR TITLE
(BSR)[PRO] script: add a pc command for docker-compose up

### DIFF
--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -31,3 +31,7 @@ function rebuild_backend {
     sudo rm -rf $ROOT_PATH/api/static/object_store_data;
     docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes'
 }
+
+function up_backend {
+    RUN='docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
+}

--- a/pc
+++ b/pc
@@ -36,18 +36,21 @@ Commands:
   reset-db-test-no-docker  Clear test data in the local database (without docker)
   reset-all-storage     Delete all local images
   restart-backend       Restart API after removing the database and files
+  restart-proxy-backend Restart API after removing the database and files (to call when using a proxy)
   restart-api-no-docker Restart API after cleaning the database (without docker)
   restore-db            Restore a postgresql database from file (and anonymize data)
   restore-db-intact     Restore a postgresql database from file (non anonymized)
   set-git-config        Define a local Git configuration
   setup-no-docker       Create the setup to use no-docker pc commands
   start-backend         Start API and backoffice on localhost
+  start-proxy-backend   Start API and backoffice on localhost (to call when using a proxy)
   start-api-no-docker   Start API without docker
-  start-backoffice-no-docker  Start Backoffice withtout docker
+  start-backoffice-no-docker  Start Backoffice without docker
   start-pro             Start PC pro frontend on localhost
   symlink               Create symlink to use \"pc\" command (admin rights may be needed)
   test-backend          Run tests for the API
   test-backoffice       Run tests for the Backoffice
+  up-backend            Start API and backoffice on localhost (does not build the images)
   "
   exit 0
 fi
@@ -208,7 +211,7 @@ elif [[ "$CMD" == "restore-db" ]]; then
     ./api/scalingo/anonymize_database.sh -p Password_ ;
     rm $backup_file'
 
-# Start API server with database and nginx server
+# Start API server with database and nginx server (builds the images first)
 elif [[ "$CMD" == "start-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
   start_backend
@@ -216,6 +219,11 @@ elif [[ "$CMD" == "start-backend" ]]; then
 elif [[ "$CMD" == "start-proxy-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
   start_proxy_backend
+
+# Start API server with database and nginx server (without building the images)
+elif [[ "$CMD" == "up-backend" ]]; then
+  source "$INFRA_SCRIPTS_PATH"/start_backend.sh
+  up_backend
 
 # Commands to start API & Backoffice without docker
 elif [[ "$CMD" == "setup-no-docker" ]]; then

--- a/scripts/pc-completion.sh
+++ b/scripts/pc-completion.sh
@@ -19,7 +19,7 @@ _pc_completions()
     opts="-h -e -b -f -t"
     
     # List of available commands
-    commands="access-db-logs alembic bash diff-schema dump-db install install-hooks logs pgcli psql psql-file psql-test python rebuild-backend reset-all-db reset-db-no-docker reset-db-test-no-docker reset-all-storage restart-backend restart-api-no-docker restore-db restore-db-intact set-git-config setup-no-docker start-backend start-api-no-docker start-backoffice-no-docker start-pro symlink test-backend test-backoffice"
+    commands="access-db-logs alembic bash diff-schema dump-db install install-hooks logs pgcli psql psql-file psql-test python rebuild-backend reset-all-db reset-db-no-docker reset-db-test-no-docker reset-all-storage restart-backend restart-proxy-backend restart-api-no-docker restore-db restore-db-intact set-git-config setup-no-docker start-backend start-proxy-backend start-api-no-docker start-backoffice-no-docker start-pro symlink test-backend test-backoffice up-backend"
 
     # Completion for options
     if [[ ${cur} == -* ]] ; then
@@ -36,4 +36,3 @@ _pc_completions()
     return 0
 }
 complete -F _pc_completions pc
-


### PR DESCRIPTION
## But de la pull request

Ajout d'une commande à pc pour lancer `docker-compose up` (sans build les images)
Ajout de la doc manquante pour les commandes -proxy

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
