### PR TITLE
(PC-31564)[PRO] feat: allow rejected offers to be archived

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -576,9 +576,9 @@ def batch_update_offers(query: BaseQuery, update_fields: dict, send_email_notifi
 
 
 def batch_update_collective_offers(query: BaseQuery, update_fields: dict) -> None:
-    allowed_validation_status = [models.OfferValidationStatus.APPROVED]
+    allowed_validation_status = {models.OfferValidationStatus.APPROVED}
     if "dateArchived" in update_fields:
-        allowed_validation_status = [models.OfferValidationStatus.APPROVED, models.OfferValidationStatus.DRAFT]
+        allowed_validation_status.update((models.OfferValidationStatus.DRAFT, models.OfferValidationStatus.REJECTED))
 
     collective_offer_ids_tuples = query.filter(
         educational_models.CollectiveOffer.validation.in_(allowed_validation_status)  # type: ignore[attr-defined]


### PR DESCRIPTION
## But de la pull request

https://passculture.atlassian.net/browse/PC-31564

Permettre d'archiver une offre refusée par la fraude

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
