### PR TITLE
Pc 31844 refocus confirm dialog

### DIFF
--- a/pro/src/components/ArchiveConfirmationModal/ArchiveConfirmationModal.tsx
+++ b/pro/src/components/ArchiveConfirmationModal/ArchiveConfirmationModal.tsx
@@ -12,6 +12,7 @@ interface OfferEducationalModalProps {
   offerId?: number
   hasMultipleOffers?: boolean
   selectedOffers?: CollectiveOfferResponseModel[]
+  isDialogOpen: boolean
 }
 
 export const ArchiveConfirmationModal = ({
@@ -20,6 +21,7 @@ export const ArchiveConfirmationModal = ({
   hasMultipleOffers = false,
   selectedOffers = [],
   offerId,
+  isDialogOpen,
 }: OfferEducationalModalProps): JSX.Element => {
   const location = useLocation()
   const { logEvent } = useAnalytics()
@@ -52,6 +54,7 @@ export const ArchiveConfirmationModal = ({
           ? 'Êtes-vous sûr de vouloir archiver ces offres ?'
           : 'Êtes-vous sûr de vouloir archiver cette offre ?'
       }
+      open={isDialogOpen}
     >
       <p>
         Une offre archivée ne peut pas être désarchivée, cette action est

--- a/pro/src/components/CancelCollectiveBookingModal/CancelCollectiveBookingModal.tsx
+++ b/pro/src/components/CancelCollectiveBookingModal/CancelCollectiveBookingModal.tsx
@@ -8,12 +8,14 @@ interface OfferEducationalModalProps {
   onDismiss(): void
   onValidate(): void
   isFromOffer?: boolean
+  isDialogOpen: boolean
 }
 
 export const CancelCollectiveBookingModal = ({
   onDismiss,
   onValidate,
   isFromOffer = false,
+  isDialogOpen,
 }: OfferEducationalModalProps): JSX.Element => {
   const modalTitle = isFromOffer
     ? 'Êtes-vous sûr de vouloir annuler la réservation liée à cette offre ? '
@@ -27,6 +29,7 @@ export const CancelCollectiveBookingModal = ({
       confirmText={isFromOffer ? 'Annuler la réservation' : 'Confirmer'}
       icon={isFromOffer ? strokeWrongIcon : strokeTrashIcon}
       title={modalTitle}
+      open={isDialogOpen}
     >
       {isFromOffer ? (
         <p className={styles['modal-text']}>Cette action est irréversible. </p>

--- a/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
@@ -289,13 +289,12 @@ export const CollectiveOfferNavigation = ({
           ].includes(activeStep),
         })}
       />
-      {isArchiveModalOpen && (
-        <ArchiveConfirmationModal
-          onDismiss={() => setIsArchiveModalOpen(false)}
-          onValidate={archiveOffer}
-          offerId={offerId}
-        />
-      )}
+      <ArchiveConfirmationModal
+        onDismiss={() => setIsArchiveModalOpen(false)}
+        onValidate={archiveOffer}
+        offerId={offerId}
+        isDialogOpen={isArchiveModalOpen}
+      />
     </>
   ) : (
     <Stepper activeStep={activeStep} className={className} steps={steps} />

--- a/pro/src/components/Dialog/ConfirmDialog/ConfirmDialog.tsx
+++ b/pro/src/components/Dialog/ConfirmDialog/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as RadixDialog from '@radix-ui/react-dialog'
 
 import strokeErrorIcon from 'icons/stroke-error.svg'
 import { Button } from 'ui-kit/Button/Button'
@@ -15,6 +15,7 @@ type ConfirmDialogProps = DialogProps & {
   isLoading?: boolean
   leftButtonAction?: () => void
   confirmButtonDisabled?: boolean
+  open?: boolean
 }
 
 export const ConfirmDialog = ({
@@ -31,7 +32,30 @@ export const ConfirmDialog = ({
   extraClassNames,
   confirmButtonDisabled = false,
   leftButtonAction = onCancel,
+  trigger,
+  open,
 }: ConfirmDialogProps): JSX.Element => {
+  const cancelButton = (
+    <Button
+      onClick={leftButtonAction}
+      data-testid="confirm-dialog-button-cancel"
+      variant={ButtonVariant.SECONDARY}
+    >
+      {cancelText}
+    </Button>
+  )
+
+  const confirmButton = (
+    <Button
+      onClick={onConfirm}
+      isLoading={isLoading}
+      disabled={isLoading || confirmButtonDisabled}
+      testId="confirm-dialog-button-confirm"
+    >
+      {confirmText}
+    </Button>
+  )
+
   return (
     <Dialog
       onCancel={onCancel}
@@ -40,24 +64,22 @@ export const ConfirmDialog = ({
       icon={icon ?? strokeErrorIcon}
       hideIcon={hideIcon}
       explanation={children}
+      trigger={trigger}
       extraClassNames={`${extraClassNames} ${styles['confirm-dialog-explanation']}`}
+      open={open}
     >
       <div className={styles['confirm-dialog-actions']}>
-        <Button
-          onClick={leftButtonAction}
-          data-testid="confirm-dialog-button-cancel"
-          variant={ButtonVariant.SECONDARY}
-        >
-          {cancelText}
-        </Button>
-        <Button
-          onClick={onConfirm}
-          isLoading={isLoading}
-          disabled={isLoading || confirmButtonDisabled}
-          testId="confirm-dialog-button-confirm"
-        >
-          {confirmText}
-        </Button>
+        {trigger ? (
+          <>
+            <RadixDialog.Close asChild>{cancelButton}</RadixDialog.Close>
+            <RadixDialog.Close asChild>{confirmButton}</RadixDialog.Close>
+          </>
+        ) : (
+          <>
+            {cancelButton}
+            {confirmButton}
+          </>
+        )}
       </div>
     </Dialog>
   )

--- a/pro/src/components/Dialog/ConfirmDialog/__specs__/ConfirmDialog.spec.tsx
+++ b/pro/src/components/Dialog/ConfirmDialog/__specs__/ConfirmDialog.spec.tsx
@@ -15,6 +15,7 @@ describe('ConfirmDialog', () => {
         onCancel={onCancel}
         confirmText="Valider"
         cancelText="Annuler"
+        open
       />
     )
 
@@ -30,6 +31,7 @@ describe('ConfirmDialog', () => {
         onCancel={onCancel}
         confirmText="Valider"
         cancelText="Annuler"
+        open
       />
     )
 
@@ -46,6 +48,7 @@ describe('ConfirmDialog', () => {
         confirmText="Valider"
         cancelText="Annuler"
         confirmButtonDisabled={true}
+        open
       />
     )
 

--- a/pro/src/components/Dialog/Dialog/Dialog.tsx
+++ b/pro/src/components/Dialog/Dialog/Dialog.tsx
@@ -16,6 +16,8 @@ export interface DialogProps {
   icon?: string
   hideIcon?: boolean
   extraClassNames?: string
+  trigger?: React.ReactNode | React.ReactNode[]
+  open?: boolean
 }
 
 export const Dialog = ({
@@ -27,11 +29,17 @@ export const Dialog = ({
   icon,
   hideIcon = false,
   extraClassNames,
+  trigger,
+  open,
 }: DialogProps): JSX.Element => {
   const titleId = useId()
 
   return (
-    <DialogBuilder defaultOpen onOpenChange={(open) => !open && onCancel()}>
+    <DialogBuilder
+      open={open}
+      onOpenChange={(open) => !open && onCancel()}
+      trigger={trigger}
+    >
       <div className={`${styles['dialog']} ${extraClassNames}`}>
         {!hideIcon && (
           <SvgIcon

--- a/pro/src/components/Dialog/RedirectDialog/RedirectDialog.tsx
+++ b/pro/src/components/Dialog/RedirectDialog/RedirectDialog.tsx
@@ -34,6 +34,7 @@ export const RedirectDialog = ({
   cancelText,
   onCancel,
   withRedirectLinkIcon = true,
+  open,
 }: RedirectDialogProps): JSX.Element => {
   return (
     <Dialog
@@ -44,6 +45,7 @@ export const RedirectDialog = ({
       hideIcon={hideIcon}
       explanation={children}
       extraClassNames={`${extraClassNames} ${styles['confirm-dialog-explanation']}`}
+      open={open}
     >
       <div className={styles['redirect-dialog-actions']}>
         <ButtonLink

--- a/pro/src/components/ImageUploader/ButtonImageDelete/ButtonImageDelete.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageDelete/ButtonImageDelete.tsx
@@ -37,13 +37,12 @@ export const ButtonImageDelete = ({
         Supprimer
       </Button>
 
-      {isModalOpen && (
-        <ModalImageDelete
-          isLoading={isLoading}
-          onConfirm={onConfirm}
-          onDismiss={() => setIsModalOpen(false)}
-        />
-      )}
+      <ModalImageDelete
+        isLoading={isLoading}
+        onConfirm={onConfirm}
+        onDismiss={() => setIsModalOpen(false)}
+        isDialogOpen={isModalOpen}
+      />
     </>
   )
 }

--- a/pro/src/components/ImageUploader/ButtonImageDelete/ButtonImageDelete.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageDelete/ButtonImageDelete.tsx
@@ -24,25 +24,24 @@ export const ButtonImageDelete = ({
   }
 
   return (
-    <>
-      <Button
-        onClick={() => setIsModalOpen(true)}
-        variant={ButtonVariant.TERNARY}
-      >
-        <SvgIcon
-          alt=""
-          className={styles['button-image-delete-icon']}
-          src={fullTrashIcon}
-        />
-        Supprimer
-      </Button>
-
-      <ModalImageDelete
-        isLoading={isLoading}
-        onConfirm={onConfirm}
-        onDismiss={() => setIsModalOpen(false)}
-        isDialogOpen={isModalOpen}
-      />
-    </>
+    <ModalImageDelete
+      isLoading={isLoading}
+      onConfirm={onConfirm}
+      onDismiss={() => setIsModalOpen(false)}
+      isDialogOpen={isModalOpen}
+      trigger={
+        <Button
+          onClick={() => setIsModalOpen(true)}
+          variant={ButtonVariant.TERNARY}
+        >
+          <SvgIcon
+            alt=""
+            className={styles['button-image-delete-icon']}
+            src={fullTrashIcon}
+          />
+          Supprimer
+        </Button>
+      }
+    />
   )
 }

--- a/pro/src/components/ImageUploader/ButtonImageDelete/ModalImageDelete.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageDelete/ModalImageDelete.tsx
@@ -7,12 +7,14 @@ interface ModalImageDeleteProps {
   isLoading: boolean
   onConfirm: () => void
   onDismiss: () => void
+  isDialogOpen: boolean
 }
 
 export const ModalImageDelete = ({
   isLoading,
   onConfirm,
   onDismiss,
+  isDialogOpen,
 }: ModalImageDeleteProps): JSX.Element => {
   return (
     <ConfirmDialog
@@ -23,6 +25,7 @@ export const ModalImageDelete = ({
       onCancel={onDismiss}
       onConfirm={onConfirm}
       title="Supprimer l’image"
+      open={isDialogOpen}
     >
       Souhaitez-vous vraiment supprimer cette image ?
     </ConfirmDialog>

--- a/pro/src/components/ImageUploader/ButtonImageDelete/ModalImageDelete.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageDelete/ModalImageDelete.tsx
@@ -8,6 +8,7 @@ interface ModalImageDeleteProps {
   onConfirm: () => void
   onDismiss: () => void
   isDialogOpen: boolean
+  trigger: React.ReactNode
 }
 
 export const ModalImageDelete = ({
@@ -15,6 +16,7 @@ export const ModalImageDelete = ({
   onConfirm,
   onDismiss,
   isDialogOpen,
+  trigger,
 }: ModalImageDeleteProps): JSX.Element => {
   return (
     <ConfirmDialog
@@ -26,6 +28,7 @@ export const ModalImageDelete = ({
       onConfirm={onConfirm}
       title="Supprimer l’image"
       open={isDialogOpen}
+      trigger={trigger}
     >
       Souhaitez-vous vraiment supprimer cette image ?
     </ConfirmDialog>

--- a/pro/src/components/RouteLeavingGuard/RouteLeavingGuard.tsx
+++ b/pro/src/components/RouteLeavingGuard/RouteLeavingGuard.tsx
@@ -47,7 +47,7 @@ export const RouteLeavingGuard = ({
     blocker.proceed()
   }
 
-  return blocker.state === 'blocked' ? (
+  return (
     <ConfirmDialog
       extraClassNames={extraClassNames}
       onCancel={closeModal}
@@ -58,8 +58,9 @@ export const RouteLeavingGuard = ({
       title={dialogTitle}
       confirmText={rightButton}
       cancelText={leftButton}
+      open={blocker.state === 'blocked'}
     >
       {children}
     </ConfirmDialog>
-  ) : null
+  )
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
@@ -62,19 +62,18 @@ export const ContactButton = ({
           {children ?? 'Contacter'}
         </Button>
       </div>
-      {isModalOpen && (
-        <RequestFormDialog
-          closeModal={closeModal}
-          offerId={offerId}
-          userEmail={userEmail}
-          userRole={userRole}
-          contactEmail={contactEmail ?? ''}
-          contactPhone={contactPhone ?? ''}
-          contactUrl={contactUrl ?? ''}
-          contactForm={contactForm ?? ''}
-          isPreview={isPreview}
-        />
-      )}
+      <RequestFormDialog
+        closeModal={closeModal}
+        offerId={offerId}
+        userEmail={userEmail}
+        userRole={userRole}
+        contactEmail={contactEmail ?? ''}
+        contactPhone={contactPhone ?? ''}
+        contactUrl={contactUrl ?? ''}
+        contactForm={contactForm ?? ''}
+        isPreview={isPreview}
+        isDialogOpen={isModalOpen}
+      />
     </>
   )
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
@@ -27,6 +27,7 @@ export interface RequestFormDialogProps {
   contactForm: string
   contactUrl: string
   isPreview: boolean
+  isDialogOpen: boolean
 }
 
 export const RequestFormDialog = ({
@@ -39,6 +40,7 @@ export const RequestFormDialog = ({
   contactForm,
   contactUrl,
   isPreview,
+  isDialogOpen,
 }: RequestFormDialogProps): JSX.Element => {
   const notify = useNotification()
 
@@ -268,6 +270,7 @@ export const RequestFormDialog = ({
       onCancel={closeRequestFormDialog}
       title=""
       hideIcon
+      open={isDialogOpen}
     >
       <span className={styles['form-title']}>
         Vous souhaitez contacter ce partenaire ?

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/RequestFormDialog.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/__specs__/RequestFormDialog.spec.tsx
@@ -23,6 +23,7 @@ const renderRequestFormDialog = (props?: Partial<RequestFormDialogProps>) => {
       contactPhone=""
       contactUrl=""
       isPreview={false}
+      isDialogOpen
       {...props}
     />
   )

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
@@ -134,13 +134,12 @@ export const PrebookingButton = ({
         )}
       </div>
 
-      {isModalOpen && (
-        <PrebookingModal
-          closeModal={closeModal}
-          preBookCurrentStock={preBookCurrentStock}
-          isPreview={isPreview}
-        />
-      )}
+      <PrebookingModal
+        closeModal={closeModal}
+        preBookCurrentStock={preBookCurrentStock}
+        isPreview={isPreview}
+        isDialogOpen={isModalOpen}
+      />
     </>
   ) : null
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingModal.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingModal.tsx
@@ -5,12 +5,14 @@ interface PrebookingModal {
   closeModal: () => void
   preBookCurrentStock: () => Promise<void>
   isPreview?: boolean
+  isDialogOpen: boolean
 }
 
 export const PrebookingModal = ({
   closeModal,
   preBookCurrentStock,
   isPreview = false,
+  isDialogOpen,
 }: PrebookingModal): JSX.Element => {
   return (
     <ConfirmDialog
@@ -21,6 +23,7 @@ export const PrebookingModal = ({
       confirmText="Préréserver"
       cancelText="Fermer"
       confirmButtonDisabled={isPreview}
+      open={isDialogOpen}
     >
       <p>
         Si oui, une fois votre préréservation confirmée :

--- a/pro/src/pages/Desk/ButtonInvalidateToken.tsx
+++ b/pro/src/pages/Desk/ButtonInvalidateToken.tsx
@@ -27,20 +27,19 @@ export const ButtonInvalidateToken = ({
   return (
     <>
       <Button onClick={openDialog}>Invalider la contremarque</Button>
-      {isDialogOpen && (
-        <ConfirmDialog
-          cancelText="Annuler"
-          confirmText="Continuer"
-          onCancel={closeDialog}
-          onConfirm={handleOnConfirm}
-          title="Voulez-vous vraiment invalider cette contremarque ?"
-        >
-          <p>
-            Cette contremarque a déjà été validée. Si vous l’invalidez, la
-            réservation ne vous sera pas remboursée.
-          </p>
-        </ConfirmDialog>
-      )}
+      <ConfirmDialog
+        cancelText="Annuler"
+        confirmText="Continuer"
+        onCancel={closeDialog}
+        onConfirm={handleOnConfirm}
+        title="Voulez-vous vraiment invalider cette contremarque ?"
+        open={isDialogOpen}
+      >
+        <p>
+          Cette contremarque a déjà été validée. Si vous l’invalidez, la
+          réservation ne vous sera pas remboursée.
+        </p>
+      </ConfirmDialog>
     </>
   )
 }

--- a/pro/src/pages/Home/Offerers/Offerers.tsx
+++ b/pro/src/pages/Home/Offerers/Offerers.tsx
@@ -74,8 +74,9 @@ export const Offerers = ({
     <>
       {userHasOfferers && (
         <>
-          {selectedOfferer && openSuccessDialog && (
+          {selectedOfferer && (
             <RedirectDialog
+              open={openSuccessDialog}
               icon={strokePartyIcon}
               redirectText="Créer une offre"
               redirectLink={{

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
@@ -90,34 +90,33 @@ export const PricingPoint = ({ offerer, venue }: PricingPointProps) => {
         </Callout>
       )}
 
-      {isConfirmSiretDialogOpen && (
-        <ConfirmDialog
-          cancelText="Annuler"
-          confirmText="Valider ma sélection"
-          onCancel={() => {
-            setIsConfirmSiretDialogOpen(false)
-          }}
-          onConfirm={handleClick}
-          icon={strokeValidIcon}
-          title="Êtes-vous sûr de vouloir sélectionner"
-          secondTitle={`ce lieu avec SIRET\u00a0?`}
-          isLoading={isSubmitingPricingPoint}
+      <ConfirmDialog
+        cancelText="Annuler"
+        confirmText="Valider ma sélection"
+        onCancel={() => {
+          setIsConfirmSiretDialogOpen(false)
+        }}
+        onConfirm={handleClick}
+        icon={strokeValidIcon}
+        title="Êtes-vous sûr de vouloir sélectionner"
+        secondTitle={`ce lieu avec SIRET\u00a0?`}
+        isLoading={isSubmitingPricingPoint}
+        open={isConfirmSiretDialogOpen}
+      >
+        <p className={styles['text-dialog']}>
+          Vous avez sélectionné un lieu avec SIRET qui sera utilisé pour le
+          calcul de vos remboursements
+          <br />
+          Ce choix ne pourra pas être modifié.
+        </p>
+        <ButtonLink
+          icon={fullLinkIcon}
+          to="https://aide.passculture.app/hc/fr/sections/4411991876241-Modalités-de-remboursements"
+          isExternal
         >
-          <p className={styles['text-dialog']}>
-            Vous avez sélectionné un lieu avec SIRET qui sera utilisé pour le
-            calcul de vos remboursements
-            <br />
-            Ce choix ne pourra pas être modifié.
-          </p>
-          <ButtonLink
-            icon={fullLinkIcon}
-            to="https://aide.passculture.app/hc/fr/sections/4411991876241-Modalités-de-remboursements"
-            isExternal
-          >
-            En savoir plus sur les remboursements
-          </ButtonLink>
-        </ConfirmDialog>
-      )}
+          En savoir plus sur les remboursements
+        </ButtonLink>
+      </ConfirmDialog>
 
       {!venue.pricingPoint && (
         <p className={styles['reimbursement-subtitle']}>

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -384,26 +384,23 @@ export const CollectiveActionsCells = ({
             </DropdownMenu.Content>
           </DropdownMenu.Portal>
         </DropdownMenu.Root>
-        {isModalOpen && shouldDisplayModal && (
-          <DuplicateOfferDialog
-            onCancel={() => setIsModalOpen(false)}
-            onConfirm={onDialogConfirm}
-          />
-        )}
-        {isCancelledBookingModalOpen && (
-          <CancelCollectiveBookingModal
-            onDismiss={() => setIsCancelledBookingModalOpen(false)}
-            onValidate={cancelBooking}
-            isFromOffer
-          />
-        )}
-        {isArchivedModalOpen && (
-          <ArchiveConfirmationModal
-            onDismiss={() => setIsArchivedModalOpen(false)}
-            onValidate={archiveOffer}
-            offerId={offer.id}
-          />
-        )}
+        <DuplicateOfferDialog
+          onCancel={() => setIsModalOpen(false)}
+          onConfirm={onDialogConfirm}
+          isDialogOpen={isModalOpen && shouldDisplayModal}
+        />
+        <CancelCollectiveBookingModal
+          onDismiss={() => setIsCancelledBookingModalOpen(false)}
+          onValidate={cancelBooking}
+          isFromOffer
+          isDialogOpen={isCancelledBookingModalOpen}
+        />
+        <ArchiveConfirmationModal
+          onDismiss={() => setIsArchivedModalOpen(false)}
+          onValidate={archiveOffer}
+          offerId={offer.id}
+          isDialogOpen={isArchivedModalOpen}
+        />
       </div>
     </td>
   )

--- a/pro/src/pages/Offers/OffersTable/Cells/DeleteDraftCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/DeleteDraftCell.tsx
@@ -66,16 +66,15 @@ export const DeleteDraftCell = ({ offer }: DeleteDraftOffersProps) => {
 
   return (
     <>
-      {isConfirmDialogOpen && (
-        <ConfirmDialog
-          icon={strokeTrashIcon}
-          cancelText="Annuler"
-          confirmText="Supprimer ce brouillon"
-          onCancel={closeDeleteDraftDialog}
-          onConfirm={onConfirmDeleteDraftOffer}
-          title={`Voulez-vous supprimer le brouillon : "${offer.name}" ?`}
-        />
-      )}
+      <ConfirmDialog
+        icon={strokeTrashIcon}
+        cancelText="Annuler"
+        confirmText="Supprimer ce brouillon"
+        onCancel={closeDeleteDraftDialog}
+        onConfirm={onConfirmDeleteDraftOffer}
+        title={`Voulez-vous supprimer le brouillon : "${offer.name}" ?`}
+        open={isConfirmDialogOpen}
+      />
       <ListIconButton
         onClick={() => setIsConfirmDialogOpen(true)}
         className={styles['button']}

--- a/pro/src/pages/Offers/OffersTable/Cells/DuplicateOfferCell/DuplicateOfferDialog/DuplicateOfferDialog.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/DuplicateOfferCell/DuplicateOfferDialog/DuplicateOfferDialog.tsx
@@ -8,9 +8,11 @@ import styles from './DuplicateOfferDialog.module.scss'
 export const DuplicateOfferDialog = ({
   onCancel,
   onConfirm,
+  isDialogOpen,
 }: {
   onCancel: () => void
   onConfirm: (shouldNotDisplayModalAgain: boolean) => void
+  isDialogOpen: boolean
 }) => {
   const [isCheckboxChecked, setIsCheckboxChecked] = useState(false)
 
@@ -22,6 +24,7 @@ export const DuplicateOfferDialog = ({
       confirmText="Créer une offre réservable"
       cancelText="Annuler"
       hideIcon
+      open={isDialogOpen}
     >
       <p className={styles['duplicate-offer-dialog-text']}>
         Les informations que vous avez renseignées dans l’offre vitrine seront

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveDeactivationConfirmDialog.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveDeactivationConfirmDialog.tsx
@@ -11,6 +11,7 @@ export interface CollectiveDeactivationConfirmDialogProps {
   nbSelectedOffers: number
   onCancel: (status: boolean) => void
   onConfirm: () => void
+  isDialogOpen: boolean
 }
 
 export const CollectiveDeactivationConfirmDialog = ({
@@ -18,6 +19,7 @@ export const CollectiveDeactivationConfirmDialog = ({
   onCancel,
   nbSelectedOffers,
   onConfirm,
+  isDialogOpen,
 }: CollectiveDeactivationConfirmDialogProps): JSX.Element => {
   const { logEvent } = useAnalytics()
   const location = useLocation()
@@ -51,6 +53,7 @@ export const CollectiveDeactivationConfirmDialog = ({
           ? `êtes-vous sûr de vouloir la masquer${NBSP}?`
           : `êtes-vous sûr de vouloir toutes les masquer${NBSP}?`
       }
+      open={isDialogOpen}
     >
       {nbSelectedOffers === 1
         ? `Dans ce cas, elle ne sera plus visible par les enseignants sur ADAGE.`

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -280,27 +280,25 @@ export function CollectiveOffersActionsBar({
 
   return (
     <>
-      {isDeactivationDialogOpen && (
-        <CollectiveDeactivationConfirmDialog
-          areAllOffersSelected={areAllOffersSelected}
-          nbSelectedOffers={selectedOffers.length}
-          onConfirm={() =>
-            updateOfferStatus(CollectiveOfferDisplayedStatus.INACTIVE)
-          }
-          onCancel={() => setIsDeactivationDialogOpen(false)}
-        />
-      )}
+      <CollectiveDeactivationConfirmDialog
+        areAllOffersSelected={areAllOffersSelected}
+        nbSelectedOffers={selectedOffers.length}
+        onConfirm={() =>
+          updateOfferStatus(CollectiveOfferDisplayedStatus.INACTIVE)
+        }
+        onCancel={() => setIsDeactivationDialogOpen(false)}
+        isDialogOpen={isDeactivationDialogOpen}
+      />
 
-      {isArchiveDialogOpen && (
-        <ArchiveConfirmationModal
-          onDismiss={() => setIsArchiveDialogOpen(false)}
-          onValidate={() =>
-            updateOfferStatus(CollectiveOfferDisplayedStatus.ARCHIVED)
-          }
-          hasMultipleOffers={selectedOffers.length > 1}
-          selectedOffers={selectedOffers}
-        />
-      )}
+      <ArchiveConfirmationModal
+        onDismiss={() => setIsArchiveDialogOpen(false)}
+        onValidate={() =>
+          updateOfferStatus(CollectiveOfferDisplayedStatus.ARCHIVED)
+        }
+        hasMultipleOffers={selectedOffers.length > 1}
+        selectedOffers={selectedOffers}
+        isDialogOpen={isArchiveDialogOpen}
+      />
 
       <ActionsBarSticky>
         <ActionsBarSticky.Left>

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveDeactivationConfirmDialog.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveDeactivationConfirmDialog.spec.tsx
@@ -25,7 +25,11 @@ describe('DeactivationConfirmDialog', () => {
   }
 
   it('should call onCancel when pressing Annuler button', async () => {
-    renderDeactivationConfirmDialog({ ...props, nbSelectedOffers: 1 })
+    renderDeactivationConfirmDialog({
+      ...props,
+      nbSelectedOffers: 1,
+      isDialogOpen: true,
+    })
 
     const onCancelButton = screen.getByText('Annuler')
     await userEvent.click(onCancelButton)
@@ -33,7 +37,11 @@ describe('DeactivationConfirmDialog', () => {
   })
 
   it('should call onConfirm when pressing Masquer button', async () => {
-    renderDeactivationConfirmDialog({ ...props, nbSelectedOffers: 1 })
+    renderDeactivationConfirmDialog({
+      ...props,
+      nbSelectedOffers: 1,
+      isDialogOpen: true,
+    })
 
     const onConfirmButton = screen.getByText('Masquer')
     await userEvent.click(onConfirmButton)
@@ -41,7 +49,11 @@ describe('DeactivationConfirmDialog', () => {
   })
 
   it('should render text for one offer', () => {
-    renderDeactivationConfirmDialog({ ...props, nbSelectedOffers: 1 })
+    renderDeactivationConfirmDialog({
+      ...props,
+      nbSelectedOffers: 1,
+      isDialogOpen: true,
+    })
 
     expect(
       screen.getByText(/Vous avez sélectionné 1 offre/)
@@ -57,7 +69,11 @@ describe('DeactivationConfirmDialog', () => {
   })
 
   it('should render text for multiple offers', () => {
-    renderDeactivationConfirmDialog({ ...props, nbSelectedOffers: 2 })
+    renderDeactivationConfirmDialog({
+      ...props,
+      nbSelectedOffers: 2,
+      isDialogOpen: true,
+    })
 
     expect(
       screen.getByText(/Vous avez sélectionné 2 offres/)

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/DeleteConfirmDialog.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/DeleteConfirmDialog.tsx
@@ -6,21 +6,24 @@ interface DeleteConfirmDialogProps {
   onCancel: () => void
   nbSelectedOffers: number
   handleDelete: () => void
+  isDialogOpen: boolean
 }
 
 export const DeleteConfirmDialog = ({
   onCancel,
   nbSelectedOffers,
   handleDelete,
+  isDialogOpen,
 }: DeleteConfirmDialogProps): JSX.Element => {
   return (
     <ConfirmDialog
-      cancelText={'Annuler'}
-      confirmText={'Supprimer ces brouillons'}
+      cancelText="Annuler"
+      confirmText="Supprimer ces brouillons"
       onCancel={onCancel}
       onConfirm={handleDelete}
       icon={strokeTrashIcon}
       title={`Voulez-vous supprimer ${pluralizeString('ce brouillon', nbSelectedOffers)} ?`}
+      open={isDialogOpen}
     />
   )
 }

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualDeactivationConfirmDialog.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualDeactivationConfirmDialog.tsx
@@ -11,6 +11,7 @@ export interface DeactivationConfirmDialogProps {
   nbSelectedOffers: number
   onCancel: (status: boolean) => void
   onConfirm: () => void
+  isDialogOpen: boolean
 }
 
 export const IndividualDeactivationConfirmDialog = ({
@@ -18,14 +19,15 @@ export const IndividualDeactivationConfirmDialog = ({
   onCancel,
   nbSelectedOffers,
   onConfirm,
+  isDialogOpen,
 }: DeactivationConfirmDialogProps): JSX.Element => {
   const { logEvent } = useAnalytics()
   const location = useLocation()
 
   return (
     <ConfirmDialog
-      cancelText={'Annuler'}
-      confirmText={'Désactiver'}
+      cancelText="Annuler"
+      confirmText="Désactiver"
       onCancel={() => {
         logEvent(Events.CLICKED_CANCELED_SELECTED_OFFERS, {
           from: location.pathname,
@@ -51,6 +53,7 @@ export const IndividualDeactivationConfirmDialog = ({
           ? `êtes-vous sûr de vouloir la désactiver${NBSP}?`
           : `êtes-vous sûr de vouloir toutes les désactiver${NBSP}?`
       }
+      open={isDialogOpen}
     >
       {nbSelectedOffers === 1
         ? `Dans ce cas, elle ne sera plus visible sur l’application pass Culture.`

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
@@ -181,22 +181,20 @@ export const IndividualOffersActionsBar = ({
 
   return (
     <>
-      {isDeactivationDialogOpen && (
-        <IndividualDeactivationConfirmDialog
-          areAllOffersSelected={areAllOffersSelected}
-          nbSelectedOffers={selectedOfferIds.length}
-          onConfirm={handleDeactivateOffers}
-          onCancel={() => setIsDeactivationDialogOpen(false)}
-        />
-      )}
+      <IndividualDeactivationConfirmDialog
+        areAllOffersSelected={areAllOffersSelected}
+        nbSelectedOffers={selectedOfferIds.length}
+        onConfirm={handleDeactivateOffers}
+        onCancel={() => setIsDeactivationDialogOpen(false)}
+        isDialogOpen={isDeactivationDialogOpen}
+      />
 
-      {isDeleteDialogOpen && (
-        <DeleteConfirmDialog
-          onCancel={() => setIsDeleteDialogOpen(false)}
-          nbSelectedOffers={selectedOfferIds.length}
-          handleDelete={handleDelete}
-        />
-      )}
+      <DeleteConfirmDialog
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        nbSelectedOffers={selectedOfferIds.length}
+        handleDelete={handleDelete}
+        isDialogOpen={isDeleteDialogOpen}
+      />
 
       <ActionsBarSticky>
         <ActionsBarSticky.Left>

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/__specs__/IndividualDeactivationConfirmDialog.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/__specs__/IndividualDeactivationConfirmDialog.spec.tsx
@@ -22,6 +22,7 @@ describe('DeactivationConfirmDialog', () => {
     onCancel: onCancelDialogMock,
     nbSelectedOffers: 0,
     onConfirm: onConfirmDialogMock,
+    isDialogOpen: true,
   }
 
   it('should called onCancel button onclick', async () => {

--- a/pro/src/pages/Reimbursements/BankInformations/AddBankInformationsDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/AddBankInformationsDialog.tsx
@@ -14,11 +14,13 @@ import styles from './AddBankInformationsDialog.module.scss'
 interface ReimbursmentPointDialogProps {
   closeDialog: () => void
   offererId?: number
+  isDialogOpen: boolean
 }
 
 export const AddBankInformationsDialog = ({
   closeDialog,
   offererId,
+  isDialogOpen,
 }: ReimbursmentPointDialogProps) => {
   const { logEvent } = useAnalytics()
   return (
@@ -27,6 +29,7 @@ export const AddBankInformationsDialog = ({
       explanation="Démarches Simplifiées est une plateforme sécurisée de démarches administratives en ligne qui permet de déposer votre dossier de compte bancaire."
       icon={strokeLinkIcon}
       onCancel={closeDialog}
+      open={isDialogOpen}
     >
       <ButtonLink
         to={DS_BANK_ACCOUNT_PROCEDURE_ID}

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.tsx
@@ -151,14 +151,13 @@ export const BankInformations = (): JSX.Element => {
       >
         Ajouter un compte bancaire
       </Button>
-      {showAddBankInformationsDialog && (
-        <AddBankInformationsDialog
-          closeDialog={() => {
-            setShowAddBankInformationsDialog(false)
-          }}
-          offererId={selectedOfferer?.id}
-        />
-      )}
+      <AddBankInformationsDialog
+        closeDialog={() => {
+          setShowAddBankInformationsDialog(false)
+        }}
+        offererId={selectedOfferer?.id}
+        isDialogOpen={showAddBankInformationsDialog}
+      />
       {selectedBankAccount !== null && selectedOfferer !== null && (
         <LinkVenuesDialog
           offererId={selectedOfferer.id}

--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
@@ -250,41 +250,37 @@ export const LinkVenuesDialog = ({
         </div>
       </DialogBuilder>
 
-      {showDiscardChangesDialog && (
-        <ConfirmDialog
-          extraClassNames={cn(styles['discard-dialog'], {
-            [styles['discard-dialog-with-banner']]:
-              hasVenuesWithoutPricingPoint,
-          })}
-          icon={strokeWarningIcon}
-          onCancel={() => setShowDiscardChangesDialog(false)}
-          title="Les informations non sauvegardées ne seront pas prises en compte"
-          onConfirm={() => {
-            setShowDiscardChangesDialog(false)
-            closeDialog()
-          }}
-          confirmText="Quitter sans enregistrer"
-          cancelText="Annuler"
-        />
-      )}
-      {showUnlinkVenuesDialog && (
-        <ConfirmDialog
-          extraClassNames={cn(styles['discard-dialog'], {
-            [styles['discard-dialog-with-banner']]:
-              hasVenuesWithoutPricingPoint,
-          })}
-          icon={strokeWarningIcon}
-          onCancel={() => setShowUnlinkVenuesDialog(false)}
-          title="Attention : le ou les lieux désélectionnés ne seront plus remboursés sur ce compte bancaire"
-          onConfirm={() => {
-            setShowUnlinkVenuesDialog(false)
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            submitForm(true)
-          }}
-          confirmText="Confirmer"
-          cancelText="Retour"
-        />
-      )}
+      <ConfirmDialog
+        extraClassNames={cn(styles['discard-dialog'], {
+          [styles['discard-dialog-with-banner']]: hasVenuesWithoutPricingPoint,
+        })}
+        icon={strokeWarningIcon}
+        onCancel={() => setShowDiscardChangesDialog(false)}
+        title="Les informations non sauvegardées ne seront pas prises en compte"
+        onConfirm={() => {
+          setShowDiscardChangesDialog(false)
+          closeDialog()
+        }}
+        confirmText="Quitter sans enregistrer"
+        cancelText="Annuler"
+        open={showDiscardChangesDialog}
+      />
+      <ConfirmDialog
+        extraClassNames={cn(styles['discard-dialog'], {
+          [styles['discard-dialog-with-banner']]: hasVenuesWithoutPricingPoint,
+        })}
+        icon={strokeWarningIcon}
+        onCancel={() => setShowUnlinkVenuesDialog(false)}
+        title="Attention : le ou les lieux désélectionnés ne seront plus remboursés sur ce compte bancaire"
+        onConfirm={() => {
+          setShowUnlinkVenuesDialog(false)
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          submitForm(true)
+        }}
+        confirmText="Confirmer"
+        cancelText="Retour"
+        open={showUnlinkVenuesDialog}
+      />
     </>
   )
 }

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/AddBankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/AddBankInformations.spec.tsx
@@ -13,7 +13,11 @@ const mockLogEvent = vi.fn()
 describe('AddBankInformations', () => {
   it('should render dialog', () => {
     renderWithProviders(
-      <AddBankInformationsDialog closeDialog={vi.fn()} offererId={0} />
+      <AddBankInformationsDialog
+        closeDialog={vi.fn()}
+        offererId={0}
+        isDialogOpen
+      />
     )
 
     expect(
@@ -37,7 +41,11 @@ describe('AddBankInformations', () => {
     }))
 
     renderWithProviders(
-      <AddBankInformationsDialog closeDialog={vi.fn()} offererId={0} />
+      <AddBankInformationsDialog
+        closeDialog={vi.fn()}
+        offererId={0}
+        isDialogOpen
+      />
     )
 
     await userEvent.click(

--- a/pro/src/pages/Signup/SignupContainer/MaybeAppUserDialog/MaybeAppUserDialog.tsx
+++ b/pro/src/pages/Signup/SignupContainer/MaybeAppUserDialog/MaybeAppUserDialog.tsx
@@ -1,11 +1,15 @@
 import './MaybeAppUserDialog.scss'
 
-import React from 'react'
-
 import { RedirectDialog } from 'components/Dialog/RedirectDialog/RedirectDialog'
 import strokeFraudIcon from 'icons/stroke-fraud.svg'
 
-export const MaybeAppUserDialog = ({ onCancel }: { onCancel: () => void }) => {
+export const MaybeAppUserDialog = ({
+  onCancel,
+  isDialogOpen,
+}: {
+  onCancel: () => void
+  isDialogOpen: boolean
+}) => {
   return (
     <RedirectDialog
       icon={strokeFraudIcon}
@@ -18,6 +22,7 @@ export const MaybeAppUserDialog = ({ onCancel }: { onCancel: () => void }) => {
       title="Il semblerait que tu ne sois pas"
       secondTitle={` un professionnel de la culture`}
       onCancel={onCancel}
+      open={isDialogOpen}
     >
       <p>
         Tu essayes de t’inscrire sur l’espace pass Culture Pro dédié aux

--- a/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
@@ -28,9 +28,10 @@ export const SignupForm = (): JSX.Element => {
     <>
       <ScrollToFirstErrorAfterSubmit />
 
-      {isModalOpen && (
-        <MaybeAppUserDialog onCancel={() => setIsModalOpen(false)} />
-      )}
+      <MaybeAppUserDialog
+        onCancel={() => setIsModalOpen(false)}
+        isDialogOpen={isModalOpen}
+      />
 
       <FormLayout>
         <FormLayout.Row>

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/StocksProviderForm/StocksProviderForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/StocksProviderForm/StocksProviderForm.tsx
@@ -91,34 +91,33 @@ export const StocksProviderForm = ({
           Lancer la synchronisation
         </Button>
       </div>
-      {isConfirmDialogOpened && (
-        <ConfirmDialog
-          cancelText="Annuler"
-          confirmText="Continuer"
-          onCancel={handleCloseConfirmDialog}
-          onConfirm={handleFormSubmit}
-          title="Demander la synchronisation par API avec un logiciel tiers ?"
-          icon={strokeConnectIcon}
+      <ConfirmDialog
+        cancelText="Annuler"
+        confirmText="Continuer"
+        onCancel={handleCloseConfirmDialog}
+        onConfirm={handleFormSubmit}
+        title="Demander la synchronisation par API avec un logiciel tiers ?"
+        icon={strokeConnectIcon}
+        open={isConfirmDialogOpened}
+      >
+        <p>
+          En sélectionnant un logiciel, vous l’autorisez à créer des offres
+          automatiquement et/ou à gérer les réservations. Chaque synchronisation
+          par API est spécifique et dépend de l’intégration développée par
+          l’éditeur du logiciel.
+        </p>
+        <ButtonLink
+          className={styles['aide-stock-button']}
+          icon={fullLinkIcon}
+          isExternal
+          to="https://aide.passculture.app/hc/fr/articles/10616916478236"
+          opensInNewTab
+          aria-label="Nouvelle fenêtre"
+          variant={ButtonVariant.QUATERNARY}
         >
-          <p>
-            En sélectionnant un logiciel, vous l’autorisez à créer des offres
-            automatiquement et/ou à gérer les réservations. Chaque
-            synchronisation par API est spécifique et dépend de l’intégration
-            développée par l’éditeur du logiciel.
-          </p>
-          <ButtonLink
-            className={styles['aide-stock-button']}
-            icon={fullLinkIcon}
-            isExternal
-            to="https://aide.passculture.app/hc/fr/articles/10616916478236"
-            opensInNewTab
-            aria-label="Nouvelle fenêtre"
-            variant={ButtonVariant.QUATERNARY}
-          >
-            Visitez notre FAQ pour plus d’informations
-          </ButtonLink>
-        </ConfirmDialog>
-      )}
+          Visitez notre FAQ pour plus d’informations
+        </ButtonLink>
+      </ConfirmDialog>
     </>
   )
 }

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/DeleteVenueProviderButton.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/DeleteVenueProviderButton.tsx
@@ -57,13 +57,12 @@ export const DeleteVenueProviderButton = ({
         Supprimer
       </Button>
 
-      {isModalOpen && (
-        <DeleteVenueProviderDialog
-          onConfirm={tryToDeleteVenueProvider}
-          onCancel={() => setIsModalOpen(false)}
-          isLoading={isLoading}
-        />
-      )}
+      <DeleteVenueProviderDialog
+        onConfirm={tryToDeleteVenueProvider}
+        onCancel={() => setIsModalOpen(false)}
+        isLoading={isLoading}
+        isDialogOpen={isModalOpen}
+      />
     </>
   )
 }

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/DeleteVenueProviderDialog.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/DeleteVenueProviderDialog.tsx
@@ -8,12 +8,14 @@ interface DeleteVenueProviderDialogProps {
   onConfirm: () => void
   onCancel: () => void
   isLoading: boolean
+  isDialogOpen: boolean
 }
 
 export const DeleteVenueProviderDialog = ({
   onConfirm,
   onCancel,
   isLoading,
+  isDialogOpen,
 }: DeleteVenueProviderDialogProps): JSX.Element => {
   return (
     <ConfirmDialog
@@ -25,6 +27,7 @@ export const DeleteVenueProviderDialog = ({
       confirmText="Supprimer la synchronisation"
       cancelText="Annuler"
       hideIcon={true}
+      open={isDialogOpen}
     >
       <div className={style['explanation']}>
         En supprimant la synchronisation de vos offres :

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/ToggleVenueProviderStatusButton.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/ToggleVenueProviderStatusButton.tsx
@@ -77,14 +77,13 @@ export const ToggleVenueProviderStatusButton = ({
         </Button>
       )}
 
-      {isModalOpen && (
-        <ToggleVenueProviderStatusDialog
-          onCancel={() => setIsModalOpen(false)}
-          onConfirm={updateVenueProviderStatus}
-          isLoading={isLoading}
-          isActive={venueProvider.isActive}
-        />
-      )}
+      <ToggleVenueProviderStatusDialog
+        onCancel={() => setIsModalOpen(false)}
+        onConfirm={updateVenueProviderStatus}
+        isLoading={isLoading}
+        isActive={venueProvider.isActive}
+        isDialogOpen={isModalOpen}
+      />
     </>
   )
 }

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/ToggleVenueProviderStatusDialog.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/ToggleVenueProviderStatusDialog.tsx
@@ -9,6 +9,7 @@ interface ToggleVenueProviderStatusDialogProps {
   onCancel: () => void
   isLoading: boolean
   isActive: boolean
+  isDialogOpen: boolean
 }
 
 export const ToggleVenueProviderStatusDialog = ({
@@ -16,6 +17,7 @@ export const ToggleVenueProviderStatusDialog = ({
   onCancel,
   isLoading,
   isActive,
+  isDialogOpen,
 }: ToggleVenueProviderStatusDialogProps) => {
   return (
     <ConfirmDialog
@@ -34,7 +36,8 @@ export const ToggleVenueProviderStatusDialog = ({
           : 'Réactiver la synchronisation'
       }
       cancelText="Annuler"
-      hideIcon={true}
+      hideIcon
+      open={isDialogOpen}
     >
       {isActive ? (
         <div className={style['explanation']}>

--- a/pro/src/pages/VenueSettings/VenueSettingsScreen.tsx
+++ b/pro/src/pages/VenueSettings/VenueSettingsScreen.tsx
@@ -224,34 +224,31 @@ export const VenueSettingsScreen = ({
           />
         </form>
 
-        {isWithdrawalDialogOpen && (
-          <ConfirmDialog
-            cancelText="Ne pas envoyer"
-            confirmText="Envoyer un email"
-            leftButtonAction={handleCancelWithdrawalDialog}
-            onCancel={() => setIsWithdrawalDialogOpen(false)}
-            onConfirm={handleConfirmWithdrawalDialog}
-            icon={strokeMailIcon}
-            title="Souhaitez-vous prévenir les bénéficiaires de la modification des modalités de retrait ?"
-          />
-        )}
-
-        {isAddressChangeDialogOpen && venue.hasOffers && (
-          <ConfirmDialog
-            cancelText="Annuler"
-            confirmText="Confirmer le changement d'adresse"
-            leftButtonAction={handleCancelAddressChangeDialog}
-            onCancel={() => setIsAddressChangeDialogOpen(false)}
-            onConfirm={handleConfirmAddressChangeDialog}
-            icon={strokeErrorIcon}
-            title="Ce changement d'adresse ne va pas s'impacter sur vos offres"
-          >
-            <p>
-              Si vous souhaitez rectifier leur localisation, vous devez les
-              modifier individuellement.
-            </p>
-          </ConfirmDialog>
-        )}
+        <ConfirmDialog
+          cancelText="Ne pas envoyer"
+          confirmText="Envoyer un email"
+          leftButtonAction={handleCancelWithdrawalDialog}
+          onCancel={() => setIsWithdrawalDialogOpen(false)}
+          onConfirm={handleConfirmWithdrawalDialog}
+          icon={strokeMailIcon}
+          title="Souhaitez-vous prévenir les bénéficiaires de la modification des modalités de retrait ?"
+          open={isWithdrawalDialogOpen}
+        />
+        <ConfirmDialog
+          cancelText="Annuler"
+          confirmText="Confirmer le changement d'adresse"
+          leftButtonAction={handleCancelAddressChangeDialog}
+          onCancel={() => setIsAddressChangeDialogOpen(false)}
+          onConfirm={handleConfirmAddressChangeDialog}
+          icon={strokeErrorIcon}
+          title="Ce changement d'adresse ne va pas s'impacter sur vos offres"
+          open={isAddressChangeDialogOpen && venue.hasOffers}
+        >
+          <p>
+            Si vous souhaitez rectifier leur localisation, vous devez les
+            modifier individuellement.
+          </p>
+        </ConfirmDialog>
       </FormikProvider>
     </>
   )

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveActionButtons.tsx
@@ -97,12 +97,11 @@ export const CollectiveActionButtons = ({
           </ButtonLink>
         )}
       </div>
-      {isModalOpen && (
-        <CancelCollectiveBookingModal
-          onDismiss={() => setIsModalOpen(false)}
-          onValidate={cancelBooking}
-        />
-      )}
+      <CancelCollectiveBookingModal
+        onDismiss={() => setIsModalOpen(false)}
+        onValidate={cancelBooking}
+        isDialogOpen={isModalOpen}
+      />
     </>
   )
 }

--- a/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreationScreen.tsx
@@ -142,11 +142,12 @@ export const CollectiveOfferPreviewCreationScreen = ({
           <Button onClick={publishOffer}>Publier l’offre</Button>
         </ActionsBarSticky.Right>
       </ActionsBarSticky>
-      {displayRedirectDialog && offerer?.id && (
+      {offerer?.id && (
         <RedirectToBankAccountDialog
           cancelRedirectUrl={confirmationUrl}
           offerId={offerer.id}
           venueId={offer.venue.id}
+          isDialogOpen={displayRedirectDialog}
         />
       )}
     </div>

--- a/pro/src/screens/IndividualOffer/DialogStockDeleteConfirm/DialogStockEventDeleteConfirm.tsx
+++ b/pro/src/screens/IndividualOffer/DialogStockDeleteConfirm/DialogStockEventDeleteConfirm.tsx
@@ -8,11 +8,13 @@ import styles from './DialogStockDeleteConfirm.module.scss'
 interface DialogStockDeleteConfirmProps {
   onConfirm: () => void
   onCancel: () => void
+  isDialogOpen: boolean
 }
 
 export const DialogStockEventDeleteConfirm = ({
   onConfirm,
   onCancel,
+  isDialogOpen,
 }: DialogStockDeleteConfirmProps) => {
   return (
     <ConfirmDialog
@@ -22,6 +24,7 @@ export const DialogStockEventDeleteConfirm = ({
       confirmText="Confirmer la suppression"
       cancelText="Annuler"
       icon={strokeTrashIcon}
+      open={isDialogOpen}
     >
       <p className={styles['first-block']}>
         {'Elle ne sera plus disponible à la réservation et '}

--- a/pro/src/screens/IndividualOffer/DialogStockDeleteConfirm/DialogStockThingDeleteConfirm.tsx
+++ b/pro/src/screens/IndividualOffer/DialogStockDeleteConfirm/DialogStockThingDeleteConfirm.tsx
@@ -6,11 +6,13 @@ import strokeTrashIcon from 'icons/stroke-trash.svg'
 interface DialogStockDeleteConfirmProps {
   onConfirm: () => void
   onCancel: () => void
+  isDialogOpen: boolean
 }
 
 export const DialogStockThingDeleteConfirm = ({
   onConfirm,
   onCancel,
+  isDialogOpen,
 }: DialogStockDeleteConfirmProps) => {
   return (
     <ConfirmDialog
@@ -20,6 +22,7 @@ export const DialogStockThingDeleteConfirm = ({
       confirmText="Supprimer"
       cancelText="Annuler"
       icon={strokeTrashIcon}
+      open={isDialogOpen}
     >
       <p>
         {'Ce stock ne sera plus disponible à la réservation et '}

--- a/pro/src/screens/IndividualOffer/DialogStocksEventEditConfirm/DialogStocksEventEditConfirm.tsx
+++ b/pro/src/screens/IndividualOffer/DialogStocksEventEditConfirm/DialogStocksEventEditConfirm.tsx
@@ -5,11 +5,13 @@ import { ConfirmDialog } from 'components/Dialog/ConfirmDialog/ConfirmDialog'
 interface DialogStocksEventEditConfirmProps {
   onConfirm: () => void
   onCancel: () => void
+  isDialogOpen: boolean
 }
 
 export const DialogStocksEventEditConfirm = ({
   onConfirm,
   onCancel,
+  isDialogOpen,
 }: DialogStocksEventEditConfirmProps) => {
   return (
     <ConfirmDialog
@@ -18,6 +20,7 @@ export const DialogStocksEventEditConfirm = ({
       title="Des réservations sont en cours pour cette offre"
       confirmText="Confirmer les modifications"
       cancelText="Annuler"
+      open={isDialogOpen}
     >
       <p>
         Si vous avez changé la date ou l’heure de l’évènement, les bénéficiaires

--- a/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
@@ -278,24 +278,23 @@ export const InformationsScreen = ({
         </form>
       </FormLayout>
 
-      {isWithdrawalMailDialogOpen && (
-        <ConfirmDialog
-          cancelText="Ne pas envoyer"
-          confirmText="Envoyer un email"
-          onCancel={() => {
-            setIsWithdrawalMailDialogOpen(false)
-          }}
-          leftButtonAction={async () => {
-            await formik.submitForm()
-          }}
-          onConfirm={async () => {
-            setSendWithdrawalMail(true)
-            await formik.submitForm()
-          }}
-          icon={strokeMailIcon}
-          title="Souhaitez-vous prévenir les bénéficiaires de la modification des modalités de retrait ?"
-        />
-      )}
+      <ConfirmDialog
+        cancelText="Ne pas envoyer"
+        confirmText="Envoyer un email"
+        onCancel={() => {
+          setIsWithdrawalMailDialogOpen(false)
+        }}
+        leftButtonAction={async () => {
+          await formik.submitForm()
+        }}
+        onConfirm={async () => {
+          setSendWithdrawalMail(true)
+          await formik.submitForm()
+        }}
+        icon={strokeMailIcon}
+        title="Souhaitez-vous prévenir les bénéficiaires de la modification des modalités de retrait ?"
+        open={isWithdrawalMailDialogOpen}
+      />
       <RouteLeavingGuardIndividualOffer
         when={formik.dirty && !formik.isSubmitting}
       />

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.tsx
@@ -113,22 +113,25 @@ export const PriceCategoriesForm = ({
           name="priceCategories"
           render={(arrayHelpers) => (
             <FormLayout.Section title="Tarifs">
-              {currentDeletionIndex !== null && (
-                <ConfirmDialog
-                  onCancel={() => setCurrentDeletionIndex(null)}
-                  onConfirm={() =>
-                    onDeletePriceCategory(
-                      currentDeletionIndex,
-                      arrayHelpers,
-                      values.priceCategories,
-                      values.priceCategories[currentDeletionIndex].id
-                    )
+              <ConfirmDialog
+                onCancel={() => setCurrentDeletionIndex(null)}
+                onConfirm={() => {
+                  if (!currentDeletionIndex) {
+                    return
                   }
-                  title="En supprimant ce tarif vous allez aussi supprimer l’ensemble des dates qui lui sont associées."
-                  confirmText="Confirmer la supression"
-                  cancelText="Annuler"
-                />
-              )}
+
+                  return onDeletePriceCategory(
+                    currentDeletionIndex,
+                    arrayHelpers,
+                    values.priceCategories,
+                    values.priceCategories[currentDeletionIndex].id
+                  )
+                }}
+                title="En supprimant ce tarif vous allez aussi supprimer l’ensemble des dates qui lui sont associées."
+                confirmText="Confirmer la supression"
+                cancelText="Annuler"
+                open={currentDeletionIndex !== null}
+              />
               {values.priceCategories.map((priceCategory, index) => (
                 <fieldset key={index}>
                   <legend className="visually-hidden">Tarif {index + 1}</legend>

--- a/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesScreen.tsx
+++ b/pro/src/screens/IndividualOffer/PriceCategoriesScreen/PriceCategoriesScreen.tsx
@@ -178,22 +178,21 @@ export const PriceCategoriesScreen = ({
 
   return (
     <FormikProvider value={formik}>
-      {isConfirmationModalOpen && (
-        <ConfirmDialog
-          onCancel={() => setIsConfirmationModalOpen(false)}
-          onConfirm={formik.submitForm}
-          title="Cette modification de tarif s’appliquera à l’ensemble des dates qui y sont associées."
-          confirmText="Confirmer la modification"
-          cancelText="Annuler"
-        >
-          {(offer.bookingsCount ?? 0) > 0 && (
-            <>
-              Le tarif restera inchangé pour les personnes ayant déjà réservé
-              cette offre.
-            </>
-          )}
-        </ConfirmDialog>
-      )}
+      <ConfirmDialog
+        onCancel={() => setIsConfirmationModalOpen(false)}
+        onConfirm={formik.submitForm}
+        title="Cette modification de tarif s’appliquera à l’ensemble des dates qui y sont associées."
+        confirmText="Confirmer la modification"
+        cancelText="Annuler"
+        open={isConfirmationModalOpen}
+      >
+        {(offer.bookingsCount ?? 0) > 0 && (
+          <>
+            Le tarif restera inchangé pour les personnes ayant déjà réservé
+            cette offre.
+          </>
+        )}
+      </ConfirmDialog>
 
       <form onSubmit={formik.handleSubmit}>
         <PriceCategoriesForm

--- a/pro/src/screens/IndividualOffer/Status/StatusToggleButton.tsx
+++ b/pro/src/screens/IndividualOffer/Status/StatusToggleButton.tsx
@@ -69,16 +69,15 @@ export const StatusToggleButton = ({ offer }: StatusToggleButtonProps) => {
 
   return (
     <>
-      {isPublicationConfirmationModalOpen && (
-        <ConfirmDialog
-          title={`Attention, vous allez publier une offre programmée pour le ${publicationDate} à ${publicationTime}.`}
-          secondTitle="Êtes-vous sûr de vouloir continuer ?"
-          cancelText="Annuler"
-          confirmText="Confirmer la publication"
-          onCancel={() => setIsPublicationConfirmationModalOpen(false)}
-          onConfirm={toggleOfferActiveStatus}
-        />
-      )}
+      <ConfirmDialog
+        title={`Attention, vous allez publier une offre programmée pour le ${publicationDate} à ${publicationTime}.`}
+        secondTitle="Êtes-vous sûr de vouloir continuer ?"
+        cancelText="Annuler"
+        confirmText="Confirmer la publication"
+        onCancel={() => setIsPublicationConfirmationModalOpen(false)}
+        onConfirm={toggleOfferActiveStatus}
+        open={isPublicationConfirmationModalOpen}
+      />
 
       <Button
         variant={ButtonVariant.TERNARY}

--- a/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/screens/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -425,12 +425,11 @@ export const StocksEventEdition = ({
 
   return (
     <FormikProvider value={formik}>
-      {isStocksEventConfirmModal && (
-        <DialogStocksEventEditConfirm
-          onConfirm={formik.submitForm}
-          onCancel={() => setIsStocksEventConfirmModal(false)}
-        />
-      )}
+      <DialogStocksEventEditConfirm
+        onConfirm={formik.submitForm}
+        onCancel={() => setIsStocksEventConfirmModal(false)}
+        isDialogOpen={isStocksEventConfirmModal}
+      />
 
       <FormLayout>
         <div aria-current="page">
@@ -836,15 +835,17 @@ export const StocksEventEdition = ({
                     }}
                   />
 
-                  {stockToDeleteWithConfirmation !== null && (
-                    <DialogStockEventDeleteConfirm
-                      onConfirm={async () => {
-                        await onDeleteStock(stockToDeleteWithConfirmation)
-                        setStockToDeleteWithConfirmation(null)
-                      }}
-                      onCancel={() => setStockToDeleteWithConfirmation(null)}
-                    />
-                  )}
+                  <DialogStockEventDeleteConfirm
+                    onConfirm={async () => {
+                      if (!stockToDeleteWithConfirmation) {
+                        return
+                      }
+                      await onDeleteStock(stockToDeleteWithConfirmation)
+                      setStockToDeleteWithConfirmation(null)
+                    }}
+                    onCancel={() => setStockToDeleteWithConfirmation(null)}
+                    isDialogOpen={stockToDeleteWithConfirmation !== null}
+                  />
                 </div>
               )}
             />
@@ -861,24 +862,25 @@ export const StocksEventEdition = ({
       <RouteLeavingGuardIndividualOffer
         when={formik.dirty && !formik.isSubmitting}
       />
-      {(shouldBlockNextPageNavigationFormIsDirty ||
-        shouldBlockPreviousPageNavigationFormIsDirty) && (
-        <ConfirmDialog
-          onCancel={resetPageNavigationBlockers}
-          leftButtonAction={() => {
-            resetPageNavigationBlockers()
-            if (shouldBlockPreviousPageNavigationFormIsDirty) {
-              previousPage()
-            } else {
-              nextPage()
-            }
-          }}
-          onConfirm={resetPageNavigationBlockers}
-          title="Les informations non enregistrées seront perdues"
-          confirmText="Rester sur la page"
-          cancelText="Quitter la page"
-        />
-      )}
+      <ConfirmDialog
+        onCancel={resetPageNavigationBlockers}
+        leftButtonAction={() => {
+          resetPageNavigationBlockers()
+          if (shouldBlockPreviousPageNavigationFormIsDirty) {
+            previousPage()
+          } else {
+            nextPage()
+          }
+        }}
+        onConfirm={resetPageNavigationBlockers}
+        title="Les informations non enregistrées seront perdues"
+        confirmText="Rester sur la page"
+        cancelText="Quitter la page"
+        open={
+          shouldBlockNextPageNavigationFormIsDirty ||
+          shouldBlockPreviousPageNavigationFormIsDirty
+        }
+      />
     </FormikProvider>
   )
 }

--- a/pro/src/screens/IndividualOffer/StocksThing/ActivationCodeFormDialog/ActivationCodeFormDialog.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/ActivationCodeFormDialog/ActivationCodeFormDialog.tsx
@@ -16,6 +16,7 @@ interface ActivationCodeFormProps {
   onSubmit: (activationCodes: string[]) => void
   today: Date
   minExpirationDate: Date | null
+  isDialogOpen: boolean
 }
 
 export const ActivationCodeFormDialog = ({
@@ -23,6 +24,7 @@ export const ActivationCodeFormDialog = ({
   onSubmit,
   today,
   minExpirationDate,
+  isDialogOpen,
 }: ActivationCodeFormProps) => {
   const [errorMessage, setErrorMessage] = useState('')
   const [unsavedActivationCodes, setUnsavedActivationCodes] =
@@ -78,6 +80,7 @@ export const ActivationCodeFormDialog = ({
       title="Ajouter des codes d’activation"
       icon={strokeCodeIcon}
       extraClassNames={styles['activation-codes-upload']}
+      open={isDialogOpen}
     >
       {hasNoActivationCodes && (
         <AddActivationCodeForm

--- a/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/IndividualOffer/StocksThing/StocksThing.tsx
@@ -326,21 +326,19 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
 
   return (
     <FormikProvider value={formik}>
-      {isDeleteConfirmVisible && (
-        <DialogStockThingDeleteConfirm
-          onConfirm={onConfirmDeleteStock}
-          onCancel={() => setIsDeleteConfirmVisible(false)}
-        />
-      )}
+      <DialogStockThingDeleteConfirm
+        onConfirm={onConfirmDeleteStock}
+        onCancel={() => setIsDeleteConfirmVisible(false)}
+        isDialogOpen={isDeleteConfirmVisible}
+      />
 
-      {isActivationCodeFormVisible && (
-        <ActivationCodeFormDialog
-          onSubmit={submitActivationCodes}
-          onCancel={() => setIsActivationCodeFormVisible(false)}
-          today={today}
-          minExpirationDate={minExpirationDate}
-        />
-      )}
+      <ActivationCodeFormDialog
+        onSubmit={submitActivationCodes}
+        onCancel={() => setIsActivationCodeFormVisible(false)}
+        today={today}
+        minExpirationDate={minExpirationDate}
+        isDialogOpen={isActivationCodeFormVisible}
+      />
 
       <form onSubmit={formik.handleSubmit} data-testid="stock-thing-form">
         <FormLayout>

--- a/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -205,13 +205,12 @@ export const SummaryScreen = () => {
             mode !== OFFER_WIZARD_MODE.CREATION ? false : formik.isSubmitting
           }
         />
-        {displayRedirectDialog && (
-          <RedirectToBankAccountDialog
-            cancelRedirectUrl={offerConfirmationStepUrl}
-            offerId={offer.venue.managingOfferer.id}
-            venueId={offer.venue.id}
-          />
-        )}
+        <RedirectToBankAccountDialog
+          cancelRedirectUrl={offerConfirmationStepUrl}
+          offerId={offer.venue.managingOfferer.id}
+          venueId={offer.venue.id}
+          isDialogOpen={displayRedirectDialog}
+        />
       </Form>
     </FormikProvider>
   )

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
@@ -252,50 +252,48 @@ export const UsefulInformationScreen = ({
           dirtyForm={formik.dirty}
         />
       </Form>
-      {isWithdrawalMailDialogOpen && (
-        <ConfirmDialog
-          cancelText="Ne pas envoyer"
-          confirmText="Envoyer un email"
-          onCancel={() => {
-            setIsWithdrawalMailDialogOpen(false)
-          }}
-          leftButtonAction={async () => {
-            await formik.submitForm()
-          }}
-          onConfirm={async () => {
-            setSendWithdrawalMail(true)
-            await formik.submitForm()
-          }}
-          icon={strokeMailIcon}
-          title="Souhaitez-vous prévenir les bénéficiaires de la modification des modalités de retrait ?"
-        />
-      )}
-      {isAddressUpdateDialogOpen && (
-        <ConfirmDialog
-          cancelText="Annuler"
-          confirmText="Je confirme le changement"
-          onCancel={() => {
-            setIsAddressUpdateDialogOpen(false)
-          }}
-          onConfirm={async () => {
-            await formik.submitForm()
-          }}
-          title="Le changement d’adresse va s’impacter à l’ensemble des réservations en cours associées."
-        >
-          <div className={styles['update-oa-wrapper']}>
-            <div>
-              Un email va être envoyé aux bénéficiaires ayant réservé les offres
-              concernées. Ils auront 48h pour annuler leur réservation s’ils le
-              souhaitent.
-            </div>
-            <Callout variant={CalloutVariant.WARNING}>
-              Si vous souhaitez que les réservations en cours conservent
-              l’ancienne adresse, veuillez créer une nouvelle offre avec la
-              nouvelle adresse.
-            </Callout>
+      <ConfirmDialog
+        cancelText="Ne pas envoyer"
+        confirmText="Envoyer un email"
+        onCancel={() => {
+          setIsWithdrawalMailDialogOpen(false)
+        }}
+        leftButtonAction={async () => {
+          await formik.submitForm()
+        }}
+        onConfirm={async () => {
+          setSendWithdrawalMail(true)
+          await formik.submitForm()
+        }}
+        icon={strokeMailIcon}
+        title="Souhaitez-vous prévenir les bénéficiaires de la modification des modalités de retrait ?"
+        open={isWithdrawalMailDialogOpen}
+      />
+      <ConfirmDialog
+        cancelText="Annuler"
+        confirmText="Je confirme le changement"
+        onCancel={() => {
+          setIsAddressUpdateDialogOpen(false)
+        }}
+        onConfirm={async () => {
+          await formik.submitForm()
+        }}
+        open={isAddressUpdateDialogOpen}
+        title="Le changement d’adresse va s’impacter à l’ensemble des réservations en cours associées."
+      >
+        <div className={styles['update-oa-wrapper']}>
+          <div>
+            Un email va être envoyé aux bénéficiaires ayant réservé les offres
+            concernées. Ils auront 48h pour annuler leur réservation s’ils le
+            souhaitent.
           </div>
-        </ConfirmDialog>
-      )}
+          <Callout variant={CalloutVariant.WARNING}>
+            Si vous souhaitez que les réservations en cours conservent
+            l’ancienne adresse, veuillez créer une nouvelle offre avec la
+            nouvelle adresse.
+          </Callout>
+        </div>
+      </ConfirmDialog>
       <RouteLeavingGuardIndividualOffer
         when={formik.dirty && !formik.isSubmitting}
       />

--- a/pro/src/screens/IndividualOffersScreen/RedirectToBankAccountDialog.tsx
+++ b/pro/src/screens/IndividualOffersScreen/RedirectToBankAccountDialog.tsx
@@ -12,12 +12,14 @@ export interface RedirectToBankAccountDialogProps {
   cancelRedirectUrl: string
   offerId: number
   venueId: number
+  isDialogOpen: boolean
 }
 
 export const RedirectToBankAccountDialog = ({
   cancelRedirectUrl,
   offerId,
   venueId,
+  isDialogOpen,
 }: RedirectToBankAccountDialogProps): JSX.Element => {
   const navigate = useNavigate()
   const { logEvent } = useAnalytics()
@@ -46,6 +48,7 @@ export const RedirectToBankAccountDialog = ({
       cancelText="Plus tard"
       cancelIcon={fullWaitIcon}
       withRedirectLinkIcon={false}
+      open={isDialogOpen}
     >
       <p>Vous pouvez dès à présent ajouter un compte bancaire.</p>
       <p>

--- a/pro/src/screens/IndividualOffersScreen/__specs__/RedirectToBankAccountDialog.tracker.spec.tsx
+++ b/pro/src/screens/IndividualOffersScreen/__specs__/RedirectToBankAccountDialog.tracker.spec.tsx
@@ -21,6 +21,7 @@ describe('screen Offers', () => {
       cancelRedirectUrl: '/url',
       offerId: 1,
       venueId: 2,
+      isDialogOpen: true,
     }
 
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -147,9 +147,10 @@ export const Offerer = (): JSX.Element => {
 
   return (
     <>
-      {showIsAppUserDialog && (
-        <MaybeAppUserDialog onCancel={formik.handleSubmit} />
-      )}
+      <MaybeAppUserDialog
+        onCancel={formik.handleSubmit}
+        isDialogOpen={showIsAppUserDialog}
+      />
       <FormLayout className={styles['offerer-layout']}>
         <FormikProvider value={formik}>
           <form

--- a/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
@@ -204,21 +204,20 @@ export const Offerers = (): JSX.Element => {
         isDisabled={false}
         legalCategoryCode={offerer.legalCategoryCode}
       />
-      {showLinkDialog && (
-        <ConfirmDialog
-          icon={strokeCollaboratorIcon}
-          onCancel={cancelLinkUserToOfferer}
-          title="Êtes-vous sûr de vouloir rejoindre cet espace ?"
-          onConfirm={doLinkAccount}
-          confirmText="Rejoindre cet espace"
-          cancelText="Annuler"
-          extraClassNames={styles['dialog-content']}
-        >
-          <div className={styles['dialog-info']}>
-            Votre demande sera prise en compte et analysée par nos équipes.
-          </div>
-        </ConfirmDialog>
-      )}
+      <ConfirmDialog
+        icon={strokeCollaboratorIcon}
+        onCancel={cancelLinkUserToOfferer}
+        title="Êtes-vous sûr de vouloir rejoindre cet espace ?"
+        onConfirm={doLinkAccount}
+        confirmText="Rejoindre cet espace"
+        cancelText="Annuler"
+        extraClassNames={styles['dialog-content']}
+        open={showLinkDialog}
+      >
+        <div className={styles['dialog-info']}>
+          Votre demande sera prise en compte et analysée par nos équipes.
+        </div>
+      </ConfirmDialog>
     </div>
   )
 }

--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
@@ -172,7 +172,11 @@ export const SelectAutocomplete = ({
           filteredOptions[hoveredOptionIndex]
         ) {
           event.preventDefault()
-          await selectOption(String(filteredOptions[hoveredOptionIndex].value))
+          if (filteredOptions[hoveredOptionIndex]) {
+            await selectOption(
+              String(filteredOptions[hoveredOptionIndex].value)
+            )
+          }
         }
         break
       case 'Escape':


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31844

**Objectif**
Changer le fonctionnement des dialogs ConfirmDialog pour qu'ils re-focus le bouton de déclenchement (trigger) quand on les ferme.
Dans un premier temps, il faut que l'ouverture/fermeture du dialog soit faite via la props `open` du dialog. Cette PR a pour objectif principal de remplacer le fonctionnement de l'affichage des ConfirmDialog.

Ensuite, pour que le re-focus fonctionne, il faut en plus que le `React.Node` du bouton de trigger soit passé en props du ConfirmDialog. Auquel cas, on n'a pas besoin du `open`, le dialog gère en interne l'ouverture via le trigger et la fermeture via les boutons cancel et submit qui sont encapsulés dans un `Dialog.Close`.

Le souci avec les ConfirmDialog est que la fermeture n'est pas au moment du clic sur le submit, mais très souvent après un await d'une requête. Dans ce cas, si on ne veut pas fermer le dialog immédiatement au clic, le bouton de submit ne doit pas fermer automatiquement le dialog via `Dialog.Close`, et le focus ne peut pas être fait automatiquement sur le trigger par radix. Dans ce cas, on doit garder un composent ConfirmDialog "contrôlé" avec la props `open` et gérer le refocus "à la main" après la fermeture depuis l'extérieur.

Le dernier commit est un exemple de comment faire avec `trigger` dans un cas où la fermeture a lieu au submit.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
