### PR TITLE
(BSR)[PRO] fix: Do not display offer location for virtual offers.

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsSummary/DetailsSummary.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsSummary/DetailsSummary.tsx
@@ -181,7 +181,7 @@ export function DetailsSummaryScreen({ offer }: DetailsSummaryScreenProps) {
             </SummarySubSection>
           )}
         </SummarySection>
-        {isOfferAddressEnabled && (
+        {!offerData.isVenueVirtual && isOfferAddressEnabled && (
           <SummarySubSection title="Localisation de l’offre">
             <SummaryDescriptionList
               descriptions={[

--- a/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
+++ b/pro/src/screens/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
@@ -299,7 +299,7 @@ export const OfferSection = ({
           })}
           aria-label="Modifier les informations pratiques de l’offre"
         >
-          {isOfferAddressEnabled && (
+          {!offerData.isVenueVirtual && isOfferAddressEnabled && (
             <SummarySubSection title="Localisation de l’offre">
               <SummaryDescriptionList
                 descriptions={[


### PR DESCRIPTION
## But de la pull request

- Les offres numériques ne devraient pas voir "Localisation de l'offre"

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
