### PR TITLE
(BSR) feat: add vscode launch configs to debug api and BO servers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,65 @@
+{
+    "configurations": [
+        // Use these two configurations to run the backend without docker
+        {
+            "name": "Flask api server",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "flask",
+            "cwd": "${workspaceFolder}/api",
+            "justMyCode": false,
+            "env": {
+                "FLASK_APP": "src/pcapi/app",
+                "FLASK_DEBUG": "1",
+                "FLASK_RUN_IP": "0.0.0.0",
+                "FLASK_RUN_PORT": "5001"
+            },
+            "args": ["run"]
+        },
+        {
+            "name": "Flask backoffice server",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "flask",
+            "cwd": "${workspaceFolder}/api",
+            "justMyCode": false,
+            "env": {
+                "FLASK_APP": "src/pcapi/backoffice_app",
+                "FLASK_DEBUG": "1",
+                "FLASK_RUN_IP": "0.0.0.0",
+                "FLASK_RUN_PORT": "5002"
+            },
+            "args": ["run"]
+        },
+        // Use these two configurations to attach to a running server
+        // You will need the env var DEBUG_ACTIVATED=1
+        {
+            "name": "Attach to api server",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "${workspaceFolder}"
+                }
+            ],
+            "connect": {"host": "localhost", "port": 10002},
+            "request": "attach",
+            "subProcess": true,
+            "type": "debugpy",
+            "justMyCode": false
+        },
+        {
+            "name": "Attach to backoffice server",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "${workspaceFolder}"
+                }
+            ],
+            "connect": {"host": "localhost", "port": 10003},
+            "request": "attach",
+            "subProcess": true,
+            "type": "debugpy",
+            "justMyCode": false
+        }
+    ]
+}

--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -62,14 +62,19 @@ with app.app_context():
 
 if __name__ == "__main__":
     port = settings.FLASK_BACKOFFICE_PORT
-    if settings.IS_DEV and settings.DEBUG_ACTIVATED:
+    is_debugger_enabled = settings.IS_DEV and settings.DEBUG_ACTIVATED
+    if is_debugger_enabled:
         import debugpy
 
         if not debugpy.is_client_connected():
-            debugpy.listen(("0.0.0.0", 10003))
-            print("⏳ Code debugger can now be attached, press F5 in VS Code for example ⏳", flush=True)
+            debug_port = 10003
+            debugpy.listen(("0.0.0.0", debug_port))
+            print(
+                f"⏳ Code debugger can now be attached on port {debug_port}, press F5 in VS Code for example ⏳",
+                flush=True,
+            )
             debugpy.wait_for_client()
             print("🎉 Code debugger attached, enjoy debugging 🎉", flush=True)
 
     set_tag("pcapi.app_type", "app")
-    app.run(host="0.0.0.0", port=port, debug=True, use_reloader=True)
+    app.run(host="0.0.0.0", port=port, debug=True, use_reloader=not is_debugger_enabled)


### PR DESCRIPTION
## But de la pull request

Ajout de configs de launch VSCode pour lancer en debug les serveurs api et backoffice (sans Docker) + attach à un serveur existant

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
