### PR TITLE
(BSR)[PRO]: add again stubbing of api-adresse

### DIFF
--- a/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/step-definitions/signupJourneyCreateOfferer.cy.ts
@@ -52,7 +52,42 @@ When('I specify an offerer with a SIRET', () => {
   }).as('venuesSiret')
   cy.intercept(
     'GET',
-    'https://api-adresse.data.gouv.fr/search/?limit=1&q=*'
+    'https://api-adresse.data.gouv.fr/search/?limit=1&q=*',
+    (req) =>
+      req.reply({
+        statusCode: 200,
+        body: {
+          type: 'FeatureCollection',
+          version: 'draft',
+          features: [
+            {
+              type: 'Feature',
+              geometry: { type: 'Point', coordinates: [2.337933, 48.863666] },
+              properties: {
+                label: '3 Rue de Valois 75001 Paris',
+                score: 0.8136893939393939,
+                housenumber: '3',
+                id: '75101_9575_00003',
+                name: '3 Rue de Valois',
+                postcode: '75001',
+                citycode: '75101',
+                x: 651428.82,
+                y: 6862829.62,
+                city: 'Paris',
+                district: 'Paris 1er Arrondissement',
+                context: '75, Paris, Île-de-France',
+                type: 'housenumber',
+                importance: 0.61725,
+                street: 'Rue de Valois',
+              },
+            },
+          ],
+          attribution: 'BAN',
+          licence: 'ETALAB-2.0',
+          query: '3 RUE DE VALOIS Paris 75001',
+          limit: 1,
+        },
+      })
   ).as('search1Address')
   cy.findByText('Continuer').click()
   cy.wait(['@getSiret', '@venuesSiret', '@search1Address']).then(


### PR DESCRIPTION
## But de la pull request

Le stub de l'appel à `https://api-adresse.data.gouv.fr/search` avait été enlevé car on observait des doublons de requêtes. Voir cette précédente PR: https://github.com/pass-culture/pass-culture-main/pull/13004

Mais aujourd'hui on a aussi eu un échec qui pourrait s'expliquer par le fait qu'on attend un appel à l'api externe qui ne répond pas et donc toute la suite est compromise. Voir l'échec sur Cypress Cloud: https://cloud.cypress.io/projects/rit5sb/runs/862/test-results/4b25df67-260d-4154-8660-fbc8f07433c9/replay

Cette PR remet ce stub qui semble indispensable (on ne doit pas faire d'appel externe depuis les tests e2e)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
