### PR TITLE
(PC-30781)[API] feat: add allowed actions to collective offers api

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -19,8 +19,6 @@ from pcapi.core.educational.adage_backends.serialize import serialize_collective
 from pcapi.core.educational.api import adage as educational_api_adage
 import pcapi.core.educational.api.national_program as national_program_api
 from pcapi.core.educational.exceptions import AdageException
-from pcapi.core.educational.models import CollectiveOffer
-from pcapi.core.educational.models import HasImageMixin
 from pcapi.core.educational.utils import get_image_from_url
 from pcapi.core.external.attributes.api import update_external_pro
 from pcapi.core.mails import transactional as transactional_mails
@@ -615,7 +613,7 @@ def publish_collective_offer_template(
     return offer_template
 
 
-def delete_image(obj: HasImageMixin) -> None:
+def delete_image(obj: educational_models.HasImageMixin) -> None:
     obj.delete_image()
     db.session.commit()
     return
@@ -788,4 +786,4 @@ def get_offer_coordinates(offer: AnyCollectiveOffer) -> tuple[float | Decimal, f
 
 
 def query_has_any_archived(collective_query: BaseQuery) -> bool:
-    return collective_query.filter(CollectiveOffer.isArchived).count() > 0
+    return collective_query.filter(educational_models.CollectiveOffer.isArchived).count() > 0

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -16,6 +16,7 @@ from pcapi.core.categories.subcategories_v2 import SubcategoryIdEnum
 from pcapi.core.educational.models import CollectiveBooking
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveOffer
+from pcapi.core.educational.models import CollectiveOfferAllowedAction
 from pcapi.core.educational.models import CollectiveOfferDisplayedStatus
 from pcapi.core.educational.models import CollectiveOfferTemplate
 from pcapi.core.educational.models import CollectiveStock
@@ -153,6 +154,7 @@ class CollectiveOfferResponseModel(BaseModel):
     venue: base_serializers.ListOffersVenueResponseModel
     status: CollectiveOfferStatus
     displayedStatus: CollectiveOfferDisplayedStatus
+    allowedActions: list[CollectiveOfferAllowedAction] | None
     educationalInstitution: EducationalInstitutionResponseModel | None
     interventionArea: list[str]
     templateId: str | None
@@ -207,6 +209,7 @@ def _serialize_offer_paginated(offer: CollectiveOffer | CollectiveOfferTemplate)
         venue=_serialize_venue(offer.venue),  # type: ignore[arg-type]
         status=offer.status.name,
         displayedStatus=offer.displayedStatus,
+        allowedActions=offer.allowed_actions,
         isShowcase=is_offer_template,
         educationalInstitution=EducationalInstitutionResponseModel.from_orm(institution) if institution else None,
         interventionArea=offer.interventionArea,
@@ -433,11 +436,13 @@ class GetCollectiveOfferResponseModel(GetCollectiveOfferBaseResponseModel):
     formats: typing.Sequence[subcategories.EacFormat] | None
     isTemplate: bool = False
     dates: TemplateDatesModel | None
+    allowedActions: list[CollectiveOfferAllowedAction] | None
 
     @classmethod
     def from_orm(cls, offer: CollectiveOffer) -> "GetCollectiveOfferResponseModel":
         result = super().from_orm(offer)
         result.formats = offer.get_formats()
+        result.allowedActions = offer.allowed_actions
 
         if result.status == CollectiveOfferStatus.INACTIVE.name:
             result.isActive = False

--- a/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
+++ b/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
@@ -164,6 +164,13 @@ class Returns200Test:
                 "end": format_into_utc_date(offer.collectiveStock.endDatetime),
                 "start": format_into_utc_date(offer.collectiveStock.startDatetime),
             },
+            "allowedActions": [
+                "CAN_EDIT_DETAILS",
+                "CAN_EDIT_DATES",
+                "CAN_EDIT_INSTITUTION",
+                "CAN_EDIT_DISCOUNT",
+                "CAN_ARCHIVE",
+            ],
         }
 
     def test_duplicate_collective_offer_without_subcategoryId(self, client):

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -43,6 +43,7 @@ export type { CollectiveBookingEducationalRedactorResponseModel } from './models
 export type { CollectiveBookingResponseModel } from './models/CollectiveBookingResponseModel';
 export { CollectiveBookingStatus } from './models/CollectiveBookingStatus';
 export { CollectiveBookingStatusFilter } from './models/CollectiveBookingStatusFilter';
+export { CollectiveOfferAllowedAction } from './models/CollectiveOfferAllowedAction';
 export { CollectiveOfferDisplayedStatus } from './models/CollectiveOfferDisplayedStatus';
 export type { CollectiveOfferInstitutionModel } from './models/CollectiveOfferInstitutionModel';
 export type { CollectiveOfferOfferVenueResponseModel } from './models/CollectiveOfferOfferVenueResponseModel';

--- a/pro/src/apiClient/v1/models/CollectiveOfferAllowedAction.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferAllowedAction.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * An enumeration.
+ */
+export enum CollectiveOfferAllowedAction {
+  CAN_EDIT_DETAILS = 'CAN_EDIT_DETAILS',
+  CAN_EDIT_DATES = 'CAN_EDIT_DATES',
+  CAN_EDIT_INSTITUTION = 'CAN_EDIT_INSTITUTION',
+  CAN_EDIT_DISCOUNT = 'CAN_EDIT_DISCOUNT',
+  CAN_DUPLICATE = 'CAN_DUPLICATE',
+  CAN_CANCEL = 'CAN_CANCEL',
+  CAN_ARCHIVE = 'CAN_ARCHIVE',
+}

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { CollectiveOfferAllowedAction } from './CollectiveOfferAllowedAction';
 import type { CollectiveOfferDisplayedStatus } from './CollectiveOfferDisplayedStatus';
 import type { CollectiveOffersBookingResponseModel } from './CollectiveOffersBookingResponseModel';
 import type { CollectiveOffersStockResponseModel } from './CollectiveOffersStockResponseModel';
@@ -13,6 +14,7 @@ import type { NationalProgramModel } from './NationalProgramModel';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 import type { TemplateDatesModel } from './TemplateDatesModel';
 export type CollectiveOfferResponseModel = {
+  allowedActions?: Array<CollectiveOfferAllowedAction> | null;
   booking?: CollectiveOffersBookingResponseModel | null;
   dates?: TemplateDatesModel | null;
   displayedStatus: CollectiveOfferDisplayedStatus;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { CollectiveBookingStatus } from './CollectiveBookingStatus';
+import type { CollectiveOfferAllowedAction } from './CollectiveOfferAllowedAction';
 import type { CollectiveOfferDisplayedStatus } from './CollectiveOfferDisplayedStatus';
 import type { CollectiveOfferOfferVenueResponseModel } from './CollectiveOfferOfferVenueResponseModel';
 import type { CollectiveOfferStatus } from './CollectiveOfferStatus';
@@ -18,6 +19,7 @@ import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 import type { TemplateDatesModel } from './TemplateDatesModel';
 export type GetCollectiveOfferResponseModel = {
+  allowedActions?: Array<CollectiveOfferAllowedAction> | null;
   audioDisabilityCompliant?: boolean | null;
   bookingEmails: Array<string>;
   collectiveStock?: GetCollectiveOfferCollectiveStockResponseModel | null;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30781

Ajout des actions autorisées en fonction du displayedStatus dans les api collective offers

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
