### PR TITLE
(BSR)[API] fix: do not fail on reaction creation if offer doesn't exists

### DIFF
--- a/api/src/pcapi/core/reactions/api.py
+++ b/api/src/pcapi/core/reactions/api.py
@@ -14,7 +14,7 @@ from pcapi.models import db
 def update_or_create_reaction(
     user_id: int, offer_id: int, reaction_type: reactions_models.ReactionTypeEnum
 ) -> reactions_models.Reaction:
-    offer = offers_models.Offer.query.get(offer_id)
+    offer = offers_models.Offer.query.get_or_404(offer_id)
     if offer.productId:
         existing_reaction = reactions_models.Reaction.query.filter_by(userId=user_id, productId=offer.productId).first()
     else:

--- a/api/tests/routes/native/v1/reaction_test.py
+++ b/api/tests/routes/native/v1/reaction_test.py
@@ -18,23 +18,39 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 
 class PostReactionTest:
+    num_queries_success = 1  # select user
+    num_queries_success += 1  # select offer
+    num_queries_success += 1  # select reaction
+    num_queries_success += 1  # Insert reaction
+
     def test_should_be_logged_in_to_post_reaction(self, client):
         with assert_num_queries(0):
             response = client.post("/native/v1/reaction", json={})
-        assert response.status_code == 400
+            assert response.status_code == 400
+
+    def test_offer_not_found(self, client):
+        user = users_factories.BeneficiaryFactory()
+        client.with_token(user.email)
+
+        num_queries = 1  # select user
+        num_queries += 1  # select offer
+        num_queries += 1  # rollback
+        with assert_num_queries(num_queries):
+            response = client.post("/native/v1/reaction", json={"offerId": 1, "reactionType": "LIKE"})
+            assert response.status_code == 404
 
     def test_post_new_like_reaction(self, client):
         user = users_factories.BeneficiaryFactory()
         offer = offers_factories.OfferFactory()
         client.with_token(user.email)
 
-        with assert_num_queries(4):
-            # SELECT offer, user, reaction
-            # INSERT reaction
-            response = client.post("/native/v1/reaction", json={"offerId": offer.id, "reactionType": "LIKE"})
+        offer_id = offer.id
+        with assert_num_queries(self.num_queries_success):
+            response = client.post("/native/v1/reaction", json={"offerId": offer_id, "reactionType": "LIKE"})
+            assert response.status_code == 204
+
         reaction = user.reactions[0]
 
-        assert response.status_code == 204
         assert reaction.reactionType == ReactionTypeEnum.LIKE
 
     def test_post_new_dislike_reaction(self, client):
@@ -42,30 +58,27 @@ class PostReactionTest:
         offer = offers_factories.OfferFactory()
         client.with_token(user.email)
 
-        with assert_num_queries(4):
-            # SELECT offer, user, reaction
-            # INSERT reaction
-            response = client.post("/native/v1/reaction", json={"offerId": offer.id, "reactionType": "DISLIKE"})
-        reaction = user.reactions[0]
-
-        assert response.status_code == 204
-        assert reaction.reactionType == ReactionTypeEnum.DISLIKE
+        offer_id = offer.id
+        with assert_num_queries(self.num_queries_success):
+            response = client.post("/native/v1/reaction", json={"offerId": offer_id, "reactionType": "DISLIKE"})
+            assert response.status_code == 204
 
     def test_edit_reaction(self, client):
         user = users_factories.BeneficiaryFactory()
         offer = offers_factories.OfferFactory()
         client.with_token(user.email)
 
-        with assert_num_queries(4):
-            # SELECT offer, user, reaction
-            # INSERT reaction
-            response = client.post("/native/v1/reaction", json={"offerId": offer.id, "reactionType": "LIKE"})
+        offer_id = offer.id
+        with assert_num_queries(self.num_queries_success):
+            response = client.post("/native/v1/reaction", json={"offerId": offer_id, "reactionType": "LIKE"})
+            assert response.status_code == 204
         reaction = user.reactions[0]
 
-        assert response.status_code == 204
+        offer_id = offer.id
+
         assert reaction.reactionType == ReactionTypeEnum.LIKE
 
-        response = client.post("/native/v1/reaction", json={"offerId": offer.id, "reactionType": "DISLIKE"})
+        response = client.post("/native/v1/reaction", json={"offerId": offer_id, "reactionType": "DISLIKE"})
         reaction = user.reactions[0]
 
         assert response.status_code == 204
@@ -77,13 +90,13 @@ class PostReactionTest:
         offer = offers_factories.OfferFactory(product=product)
         client.with_token(user.email)
 
-        with assert_num_queries(4):
-            # SELECT offer, user, reaction
-            # INSERT reaction
-            response = client.post("/native/v1/reaction", json={"offerId": offer.id, "reactionType": "LIKE"})
+        offer_id = offer.id
+        with assert_num_queries(self.num_queries_success):
+            response = client.post("/native/v1/reaction", json={"offerId": offer_id, "reactionType": "LIKE"})
+            assert response.status_code == 204
+
         reaction = user.reactions[0]
 
-        assert response.status_code == 204
         assert reaction.reactionType == ReactionTypeEnum.LIKE
         assert reaction.product == product
 


### PR DESCRIPTION
## But de la pull request
Fix [sentry error](https://sentry.passculture.team/organizations/sentry/issues/1618510/?project=5&referrer=slack) when trying to add a reaction to an unknown offer

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
