### PR TITLE
(PC-31795)[API] chore: drop unused indexes

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 8523f3e2d7d6 (pre) (head)
-4a4fb0253a9b (post) (head)
+265af0d4682c (post) (head)

--- a/api/src/pcapi/alembic/versions/20240911T145845_afa7af785d3a_drop_unused_index_collective_offer_lastValidationDate.py
+++ b/api/src/pcapi/alembic/versions/20240911T145845_afa7af785d3a_drop_unused_index_collective_offer_lastValidationDate.py
@@ -1,0 +1,40 @@
+"""Drop unused index on collective_offer.lastValidationDate
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "afa7af785d3a"
+down_revision = "4a4fb0253a9b"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.drop_index(
+            "ix_collective_offer_lastValidationDate",
+            table_name="collective_offer",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.create_index(
+            "ix_collective_offer_lastValidationDate",
+            "collective_offer",
+            ["lastValidationDate"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")

--- a/api/src/pcapi/alembic/versions/20240911T150554_29b3530a7eac_drop_unused_index_collective_offer_template_lastValidationDate.py
+++ b/api/src/pcapi/alembic/versions/20240911T150554_29b3530a7eac_drop_unused_index_collective_offer_template_lastValidationDate.py
@@ -1,0 +1,40 @@
+"""Drop unused index on collective_offer_template.lastValidationDate
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "29b3530a7eac"
+down_revision = "afa7af785d3a"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.drop_index(
+            "ix_collective_offer_template_lastValidationDate",
+            table_name="collective_offer_template",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.create_index(
+            "ix_collective_offer_template_lastValidationDate",
+            "collective_offer_template",
+            ["lastValidationDate"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")

--- a/api/src/pcapi/alembic/versions/20240911T151216_60adfaea930c_drop_unused_index_offer_lastValidationDate.py
+++ b/api/src/pcapi/alembic/versions/20240911T151216_60adfaea930c_drop_unused_index_offer_lastValidationDate.py
@@ -1,0 +1,40 @@
+"""Drop unused index on offer.lastValidationDate
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "60adfaea930c"
+down_revision = "29b3530a7eac"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.drop_index(
+            "ix_offer_lastValidationDate",
+            table_name="offer",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.create_index(
+            "ix_offer_lastValidationDate",
+            "offer",
+            ["lastValidationDate"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")

--- a/api/src/pcapi/alembic/versions/20240911T152012_265af0d4682c_drop_unused_index_offer_music_type.py
+++ b/api/src/pcapi/alembic/versions/20240911T152012_265af0d4682c_drop_unused_index_offer_music_type.py
@@ -1,0 +1,39 @@
+"""Drop unused index on offer.jsonData['musicType']
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "265af0d4682c"
+down_revision = "60adfaea930c"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.drop_index(
+            "offer_music_type_idx",
+            table_name="offer",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.execute(
+            """
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS
+                offer_music_type_idx ON public.offer USING btree (("jsonData" ->> 'musicType'::text))
+                WHERE (("jsonData" ->> 'musicType'::text)) IS NOT NULL;
+            """
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -595,7 +595,6 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     sa.Index("offer_idAtProvider", idAtProvider)
     sa.Index("offer_ean_idx", extraData["ean"].astext)
     sa.Index("offer_visa_idx", extraData["visa"].astext)
-    sa.Index("offer_music_type_idx", extraData["musicType"].astext, postgresql_where=extraData["musicType"] is not None)
     sa.Index(
         "offer_music_subcategory_with_gtl_id_substr_idx",
         sa.func.substr(extraData["gtl_id"].astext, 1, 2),

--- a/api/src/pcapi/models/offer_mixin.py
+++ b/api/src/pcapi/models/offer_mixin.py
@@ -52,7 +52,7 @@ class OfferValidationType(enum.Enum):
 
 @declarative_mixin
 class ValidationMixin:
-    lastValidationDate = sa.Column(sa.DateTime, index=True, nullable=True)
+    lastValidationDate = sa.Column(sa.DateTime, nullable=True)
 
     lastValidationType = sa.Column(sa.Enum(OfferValidationType, name="validation_type"), nullable=True)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31795

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
