### PR TITLE
(PC-31896)[PRO] fix: algolia adage offer format bug

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -58,7 +58,7 @@ export type SuggestionItem = AutocompleteQuerySuggestionsHit & {
   offerer: {
     name: string
   }
-  formats: string[]
+  formats?: string[]
 }
 
 const ALGOLIA_NUMBER_RECENT_SEARCHES = 5
@@ -239,7 +239,8 @@ export const Autocomplete = ({
           )
 
           if (itemId >= 0 && itemId < 3) {
-            await formik.setFieldValue('formats', [item.formats[0]])
+            item.formats &&
+              (await formik.setFieldValue('formats', [item.formats[0]]))
           } else {
             await formik.setFieldValue('formats', [])
           }
@@ -532,12 +533,16 @@ export const Autocomplete = ({
                       {...autocomplete.getListProps()}
                     >
                       {keywordSuggestionsItems.map((item, index) => {
-                        let displayValue = null
-                        const shouldDisplayFormats =
-                          index <= 2 && item.formats.length > 0
+                        let shouldDisplayFormats = false
+                        let displayValue = ''
 
-                        if (shouldDisplayFormats) {
-                          displayValue = item.formats[0]
+                        if (item.formats) {
+                          shouldDisplayFormats =
+                            index <= 2 && item.formats.length > 0
+
+                          if (shouldDisplayFormats) {
+                            displayValue = item.formats[0]
+                          }
                         }
 
                         return (


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31896

Liée à un problème avec les suggestions algolia qui parfois n'ont pas de formats à la génération, pour ne plus avoir de crash sur adage on corrige côté front, un autre ticket back a été créé pour investiguer si il y a encore des offres sans formats qui sont indexés sur algolia. 
Lorsqu'une suggestion n'a pas de formats, on n'affiche plus son format

Pour reproduire en testing : 
il faut faire une recherche avec 'no' pour qu'on n'affiche plus le format
pour vérifier qu'il y a toujours le format si une suggestion en a une : recherche avec 'offer'
