### PR TITLE
(PC-31693)[PRO] style: Fix Callout title size.

### DIFF
--- a/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
+++ b/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
@@ -154,6 +154,7 @@ export const CollectiveOfferConfirmationScreen = ({
 
       <Callout
         className={styles['confirmation-banner']}
+        title="Quelle est la prochaine étape ?"
         links={[
           {
             href: `https://aide.passculture.app/hc/fr/articles/4416082284945--Acteurs-Culturels-Quel-est-le-cycle-de-vie-de-mon-offre-collective-de-sa-cr%C3%A9ation-%C3%A0-son-remboursement`,
@@ -163,9 +164,6 @@ export const CollectiveOfferConfirmationScreen = ({
           },
         ]}
       >
-        <h2 className={styles['confirmation-banner-title']}>
-          Quelle est la prochaine étape ?
-        </h2>
         {isShowcase ? (
           <>
             Les enseignants intéressés par votre offre vitrine vous contacterons


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31693

**Objectif**
Corriger l'affichage de la taille de texte du titre du callout au moment de la validation de publication d'une offre collective :
![Capture d’écran 2024-09-06 à 10 56 07](https://github.com/user-attachments/assets/cfb7372f-f36c-4901-ad06-6b04274981c9)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
