### PR TITLE
(BSR)[API] chore: add atomic decorators in backoffice root routes

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -1300,7 +1300,7 @@ def create_extract_user_gdpr_data(user_id: int) -> utils.BackofficeResponse:
             users_models.User.id == user_id,
         )
         .options(
-            sa.orm.load_only(users_models.User.firstName, users_models.User.lastName),
+            sa.orm.load_only(users_models.User.firstName, users_models.User.lastName, users_models.User.roles),
             sa.orm.joinedload(users_models.User.gdprUserDataExtract),
         )
         .one_or_none()

--- a/api/src/pcapi/routes/backoffice/autocomplete.py
+++ b/api/src/pcapi/routes/backoffice/autocomplete.py
@@ -429,6 +429,7 @@ def prefill_addresses_choices(autocomplete_field: fields.PCTomSelectField) -> No
 
 
 @blueprint.backoffice_web.route("/autocomplete/addresses", methods=["GET"])
+@atomic()
 @login_required
 @spectree_serialize(response_model=AutocompleteResponse, api=blueprint.backoffice_web_schema)
 def autocomplete_addresses() -> AutocompleteResponse:

--- a/api/src/pcapi/routes/backoffice/health_check.py
+++ b/api/src/pcapi/routes/backoffice/health_check.py
@@ -1,16 +1,19 @@
 from flask import current_app
 
+from pcapi.repository import atomic
 from pcapi.utils.health_checker import check_database_connection
 from pcapi.utils.health_checker import read_version_from_file
 
 
 @current_app.route("/health/api", methods=["GET"])
+@atomic()
 def health_api() -> tuple[str, int]:
     output = read_version_from_file()
     return output, 200
 
 
 @current_app.route("/health/database", methods=["GET"])
+@atomic()
 def health_database() -> tuple[str, int]:
     database_working = check_database_connection()
     return_code = 200 if database_working else 500

--- a/api/src/pcapi/routes/backoffice/home.py
+++ b/api/src/pcapi/routes/backoffice/home.py
@@ -12,6 +12,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.models import db
 from pcapi.models import offer_mixin
+from pcapi.repository import atomic
 
 from . import blueprint
 from . import utils
@@ -82,6 +83,7 @@ def _get_fraud_stats() -> dict[str, typing.Any]:
 
 
 @blueprint.backoffice_web.route("/", methods=["GET"])
+@atomic()
 def home() -> utils.BackofficeResponse:
     if not current_user or current_user.is_anonymous:
         return render_template("home/login.html")

--- a/api/src/pcapi/routes/backoffice/redirect.py
+++ b/api/src/pcapi/routes/backoffice/redirect.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import BadRequest
 from wtforms import validators
 
 from pcapi.connectors import virustotal
+from pcapi.repository import atomic
 
 from . import blueprint
 from . import utils
@@ -37,6 +38,7 @@ class SafeRedirectForm(forms_utils.PCForm):
 
 
 @blueprint.backoffice_web.route("/redirect", methods=["GET"])
+@atomic()
 @utils.custom_login_required(redirect_to=".home")
 def safe_redirect() -> utils.BackofficeResponse:
     form = SafeRedirectForm(request.args)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31791

Ajout du décorateur atomic sur les routes

siret_api
autocomplete
health_check
home
move_siret
redirect

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
