### PR TITLE
(PC-30829)[PRO] feat: OffererAddress select in offers filters.

### DIFF
--- a/pro/src/config/swrQueryKeys.ts
+++ b/pro/src/config/swrQueryKeys.ts
@@ -39,6 +39,7 @@ export const GET_MUSIC_TYPES_QUERY_KEY = 'getMusicTypes'
 export const GET_NATIONAL_PROGRAMS_QUERY_KEY = 'getNationalPrograms'
 export const GET_NEW_OFFERERS_PLAYLIST_QUERY_KEY = 'getNewOfferersPlaylist'
 export const GET_OFFER_QUERY_KEY = 'getOffer'
+export const GET_OFFERER_ADDRESS_QUERY_KEY = 'getoffererAddresses'
 export const GET_OFFERER_BANK_ACCOUNTS_AND_ATTACHED_VENUES_QUERY_KEY =
   'getOffererBankAccountsAndAttachedVenues'
 export const GET_OFFERER_QUERY_KEY = 'getOfferer'

--- a/pro/src/core/Offers/constants.ts
+++ b/pro/src/core/Offers/constants.ts
@@ -58,6 +58,7 @@ export const OFFER_STATUS_DRAFT = OfferStatus.DRAFT
 
 const ALL_OFFERS = ''
 export const ALL_VENUES = 'all'
+const ALL_OFFERER_ADDRESSES = 'all'
 const ALL_CATEGORIES = 'all'
 export const ALL_FORMATS = 'all'
 export const ALL_STATUS = 'all'
@@ -80,7 +81,7 @@ export const DEFAULT_SEARCH_FILTERS: SearchFiltersParams = {
   periodBeginningDate: ALL_EVENT_PERIODS,
   periodEndingDate: ALL_EVENT_PERIODS,
   page: DEFAULT_PAGE,
-  offererAddressId: 'all',
+  offererAddressId: ALL_OFFERER_ADDRESSES,
 }
 
 export const DEFAULT_COLLECTIVE_SEARCH_FILTERS: CollectiveSearchFiltersParams =
@@ -99,6 +100,11 @@ export const DEFAULT_COLLECTIVE_SEARCH_FILTERS: CollectiveSearchFiltersParams =
 export const ALL_VENUES_OPTION: SelectOption = {
   label: 'Tous les lieux',
   value: ALL_VENUES,
+}
+
+export const ALL_OFFERER_ADDRESS_OPTION: SelectOption = {
+  label: 'Toutes les adresses',
+  value: ALL_OFFERER_ADDRESSES,
 }
 
 export const ALL_CATEGORIES_OPTION: SelectOption = {

--- a/pro/src/core/Offers/utils/serializer.ts
+++ b/pro/src/core/Offers/utils/serializer.ts
@@ -20,6 +20,7 @@ export const serializeApiFilters = (
     'offererId',
     'status',
     'venueId',
+    'offererAddressId',
     'categoryId',
     'creationMode',
     'periodBeginningDate',

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -6,6 +6,7 @@ import { api } from 'apiClient/api'
 import { AppLayout } from 'app/AppLayout'
 import {
   GET_CATEGORIES_QUERY_KEY,
+  GET_OFFERER_ADDRESS_QUERY_KEY,
   GET_OFFERER_QUERY_KEY,
   GET_VENUES_QUERY_KEY,
 } from 'config/swrQueryKeys'
@@ -22,7 +23,10 @@ import { serializeApiFilters } from 'core/Offers/utils/serializer'
 import { Audience } from 'core/shared/types'
 import { useCurrentUser } from 'hooks/useCurrentUser'
 import { useIsNewInterfaceActive } from 'hooks/useIsNewInterfaceActive'
-import { formatAndOrderVenues } from 'repository/venuesService'
+import {
+  formatAndOrderAddresses,
+  formatAndOrderVenues,
+} from 'repository/venuesService'
 import { IndividualOffersScreen } from 'screens/IndividualOffersScreen/IndividualOffersScreen'
 import { selectCurrentOffererId } from 'store/user/selectors'
 import { Spinner } from 'ui-kit/Spinner/Spinner'
@@ -81,6 +85,14 @@ export const OffersRoute = (): JSX.Element => {
   )
   const venues = formatAndOrderVenues(data.venues)
 
+  const offererAddressQuery = useSWR(
+    [GET_OFFERER_ADDRESS_QUERY_KEY, offerer?.id],
+    ([, offererIdParam]) =>
+      offererIdParam ? api.getOffererAddresses(offererIdParam, false) : [],
+    { fallbackData: [] }
+  )
+  const offererAddresses = formatAndOrderAddresses(offererAddressQuery.data)
+
   const isFilterByVenueOrOfferer = hasSearchFilters(urlSearchFilters, [
     'venueId',
     'offererId',
@@ -117,6 +129,8 @@ export const OffersRoute = (): JSX.Element => {
       creationMode,
       periodBeginningDate,
       periodEndingDate,
+      offererAddressId,
+      collectiveOfferType,
     } = serializeApiFilters(apiFilters)
 
     return api.listOffers(
@@ -127,7 +141,9 @@ export const OffersRoute = (): JSX.Element => {
       categoryId,
       creationMode,
       periodBeginningDate,
-      periodEndingDate
+      periodEndingDate,
+      collectiveOfferType,
+      offererAddressId
     )
   })
 
@@ -149,6 +165,7 @@ export const OffersRoute = (): JSX.Element => {
           redirectWithUrlFilters={redirectWithUrlFilters}
           urlSearchFilters={urlSearchFilters}
           venues={venues}
+          offererAddresses={offererAddresses}
           isRestrictedAsAdmin={isRestrictedAsAdmin}
         />
       )}

--- a/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
@@ -17,6 +17,7 @@ import {
   listOffersOfferFactory,
   venueListItemFactory,
 } from 'utils/individualApiFactories'
+import { offererAddressFactory } from 'utils/offererAddressFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 import { sharedCurrentUserFactory } from 'utils/storeFactories'
 
@@ -111,6 +112,8 @@ describe('route Offers when user is admin', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
+      undefined,
       undefined
     )
   })
@@ -139,6 +142,8 @@ describe('route Offers when user is admin', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
+        undefined,
         undefined
       )
     })
@@ -148,6 +153,9 @@ describe('route Offers when user is admin', () => {
     vi.spyOn(api, 'getOfferer').mockResolvedValue(
       defaultGetOffererResponseModel
     )
+    vi.spyOn(api, 'getOffererAddresses').mockResolvedValue([
+      offererAddressFactory(),
+    ])
     const filters = {
       offererId: defaultGetOffererResponseModel.id.toString(),
       status: OfferStatus.INACTIVE,
@@ -156,7 +164,11 @@ describe('route Offers when user is admin', () => {
 
     await userEvent.click(screen.getByTestId('remove-offerer-filter'))
 
+    expect(api.getOffererAddresses).toHaveBeenCalled()
+
     expect(api.listOffers).toHaveBeenLastCalledWith(
+      undefined,
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -174,6 +186,11 @@ describe('route Offers when user is admin', () => {
     vi.spyOn(api, 'getOfferer').mockResolvedValue(
       defaultGetOffererResponseModel
     )
+    vi.spyOn(api, 'getOffererAddresses').mockResolvedValueOnce([
+      offererAddressFactory({
+        label: 'Label',
+      }),
+    ])
     const filters = {
       venueId: venueId.toString(),
       status: OfferStatus.INACTIVE,
@@ -187,6 +204,8 @@ describe('route Offers when user is admin', () => {
       undefined,
       'INACTIVE',
       venueId.toString(),
+      undefined,
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/pro/src/repository/__specs__/venuesService.spec.ts
+++ b/pro/src/repository/__specs__/venuesService.spec.ts
@@ -1,9 +1,11 @@
 import { addressResponseIsEditableModelFactory } from 'utils/commonOffersApiFactories'
 import { venueListItemFactory } from 'utils/individualApiFactories'
+import { offererAddressFactory } from 'utils/offererAddressFactories'
 
 import {
   computeAddressDisplayName,
   computeVenueDisplayName,
+  formatAndOrderAddresses,
   formatAndOrderVenues,
 } from '../venuesService'
 
@@ -39,24 +41,30 @@ describe('formatAndOrderVenues', () => {
     ])
   })
 
-  it('should format venue option with "offerer name - offre numérique" when venue is virtual', () => {
-    const venues = [
-      venueListItemFactory({
-        id: 1,
-        name: 'Offre numérique',
-        offererName: 'gilbert Joseph',
-        isVirtual: true,
-      }),
-    ]
+  describe('formatAndOrderAddresses', () => {
+    it('should sort offerer addresses alphabetically', () => {
+      const offererAddress = [
+        offererAddressFactory({
+          label: 'Adresse',
+        }),
+        offererAddressFactory({
+          street: '2 rue de Montreuil',
+        }),
+      ]
 
-    const formattedValues = formatAndOrderVenues(venues)
+      const sortingValues = formatAndOrderAddresses(offererAddress)
 
-    expect(formattedValues).toStrictEqual([
-      {
-        label: 'gilbert Joseph - Offre numérique',
-        value: venues[0].id.toString(),
-      },
-    ])
+      expect(sortingValues).toStrictEqual([
+        {
+          label: '2 rue de Montreuil 75001 Paris',
+          value: offererAddress[1].id.toString(),
+        },
+        {
+          label: 'Adresse - 1 Rue de paris 75001 Paris',
+          value: offererAddress[0].id.toString(),
+        },
+      ])
+    })
   })
 })
 

--- a/pro/src/repository/venuesService.ts
+++ b/pro/src/repository/venuesService.ts
@@ -1,5 +1,6 @@
 import {
   type AddressResponseIsEditableModel,
+  GetOffererAddressesResponseModel,
   ListOffersVenueResponseModel,
   VenueListItemResponseModel,
 } from 'apiClient/v1'
@@ -41,5 +42,15 @@ export const formatAndOrderVenues = (venues: VenueListItemResponseModel[]) =>
     .map((venue) => ({
       value: venue.id.toString(),
       label: computeVenueDisplayName(venue),
+    }))
+    .sort(sortAlphabeticallyByLabel)
+
+export const formatAndOrderAddresses = (
+  addresses: GetOffererAddressesResponseModel
+) =>
+  addresses
+    .map((offerAddress) => ({
+      value: offerAddress.id.toString(),
+      label: computeAddressDisplayName(offerAddress),
     }))
     .sort(sortAlphabeticallyByLabel)

--- a/pro/src/screens/IndividualOffersScreen/IndividualOffersScreen.tsx
+++ b/pro/src/screens/IndividualOffersScreen/IndividualOffersScreen.tsx
@@ -60,6 +60,7 @@ export type IndividualOffersScreenProps = {
   ) => void
   urlSearchFilters: SearchFiltersParams
   venues: SelectOption[]
+  offererAddresses: SelectOption[]
   categories?: SelectOption[]
   isRestrictedAsAdmin?: boolean
   offers?: ListOffersOfferResponseModel[]
@@ -74,6 +75,7 @@ export const IndividualOffersScreen = ({
   redirectWithUrlFilters,
   urlSearchFilters,
   venues,
+  offererAddresses,
   categories,
   isRestrictedAsAdmin,
   offers = [],
@@ -239,6 +241,7 @@ export const IndividualOffersScreen = ({
         selectedFilters={selectedFilters}
         setSelectedFilters={setSelectedFilters}
         venues={venues}
+        offererAddresses={offererAddresses}
         isRestrictedAsAdmin={isRestrictedAsAdmin}
       />
       {userHasNoOffers ? (

--- a/pro/src/screens/IndividualOffersScreen/IndividualOffersSearchFilters/IndividualOffersSearchFilters.tsx
+++ b/pro/src/screens/IndividualOffersScreen/IndividualOffersSearchFilters/IndividualOffersSearchFilters.tsx
@@ -4,6 +4,7 @@ import { GetOffererResponseModel, OfferStatus } from 'apiClient/v1'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import {
   ALL_CATEGORIES_OPTION,
+  ALL_OFFERER_ADDRESS_OPTION,
   ALL_STATUS,
   ALL_VENUES_OPTION,
   CREATION_MODES_OPTIONS,
@@ -12,6 +13,7 @@ import {
 import { SearchFiltersParams } from 'core/Offers/types'
 import { hasSearchFilters } from 'core/Offers/utils/hasSearchFilters'
 import { SelectOption } from 'custom_types/form'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useIsNewInterfaceActive } from 'hooks/useIsNewInterfaceActive'
 import fullRefreshIcon from 'icons/full-refresh.svg'
 import strokeCloseIcon from 'icons/stroke-close.svg'
@@ -35,6 +37,7 @@ interface IndividualOffersSearchFiltersProps {
   disableAllFilters: boolean
   resetFilters: () => void
   venues: SelectOption[]
+  offererAddresses: SelectOption[]
   categories?: SelectOption[]
   isRestrictedAsAdmin?: boolean
 }
@@ -59,10 +62,12 @@ export const IndividualOffersSearchFilters = ({
   removeOfferer,
   disableAllFilters,
   venues,
+  offererAddresses,
   categories,
   isRestrictedAsAdmin = false,
 }: IndividualOffersSearchFiltersProps): JSX.Element => {
   const isNewInterfaceActive = useIsNewInterfaceActive()
+  const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
 
   const updateSearchFilters = (
     newSearchFilters: Partial<SearchFiltersParams>
@@ -79,6 +84,10 @@ export const IndividualOffersSearchFilters = ({
 
   const storeSelectedVenue = (event: FormEvent<HTMLSelectElement>) => {
     updateSearchFilters({ venueId: event.currentTarget.value })
+  }
+
+  const storeSelectedOfferAddress = (event: FormEvent<HTMLSelectElement>) => {
+    updateSearchFilters({ offererAddressId: event.currentTarget.value })
   }
 
   const storeSelectedCategory = (event: FormEvent<HTMLSelectElement>) => {
@@ -156,16 +165,30 @@ export const IndividualOffersSearchFilters = ({
           />
         </FieldLayout>
         <FormLayout.Row inline>
-          <FieldLayout label="Lieu" name="lieu" isOptional>
-            <SelectInput
-              defaultOption={ALL_VENUES_OPTION}
-              onChange={storeSelectedVenue}
-              disabled={disableAllFilters}
-              name="lieu"
-              options={venues}
-              value={selectedFilters.venueId}
-            />
-          </FieldLayout>
+          {isOfferAddressEnabled ? (
+            <FieldLayout label="Adresse" name="address" isOptional>
+              <SelectInput
+                defaultOption={ALL_OFFERER_ADDRESS_OPTION}
+                onChange={storeSelectedOfferAddress}
+                disabled={offererAddresses.length === 0 || disableAllFilters}
+                name="address"
+                options={offererAddresses}
+                data-testid="address-select"
+                value={selectedFilters.offererAddressId}
+              />
+            </FieldLayout>
+          ) : (
+            <FieldLayout label="Lieu" name="lieu" isOptional>
+              <SelectInput
+                defaultOption={ALL_VENUES_OPTION}
+                onChange={storeSelectedVenue}
+                disabled={disableAllFilters}
+                name="lieu"
+                options={venues}
+                value={selectedFilters.venueId}
+              />
+            </FieldLayout>
+          )}
 
           {categories && (
             <FieldLayout label="Catégories" name="categorie" isOptional>

--- a/pro/src/screens/IndividualOffersScreen/__specs__/IndividualOffersScreen.tracker.spec.tsx
+++ b/pro/src/screens/IndividualOffersScreen/__specs__/IndividualOffersScreen.tracker.spec.tsx
@@ -7,8 +7,8 @@ import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { Audience } from 'core/shared/types'
 import {
   defaultGetOffererResponseModel,
-  getOfferManagingOffererFactory,
   getOffererNameFactory,
+  getOfferManagingOffererFactory,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 import { sharedCurrentUserFactory } from 'utils/storeFactories'
@@ -55,6 +55,7 @@ describe('tracker IndividualOffersScreen', () => {
       audience: Audience.INDIVIDUAL,
       redirectWithUrlFilters: vi.fn(),
       venues: [],
+      offererAddresses: [],
       categories: [],
     }
 

--- a/pro/src/utils/offererAddressFactories.ts
+++ b/pro/src/utils/offererAddressFactories.ts
@@ -1,0 +1,20 @@
+/* istanbul ignore file: Those are test helpers, their coverage is not relevant */
+
+import { GetOffererAddressWithIsEditableResponseModel } from 'apiClient/v1'
+
+let offererAddressId = 1
+
+export const offererAddressFactory = (
+  customOffererAddress: Partial<GetOffererAddressWithIsEditableResponseModel> = {}
+): GetOffererAddressWithIsEditableResponseModel => {
+  const currentOaId = offererAddressId++
+
+  return {
+    id: currentOaId,
+    city: 'Paris',
+    isEditable: true,
+    postalCode: '75001',
+    street: '1 Rue de paris',
+    ...customOffererAddress,
+  }
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30829

- Ajout du filtre par adresse dans les offres

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
