### PR TITLE
PC-30384-Ajouts de OFFER_ADDRESS dans certains mails

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -937,6 +937,7 @@ def find_individual_bookings_event_happening_tomorrow_query() -> list[Booking]:
             .options(
                 contains_eager(Offer.venue),
                 contains_eager(Offer.criteria),
+                joinedload(Offer.offererAddress).load_only(OffererAddress.label).joinedload(OffererAddress.address),
             )
         )
         .all()

--- a/api/src/pcapi/core/geography/models.py
+++ b/api/src/pcapi/core/geography/models.py
@@ -32,6 +32,10 @@ class Address(PcObject, Base, Model):
         sa.Boolean, nullable=True, server_default=sa.sql.expression.false(), default=False
     )
 
+    @property
+    def fullAddress(self) -> str:
+        return f"{self.street} - {self.postalCode} - {self.city}" if self.street else f"{self.postalCode} - {self.city}"
+
     __table_args__ = (
         sa.Index(
             "ix_partial_unique_address_per_street_and_insee_code",

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
@@ -47,6 +47,7 @@ def get_booking_cancellation_by_beneficiary_to_pro_email_data(
             "USER_EMAIL": booking.email,
             "USER_NAME": f"{booking.firstName} {booking.lastName}",
             "VENUE_NAME": booking.stock.offer.venue.name,
+            "OFFER_ADDRESS": booking.stock.offer.fullAddress,
         },
         reply_to=models.EmailInfo(
             email=booking.email,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro.py
@@ -31,6 +31,7 @@ def get_booking_cancellation_confirmation_by_pro_email_data(
             "EVENT_HOUR": event_hour,
             "QUANTITY": quantity,
             "RESERVATIONS_NUMBER": len(bookings),
+            "OFFER_ADDRESS": offer.fullAddress,
         },
     )
 

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -104,5 +104,6 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "OFFER_WITHDRAWAL_DELAY": bookings_common.get_offer_withdrawal_delay(booking),
             "OFFER_WITHDRAWAL_TYPE": bookings_common.get_offer_withdrawal_type(booking),
             "FEATURES": ", ".join(stock.features),
+            "OFFER_ADDRESS": offer.fullAddress,
         },
     )

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
@@ -65,5 +65,6 @@ def get_booking_event_reminder_to_beneficiary_email_data(
                 else booking.stock.offer.venue.name
             ),
             "VENUE_POSTAL_CODE": booking.stock.offer.venue.postalCode,
+            "OFFER_ADDRESS": booking.stock.offer.fullAddress,
         },
     )

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_expiration_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_expiration_to_pro.py
@@ -19,6 +19,7 @@ def get_bookings_expiration_to_pro_email_data(
             "BOOKINGS": _extract_bookings_information_from_bookings_list(bookings),
             "DEPARTMENT": departement_code,
             "WITHDRAWAL_PERIOD": withdrawal_period,
+            "OFFER_ADRESS": bookings[0].stock.offer.fullAddress,
         },
     )
 

--- a/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
@@ -104,6 +104,7 @@ def get_new_booking_to_pro_email_data(
                 else booking_constants.BOOKINGS_AUTO_EXPIRY_DELAY.days
             ),
             "FEATURES": ", ".join(booking.stock.features),
+            "OFFER_ADDRESS": offer.fullAddress,
         },
     )
 

--- a/api/src/pcapi/core/mails/transactional/pro/event_offer_postponed_confirmation_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/event_offer_postponed_confirmation_to_pro.py
@@ -27,5 +27,6 @@ def get_event_offer_postponed_confirmation_to_pro_email_data(
                 format_date(get_event_datetime(stock), format="full", locale="fr") if stock.offer.isEvent else None
             ),
             "BOOKING_COUNT": booking_count,
+            "OFFER_ADDRESS": stock.offer.fullAddress,
         },
     )

--- a/api/src/pcapi/core/mails/transactional/pro/first_venue_approved_offer_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/first_venue_approved_offer_to_pro.py
@@ -48,6 +48,7 @@ def get_first_venue_approved_offer_email_data(offer: Offer) -> models.Transactio
             ),
             "PC_PRO_OFFER_LINK": build_pc_pro_offer_link(offer),
             "NEEDS_BANK_INFORMATION_REMINDER": venue.current_bank_account is None,
+            "OFFER_ADDRESS": offer.fullAddress,
         },
     )
 

--- a/api/src/pcapi/core/mails/transactional/pro/offer_validation_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/offer_validation_to_pro.py
@@ -36,6 +36,7 @@ def retrieve_data_for_offer_rejection_email(
             "VENUE_NAME": offer.venue.publicName or offer.venue.name,
             "PC_PRO_OFFER_LINK": build_pc_pro_offer_link(offer),
             "IS_COLLECTIVE_OFFER": not isinstance(offer, Offer),
+            "OFFER_ADDRESS": offer.fullAddress if isinstance(offer, Offer) else None,
         },
     )
 

--- a/api/src/pcapi/core/mails/transactional/pro/offer_validation_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/offer_validation_to_pro.py
@@ -21,6 +21,7 @@ def retrieve_data_for_offer_approval_email(
             "PUBLICATION_DATE": publication_date,
             "VENUE_NAME": offer.venue.publicName or offer.venue.name,
             "PC_PRO_OFFER_LINK": build_pc_pro_offer_link(offer),
+            "OFFER_ADDRESS": offer.fullAddress if isinstance(offer, Offer) else None,
         },
     )
 

--- a/api/src/pcapi/core/mails/transactional/pro/reminder_before_event_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/reminder_before_event_to_pro.py
@@ -18,6 +18,7 @@ def get_reminder_7_days_before_event_email_data(stock: Stock) -> models.Transact
             "EVENT_DATE": format_date(event_datetime, format="full", locale="fr"),
             "EVENT_HOUR": get_time_formatted_for_email(event_datetime),
             "BOOKING_COUNT": stock.dnBookedQuantity,
+            "OFFER_ADDRESS": stock.offer.fullAddress,
         },
     )
 

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -1289,6 +1289,10 @@ class OffererAddress(PcObject, Base, Model):
     def isLinkedToVenue(cls) -> sa.sql.elements.BooleanClauseList:  # pylint: disable=no-self-argument
         return sa.select(1).where(Venue.offererAddressId == cls.id).exists()
 
+    @property
+    def fullAddress(self) -> str:
+        return f"{self.label} - {self.address.fullAddress}" if self.label else self.address.fullAddress
+
 
 class OffererConfidenceLevel(enum.Enum):
     # No default value when offerer follows rules in offer_validation_rule table,

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -214,6 +214,7 @@ class DigitalOfferFactory(OfferFactory):
     subcategoryId = subcategories.VOD.id
     url = factory.Sequence("http://example.com/offer/{}".format)
     venue = factory.SubFactory(offerers_factories.VirtualVenueFactory)
+    offererAddress = None
 
 
 class PriceCategoryLabelFactory(BaseFactory):

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -937,6 +937,12 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
             return None
         return self.futureOffer.publicationDate
 
+    @property
+    def fullAddress(self) -> str | None:
+        if self.offererAddress:
+            return self.offererAddress.fullAddress
+        return None
+
 
 class ActivationCode(PcObject, Base, Model):
     __tablename__ = "activation_code"

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1092,6 +1092,15 @@ def get_offer_and_extradata(offer_id: int) -> models.Offer | None:
         .options(sa_orm.joinedload(models.Offer.priceCategories).joinedload(models.PriceCategory.priceCategoryLabel))
         .options(sa_orm.with_expression(models.Offer.isNonFreeOffer, is_non_free_offer_subquery(offer_id)))
         .options(sa_orm.with_expression(models.Offer.bookingsCount, get_bookings_count_subquery(offer_id)))
+        .options(
+            sa_orm.joinedload(models.Offer.offererAddress)
+            .load_only(
+                offerers_models.OffererAddress.id,
+                offerers_models.OffererAddress.label,
+                offerers_models.OffererAddress.addressId,
+            )
+            .joinedload(offerers_models.OffererAddress.address),
+        )
         .one_or_none()
     )
 

--- a/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
@@ -250,7 +250,18 @@ def mark_booking_as_used(booking_id: int) -> utils.BackofficeResponse:
 @repository.atomic()
 @utils.permission_required(perm_models.Permissions.MANAGE_BOOKINGS)
 def mark_booking_as_cancelled(booking_id: int) -> utils.BackofficeResponse:
-    booking = bookings_models.Booking.query.filter_by(id=booking_id).one_or_none()
+    booking = (
+        bookings_models.Booking.query.filter_by(id=booking_id)
+        .options(
+            sa.orm.load_only(bookings_models.Booking.stock.offer.offererAddress.label),
+            sa.orm.load_only(
+                bookings_models.Booking.stock.offer.offererAddress.address.street,
+                bookings_models.Booking.stock.offer.offererAddress.address.postalCode,
+                bookings_models.Booking.stock.offer.offererAddress.address.city,
+            ),
+        )
+        .one_or_none()
+    )
     if not booking:
         raise NotFound()
 

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -717,6 +717,7 @@ def _batch_validate_offers(offer_ids: list[int]) -> None:
             sa.orm.joinedload(offers_models.Offer.venue).load_only(
                 offerers_models.Venue.bookingEmail, offerers_models.Venue.name, offerers_models.Venue.publicName
             ),
+            sa.orm.joinedload(offers_models.Offer.offererAddress).joinedload(offerers_models.OffererAddress.address),
         )
         .options(sa.orm.contains_eager(offers_models.Offer.futureOffer))
     ).all()

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -207,6 +207,7 @@ class BookOfferTest:
         assert email_data1["template"] == dataclasses.asdict(
             TransactionalEmail.FIRST_VENUE_BOOKING_TO_PRO.value
         )  # to offerer
+        email_data1["params"]["OFFER_ADDRESS"] == stock.offer.fullAddress
         email_data2 = mails_testing.outbox[1]
         assert email_data2["template"] == dataclasses.asdict(
             TransactionalEmail.BOOKING_CONFIRMATION_BY_BENEFICIARY.value

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -5666,3 +5666,17 @@ class GetTomorrowEventOfferTest:
         bookings = booking_repository.find_individual_bookings_event_happening_tomorrow_query()
 
         assert len(bookings) == 2
+
+    def test_find_tomorrow_event_offer_without_address(self):
+        tomorrow = datetime.utcnow() + timedelta(days=1)
+        bookings_factories.BookingFactory(
+            stock=offers_factories.EventStockFactory(
+                beginningDatetime=tomorrow,
+                offer__offererAddress=None,
+            )
+        )
+
+        with assert_num_queries(1):
+            bookings = booking_repository.find_individual_bookings_event_happening_tomorrow_query()
+
+        assert len(bookings) == 1

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro_test.py
@@ -90,6 +90,7 @@ class SendBeneficiaryUserDrivenCancellationEmailToOffererTest:
             "USER_EMAIL": booking.email,
             "USER_NAME": booking.userName,
             "VENUE_NAME": booking.venue.name,
+            "OFFER_ADDRESS": booking.stock.offer.fullAddress,
         }
 
 
@@ -120,6 +121,7 @@ class MakeOffererBookingRecapEmailAfterUserCancellationTest:
             "USER_EMAIL": booking.email,
             "USER_NAME": booking.userName,
             "VENUE_NAME": venue.name,
+            "OFFER_ADDRESS": booking.stock.offer.fullAddress,
         }
 
     @pytest.mark.usefixtures("db_session")
@@ -148,6 +150,7 @@ class MakeOffererBookingRecapEmailAfterUserCancellationTest:
             "USER_EMAIL": booking1.email,
             "USER_NAME": booking1.userName,
             "VENUE_NAME": venue.name,
+            "OFFER_ADDRESS": booking1.stock.offer.fullAddress,
         }
 
     @pytest.mark.usefixtures("db_session")
@@ -176,4 +179,5 @@ class MakeOffererBookingRecapEmailAfterUserCancellationTest:
             "USER_EMAIL": booking1.email,
             "USER_NAME": booking1.userName,
             "VENUE_NAME": virtual_venue.name,
+            "OFFER_ADDRESS": booking1.stock.offer.fullAddress,
         }

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro_test.py
@@ -50,6 +50,7 @@ class BookingCancellationConfirmationByProEmailData:
             "EVENT_HOUR": "12h20",
             "QUANTITY": 2,
             "RESERVATIONS_NUMBER": 1,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_should_return_email_data_when_multiple_bookings_and_offer_is_a_thing(self):
@@ -95,6 +96,7 @@ class BookingCancellationConfirmationByProEmailData:
             "EVENT_HOUR": "",
             "QUANTITY": 7,
             "RESERVATIONS_NUMBER": 2,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
 

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -76,6 +76,7 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
             "OFFER_WITHDRAWAL_TYPE": None,
             "OFFER_WITHDRAWAL_DELAY": None,
             "FEATURES": "",
+            "OFFER_ADDRESS": booking.stock.offer.fullAddress,
         },
     )
     email_data.params.update(overrides)

--- a/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
@@ -87,6 +87,7 @@ class GetBookingEventReminderToBeneficiaryEmailDataTest:
             "VENUE_CITY": "Paris",
             "VENUE_NAME": "Le Petit Rintintin",
             "VENUE_POSTAL_CODE": "75002",
+            "OFFER_ADDRESS": booking.stock.offer.fullAddress,
         }
 
     def should_return_event_specific_data_for_email_when_offer_is_a_duo_event(self):

--- a/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
@@ -64,6 +64,7 @@ def get_expected_base_email_data(booking, **overrides):
         "VENUE_NAME": "Lieu de l'offreur",
         "WITHDRAWAL_PERIOD": 30,
         "FEATURES": "",
+        "OFFER_ADDRESS": booking.stock.offer.fullAddress,
     }
     email_data_params.update(overrides)
     return email_data_params

--- a/api/tests/core/mails/transactional/pro/event_offer_postponed_confirmation_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/event_offer_postponed_confirmation_to_pro_test.py
@@ -45,6 +45,7 @@ class SendEventOfferPosponedConfirmationToProEmailTest:
             "VENUE_NAME": venue.name,
             "EVENT_DATE": "mardi 1 mars 2022",
             "BOOKING_COUNT": 3,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_get_email_metadata(self):
@@ -66,4 +67,5 @@ class SendEventOfferPosponedConfirmationToProEmailTest:
             "VENUE_NAME": venue.name,
             "EVENT_DATE": "mercredi 2 mars 2022",
             "BOOKING_COUNT": 3,
+            "OFFER_ADDRESS": offer.fullAddress,
         }

--- a/api/tests/core/mails/transactional/pro/first_venue_approved_offer_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/first_venue_approved_offer_to_pro_test.py
@@ -37,6 +37,7 @@ class SendinblueSendFirstVenueOfferEmailTest:
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "WITHDRAWAL_PERIOD": 30,
             "NEEDS_BANK_INFORMATION_REMINDER": True,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_get_first_venue_approved_book_offer_correct_email_metadata(self):
@@ -63,6 +64,7 @@ class SendinblueSendFirstVenueOfferEmailTest:
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "WITHDRAWAL_PERIOD": 10,
             "NEEDS_BANK_INFORMATION_REMINDER": True,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_get_first_venue_with_bank_account_validated_correct_email_metadata(self):
@@ -70,7 +72,11 @@ class SendinblueSendFirstVenueOfferEmailTest:
         offerers_factories.VenueBankAccountLinkFactory(venue=venue)
         offer = offers_factories.OfferFactory(name="Ma première offre", venue=venue)
 
-        with assert_num_queries(2):
+        # offer
+        # venue
+        # offererAddress
+        # Address
+        with assert_num_queries(4):
             new_offer_validation_email = get_first_venue_approved_offer_email_data(offer)
 
         assert new_offer_validation_email.template == TransactionalEmail.FIRST_VENUE_APPROVED_OFFER_TO_PRO.value
@@ -83,6 +89,7 @@ class SendinblueSendFirstVenueOfferEmailTest:
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "WITHDRAWAL_PERIOD": 30,
             "NEEDS_BANK_INFORMATION_REMINDER": False,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_send_offer_approval_email(self):
@@ -108,4 +115,5 @@ class SendinblueSendFirstVenueOfferEmailTest:
             "IS_DIGITAL": False,
             "WITHDRAWAL_PERIOD": 30,
             "NEEDS_BANK_INFORMATION_REMINDER": True,
+            "OFFER_ADDRESS": offer.fullAddress,
         }

--- a/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
@@ -93,6 +93,7 @@ class SendinblueSendOfferValidationTest:
             "OFFER_NAME": "Ma petite offre",
             "VENUE_NAME": "Mon stade",
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_get_validation_rejection_correct_collective_attribute(self):
@@ -105,6 +106,7 @@ class SendinblueSendOfferValidationTest:
         # Then
         assert new_offer_validation_email.template == TransactionalEmail.OFFER_REJECTION_TO_PRO.value
         assert new_offer_validation_email.params["IS_COLLECTIVE_OFFER"] is True
+        assert new_offer_validation_email.params["OFFER_ADDRESS"] is None
 
     def test_get_validation_rejection_correct_collective_template_attribute(self):
         # Given
@@ -116,6 +118,7 @@ class SendinblueSendOfferValidationTest:
         # Then
         assert new_offer_validation_email.template == TransactionalEmail.OFFER_REJECTION_TO_PRO.value
         assert new_offer_validation_email.params["IS_COLLECTIVE_OFFER"] is True
+        assert new_offer_validation_email.params["OFFER_ADDRESS"] is None
 
     def test_send_validated_offer_rejection_email(
         self,
@@ -192,4 +195,5 @@ class SendinblueSendOfferValidationTest:
             "OFFER_NAME": offer.name,
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "VENUE_NAME": venue.name,
+            "OFFER_ADDRESS": offer.fullAddress,
         }

--- a/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
@@ -19,10 +19,10 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 
 class SendinblueSendOfferValidationTest:
-    def test_get_validation_approval_correct_email_metadata(self):
+    @pytest.mark.parametrize("factory_class", [offers_factories.DigitalOfferFactory, offers_factories.OfferFactory])
+    def test_get_validation_approval_correct_email_metadata(self, factory_class):
         # Given
-        offer = offers_factories.OfferFactory(name="Ma petite offre", venue__name="Mon stade")
-
+        offer = factory_class(name="Ma petite offre", venue__name="Mon stade")
         # When
         new_offer_validation_email = retrieve_data_for_offer_approval_email(offer)
 
@@ -33,6 +33,7 @@ class SendinblueSendOfferValidationTest:
             "PUBLICATION_DATE": None,
             "VENUE_NAME": "Mon stade",
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_get_validation_approval_correct_email_metadata_when_future_offer(self):
@@ -51,6 +52,7 @@ class SendinblueSendOfferValidationTest:
             "PUBLICATION_DATE": publication_date.strftime("%d/%m/%Y"),
             "VENUE_NAME": "Mon stade",
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_send_offer_approval_email(
@@ -74,6 +76,7 @@ class SendinblueSendOfferValidationTest:
             "PUBLICATION_DATE": None,
             "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "VENUE_NAME": venue.name,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_get_validation_rejection_correct_email_metadata(self):

--- a/api/tests/core/mails/transactional/pro/reminder_before_event_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/reminder_before_event_to_pro_test.py
@@ -42,6 +42,7 @@ class Reminder7DaysBeforeEventToProEmailTest:
             "EVENT_DATE": "dimanche 1 mai 2022",
             "EVENT_HOUR": "16h10",
             "BOOKING_COUNT": 3,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_sends_email_to_pro_venue_booking_email_when_offer_booking_email_is_missing(self):
@@ -69,6 +70,7 @@ class Reminder7DaysBeforeEventToProEmailTest:
             "EVENT_DATE": "dimanche 1 mai 2022",
             "EVENT_HOUR": "16h10",
             "BOOKING_COUNT": 2,
+            "OFFER_ADDRESS": offer.fullAddress,
         }
 
     def test_get_email_metadata(self):
@@ -89,4 +91,5 @@ class Reminder7DaysBeforeEventToProEmailTest:
             "EVENT_DATE": "mercredi 2 mars 2022",
             "EVENT_HOUR": "15h20",
             "BOOKING_COUNT": 1,
+            "OFFER_ADDRESS": offer.fullAddress,
         }

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -5,6 +5,7 @@ import pytest
 import pcapi.core.bookings.constants as bookings_constants
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories_v2 as subcategories
+from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories
 from pcapi.core.offers import models
 import pcapi.core.providers.factories as providers_factories
@@ -673,3 +674,24 @@ class OfferIsActivableTest:
         )
         factories.StockFactory(offer=offer_from_active_venue_provider)
         assert offer_from_active_venue_provider.isActivable
+
+
+class OfferfullAddressTest:
+    @pytest.mark.parametrize(
+        "label,street,expected_full_address",
+        [
+            ("label", "street of the full address", "label - street of the full address - 75000 - Paris"),
+            (None, "street of the full address", "street of the full address - 75000 - Paris"),
+            ("label", None, "label - 75000 - Paris"),
+            (None, None, "75000 - Paris"),
+        ],
+    )
+    def test_full_address(self, label, street, expected_full_address):
+        oa = offerers_factories.OffererAddressFactory(
+            label=label,
+            address__street=street,
+            address__postalCode="75000",
+            address__city="Paris",
+        )
+        offer = factories.OfferFactory(offererAddress=oa)
+        assert offer.fullAddress == expected_full_address

--- a/api/tests/routes/pro/patch_publish_offer_test.py
+++ b/api/tests/routes/pro/patch_publish_offer_test.py
@@ -46,8 +46,10 @@ class Returns200Test:
     num_queries += 1  # 13 update offer
 
     @patch("pcapi.core.mails.transactional.send_first_venue_approved_offer_email_to_pro")
+    @patch("pcapi.core.offers.api.rule_flags_offer", return_value=False)
     def test_patch_publish_offer(
         self,
+        mock_rule_flags_offer,
         mocked_send_first_venue_approved_offer_email_to_pro,
         mock_async_index_offer_ids,
         client,
@@ -76,8 +78,10 @@ class Returns200Test:
         mocked_send_first_venue_approved_offer_email_to_pro.assert_called_once_with(offer)
 
     @patch("pcapi.core.mails.transactional.send_first_venue_approved_offer_email_to_pro")
+    @patch("pcapi.core.offers.api.rule_flags_offer", return_value=False)
     def test_patch_publish_future_offer(
         self,
+        mock_rule_flags_offer,
         mocked_send_first_venue_approved_offer_email_to_pro,
         mock_async_index_offer_ids,
         client,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30384

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
