### PR TITLE
(PC-31680)[ADAGE] feat: add institution in sandbox collective offers …

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_institutions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_institutions.py
@@ -90,7 +90,7 @@ def create_institutions() -> list[educational_models.EducationalInstitution]:
                 programs=[program],
                 postalCode="13014",
             ),
-            educational_factories.EducationalInstitutionFactory(institutionId="0921545E"),
+            educational_factories.EducationalInstitutionFactory(institutionId="0921935D"),
             educational_factories.EducationalInstitutionFactory(institutionId="0752525M"),
             educational_factories.EducationalInstitutionFactory(institutionId="0752902X"),
             educational_factories.EducationalInstitutionFactory(institutionId="0781537X"),

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -128,11 +128,12 @@ def create_offers_base_list(
     offers = []
     templates = []
     if basic_offers:
-        for _i in range(size):
+        for _ in range(size):
             stock = educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name}",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
                 collectiveOffer__venue=next(venue_iterator),
+                collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__nationalProgram=next(national_program_iterator),
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 collectiveOffer__author=user_factory.ProFactory(email="eac_1_lieu@example.com"),
@@ -140,12 +141,33 @@ def create_offers_base_list(
                 beginningDatetime=datetime.utcnow() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
+
+        if settings.CREATE_ADAGE_TESTING_DATA:
+            # add an offer with and emoji so that ADAGE can check that the encoding works
+            institution = educational_models.EducationalInstitution.query.filter(
+                educational_models.EducationalInstitution.institutionId == "0131251P"
+            ).one()
+
+            stock = educational_factories.CollectiveStockFactory(
+                collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name} 🍕",
+                collectiveOffer__educational_domains=[next(domains_iterator)],
+                collectiveOffer__venue=next(venue_iterator),
+                collectiveOffer__institution=institution,
+                collectiveOffer__nationalProgram=next(national_program_iterator),
+                collectiveOffer__bookingEmails=["toto@totoland.com"],
+                collectiveOffer__author=user_factory.ProFactory(email="eac_1_lieu@example.com"),
+                collectiveOffer__formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
+                beginningDatetime=datetime.utcnow() + timedelta(days=60),
+            )
+            offers.append(stock.collectiveOffer)
+
     if image_offers:
-        for _i in range(5):
+        for _ in range(size):
             stock = educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name} with image",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
                 collectiveOffer__venue=next(venue_iterator),
+                collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 beginningDatetime=datetime.utcnow() + timedelta(days=60),
             )
@@ -167,7 +189,7 @@ def create_offers_base_list(
                 lastName="MARIANNE",
                 civility="Mme",
             )
-        for _i in range(5):
+        for _ in range(size):
             stock = educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name} to teacher",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
@@ -178,8 +200,9 @@ def create_offers_base_list(
                 beginningDatetime=datetime.utcnow() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
+
     if public_api_offers:
-        for _i in range(5):
+        for _ in range(size):
             stock = educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name} public api",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
@@ -192,36 +215,42 @@ def create_offers_base_list(
                 beginningDatetime=datetime.utcnow() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
+
     if expired_offers:
-        for _i in range(5):
+        for _ in range(size):
             stock = educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name} expired",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
                 collectiveOffer__venue=next(venue_iterator),
+                collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 bookingLimitDatetime=datetime.utcnow() - timedelta(days=2),
                 beginningDatetime=datetime.utcnow(),
             )
             offers.append(stock.collectiveOffer)
+
     if pending_offers:
-        for _i in range(5):
+        for _ in range(size):
             educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name} pending",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
                 collectiveOffer__venue=next(venue_iterator),
+                collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__validation=OfferValidationStatus.PENDING,
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 beginningDatetime=datetime.utcnow() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
+
     if offers_next_year:
         current_year = datetime.utcnow().year
         target_year = current_year + 2 if datetime.utcnow().month >= 9 else current_year + 1
-        for _i in range(5):
+        for _ in range(size):
             stock = educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer next year {next(number_iterator)} pour {offerer.name}",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
                 collectiveOffer__venue=next(venue_iterator),
+                collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 beginningDatetime=datetime(target_year, 3, 18),
                 bookingLimitDatetime=datetime(target_year, 3, 3),
@@ -229,29 +258,33 @@ def create_offers_base_list(
             offers.append(stock.collectiveOffer)
 
     if offers_intervention_56:
-        for _ in range(5):
+        for _ in range(size):
             stock = educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name} interventionArea 56",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
                 collectiveOffer__venue=next(venue_iterator),
+                collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__interventionArea=["56"],
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 beginningDatetime=datetime.utcnow() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
+
     if offers_intervention_91:
-        for _i in range(5):
+        for _ in range(size):
             stock = educational_factories.CollectiveStockFactory(
                 collectiveOffer__name=f"offer {next(number_iterator)} pour {offerer.name} interventionArea 91",
                 collectiveOffer__educational_domains=[next(domains_iterator)],
                 collectiveOffer__venue=next(venue_iterator),
+                collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__interventionArea=["91"],
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 beginningDatetime=datetime.utcnow() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
+
     if basic_templates:
-        for _i in range(5):
+        for _ in range(5):
             template = educational_factories.CollectiveOfferTemplateFactory(
                 name=f"offer {next(number_iterator)} pour {offerer.name} basic template",
                 educational_domains=[next(domains_iterator)],
@@ -262,6 +295,7 @@ def create_offers_base_list(
                 formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
             )
             templates.append(template)
+
         if from_templates_offers:
             for template in 4 * [templates[0]] + 1 * [templates[1]]:
                 educational_factories.CollectiveStockFactory(
@@ -272,7 +306,9 @@ def create_offers_base_list(
                     collectiveOffer__institution=next(institution_iterator),
                     collectiveOffer__nationalProgram=next(national_program_iterator),
                     collectiveOffer__bookingEmails=["toto@totoland.com"],
+                    beginningDatetime=datetime.utcnow() + timedelta(days=60),
                 )
+
     if image_template:
         for _ in range(5):
             template = educational_factories.CollectiveOfferTemplateFactory(
@@ -283,8 +319,9 @@ def create_offers_base_list(
             )
             add_image_to_offer(template, next(image_iterator))
             templates.append(template)
+
     if offers_with_request:
-        for i in range(5):
+        for i in range(size):
             number = next(number_iterator)
             template = educational_factories.CollectiveOfferTemplateFactory(
                 name=f"offer {number} pour {offerer.name} template request",


### PR DESCRIPTION
…and create more offers for adage

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31680

On créé, pour chaque statut possible, une offre par établissement (dans le cas `CREATE_ADAGE_TESTING_DATA`).
On lie chaque offre à un établissement, ce qui est obligatoire pour une offre non brouillon (mais il n y a pas de contrainte associé).
On remplace également l'UAI 0921545E par 0921935D et on ajoute un emoji (demande côté Adage pour leurs tests).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
