### PR TITLE
Pc 31411/public api back to pending collective booking route

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -275,6 +275,7 @@ class CancelledCollectiveBookingFactory(CollectiveBookingFactory):
 class PendingCollectiveBookingFactory(CollectiveBookingFactory):
     cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=10))
     confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=10))
+    confirmationDate = None
     status = models.CollectiveBookingStatus.PENDING
 
 

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -11199,6 +11199,60 @@
                 ]
             }
         },
+        "/v2/collective/adage_mock/bookings/{booking_id}/pending": {
+            "post": {
+                "description": "Like this could happen within the Adage platform.\n\nWarning: not available for production nor integration environments",
+                "operationId": "ResetCollectiveBooking",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "booking_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "This collective booking's status has been successfully updated"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API."
+                    },
+                    "403": {
+                        "description": "Collective booking status updated has been refused"
+                    },
+                    "404": {
+                        "description": "The collective offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Adage mock: reset collective booking back to pending state.",
+                "tags": [
+                    "Collective bookings Adage mock"
+                ]
+            }
+        },
         "/v2/collective/bookings/{booking_id}": {
             "patch": {
                 "description": "Cancel an collective event booking.",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31411

Ajout d'une nouvelle route pour simuler une action Adage manquante : repasser une réservation collective à l'état `PENDING`.

### Au passage

Petit fix concernant une _factory_.