### PR TITLE
(PC-31776)[BO] fix: do not fail to set permanent venues in batch action when one has an inconsistent SIRET

### DIFF
--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -2381,7 +2381,13 @@ class BatchEditVenuesTest(PostEndpointHelper):
     ):
         new_criterion = criteria_factories.CriterionFactory()
         venues = [
-            offerers_factories.VenueFactory(criteria=criteria[:2], isPermanent=set_permanent),
+            offerers_factories.VenueFactory(
+                # Ensure that inconsistency in database does not prevent from updating tags and/or permanent status
+                managingOfferer__siren="111111111",
+                siret="22222222233333",
+                criteria=criteria[:2],
+                isPermanent=set_permanent,
+            ),
             offerers_factories.VenueFactory(criteria=criteria[1:], isPermanent=not set_permanent),
         ]
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-31776

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
