### PR TITLE
(PC-30592)[ADAGE] fix: add details in adage exception message

### DIFF
--- a/api/tests/core/educational/adage_backends/test_adage.py
+++ b/api/tests/core/educational/adage_backends/test_adage.py
@@ -17,6 +17,13 @@ ADAGE_RESPONSE_FOR_INSTITUTION_WITHOUT_EMAIL = {
     "detail": "EMAIL_ADDRESS_DOES_NOT_EXIST",
 }
 
+ADAGE_RESPONSE_FOR_ERROR = {
+    "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+    "title": "Error",
+    "status": 500,
+    "detail": "ERROR",
+}
+
 
 @pytest.mark.usefixtures("db_session")
 class AdageHttpClientTest:
@@ -57,9 +64,11 @@ class AdageHttpClientTest:
         booking_data = prebooking.serialize_collective_booking(booking)
 
         # When
-        requests_mock.post(f"{MOCK_API_URL}/v1/prereservation", status_code=500)
-        with pytest.raises(AdageException):
+        requests_mock.post(f"{MOCK_API_URL}/v1/prereservation", status_code=500, json=ADAGE_RESPONSE_FOR_ERROR)
+        with pytest.raises(AdageException) as ex:
             adage_client.notify_prebooking(booking_data)
+
+        assert ex.value.message == "Error posting new prebooking to Adage API - status code: 500 - error code: ERROR"
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_institution_association_success_if_201(self, requests_mock):
@@ -108,9 +117,11 @@ class AdageHttpClientTest:
         offer_data = serialize_collective_offer(offer)
 
         # When
-        requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=500)
-        with pytest.raises(AdageException):
+        requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=500, json=ADAGE_RESPONSE_FOR_ERROR)
+        with pytest.raises(AdageException) as ex:
             adage_client.notify_institution_association(offer_data)
+
+        assert ex.value.message == "Error getting Adage API - status code: 500 - error code: ERROR"
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_redactor_when_collective_request_is_made_success_if_201(self, requests_mock):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30592

Ajout de détail dans le message de l'exception quand l'API Adage renvoie une erreur

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
