### PR TITLE
(PC-31797)[API] script: clear empty extra data from offer

### DIFF
--- a/api/src/pcapi/scripts/rattrapage_extra_data/main.py
+++ b/api/src/pcapi/scripts/rattrapage_extra_data/main.py
@@ -1,0 +1,59 @@
+import argparse
+import logging
+
+from pcapi.core.offers.models import Offer
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+EXTRA_DATA_TO_CLEAR = {
+    "ean",
+    "isbn",
+    "visa",
+    "author",
+    "gtl_id",
+    "speaker",
+    "showType",
+    "musicType",
+    "performer",
+    "showSubType",
+    "musicSubType",
+    "stageDirector",
+}
+
+
+def fix_extra_data(do_update: bool, offer_ids: list) -> None:
+    logger.info("(PC-31797) script to clear extra data started")
+    offer_list = Offer.query.filter(Offer.id.in_(offer_ids)).all()
+    unprocessed_offer_list = set()
+    for offer in offer_list:
+        if offer.extraData:
+            for key, value in offer.extraData:
+                if value == "" and key in EXTRA_DATA_TO_CLEAR:
+                    try:
+                        offer.extraData.pop(key)
+                    except KeyError:
+                        logger.info("Failed to remove %s from offer with ID %d", key, offer.id)
+            db.session.add(offer)
+        else:
+            unprocessed_offer_list.add(offer.id)
+    logger.info("Offer IDs that have not been processed : %s", unprocessed_offer_list)
+    if do_update:
+        db.session.commit()
+    else:
+        db.session.rollback()
+    logger.info("(PC-31797) script to clear extra data finished")
+
+
+if __name__ == "__main__":
+    from pcapi.flask_app import app
+
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser(description="Remove empty fields from extra data for given offer ids")
+    parser.add_argument("--offer-ids", nargs="+", help="Liste d'Offer IDs", required=True)
+    parser.add_argument("--not-dry", action="store_true", help="set to really process (dry-run by default)")
+    args = parser.parse_args()
+
+    fix_extra_data(do_update=args.not_dry, offer_ids=args.offer_ids)


### PR DESCRIPTION
## But de la pull request

Script qui ne sera pas mergé. La liste des offer ids dont les extra data sont à corriger est dans le ticket Jira

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31797

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
