### PR TITLE
(PC-31411)[API] feat: Add 2 endpoint to mock adage bookings lifecycle

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -275,6 +275,7 @@ class CancelledCollectiveBookingFactory(CollectiveBookingFactory):
 class PendingCollectiveBookingFactory(CollectiveBookingFactory):
     cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=10))
     confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=10))
+    confirmationDate = None
     status = models.CollectiveBookingStatus.PENDING
 
 

--- a/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
@@ -12,6 +12,7 @@ from pcapi.core.finance import api as finance_api
 from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import models as providers_models
+from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ForbiddenError
 from pcapi.models.api_errors import ResourceNotFoundError
@@ -156,6 +157,61 @@ def use_collective_booking(booking_id: int) -> None:
         raise ApiErrors({"code": "FAILED_TO_USE_BOOKING_TRY_AGAIN_LATER"}, status_code=500)
 
 
+@blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/pending", methods=["POST"])
+@utils.exclude_prod_environment
+@provider_api_key_required
+@spectree_serialize(
+    api=spectree_schemas.public_api_schema,
+    on_success_status=204,
+    tags=[tags.COLLECTIVE_ADAGE_MOCK],
+    resp=SpectreeResponse(
+        **(
+            http_responses.HTTP_204_COLLECTIVE_BOOKING_STATUS_UPDATE
+            | http_responses.HTTP_40X_SHARED_BY_API_ENDPOINTS
+            | http_responses.HTTP_403_COLLECTIVE_BOOKING_STATUS_UPDATE_REFUSED
+            | http_responses.HTTP_404_COLLECTIVE_OFFER_NOT_FOUND
+        )
+    ),
+)
+def reset_collective_booking(booking_id: int) -> None:
+    """
+    Adage mock: reset collective booking back to pending state.
+
+    Like this could happen within the Adage platform.
+
+    Warning: not available for production nor integration environments
+    """
+    booking = _get_booking_or_raise_404(booking_id)
+
+    if booking.status == models.CollectiveBookingStatus.USED:
+        raise ForbiddenError({"code": "CANNOT_SET_BACK_USED_BOOKING_TO_PENDING"})
+    if booking.status == models.CollectiveBookingStatus.REIMBURSED:
+        raise ForbiddenError({"code": "CANNOT_SET_BACK_REIMBURSED_BOOKING_TO_PENDING"})
+
+    try:
+        if booking.status == models.CollectiveBookingStatus.CANCELLED:
+            booking.uncancel_booking()
+    except Exception as err:
+        db.session.rollback()
+
+        err_extras = {"booking": booking.id, "api_key": current_api_key.id, "err": str(err)}
+        logger.error("Adage mock. Failed to set cancelled booking back to pending state", extra=err_extras)
+        raise ApiErrors({"code": "FAILED_TO_SET_BACK_CANCELLED_BOOKING_TO_PENDING"}, status_code=500)
+
+    try:
+        booking.status = models.CollectiveBookingStatus.PENDING
+        booking.confirmationDate = None
+
+        db.session.add(booking)
+        db.session.commit()
+    except Exception as err:
+        db.session.rollback()
+
+        err_extras = {"booking": booking.id, "api_key": current_api_key.id, "err": str(err)}
+        logger.error("Adage mock. Failed to set booking back to pending state", extra=err_extras)
+        raise ApiErrors({"code": "FAILED_TO_SET_BACK_BOOKING_TO_PENDING"}, status_code=500)
+
+
 def _get_booking_or_raise_404(booking_id: int) -> models.CollectiveBooking:
     booking = (
         models.CollectiveBooking.query.filter(models.CollectiveBooking.id == booking_id)
@@ -167,7 +223,7 @@ def _get_booking_or_raise_404(booking_id: int) -> models.CollectiveBooking:
         .filter(providers_models.VenueProvider.isActive == True)
         .options(
             sa.orm.joinedload(models.CollectiveBooking.collectiveStock)
-            .load_only(models.CollectiveStock.id)
+            .load_only(models.CollectiveStock.id, models.CollectiveStock.beginningDatetime)
             .joinedload(models.CollectiveStock.collectiveOffer)
             .load_only(models.CollectiveOffer.id),
         )

--- a/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
@@ -218,7 +218,7 @@ def reset_collective_booking(booking_id: int) -> None:
         raise ApiErrors({"code": "FAILED_TO_SET_BACK_BOOKING_TO_PENDING"}, status_code=500)
 
 
-@blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/repay", methods=["POST"])
+@blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/reimburse", methods=["POST"])
 @utils.exclude_prod_environment
 @provider_api_key_required
 @spectree_serialize(
@@ -234,9 +234,9 @@ def reset_collective_booking(booking_id: int) -> None:
         )
     ),
 )
-def repay_collective_booking(booking_id: int) -> None:
+def reimburse_collective_booking(booking_id: int) -> None:
     """
-    Mock collective booking repayment.
+    Mock collective booking reimbursement.
 
     Like this could happen within the Adage platform.
 

--- a/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
@@ -53,7 +53,9 @@ def confirm_collective_booking(booking_id: int) -> None:
 
     Like this could happen within the Adage platform.
 
-    Warning: not available for production nor integration environments
+    **WARNING:** this endpoint is not available from the production
+    environment as it is a mock meant to ease the test of your
+    integrations.
     """
     _get_booking_or_raise_404(booking_id)  # check booking is linked to the provider
     try:
@@ -94,7 +96,9 @@ def adage_mock_cancel_collective_booking(booking_id: int) -> None:
 
     Like this could happen within the Adage platform.
 
-    Warning: not available for production nor integration environments
+    **WARNING:** this endpoint is not available from the production
+    environment as it is a mock meant to ease the test of your
+    integrations.
     """
     booking = _get_booking_or_raise_404(booking_id)
 
@@ -179,7 +183,9 @@ def reset_collective_booking(booking_id: int) -> None:
 
     Like this could happen within the Adage platform.
 
-    Warning: not available for production nor integration environments
+    **WARNING:** this endpoint is not available from the production
+    environment as it is a mock meant to ease the test of your
+    integrations.
     """
     booking = _get_booking_or_raise_404(booking_id)
 
@@ -234,7 +240,9 @@ def repay_collective_booking(booking_id: int) -> None:
 
     Like this could happen within the Adage platform.
 
-    Warning: not available for production nor integration environments
+    **WARNING:** this endpoint is not available from the production
+    environment as it is a mock meant to ease the test of your
+    integrations.
     """
     booking = _get_booking_or_raise_404(booking_id)
 

--- a/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
@@ -212,6 +212,50 @@ def reset_collective_booking(booking_id: int) -> None:
         raise ApiErrors({"code": "FAILED_TO_SET_BACK_BOOKING_TO_PENDING"}, status_code=500)
 
 
+@blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/repay", methods=["POST"])
+@utils.exclude_prod_environment
+@provider_api_key_required
+@spectree_serialize(
+    api=spectree_schemas.public_api_schema,
+    on_success_status=204,
+    tags=[tags.COLLECTIVE_ADAGE_MOCK],
+    resp=SpectreeResponse(
+        **(
+            http_responses.HTTP_204_COLLECTIVE_BOOKING_STATUS_UPDATE
+            | http_responses.HTTP_40X_SHARED_BY_API_ENDPOINTS
+            | http_responses.HTTP_403_COLLECTIVE_BOOKING_STATUS_UPDATE_REFUSED
+            | http_responses.HTTP_404_COLLECTIVE_OFFER_NOT_FOUND
+        )
+    ),
+)
+def repay_collective_booking(booking_id: int) -> None:
+    """
+    Mock collective booking repayment.
+
+    Like this could happen within the Adage platform.
+
+    Warning: not available for production nor integration environments
+    """
+    booking = _get_booking_or_raise_404(booking_id)
+
+    if booking.status != models.CollectiveBookingStatus.USED:
+        raise ForbiddenError({"code": f"CANNOT_REIMBURSE_{booking.status.value}_BOOKING"})
+
+    try:
+        booking.status = models.CollectiveBookingStatus.REIMBURSED
+        booking.reimbursementDate = datetime.now(timezone.utc)  # pylint: disable=datetime-now
+
+        db.session.add(booking)
+        db.session.commit()
+    except Exception as err:
+        db.session.rollback()
+
+        err_extras = {"booking": booking.id, "api_key": current_api_key.id, "error": str(err)}
+        logger.error("Adage mock. Failed to repay booking.", extra=err_extras)
+
+        raise ApiErrors({"code": "REPAYMENT_FAILED_TRY_AGAIN_LATER"}, status_code=500)
+
+
 def _get_booking_or_raise_404(booking_id: int) -> models.CollectiveBooking:
     booking = (
         models.CollectiveBooking.query.filter(models.CollectiveBooking.id == booking_id)

--- a/api/tests/routes/public/collective/endpoints/adage_mock/base.py
+++ b/api/tests/routes/public/collective/endpoints/adage_mock/base.py
@@ -1,0 +1,46 @@
+import pytest
+
+from pcapi.core.educational import factories
+from pcapi.core.educational import models
+
+from tests.conftest import TestClient
+from tests.routes.public.helpers import PublicAPIRestrictedEnvEndpointHelper
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+# pylint: disable=abstract-method
+class AdageMockEndpointHelper(PublicAPIRestrictedEnvEndpointHelper):
+    default_factory = factories.PendingCollectiveBookingFactory
+
+    def setup_base_resource(self, *, factory=None, provider=None, venue=None, deposit=None) -> models.CollectiveBooking:
+        venue = venue or self.setup_venue()
+        deposit = deposit or factories.EducationalDepositFactory()
+        factory = factory or self.default_factory
+        offer = factories.CollectiveOfferFactory(provider=provider, venue=venue)
+        return factory(
+            collectiveStock__collectiveOffer=offer,
+            educationalInstitution=deposit.educationalInstitution,
+            educationalYear=deposit.educationalYear,
+        )
+
+    def test_should_raise_404_because_has_no_access_to_venue(self, client: TestClient):
+        plain_api_key, _ = self.setup_provider()
+        pending_booking = self.setup_base_resource()
+        self.assert_request_has_expected_result(
+            client.with_explicit_token(plain_api_key),
+            url_params={"booking_id": pending_booking.id},
+            expected_status_code=404,
+            expected_error_json={"code": "BOOKING_NOT_FOUND"},
+        )
+
+    def test_should_raise_404_because_venue_provider_is_inactive(self, client: TestClient):
+        plain_api_key, venue_provider = self.setup_inactive_venue_provider()
+        pending_booking = self.setup_base_resource(venue=venue_provider.venue, provider=venue_provider.provider)
+        self.assert_request_has_expected_result(
+            client.with_explicit_token(plain_api_key),
+            url_params={"booking_id": pending_booking.id},
+            expected_status_code=404,
+            expected_error_json={"code": "BOOKING_NOT_FOUND"},
+        )

--- a/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
+++ b/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
@@ -641,10 +641,10 @@ class RepayCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
     @pytest.mark.parametrize(
         "booking_factory,expected_json",
         [
-            (factories.PendingCollectiveBookingFactory, {"code": f"CANNOT_REIMBURSE_PENDING_BOOKING"}),
-            (factories.CancelledCollectiveBookingFactory, {"code": f"CANNOT_REIMBURSE_CANCELLED_BOOKING"}),
-            (factories.ConfirmedCollectiveBookingFactory, {"code": f"CANNOT_REIMBURSE_CONFIRMED_BOOKING"}),
-            (factories.ReimbursedCollectiveBookingFactory, {"code": f"CANNOT_REIMBURSE_REIMBURSED_BOOKING"}),
+            (factories.PendingCollectiveBookingFactory, {"code": "CANNOT_REIMBURSE_PENDING_BOOKING"}),
+            (factories.CancelledCollectiveBookingFactory, {"code": "CANNOT_REIMBURSE_CANCELLED_BOOKING"}),
+            (factories.ConfirmedCollectiveBookingFactory, {"code": "CANNOT_REIMBURSE_CONFIRMED_BOOKING"}),
+            (factories.ReimbursedCollectiveBookingFactory, {"code": "CANNOT_REIMBURSE_REIMBURSED_BOOKING"}),
         ],
     )
     def test_should_raise_403_when_status_is_not_used(self, client, booking_factory, expected_json):

--- a/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
+++ b/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
@@ -450,7 +450,7 @@ class ResetCollectiveBookingTest(AdageMockEndpointHelper):
 
 
 class RepayCollectiveBookingTest(AdageMockEndpointHelper):
-    endpoint_url = "/v2/collective/adage_mock/bookings/{booking_id}/repay"
+    endpoint_url = "/v2/collective/adage_mock/bookings/{booking_id}/reimburse"
     endpoint_method = "post"
     default_path_params = {"booking_id": 1}
     default_factory = factories.UsedCollectiveBookingFactory

--- a/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
+++ b/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
@@ -467,3 +467,113 @@ class UseCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
                 expected_status_code=500,
                 expected_error_json={"code": "FAILED_TO_USE_BOOKING_TRY_AGAIN_LATER"},
             )
+
+
+class ResetCollectiveBookingTest(PublicAPIRestrictedEnvEndpointHelper):
+    endpoint_url = "/v2/collective/adage_mock/bookings/{booking_id}/pending"
+    endpoint_method = "post"
+    default_path_params = {"booking_id": 1}
+    default_factory = factories.PendingCollectiveBookingFactory
+
+    def setup_base_resource(self, *, factory=None, provider=None, venue=None) -> models.CollectiveBooking:
+        # data
+        venue = venue or self.setup_venue()
+        deposit = factories.EducationalDepositFactory()
+        offer = factories.CollectiveOfferFactory(provider=provider, venue=venue)
+        # factory
+        factory = factory or self.default_factory
+
+        return factory(
+            collectiveStock__collectiveOffer=offer,
+            educationalInstitution=deposit.educationalInstitution,
+            educationalYear=deposit.educationalYear,
+        )
+
+    def test_should_raise_404_because_has_no_access_to_venue(self, client: TestClient):
+        plain_api_key, _ = self.setup_provider()
+        booking = self.setup_base_resource()
+        self.assert_request_has_expected_result(
+            client.with_explicit_token(plain_api_key),
+            url_params={"booking_id": booking.id},
+            expected_status_code=404,
+            expected_error_json={"code": "BOOKING_NOT_FOUND"},
+        )
+
+    def test_should_raise_404_because_venue_provider_is_inactive(self, client: TestClient):
+        plain_api_key, venue_provider = self.setup_inactive_venue_provider()
+        booking = self.setup_base_resource(venue=venue_provider.venue, provider=venue_provider.provider)
+        self.assert_request_has_expected_result(
+            client.with_explicit_token(plain_api_key),
+            url_params={"booking_id": booking.id},
+            expected_status_code=404,
+            expected_error_json={"code": "BOOKING_NOT_FOUND"},
+        )
+
+    def test_can_reset_pending_booking(self, client):
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+        booking = self.setup_base_resource(venue=venue_provider.venue, provider=venue_provider.provider)
+        auth_client = client.with_explicit_token(plain_api_key)
+        with assert_attribute_does_not_change(booking, "status"):
+            expected_num_queries = 1  # 1. get api key
+            expected_num_queries += 1  # 2. get FF
+            expected_num_queries += 1  # 3. get collective booking (no update triggered since status does not change)
+
+            booking_id = booking.id
+            with assert_num_queries(expected_num_queries):
+                self.assert_request_has_expected_result(
+                    auth_client,
+                    url_params={"booking_id": booking_id},
+                    expected_status_code=204,
+                )
+
+    @pytest.mark.parametrize(
+        "booking_factory", [factories.ConfirmedCollectiveBookingFactory, factories.CancelledCollectiveBookingFactory]
+    )
+    def test_can_reset_confirmed_booking(self, client, booking_factory):
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+        booking = self.setup_base_resource(
+            factory=booking_factory, venue=venue_provider.venue, provider=venue_provider.provider
+        )
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_value_changes_to(booking, "status", models.CollectiveBookingStatus.PENDING):
+            expected_num_queries = 1  # 1. get api key
+            expected_num_queries += 1  # 2. get FF
+            expected_num_queries += 1  # 3. get collective booking
+            expected_num_queries += 1  # 4. update booking
+
+            booking_id = booking.id
+            with assert_num_queries(expected_num_queries):
+                self.assert_request_has_expected_result(
+                    auth_client,
+                    url_params={"booking_id": booking_id},
+                    expected_status_code=204,
+                )
+
+    @pytest.mark.parametrize(
+        "booking_factory,expected_json",
+        [
+            (factories.UsedCollectiveBookingFactory, {"code": "CANNOT_SET_BACK_USED_BOOKING_TO_PENDING"}),
+            (factories.ReimbursedCollectiveBookingFactory, {"code": "CANNOT_SET_BACK_REIMBURSED_BOOKING_TO_PENDING"}),
+        ],
+    )
+    def test_cannot_reset_used_booking(self, client, booking_factory, expected_json):
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+        booking = self.setup_base_resource(
+            factory=booking_factory, venue=venue_provider.venue, provider=venue_provider.provider
+        )
+        auth_client = client.with_explicit_token(plain_api_key)
+
+        with assert_attribute_does_not_change(booking, "status"):
+            expected_num_queries = 1  # 1. get api key
+            expected_num_queries += 1  # 2. get FF
+            expected_num_queries += 1  # 3. get collective booking
+
+            booking_id = booking.id
+            with assert_num_queries(expected_num_queries):
+                self.assert_request_has_expected_result(
+                    auth_client,
+                    url_params={"booking_id": booking_id},
+                    expected_status_code=403,
+                    expected_error_json=expected_json,
+                )

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -11253,10 +11253,10 @@
                 ]
             }
         },
-        "/v2/collective/adage_mock/bookings/{booking_id}/repay": {
+        "/v2/collective/adage_mock/bookings/{booking_id}/reimburse": {
             "post": {
                 "description": "Like this could happen within the Adage platform.\n\n**WARNING:** this endpoint is not available from the production environment as it is a mock meant to ease the test of your integrations.",
-                "operationId": "RepayCollectiveBooking",
+                "operationId": "ReimburseCollectiveBooking",
                 "parameters": [
                     {
                         "description": "",
@@ -11301,7 +11301,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "summary": "Mock collective booking repayment.",
+                "summary": "Mock collective booking reimbursement.",
                 "tags": [
                     "Collective bookings Adage mock"
                 ]

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -11093,7 +11093,7 @@
         },
         "/v2/collective/adage_mock/bookings/{booking_id}/cancel": {
             "post": {
-                "description": "Like this could happen within the Adage platform.\n\nWarning: not available for production nor integration environments",
+                "description": "Like this could happen within the Adage platform.\n\n**WARNING:** this endpoint is not available from the production environment as it is a mock meant to ease the test of your integrations.",
                 "operationId": "AdageMockCancelCollectiveBooking",
                 "parameters": [
                     {
@@ -11147,7 +11147,7 @@
         },
         "/v2/collective/adage_mock/bookings/{booking_id}/confirm": {
             "post": {
-                "description": "Like this could happen within the Adage platform.\n\nWarning: not available for production nor integration environments",
+                "description": "Like this could happen within the Adage platform.\n\n**WARNING:** this endpoint is not available from the production environment as it is a mock meant to ease the test of your integrations.",
                 "operationId": "ConfirmCollectiveBooking",
                 "parameters": [
                     {
@@ -11201,7 +11201,7 @@
         },
         "/v2/collective/adage_mock/bookings/{booking_id}/pending": {
             "post": {
-                "description": "Like this could happen within the Adage platform.\n\nWarning: not available for production nor integration environments",
+                "description": "Like this could happen within the Adage platform.\n\n**WARNING:** this endpoint is not available from the production environment as it is a mock meant to ease the test of your integrations.",
                 "operationId": "ResetCollectiveBooking",
                 "parameters": [
                     {
@@ -11248,6 +11248,60 @@
                     }
                 ],
                 "summary": "Adage mock: reset collective booking back to pending state.",
+                "tags": [
+                    "Collective bookings Adage mock"
+                ]
+            }
+        },
+        "/v2/collective/adage_mock/bookings/{booking_id}/repay": {
+            "post": {
+                "description": "Like this could happen within the Adage platform.\n\n**WARNING:** this endpoint is not available from the production environment as it is a mock meant to ease the test of your integrations.",
+                "operationId": "RepayCollectiveBooking",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "booking_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "This collective booking's status has been successfully updated"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API."
+                    },
+                    "403": {
+                        "description": "Collective booking status updated has been refused"
+                    },
+                    "404": {
+                        "description": "The collective offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Mock collective booking repayment.",
                 "tags": [
                     "Collective bookings Adage mock"
                 ]

--- a/api/tests/routes/public/expected_openapi.json
+++ b/api/tests/routes/public/expected_openapi.json
@@ -11199,6 +11199,60 @@
                 ]
             }
         },
+        "/v2/collective/adage_mock/bookings/{booking_id}/pending": {
+            "post": {
+                "description": "Like this could happen within the Adage platform.\n\nWarning: not available for production nor integration environments",
+                "operationId": "ResetCollectiveBooking",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "booking_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "This collective booking's status has been successfully updated"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API."
+                    },
+                    "403": {
+                        "description": "Collective booking status updated has been refused"
+                    },
+                    "404": {
+                        "description": "The collective offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Adage mock: reset collective booking back to pending state.",
+                "tags": [
+                    "Collective bookings Adage mock"
+                ]
+            }
+        },
         "/v2/collective/bookings/{booking_id}": {
             "patch": {
                 "description": "Cancel an collective event booking.",


### PR DESCRIPTION
## But de la pull request

Travail initié par @jeremieb-pass.  (PR d'origine: https://github.com/pass-culture/pass-culture-main/pull/14148)

Tickets Jira : 
- https://passculture.atlassian.net/browse/PC-31411
- https://passculture.atlassian.net/browse/PC-31452

Ajout de deux routes mockant les comportement d'une réservation sur adage :
- une route pour mocker le remboursement
- une route pour reset le statut d'une réservation

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
