### PR TITLE
(BSR)[API] chore: update docusaurus version

### DIFF
--- a/api/documentation/package-lock.json
+++ b/api/documentation/package-lock.json
@@ -8,8 +8,8 @@
       "name": "documentation-2",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.4.0",
-        "@docusaurus/preset-classic": "^3.4.0",
+        "@docusaurus/core": "^3.5.2",
+        "@docusaurus/preset-classic": "^3.5.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -18,9 +18,9 @@
         "redocusaurus": "^2.0.2"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.4.0",
-        "@docusaurus/tsconfig": "^3.4.0",
-        "@docusaurus/types": "^3.4.0",
+        "@docusaurus/module-type-aliases": "^3.5.2",
+        "@docusaurus/tsconfig": "^3.5.2",
+        "@docusaurus/types": "^3.5.2",
         "typescript": "~5.2.2"
       },
       "engines": {
@@ -69,74 +69,126 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.23.3.tgz",
-      "integrity": "sha512-vRHXYCpPlTDE7i6UOy2xE03zHF2C8MEFjPN2v7fRbqVpcOvAUQK81x3Kc21xyb5aSIpYCjWCZbYZuz8Glyzyyg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
+      "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.23.3.tgz",
-      "integrity": "sha512-h9XcNI6lxYStaw32pHpB1TMm0RuxphF+Ik4o7tcQiodEdpKK+wKufY6QXtba7t3k8eseirEMVB83uFFF3Nu54A=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
+      "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.23.3.tgz",
-      "integrity": "sha512-yvpbuUXg/+0rbcagxNT7un0eo3czx2Uf0y4eiR4z4SD7SiptwYTpbuS0IHxcLHG3lq22ukx1T6Kjtk/rT+mqNg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
+      "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.23.3.tgz",
-      "integrity": "sha512-hpa6S5d7iQmretHHF40QGq6hz0anWEHGlULcTIT9tbUssWUriN9AUXIFQ8Ei4w9azD0hc1rUok9/DeQQobhQMA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
+      "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.23.3.tgz",
-      "integrity": "sha512-LBsEARGS9cj8VkTAVEZphjxTjMVCci+zIIiRhpFun9jGDUlS1XmhCW7CTrnaWeIuCQS/2iPyRqSy1nXPjcBLRA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+      "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.23.3.tgz",
-      "integrity": "sha512-l6EiPxdAlg8CYhroqS5ybfIczsGUIAC47slLPOMDeKSVXYG1n0qGiz4RjAHLw2aD0xzh2EXZ7aRguPfz7UKDKw==",
-      "dependencies": {
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.4.3.tgz",
+      "integrity": "sha512-6BoqQ1/Xjwol7kL5Z7TwSphff0mN4pwpydTi6VOkKs7X3piBj6cuJ3FLjHnaVCwMvcaO9hW3gbx+M0u1sYekig==",
+      "peer": true,
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.23.3.tgz",
-      "integrity": "sha512-3E3yF3Ocr1tB/xOZiuC3doHQBQ2zu2MPTYZ0d4lpfWads2WTKG7ZzmGnsHmm63RflvDeLK/UVx7j2b3QuwKQ2g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+      "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.23.3.tgz",
-      "integrity": "sha512-P4VAKFHqU0wx9O+q29Q8YVuaowaZ5EM77rxfmGnkHUJggh28useXQdopokgwMeYw2XUht49WX5RcTQ40rZIabw==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.4.3.tgz",
+      "integrity": "sha512-SJ2ofwdyknkwfSXQi7xvrOR93lNxjsgS1+vOdOkOF1t6HgWxnPXHZoP2hUSsrKExSQWmeE7UUbpvhHZkFxGLeA==",
+      "peer": true,
       "dependencies": {
-        "@algolia/client-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/client-common": "5.4.3",
+        "@algolia/requester-browser-xhr": "5.4.3",
+        "@algolia/requester-fetch": "5.4.3",
+        "@algolia/requester-node-http": "5.4.3"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -145,65 +197,120 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.23.3.tgz",
-      "integrity": "sha512-y9kBtmJwiZ9ZZ+1Ek66P0M68mHQzKRxkW5kAAXYN/rdzgDN0d2COsViEFufxJ0pb45K4FRcfC7+33YB4BLrZ+g=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
+      "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.23.3.tgz",
-      "integrity": "sha512-8xoiseoWDKuCVnWP8jHthgaeobDLolh00KJAdMe9XPrWPuf1by732jSpgy2BlsLTaT9m32pHI8CRfrOqQzHv3A==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
+      "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
       "dependencies": {
-        "@algolia/logger-common": "4.23.3"
+        "@algolia/logger-common": "4.24.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.23.3.tgz",
-      "integrity": "sha512-9fK4nXZF0bFkdcLBRDexsnGzVmu4TSYZqxdpgBW2tEyfuSSY54D4qSRkLmNkrrz4YFvdh2GM1gA8vSsnZPR73w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+      "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.3",
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/cache-in-memory": "4.23.3",
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/logger-console": "4.23.3",
-        "@algolia/requester-browser-xhr": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/requester-node-http": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.23.3.tgz",
-      "integrity": "sha512-jDWGIQ96BhXbmONAQsasIpTYWslyjkiGu0Quydjlowe+ciqySpiDUrJHERIRfELE5+wFc7hc1Q5hqjGoV7yghw==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.4.3.tgz",
+      "integrity": "sha512-XgxyUzUQei5MDNkjss5ioID00sRkazgYAojZpz8B1gNvWaSx/FQd/7MlVoi4HBtSJNi1pkgpsVGGlMp6nTZdyA==",
+      "peer": true,
       "dependencies": {
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/client-common": "5.4.3"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.23.3.tgz",
-      "integrity": "sha512-xloIdr/bedtYEGcXCiF2muajyvRhwop4cMZo+K2qzNht0CMzlRkm8YsDdj5IaBhshqfgmBb3rTg4sL4/PpvLYw=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
+      "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA=="
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.4.3.tgz",
+      "integrity": "sha512-Z6VuKQrBd6+TzyL1jsLI1kkoeXTY/g3SR01Z674vTZpdZlimiI9HMMHkgHthtK1speMjfPGDcTggi4TcOxXpMQ==",
+      "peer": true,
+      "dependencies": {
+        "@algolia/client-common": "5.4.3"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.23.3.tgz",
-      "integrity": "sha512-zgu++8Uj03IWDEJM3fuNl34s746JnZOWn1Uz5taV1dFyJhVM/kTNw9Ik7YJWiUNHJQXcaD8IXD1eCb0nq/aByA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.4.3.tgz",
+      "integrity": "sha512-gNIaj31fFz3pbIM7LiS1iu4/1ZX+lJdWd+UiM9ECaGtZYpkdxxqbfyMHieISVLNsVezOpYgS2BYeKe8d5+se/Q==",
+      "peer": true,
       "dependencies": {
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/client-common": "5.4.3"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.23.3.tgz",
-      "integrity": "sha512-Wjl5gttqnf/gQKJA+dafnD0Y6Yw97yvfY8R9h0dQltX1GXTgNs1zWgvtWW0tHl1EgMdhAyw189uWiZMnL3QebQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
+      "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/requester-common": "4.23.3"
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2099,18 +2206,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.0.tgz",
-      "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.1.tgz",
+      "integrity": "sha512-VtVb5DS+0hRIprU2CO6ZQjK2Zg4QU5HrDM1+ix6rT0umsYvFvatMAnf97NHZlVWDaaLlx7GRfR/7FikANiM2Fg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.0.tgz",
-      "integrity": "sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.1.tgz",
+      "integrity": "sha512-qXZkEPvybVhSXj0K7U3bXc233tk5e8PfhoZ6MhPOiik/qUQxYC+Dn9DnoS7CxHQQhHfCvTiN0eY9M12oRghEXw==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.9.3",
         "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.6.0",
+        "@docsearch/css": "3.6.1",
         "algoliasearch": "^4.19.1"
       },
       "peerDependencies": {
@@ -2135,9 +2242,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
+      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2149,12 +2256,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/cssnano-preset": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2215,14 +2322,15 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@mdx-js/react": "^3.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz",
-      "integrity": "sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
+      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
         "postcss": "^8.4.38",
@@ -2234,9 +2342,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
+      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2246,13 +2354,13 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz",
-      "integrity": "sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
+      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2284,11 +2392,11 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
-      "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.2.tgz",
+      "integrity": "sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==",
       "dependencies": {
-        "@docusaurus/types": "3.4.0",
+        "@docusaurus/types": "3.5.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2302,18 +2410,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz",
-      "integrity": "sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.5.2.tgz",
+      "integrity": "sha512-R7ghWnMvjSf+aeNDH0K4fjyQnt5L0KzUEnUhmf1e3jZrv3wogeytZNN6n7X8yHcMsuZHPOrctQhXWnmxu+IRRg==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
-        "cheerio": "^1.0.0-rc.12",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
+        "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2328,23 +2437,25 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz",
-      "integrity": "sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.5.2.tgz",
+      "integrity": "sha512-Bt+OXn/CPtVqM3Di44vHjE7rPCEsRCB/DMo2qoOuozB9f7+lsdrHvD0QCHdBs0uhz6deYJDppAr2VgqybKPlVQ==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2363,15 +2474,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz",
-      "integrity": "sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.5.2.tgz",
+      "integrity": "sha512-WzhHjNpoQAUz/ueO10cnundRz+VUtkjFhhaQ9jApyv1a46FPURO4cef89pyNIOMny1fjDz/NUN2z6Yi+5WUrCw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2385,13 +2496,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz",
-      "integrity": "sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.5.2.tgz",
+      "integrity": "sha512-kBK6GlN0itCkrmHuCS6aX1wmoWc5wpd5KJlqQ1FyrF0cLDnvsYSnh7+ftdwzt7G6lGBho8lrVwkkL9/iQvaSOA==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2405,13 +2516,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz",
-      "integrity": "sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.5.2.tgz",
+      "integrity": "sha512-rjEkJH/tJ8OXRE9bwhV2mb/WP93V441rD6XnM6MIluu7rk8qg38iSxS43ga2V2Q/2ib53PcqbDEJDG/yWQRJhQ==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2423,13 +2534,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
-      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.5.2.tgz",
+      "integrity": "sha512-lm8XL3xLkTPHFKKjLjEEAHUrW0SZBSHBE1I+i/tmYMBsjCcUB5UJ52geS5PSiOCFVR74tbPGcPHEV/gaaxFeSA==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2442,13 +2553,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz",
-      "integrity": "sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.5.2.tgz",
+      "integrity": "sha512-QkpX68PMOMu10Mvgvr5CfZAzZQFx8WLlOiUQ/Qmmcl6mjGK6H21WLT5x7xDmcpCoKA/3CegsqIqBR+nA137lQg==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2460,16 +2571,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz",
-      "integrity": "sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.5.2.tgz",
+      "integrity": "sha512-DnlqYyRAdQ4NHY28TfHuVk414ft2uruP4QWCH//jzpHjqvKyXjj2fmDtI8RPUBh9K8iZKFMHRnLtzJKySPWvFA==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2483,23 +2594,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz",
-      "integrity": "sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.5.2.tgz",
+      "integrity": "sha512-3ihfXQ95aOHiLB5uCu+9PRy2gZCeSZoDcqpnDvf3B+sTrMvMTr8qRUzBvWkoIqc82yG5prCboRjk1SVILKx6sg==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/plugin-debug": "3.4.0",
-        "@docusaurus/plugin-google-analytics": "3.4.0",
-        "@docusaurus/plugin-google-gtag": "3.4.0",
-        "@docusaurus/plugin-google-tag-manager": "3.4.0",
-        "@docusaurus/plugin-sitemap": "3.4.0",
-        "@docusaurus/theme-classic": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-search-algolia": "3.4.0",
-        "@docusaurus/types": "3.4.0"
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/plugin-content-blog": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/plugin-content-pages": "3.5.2",
+        "@docusaurus/plugin-debug": "3.5.2",
+        "@docusaurus/plugin-google-analytics": "3.5.2",
+        "@docusaurus/plugin-google-gtag": "3.5.2",
+        "@docusaurus/plugin-google-tag-manager": "3.5.2",
+        "@docusaurus/plugin-sitemap": "3.5.2",
+        "@docusaurus/theme-classic": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-search-algolia": "3.5.2",
+        "@docusaurus/types": "3.5.2"
       },
       "engines": {
         "node": ">=18.0"
@@ -2510,26 +2621,26 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz",
-      "integrity": "sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.5.2.tgz",
+      "integrity": "sha512-XRpinSix3NBv95Rk7xeMF9k4safMkwnpSgThn0UNQNumKvmcIYjfkwfh2BhwYh/BxMXQHJ/PdmNh22TQFpIaYg==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/plugin-content-blog": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/plugin-content-pages": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-translations": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
-        "infima": "0.2.0-alpha.43",
+        "infima": "0.2.0-alpha.44",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.26",
@@ -2549,17 +2660,14 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.4.0.tgz",
-      "integrity": "sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.5.2.tgz",
+      "integrity": "sha512-QXqlm9S6x9Ibwjs7I2yEDgsCocp708DrCrgHgKwg2n2AY0YQ6IjU0gAK35lHRLOvAoJUfCKpQAwUykB0R7+Eew==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2573,23 +2681,24 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz",
-      "integrity": "sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.5.2.tgz",
+      "integrity": "sha512-qW53kp3VzMnEqZGjakaV90sst3iN1o32PH+nawv1uepROO8aEGxptcq2R5rsv7aBShSRbZwIobdvSYKsZ5pqvA==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-translations": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2608,9 +2717,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz",
-      "integrity": "sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.5.2.tgz",
+      "integrity": "sha512-GPZLcu4aT1EmqSTmbdpVrDENGR2yObFEX8ssEFYTCiAIVc0EihNSdOIBTazUvgNqwvnoU1A8vIs1xyzc3LITTw==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2620,15 +2729,15 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.4.0.tgz",
-      "integrity": "sha512-0qENiJ+TRaeTzcg4olrnh0BQ7eCxTgbYWBnWUeQDc84UYkt/T3pDNnm3SiQkqPb+YQ1qtYFlC0RriAElclo8Dg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.5.2.tgz",
+      "integrity": "sha512-rQ7toURCFnWAIn8ubcquDs0ewhPwviMzxh6WpRjBW7sJVCXb6yzwUaY3HMNa0VXCFw+qkIbFywrMTf+Pb4uHWQ==",
       "dev": true
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
-      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
+      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -2646,12 +2755,12 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.4.0.tgz",
-      "integrity": "sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
+      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "@svgr/webpack": "^8.1.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2684,9 +2793,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.4.0.tgz",
-      "integrity": "sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
+      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2703,13 +2812,13 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
-      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
+      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -3955,36 +4064,71 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.23.3.tgz",
-      "integrity": "sha512-Le/3YgNvjW9zxIQMRhUHuhiUjAlKY/zsdZpfq4dlLqg6mEm0nL6yk+7f2hDOtLpxsgE4jSzDmvHL7nXdBp5feg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+      "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.3",
-        "@algolia/cache-common": "4.23.3",
-        "@algolia/cache-in-memory": "4.23.3",
-        "@algolia/client-account": "4.23.3",
-        "@algolia/client-analytics": "4.23.3",
-        "@algolia/client-common": "4.23.3",
-        "@algolia/client-personalization": "4.23.3",
-        "@algolia/client-search": "4.23.3",
-        "@algolia/logger-common": "4.23.3",
-        "@algolia/logger-console": "4.23.3",
-        "@algolia/recommend": "4.23.3",
-        "@algolia/requester-browser-xhr": "4.23.3",
-        "@algolia/requester-common": "4.23.3",
-        "@algolia/requester-node-http": "4.23.3",
-        "@algolia/transporter": "4.23.3"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-account": "4.24.0",
+        "@algolia/client-analytics": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-personalization": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/recommend": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.21.0.tgz",
-      "integrity": "sha512-hjVOrL15I3Y3K8xG0icwG1/tWE+MocqBrhW6uVBWpU+/kVEMK0BnM2xdssj6mZM61eJ4iRxHR0djEI3ENOpR8w==",
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.5.tgz",
+      "integrity": "sha512-lWvhdnc+aKOKx8jyA3bsdEgHzm/sglC4cYdMG4xSQyRiPLJVJtH/IVYZG3Hp6PkTEhQqhyVYkeP9z2IlcHJsWw==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 6"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/algoliasearch/node_modules/@algolia/requester-node-http": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/ansi-align": {
@@ -4098,9 +4242,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.19",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
       "funding": [
         {
           "type": "opencollective",
@@ -4116,11 +4260,11 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.23.0",
-        "caniuse-lite": "^1.0.30001599",
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "bin": {
@@ -4339,9 +4483,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4357,10 +4501,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4478,9 +4622,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001620",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
-      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
+      "version": "1.0.30001660",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
+      "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5865,9 +6009,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.776",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.776.tgz",
-      "integrity": "sha512-s694bi3+gUzlliqxjPHpa9NRTlhzTgB34aan+pVKZmOTGy2xoZXl+8E1B8i5p5rtev3PKMK/H4asgNejC+YHNg=="
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.24.tgz",
+      "integrity": "sha512-0x0wLCmpdKFCi9ulhvYZebgcPmHTkFVUfU2wzDykadkslKwT4oAmDTHEKLnlrDsMGZe4B+ksn8quZfZjYsBetA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -7684,9 +7828,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.43",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
-      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==",
+      "version": "0.2.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.44.tgz",
+      "integrity": "sha512-tuRkUSO/lB3rEhLJk25atwAjgLuzq070+pOW8XcvpHky/YbENnRRdPd85IBkyeTgttmOy5ah+yHYsK1HhUd4lQ==",
       "engines": {
         "node": ">=12"
       }
@@ -10768,9 +10912,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -12360,9 +12504,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-json-view-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.4.0.tgz",
-      "integrity": "sha512-wh6F6uJyYAmQ4fK0e8dSQMEWuvTs2Wr3el3sLD9bambX1+pSWUVXIz1RFaoy3TI1mZ0FqdpKq9YgbgTTgyrmXA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.5.0.tgz",
+      "integrity": "sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==",
       "engines": {
         "node": ">=14"
       },
@@ -13017,9 +13161,9 @@
       "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ=="
     },
     "node_modules/rtlcss": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.1.1.tgz",
-      "integrity": "sha512-/oVHgBtnPNcggP2aVXQjSy6N1mMAfHg4GSag0QtZBlD5bdDgAHwr4pydqJGd+SUCu9260+Pjqbjwtvu7EMH1KQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
+      "integrity": "sha512-FI+pHEn7Wc4NqKXMXFM+VAYKEj/mRIcW4h24YVwVtyjI+EqGrLc2Hx/Ny0lrZ21cBWU2goLy36eqMcNj3AQJig==",
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0",
@@ -13111,9 +13255,9 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.14.0.tgz",
-      "integrity": "sha512-OLN6MsPMCghDOqlCtsIsYgtsC0pnwVTyT9Mu6A3ewOj1DxvzZF6COrn2g86E/c05xbktB0XN04m/t1Z+n+fTGw==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.2.tgz",
+      "integrity": "sha512-zFNpOpUO+tY2D85KrxJ+aqwnIfdEGi06UH2+xEb+Bp9Mwznmauqc9djbnBibJO5mpfUPPa8st6Sx65+vbeO45g==",
       "peer": true
     },
     "node_modules/section-matter": {
@@ -14399,9 +14543,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/api/documentation/package.json
+++ b/api/documentation/package.json
@@ -15,8 +15,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.4.0",
-    "@docusaurus/preset-classic": "^3.4.0",
+    "@docusaurus/core": "^3.5.2",
+    "@docusaurus/preset-classic": "^3.5.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -25,9 +25,9 @@
     "redocusaurus": "^2.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.4.0",
-    "@docusaurus/tsconfig": "^3.4.0",
-    "@docusaurus/types": "^3.4.0",
+    "@docusaurus/module-type-aliases": "^3.5.2",
+    "@docusaurus/tsconfig": "^3.5.2",
+    "@docusaurus/types": "^3.5.2",
     "typescript": "~5.2.2"
   },
   "browserslist": {


### PR DESCRIPTION
## But de la pull request

Update des dépendances `@docusaurus/core` et `@docusaurus/preset-classic`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
