### PR TITLE
(PC-31761)[API] feat: add isMobile parameter on consult playlist logs…

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -175,6 +175,7 @@ def log_consult_playlist_element(
             "playlistId": body.playlistId,
             "from": body.iframeFrom,
             "queryId": body.queryId,
+            "isMobile": body.isMobile,
         },
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -45,6 +45,7 @@ class PlaylistBody(AdageBaseModel):
     playlistId: int
     elementId: int | None
     index: int | None
+    isMobile: bool | None
 
 
 class SearchBody(AdageBaseModel):

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -58,15 +58,15 @@ class LogsTest:
         }
 
     @pytest.mark.parametrize(
-        "playlist_type,element_id,index,offer_id,venue_id,domain_id",
+        "playlist_type,element_id,index,offer_id,venue_id,domain_id,is_mobile",
         [
-            ("offer", 34, 1, 34, None, None),
-            ("venue", 45, 2, None, 45, None),
-            ("domain", 56, None, None, None, 56),
+            ("offer", 34, 1, 34, None, None, None),
+            ("venue", 45, 2, None, 45, None, True),
+            ("domain", 56, None, None, None, 56, False),
         ],
     )
     def test_log_consult_playlist_element(
-        self, test_client, caplog, playlist_type, element_id, index, offer_id, venue_id, domain_id
+        self, test_client, caplog, playlist_type, element_id, index, offer_id, venue_id, domain_id, is_mobile
     ):
         with caplog.at_level(logging.INFO):
             response = test_client.post(
@@ -79,6 +79,7 @@ class LogsTest:
                     "index": index,
                     "playlistId": 99,
                     "playlistType": playlist_type,
+                    "isMobile": is_mobile,
                 },
             )
 
@@ -96,6 +97,7 @@ class LogsTest:
             "venueId": venue_id,
             "domainId": domain_id,
             "index": index,
+            "isMobile": is_mobile,
         }
 
     def test_log_has_seen_whole_playlist(self, test_client, caplog):

--- a/pro/src/apiClient/adage/models/PlaylistBody.ts
+++ b/pro/src/apiClient/adage/models/PlaylistBody.ts
@@ -8,6 +8,7 @@ export type PlaylistBody = {
   iframeFrom: string;
   index?: number | null;
   isFromNoResult?: boolean | null;
+  isMobile?: boolean | null;
   playlistId: number;
   playlistType: AdagePlaylistType;
   queryId?: string | null;


### PR DESCRIPTION
… route

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31761

Ajout d'un paramètre `isMobile` à la route /logs/consult-playlist-element

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
