### PR TITLE
(PC-31756)[BO] feat: add ff that allow extended search on offerer and venue

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -110,6 +110,9 @@ class FeatureToggle(enum.Enum):
     )
     ENABLE_PRO_NEW_NAV_MODIFICATION = "Activer la modification du statut de la navigation du portail pro"
     WIP_ENABLE_NEW_HASHING_ALGORITHM = "Activer le nouveau système de hachage des clés publiques d'API"
+    WIP_ENABLE_BO_PRO_SEARCH_BY_SIMILARITY = (
+        "Activer la recherche par similarité pour les structures et lieux dans le backoffice"
+    )
     WIP_BENEFICIARY_EXTRACT_TOOL = "Activer l'extraction de données personnelles (RGPD)"
     USE_END_DATE_FOR_COLLECTIVE_PRICING = "Utiliser la date de fin du stock collectif comme date de valorisation."
     WIP_ENABLE_OFFER_ADDRESS = "Activer l'association des offres à des adresses."


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31756

### verification front 

Lorsque le feature flag est activé :
<img width="1143" alt="Capture d’écran 2024-09-17 à 17 47 46" src="https://github.com/user-attachments/assets/c4ee4528-31e1-44dc-a6c8-7a12fcabe0e1">
ALORS 
au niveau des structures, la recherche approximative fonctionne ( comme avant ) 
<img width="1418" alt="Capture d’écran 2024-09-17 à 17 49 36" src="https://github.com/user-attachments/assets/acfa276f-8324-48c5-ac90-86ebb79939ce">
de meme que la recherche filtres accent, lettre capital, charactere speciaux
au niveau des lieux la recherche approximative fonctionne (comme avant)
<img width="1501" alt="Capture d’écran 2024-09-17 à 17 52 10" src="https://github.com/user-attachments/assets/81764b5f-1f63-4693-ba95-9bb150fbf4c2">


Lorsque le feature flag est désactiver 
ALORS
la recherche est moins approximative et l'on ne verra pas si il y a une faute sur quelque chose de tapé sauf accent, casse etc
<img width="1393" alt="Capture d’écran 2024-09-17 à 17 53 19" src="https://github.com/user-attachments/assets/bc0e4c58-81c5-4580-a7e9-bf45e4ac63e0">
de meme dans les lieux 
<img width="1278" alt="Capture d’écran 2024-09-17 à 17 55 48" src="https://github.com/user-attachments/assets/73bbf77b-68e5-470f-b79d-eaad463348c4">



### verification back

- CI - verte 
- faute d'orthographe - OK
- commentaire à mettre/retirer/corriger - OK

### cas de test détecté: 

LORSQUE 
j'effectue une recherche de structure via le nom et que le feature flag est activé
ALORS
la recherche peut etre approximative, les résultats m'afficheront une recherche ou la casse, les accents sont présent ou non, si il y a une faute de frappe dans la recherche alors la recherche fonctionnera et affichera les recherches de manière approximative

LORSQUE 
j'effectue une recherche de lieux via le nom OU le nom publique et que le feature flag est activé
ALORS
la recherche peut etre approximative, les résultats m'afficheront une recherche ou la casse, les accents sont présent ou non, si il y a une faute de frappe dans la recherche alors la recherche fonctionnera et affichera les recherches de manière approximative

LORSQUE
j'effectue une recherche de structure et que le feature flag est desactivé
ALORS
la recherche n'est pas approximative, les résultats m'afficheront une recherche ou la casse, les accents sont présent ou non

LORSQUE
j'effectue une recherche de lieux via le nom ou le nom publique et que le feature flag est desactivé
ALORS
la recherche n'est pas approximative, les résultats m'afficheront une recherche ou la casse, les accents sont présent ou non

### Verification ticket

- nom du ticket conforme -> OK
- auteur du ticket -> OK 
- nombre de commit ->OK
- nom du commit -> OK
- mettre le ticket en code-review ->OK

### Tache restante si WIP + AUTRE

- refresh de la page github -> OK
- Rien de visible


