### PR TITLE
(PC-31649)[API] fix: ignore verso image if placeholder

### DIFF
--- a/api/src/pcapi/connectors/serialization/titelive_serializers.py
+++ b/api/src/pcapi/connectors/serialization/titelive_serializers.py
@@ -72,6 +72,7 @@ class TiteliveArticle(BaseModel):
         gencod: pydantic_v1.constr(min_length=13, max_length=13)
     gtl: TiteliveGtl | None
     has_image: bool = pydantic_v1.Field(alias="image")
+    has_verso_image: bool = pydantic_v1.Field(alias="image_4")
     imagesUrl: TiteliveImage
     # TODO: (lixxday, 2024-04-17): titlelive sends an int for dispo, casting to str works ; but we probably want to change this
     dispo: str
@@ -90,7 +91,7 @@ class TiteliveArticle(BaseModel):
             return None
         return gtl
 
-    @pydantic_v1.validator("has_image", pre=True)
+    @pydantic_v1.validator("has_image", "has_verso_image", pre=True)
     def validate_image(cls, image: str | int | None) -> bool:
         # The API currently sends 0 (int) if no image is available, and "1" (str) if an image is available.
         # Because it has been famously flaky in the past, we are being defensive here and consider:

--- a/api/src/pcapi/core/providers/titelive_api.py
+++ b/api/src/pcapi/core/providers/titelive_api.py
@@ -183,15 +183,20 @@ class TiteliveSearch(abc.ABC, typing.Generic[TiteliveWorkType]):
         products: list[offers_models.Product],
         titelive_page: list[TiteliveWorkType],
     ) -> list[offers_models.Product]:
-        thumbnail_url_by_ean: dict[str, dict[offers_models.TiteliveImageType, str | None]] = {
-            article.gencod: {
-                offers_models.TiteliveImageType.RECTO: article.imagesUrl.recto,
-                offers_models.TiteliveImageType.VERSO: article.imagesUrl.verso,
-            }
-            for work in titelive_page
-            for article in work.article
-            if article.has_image
-        }
+        thumbnail_url_by_ean: dict[str, dict[offers_models.TiteliveImageType, str]] = {}
+
+        for work in titelive_page:
+            for article in work.article:
+                thumbnail_url_by_ean[article.gencod] = {}
+                if article.has_image:
+                    thumbnail_url_by_ean[article.gencod][
+                        offers_models.TiteliveImageType.RECTO
+                    ] = article.imagesUrl.recto
+                if article.has_verso_image:
+                    thumbnail_url_by_ean[article.gencod][
+                        offers_models.TiteliveImageType.VERSO
+                    ] = article.imagesUrl.verso
+
         for product in products:
             assert product.extraData, "product %s initialized without extra data" % product.id
 

--- a/api/tests/connectors/titelive/fixtures.py
+++ b/api/tests/connectors/titelive/fixtures.py
@@ -492,7 +492,7 @@ TWO_BOOKS_RESPONSE_FIXTURE = {
                     "image": "1",
                     "image_spe": "1",
                     "image_alkor": 0,
-                    "image_4": "1",
+                    "image_4": 0,
                     "imagesUrl": {
                         "recto": "https://images.epagine.fr/676/9782848018676_1_75.jpg",
                         "vign": "https://images.epagine.fr/676/9782848018676_1_v.jpg",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31649
Titelive envoie parfois une image "verso" qui n'est qu'in placeholder. Heureusement il donne aussi l'info s'il y a une _vraie_ image verso avec le champ "image_4"
On utilise ça
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
