### PR TITLE
(PC-31878)[API]fix: Mise à jour des extraData d'offres sur les conditional_fields seulement

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -286,6 +286,8 @@ def patch_draft_offer(
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
     try:
         with repository.transaction():
+            if body_extra_data := offers_api.deserialize_extra_data(body.extra_data, offer.subcategoryId):
+                body.extra_data = body_extra_data
             offer = offers_api.update_draft_offer(offer, body)
     except (exceptions.OfferCreationBaseException, exceptions.OfferEditionBaseException) as error:
         raise api_errors.ApiErrors(error.errors, status_code=400)
@@ -423,6 +425,8 @@ def patch_offer(
     try:
         with repository.transaction():
             updates = body.dict(by_alias=True, exclude_unset=True)
+            if body_extra_data := offers_api.deserialize_extra_data(body.extraData, offer.subcategoryId):
+                updates["extraData"] = body_extra_data
 
             offer_body = offers_schemas.UpdateOffer(**updates)
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1484,29 +1484,6 @@ class UpdateOfferTest:
         assert offer.name == "New name"
         assert offer.description == "new Description"
 
-    def test_raise_error_if_update_ean_for_offer_with_existing_ean(self):
-        offer = factories.OfferFactory(
-            name="Old name",
-            extraData={"ean": "1234567890123", "musicSubType": 524, "musicType": 520},
-            subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
-        )
-        body = offers_schemas.UpdateOffer(
-            name="New name",
-            description="new Description",
-            extraData={"ean": "1234567890124", "gtl_id": "02000000"},
-        )
-        offer = api.update_offer(offer, body)
-        db.session.flush()
-
-        assert offer.name == "New name"
-        assert offer.description == "new Description"
-        assert offer.extraData == {
-            "ean": "1234567890124",
-            "gtl_id": "02000000",
-            "musicType": "501",
-            "musicSubType": "-1",
-        }
-
     def test_cannot_update_with_name_too_long(self):
         offer = factories.OfferFactory(name="Old name", extraData={"ean": "1234567890124"})
         body = offers_schemas.UpdateOffer(name="Luftballons" * 99)

--- a/api/tests/routes/pro/patch_draft_offer_test.py
+++ b/api/tests/routes/pro/patch_draft_offer_test.py
@@ -105,36 +105,23 @@ class Returns200Test:
         assert updated_offer.description == "New description"
         assert not updated_offer.product
 
-    def test_patch_draft_offer_with_form_required_fields_should_not_update_existing_extra_data(self, client):
+    def test_patch_draft_with_extra_data(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
-        venue = offerers_factories.VirtualVenueFactory(managingOfferer=user_offerer.offerer)
-        ems_provider = get_provider_by_local_class("EMSStocks")
-        venue_provider = providers_factories.VenueProviderFactory(provider=ems_provider, venue=venue)
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(venue=venue_provider.venue)
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
         offer = offers_factories.EventOfferFactory(
             name="Film",
-            venue=venue_provider.venue,
+            venue=venue,
             subcategoryId=subcategories.SEANCE_CINE.id,
-            lastProviderId=cinema_provider_pivot.provider.id,
             isDuo=False,
             description="description",
-            extraData={"stageDirector": "Greta Gerwig"},
+            extraData=None,
         )
 
         data = {
             "name": "Film",
             "description": "description",
             "subcategoryId": subcategories.SEANCE_CINE.id,
-            "extraData": {
-                "author": "",
-                "gtl_id": "",
-                "performer": "",
-                "showType": "",
-                "showSubType": "",
-                "speaker": "",
-                "stageDirector": "Greta Gerwig",
-                "visa": "",
-            },
+            "extraData": {"stageDirector": "Greta Gerwig"},
         }
         response = client.with_session_auth("user@example.com").patch(f"/offers/draft/{offer.id}", json=data)
         assert response.status_code == 200
@@ -143,7 +130,7 @@ class Returns200Test:
         updated_offer = Offer.query.get(offer.id)
         assert updated_offer.extraData == {"stageDirector": "Greta Gerwig"}
 
-    def test_patch_draft_offer_with_form_required_fields_should_not_create_extra_data(self, client):
+    def test_patch_draft_offer_with_empty_extra_data(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
         venue = offerers_factories.VirtualVenueFactory(managingOfferer=user_offerer.offerer)
         ems_provider = get_provider_by_local_class("EMSStocks")
@@ -179,7 +166,114 @@ class Returns200Test:
         assert response.json["id"] == offer.id
 
         updated_offer = Offer.query.get(offer.id)
-        assert updated_offer.extraData == {}
+        assert updated_offer.extraData == {
+            "author": "",
+            "gtl_id": "",
+            "performer": "",
+            "showType": "",
+            "showSubType": "",
+            "speaker": "",
+            "stageDirector": "",
+            "visa": "",
+        }
+
+    def test_patch_draft_offer_with_existing_extra_data_with_new_extra_data(self, client):
+        user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+        offer = offers_factories.EventOfferFactory(
+            name="Film",
+            venue=venue,
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            isDuo=False,
+            description="description",
+            extraData={
+                "cast": ["Joan Baez", "Joe Cocker", "David Crosby"],
+                "eidr": "10.5240/ADBD-3CAA-43A0-7BF0-86E2-K",
+                "type": "FEATURE_FILM",
+                "visa": "37205",
+                "title": "Woodstock",
+                "genres": ["DOCUMENTARY", "HISTORICAL", "MUSIC"],
+                "credits": [
+                    {"person": {"lastName": "Wadleigh", "firstName": "Michael"}, "position": {"name": "DIRECTOR"}}
+                ],
+                "runtime": 185,
+                "theater": {"allocine_room_id": "W0135", "allocine_movie_id": 2634},
+                "backlink": "https://www.allocine.fr/film/fichefilm_gen_cfilm=2634.html",
+                "synopsis": "Le plus important rassemblement de la musique pop de ces vingt derni\u00e8res ann\u00e9es. Des groupes qui ont marqu\u00e9 leur \u00e9poque et une jeunesse qui a marqu\u00e9 la sienne.",
+                "companies": [{"name": "Wadleigh-Maurice", "activity": "Production"}],
+                "countries": ["USA"],
+                "posterUrl": "https://fr.web.img2.acsta.net/pictures/14/06/20/12/25/387023.jpg",
+                "allocineId": 2634,
+                "originalTitle": "Woodstock",
+                "stageDirector": "Michael Wadleigh",
+                "productionYear": 1970,
+            },
+        )
+
+        data = {
+            "name": "Film",
+            "description": "description",
+            "subcategoryId": subcategories.SEANCE_CINE.id,
+            "extraData": {
+                "author": "",
+                "gtl_id": "",
+                "performer": "",
+                "showType": "",
+                "showSubType": "",
+                "speaker": "",
+                "stageDirector": "Greta Gerwig",
+                "visa": "",
+                "cast": ["Joan Baez", "Joe Cocker", "David Crosby"],
+                "eidr": "10.5240/ADBD-3CAA-43A0-7BF0-86E2-K",
+                "type": "FEATURE_FILM",
+                "title": "Woodstock",
+                "genres": ["DOCUMENTARY", "HISTORICAL", "MUSIC"],
+                "credits": [
+                    {"person": {"lastName": "Wadleigh", "firstName": "Michael"}, "position": {"name": "DIRECTOR"}}
+                ],
+                "runtime": 185,
+                "theater": {"allocine_room_id": "W0135", "allocine_movie_id": 2634},
+                "backlink": "https://www.allocine.fr/film/fichefilm_gen_cfilm=2634.html",
+                "synopsis": "Le plus important rassemblement de la musique pop de ces vingt derni\u00e8res ann\u00e9es. Des groupes qui ont marqu\u00e9 leur \u00e9poque et une jeunesse qui a marqu\u00e9 la sienne.",
+                "companies": [{"name": "Wadleigh-Maurice", "activity": "Production"}],
+                "countries": ["USA"],
+                "posterUrl": "https://fr.web.img2.acsta.net/pictures/14/06/20/12/25/387023.jpg",
+                "allocineId": 2634,
+                "originalTitle": "Woodstock",
+                "productionYear": 1970,
+            },
+        }
+        response = client.with_session_auth("user@example.com").patch(f"/offers/draft/{offer.id}", json=data)
+        assert response.status_code == 200
+        assert response.json["id"] == offer.id
+
+        updated_offer = Offer.query.get(offer.id)
+        assert updated_offer.extraData == {
+            "cast": ["Joan Baez", "Joe Cocker", "David Crosby"],
+            "eidr": "10.5240/ADBD-3CAA-43A0-7BF0-86E2-K",
+            "type": "FEATURE_FILM",
+            "visa": "",
+            "title": "Woodstock",
+            "genres": ["DOCUMENTARY", "HISTORICAL", "MUSIC"],
+            "credits": [{"person": {"lastName": "Wadleigh", "firstName": "Michael"}, "position": {"name": "DIRECTOR"}}],
+            "runtime": 185,
+            "theater": {"allocine_room_id": "W0135", "allocine_movie_id": 2634},
+            "backlink": "https://www.allocine.fr/film/fichefilm_gen_cfilm=2634.html",
+            "synopsis": "Le plus important rassemblement de la musique pop de ces vingt derni\u00e8res ann\u00e9es. Des groupes qui ont marqu\u00e9 leur \u00e9poque et une jeunesse qui a marqu\u00e9 la sienne.",
+            "companies": [{"name": "Wadleigh-Maurice", "activity": "Production"}],
+            "countries": ["USA"],
+            "posterUrl": "https://fr.web.img2.acsta.net/pictures/14/06/20/12/25/387023.jpg",
+            "allocineId": 2634,
+            "originalTitle": "Woodstock",
+            "stageDirector": "Greta Gerwig",
+            "productionYear": 1970,
+            "author": "",
+            "gtl_id": "",
+            "performer": "",
+            "showType": "",
+            "showSubType": "",
+            "speaker": "",
+        }
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -147,6 +147,7 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
         assert event_offer.extraData == {
             "author": "Maurice",
             "performer": "Pink Pâtisserie",
+            "stageDirector": "Robert",
         }
 
     def test_patch_all_fields(self, client):

--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsScreen.tsx
@@ -105,7 +105,7 @@ export const DetailsScreen = ({ venues }: DetailsScreenProps): JSX.Element => {
         ? await api.postDraftOffer(serializeDetailsPostData(formValues))
         : await api.patchDraftOffer(
             offer.id,
-            serializeDetailsPatchData(formValues)
+            serializeDetailsPatchData(formValues, !!offer.lastProvider)
           )
 
       const receivedOfferId = response.id

--- a/pro/src/screens/IndividualOffer/DetailsScreen/utils.ts
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/utils.ts
@@ -375,11 +375,15 @@ type PatchPayload = {
 }
 
 export function serializeDetailsPatchData(
-  formValues: DetailsFormValues
+  formValues: DetailsFormValues,
+  isLastProviderOffer: boolean
 ): PatchPayload {
-  // Always remove EAN from serializedExtraData.
-  const extraData = serializeExtraData(formValues)
-  delete extraData.ean
+  let extraData
+  if (!isLastProviderOffer) {
+    // Always remove EAN from serializedExtraData.
+    extraData = serializeExtraData(formValues)
+    delete extraData.ean
+  }
 
   return {
     name: formValues.name,

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
@@ -200,8 +200,14 @@ export const UsefulInformationScreen = ({
     subcategories: conditionalFields,
     isOfferAddressEnabled,
   })
+
+  const initialValues = setDefaultInitialValuesFromOffer({
+    offer,
+    selectedVenue,
+  })
+
   const formik = useFormik({
-    initialValues: setDefaultInitialValuesFromOffer({ offer, selectedVenue }),
+    initialValues,
     onSubmit,
     validationSchema,
   })


### PR DESCRIPTION
## But de la pull request

Lors d'un `PATCH offer` et/ou `PATCH draft offer`, les `extra_data` de l'offre sont écrasées par les données renvoyées par le front. Cela entraîne la disparition de données synchronisées (avec allociné lors de l'édition du champ `isDuo` qui appelle la route `PATCH offer`) ou lorsqu'on appelle la route `PATCH Draft Offer` avec un `EAN`: 

__explications__:  le front ne renvoie pas ce champ lors de l'appel à cette route, puisqu'il ne peut pas être modifié (choix tech front). On récupère des `extraData` sans l'`EAN`. Lors de l'appel à `_format_extra_data(...)`, on écrase les `extra_data` avec les données du formulaire renvoyés par le front (donc pas les `EAN`) -> les `EAN` disparaissent des `extraData` 

On corrige en repartant des extraData existant lors du PATCH, et on fait un vrai PATCH des extra data sans supprimer ou ajouter d'informations

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31878

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
