### PR TITLE
(PC-31830)[PRO] fix: Fix Offers.admin unit test.

### DIFF
--- a/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.admin.spec.tsx
@@ -164,7 +164,9 @@ describe('route Offers when user is admin', () => {
 
     await userEvent.click(screen.getByTestId('remove-offerer-filter'))
 
-    expect(api.getOffererAddresses).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(api.getOffererAddresses).toHaveBeenCalled()
+    })
 
     expect(api.listOffers).toHaveBeenLastCalledWith(
       undefined,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31830

**Objectif**
Corriger le test sur `Offers.admin.spec.tsx` "should reset status filter when offerer filter is removed" qui échoue en local chez moi au moment de `expect(api.getOffererAddresses).toHaveBeenCalled()`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
