### PR TITLE
(PC-31752)[API] Filtre des lieux virtuels pour effectuer la vérification d'existence d'une offre avec un EAN.

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -633,7 +633,7 @@ def check_product_cgu_and_offerer(
             },
             status_code=422,
         )
-    if len(offerer.managedVenues) == 1:
+    if len([venue for venue in offerer.managedVenues if venue.isVirtual is False]) == 1:
         try:
             check_ean_does_not_exist(ean, offerer.managedVenues[0])
         except exceptions.OfferAlreadyExists:

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -641,7 +641,11 @@ def get_product_by_ean(ean: str, offerer_id: int) -> offers_serialize.GetProduct
     offerer = (
         offerers_models.Offerer.query.filter_by(id=offerer_id)
         .options(load_only(offerers_models.Offerer.id))
-        .options(joinedload(offerers_models.Offerer.managedVenues).load_only(offerers_models.Venue.id))
+        .options(
+            joinedload(offerers_models.Offerer.managedVenues).load_only(
+                offerers_models.Venue.id, offerers_models.Venue.isVirtual
+            )
+        )
         .one_or_none()
     )
     check_product_cgu_and_offerer(product, ean, offerer)

--- a/api/tests/routes/pro/get_product_by_ean_test.py
+++ b/api/tests/routes/pro/get_product_by_ean_test.py
@@ -134,6 +134,7 @@ class Returns422Test:
         offerer_id = offerer.id
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
         product = offers_factories.ProductFactory(
             description="Product description",
             name="Product name",


### PR DESCRIPTION
Suite de la PR sur la validation d'une offre. 
Une vérification d'existence d'une offre avec le même EAN est faite.
Nous faisons la vérification seulement si la structure ne possède qu'un lieux (physique) car il est impossible de connaitre le lieux choisie à cette étape du formulaire. Dans la précédente PR, le filtre sur les lieux physique a été oublié, il s'agit d'un correctif.  

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31752

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
