### PR TITLE
(PC-31832)[PRO] fix: Dont select inexistant index when selecting an o…

### DIFF
--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
@@ -166,7 +166,11 @@ export const SelectAutocomplete = ({
         break
       case ' ': //  Space key
       case 'Enter':
-        if (isOpen && hoveredOptionIndex !== null) {
+        if (
+          isOpen &&
+          hoveredOptionIndex !== null &&
+          filteredOptions[hoveredOptionIndex]
+        ) {
           event.preventDefault()
           await selectOption(String(filteredOptions[hoveredOptionIndex].value))
         }


### PR DESCRIPTION
…ption in select autocomplete.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31832

**Objectif**
Ne pas accéder à des index qui n'existent pas dans SelectAutocomplete (J'ai pas reproduit).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
