### PR TITLE
(PC-31816)[BO] feat: add new 'commercial gesture' pricing category in exported invoices csv

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -600,7 +600,7 @@ def _price_event(event: models.FinanceEvent) -> models.Pricing:
         lines = [
             models.PricingLine(
                 amount=amount,
-                category=models.PricingLineCategory.OFFERER_REVENUE,
+                category=models.PricingLineCategory.COMMERCIAL_GESTURE,
             ),
             models.PricingLine(
                 amount=0,

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -176,6 +176,7 @@ class PricingLineCategory(enum.Enum):
     OFFERER_REVENUE = "offerer revenue"
     OFFERER_CONTRIBUTION = "offerer contribution"
     PASS_CULTURE_COMMISSION = "pass culture commission"
+    COMMERCIAL_GESTURE = "commercial gesture"
 
 
 class PricingLogReason(enum.Enum):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31816

Ajout de la catégorie de valorisation "geste commercial" dans l'export csv invoices.

Avant :

<img width="1112" alt="Capture d’écran 2024-09-17 à 09 16 57" src="https://github.com/user-attachments/assets/33c367a7-be9f-491a-953a-1c55118a1e59">

Après : 

<img width="1110" alt="Capture d’écran 2024-09-17 à 09 16 30" src="https://github.com/user-attachments/assets/7b640609-a885-45e3-a327-98141e28ee40">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
