### PR TITLE
(PC-31814)[API] fix: post multiple favorite on same offer

### DIFF
--- a/api/src/pcapi/core/educational/api/favorites.py
+++ b/api/src/pcapi/core/educational/api/favorites.py
@@ -1,11 +1,12 @@
 import typing
 
 import sqlalchemy as sa
+from sqlalchemy import exc
 
+from pcapi import repository
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
-from pcapi.repository import repository
 
 
 def get_redactors_favorite_templates_subset(
@@ -20,24 +21,40 @@ def get_redactors_favorite_templates_subset(
 
 
 def add_offer_to_favorite_adage(
-    redactorId: int,
-    offerId: int,
+    redactor_id: int,
+    offer_id: int,
 ) -> educational_models.CollectiveOfferEducationalRedactor:
-    favorite_offer = educational_models.CollectiveOfferEducationalRedactor(
-        educationalRedactorId=redactorId, collectiveOfferId=offerId
-    )
-    repository.save(favorite_offer)
+    try:
+        with repository.transaction():
+            favorite_offer = educational_models.CollectiveOfferEducationalRedactor(
+                educationalRedactorId=redactor_id, collectiveOfferId=offer_id
+            )
+            db.session.add(favorite_offer)
+    except exc.IntegrityError as exception:
+        favorite_offer = educational_models.CollectiveOfferEducationalRedactor.query.filter_by(
+            educationalRedactorId=redactor_id, collectiveOfferId=offer_id
+        ).one_or_none()
+        if not favorite_offer:
+            raise exception
     return favorite_offer
 
 
 def add_offer_template_to_favorite_adage(
-    redactorId: int,
-    offerId: int,
+    redactor_id: int,
+    offer_id: int,
 ) -> educational_models.CollectiveOfferTemplateEducationalRedactor:
-    favorite_offer = educational_models.CollectiveOfferTemplateEducationalRedactor(
-        educationalRedactorId=redactorId, collectiveOfferTemplateId=offerId
-    )
-    repository.save(favorite_offer)
+    try:
+        with repository.transaction():
+            favorite_offer = educational_models.CollectiveOfferTemplateEducationalRedactor(
+                educationalRedactorId=redactor_id, collectiveOfferTemplateId=offer_id
+            )
+            db.session.add(favorite_offer)
+    except exc.IntegrityError as exception:
+        favorite_offer = educational_models.CollectiveOfferTemplateEducationalRedactor.query.filter_by(
+            educationalRedactorId=redactor_id, collectiveOfferTemplateId=offer_id
+        ).one_or_none()
+        if not favorite_offer:
+            raise exception
     return favorite_offer
 
 

--- a/api/src/pcapi/routes/adage_iframe/favorites.py
+++ b/api/src/pcapi/routes/adage_iframe/favorites.py
@@ -30,8 +30,8 @@ def post_collective_offer_favorites(
         raise ApiErrors({"message": "Redactor not found"}, status_code=403)
 
     educational_api.add_offer_to_favorite_adage(
-        redactorId=redactor.id,
-        offerId=offer.id,
+        redactor_id=redactor.id,
+        offer_id=offer.id,
     )
 
     return
@@ -54,8 +54,8 @@ def post_collective_template_favorites(
         raise ApiErrors({"message": "Redactor not found"}, status_code=403)
 
     educational_api.add_offer_template_to_favorite_adage(
-        redactorId=redactor.id,
-        offerId=offerTemplate.id,
+        redactor_id=redactor.id,
+        offer_id=offerTemplate.id,
     )
 
     return

--- a/api/tests/routes/adage_iframe/post_favorite_offer_test.py
+++ b/api/tests/routes/adage_iframe/post_favorite_offer_test.py
@@ -16,11 +16,29 @@ class FavoriteOfferTest:
             email=educational_redactor.email, uai=educational_institution.institutionId
         )
 
-        # when
         response = test_client.post(
             f"/adage-iframe/collective/offers/{collective_offer.id}/favorites",
         )
 
+        assert response.status_code == 204
+
+    def test_post_favorite_offer_multiple_times_test(self, client):
+        collective_offer = educational_factories.CollectiveOfferFactory()
+        educational_redactor = educational_factories.EducationalRedactorFactory()
+        educational_institution = educational_factories.EducationalInstitutionFactory()
+
+        test_client = client.with_adage_token(
+            email=educational_redactor.email, uai=educational_institution.institutionId
+        )
+
+        response = test_client.post(
+            f"/adage-iframe/collective/offers/{collective_offer.id}/favorites",
+        )
+        assert response.status_code == 204
+
+        response = test_client.post(
+            f"/adage-iframe/collective/offers/{collective_offer.id}/favorites",
+        )
         assert response.status_code == 204
 
     def test_post_favorite_no_offer_test(self, client):
@@ -31,7 +49,6 @@ class FavoriteOfferTest:
             email=educational_redactor.email, uai=educational_institution.institutionId
         )
 
-        # when
         response = test_client.post(
             "/adage-iframe/collective/offers/non/favorites",
         )
@@ -40,7 +57,6 @@ class FavoriteOfferTest:
     def test_post_favorite_not_authentified_test(self, client):
         collective_offer = educational_factories.CollectiveOfferFactory()
 
-        # when
         response = client.post(
             f"/adage-iframe/collective/offers/{collective_offer.id}/favorites",
         )

--- a/api/tests/routes/adage_iframe/post_favorite_template_test.py
+++ b/api/tests/routes/adage_iframe/post_favorite_template_test.py
@@ -16,11 +16,29 @@ class FavoriteTemplateTest:
             email=educational_redactor.email, uai=educational_institution.institutionId
         )
 
-        # when
         response = test_client.post(
             f"/adage-iframe/collective/templates/{collective_offer_template.id}/favorites",
         )
 
+        assert response.status_code == 204
+
+    def test_post_favorite_offer_template_multiple_times_test(self, client, caplog):
+        collective_offer_template = educational_factories.CollectiveOfferTemplateFactory()
+        educational_redactor = educational_factories.EducationalRedactorFactory()
+        educational_institution = educational_factories.EducationalInstitutionFactory()
+
+        test_client = client.with_adage_token(
+            email=educational_redactor.email, uai=educational_institution.institutionId
+        )
+
+        response = test_client.post(
+            f"/adage-iframe/collective/templates/{collective_offer_template.id}/favorites",
+        )
+        assert response.status_code == 204
+
+        response = test_client.post(
+            f"/adage-iframe/collective/templates/{collective_offer_template.id}/favorites",
+        )
         assert response.status_code == 204
 
     def test_post_favorite_no_template_test(self, client, caplog):
@@ -31,7 +49,6 @@ class FavoriteTemplateTest:
             email=educational_redactor.email, uai=educational_institution.institutionId
         )
 
-        # when
         response = test_client.post(
             "/adage-iframe/collective/templates/non/favorites",
         )
@@ -41,7 +58,6 @@ class FavoriteTemplateTest:
     def test_post_favorite_not_authentified_test(self, client, caplog):
         collective_offer_template = educational_factories.CollectiveOfferTemplateFactory()
 
-        # when
         response = client.post(
             f"/adage-iframe/collective/templates/{collective_offer_template.id}/favorites",
         )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31814
Fixes this [sentry issue](https://sentry.passculture.team/organizations/sentry/issues/427587/?project=5&query=is%3Aunresolved+Error+in+repository.save&referrer=issue-stream&statsPeriod=14d&stream_index=0) . Inspired by what is done [for beneficiary favorites](https://github.com/pass-culture/pass-culture-main/blob/b127b20547139ad8d679b0278f49df24b60a2ae2/api/src/pcapi/routes/native/v1/favorites.py#L202) 
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
