### PR TITLE
(PC-31789)[API] feat: limit booking count reindexation in staging

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -787,10 +787,14 @@ def update_last_30_days_bookings_for_movies() -> list[offers_models.Product]:
 
 
 def update_booking_count_by_product() -> list[offers_models.Product]:
-    updated_products = update_last_30_days_bookings_for_eans()
-    updated_products += update_last_30_days_bookings_for_movies()
+    updated_ean_products = update_last_30_days_bookings_for_eans()
+    updated_movie_products = update_last_30_days_bookings_for_movies()
 
-    return updated_products
+    if settings.ALGOLIA_OFFERS_INDEX_MAX_SIZE >= 0:
+        updated_ean_products = updated_ean_products[:100]
+        updated_movie_products = updated_movie_products[:100]
+
+    return updated_ean_products + updated_movie_products
 
 
 def clean_processing_queues() -> None:

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -391,6 +391,18 @@ class ReadProductBookingCountTest:
         assert search_testing.search_store["offers"][offer.id]["offer"].get("last30DaysBookings") == 1
 
 
+@mock.patch("pcapi.core.search.update_last_30_days_bookings_for_eans", return_value=list(range(101)))
+@mock.patch("pcapi.core.search.update_last_30_days_bookings_for_movies", return_value=list(range(101)))
+def test_limit_products_to_reindex_depending_on_algolia_limit(_mock_eans, _mock_movies):
+    with override_settings(ALGOLIA_OFFERS_INDEX_MAX_SIZE=-1):
+        items = search.update_booking_count_by_product()
+        assert len(items) == 202
+
+    with override_settings(ALGOLIA_OFFERS_INDEX_MAX_SIZE=1):
+        items = search.update_booking_count_by_product()
+        assert len(items) == 200
+
+
 def test_booking_count_for_movies():
     product = offers_factories.ProductFactory(subcategoryId=subcategories_v2.SEANCE_CINE.id)
     offer = offers_factories.OfferFactory(product=product)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31789

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
