### PR TITLE
(PC-31391)[PRO] feat: Sauvegarde de l'adresse lors de la création/édition de l'offre

### DIFF
--- a/pro/src/components/Address/Address.tsx
+++ b/pro/src/components/Address/Address.tsx
@@ -36,7 +36,7 @@ export const AddressSelect = ({
   const [addressesMap, setAddressesMap] = useState<
     Record<string, AutocompleteItemProps>
   >({})
-  const [searchField] = useField('search-addressAutocomplete')
+  const [searchField, searchFieldMeta] = useField('search-addressAutocomplete')
   const [selectedField] = useField('addressAutocomplete')
   useEffect(() => {
     setOptions([{ label: selectedField.value, value: selectedField.value }])
@@ -60,7 +60,7 @@ export const AddressSelect = ({
           label: item.label,
         }))
       )
-    } else if (searchField.value.length === 0) {
+    } else if (searchField.value.length === 0 && searchFieldMeta.touched) {
       setOptions([])
       handleAddressSelect(setFieldValue, undefined, searchField)
     }

--- a/pro/src/components/IndividualOfferForm/OfferLocation/OfferLocation.module.scss
+++ b/pro/src/components/IndividualOfferForm/OfferLocation/OfferLocation.module.scss
@@ -3,7 +3,7 @@
 
 .offerlocation-wrapper {
   .infotext {
-    @include fonts.body-exergue;
+    @include fonts.body;
 
     margin-top: rem.torem(24px);
     margin-bottom: rem.torem(24px);

--- a/pro/src/components/IndividualOfferForm/OfferLocation/OfferLocation.tsx
+++ b/pro/src/components/IndividualOfferForm/OfferLocation/OfferLocation.tsx
@@ -93,7 +93,7 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
           withBorder
           label={venueFullText}
           name="offerlocation"
-          value={venue?.address?.id.toString() ?? ''}
+          value={venue?.address?.id_oa.toString() ?? ''}
           required
           onChange={onChangeOfferLocation}
         />

--- a/pro/src/components/IndividualOfferForm/types.ts
+++ b/pro/src/components/IndividualOfferForm/types.ts
@@ -40,13 +40,13 @@ export interface IndividualOfferFormValues {
   manuallySetAddress?: boolean
   'search-addressAutocomplete'?: string
   addressAutocomplete?: string
-  street?: string
+  banId?: string | null
+  street?: string | null
   postalCode?: string
   city?: string
   coords?: string
   latitude?: string
   longitude?: string
-  banId?: string
 }
 
 export type IndividualOfferForm = FormikProps<IndividualOfferFormValues>

--- a/pro/src/components/IndividualOfferForm/types.ts
+++ b/pro/src/components/IndividualOfferForm/types.ts
@@ -36,7 +36,7 @@ export interface IndividualOfferFormValues {
   isVenueVirtual?: boolean
   bookingContact?: string
   offerlocation?: string | undefined
-  locationLabel?: string
+  locationLabel?: string | null
   manuallySetAddress?: boolean
   'search-addressAutocomplete'?: string
   addressAutocomplete?: string

--- a/pro/src/components/OfferAppPreview/OfferAppPreview.tsx
+++ b/pro/src/components/OfferAppPreview/OfferAppPreview.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { GetIndividualOfferResponseModel } from 'apiClient/v1'
+import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { getIndividualOfferImage } from 'screens/IndividualOffer/utils/getIndividualOfferImage'
 
 import style from './OfferAppPreview.module.scss'
@@ -8,7 +9,7 @@ import { OptionsIcons } from './OptionsIcons/OptionsIcons'
 import { VenueDetails } from './VenueDetails/VenueDetails'
 
 interface OfferAppPreviewProps {
-  offer: GetIndividualOfferResponseModel
+  offer: GetIndividualOfferWithAddressResponseModel
 }
 
 export const OfferAppPreview = ({
@@ -16,6 +17,8 @@ export const OfferAppPreview = ({
 }: OfferAppPreviewProps): JSX.Element => {
   const { venue } = offer
   const image = getIndividualOfferImage(offer)
+
+  const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
 
   const cropPreviewText = (text: string, maxLength = 300): string => {
     if (text.trim().length > maxLength) {
@@ -60,6 +63,7 @@ export const OfferAppPreview = ({
         {!venue.isVirtual && (
           <VenueDetails
             venue={venue}
+            address={isOfferAddressEnabled ? offer.address : undefined}
             withdrawalDetails={
               offer.withdrawalDetails
                 ? cropPreviewText(offer.withdrawalDetails)

--- a/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.tsx
+++ b/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.tsx
@@ -2,6 +2,7 @@ import {
   AddressResponseIsEditableModel,
   GetOfferVenueResponseModel,
 } from 'apiClient/v1'
+import { computeAddressDisplayName } from 'repository/venuesService'
 
 import style from './VenueDetails.module.scss'
 
@@ -16,18 +17,19 @@ export const VenueDetails = ({
   address,
   withdrawalDetails,
 }: VenueDetailsProps): JSX.Element => {
-  const addressObj = address || venue
+  const { street, postalCode, city } = address || venue
 
   const label = address ? address.label : venue.publicName || venue.name
 
-  const venueAddressString = [
-    label,
-    addressObj.street,
-    addressObj.postalCode,
-    addressObj.city,
-  ]
-    .filter((str) => Boolean(str))
-    .join(' - ')
+  const venueAddressString = computeAddressDisplayName(
+    {
+      label,
+      street,
+      postalCode: postalCode || '',
+      city: city || '',
+    },
+    true
+  )
 
   return (
     <div className={style['venue-details']}>

--- a/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.tsx
+++ b/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.tsx
@@ -1,24 +1,30 @@
-import React from 'react'
-
-import { GetOfferVenueResponseModel } from 'apiClient/v1'
+import {
+  AddressResponseIsEditableModel,
+  GetOfferVenueResponseModel,
+} from 'apiClient/v1'
 
 import style from './VenueDetails.module.scss'
 
 interface VenueDetailsProps {
   venue: GetOfferVenueResponseModel
+  address?: AddressResponseIsEditableModel | null
   withdrawalDetails?: string
 }
 
 export const VenueDetails = ({
   venue,
+  address,
   withdrawalDetails,
 }: VenueDetailsProps): JSX.Element => {
-  const venueName = venue.publicName || venue.name
+  const addressObj = address || venue
+
+  const label = address ? address.label : venue.publicName || venue.name
+
   const venueAddressString = [
-    venueName,
-    venue.street,
-    venue.postalCode,
-    venue.city,
+    label,
+    addressObj.street,
+    addressObj.postalCode,
+    addressObj.city,
   ]
     .filter((str) => Boolean(str))
     .join(' - ')

--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
@@ -132,8 +132,10 @@ export const DetailsForm = ({
     subcategoryId === SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_CD ||
     subcategoryId === SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE
 
+  // Show the field if more than 1 venue (whatever the FF),
+  // otherwise if there is only 1 venue, we want to show only if both offerAddress and splitOfferEnabled are enabled
   const SHOW_VENUE_SELECTION_FIELD =
-    !areSuggestedSubcategoriesUsed || venueOptions.length > 1
+    venueOptions.length > 1 || (!offerAddressEnabled && !splitOfferEnabled)
 
   const selectedOffererId = useSelector(selectCurrentOffererId)
 

--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsForm.tsx
@@ -77,6 +77,7 @@ export const DetailsForm = ({
   )
 
   const offerAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
+  const splitOfferEnabled = useActiveFeature('WIP_SPLIT_OFFER')
 
   async function getSuggestedSubcategories() {
     if (!areSuggestedSubcategoriesUsed && !offer) {

--- a/pro/src/screens/IndividualOffer/DetailsScreen/__specs__/DetailsScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/__specs__/DetailsScreen.spec.tsx
@@ -811,7 +811,8 @@ describe('screens:IndividualOffer::Informations', () => {
     props.venues = [venueListItemFactory({ id: 189 })]
 
     renderDetailsScreen(props, contextValue, {
-      features: ['WIP_SUGGESTED_SUBCATEGORIES'],
+      // There is no world where WIP_SUGGESTED_SUBCATEGORIES is enabled without WIP_SPLIT_OFFER
+      features: ['WIP_SPLIT_OFFER', 'WIP_SUGGESTED_SUBCATEGORIES'],
     })
 
     expect(screen.queryByText(/Lieu/)).not.toBeInTheDocument()

--- a/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/serializers.spec.ts
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/__specs__/serializers.spec.ts
@@ -136,5 +136,34 @@ describe('test updateIndividualOffer::serializers', () => {
         })
       ).toEqual(patchBody)
     })
+
+    it('should serialize patchBody with address data (WIP_ENABLE_OFFER_ADDRESS)', () => {
+      formValues = {
+        ...formValues,
+        city: 'Paris',
+        latitude: '48.853320',
+        longitude: '2.348979',
+        postalCode: '75001',
+        street: '3 Rue de Valois',
+        locationLabel: 'Bureau',
+      }
+      patchBody = {
+        ...patchBody,
+        address: {
+          city: 'Paris',
+          latitude: '48.853320',
+          longitude: '2.348979',
+          postalCode: '75001',
+          street: '3 Rue de Valois',
+          label: 'Bureau',
+        },
+      }
+      expect(
+        serializePatchOffer({
+          offer: getIndividualOfferFactory(),
+          formValues,
+        })
+      ).toEqual(patchBody)
+    })
   })
 })

--- a/pro/src/screens/IndividualOffer/InformationsScreen/serializePatchOffer.ts
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/serializePatchOffer.ts
@@ -76,7 +76,8 @@ export const serializePatchOffer = ({
   }
 
   let addressValues = {}
-
+  // Once WIP_ENABLE_OFFER_ADDRESS have been adopted, just remove this condition and place Object address in the lower return
+  //  (address data would always be present in payload)
   if (
     sentValues.city &&
     sentValues.latitude &&

--- a/pro/src/screens/IndividualOffer/InformationsScreen/serializePatchOffer.ts
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/serializePatchOffer.ts
@@ -111,5 +111,13 @@ export const serializePatchOffer = ({
     url: sentValues.url || undefined,
     shouldSendMail: shouldSendMail,
     bookingContact: sentValues.bookingContact || undefined,
+    address: {
+      city: sentValues.city ?? '',
+      latitude: sentValues.latitude ?? '',
+      longitude: sentValues.longitude ?? '',
+      postalCode: sentValues.postalCode ?? '',
+      street: sentValues.street ?? '',
+      label: sentValues.locationLabel ?? '',
+    },
   }
 }

--- a/pro/src/screens/IndividualOffer/InformationsScreen/serializePatchOffer.ts
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/serializePatchOffer.ts
@@ -75,6 +75,28 @@ export const serializePatchOffer = ({
     sentValues = Object.fromEntries(filtered)
   }
 
+  let addressValues = {}
+
+  if (
+    sentValues.city &&
+    sentValues.latitude &&
+    sentValues.longitude &&
+    sentValues.postalCode &&
+    sentValues.street &&
+    sentValues.locationLabel
+  ) {
+    addressValues = {
+      address: {
+        city: sentValues.city,
+        latitude: sentValues.latitude,
+        longitude: sentValues.longitude,
+        postalCode: sentValues.postalCode,
+        street: sentValues.street,
+        label: sentValues.locationLabel,
+      },
+    }
+  }
+
   return {
     audioDisabilityCompliant:
       sentValues.accessibility &&
@@ -111,13 +133,6 @@ export const serializePatchOffer = ({
     url: sentValues.url || undefined,
     shouldSendMail: shouldSendMail,
     bookingContact: sentValues.bookingContact || undefined,
-    address: {
-      city: sentValues.city ?? '',
-      latitude: sentValues.latitude ?? '',
-      longitude: sentValues.longitude ?? '',
-      postalCode: sentValues.postalCode ?? '',
-      street: sentValues.street ?? '',
-      label: sentValues.locationLabel ?? '',
-    },
+    ...addressValues,
   }
 }

--- a/pro/src/screens/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
@@ -648,9 +648,10 @@ describe('Summary', () => {
         await screen.findByText('Localisation de l’offre')
       ).toBeInTheDocument()
 
+      // Should be present in recap section and in app preview section
       expect(
-        await screen.findByText('mon adresse - ma street 1 ma ville')
-      ).toBeInTheDocument()
+        await screen.findAllByText('mon adresse - ma street 1 ma ville')
+      ).toHaveLength(2)
     })
   })
 

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
@@ -175,7 +175,7 @@ export const UsefulInformationScreen = ({
     isOfferAddressEnabled,
   })
   const formik = useFormik({
-    initialValues: setDefaultInitialValuesFromOffer(offer, { selectedVenue }),
+    initialValues: setDefaultInitialValuesFromOffer({ offer, selectedVenue }),
     onSubmit,
     validationSchema,
   })

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/UsefulInformationScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/UsefulInformationScreen.spec.tsx
@@ -182,6 +182,18 @@ describe('screens:IndividualOffer::UsefulInformation', () => {
     expect(
       screen.queryByLabelText(/Intitulé de la localisation/)
     ).toBeInTheDocument()
+
+    // If user toggle manual address fields
+    await userEvent.click(
+      screen.getByTitle(/Renseignez l’adresse manuellement/)
+    )
+    // ...then he should see the different address fields
+    expect(
+      screen.queryByLabelText(/Adresse postale/, { selector: '#street' })
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Code postal/)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Ville/)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Coordonnées GPS/)).toBeInTheDocument()
   })
 
   it('should submit the form with correct payload', async () => {

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/UsefulInformationScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/UsefulInformationScreen.spec.tsx
@@ -98,10 +98,15 @@ describe('screens:IndividualOffer::UsefulInformation', () => {
       categories,
       subCategories,
     })
+
+    vi.spyOn(api, 'getVenues').mockResolvedValue({
+      venues: [{ ...venueListItemFactory({ id: 1 }) }],
+    })
   })
 
   it('should render the component', async () => {
     renderUsefulInformationScreen(props, contextValue)
+
     expect(
       await screen.findByRole('heading', { name: 'Retrait de l’offre' })
     ).toBeInTheDocument()
@@ -185,8 +190,6 @@ describe('screens:IndividualOffer::UsefulInformation', () => {
         id: 12,
       })
     )
-    vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: [] })
-
     renderUsefulInformationScreen(props, contextValue)
 
     const withdrawalField = await screen.findByLabelText(

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
@@ -3,6 +3,7 @@ import {
   SubcategoryResponseModel,
   WithdrawalTypeEnum,
 } from 'apiClient/v1'
+import { OFFER_LOCATION } from 'components/IndividualOfferForm/OfferLocation/constants'
 import { CATEGORY_STATUS } from 'core/Offers/constants'
 import { AccessibilityEnum } from 'core/shared/types'
 import {
@@ -217,6 +218,63 @@ describe('setDefaultInitialValuesFromOffer', () => {
     const result = setDefaultInitialValuesFromOffer(
       mockOfferWithNullWithdrawalDelay
     )
+
+    expect(result).toEqual(expectedValues)
+  })
+
+  it('should handle address fields', () => {
+    mockOffer.address = {
+      id: 1,
+      id_oa: 997,
+      isEditable: true,
+      isManualEdition: true,
+      latitude: 48.85332,
+      longitude: 2.348979,
+      postalCode: '75001',
+      street: '3 rue de Valois',
+      city: 'Paris',
+      label: 'Bureau',
+      banId: '35288_7283_00001',
+    }
+
+    const { street, postalCode, city, latitude, longitude } = mockOffer.address!
+    const addressAutocomplete = `${street} ${postalCode} ${city}`
+    const coords = `${latitude}, ${longitude}`
+
+    const expectedValues = {
+      isEvent: true,
+      isNational: false,
+      isVenueVirtual: false,
+      withdrawalDetails: 'Detailed info',
+      withdrawalDelay: 3,
+      withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+      accessibility: {
+        [AccessibilityEnum.VISUAL]: true,
+        [AccessibilityEnum.MENTAL]: false,
+        [AccessibilityEnum.AUDIO]: true,
+        [AccessibilityEnum.MOTOR]: false,
+        [AccessibilityEnum.NONE]: false,
+      },
+      bookingEmail: 'test@example.com',
+      bookingContact: 'Contact Info',
+      receiveNotificationEmails: true,
+      url: 'http://example.com',
+
+      offerlocation: OFFER_LOCATION.OTHER_ADDRESS,
+      manuallySetAddress: true,
+      'search-addressAutocomplete': addressAutocomplete,
+      addressAutocomplete,
+      coords,
+      banId: '35288_7283_00001',
+      locationLabel: 'Bureau',
+      street: '3 rue de Valois',
+      postalCode: '75001',
+      city: 'Paris',
+      latitude: '48.85332',
+      longitude: '2.348979',
+    }
+
+    const result = setDefaultInitialValuesFromOffer(mockOffer)
 
     expect(result).toEqual(expectedValues)
   })

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
@@ -123,7 +123,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
       url: 'http://example.com',
     }
 
-    const result = setDefaultInitialValuesFromOffer(mockOffer)
+    const result = setDefaultInitialValuesFromOffer({ offer: mockOffer })
 
     expect(result).toEqual(expectedValues)
   })
@@ -159,9 +159,9 @@ describe('setDefaultInitialValuesFromOffer', () => {
       url: DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['url'],
     }
 
-    const result = setDefaultInitialValuesFromOffer(
-      mockOfferWithMissingProperties
-    )
+    const result = setDefaultInitialValuesFromOffer({
+      offer: mockOfferWithMissingProperties,
+    })
 
     expect(result).toEqual(expectedValues)
   })
@@ -197,9 +197,9 @@ describe('setDefaultInitialValuesFromOffer', () => {
       url: DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['url'],
     }
 
-    const result = setDefaultInitialValuesFromOffer(
-      mockOfferWithMissingProperties
-    )
+    const result = setDefaultInitialValuesFromOffer({
+      offer: mockOfferWithMissingProperties,
+    })
 
     expect(result).toEqual(expectedValues)
   })
@@ -211,13 +211,13 @@ describe('setDefaultInitialValuesFromOffer', () => {
     })
 
     const expectedValues = {
-      ...setDefaultInitialValuesFromOffer(mockOffer),
+      ...setDefaultInitialValuesFromOffer({ offer: mockOffer }),
       withdrawalDelay: undefined,
     }
 
-    const result = setDefaultInitialValuesFromOffer(
-      mockOfferWithNullWithdrawalDelay
-    )
+    const result = setDefaultInitialValuesFromOffer({
+      offer: mockOfferWithNullWithdrawalDelay,
+    })
 
     expect(result).toEqual(expectedValues)
   })
@@ -274,7 +274,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
       longitude: '2.348979',
     }
 
-    const result = setDefaultInitialValuesFromOffer(mockOffer)
+    const result = setDefaultInitialValuesFromOffer({ offer: mockOffer })
 
     expect(result).toEqual(expectedValues)
   })

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/types.ts
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/types.ts
@@ -13,5 +13,17 @@ export type UsefulInformationFormValues = {
   url: string
   isVenueVirtual?: boolean
   bookingContact?: string
+
   offerlocation?: string | undefined
+  manuallySetAddress?: boolean
+  'search-addressAutocomplete'?: string
+  addressAutocomplete?: string
+  coords?: string
+  banId?: string | null
+  locationLabel?: string | null
+  street?: string | null
+  postalCode?: string
+  city?: string
+  latitude?: string
+  longitude?: string
 }

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/utils.ts
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/utils.ts
@@ -13,6 +13,7 @@ import {
 } from 'core/Offers/constants'
 import { isOfferSynchronized } from 'core/Offers/utils/synchronization'
 import { AccessibilityEnum } from 'core/shared/types'
+import { computeAddressDisplayName } from 'repository/venuesService'
 
 import { DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES } from './constants'
 import { UsefulInformationFormValues } from './types'
@@ -36,13 +37,14 @@ export const getFilteredVenueListBySubcategory = (
   )
 }
 
-interface DefaultInitialValuesFromOfferOptions {
-  selectedVenue: VenueListItemResponseModel | undefined
+interface SetDefaultInitialValuesFromOfferProps {
+  offer: GetIndividualOfferWithAddressResponseModel
+  selectedVenue?: VenueListItemResponseModel | undefined
 }
-export function setDefaultInitialValuesFromOffer(
-  offer: GetIndividualOfferWithAddressResponseModel,
-  options?: DefaultInitialValuesFromOfferOptions
-): UsefulInformationFormValues {
+export function setDefaultInitialValuesFromOffer({
+  offer,
+  selectedVenue = undefined,
+}: SetDefaultInitialValuesFromOfferProps): UsefulInformationFormValues {
   const baseAccessibility = {
     [AccessibilityEnum.VISUAL]: offer.visualDisabilityCompliant,
     [AccessibilityEnum.MENTAL]: offer.mentalDisabilityCompliant,
@@ -56,16 +58,16 @@ export function setDefaultInitialValuesFromOffer(
 
   let addressFields = {}
   if (offer.address) {
-    const { street, postalCode, city, latitude, longitude } = offer.address
-    const addressAutocomplete = `${street} ${postalCode} ${city}`
+    const { latitude, longitude } = offer.address
+    const addressAutocomplete = computeAddressDisplayName(offer.address, false)
     const coords = `${latitude}, ${longitude}`
 
     // If the venue's OA selected at step 1 is the same than the one we have saved in offer draft,
     //  then set this OA id in formik field (so it will be checked by default)
     //  Else, we can assume it's an "other" address
     const offerlocation =
-      options?.selectedVenue?.address &&
-      options.selectedVenue.address.id_oa === offer.address.id_oa
+      selectedVenue?.address &&
+      selectedVenue.address.id_oa === offer.address.id_oa
         ? offer.address.id_oa
         : OFFER_LOCATION.OTHER_ADDRESS
 

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/utils.ts
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/utils.ts
@@ -41,7 +41,7 @@ interface DefaultInitialValuesFromOfferOptions {
 }
 export function setDefaultInitialValuesFromOffer(
   offer: GetIndividualOfferWithAddressResponseModel,
-  options: DefaultInitialValuesFromOfferOptions
+  options?: DefaultInitialValuesFromOfferOptions
 ): UsefulInformationFormValues {
   const baseAccessibility = {
     [AccessibilityEnum.VISUAL]: offer.visualDisabilityCompliant,
@@ -64,7 +64,7 @@ export function setDefaultInitialValuesFromOffer(
     //  then set this OA id in formik field (so it will be checked by default)
     //  Else, we can assume it's an "other" address
     const offerlocation =
-      options.selectedVenue?.address &&
+      options?.selectedVenue?.address &&
       options.selectedVenue.address.id_oa === offer.address.id_oa
         ? offer.address.id_oa
         : OFFER_LOCATION.OTHER_ADDRESS


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31391

Features flags à activer :
- WIP_SPLIT_OFFER
- WIP_ENABLE_OFFER_ADDRESS

> [!NOTE]
> Pour tester en local la sauvegarde de l'adresse, il faut désactiver le connecteur de l'API adresse en modifiant la variable d'environnement suivante dans `api/.env.development`
> ```env
> # ADRESSE_BACKEND=pcapi.connectors.api_adresse.TestingBackend
> ADRESSE_BACKEND=pcapi.connectors.api_adresse.ApiAdresseBackend
> ```
> … et relancer le conteneur `pc-api` 

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
