### PR TITLE
(PC-31932)[PRO] fix: OA fields are not required for virtual offers.

### DIFF
--- a/pro/src/components/IndividualOfferForm/OfferLocation/validationSchema.ts
+++ b/pro/src/components/IndividualOfferForm/OfferLocation/validationSchema.ts
@@ -4,40 +4,60 @@ import { OFFER_LOCATION } from 'components/IndividualOfferForm/OfferLocation/con
 import { checkCoords } from 'utils/coords'
 
 const locationSchema = {
-  offerlocation: yup.string().required('Veuillez sélectionner un choix'),
+  offerlocation: yup.string().when('isVenueVirtual', {
+    is: false,
+    then: (schema) => schema.required('Veuillez sélectionner un choix'),
+  }),
   addressAutocomplete: yup
     .string()
-    .when(['offerlocation', 'manuallySetAddress'], {
-      is: (offerLocation: string, manuallySetAddress: boolean) =>
-        offerLocation === OFFER_LOCATION.OTHER_ADDRESS && !manuallySetAddress,
+    .when(['offerlocation', 'manuallySetAddress', 'isVenueVirtual'], {
+      is: (
+        offerLocation: string,
+        manuallySetAddress: boolean,
+        isVenueVirtual: boolean
+      ) =>
+        !isVenueVirtual &&
+        offerLocation === OFFER_LOCATION.OTHER_ADDRESS &&
+        !manuallySetAddress,
       then: (schema) =>
         schema.required(
           'Veuillez sélectionner une adresse parmi les suggestions'
         ),
     }),
-  street: yup.string().when('offerlocation', {
-    is: OFFER_LOCATION.OTHER_ADDRESS,
+  street: yup.string().when(['offerlocation', 'isVenueVirtual'], {
+    is: (offerLocation: string, isVenueVirtual: boolean) =>
+      !isVenueVirtual && offerLocation === OFFER_LOCATION.OTHER_ADDRESS,
     then: (schema) =>
       schema.required('Veuillez renseigner une adresse postale'),
   }),
-  postalCode: yup.string().when('offerlocation', {
-    is: OFFER_LOCATION.OTHER_ADDRESS,
+  postalCode: yup.string().when(['offerlocation', 'isVenueVirtual'], {
+    is: (offerLocation: string, isVenueVirtual: boolean) =>
+      !isVenueVirtual && offerLocation === OFFER_LOCATION.OTHER_ADDRESS,
     then: (schema) => schema.required('Veuillez renseigner un code postal'),
   }),
-  city: yup.string().when('offerlocation', {
-    is: OFFER_LOCATION.OTHER_ADDRESS,
+  city: yup.string().when(['offerlocation', 'isVenueVirtual'], {
+    is: (offerLocation: string, isVenueVirtual: boolean) =>
+      !isVenueVirtual && offerLocation === OFFER_LOCATION.OTHER_ADDRESS,
     then: (schema) => schema.required('Veuillez renseigner une ville'),
   }),
-  coords: yup.string().when(['offerlocation', 'manuallySetAddress'], {
-    is: (offerLocation: string, manuallySetAddress: boolean) =>
-      offerLocation === OFFER_LOCATION.OTHER_ADDRESS && manuallySetAddress,
-    then: (schema) =>
-      schema
-        .required('Veuillez renseigner les coordonnées GPS')
-        .test('coords', 'Veuillez respecter le format attendu', (value) =>
-          checkCoords(value)
-        ),
-  }),
+  coords: yup
+    .string()
+    .when(['offerlocation', 'manuallySetAddress', 'isVenueVirtual'], {
+      is: (
+        offerLocation: string,
+        manuallySetAddress: boolean,
+        isVenueVirtual: boolean
+      ) =>
+        !isVenueVirtual &&
+        offerLocation === OFFER_LOCATION.OTHER_ADDRESS &&
+        manuallySetAddress,
+      then: (schema) =>
+        schema
+          .required('Veuillez renseigner les coordonnées GPS')
+          .test('coords', 'Veuillez respecter le format attendu', (value) =>
+            checkCoords(value)
+          ),
+    }),
 }
 
 export const validationSchema = {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31932

Pas d'oa pour les liens numériques

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
