### PR TITLE
PC-30542 fixing test api

### DIFF
--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -182,7 +182,7 @@ class BookOfferTest:
         # 1 - SELECT from offer that I don't get
         # 1 - SELECT bookings for the venue ???
         # 1 - SELECT feature
-        with assert_num_queries(34):
+        with assert_num_queries(35):
             booking = api.book_offer(beneficiary=beneficiary, stock_id=stock_id, quantity=1)
 
         # One request should have been sent to Batch to trigger the event


### PR DESCRIPTION
## But de la pull request
fix le test tests/core/bookings/test_api.py::BookOfferTest::test_create_booking qui echoue en local
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30542

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
