### PR TITLE
(PC-31838)[API] feat: add allowed actions for collective offer templates

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -446,3 +446,34 @@ def create_collective_offer_by_status(
             return CollectiveOfferFactory(**kwargs)
 
     raise NotImplementedStatus(f"Factory for {status}")
+
+
+def create_collective_offer_template_by_status(
+    status: CollectiveOfferDisplayedStatus,
+    **kwargs: typing.Any,
+) -> models.CollectiveOfferTemplate:
+    match status.value:
+        case CollectiveOfferDisplayedStatus.ARCHIVED.value:
+            kwargs["dateArchived"] = datetime.datetime.utcnow()
+            return CollectiveOfferTemplateFactory(**kwargs)
+
+        case CollectiveOfferDisplayedStatus.REJECTED.value:
+            kwargs["validation"] = OfferValidationStatus.REJECTED
+            return CollectiveOfferTemplateFactory(**kwargs)
+
+        case CollectiveOfferDisplayedStatus.PENDING.value:
+            kwargs["validation"] = OfferValidationStatus.PENDING
+            return CollectiveOfferTemplateFactory(**kwargs)
+
+        case CollectiveOfferDisplayedStatus.DRAFT.value:
+            kwargs["validation"] = OfferValidationStatus.DRAFT
+            return CollectiveOfferTemplateFactory(**kwargs)
+
+        case CollectiveOfferDisplayedStatus.INACTIVE.value:
+            kwargs["isActive"] = False
+            return CollectiveOfferTemplateFactory(**kwargs)
+
+        case CollectiveOfferDisplayedStatus.ACTIVE.value:
+            return CollectiveOfferTemplateFactory(**kwargs)
+
+    raise NotImplementedStatus(f"Factory for {status}")

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -141,6 +141,15 @@ class CollectiveOfferAllowedAction(enum.Enum):
     CAN_ARCHIVE = "CAN_ARCHIVE"
 
 
+class CollectiveOfferTemplateAllowedAction(enum.Enum):
+    CAN_EDIT_DETAILS = "CAN_EDIT_DETAILS"
+    CAN_DUPLICATE = "CAN_DUPLICATE"
+    CAN_ARCHIVE = "CAN_ARCHIVE"
+    CAN_CREATE_BOOKABLE_OFFER = "CAN_CREATE_BOOKABLE_OFFER"
+    CAN_PUBLISH = "CAN_PUBLISH"
+    CAN_HIDE = "CAN_HIDE"
+
+
 ALLOWED_ACTIONS_BY_DISPLAYED_STATUS: dict[CollectiveOfferDisplayedStatus, tuple[CollectiveOfferAllowedAction, ...]] = {
     CollectiveOfferDisplayedStatus.DRAFT: (
         CollectiveOfferAllowedAction.CAN_EDIT_DETAILS,
@@ -192,6 +201,38 @@ ALLOWED_ACTIONS_BY_DISPLAYED_STATUS: dict[CollectiveOfferDisplayedStatus, tuple[
     ),
     CollectiveOfferDisplayedStatus.ARCHIVED: (CollectiveOfferAllowedAction.CAN_DUPLICATE,),
     CollectiveOfferDisplayedStatus.INACTIVE: (),
+}
+
+TEMPLATE_ALLOWED_ACTIONS_BY_DISPLAYED_STATUS: dict[
+    CollectiveOfferDisplayedStatus, tuple[CollectiveOfferTemplateAllowedAction, ...]
+] = {
+    CollectiveOfferDisplayedStatus.DRAFT: (
+        CollectiveOfferTemplateAllowedAction.CAN_EDIT_DETAILS,
+        CollectiveOfferTemplateAllowedAction.CAN_ARCHIVE,
+    ),
+    CollectiveOfferDisplayedStatus.PENDING: (CollectiveOfferTemplateAllowedAction.CAN_DUPLICATE,),
+    CollectiveOfferDisplayedStatus.ACTIVE: (
+        CollectiveOfferTemplateAllowedAction.CAN_EDIT_DETAILS,
+        CollectiveOfferTemplateAllowedAction.CAN_DUPLICATE,
+        CollectiveOfferTemplateAllowedAction.CAN_ARCHIVE,
+        CollectiveOfferTemplateAllowedAction.CAN_CREATE_BOOKABLE_OFFER,
+        CollectiveOfferTemplateAllowedAction.CAN_HIDE,
+    ),
+    CollectiveOfferDisplayedStatus.REJECTED: (
+        CollectiveOfferTemplateAllowedAction.CAN_DUPLICATE,
+        CollectiveOfferTemplateAllowedAction.CAN_ARCHIVE,
+    ),
+    CollectiveOfferDisplayedStatus.ARCHIVED: (
+        CollectiveOfferTemplateAllowedAction.CAN_DUPLICATE,
+        CollectiveOfferTemplateAllowedAction.CAN_CREATE_BOOKABLE_OFFER,
+    ),
+    CollectiveOfferDisplayedStatus.INACTIVE: (
+        CollectiveOfferTemplateAllowedAction.CAN_EDIT_DETAILS,
+        CollectiveOfferTemplateAllowedAction.CAN_DUPLICATE,
+        CollectiveOfferTemplateAllowedAction.CAN_ARCHIVE,
+        CollectiveOfferTemplateAllowedAction.CAN_CREATE_BOOKABLE_OFFER,
+        CollectiveOfferTemplateAllowedAction.CAN_PUBLISH,
+    ),
 }
 
 
@@ -773,7 +814,7 @@ class CollectiveOffer(
         return CollectiveOfferDisplayedStatus.ACTIVE
 
     @property
-    def allowed_actions(self) -> list[CollectiveOfferAllowedAction]:
+    def allowedActions(self) -> list[CollectiveOfferAllowedAction]:
         displayed_status = self.displayedStatus
         allowed_actions = ALLOWED_ACTIONS_BY_DISPLAYED_STATUS[displayed_status]
 
@@ -1029,9 +1070,8 @@ class CollectiveOfferTemplate(
         return CollectiveOfferDisplayedStatus.ACTIVE
 
     @property
-    def allowed_actions(self) -> None:
-        # TODO: this will be implemented once the actions are defined for an OfferTemplate
-        return None
+    def allowedActions(self) -> list[CollectiveOfferTemplateAllowedAction]:
+        return list(TEMPLATE_ALLOWED_ACTIONS_BY_DISPLAYED_STATUS[self.displayedStatus])
 
     @property
     def start(self) -> datetime | None:

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -149,7 +149,10 @@ class CollectiveOfferResponseModel(BaseModel):
     venue: base_serializers.ListOffersVenueResponseModel
     status: CollectiveOfferStatus
     displayedStatus: educational_models.CollectiveOfferDisplayedStatus
-    allowedActions: list[educational_models.CollectiveOfferAllowedAction] | None
+    allowedActions: (
+        list[educational_models.CollectiveOfferAllowedAction]
+        | list[educational_models.CollectiveOfferTemplateAllowedAction]
+    )
     educationalInstitution: EducationalInstitutionResponseModel | None
     interventionArea: list[str]
     templateId: str | None
@@ -206,7 +209,7 @@ def _serialize_offer_paginated(
         venue=_serialize_venue(offer.venue),  # type: ignore[arg-type]
         status=offer.status.name,
         displayedStatus=offer.displayedStatus,
-        allowedActions=offer.allowed_actions,
+        allowedActions=offer.allowedActions,
         isShowcase=is_offer_template,
         educationalInstitution=EducationalInstitutionResponseModel.from_orm(institution) if institution else None,
         interventionArea=offer.interventionArea,
@@ -380,6 +383,7 @@ class GetCollectiveOfferTemplateResponseModel(GetCollectiveOfferBaseResponseMode
     contactPhone: str | None
     contactUrl: str | None
     contactForm: educational_models.OfferContactFormEnum | None
+    allowedActions: list[educational_models.CollectiveOfferTemplateAllowedAction]
 
     class Config:
         orm_mode = True
@@ -435,13 +439,12 @@ class GetCollectiveOfferResponseModel(GetCollectiveOfferBaseResponseModel):
     formats: typing.Sequence[subcategories.EacFormat] | None
     isTemplate: bool = False
     dates: TemplateDatesModel | None
-    allowedActions: list[educational_models.CollectiveOfferAllowedAction] | None
+    allowedActions: list[educational_models.CollectiveOfferAllowedAction]
 
     @classmethod
     def from_orm(cls, offer: educational_models.CollectiveOffer) -> "GetCollectiveOfferResponseModel":
         result = super().from_orm(offer)
         result.formats = offer.get_formats()
-        result.allowedActions = offer.allowed_actions
 
         if result.status == CollectiveOfferStatus.INACTIVE.name:
             result.isActive = False

--- a/api/tests/routes/pro/get_collective_offer_template_test.py
+++ b/api/tests/routes/pro/get_collective_offer_template_test.py
@@ -53,6 +53,13 @@ class Returns200Test:
         }
         assert response.json["formats"] == offer.formats
         assert response.json["displayedStatus"] == "ACTIVE"
+        assert response.json["allowedActions"] == [
+            "CAN_EDIT_DETAILS",
+            "CAN_DUPLICATE",
+            "CAN_ARCHIVE",
+            "CAN_CREATE_BOOKABLE_OFFER",
+            "CAN_HIDE",
+        ]
 
     def test_performance(self, client):
         # Given

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -53,6 +53,7 @@ export type { CollectiveOfferResponseModel } from './models/CollectiveOfferRespo
 export type { CollectiveOffersBookingResponseModel } from './models/CollectiveOffersBookingResponseModel';
 export type { CollectiveOffersStockResponseModel } from './models/CollectiveOffersStockResponseModel';
 export { CollectiveOfferStatus } from './models/CollectiveOfferStatus';
+export { CollectiveOfferTemplateAllowedAction } from './models/CollectiveOfferTemplateAllowedAction';
 export type { CollectiveOfferTemplateBodyModel } from './models/CollectiveOfferTemplateBodyModel';
 export type { CollectiveOfferTemplateResponseIdModel } from './models/CollectiveOfferTemplateResponseIdModel';
 export { CollectiveOfferType } from './models/CollectiveOfferType';

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
@@ -7,6 +7,7 @@ import type { CollectiveOfferDisplayedStatus } from './CollectiveOfferDisplayedS
 import type { CollectiveOffersBookingResponseModel } from './CollectiveOffersBookingResponseModel';
 import type { CollectiveOffersStockResponseModel } from './CollectiveOffersStockResponseModel';
 import type { CollectiveOfferStatus } from './CollectiveOfferStatus';
+import type { CollectiveOfferTemplateAllowedAction } from './CollectiveOfferTemplateAllowedAction';
 import type { EacFormat } from './EacFormat';
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
 import type { ListOffersVenueResponseModel } from './ListOffersVenueResponseModel';
@@ -14,7 +15,7 @@ import type { NationalProgramModel } from './NationalProgramModel';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 import type { TemplateDatesModel } from './TemplateDatesModel';
 export type CollectiveOfferResponseModel = {
-  allowedActions?: Array<CollectiveOfferAllowedAction> | null;
+  allowedActions: (Array<CollectiveOfferAllowedAction> | Array<CollectiveOfferTemplateAllowedAction>);
   booking?: CollectiveOffersBookingResponseModel | null;
   dates?: TemplateDatesModel | null;
   displayedStatus: CollectiveOfferDisplayedStatus;

--- a/pro/src/apiClient/v1/models/CollectiveOfferTemplateAllowedAction.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferTemplateAllowedAction.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * An enumeration.
+ */
+export enum CollectiveOfferTemplateAllowedAction {
+  CAN_EDIT_DETAILS = 'CAN_EDIT_DETAILS',
+  CAN_DUPLICATE = 'CAN_DUPLICATE',
+  CAN_ARCHIVE = 'CAN_ARCHIVE',
+  CAN_CREATE_BOOKABLE_OFFER = 'CAN_CREATE_BOOKABLE_OFFER',
+  CAN_PUBLISH = 'CAN_PUBLISH',
+  CAN_HIDE = 'CAN_HIDE',
+}

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -19,7 +19,7 @@ import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 import type { TemplateDatesModel } from './TemplateDatesModel';
 export type GetCollectiveOfferResponseModel = {
-  allowedActions?: Array<CollectiveOfferAllowedAction> | null;
+  allowedActions: Array<CollectiveOfferAllowedAction>;
   audioDisabilityCompliant?: boolean | null;
   bookingEmails: Array<string>;
   collectiveStock?: GetCollectiveOfferCollectiveStockResponseModel | null;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
@@ -5,6 +5,7 @@
 import type { CollectiveOfferDisplayedStatus } from './CollectiveOfferDisplayedStatus';
 import type { CollectiveOfferOfferVenueResponseModel } from './CollectiveOfferOfferVenueResponseModel';
 import type { CollectiveOfferStatus } from './CollectiveOfferStatus';
+import type { CollectiveOfferTemplateAllowedAction } from './CollectiveOfferTemplateAllowedAction';
 import type { EacFormat } from './EacFormat';
 import type { GetCollectiveOfferVenueResponseModel } from './GetCollectiveOfferVenueResponseModel';
 import type { NationalProgramModel } from './NationalProgramModel';
@@ -14,6 +15,7 @@ import type { StudentLevels } from './StudentLevels';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
 import type { TemplateDatesModel } from './TemplateDatesModel';
 export type GetCollectiveOfferTemplateResponseModel = {
+  allowedActions: Array<CollectiveOfferTemplateAllowedAction>;
   audioDisabilityCompliant?: boolean | null;
   bookingEmails: Array<string>;
   contactEmail?: string | null;

--- a/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
+++ b/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
@@ -67,9 +67,13 @@ export const CollectiveOfferSummary = ({
             <CollectiveOfferVenueSection venue={offer.venue} />
             <CollectiveOfferTypeSection offer={offer} />
             <CollectiveOfferImagePreview offer={offer} />
-            {offer.isTemplate && <CollectiveOfferDateSection offer={offer} />}
+            {isCollectiveOfferTemplate(offer) && (
+              <CollectiveOfferDateSection offer={offer} />
+            )}
             <CollectiveOfferLocationSection offer={offer} />
-            {offer.isTemplate && <CollectiveOfferPriceSection offer={offer} />}
+            {isCollectiveOfferTemplate(offer) && (
+              <CollectiveOfferPriceSection offer={offer} />
+            )}
             <CollectiveOfferParticipantSection students={offer.students} />
             <AccessibilitySummarySection
               accessibleItem={offer}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/__specs__/AdagePreviewLayout.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdagePreviewLayout/__specs__/AdagePreviewLayout.spec.tsx
@@ -2,6 +2,7 @@ import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 
 import { api } from 'apiClient/api'
 import {
+  GetCollectiveOfferResponseModel,
   GetCollectiveOfferTemplateResponseModel,
   OfferAddressType,
 } from 'apiClient/v1'
@@ -17,7 +18,9 @@ import { renderWithProviders } from 'utils/renderWithProviders'
 import { AdagePreviewLayout } from '../AdagePreviewLayout'
 
 function renderAdagePreviewLayout(
-  offer: GetCollectiveOfferTemplateResponseModel = getCollectiveOfferTemplateFactory()
+  offer:
+    | GetCollectiveOfferTemplateResponseModel
+    | GetCollectiveOfferResponseModel = getCollectiveOfferTemplateFactory()
 ) {
   renderWithProviders(
     <AdageUserContextProvider adageUser={defaultAdageUser}>

--- a/pro/src/screens/OfferEducational/useCollectiveOfferFromParams.tsx
+++ b/pro/src/screens/OfferEducational/useCollectiveOfferFromParams.tsx
@@ -42,7 +42,11 @@ export const useCollectiveOfferFromParams = (
 
   const isTemplate = isTemplateId || pathNameIncludesTemplate
 
-  const { data: offer } = useSWR(
+  const { data: offer } = useSWR<
+    GetCollectiveOfferResponseModel | GetCollectiveOfferTemplateResponseModel,
+    any,
+    [string, number] | null
+  >(
     offerId !== undefined
       ? [
           isTemplate

--- a/pro/src/utils/collectiveApiFactories.ts
+++ b/pro/src/utils/collectiveApiFactories.ts
@@ -56,6 +56,7 @@ export const collectiveOfferFactory = (
     isPublicApi: false,
     interventionArea: [],
     isShowcase: false,
+    allowedActions: [],
     ...customCollectiveOffer,
   }
 }
@@ -116,6 +117,7 @@ export const getCollectiveOfferFactory = (
     isVisibilityEditable: true,
     isTemplate: false,
     collectiveStock: getCollectiveOfferCollectiveStockFactory(),
+    allowedActions: [],
     ...customCollectiveOffer,
   }
 }
@@ -148,6 +150,7 @@ export const getCollectiveOfferTemplateFactory = (
     start: new Date().toISOString(),
     end: addDays(new Date(), 1).toISOString(),
   },
+  allowedActions: [],
   ...customCollectiveOfferTemplate,
 })
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31838

Ajout des actions autorisées sur une offre vitrine en fonction du statut.
Envoi au front quand on récupère une offre ou la liste des offres vitrines.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
