### PR TITLE
(PC-31863)[PRO] fix: stop displaying EAN search when draft offer is created but not product based

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsScreen.tsx
@@ -181,13 +181,17 @@ export const DetailsScreen = ({ venues }: DetailsScreenProps): JSX.Element => {
   // (Draft) offers are created via POST request.
   // On Details screen, the form might be pre-filled with a product,
   // until the form is submitted, the draft offer is not created yet.
-  const isOfferProductBased = !!offer?.productId
+  const isOfferProductBased = !!offer && !!offer.productId
+  const isOfferButNotProductBased = !!offer && !offer.productId
   const isNotAnOfferYetButProductBased = !offer && !!formik.values.productId
   const isProductBased = isOfferProductBased || isNotAnOfferYetButProductBased
 
   const readOnlyFields = setFormReadOnlyFields(offer, isProductBased)
   const isEanSearchDisplayed =
-    isSearchByEanEnabled && isRecordStore && mode === OFFER_WIZARD_MODE.CREATION
+    isSearchByEanEnabled &&
+    isRecordStore &&
+    mode === OFFER_WIZARD_MODE.CREATION &&
+    !isOfferButNotProductBased
 
   return (
     <FormikProvider value={formik}>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31863

## Objectifs : 
- Lorsque l'on crée une offre individuelle, si on passe de "Détails" à "Informations" en cliquant sur "Enregistrer & continuer", alors l'offre devient une draft offer (une requête POST est effectuée).
- En revenant sur "Détails", on se base sur les valeurs de l'objet draft offer ainsi créé. 
- Si ce draft offer n'est pas basé sur un produit, alors on considère que la recherche EAN ne doit plus être disponible.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
