### PR TITLE
(BSR)[PRO] test: workaround for flaky sandbox with changing data

### DIFF
--- a/pro/cypress/e2e/features/searchIndividualOffer.feature
+++ b/pro/cypress/e2e/features/searchIndividualOffer.feature
@@ -60,8 +60,8 @@ Feature: Search individual offers
     And I select a date in one month
     And I validate my filters
     Then These 1 results should be displayed
-      |  |  | Titre                            | Lieu                    | Stocks | Status  |
-      |  |  | Un concert d'electro inoubliable | Michel et son accordéon |  1 000 | publiée |
+      |  |  | Titre                            | Lieu   | Stocks | Status  |
+      |  |  | Un concert d'electro inoubliable | Michel |  1 000 | publiée |
 
   Scenario: A search combining several filters should display expected results
     When I select offerer "Réseau de librairies" in offer page


### PR DESCRIPTION
## But de la pull request

Déjà 2 échecs des tests e2e à cause de la sandbox qui ne génère pas toujours les mêmes données!
Voir [ici](https://cloud.cypress.io/projects/rit5sb/runs/822/test-results/cf07fd9d-f75d-4dbd-b326-e67c685374f5/replay)

On est moins strict sur les comparaisons d'affichage pour que ça passe avec `Michel et son accordéon` et `Michel - Offre numérique`

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
