### PR TITLE
Pc 31918 fix offers filter pagination

### DIFF
--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTable.module.scss
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTable.module.scss
@@ -2,17 +2,13 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_size.scss" as size;
 
-.offers-pagination {
-  margin-top: rem.torem(32px);
-}
-
 .select-all-container {
   display: flex;
   align-items: center;
   position: relative;
   margin-bottom: rem.torem(20px);
 
-  label {
+  &-label {
     @include fonts.caption;
   }
 }

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableHead/CollectiveOffersTableHead.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersTableHead/CollectiveOffersTableHead.tsx
@@ -3,8 +3,7 @@ import classNames from 'classnames'
 import { SortArrow } from 'components/StocksEventList/SortArrow'
 import { useActiveFeature } from 'hooks/useActiveFeature'
 import { SortingMode } from 'hooks/useColumnSorting'
-
-import { CollectiveOffersSortingColumn } from '../CollectiveOffersTable'
+import { CollectiveOffersSortingColumn } from 'screens/CollectiveOffersScreen/CollectiveOffersScreen'
 
 import styles from './CollectiveOffersTableHead.module.scss'
 

--- a/pro/src/screens/CollectiveOffersScreen/CollectiveOffersScreen.module.scss
+++ b/pro/src/screens/CollectiveOffersScreen/CollectiveOffersScreen.module.scss
@@ -20,3 +20,7 @@
     }
   }
 }
+
+.offers-pagination {
+  margin-top: rem.torem(32px);
+}

--- a/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.module.scss
+++ b/pro/src/screens/TemplateCollectiveOffersScreen/TemplateCollectiveOffersScreen.module.scss
@@ -20,3 +20,7 @@
 
   margin-bottom: rem.torem(32px);
 }
+
+.offers-pagination {
+  margin-top: rem.torem(32px);
+}

--- a/pro/src/utils/__specs__/sortCollectiveOffers.spec.tsx
+++ b/pro/src/utils/__specs__/sortCollectiveOffers.spec.tsx
@@ -1,0 +1,94 @@
+import { SortingMode } from 'hooks/useColumnSorting'
+import { CollectiveOffersSortingColumn } from 'screens/CollectiveOffersScreen/CollectiveOffersScreen'
+import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import { sortCollectiveOffers } from 'utils/sortCollectiveOffers'
+
+describe('sortCollectiveOffers', () => {
+  it('should sort collective offers in a descending order', () => {
+    const offers = [
+      collectiveOfferFactory({
+        id: 1,
+        dates: { start: '2024-07-15T00:00:00Z', end: '2024-08-15T00:00:00Z' },
+      }),
+      collectiveOfferFactory({
+        id: 2,
+        dates: { start: '2024-07-16T00:00:00Z', end: '2024-08-15T00:00:00Z' },
+      }),
+    ]
+    const sortedOffers = sortCollectiveOffers(
+      offers,
+      CollectiveOffersSortingColumn.EVENT_DATE,
+      SortingMode.DESC
+    )
+
+    expect(sortedOffers[0].id).toEqual(2)
+  })
+
+  it('should sort collective offers in a ascending order', () => {
+    const offers = [
+      collectiveOfferFactory({
+        id: 1,
+        dates: { start: '2024-07-15T00:00:00Z', end: '2024-08-15T00:00:00Z' },
+      }),
+      collectiveOfferFactory({
+        id: 2,
+        dates: { start: '2024-07-16T00:00:00Z', end: '2024-08-15T00:00:00Z' },
+      }),
+    ]
+    const sortedOffers = sortCollectiveOffers(
+      offers,
+      CollectiveOffersSortingColumn.EVENT_DATE,
+      SortingMode.ASC
+    )
+
+    expect(sortedOffers[0].id).toEqual(1)
+  })
+
+  it('should not sort offers if the column sort is not defined', () => {
+    const offers = [
+      collectiveOfferFactory({
+        id: 1,
+        dates: { start: '2024-07-15T00:00:00Z', end: '2024-08-15T00:00:00Z' },
+      }),
+      collectiveOfferFactory({
+        id: 2,
+        dates: { start: '2024-07-16T00:00:00Z', end: '2024-08-15T00:00:00Z' },
+      }),
+    ]
+    const sortedOffersAsc = sortCollectiveOffers(offers, null, SortingMode.ASC)
+    const sortedOffersDesc = sortCollectiveOffers(
+      offers,
+      null,
+      SortingMode.DESC
+    )
+
+    expect(sortedOffersAsc[0].id).toEqual(1)
+    expect(sortedOffersDesc[0].id).toEqual(1)
+  })
+
+  it('should not sort offers if the dates do not exist', () => {
+    const offers = [
+      collectiveOfferFactory({
+        id: 1,
+        dates: undefined,
+      }),
+      collectiveOfferFactory({
+        id: 2,
+        dates: undefined,
+      }),
+    ]
+    const sortedOffersAsc = sortCollectiveOffers(
+      offers,
+      CollectiveOffersSortingColumn.EVENT_DATE,
+      SortingMode.ASC
+    )
+    const sortedOffersDesc = sortCollectiveOffers(
+      offers,
+      CollectiveOffersSortingColumn.EVENT_DATE,
+      SortingMode.DESC
+    )
+
+    expect(sortedOffersAsc[0].id).toEqual(1)
+    expect(sortedOffersDesc[0].id).toEqual(1)
+  })
+})

--- a/pro/src/utils/sortCollectiveOffers.ts
+++ b/pro/src/utils/sortCollectiveOffers.ts
@@ -1,0 +1,31 @@
+import { CollectiveOfferResponseModel } from 'apiClient/v1'
+import { SortingMode } from 'hooks/useColumnSorting'
+import { CollectiveOffersSortingColumn } from 'screens/CollectiveOffersScreen/CollectiveOffersScreen'
+
+const sortByDate = (dateA: string, dateB: string, mode: SortingMode) => {
+  return (
+    (dateA === dateB ? 0 : dateA > dateB ? -1 : 1) *
+    (mode === SortingMode.ASC ? -1 : 1)
+  )
+}
+
+export function sortCollectiveOffers(
+  offers: CollectiveOfferResponseModel[],
+  currentSortingColumn: CollectiveOffersSortingColumn | null,
+  sortingMode: SortingMode
+) {
+  const sortedOffers = offers.slice()
+
+  switch (currentSortingColumn) {
+    case CollectiveOffersSortingColumn.EVENT_DATE:
+      return sortedOffers.sort((offerA, offerB) =>
+        sortByDate(
+          offerA.dates?.start ?? '',
+          offerB.dates?.start ?? '',
+          sortingMode
+        )
+      )
+    default:
+      return sortedOffers
+  }
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31918

**Objectif**
Corriger le bug suivant : sur la page des offres collectives, si on va a la page 2 et qu'on filtre de manière à avoir entre 1 et 10 résultats (ex: filtrer sur le statut en attente), la table affiche le thead mais pas de contenu dans le tbody.

Pour corriger, il faut synchroniser la page active dans le hook `usePagination` avec celle qu'on passe à la fonction de redirection `applyUrlFiltersAndRedirect`. Pour ça il faut utiliser la fonction du hook de pagination `setPage` et donc faire remonter la logique le pagination dans le screen (et la logique de tri aussi puisque la pagination en dépend).

Pour la duplication c'est des pages différentes avec des systèmes de filtres qui vont diverger donc ça me choque pas 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
