### PR TITLE
(PC-31505)[PRO] feat: tracker save and quit eac button

### DIFF
--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -43,6 +43,7 @@ export enum Events {
   CLICKED_PAGINATION_PREVIOUS_PAGE = 'hasClickedPaginationPreviousPage',
   CLICKED_CONTACT_OUR_TEAMS = 'hasClickedContactOurTeams',
   CLICKED_ARCHIVE_COLLECTIVE_OFFER = 'hasClickedArchiveCollectiveOffer',
+  CLICKED_SAVE_DRAFT_AND_EXIT_COLLECTIVE_OFFER = 'hasClickedSaveDraftAndExitCollectiveOffer',
   FIRST_LOGIN = 'firstLogin',
   PAGE_VIEW = 'page_view',
   SIGNUP_FORM_ABORT = 'signupFormAbort',

--- a/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreationScreen.tsx
@@ -9,11 +9,13 @@ import {
   GetCollectiveOfferTemplateResponseModel,
   GetOffererResponseModel,
 } from 'apiClient/v1'
+import { useAnalytics } from 'app/App/analytics/firebase'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import {
   GET_COLLECTIVE_OFFER_QUERY_KEY,
   GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY,
 } from 'config/swrQueryKeys'
+import { Events } from 'core/FirebaseEvents/constants'
 import { Mode, isCollectiveOfferTemplate } from 'core/OfferEducational/types'
 import { useActiveFeature } from 'hooks/useActiveFeature'
 import { useNotification } from 'hooks/useNotification'
@@ -37,6 +39,7 @@ export const CollectiveOfferPreviewCreationScreen = ({
   const notify = useNotification()
   const navigate = useNavigate()
   const { mutate } = useSWRConfig()
+  const { logEvent } = useAnalytics()
   const [displayRedirectDialog, setDisplayRedirectDialog] = useState(false)
 
   const isCollectiveOfferDraftEnabled = useActiveFeature(
@@ -133,6 +136,10 @@ export const CollectiveOfferPreviewCreationScreen = ({
               to="/offres/collectives"
               variant={ButtonVariant.SECONDARY}
               onClick={() => {
+                logEvent(Events.CLICKED_SAVE_DRAFT_AND_EXIT_COLLECTIVE_OFFER, {
+                  from: location.pathname,
+                })
+
                 notify.success('Brouillon sauvegardé dans la liste des offres')
               }}
             >


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31505

Le bouton s'affiche seulement sous FF (WIP_ENABLE_COLLECTIVE_DRAFT_OFFERS)
Ajout d'un tracker pour le bouton Sauvegarder le brouillon et quitter lors de la création d'une offre collective

## Vérifications

- [x] J'ai écrit les tests nécessaires