### PR TITLE
Pc 31764 offers list role status

### DIFF
--- a/pro/src/components/SideNavLinks/SideNavLinks.module.scss
+++ b/pro/src/components/SideNavLinks/SideNavLinks.module.scss
@@ -40,7 +40,6 @@
 .nav-links {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   padding-top: rem.torem(24px);
   height: 100%;
   border-right: rem.torem(1px) solid var(--color-grey-medium);
@@ -73,11 +72,18 @@
     margin-bottom: rem.torem(16px);
 
     &-separator {
-      background-color: var(--color-grey-medium);
-      margin: 0 rem.torem(16px);
-      height: rem.torem(1px);
-      margin-bottom: rem.torem(16px);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
     }
+  }
+
+  .separator-line {
+    background-color: var(--color-grey-medium);
+    margin: 0 rem.torem(16px);
+    height: rem.torem(1px);
+    margin-bottom: rem.torem(16px);
   }
 
   &-item {

--- a/pro/src/components/SideNavLinks/SideNavLinks.tsx
+++ b/pro/src/components/SideNavLinks/SideNavLinks.tsx
@@ -112,46 +112,52 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
         [styles['nav-links-open']]: isLateralPanelOpen,
       })}
     >
-      <div className={styles['nav-links-first-group']}>
-        {selectedOffererQuery.data && isUserOffererValidated && (
-          <li className={styles['nav-links-create-offer-wrapper']}>
-            <ButtonLink variant={ButtonVariant.PRIMARY} to={createOfferPageUrl}>
-              Créer une offre
-            </ButtonLink>
-          </li>
-        )}
-        <li>
-          <NavLink
-            to="/accueil"
-            className={({ isActive }) =>
-              classnames(styles['nav-links-item'], {
-                [styles['nav-links-item-active']]: isActive,
-              })
-            }
-          >
-            <SvgIcon src={strokeHomeIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
-            <span className={styles['nav-links-item-title']}>Accueil</span>
-          </NavLink>
+      {selectedOffererQuery.data && isUserOffererValidated && (
+        <li className={styles['nav-links-create-offer-wrapper']}>
+          <ButtonLink variant={ButtonVariant.PRIMARY} to={createOfferPageUrl}>
+            Créer une offre
+          </ButtonLink>
         </li>
-        <li>
-          <button
-            onClick={() =>
-              dispatch(setIsIndividualSectionOpen(!isIndividualSectionOpen))
-            }
-            className={(styles['nav-links-item'], styles['nav-section-button'])}
-            aria-expanded={isIndividualSectionOpen}
+      )}
+      <li>
+        <NavLink
+          to="/accueil"
+          className={({ isActive }) =>
+            classnames(styles['nav-links-item'], {
+              [styles['nav-links-item-active']]: isActive,
+            })
+          }
+        >
+          <SvgIcon src={strokeHomeIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
+          <span className={styles['nav-links-item-title']}>Accueil</span>
+        </NavLink>
+      </li>
+      <li>
+        <button
+          onClick={() =>
+            dispatch(setIsIndividualSectionOpen(!isIndividualSectionOpen))
+          }
+          className={(styles['nav-links-item'], styles['nav-section-button'])}
+          aria-expanded={isIndividualSectionOpen}
+          aria-controls="individual-sublist"
+          id="individual-sublist-button"
+        >
+          <SvgIcon src={strokePhoneIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
+          <span className={styles['nav-section-title']}>Individuel</span>
+          <SvgIcon
+            src={isIndividualSectionOpen ? fullUpIcon : fullDownIcon}
+            alt=""
+            width="18"
+            className={styles['nav-section-icon']}
+          />
+        </button>
+
+        {isIndividualSectionOpen && (
+          <ul
+            id="individual-sublist"
+            aria-labelledby="individual-sublist-button"
           >
-            <SvgIcon src={strokePhoneIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
-            <span className={styles['nav-section-title']}>Individuel</span>
-            <SvgIcon
-              src={isIndividualSectionOpen ? fullUpIcon : fullDownIcon}
-              alt=""
-              width="18"
-              className={styles['nav-section-icon']}
-            />
-          </button>
-          {isIndividualSectionOpen && (
-            <>
+            <li>
               <NavLink
                 to="/offres"
                 className={({ isActive }) =>
@@ -165,6 +171,8 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
                   Offres
                 </span>
               </NavLink>
+            </li>
+            <li>
               <NavLink
                 to="/reservations"
                 end
@@ -178,6 +186,8 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
                   Réservations
                 </span>
               </NavLink>
+            </li>
+            <li>
               <NavLink
                 to="/guichet"
                 className={({ isActive }) =>
@@ -190,7 +200,9 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
                   Guichet
                 </span>
               </NavLink>
-              {currentUser?.hasPartnerPage && venueId && (
+            </li>
+            {currentUser?.hasPartnerPage && venueId && (
+              <li>
                 <NavLink
                   to={`/structures/${offererId}/lieux/${venueId}`}
                   className={({ isActive }) =>
@@ -204,34 +216,37 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
                     Page sur l’application
                   </span>
                 </NavLink>
-              )}
-            </>
-          )}
-        </li>
-        <li>
-          <button
-            onClick={() =>
-              dispatch(setIsCollectiveSectionOpen(!isCollectiveSectionOpen))
-            }
-            className={(styles['nav-links-item'], styles['nav-section-button'])}
-            aria-expanded={isCollectiveSectionOpen}
+              </li>
+            )}
+          </ul>
+        )}
+      </li>
+      <li>
+        <button
+          onClick={() =>
+            dispatch(setIsCollectiveSectionOpen(!isCollectiveSectionOpen))
+          }
+          className={(styles['nav-links-item'], styles['nav-section-button'])}
+          aria-expanded={isCollectiveSectionOpen}
+          aria-controls="collective-sublist"
+          id="collective-sublist-button"
+        >
+          <SvgIcon src={strokeTeacherIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
+          <span className={styles['nav-section-title']}>Collectif</span>
+          <SvgIcon
+            src={isCollectiveSectionOpen ? fullUpIcon : fullDownIcon}
+            alt=""
+            width="18"
+            className={styles['nav-section-icon']}
+          />
+        </button>
+        {isCollectiveSectionOpen && (
+          <ul
+            id="collective-sublist"
+            aria-labelledby="collective-sublist-button"
           >
-            <SvgIcon
-              src={strokeTeacherIcon}
-              alt=""
-              width={NAV_ITEM_ICON_SIZE}
-            />
-            <span className={styles['nav-section-title']}>Collectif</span>
-            <SvgIcon
-              src={isCollectiveSectionOpen ? fullUpIcon : fullDownIcon}
-              alt=""
-              width="18"
-              className={styles['nav-section-icon']}
-            />
-          </button>
-          {isCollectiveSectionOpen && (
-            <>
-              {isNewCollectiveOffersStructureEnabled && (
+            {isNewCollectiveOffersStructureEnabled && (
+              <li>
                 <NavLink
                   to="/offres/vitrines"
                   className={({ isActive }) =>
@@ -244,7 +259,9 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
                     Offres vitrines
                   </span>
                 </NavLink>
-              )}
+              </li>
+            )}
+            <li>
               <NavLink
                 to="/offres/collectives"
                 className={({ isActive }) =>
@@ -257,6 +274,8 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
                   Offres
                 </span>
               </NavLink>
+            </li>
+            <li>
               <NavLink
                 to="/reservations/collectives"
                 end
@@ -270,7 +289,9 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
                   Réservations
                 </span>
               </NavLink>
-              {venueId && (
+            </li>
+            {venueId && (
+              <li>
                 <NavLink
                   to={`/structures/${offererId}/lieux/${venueId}/collectif`}
                   className={({ isActive }) =>
@@ -284,59 +305,62 @@ export const SideNavLinks = ({ isLateralPanelOpen }: SideNavLinksProps) => {
                     Page dans ADAGE
                   </span>
                 </NavLink>
-              )}
-            </>
-          )}
-        </li>
-        {isOffererStatsActive && (
-          <li>
-            <NavLink
-              to="/statistiques"
-              className={({ isActive }) =>
-                classnames(styles['nav-links-item'], {
-                  [styles['nav-links-item-active']]: isActive,
-                })
-              }
-            >
-              <SvgIcon src={strokePieIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
-              Statistiques
-            </NavLink>
-          </li>
+              </li>
+            )}
+          </ul>
         )}
-      </div>
-      <div className={styles['nav-links-last-group']}>
-        <div className={styles['nav-links-last-group-separator']} />
+      </li>
+      {isOffererStatsActive && (
         <li>
           <NavLink
-            to="/remboursements"
+            to="/statistiques"
             className={({ isActive }) =>
               classnames(styles['nav-links-item'], {
                 [styles['nav-links-item-active']]: isActive,
               })
             }
           >
-            <SvgIcon src={strokeEuroIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
-            Gestion financière
+            <SvgIcon src={strokePieIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
+            Statistiques
           </NavLink>
         </li>
-        <li>
-          <NavLink
-            to="/collaborateurs"
-            className={({ isActive }) =>
-              classnames(styles['nav-links-item'], {
-                [styles['nav-links-item-active']]: isActive,
-              })
-            }
-          >
-            <SvgIcon
-              src={strokeCollaboratorIcon}
-              alt=""
-              width={NAV_ITEM_ICON_SIZE}
-            />
-            Collaborateurs
-          </NavLink>
-        </li>
-      </div>
+      )}
+      <li
+        className={styles['nav-links-last-group-separator']}
+        aria-hidden="true"
+      >
+        <div className={styles['separator-line']} />
+      </li>
+      <li>
+        <NavLink
+          to="/remboursements"
+          className={({ isActive }) =>
+            classnames(styles['nav-links-item'], {
+              [styles['nav-links-item-active']]: isActive,
+            })
+          }
+        >
+          <SvgIcon src={strokeEuroIcon} alt="" width={NAV_ITEM_ICON_SIZE} />
+          Gestion financière
+        </NavLink>
+      </li>
+      <li>
+        <NavLink
+          to="/collaborateurs"
+          className={({ isActive }) =>
+            classnames(styles['nav-links-item'], {
+              [styles['nav-links-item-active']]: isActive,
+            })
+          }
+        >
+          <SvgIcon
+            src={strokeCollaboratorIcon}
+            alt=""
+            width={NAV_ITEM_ICON_SIZE}
+          />
+          Collaborateurs
+        </NavLink>
+      </li>
     </ul>
   )
 }

--- a/pro/src/components/SideNavLinks/__specs__/SideNavLinks.spec.tsx
+++ b/pro/src/components/SideNavLinks/__specs__/SideNavLinks.spec.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
 
 import { api } from 'apiClient/api'
 import {
@@ -15,7 +16,7 @@ import { sharedCurrentUserFactory } from 'utils/storeFactories'
 import { SideNavLinks } from '../SideNavLinks'
 
 const renderSideNavLinks = (options: RenderWithProvidersOptions = {}) => {
-  renderWithProviders(<SideNavLinks isLateralPanelOpen={true} />, {
+  return renderWithProviders(<SideNavLinks isLateralPanelOpen={true} />, {
     initialRouterEntries: ['/'],
     user: sharedCurrentUserFactory({ hasPartnerPage: true }),
     ...options,
@@ -23,6 +24,10 @@ const renderSideNavLinks = (options: RenderWithProvidersOptions = {}) => {
 }
 
 describe('SideNavLinks', () => {
+  it('should not have accessibility violations', async () => {
+    const { container } = renderSideNavLinks()
+    expect(await axe(container)).toHaveNoViolations()
+  })
   it('should toggle individual section on individual section button click', async () => {
     renderSideNavLinks()
 

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -26,7 +26,6 @@ import { useIsNewInterfaceActive } from 'hooks/useIsNewInterfaceActive'
 import { formatAndOrderVenues } from 'repository/venuesService'
 import { CollectiveOffersScreen } from 'screens/CollectiveOffersScreen/CollectiveOffersScreen'
 import { selectCurrentOffererId } from 'store/user/selectors'
-import { Spinner } from 'ui-kit/Spinner/Spinner'
 
 export const CollectiveOffers = (): JSX.Element => {
   const urlSearchFilters = useQueryCollectiveSearchFilters()
@@ -142,22 +141,18 @@ export const CollectiveOffers = (): JSX.Element => {
 
   return (
     <AppLayout>
-      {offersQuery.isLoading ? (
-        <Spinner />
-      ) : (
-        <CollectiveOffersScreen
-          currentPageNumber={currentPageNumber}
-          currentUser={currentUser}
-          initialSearchFilters={apiFilters}
-          isLoading={offersQuery.isLoading}
-          offerer={offerer}
-          offers={displayedOffers}
-          redirectWithUrlFilters={redirectWithUrlFilters}
-          urlSearchFilters={urlSearchFilters}
-          venues={venues}
-          isRestrictedAsAdmin={isRestrictedAsAdmin}
-        />
-      )}
+      <CollectiveOffersScreen
+        currentPageNumber={currentPageNumber}
+        currentUser={currentUser}
+        initialSearchFilters={apiFilters}
+        isLoading={offersQuery.isLoading}
+        offerer={offerer}
+        offers={displayedOffers}
+        redirectWithUrlFilters={redirectWithUrlFilters}
+        urlSearchFilters={urlSearchFilters}
+        venues={venues}
+        isRestrictedAsAdmin={isRestrictedAsAdmin}
+      />
     </AppLayout>
   )
 }

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -151,7 +151,7 @@ export const OffersRoute = (): JSX.Element => {
 
   return (
     <AppLayout>
-      {offersQuery.isLoading || offererQuery.isLoading ? (
+      {offererQuery.isLoading ? (
         <Spinner />
       ) : (
         <IndividualOffersScreen

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTable.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTable.tsx
@@ -23,7 +23,6 @@ type CollectiveOffersTableProps = {
   areAllOffersSelected: boolean
   hasOffers: boolean
   isLoading: boolean
-  offersCount: number
   pageCount: number
   resetFilters: () => void
   setSelectedOffer: (offer: CollectiveOfferResponseModel) => void
@@ -32,7 +31,7 @@ type CollectiveOffersTableProps = {
   isAtLeastOneOfferChecked: boolean
   isRestrictedAsAdmin?: boolean
   selectedOffers: CollectiveOfferResponseModel[]
-  offers: CollectiveOfferResponseModel[] | undefined
+  offers: CollectiveOfferResponseModel[]
 }
 
 export enum CollectiveOffersSortingColumn {
@@ -89,7 +88,6 @@ export const CollectiveOffersTable = ({
   areAllOffersSelected,
   hasOffers,
   isLoading,
-  offersCount,
   pageCount,
   resetFilters,
   selectedOffers,
@@ -117,24 +115,26 @@ export const CollectiveOffersTable = ({
   )
 
   return (
-    <div aria-busy={isLoading} aria-live="polite">
+    <div>
+      <div role="status">
+        {offers.length > MAX_OFFERS_TO_DISPLAY && (
+          <Banner type="notification-info">
+            L’affichage est limité à 500 offres. Modifiez les filtres pour
+            affiner votre recherche.
+          </Banner>
+        )}
+        {hasOffers ? (
+          `${getOffersCountToDisplay(offers.length)} ${
+            offers.length <= 1 ? 'offre' : 'offres'
+          }`
+        ) : (
+          <span className="visually-hidden">aucune offre trouvée</span>
+        )}
+      </div>
       {isLoading ? (
         <Spinner className={styles['loading-spinner']} />
       ) : (
         <>
-          {offersCount > MAX_OFFERS_TO_DISPLAY && (
-            <Banner type="notification-info">
-              L’affichage est limité à 500 offres. Modifiez les filtres pour
-              affiner votre recherche.
-            </Banner>
-          )}
-          {hasOffers && (
-            <div>
-              {`${getOffersCountToDisplay(offersCount)} ${
-                offersCount <= 1 ? 'offre' : 'offres'
-              }`}
-            </div>
-          )}
           {hasOffers && (
             <>
               <div className={styles['select-all-container']}>

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTable.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTable.tsx
@@ -64,24 +64,26 @@ export const IndividualOffersTable = ({
     )
 
   return (
-    <div aria-busy={isLoading} aria-live="polite">
+    <div>
+      <div role="status">
+        {offersCount > MAX_OFFERS_TO_DISPLAY && (
+          <Banner type="notification-info">
+            L’affichage est limité à 500 offres. Modifiez les filtres pour
+            affiner votre recherche.
+          </Banner>
+        )}
+        {hasOffers && (
+          <div>
+            {`${getOffersCountToDisplay(offersCount)} ${
+              offersCount <= 1 ? 'offre' : 'offres'
+            }`}
+          </div>
+        )}
+      </div>
       {isLoading ? (
         <Spinner className={styles['loading-spinner']} />
       ) : (
         <>
-          {offersCount > MAX_OFFERS_TO_DISPLAY && (
-            <Banner type="notification-info">
-              L’affichage est limité à 500 offres. Modifiez les filtres pour
-              affiner votre recherche.
-            </Banner>
-          )}
-          {hasOffers && (
-            <div>
-              {`${getOffersCountToDisplay(offersCount)} ${
-                offersCount <= 1 ? 'offre' : 'offres'
-              }`}
-            </div>
-          )}
           {hasOffers && (
             <>
               <div className={styles['select-all-container']}>

--- a/pro/src/screens/CollectiveOffersScreen/CollectiveOffersScreen.tsx
+++ b/pro/src/screens/CollectiveOffersScreen/CollectiveOffersScreen.tsx
@@ -185,7 +185,6 @@ export const CollectiveOffersScreen = ({
             areAllOffersSelected={areAllOffersSelected}
             hasOffers={hasOffers}
             isLoading={isLoading}
-            offersCount={offers.length}
             pageCount={pageCount}
             resetFilters={resetFilters}
             selectedOffers={selectedOffers}

--- a/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.tsx
+++ b/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.tsx
@@ -185,7 +185,6 @@ export const TemplateCollectiveOffersScreen = ({
             areAllOffersSelected={areAllOffersSelected}
             hasOffers={hasOffers}
             isLoading={isLoading}
-            offersCount={offers.length}
             pageCount={pageCount}
             resetFilters={resetFilters}
             selectedOffers={selectedOffers}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31764

**Objectif**
2 correctifs a11y :
- Annoncer le nombre d'offres trouvées quand on fait une recherche sur les offres indiv et collectives. Pour ça il faut que le conteneur en `role="alert"` du message à annoncer soit déjà dans le DOM avant le changement (et n'apparaisse pas au moment du changement). Il a fallu enlever le loader au niveau de la page qui semble inutile (et qui fait un rechargement de page à chaque fois qu'on fait une recherche qui est pas en cache).
- Enlever les divs entre le `ul` et les `li` des `NavLinks` 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
