### PR TITLE
PC-31782-migrer-les-routes-du-bo-vers-atomic-part-11

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1493,7 +1493,7 @@ def whitelist_product(idAtProviders: str) -> models.Product | None:
     product.gcuCompatibilityType = models.GcuCompatibilityType.COMPATIBLE
 
     db.session.add(product)
-    db.session.commit()
+    db.session.flush()
     return product
 
 


### PR DESCRIPTION
## But de la pull request

https://passculture.atlassian.net/browse/PC-31782
Voir l'epic https://passculture.atlassian.net/browse/PC-29667

Ajout du décorateur atomic sur les routes
- test_users
- titelive

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
