### PR TITLE
(PC-31452)[API] feat: public api: adage mock: repay booking

### DIFF
--- a/api/tests/routes/public/collective/endpoints/simulate_adage_steps/test_bookings.py
+++ b/api/tests/routes/public/collective/endpoints/simulate_adage_steps/test_bookings.py
@@ -407,7 +407,6 @@ class UseCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
         plain_api_key, provider = self.setup_provider()
         used_booking = build_used_booking(provider)
         auth_client = client.with_explicit_token(plain_api_key)
-
         error = {"code": "ONLY_CONFIRMED_BOOKING_CAN_BE_USED"}
         with assert_attribute_does_not_change(used_booking, "status"):
             self.use_booking(auth_client, used_booking.id, status_code=403, json_error=error)
@@ -442,7 +441,6 @@ class UseCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
         plain_api_key, provider = self.setup_provider()
         confirmed_booking = build_confirmed_booking(provider)
         auth_client = client.with_explicit_token(plain_api_key)
-
         api_mock.add_event.side_effect = [RuntimeError("test")]
 
         with assert_attribute_does_not_change(confirmed_booking, "status"):
@@ -456,3 +454,71 @@ class UseCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
             expected_status_code=status_code,
             expected_error_json=json_error,
         )
+
+
+class RepayCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
+    endpoint_url = "/v2/collective/adage_mock/bookings/{booking_id}/repay"
+    endpoint_method = "post"
+    default_path_params = {"booking_id": 1}
+
+    def test_cannot_repay_booking_not_linked_to_key(self, client):
+        plain_api_key, _ = self.setup_provider()
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        booking = factories.CollectiveBookingFactory()
+        with assert_attribute_does_not_change(booking, "status"):
+            self.repay_booking(auth_client, booking.id, status_code=404)
+
+    def test_can_repay_used_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        used_booking = build_used_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+        with assert_attribute_value_changes_to(used_booking, "status", models.CollectiveBookingStatus.REIMBURSED):
+            booking_id = used_booking.id
+
+            expected_num_queries = 1  # 1. get api key
+            expected_num_queries += 1  # 2. get FF
+            expected_num_queries += 1  # 3. get collective booking
+            expected_num_queries += 1  # 4. update booking
+            with assert_num_queries(expected_num_queries):
+                self.repay_booking(auth_client, booking_id, status_code=204)
+
+    def test_cannot_repay_pending_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        pending_booking = build_pending_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_does_not_change(pending_booking, "status"):
+            self.repay_booking(auth_client, pending_booking.id, status_code=403)
+
+    def test_cannot_repay_cancelled_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        cancelled_booking = build_cancelled_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_does_not_change(cancelled_booking, "status"):
+            self.repay_booking(auth_client, cancelled_booking.id, status_code=403)
+
+    def test_cannot_repay_confirmed_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        confirmed_booking = build_confirmed_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_does_not_change(confirmed_booking, "status"):
+            self.repay_booking(auth_client, confirmed_booking.id, status_code=403)
+
+    def test_cannot_repay_reimbursed_booking(self, client):
+        plain_api_key, provider = self.setup_provider()
+        reimbursed_booking = build_reimbursed_booking(provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_does_not_change(reimbursed_booking, "status"):
+            self.repay_booking(auth_client, reimbursed_booking.id, status_code=403)
+
+    def repay_booking(self, client, booking_id, status_code, json_error=None):
+        response = self.send_request(client, url_params={"booking_id": booking_id})
+
+        assert response.status_code == status_code
+        if json_error:
+            for key, msg in json_error.items():
+                assert response.json.get(key) == msg

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -11199,6 +11199,60 @@
                 ]
             }
         },
+        "/v2/collective/adage_mock/bookings/{booking_id}/repay": {
+            "post": {
+                "description": "Like this could happen within the Adage platform.\n\nWarning: not available for production nor integration environments",
+                "operationId": "RepayCollectiveBooking",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "booking_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "This collective booking's status has been successfully updated"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API."
+                    },
+                    "403": {
+                        "description": "Collective booking status updated has been refused"
+                    },
+                    "404": {
+                        "description": "The collective offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Mock collective booking repayment.",
+                "tags": [
+                    "Collective bookings Adage mock"
+                ]
+            }
+        },
         "/v2/collective/bookings/{booking_id}": {
             "patch": {
                 "description": "Cancel an collective event booking.",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31452

Nouvelle route pour simuler une action Adage manquante en intégration : passer une réservation collective à l'état remboursé (la partie financière n'est pas nécessaire ici, seul le statut importe).