### PR TITLE
(BSR)[API]fix: Ajout d'un test de création d'offre CD ou vinyle sans EAN pour un disquaire si FF WIP_EAN_CREATION désactivée

### DIFF
--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -58,6 +58,22 @@ class Returns201Test:
         assert response_dict["isDuo"] == True
         assert not offer.product
 
+    @override_features(WIP_EAN_CREATION=False)
+    def test_create_offer_cd_or_vinyl_without_product_venue_record_store_should_succeed(self, client):
+        venue = offerers_factories.VenueFactory(venueTypeCode=VenueTypeCode.RECORD_STORE)
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
+
+        data = {
+            "name": "Celeste",
+            "subcategoryId": subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
+            "venueId": venue.id,
+            "extraData": {"gtl_id": "07000000"},
+        }
+        response = client.with_session_auth("user@example.com").post("/offers/draft", json=data)
+
+        assert response.status_code == 201
+
     def test_created_offer_from_product_should_return_product_id(self, client):
         venue = offerers_factories.VenueFactory()
         offerer = venue.managingOfferer


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

Ajout d'un test permettant de s'assurer une non régression avec les modifications faites sur les extraData.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
