### PR TITLE
(PC-31894)[API] feat: remove description double writing

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -121,7 +121,6 @@ def build_new_offer_from_product(
 ) -> models.Offer:
     return models.Offer(
         bookingEmail=venue.bookingEmail,
-        description=product.description,  # type: ignore[call-arg]
         extraData=product.extraData,
         idAtProvider=id_at_provider,
         lastProviderId=provider_id,

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -622,7 +622,10 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
 
     @description.setter
     def description(self, value: str | None) -> None:
-        self._description = value
+        if self.product:
+            self._description = None
+        else:
+            self._description = value
 
     @property
     def isEducational(self) -> bool:

--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -90,7 +90,6 @@ class AllocineStocks(LocalProvider):
     def update_from_movie_information(self, offer: offers_models.Offer) -> None:
         offer.name = self.product.name
         offer.extraData = offer.extraData or offers_models.OfferExtraData()
-        offer.description = self.product.description
         offer.durationMinutes = self.product.durationMinutes
         offer.product = self.product
         if self.product.extraData:

--- a/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
@@ -89,7 +89,6 @@ class BoostStocks(LocalProvider):
         offer.extraData = offer.extraData or offers_models.OfferExtraData()
         if self.product:
             offer.name = self.product.name
-            offer.description = self.product.description
             offer.durationMinutes = self.product.durationMinutes
             if self.product.extraData:
                 offer.extraData.update(self.product.extraData)

--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -121,7 +121,6 @@ class CDSStocks(LocalProvider):
         offer.extraData = offer.extraData or offers_models.OfferExtraData()
         if self.product:
             offer.name = self.product.name
-            offer.description = self.product.description
             offer.durationMinutes = self.product.durationMinutes
             if self.product.extraData:
                 offer.extraData.update(self.product.extraData)

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -25,6 +25,7 @@ from pcapi.core.providers import models as providers_models
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.local_providers.provider_api import synchronize_provider_api
+from pcapi.models import db
 from pcapi.routes.serialization.venue_provider_serialize import PostVenueProviderBody
 
 
@@ -212,6 +213,7 @@ class SynchronizeStocksTest:
 
         # Test fill offers attributes
         assert created_offer.bookingEmail == venue.bookingEmail
+        assert created_offer._description is None
         assert created_offer.description == product.description
         assert created_offer.extraData == product.extraData
         assert created_offer.name == product.name
@@ -287,10 +289,15 @@ class SynchronizeStocksTest:
             provider_id=provider.id,
         )
 
+        # We need to commit to have the offer description property working
+        db.session.add_all([*new_offers, product])
+        db.session.commit()
+
         # Then
         assert len(new_offers) == 1
         new_offer = new_offers[0]
         assert new_offer.bookingEmail == "booking_email"
+        assert new_offer._description is None
         assert new_offer.description == "product_desc"
         assert new_offer.extraData == {"extra": "data"}
         assert new_offer.idAtProvider == "ean_product_ref"

--- a/api/tests/local_providers/allocine_stocks_test.py
+++ b/api/tests/local_providers/allocine_stocks_test.py
@@ -116,6 +116,7 @@ class UpdateObjectsTest:
         created_offer = offers_models.Offer.query.one()
 
         assert created_offer.bookingEmail == "toto@example.com"
+        assert created_offer._description is None
         assert (
             created_offer.description
             == "Alors que la Premi\u00e8re Guerre Mondiale a \u00e9clat\u00e9, et en r\u00e9ponse aux propos des intellectuels allemands de l'\u00e9poque, Sacha Guitry filme les grands artistes de l'\u00e9poque qui contribuent au rayonnement culturel de la France.\n"

--- a/api/tests/local_providers/cinema_providers/boost/boost_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/boost/boost_stocks_test.py
@@ -146,6 +146,7 @@ class BoostStocksTest:
         assert created_offers[0].product == self._get_product_by_allocine_id(270935)
         assert created_offers[0].venue == venue_provider.venue
         assert created_offers[0].offererAddressId == venue_provider.venue.offererAddressId
+        assert created_offers[0]._description is None
         assert created_offers[0].description == "Description du produit allociné 3"
         assert created_offers[0].durationMinutes == 333
         assert created_offers[0].isDuo
@@ -164,6 +165,7 @@ class BoostStocksTest:
         assert created_offers[1].name == "Produit allociné 4"
         assert created_offers[1].product == self._get_product_by_allocine_id(269975)
         assert created_offers[1].venue == venue_provider.venue
+        assert created_offers[1]._description is None
         assert created_offers[1].description == "Description du produit allociné 4"
         assert created_offers[1].durationMinutes == 444
         assert created_offers[1].isDuo
@@ -231,6 +233,7 @@ class BoostStocksTest:
         assert created_offer.name == "Produit allociné 1"
         assert created_offer.product == self._get_product_by_allocine_id(263242)
         assert created_offer.venue == venue_provider.venue
+        assert created_offer._description is None
         assert created_offer.description == "Description du produit allociné 1"
         assert created_offer.durationMinutes == 111
         assert created_offer.isDuo

--- a/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
@@ -219,6 +219,7 @@ class CDSStocksTest:
         assert created_offers[0].product
         assert created_offers[0].venue == venue_provider.venue
         assert created_offers[0].offererAddressId == venue_provider.venue.offererAddressId
+        assert created_offers[0]._description is None
         assert created_offers[0].description == "Description du produit allociné 1"
         assert created_offers[0].durationMinutes == 111
         assert created_offers[0].isDuo

--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -87,6 +87,8 @@ class Returns201Test:
         assert response_dict["productId"] == product.id
         assert response_dict["extraData"] == {"ean": "9782123456803"}
         assert offer.product == product
+        assert offer._description is None
+        assert offer.description == product.description
 
     def test_create_offer_other_than_CD_or_vinyl_without_EAN_code_should_succeed_for_record_store(self, client):
         venue = offerers_factories.VenueFactory(venueTypeCode=VenueTypeCode.RECORD_STORE)
@@ -165,6 +167,8 @@ class Returns201Test:
         assert response_dict["productId"] == offer.productId
         assert response_dict["extraData"] == {"gtl_id": "07000000", "ean": "1234567891234"}
         assert offer.product == product
+        assert offer.description == product.description
+        assert offer._description is None
 
     def test_create_offer_on_venue_with_accessibility_informations(self, client):
         venue = offerers_factories.VenueFactory(

--- a/api/tests/routes/public/individual_offers/v1/post_product_by_ean_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_by_ean_test.py
@@ -121,6 +121,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
 
         created_offer = offers_models.Offer.query.one()
         assert created_offer.bookingEmail == venue.bookingEmail
+        assert created_offer._description is None
         assert created_offer.description == product.description
         assert created_offer.extraData == product.extraData
         assert created_offer.lastProvider.name == "Technical provider"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31894
Do not save description in offer when a product is linked to this offer 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
