### PR TITLE
(BSR)[API] feat: remove `abc` from `PublicAPIEndpointBaseHelper` definition

### DIFF
--- a/api/tests/routes/public/helpers.py
+++ b/api/tests/routes/public/helpers.py
@@ -1,4 +1,3 @@
-import abc
 import contextlib
 import uuid
 
@@ -20,24 +19,22 @@ from tests.conftest import TestClient
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-class PublicAPIEndpointBaseHelper(abc.ABC):
+class PublicAPIEndpointBaseHelper:
     """
     For Public API endpoints that require authentication
     """
 
     @property
-    @abc.abstractmethod
     def endpoint_url(self):
-        raise NotImplementedError()
+        raise NotImplementedError("You must add an attribute `endpoint_url` in your test class definition")
 
     @property
-    @abc.abstractmethod
     def endpoint_method(self):
         """
         Http verb used to call the endpoint
         Expected values: 'get', 'post', 'patch', 'delete'
         """
-        raise NotImplementedError()
+        raise NotImplementedError("You must add an attribute `endpoint_method` in your test class definition")
 
     @property
     def default_path_params(self) -> dict:
@@ -101,16 +98,15 @@ class PublicAPIEndpointBaseHelper(abc.ABC):
         return offerers_factories.VenueFactory()
 
 
+# pylint: disable=abstract-method
 class PublicAPIVenueEndpointHelper(PublicAPIEndpointBaseHelper):
     """
     For Public API endpoints that require an active `VenueProvider`
     """
 
-    @abc.abstractmethod
     def test_should_raise_404_because_has_no_access_to_venue(self, client: TestClient):
         raise NotImplementedError()
 
-    @abc.abstractmethod
     def test_should_raise_404_because_venue_provider_is_inactive(self, client: TestClient):
         raise NotImplementedError()
 

--- a/api/tests/routes/public/individual_offers/v1/post_image_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_image_test.py
@@ -23,14 +23,12 @@ IMAGES_DIR = Path(tests.__path__[0]) / "files"
 @pytest.mark.usefixtures("db_session")
 class PostProductImageTest(PublicAPIVenueEndpointHelper, ProductEndpointHelper):
     endpoint_url = "/public/offers/v1/{offer_id}/image"
+    endpoint_method = "post"
+    default_path_params = {"offer_id": 123435}
 
     def _get_valid_form(self) -> dict:
         thumb = (IMAGES_DIR / "mouette_full_size.jpg").read_bytes()
         return {"file": (BytesIO(thumb), "image.jpg"), "credit": "John Do"}
-
-    def test_should_raise_401_because_not_authenticated(self, client):
-        response = client.post(self.endpoint_url.format(offer_id="123435"))
-        assert response.status_code == 401
 
     def test_should_raise_404_because_has_no_access_to_venue(self, client):
         plain_api_key, _ = self.setup_provider()


### PR DESCRIPTION
With `abc.abstractmethod`, if an abstract method or an abstract property was not defined in the child class, all the tests were skipped. Now instead it raises a `NotImplementError`

## But de la pull request

### Description

With `abc.abstractmethod`, if an abstract method or an abstract property was not defined in the child class, all the tests were skipped. Now instead it raises a `NotImplementError`.

**Before:**
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/61e36bb3-c840-4f44-98a4-16080e333afb">
**Now:**
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/50085334-ff7f-4f95-a9f0-697bdb073c26">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
