### PR TITLE
(BSR)[PRO] fix: firebase PRO deployment

### DIFF
--- a/.github/workflows/dev_on_workflow_configure_live_channel_pro_generic.yml
+++ b/.github/workflows/dev_on_workflow_configure_live_channel_pro_generic.yml
@@ -44,7 +44,10 @@ jobs:
         env:
           CREDENTIALS: ${{ steps.secrets.outputs.FIREBASE_TOKEN }}
           GOOGLE_APPLICATION_CREDENTIALS: "credentials.json"
+        # Temporary workaround to deploy firebase. Lines 49-51 should be replaced by `curl -sL https://firebase.tools | bash`
         run: |
-          curl -sL https://firebase.tools | bash
+          curl -sL https://firebase.tools > temp.sh
+          sed -i s/latest/v13.16.0/ temp.sh
+          cat temp.sh | bash
           echo $CREDENTIALS > credentials.json
           firebase hosting:clone pc-pro-${{ inputs.ENV }}:${{ inputs.VERSION }} pc-pro-${{ inputs.ENV }}:live


### PR DESCRIPTION
## But de la pull request
Because of [this issue](https://github.com/firebase/firebase-tools/issues/7648) pro deployment failed. 
We try this workaround to unlock the situation

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
