### PR TITLE
(PC-31773)[PRO] style: Fix font-weight of bold on safari and firefox.

### DIFF
--- a/pro/src/styles/global/_layout.scss
+++ b/pro/src/styles/global/_layout.scss
@@ -7,6 +7,7 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+  font-synthesis: none;
 }
 
 html {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31773

**Objectif**
Corriger l'affichage du bold sur Firefox et Safari. Ces navigateurs n'interprètent pas les `font-face` de la même manière que Chrome, et ne comprennent pas que Montserrat-Bold ayant une `font-weight` définie à 600 dans la `font-face` est une police bold (on voit dans l'onglet Style/Police de Safari que la police interprétée est Montserrat Thin (?)). 
Donc quand on applique le `font-weight: 600` de nouveau dans la mixin, le navigateur essaie de créer du bold lui-même en épaississant les glyphes de la police.

Pour éviter ça, j'ai ajouté la propriété CSS qui interdit au navigateur de prendre ce genre de liberté.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
