### PR TITLE
(PC-31785)[API] feat: change `@api_key_required` for `@provider_api_key_required` in public API current endpoints

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/bookings.py
@@ -13,12 +13,12 @@ from pcapi.routes.public.documentation_constants import http_responses
 from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/bookings/<int:booking_id>", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_BOOKINGS],

--- a/api/src/pcapi/routes/public/collective/endpoints/categories.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/categories.py
@@ -9,11 +9,11 @@ from pcapi.routes.public.documentation_constants import http_responses
 from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/categories", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     deprecated=True,
@@ -46,7 +46,7 @@ def list_categories() -> offers_serialization.CollectiveOffersListCategoriesResp
 
 
 @blueprints.public_api.route("/v2/collective/subcategories", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     deprecated=True,

--- a/api/src/pcapi/routes/public/collective/endpoints/domains.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/domains.py
@@ -7,11 +7,11 @@ from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.cache import cached_view
-from pcapi.validation.routes.users_authentifications import api_key_required
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/educational-domains", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/educational_institutions.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/educational_institutions.py
@@ -6,11 +6,11 @@ from pcapi.routes.public.documentation_constants import http_responses
 from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/educational-institutions/", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/national_programs.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/national_programs.py
@@ -6,11 +6,11 @@ from pcapi.routes.public.documentation_constants import tags
 from pcapi.routes.serialization import national_programs as serialization
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/national-programs/", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -22,12 +22,12 @@ from pcapi.routes.serialization import collective_offers_serialize
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.image_conversion import DO_NOT_CROP
-from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/offers/", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -66,7 +66,7 @@ def get_collective_offers_public(
 
 
 @blueprints.public_api.route("/v2/collective/offers/<int:offer_id>", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -116,7 +116,7 @@ def get_collective_offer_public(
 
 
 @blueprints.public_api.route("/v2/collective/offers/", methods=["POST"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -250,7 +250,7 @@ def post_collective_offer_public(
 
 
 @blueprints.public_api.route("/v2/collective/offers/<int:offer_id>", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -538,7 +538,7 @@ def patch_collective_offer_public(
 
 
 @blueprints.public_api.route("/v2/collective/offers/formats", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],

--- a/api/src/pcapi/routes/public/collective/endpoints/simulate_adage_steps/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/simulate_adage_steps/bookings.py
@@ -19,8 +19,8 @@ from pcapi.routes.public.documentation_constants import http_responses
 from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 logger = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 @blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/confirm", methods=["POST"])
 @utils.exclude_prod_environment
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     on_success_status=204,
@@ -70,7 +70,7 @@ def confirm_collective_booking(booking_id: int) -> None:
 
 @blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/cancel", methods=["POST"])
 @utils.exclude_prod_environment
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     on_success_status=204,

--- a/api/src/pcapi/routes/public/collective/endpoints/students_levels.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/students_levels.py
@@ -6,11 +6,11 @@ from pcapi.routes.public.documentation_constants import http_responses
 from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/student-levels", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/venues.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/venues.py
@@ -8,12 +8,12 @@ from pcapi.routes.public.documentation_constants import tags
 import pcapi.routes.public.serialization.venues as venues_serialization
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/venues", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_VENUES],
@@ -44,7 +44,7 @@ def list_venues() -> serialization.CollectiveOffersListVenuesResponseModel:
 
 
 @blueprints.public_api.route("/v2/collective/offerer_venues", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_VENUES],

--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
@@ -16,8 +16,8 @@ from pcapi.routes.public.documentation_constants import http_responses
 from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 from . import bookings_serialization as serialization
 
@@ -64,7 +64,7 @@ def _get_paginated_and_filtered_bookings(
 
 
 @blueprints.public_api.route("/public/bookings/v1/bookings", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     response_model=serialization.GetFilteredBookingsResponse,
@@ -119,7 +119,7 @@ def _get_booking_by_token(token: str) -> booking_models.Booking | None:
 
 
 @blueprints.public_api.route("/public/bookings/v1/token/<string:token>", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     response_model=serialization.GetBookingResponse,
@@ -161,7 +161,7 @@ def get_booking_by_token(token: str) -> serialization.GetBookingResponse:
 
 
 @blueprints.public_api.route("/public/bookings/v1/use/token/<token>", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     on_success_status=204,
     api=spectree_schemas.public_api_schema,
@@ -202,7 +202,7 @@ def validate_booking_by_token(token: str) -> None:
 
 
 @blueprints.public_api.route("/public/bookings/v1/keep/token/<token>", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     on_success_status=204,
     api=spectree_schemas.public_api_schema,
@@ -249,7 +249,7 @@ def cancel_booking_validation_by_token(token: str) -> None:
 
 
 @blueprints.public_api.route("/public/bookings/v1/cancel/token/<token>", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     on_success_status=204,
     api=spectree_schemas.public_api_schema,

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -23,8 +23,8 @@ from pcapi.routes.public.services import authorization
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.custom_keys import get_field
-from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 from . import serialization
 from . import utils
@@ -44,7 +44,7 @@ def _deserialize_has_ticket(
 
 
 @blueprints.public_api.route("/public/offers/v1/events", methods=["POST"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFERS],
@@ -129,7 +129,7 @@ def post_event_offer(body: serialization.EventOfferCreation) -> serialization.Ev
 
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFERS],
@@ -161,7 +161,7 @@ def get_event(event_id: int) -> serialization.EventOfferResponse:
 
 
 @blueprints.public_api.route("/public/offers/v1/events", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFERS],
@@ -198,7 +198,7 @@ def get_events(query: serialization.GetOffersQueryParams) -> serialization.Event
 
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFERS],
@@ -263,7 +263,7 @@ def edit_event(event_id: int, body: serialization.EventOfferEdition) -> serializ
 
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/price_categories", methods=["POST"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_PRICES],
@@ -316,7 +316,7 @@ def post_event_price_categories(
 
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/price_categories", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_PRICES],
@@ -355,7 +355,7 @@ def get_event_price_categories(
 @blueprints.public_api.route(
     "/public/offers/v1/events/<int:event_id>/price_categories/<int:price_category_id>", methods=["PATCH"]
 )
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_PRICES],
@@ -412,7 +412,7 @@ def patch_event_price_category(
 
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/dates", methods=["POST"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_STOCKS],
@@ -475,7 +475,7 @@ def post_event_stocks(event_id: int, body: serialization.DatesCreation) -> seria
 
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/dates", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_STOCKS],
@@ -524,7 +524,7 @@ def get_event_stocks(event_id: int, query: serialization.GetDatesQueryParams) ->
 
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/dates/<int:stock_id>", methods=["DELETE"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_STOCKS],
@@ -564,7 +564,7 @@ def delete_event_stock(event_id: int, stock_id: int) -> None:
 
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/dates/<int:stock_id>", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_STOCKS],
@@ -653,7 +653,7 @@ def patch_event_stock(
         )
     ),
 )
-@api_key_required
+@provider_api_key_required
 def get_event_categories() -> serialization.GetEventCategoriesResponse:
     """
     Get event categories

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -35,8 +35,8 @@ from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils import image_conversion
 from pcapi.utils.custom_keys import get_field
-from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
+from pcapi.validation.routes.users_authentifications import provider_api_key_required
 from pcapi.workers import worker
 from pcapi.workers.decorators import job
 
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 
 @blueprints.public_api.route("/public/offers/v1/offerer_venues", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.VENUES],
@@ -75,7 +75,7 @@ def get_offerer_venues(
 
 
 @blueprints.public_api.route("/public/offers/v1/show_types", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.OFFER_ATTRIBUTES],
@@ -105,7 +105,7 @@ def get_show_types() -> serialization.GetShowTypesResponse:
 
 
 @blueprints.public_api.route("/public/offers/v1/music_types", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.OFFER_ATTRIBUTES],
@@ -137,7 +137,7 @@ def get_music_types() -> serialization.GetMusicTypesResponse:
 
 
 @blueprints.public_api.route("/public/offers/v1/music_types/all", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.OFFER_ATTRIBUTES],
@@ -168,7 +168,7 @@ def get_all_titelive_music_types() -> serialization.GetMusicTypesResponse:
 
 
 @blueprints.public_api.route("/public/offers/v1/music_types/event", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.OFFER_ATTRIBUTES],
@@ -278,7 +278,7 @@ def _create_stock(product: offers_models.Offer, body: serialization.ProductOffer
 
 
 @blueprints.public_api.route("/public/offers/v1/products", methods=["POST"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -324,7 +324,7 @@ def post_product_offer(body: serialization.ProductOfferCreation) -> serializatio
 
 
 @blueprints.public_api.route("/public/offers/v1/products/ean", methods=["POST"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_EAN_OFFERS],
@@ -567,7 +567,7 @@ def _create_offer_from_product(
 
 
 @blueprints.public_api.route("/public/offers/v1/products/<int:product_id>", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -599,7 +599,7 @@ def get_product(product_id: int) -> serialization.ProductOfferResponse:
 
 
 @blueprints.public_api.route("/public/offers/v1/products/ean", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_EAN_OFFERS],
@@ -636,7 +636,7 @@ def get_product_by_ean(
 
 
 @blueprints.public_api.route("/public/offers/v1/products/ean/check_availability", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_EAN_OFFERS],
@@ -715,7 +715,7 @@ def _retrieve_offer_by_eans_query(eans: list[str], venueId: int) -> sqla.orm.Que
 
 
 @blueprints.public_api.route("/public/offers/v1/products", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -765,7 +765,7 @@ def _check_offer_can_be_edited(offer: offers_models.Offer) -> None:
 
 
 @blueprints.public_api.route("/public/offers/v1/products", methods=["PATCH"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -876,7 +876,7 @@ def _upsert_product_stock(
 
 
 @blueprints.public_api.route("/public/offers/v1/products/categories", methods=["GET"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -905,7 +905,7 @@ def get_product_categories() -> serialization.GetProductCategoriesResponse:
 
 
 @blueprints.public_api.route("/public/offers/v1/<int:offer_id>/image", methods=["POST"])
-@api_key_required
+@provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.IMAGE],

--- a/api/tests/routes/public/collective/endpoints/get_list_subcategories_test.py
+++ b/api/tests/routes/public/collective/endpoints/get_list_subcategories_test.py
@@ -3,20 +3,22 @@ import pytest
 from pcapi.core import testing
 import pcapi.core.offerers.factories as offerers_factories
 
+from tests.routes.public.helpers import PublicAPIEndpointBaseHelper
+
 
 @pytest.mark.usefixtures("db_session")
-class CollectiveOffersGetCategoriesTest:
+class CollectiveOffersGetCategoriesTest(PublicAPIEndpointBaseHelper):
+    endpoint_url = "/v2/collective/subcategories"
+    endpoint_method = "get"
+
     num_queries = 1  # select api_key, offerer and provider
     num_queries += 1  # select features
 
     def test_list_sub_categories(self, client):
-        offerer = offerers_factories.OffererFactory()
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        plain_api_key, _ = self.setup_provider()
 
         with testing.assert_num_queries(2):
-            response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-                "/v2/collective/subcategories"
-            )
+            response = client.with_explicit_token(plain_api_key).get(self.endpoint_url)
             assert response.status_code == 200
 
         assert response.json == [

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
@@ -140,18 +140,16 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIEndpointBaseHelper):
 
     def test_patch_offer_price_should_be_lower(self, client):
         # Given
-        stock = educational_factories.CollectiveStockFactory()
-        offerer = stock.collectiveOffer.venue.managingOfferer
-        offerers_factories.ApiKeyFactory(offerer=offerer)
-
-        payload = {
-            "totalPrice": 1196.25,
-        }
+        plain_api_key, provider = self.setup_provider()
+        venue_provider = provider_factories.VenueProviderFactory(provider=provider)
+        offer = educational_factories.CollectiveOfferFactory(venue=venue_provider.venue)
+        stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer)
 
         # When
         with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
-                f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
+            response = client.with_explicit_token(plain_api_key).patch(
+                self.endpoint_url.format(offer_id=stock.collectiveOffer.id),
+                json={"totalPrice": 1196.25},
             )
 
         # Then


### PR DESCRIPTION
No change for old stock and booking endpoints (`/v2/stock` & `/v2/booking`). All the current endpoints requires the api key to authenticate a `provider` (and not an `offerer` like the old endpoint did)

## But de la pull request

Ticket Jira (ou description si BSR) :https://passculture.atlassian.net/browse/PC-31785

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
