### PR TITLE
(PC-31285)[PRO] fix: make redirection callback appear when WIP_EAN_SEARCH only

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsSubForm/DetailsSubForm.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsSubForm/DetailsSubForm.spec.tsx
@@ -51,17 +51,24 @@ const DetailsSubFormWrappedWithFormik = ({
   )
 }
 
-const renderDetailsSubForm = (args?: DetailsSubFormTestProps) => {
+const renderDetailsSubForm = ({
+  props,
+  enableEANSearch = false,
+}: {
+  props?: DetailsSubFormTestProps
+  enableEANSearch?: boolean
+}) => {
   return renderWithProviders(
     <IndividualOfferContext.Provider value={contextValue}>
-      <DetailsSubFormWrappedWithFormik {...args} />
-    </IndividualOfferContext.Provider>
+      <DetailsSubFormWrappedWithFormik {...props} />
+    </IndividualOfferContext.Provider>,
+    enableEANSearch ? { features: ['WIP_EAN_CREATION'] } : {}
   )
 }
 
 describe('DetailsSubForm', () => {
   it('should display conditional fields based on the selected category', () => {
-    renderDetailsSubForm()
+    renderDetailsSubForm({})
 
     const subFormTextInputs = {
       speaker: /Intervenant/,
@@ -91,26 +98,34 @@ describe('DetailsSubForm', () => {
     expect(subFormDurationInput).toBeInTheDocument()
   })
 
-  describe('when the offer is product-based', () => {
-    it('should not display the EAN field since it would duplicate top EAN search/input field', () => {
-      renderDetailsSubForm({ isProductBased: true })
+  describe('when the EAN search is available', () => {
+    describe('when the offer is product-based', () => {
+      it('should not display the EAN field since it would duplicate top EAN search/input field', () => {
+        renderDetailsSubForm({
+          props: { isProductBased: true },
+          enableEANSearch: true,
+        })
 
-      const eanInput = screen.queryByRole('textbox', { name: /EAN/ })
-      expect(eanInput).not.toBeInTheDocument()
-    })
-  })
-
-  describe('when the offer is non-product based', () => {
-    it('should display a callout instead when the offer is a CD/vinyl', () => {
-      renderDetailsSubForm({
-        isProductBased: false,
-        isOfferCDOrVinyl: true,
+        const eanInput = screen.queryByRole('textbox', { name: /EAN/ })
+        expect(eanInput).not.toBeInTheDocument()
       })
+    })
 
-      const calloutWrapper = screen.getByRole('alert')
-      const calloutLabel = /Cette catégorie nécessite un EAN./
-      expect(calloutWrapper).toBeInTheDocument()
-      expect(calloutWrapper).toHaveTextContent(calloutLabel)
+    describe('when the offer is non-product based', () => {
+      it('should display a callout instead when the offer is a CD/vinyl', () => {
+        renderDetailsSubForm({
+          props: {
+            isProductBased: false,
+            isOfferCDOrVinyl: true,
+          },
+          enableEANSearch: true,
+        })
+
+        const calloutWrapper = screen.getByRole('alert')
+        const calloutLabel = /Cette catégorie nécessite un EAN./
+        expect(calloutWrapper).toBeInTheDocument()
+        expect(calloutWrapper).toHaveTextContent(calloutLabel)
+      })
     })
   })
 })

--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsSubForm/DetailsSubForm.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsSubForm/DetailsSubForm.tsx
@@ -10,6 +10,7 @@ import { ImageUploaderOffer } from 'components/IndividualOfferForm/ImageUploader
 import { GET_MUSIC_TYPES_QUERY_KEY } from 'config/swrQueryKeys'
 import { showOptionsTree } from 'core/Offers/categoriesSubTypes'
 import { IndividualOfferImage } from 'core/Offers/types'
+import { useActiveFeature } from 'hooks/useActiveFeature'
 import { Select } from 'ui-kit/form/Select/Select'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 import { TimePicker } from 'ui-kit/form/TimePicker/TimePicker'
@@ -52,6 +53,7 @@ export const DetailsSubForm = ({
   const {
     values: { categoryId, showType, subcategoryConditionalFields },
   } = useFormikContext<DetailsFormValues>()
+  const isSearchByEanEnabled = useActiveFeature('WIP_EAN_CREATION')
 
   const musicTypesQuery = useSWR(
     GET_MUSIC_TYPES_QUERY_KEY,
@@ -75,7 +77,8 @@ export const DetailsSubForm = ({
   // In the context of an offer creation, vinyls & CDs must be
   // product-based offers so the form must be pre-filled with
   // the results of an EAN search.
-  const displayRedirectionCallout = !isProductBased && isOfferCDOrVinyl
+  const displayRedirectionCallout =
+    isSearchByEanEnabled && !isProductBased && isOfferCDOrVinyl
   const displayImageUploader = !isProductBased || imageOffer
   const displayArtisticInformations = ARTISTIC_INFORMATION_FIELDS.some(
     (field) => subcategoryConditionalFields.includes(field)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31285
Hotfix !

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
