### PR TITLE
Dramelet/bsr yet another flaky test fix

### DIFF
--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -156,42 +156,7 @@ class BookOfferTest:
         # There is a different email for the first venue booking
         bookings_factories.BookingFactory(stock=stock)
 
-        num_queries = 1  # SELECT the stock, offer, venue, offerer_address, address
-        num_queries += 1  # Check if the venue as bookings
-        num_queries += 1  # SELECT the stock FOR UPDATE (joined with offer)
-        num_queries += 1  # SELECT the user
-        num_queries += 1  # SELECT the user FOR UPDATE
-        num_queries += 1  # Check if the user already has a booking on this stock
-        num_queries += 1  # SELECT offerer
-        num_queries += 1  # SELECT user's deposit
-        num_queries += 1  # SELECT the bookings not cancelled related to the deposit
-        num_queries += 1  # Check if a booking with this token exists
-        num_queries += 1  # UPDATE dnBookedQuantity
-        num_queries += 1  # INSERT the new booking
-        num_queries += 1  # SELECT user
-        num_queries += 1  # SELECT stock and suitable offer
-        num_queries += 1  # SELECT booking
-        num_queries += 1  # SELECT external booking
-        num_queries += 1  # SELECT stock
-        num_queries += 1  # SELECT venue
-        num_queries += 1  # SELECT offerer
-        num_queries += 1  # SELECT provider
-        num_queries += 1  # SELECT venue with bank activation & bank account
-        num_queries += 1  # SELECT activationCode related to booking
-        num_queries += 1  # SELECT criterion related to offer
-        num_queries += 1  # SELECT booking related to the user and the offer order by creationDate
-        num_queries += 1  # SELECT user's favorites
-        num_queries += 1  # SELECT user's deposit
-        num_queries += 1  # SELECT user's wallet
-        num_queries += 1  # SELECT user's action history
-        num_queries += 1  # SELECT user, user_offerer, venue
-        num_queries += 1  # SELECT offerer, venue
-        num_queries += 1  # Check if a collectiveOffer from "Marseille en grand" exists
-        num_queries += 1  # Check if the offer has up to date stocks
-        num_queries += 1  # Check if the venue has up to date bookings
-        num_queries += 1  # SELECT FeatureToggle
-        with assert_num_queries(num_queries):
-            booking = api.book_offer(beneficiary=beneficiary, stock_id=stock_id, quantity=1)
+        booking = api.book_offer(beneficiary=beneficiary, stock_id=stock_id, quantity=1)
 
         # One request should have been sent to Batch to trigger the event
         # HAS_BOOKED_OFFER, and another one with the user's


### PR DESCRIPTION
As seen in https://github.com/pass-culture/pass-culture-main/commit/3fe544a999db496207dc1c52f1c83ff166dd1ab8, this test is flaky.
A `SELECT * FROM venue` can be issued in the buisness code between the steps
`check_stock_is_bookable` and `check_expenses_limits` while the Venue
has still successfully joinedload previously.
While this issue is unresolved, we don’t want to count the queries
as this make this test flaky.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
