### PR TITLE
(PC-31909)[BO] feat: FF switching BO column names

### DIFF
--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -63,7 +63,11 @@ class BaseBookingListForm(FlaskForm):
         endpoint="backoffice_web.autocomplete_offerers",
     )
     venue = fields.PCTomSelectField(
-        "Lieux", multiple=True, choices=[], validate_choice=False, endpoint="backoffice_web.autocomplete_venues"
+        typing.cast(str, utils.VenueRenaming("Lieux", "Partenaires culturels")),
+        multiple=True,
+        choices=[],
+        validate_choice=False,
+        endpoint="backoffice_web.autocomplete_venues",
     )
     status = fields.PCSelectMultipleField("États")
     cashflow_batches = fields.PCTomSelectField(

--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -124,7 +124,7 @@ class GetDownloadBookingsForm(FlaskForm):
     class Meta:
         csrf = False
 
-    venue = fields.PCIntegerField("Lieu")
+    venue = fields.PCIntegerField(utils.VenueRenaming("Lieux", "Partenaires culturels"))
     from_to_date = fields.PCDateRangeField(
         "Créées entre",
         validators=(wtforms.validators.Optional(),),

--- a/api/src/pcapi/routes/backoffice/collective_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/forms.py
@@ -31,7 +31,7 @@ class CollectiveOffersSearchAttributes(enum.Enum):
     REGION = "Région"
     VALIDATION = "État"
     ID = "ID de l'offre"
-    VENUE = "Lieu"
+    VENUE = typing.cast(str, forms_utils.VenueRenaming("Lieux", "Partenaires culturels"))
     NAME = "Nom de l'offre"
     STATUS = "Statut"
     OFFERER = "Structure"
@@ -159,7 +159,7 @@ class CollectiveOfferAdvancedSearchSubForm(forms_utils.PCForm):
         ],
     )
     venue = fields.PCTomSelectField(
-        "Lieux",
+        typing.cast(str, forms_utils.VenueRenaming("Lieux", "Partenaires culturels")),
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -288,7 +288,11 @@ class GetCollectiveOfferTemplatesListForm(forms.GetOffersBaseFields):
         endpoint="backoffice_web.autocomplete_offerers",
     )
     venue = fields.PCTomSelectField(
-        "Lieux", multiple=True, choices=[], validate_choice=False, endpoint="backoffice_web.autocomplete_venues"
+        typing.cast(str, forms_utils.VenueRenaming("Lieux", "Partenaires culturels")),
+        multiple=True,
+        choices=[],
+        validate_choice=False,
+        endpoint="backoffice_web.autocomplete_venues",
     )
     status = fields.PCSelectMultipleField(
         "États",

--- a/api/src/pcapi/routes/backoffice/criteria/forms.py
+++ b/api/src/pcapi/routes/backoffice/criteria/forms.py
@@ -1,3 +1,5 @@
+import typing
+
 from flask_wtf import FlaskForm
 import wtforms
 
@@ -44,7 +46,9 @@ class SearchTagForm(utils.PCForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Tags offres et lieux")
+    q = fields.PCOptSearchField(
+        typing.cast(str, utils.VenueRenaming("Tags offres et lieux", "Tags offres et partenaires culturels"))
+    )
 
     page = wtforms.HiddenField("page", default="1", validators=(wtforms.validators.Optional(),))
     per_page = fields.PCSelectField(

--- a/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/forms.py
+++ b/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/forms.py
@@ -7,6 +7,7 @@ import wtforms
 
 from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories_v2
+from pcapi.models import feature
 from pcapi.routes.backoffice.forms import fields
 from pcapi.routes.backoffice.forms import utils
 
@@ -114,11 +115,20 @@ class CreateCustomReimbursementRuleForm(FlaskForm):
         venue_id = self._fields["venue"].data[0]
 
         if not offerer_id and not venue_id:
-            flash("Il faut obligatoirement renseigner une structure ou un lieu", "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash("Il faut obligatoirement renseigner une structure ou un partenaire culturel", "warning")
+            else:
+                flash("Il faut obligatoirement renseigner une structure ou un lieu", "warning")
             return False
 
         if offerer_id and venue_id:
-            flash("Un tarif dérogatoire ne peut pas concerner un lieu et une structure en même temps", "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(
+                    "Un tarif dérogatoire ne peut pas concerner un partenaire culturel et une structure en même temps",
+                    "warning",
+                )
+            else:
+                flash("Un tarif dérogatoire ne peut pas concerner un lieu et une structure en même temps", "warning")
             return False
         return super().validate(extra_validators)
 

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -34,6 +34,7 @@ from pcapi.core.users import models as users_models
 from pcapi.domain import show_types
 from pcapi.models import offer_mixin
 from pcapi.models import validation_status_mixin
+from pcapi.models.feature import FeatureToggle
 from pcapi.routes.backoffice.accounts import serialization as serialization_accounts
 from pcapi.utils import urls
 from pcapi.utils.csr import Csr
@@ -955,6 +956,8 @@ def format_offer_validation_sub_rule_field(sub_rule_field: offers_models.OfferVa
         case offers_models.OfferValidationSubRuleField.SHOW_SUB_TYPE_OFFER:
             return "Le sous-type de spectacle de l'offre individuelle"
         case offers_models.OfferValidationSubRuleField.ID_VENUE:
+            if FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                return "Le partenaire culturel proposant l'offre"
             return "Le lieu proposant l'offre"
         case offers_models.OfferValidationSubRuleField.ID_OFFERER:
             return "La structure proposant l'offre"

--- a/api/src/pcapi/routes/backoffice/finance/forms.py
+++ b/api/src/pcapi/routes/backoffice/finance/forms.py
@@ -1,4 +1,5 @@
 import enum
+import typing
 
 from flask_wtf import FlaskForm
 from wtforms.validators import Optional
@@ -83,7 +84,9 @@ class GetIncidentsSearchForm(forms_utils.PCForm):
     )
 
     venue = fields.PCTomSelectField(
-        "Lieux porteurs de l'offre",
+        typing.cast(
+            str, forms_utils.VenueRenaming("Lieux porteurs de l'offre", "Partenaires culturels porteurs de l'offre")
+        ),
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/finance/validation.py
+++ b/api/src/pcapi/routes/backoffice/finance/validation.py
@@ -4,6 +4,7 @@ from pcapi.core.bookings import models as bookings_models
 from pcapi.core.educational import models as educational_models
 from pcapi.core.finance import models as finance_models
 from pcapi.models import db
+from pcapi.models import feature
 
 
 class Valid:
@@ -72,8 +73,13 @@ def check_incident_bookings(bookings: list[bookings_models.Booking]) -> Valid:
         )
 
     if len({booking.venueId for booking in bookings}) > 1:
+        if not feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            return Valid(
+                is_valid=False, message="Un incident ne peut être créé qu'à partir de réservations venant du même lieu."
+            )
         return Valid(
-            is_valid=False, message="Un incident ne peut être créé qu'à partir de réservations venant du même lieu."
+            is_valid=False,
+            message="Un incident ne peut être créé qu'à partir de réservations venant du même partenaire culturel.",
         )
 
     if sum(booking.total_amount for booking in bookings) == 0:
@@ -111,9 +117,14 @@ def check_commercial_gesture_bookings(bookings: list[bookings_models.Booking]) -
         )
 
     if len({booking.venueId for booking in bookings}) > 1:
+        if not feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            return Valid(
+                is_valid=False,
+                message="Un geste commercial ne peut être créé qu'à partir de réservations venant du même lieu.",
+            )
         return Valid(
             is_valid=False,
-            message="Un geste commercial ne peut être créé qu'à partir de réservations venant du même lieu.",
+            message="Un geste commercial ne peut être créé qu'à partir de réservations venant du même partenaire culturel.",
         )
 
     return Valid(True)

--- a/api/src/pcapi/routes/backoffice/forms/pro_support.py
+++ b/api/src/pcapi/routes/backoffice/forms/pro_support.py
@@ -1,11 +1,27 @@
+import typing
+
 from flask_wtf import FlaskForm
+
+import pcapi.routes.backoffice.forms.utils as forms_utils
 
 from . import fields
 
 
 class MoveSiretForm(FlaskForm):
-    source_venue = fields.PCIntegerField("Venue ID du lieu source")
-    target_venue = fields.PCIntegerField("Venue ID du lieu cible")
+    source_venue = fields.PCIntegerField(
+        forms_utils.VenueRenaming("Venue ID du lieu source", "Venue ID du partenaire culturel source")
+    )
+    target_venue = fields.PCIntegerField(
+        forms_utils.VenueRenaming("Venue ID du lieu cible", "Venue ID du partenaire culturel cible")
+    )
     siret = fields.PCSiretField("SIRET")
-    comment = fields.PCCommentField("Commentaire associé au lieu source, sans SIRET")
+    comment = fields.PCCommentField(
+        typing.cast(
+            str,
+            forms_utils.VenueRenaming(
+                "Commentaire associé au lieu source, sans SIRET",
+                "Commentaire associé au partenaire culturel source, sans SIRET",
+            ),
+        )
+    )
     override_revenue_check = fields.PCSwitchBooleanField("Ignorer la limite de revenus annuels")

--- a/api/src/pcapi/routes/backoffice/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice/forms/utils.py
@@ -4,6 +4,7 @@ import typing
 
 from flask_wtf import FlaskForm
 
+from pcapi.models import feature
 from pcapi.utils import email as email_utils
 
 
@@ -29,3 +30,17 @@ def choices_from_enum(
 def is_slug(string: str) -> bool:
     pattern = r"^[a-z0-9\-]+$"
     return bool(re.match(pattern, string))
+
+
+class VenueRenaming:
+    def __init__(self, value_off: str, value_on: str) -> None:
+        self.value_off = value_off
+        self.value_on = value_on
+
+    def __str__(self) -> str:
+        if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            return str(self.value_on)
+        return str(self.value_off)
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/api/src/pcapi/routes/backoffice/move_siret.py
+++ b/api/src/pcapi/routes/backoffice/move_siret.py
@@ -9,6 +9,7 @@ from markupsafe import escape
 from pcapi.core.finance import siret_api
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
+from pcapi.models import feature
 
 from . import utils
 from .forms import pro_support as pro_support_forms
@@ -30,41 +31,76 @@ def _validate_move_siret_form() -> (
         return form, None, None
 
     if form.source_venue.data == form.target_venue.data:
-        flash("Les lieux source et destination doivent être différents", "warning")
+        if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            flash("Les partenaires culturels source et destination doivent être différents", "warning")
+        else:
+            flash("Les lieux source et destination doivent être différents", "warning")
         return form, None, None
 
     source_venue = offerers_models.Venue.query.filter_by(id=form.source_venue.data).one_or_none()
     if not source_venue:
-        flash(
-            Markup("Aucun lieu n'a été trouvé avec l'ID <b>{venue_id}</b>").format(venue_id=form.source_venue.data),
-            "warning",
-        )
+        if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            flash(
+                Markup("Aucun partenaire culturel n'a été trouvé avec l'ID <b>{venue_id}</b>").format(
+                    venue_id=form.source_venue.data
+                ),
+                "warning",
+            )
+        else:
+            flash(
+                Markup("Aucun lieu n'a été trouvé avec l'ID <b>{venue_id}</b>").format(venue_id=form.source_venue.data),
+                "warning",
+            )
         return form, None, None
 
     target_venue = offerers_models.Venue.query.filter_by(id=form.target_venue.data).one_or_none()
     if not target_venue:
-        flash(
-            Markup("Aucun lieu n'a été trouvé avec l'ID <b>{venue_id}</b>").format(venue_id=form.target_venue.data),
-            "warning",
-        )
+        if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            flash(
+                Markup("Aucun partenaire culturel n'a été trouvé avec l'ID <b>{venue_id}</b>").format(
+                    venue_id=form.target_venue.data
+                ),
+                "warning",
+            )
+        else:
+            flash(
+                Markup("Aucun lieu n'a été trouvé avec l'ID <b>{venue_id}</b>").format(venue_id=form.target_venue.data),
+                "warning",
+            )
         return form, None, None
 
     if source_venue.siret != form.siret.data:
-        flash(
-            Markup("Le SIRET <b>{siret}</b> ne correspond pas au lieu <b>{venue_id}</b>").format(
-                siret=form.siret.data, venue_id=form.source_venue.data
-            ),
-            "warning",
-        )
+        if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            flash(
+                Markup("Le SIRET <b>{siret}</b> ne correspond pas au partenaire culturel <b>{venue_id}</b>").format(
+                    siret=form.siret.data, venue_id=form.source_venue.data
+                ),
+                "warning",
+            )
+        else:
+            flash(
+                Markup("Le SIRET <b>{siret}</b> ne correspond pas au lieu <b>{venue_id}</b>").format(
+                    siret=form.siret.data, venue_id=form.source_venue.data
+                ),
+                "warning",
+            )
         return form, None, None
 
     if target_venue.isVirtual:
-        flash(
-            Markup("Le lieu cible <b>{venue_name}</b> (ID {venue_id}) est un lieu virtuel").format(
-                venue_name=target_venue.name, venue_id=target_venue.id
-            ),
-            "warning",
-        )
+        if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            flash(
+                Markup(
+                    "Le partenaire culturel cible <b>{venue_name}</b> (ID {venue_id}) est un partenaire culturel virtuel"
+                ).format(venue_name=target_venue.name, venue_id=target_venue.id),
+                "warning",
+            )
+        else:
+            flash(
+                Markup("Le lieu cible <b>{venue_name}</b> (ID {venue_id}) est un lieu virtuel").format(
+                    venue_name=target_venue.name, venue_id=target_venue.id
+                ),
+                "warning",
+            )
         return form, None, None
 
     return form, source_venue, target_venue

--- a/api/src/pcapi/routes/backoffice/offer_validation_rules/forms.py
+++ b/api/src/pcapi/routes/backoffice/offer_validation_rules/forms.py
@@ -1,6 +1,7 @@
 import enum
 import json
 import re
+import typing
 
 from flask_wtf import FlaskForm
 import wtforms
@@ -10,6 +11,7 @@ from pcapi.core.categories import subcategories_v2
 from pcapi.core.offers import models as offers_models
 from pcapi.domain.show_types import SHOW_SUB_TYPES_LABEL_BY_CODE
 from pcapi.routes.backoffice import autocomplete
+import pcapi.routes.backoffice.forms.utils as forms_utils
 from pcapi.utils.clean_accents import clean_accents
 
 from .. import filters
@@ -82,7 +84,7 @@ class SearchRuleForm(FlaskForm):
         endpoint="backoffice_web.autocomplete_offerers",
     )
     venue = fields.PCTomSelectField(
-        "Lieux",
+        typing.cast(str, forms_utils.VenueRenaming("Lieux", "Partenaires culturels")),
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -140,7 +142,7 @@ class OfferValidationSubRuleForm(FlaskForm):
         "Type de l'offre", choices=utils.choices_from_enum(OfferType), field_list_compatibility=True
     )
     venue = fields.PCTomSelectField(
-        "Lieu",
+        typing.cast(str, forms_utils.VenueRenaming("Lieu", "Partenaire culturel")),
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offers/forms.py
@@ -38,7 +38,7 @@ class IndividualOffersSearchAttributes(enum.Enum):
     VALIDATION = "État"
     ID = "ID de l'offre"
     MEDIATION = "Image"
-    VENUE = "Lieu"
+    VENUE = forms_utils.VenueRenaming("Lieu", "Partenaire culturel")
     ADDRESS = "Adresse de l'offre"
     NAME = "Nom de l'offre"
     SYNCHRONIZED = "Offre synchronisée"
@@ -246,7 +246,7 @@ class OfferAdvancedSearchSubForm(forms_utils.PCForm):
         ],
     )
     venue = fields.PCTomSelectField(
-        "Lieux",
+        typing.cast(str, forms_utils.VenueRenaming("Lieux", "Partenaires culturels")),
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -415,7 +415,9 @@ class BatchEditOfferForm(empty_forms.BatchForm, EditOfferForm):
 
 
 class EditOfferVenueForm(FlaskForm):
-    venue = fields.PCSelectWithPlaceholderValueField("Nouveau lieu", choices=[], validate_choice=False)
+    venue = fields.PCSelectWithPlaceholderValueField(
+        forms_utils.VenueRenaming("Nouveau lieu", "Nouveau partenaire culturel"), choices=[], validate_choice=False
+    )
     notify_beneficiary = fields.PCSwitchBooleanField("Notifier les jeunes", full_row=True)
 
     def set_venue_choices(self, venues: list[offerers_models.Venue]) -> None:

--- a/api/src/pcapi/routes/backoffice/pivots/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pivots/blueprint.py
@@ -12,6 +12,7 @@ from pcapi.core.history import models as history_models
 from pcapi.core.offerers import models as offerer_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.models import db
+from pcapi.models import feature
 
 from . import forms
 from .. import autocomplete
@@ -79,7 +80,13 @@ def create_pivot(name: str) -> utils.BackofficeResponse:
 
     venue = offerer_models.Venue.query.filter_by(id=form.venue_id.data[0]).one_or_none()
     if not venue:
-        flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=form.venue_id.data[0]), "warning")
+        if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+            flash(
+                Markup("Le partenaire culturel id={venue_id} n'existe pas").format(venue_id=form.venue_id.data[0]),
+                "warning",
+            )
+        else:
+            flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=form.venue_id.data[0]), "warning")
         return redirect(url_for(".get_pivots", active_tab=name), code=303)
 
     try:

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/boost.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/boost.py
@@ -13,6 +13,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
 from pcapi.models import db
+from pcapi.models import feature
 from pcapi.utils import requests
 
 from .. import forms
@@ -61,14 +62,27 @@ class BoostContext(PivotContext):
 
         venue = offerers_models.Venue.query.filter_by(id=venue_id).one_or_none()
         if not venue:
-            flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(Markup("Le partenaire culturel id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
+            else:
+                flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
             return False
         pivot = providers_models.CinemaProviderPivot.query.filter_by(venueId=venue_id).one_or_none()
         if pivot:
-            flash(
-                Markup("Des identifiants cinéma existent déjà pour ce lieu id={venue_id}").format(venue_id=venue_id),
-                "warning",
-            )
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(
+                    Markup("Des identifiants cinéma existent déjà pour ce partenaire culturel id={venue_id}").format(
+                        venue_id=venue_id
+                    ),
+                    "warning",
+                )
+            else:
+                flash(
+                    Markup("Des identifiants cinéma existent déjà pour ce lieu id={venue_id}").format(
+                        venue_id=venue_id
+                    ),
+                    "warning",
+                )
             return False
 
         cinema_provider_pivot = providers_models.CinemaProviderPivot(

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/cgr.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/cgr.py
@@ -10,6 +10,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
 from pcapi.models import db
+from pcapi.models import feature
 from pcapi.utils.crypto import decrypt
 from pcapi.utils.crypto import encrypt
 
@@ -62,14 +63,27 @@ class CGRContext(PivotContext):
 
         venue = offerers_models.Venue.query.filter_by(id=venue_id).one_or_none()
         if not venue:
-            flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(Markup("Le partenaire culturel id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
+            else:
+                flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
             return False
         pivot = providers_models.CinemaProviderPivot.query.filter_by(venueId=venue.id).one_or_none()
         if pivot:
-            flash(
-                Markup("Des identifiants cinéma existent déjà pour ce lieu id={venue.id}").format(venue_id=venue_id),
-                "warning",
-            )
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(
+                    Markup("Des identifiants cinéma existent déjà pour ce partenaire culturel id={venue.id}").format(
+                        venue_id=venue_id
+                    ),
+                    "warning",
+                )
+            else:
+                flash(
+                    Markup("Des identifiants cinéma existent déjà pour ce lieu id={venue.id}").format(
+                        venue_id=venue_id
+                    ),
+                    "warning",
+                )
             return False
 
         cinema_provider_pivot = providers_models.CinemaProviderPivot(

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/cineoffice.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/cineoffice.py
@@ -12,6 +12,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
 from pcapi.models import db
+from pcapi.models import feature
 from pcapi.utils import requests
 
 from .. import forms
@@ -61,14 +62,27 @@ class CineofficeContext(PivotContext):
 
         venue = offerers_models.Venue.query.filter_by(id=venue_id).one_or_none()
         if not venue:
-            flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(Markup("Le partenaire culturel id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
+            else:
+                flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
             return False
         pivot = providers_models.CinemaProviderPivot.query.filter_by(venueId=venue_id).one_or_none()
         if pivot:
-            flash(
-                Markup("Des identifiants cinéma existent déjà pour ce lieu id={venue_id}").format(venue_id=venue_id),
-                "warning",
-            )
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(
+                    Markup("Des identifiants cinéma existent déjà pour ce partenaire culturel id={venue_id}").format(
+                        venue_id=venue_id
+                    ),
+                    "warning",
+                )
+            else:
+                flash(
+                    Markup("Des identifiants cinéma existent déjà pour ce lieu id={venue_id}").format(
+                        venue_id=venue_id
+                    ),
+                    "warning",
+                )
             return False
 
         cinema_provider_pivot = providers_models.CinemaProviderPivot(

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/ems.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/ems.py
@@ -10,6 +10,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
 from pcapi.models import db
+from pcapi.models import feature
 
 from .. import forms
 from .base import PivotContext
@@ -63,15 +64,28 @@ class EMSContext(PivotContext):
 
         venue = offerers_models.Venue.query.filter_by(id=venue_id).one_or_none()
         if not venue:
-            flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(Markup("Le partenaire culturel id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
+            else:
+                flash(Markup("Le lieu id={venue_id} n'existe pas").format(venue_id=venue_id), "warning")
             return False
 
         pivot = providers_models.CinemaProviderPivot.query.filter_by(venueId=venue.id).one_or_none()
         if pivot:
-            flash(
-                Markup("Des identifiants cinéma existent déjà pour ce lieu id={venue_id}").format(venue_id=venue_id),
-                "warning",
-            )
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash(
+                    Markup("Des identifiants cinéma existent déjà pour ce partenaire culturel id={venue_id}").format(
+                        venue_id=venue_id
+                    ),
+                    "warning",
+                )
+            else:
+                flash(
+                    Markup("Des identifiants cinéma existent déjà pour ce lieu id={venue_id}").format(
+                        venue_id=venue_id
+                    ),
+                    "warning",
+                )
             return False
 
         cinema_provider_pivot = providers_models.CinemaProviderPivot(

--- a/api/src/pcapi/routes/backoffice/pivots/forms.py
+++ b/api/src/pcapi/routes/backoffice/pivots/forms.py
@@ -1,10 +1,13 @@
 import re
+import typing
 
 from flask import flash
 from flask_wtf import FlaskForm
 import wtforms
 
 from pcapi.core.providers import repository as providers_repository
+from pcapi.models import feature
+from pcapi.routes.backoffice.forms import utils as forms_utils
 
 from ..forms import fields
 
@@ -13,12 +16,20 @@ class SearchPivotForm(FlaskForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("ID ou nom de lieu, identifiant cinéma")
+    q = fields.PCOptSearchField(
+        typing.cast(
+            str,
+            forms_utils.VenueRenaming(
+                "ID ou nom de lieu, identifiant cinéma",
+                "ID ou nom de partenaire culturel, identifiant cinéma",
+            ),
+        )
+    )
 
 
 class EditPivotForm(FlaskForm):
     venue_id = fields.PCTomSelectField(
-        "Lieu",
+        typing.cast(str, forms_utils.VenueRenaming("Lieu", "Partenaire culturel")),
         choices=[],
         validate_choice=False,
         endpoint="backoffice_web.autocomplete_venues",
@@ -58,7 +69,10 @@ class EditBoostForm(EditPivotForm):
             id_at_provider=self.cinema_id.data, provider_id=boost_provider.id
         )
         if pivot and pivot.venueId != self.venue_id.data[0]:
-            flash("Cet identifiant cinéma existe déjà pour un autre lieu", "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash("Cet identifiant cinéma existe déjà pour un autre partenaire culturel", "warning")
+            else:
+                flash("Cet identifiant cinéma existe déjà pour un autre lieu", "warning")
             return False
 
         return super().validate(extra_validators)
@@ -85,7 +99,10 @@ class EditCGRForm(EditPivotForm):
             id_at_provider=self.cinema_id.data, provider_id=cgr_provider.id
         )
         if pivot and pivot.venueId != self.venue_id.data[0]:
-            flash("Cet identifiant cinéma existe déjà pour un autre lieu", "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash("Cet identifiant cinéma existe déjà pour un autre partenaire culturel", "warning")
+            else:
+                flash("Cet identifiant cinéma existe déjà pour un autre lieu", "warning")
             return False
 
         return super().validate(extra_validators)
@@ -114,7 +131,10 @@ class EditCineOfficeForm(EditPivotForm):
             id_at_provider=self.cinema_id.data, provider_id=cds_provider.id
         )
         if pivot and pivot.venueId != self.venue_id.data[0]:
-            flash("Cet identifiant cinéma existe déjà pour un autre lieu", "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash("Cet identifiant cinéma existe déjà pour un autre partenaire culturel", "warning")
+            else:
+                flash("Cet identifiant cinéma existe déjà pour un autre lieu", "warning")
             return False
 
         return super().validate(extra_validators)
@@ -139,7 +159,10 @@ class EditEMSForm(EditPivotForm):
             id_at_provider=self.cinema_id.data, provider_id=ems_provider.id
         )
         if pivot and pivot.venueId != self.venue_id.data[0]:
-            flash("Cet identifiant cinéma existe déjà pour un autre lieu", "warning")
+            if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+                flash("Cet identifiant cinéma existe déjà pour un autre partenaire culturel", "warning")
+            else:
+                flash("Cet identifiant cinéma existe déjà pour un autre lieu", "warning")
             return False
 
         return super().validate(extra_validators)

--- a/api/src/pcapi/routes/backoffice/pro/forms.py
+++ b/api/src/pcapi/routes/backoffice/pro/forms.py
@@ -75,7 +75,7 @@ class CreateOffererForm(FlaskForm):
     email = fields.PCEmailField("Adresse email du compte pro")
     siret = fields.PCSiretField("SIRET")
     public_name = fields.PCStringField(
-        "Nom d'usage du lieu",
+        typing.cast(str, utils.VenueRenaming("Nom d'usage du lieu", "Nom d'usage du partenaire culturel")),
         validators=(
             wtforms.validators.DataRequired("Information obligatoire"),
             wtforms.validators.Length(max=255, message="doit contenir au maximum %(max)d caractères"),

--- a/api/src/pcapi/routes/backoffice/pro/forms.py
+++ b/api/src/pcapi/routes/backoffice/pro/forms.py
@@ -35,7 +35,7 @@ def format_search_type_options(type_option: TypeOptions) -> str:
         case TypeOptions.OFFERER:
             return "Structure"
         case TypeOptions.VENUE:
-            return "Lieu"
+            return typing.cast(str, utils.VenueRenaming("Lieu", "Partenaire culturel"))
         case TypeOptions.USER:
             return "Compte pro"
         case TypeOptions.BANK_ACCOUNT:

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
@@ -90,7 +90,11 @@
       </div>
       <div class="mt-4">
         {% call build_details_tabs_wrapper() %}
-          {{ build_details_tab("linked-venues", "Lieux associés", active_tab == 'linked_venues') }}
+          {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+            {{ build_details_tab("linked-venues", "Partenaires culturels associés", active_tab == 'linked_venues') }}
+          {% else %}
+            {{ build_details_tab("linked-venues", "Lieux associés", active_tab == 'linked_venues') }}
+          {% endif %}
           {{ build_details_tab("history", "Historique du compte bancaire", active_tab == 'history') }}
           {{ build_details_tab("invoices", "Remboursements", active_tab == 'invoices') }}
         {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -63,7 +63,13 @@
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
               <th scope="col">Structure</th>
-              <th scope="col">Lieu</th>
+              <th scope="col">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  Partenaire culturel
+                {% else %}
+                  Lieu
+                {% endif %}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -107,7 +107,13 @@
               </div>
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Lieu :</span> {{ links.build_venue_name_to_details_link(collective_offer.venue) }}
+                  <span class="fw-bold">
+                    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                      Partenaire culturel :
+                    {% else %}
+                      Lieu :
+                    {% endif %}
+                  </span> {{ links.build_venue_name_to_details_link(collective_offer.venue) }}
                 </p>
               </div>
               {% if collective_offer.template %}

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
@@ -1,5 +1,5 @@
 {% from "components/forms.html" import build_advanced_filters_form with context %}
-{% import "components/links.html" as links %}
+{% import "components/links.html" as links with context %}
 {% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 {% extends "layouts/connected.html" %}
 {% block page %}
@@ -61,7 +61,13 @@
               <th scope="col">Date de l'évènement</th>
               {% if has_permission("PRO_FRAUD_ACTIONS") %}<th scope="col">Tarif</th>{% endif %}
               <th scope="col">Structure</th>
-              <th scope="col">Lieu</th>
+              <th scope="col">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  Partenaire culturel
+                {% else %}
+                  Lieu
+                {% endif %}
+              </th>
               <th scope="col">{# icon #}</th>
             </tr>
           </thead>

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/details.html
@@ -70,7 +70,13 @@
               </div>
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Lieu :</span> {{ links.build_venue_name_to_details_link(collective_offer_template.venue) }}
+                  <span class="fw-bold">
+                    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                      Partenaire culturel :
+                    {% else %}
+                      Lieu :
+                    {% endif %}
+                  </span> {{ links.build_venue_name_to_details_link(collective_offer_template.venue) }}
                 </p>
               </div>
             </div>

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
@@ -1,5 +1,5 @@
 {% from "components/forms.html" import build_filters_form with context %}
-{% import "components/links.html" as links %}
+{% import "components/links.html" as links with context %}
 {% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 {% extends "layouts/connected.html" %}
 {% block page %}
@@ -59,7 +59,13 @@
                 {% endif %}
               </th>
               <th scope="col">Structure</th>
-              <th scope="col">Lieu</th>
+              <th scope="col">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  Partenaire culturel
+                {% else %}
+                  Lieu
+                {% endif %}
+              </th>
               <th scope="col">{# icon #}</th>
             </tr>
           </thead>

--- a/api/src/pcapi/routes/backoffice/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/badges.html
@@ -17,9 +17,9 @@
 {% macro build_old_navigation_badge() %}
   <span class="me-1 pb-1 badge rounded-pill text-bg-secondary-lighter">Ancienne interface</span>
 {% endmacro %}
-{% macro build_venue_badges(venue, is_ENABLE_OFFER_ADDRESS_active) %}
+{% macro build_venue_badges(venue) %}
   <span class="me-1 pb-1 badge rounded-pill text-bg-secondary align-middle">
-    {% if is_ENABLE_OFFER_ADDRESS_active %}
+    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
       {% if venue.isPermanent %}
         Partenaire culturel permanent
       {% else %}

--- a/api/src/pcapi/routes/backoffice/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/badges.html
@@ -17,12 +17,20 @@
 {% macro build_old_navigation_badge() %}
   <span class="me-1 pb-1 badge rounded-pill text-bg-secondary-lighter">Ancienne interface</span>
 {% endmacro %}
-{% macro build_venue_badges(venue) %}
+{% macro build_venue_badges(venue, is_ENABLE_OFFER_ADDRESS_active) %}
   <span class="me-1 pb-1 badge rounded-pill text-bg-secondary align-middle">
-    {% if venue.isPermanent %}
-      Lieu permanent
+    {% if is_ENABLE_OFFER_ADDRESS_active %}
+      {% if venue.isPermanent %}
+        Partenaire culturel permanent
+      {% else %}
+        Partenaire culturel
+      {% endif %}
     {% else %}
-      Lieu
+      {% if venue.isPermanent %}
+        Lieu permanent
+      {% else %}
+        Lieu
+      {% endif %}
     {% endif %}
   </span>
   {% if not venue.managingOfferer.isActive %}

--- a/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
@@ -28,7 +28,11 @@
               <p>{{ action.rule.name }}</p>
               {{ build_sub_rules_extra_data(action.extraData['sub_rules_info']) }}
             {% elif action.actionType.name in ["LINK_VENUE_BANK_ACCOUNT_DEPRECATED", "LINK_VENUE_BANK_ACCOUNT_CREATED"] %}
-              Lieu : {{ links.build_venue_name_to_details_link(action.venue) }}
+              {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                Partenaire culturel : {{ links.build_venue_name_to_details_link(action.venue) }}
+              {% else %}
+                Lieu : {{ links.build_venue_name_to_details_link(action.venue) }}
+              {% endif %}
             {% elif action.actionType.name == "OFFERER_ATTESTATION_CHECKED" %}
               L'état positif ou négatif de l'attestation {{ action.extraData['provider'] }} a été visualisé
             {% elif action.actionType.name == "SYNC_VENUE_TO_PROVIDER" %}
@@ -61,7 +65,13 @@
                 <div>
                   <span class="fw-bold">Informations modifiées :</span>
                   {% if show_venue and action.venueId %}
-                    sur le lieu {{ links.build_venue_name_to_details_link(action.venue) }}
+                    sur le
+                    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                      partenaire culturel
+                    {% else %}
+                      lieu
+                    {% endif %}
+                    {{ links.build_venue_name_to_details_link(action.venue) }}
                     ({{ action.venueId }})
                   {% endif %}
                 </div>

--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -91,13 +91,13 @@
   <a href="{{ url_for(endpoint, venue=venue.id) }}"
      class="link-primary"
      target="_blank"
-     title="{{ hint }} associées au lieu"><i class="bi bi-eye h5"></i></a>
+     title="{{ hint }} associées au {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}partenaire culturel{% else %}lieu{% endif %}"><i class="bi bi-eye h5"></i></a>
 {% endmacro %}
 {% macro build_venue_offers_icon_link_advanced(endpoint, hint, venue) %}
   <a href="{{ url_for(endpoint) }}?search-0-search_field=VENUE&search-0-operator=IN&search-0-venue={{ venue.id }}"
      class="link-primary"
      target="_blank"
-     title="{{ hint }} associées au lieu"><i class="bi bi-eye h5"></i></a>
+     title="{{ hint }} associées au {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}partenaire culturel{% else %}lieu{% endif %}"><i class="bi bi-eye h5"></i></a>
 {% endmacro %}
 {% macro build_offer_details_link(offer) %}
   <a href="{{ url_for('backoffice_web.offer.get_offer_details', offer_id=offer.id) }}"

--- a/api/src/pcapi/routes/backoffice/templates/components/offerer_validation/extra_row.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/offerer_validation/extra_row.html
@@ -17,7 +17,13 @@
               {% for dms_venue in dms_venues %}
                 {% if dms_venue.state %}
                   <ul>
-                    <li>{{ ("Nom : " + dms_venue.name) if dms_venue.name else "Dossier sans lieu" }}</li>
+                    <li>
+                      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                        {{ ("Nom : " + dms_venue.name) if dms_venue.name else "Dossier sans partenaire culturel" }}
+                      {% else %}
+                        {{ ("Nom : " + dms_venue.name) if dms_venue.name else "Dossier sans lieu" }}
+                      {% endif %}
+                    </li>
                     <li>SIRET : {{ dms_venue.siret }}</li>
                     <li>Statut du dossier DMS ADAGE : {{ dms_venue.state | format_dms_status }}</li>
                     <li>Date de dernière modification : {{ dms_venue.lastChangeDate | format_string_to_date_time }}</li>

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_bank_account.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_bank_account.html
@@ -1,4 +1,3 @@
-{% from "components/badges.html" import build_venue_badges %}
 {% from "components/links.html" import build_offerer_name_to_details_link %}
 <div class="card shadow">
   <div class="card-body">

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
@@ -1,8 +1,8 @@
-{% from "components/badges.html" import build_venue_badges %}
+{% from "components/badges.html" import build_venue_badges with context %}
 {% from "components/links.html" import build_offerer_name_to_details_link %}
 <div class="card shadow">
   <div class="card-body">
-    <h5 class="mb-3">{{ build_venue_badges(row, is_feature_active("WIP_ENABLE_OFFER_ADDRESS") ) }}</h5>
+    <h5 class="mb-3">{{ build_venue_badges(row) }}</h5>
     {% set link = get_link_to_detail(row.id, form=search_form, search_rank=index, total_items=rows.total) %}
     <h5 class="card-title">
       <a href="{{ link }}"

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
@@ -2,7 +2,7 @@
 {% from "components/links.html" import build_offerer_name_to_details_link %}
 <div class="card shadow">
   <div class="card-body">
-    <h5 class="mb-3">{{ build_venue_badges(row) }}</h5>
+    <h5 class="mb-3">{{ build_venue_badges(row, is_feature_active("WIP_ENABLE_OFFER_ADDRESS") ) }}</h5>
     {% set link = get_link_to_detail(row.id, form=search_form, search_rank=index, total_items=rows.total) %}
     <h5 class="card-title">
       <a href="{{ link }}"

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
@@ -23,7 +23,7 @@
     <div class="filters-container">{{ forms.build_filters_form(form, dst) }}</div>
     <div class="row">
       <div class="col-md-11 mb-4">
-        <turbo-frame id="reimbursement_stats" src="{{ url_for('backoffice_web.reimbursement_rules.get_stats') }}">
+        <turbo-frame id="reimbursement_stats" src="{{ url_for("backoffice_web.reimbursement_rules.get_stats") }}">
         {{ build_loading_spinner() }}
         </turbo-frame>
       </div>
@@ -47,7 +47,13 @@
               <th scope="col">ID règle</th>
               <th scope="col">Structure</th>
               <th scope="col">SIREN</th>
-              <th scope="col">Lieu</th>
+              <th scope="col">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  Partenaire culturel
+                {% else %}
+                  Lieu
+                {% endif %}
+              </th>
               <th scope="col">Offre</th>
               <th scope="col">Taux de remboursement</th>
               <th scope="col">Montant remboursé</th>

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list/stats.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list/stats.html
@@ -12,7 +12,14 @@
     <div class="card-body">
       <h5 class="fs-2 card-title">{{ stats.by_venue or 0 }}</h5>
       <p class="card-text fw-light small mb-0">
-        tarifs dérogatoires sur des <b>lieux</b>
+        tarifs dérogatoires sur des
+        <b>
+          {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+            partenaires culturels
+          {% else %}
+            lieux
+          {% endif %}
+        </b>
       </p>
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general_commercial_gesture.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general_commercial_gesture.html
@@ -35,7 +35,13 @@
         <div class="d-flex justify-content-start">
           <div class="d-flex flex-column pe-5">
             <p class="mb-1">
-              <span class="fw-bold">Lieu porteur de l'offre :</span> {{ links.build_venue_name_to_details_link(incident.venue) }}
+              <span class="fw-bold">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  Partenaire culturel porteur de l'offre :
+                {% else %}
+                  Lieu porteur de l'offre :
+                {% endif %}
+              </span> {{ links.build_venue_name_to_details_link(incident.venue) }}
             </p>
             {% set bank_account_link = incident.venue.current_bank_account_link %}
             <p class="mb-1">

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general_overpayment.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/get/general_overpayment.html
@@ -47,7 +47,14 @@
         <div class="d-flex justify-content-start">
           <div class="d-flex flex-column pe-5">
             <p class="mb-1">
-              <span class="fw-bold">Lieu porteur de l'offre :</span> {{ links.build_venue_name_to_details_link(incident.venue) }}
+              <span class="fw-bold">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  Partenaire culturel
+                {% else %}
+                  Lieu
+                {% endif %}
+                porteur de l'offre :
+              </span> {{ links.build_venue_name_to_details_link(incident.venue) }}
             </p>
             {% set bank_account_link = incident.venue.current_bank_account_link %}
             <p class="mb-1">

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/list.html
@@ -30,7 +30,13 @@
                 <th scope="col">Nb. Réservation(s)</th>
                 <th scope="col">Montant total</th>
                 <th scope="col">Structure</th>
-                <th scope="col">Porteur de l'offre (lieu)</th>
+                <th scope="col">
+                  {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                    Partenaire culturel
+                  {% else %}
+                    Porteur de l'offre (lieu)
+                  {% endif %}
+                </th>
                 <th scope="col">Origine de la demande</th>
               </tr>
             </thead>

--- a/api/src/pcapi/routes/backoffice/templates/fraud/domain_names.html
+++ b/api/src/pcapi/routes/backoffice/templates/fraud/domain_names.html
@@ -1,4 +1,3 @@
-{% from "components/badges.html" import build_venue_badges %}
 {% from "components/forms.html" import build_form_fields_group with context %}
 {% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 {% from "components/presentation/details/tabs.html" import build_details_tab %}

--- a/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
@@ -62,14 +62,14 @@
                       class="btn btn-outline-primary"
                       data-modal-selector="#overpayment-creation-modal"
                       data-mode="fetch"
-                      data-fetch-url="{{ url_for('backoffice_web.finance_incidents.get_individual_bookings_overpayment_creation_form') }}"
+                      data-fetch-url="{{ url_for("backoffice_web.finance_incidents.get_individual_bookings_overpayment_creation_form") }}"
                       data-use-confirmation-modal="true">Créer un incident</button>
               <button disabled
                       type="button"
                       class="btn btn-outline-primary"
                       data-modal-selector="#commercial-gesture-creation-modal"
                       data-mode="fetch"
-                      data-fetch-url="{{ url_for('backoffice_web.finance_incidents.get_individual_bookings_commercial_gesture_creation_form') }}"
+                      data-fetch-url="{{ url_for("backoffice_web.finance_incidents.get_individual_bookings_commercial_gesture_creation_form") }}"
                       data-use-confirmation-modal="true">Créer un geste commercial</button>
             </div>
           {% endif %}
@@ -99,7 +99,13 @@
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
               <th scope="col">Structure</th>
-              <th scope="col">Lieu</th>
+              <th scope="col">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  Partenaire culturel
+                {% else %}
+                  Lieu
+                {% endif %}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
@@ -33,7 +33,7 @@
             aria-controls="{{ pc_collapse_menu_id }}">
       <i class="bi bi-list text-white h4"></i>
     </button>
-    <a href="{{ url_for('backoffice_web.home') }}"
+    <a href="{{ url_for("backoffice_web.home") }}"
        class="card-link">
       <p class="my-0 ms-5 navbar-brand text-white btn">
         <svg width="105.532"
@@ -44,8 +44,8 @@
         Back Office
       </p>
     </a>
-    <form action="{{ url_for('backoffice_web.logout') }}"
-          name="{{ url_for('backoffice_web.logout') | action_to_name }}"
+    <form action="{{ url_for("backoffice_web.logout") }}"
+          name="{{ url_for("backoffice_web.logout") | action_to_name }}"
           method="post">
       {{ csrf_token }}
       <button type="submit"
@@ -89,9 +89,19 @@
                     {{ menu_section_item('Opérations sur plusieurs offres', 'backoffice_web.multiple_offers.multiple_offers_home') }}
                     {{ menu_section_item('Recherche EAN via Tite Live', 'backoffice_web.titelive.search_titelive') }}
                   {% endif %}
-                  {% if has_permission("READ_TAGS") %}{{ menu_section_item('Tags des offres et lieux', 'backoffice_web.tags.list_tags') }}{% endif %}
+                  {% if has_permission("READ_TAGS") %}
+                    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                      {{ menu_section_item('Tags des offres et partenaires culturels', 'backoffice_web.tags.list_tags') }}
+                    {% else %}
+                      {{ menu_section_item('Tags des offres et lieux', 'backoffice_web.tags.list_tags') }}
+                    {% endif %}
+                  {% endif %}
                   {% if has_permission("READ_PRO_ENTITY") and has_permission("MANAGE_PRO_ENTITY") %}
-                    {{ menu_section_item('Actions sur les lieux', 'backoffice_web.venue.list_venues') }}
+                    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                      {{ menu_section_item('Actions sur les partenaires culturels', 'backoffice_web.venue.list_venues') }}
+                    {% else %}
+                      {{ menu_section_item('Actions sur les lieux', 'backoffice_web.venue.list_venues') }}
+                    {% endif %}
                   {% endif %}
                   {% if has_permission("READ_PRO_ENTITY") %}{{ menu_section_item('Préférences', 'backoffice_web.preferences.edit_preferences') }}{% endif %}
                 {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -83,7 +83,11 @@
               {% endif %}
               {% if edit_offer_venue_form %}
                 {% set edit_offer_venue_aria_described_by_id = random_hash() %}
-                {{ build_modal_form("edit-offer-venue", url_for("backoffice_web.offer.edit_offer_venue", offer_id=offer.id) , edit_offer_venue_form, "Modifier le lieu", "Modifier le lieu", "Enregistrer") }}
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  {{ build_modal_form("edit-offer-venue", url_for("backoffice_web.offer.edit_offer_venue", offer_id=offer.id) , edit_offer_venue_form, "Modifier le partenaire culturel", "Modifier le partenaire culturel", "Enregistrer") }}
+                {% else %}
+                  {{ build_modal_form("edit-offer-venue", url_for("backoffice_web.offer.edit_offer_venue", offer_id=offer.id) , edit_offer_venue_form, "Modifier le lieu", "Modifier le lieu", "Enregistrer") }}
+                {% endif %}
               {% endif %}
             </div>
             <div class="col-2"></div>
@@ -177,7 +181,13 @@
               </div>
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Lieu :</span> {{ links.build_venue_name_to_details_link(offer.venue) }}
+                  <span class="fw-bold">
+                    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                      Partenaire culturel :
+                    {% else %}
+                      Lieu :
+                    {% endif %}
+                  </span> {{ links.build_venue_name_to_details_link(offer.venue) }}
                 </p>
               </div>
               {% if offer.offererAddress %}

--- a/api/src/pcapi/routes/backoffice/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/list.html
@@ -1,5 +1,5 @@
 {% from "components/forms.html" import build_advanced_filters_form with context %}
-{% import "components/links.html" as links %}
+{% import "components/links.html" as links with context %}
 {% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 {% extends "layouts/connected.html" %}
 {% block page %}
@@ -107,7 +107,13 @@
               <th scope="col">Dernière validation</th>
               <th scope="col">Dép.</th>
               <th scope="col">Structure</th>
-              <th scope="col">Lieu</th>
+              <th scope="col">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  Partenaire culturel
+                {% else %}
+                  Lieu
+                {% endif %}
+              </th>
               <th scope="col">{# icon #}</th>
             </tr>
           </thead>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -132,10 +132,18 @@
                 <span class="fw-bold">Peut créer une offre EAC : {{ offerer.allowedOnAdage | format_bool_badge }}</span>
               </p>
               <p class="mb-1">
-                <span class="fw-bold">Lieux cartographiés sur ADAGE : {{ adage_information }}</span>
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  <span class="fw-bold">Partenaires culturels cartographiés sur ADAGE : {{ adage_information }}</span>
+                {% else %}
+                  <span class="fw-bold">Lieux cartographiés sur ADAGE : {{ adage_information }}</span>
+                {% endif %}
               </p>
               <p class="mb-1">
-                <span class="fw-bold">Présence CB dans les lieux :</span>
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  <span class="fw-bold">Présence CB dans les partenaires culturels :</span>
+                {% else %}
+                  <span class="fw-bold">Présence CB dans les lieux :</span>
+                {% endif %}
                 {{ bank_information_status.ok }} OK
                 / {{ bank_information_status.ko }} KO
               </p>
@@ -242,7 +250,11 @@
             {{ build_details_tab("entreprise", "Données Entreprise", active_tab == 'entreprise') }}
           {% endif %}
           {{ build_details_tab("pro-users", "Comptes pro", active_tab == 'users') }}
-          {{ build_details_tab("managed-venues", "Lieux", active_tab == 'managed_venues') }}
+          {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+            {{ build_details_tab("managed-venues", "Partenaires culturels", active_tab == 'managed_venues') }}
+          {% else %}
+            {{ build_details_tab("managed-venues", "Lieux", active_tab == 'managed_venues') }}
+          {% endif %}
           {% if has_offerer_address %}
             {# tab is hidden when there is no address in database; so it does not need a FF until migration #}
             {{ build_details_tab("addresses", "Adresses", active_tab == 'addresses') }}

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/collective_dms_applications.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/collective_dms_applications.html
@@ -8,7 +8,13 @@
       <th scope="col">Date de dépôt</th>
       <th scope="col">État</th>
       <th scope="col">Date de dernière mise à jour</th>
-      <th scope="col">Lieu</th>
+      <th scope="col">
+        {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+          Partenaire culturel
+        {% else %}
+          Lieu
+        {% endif %}
+      </th>
       <th scope="col">SIRET</th>
     </tr>
   </thead>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/managed_venues.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/managed_venues.html
@@ -24,7 +24,15 @@
         </td>
         <td>{{ links.build_siret_to_external_link(venue) }}</td>
         <td>
-          {% if venue.isPermanent %}<span class="visually-hidden">Lieu permanent</span><i class="bi bi-check-circle-fill"></i>{% endif %}
+          {% if venue.isPermanent %}
+            <span class="visually-hidden">
+              {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                Partenaire culturel permanent
+              {% else %}
+                Lieu permanent
+              {% endif %}
+            </span><i class="bi bi-check-circle-fill"></i>
+          {% endif %}
         </td>
         <td>{{ venue.venueTypeCode.value }}</td>
         <td>

--- a/api/src/pcapi/routes/backoffice/templates/pivots/get/allocine.html
+++ b/api/src/pcapi/routes/backoffice/templates/pivots/get/allocine.html
@@ -7,8 +7,13 @@
   <thead>
     <tr>
       <th scope="col"></th>
-      <th scope="col">Id du Lieu</th>
-      <th scope="col">Lieu</th>
+      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+        <th scope="col">Id du partenaire culturel</th>
+        <th scope="col">Partenaire culturel</th>
+      {% else %}
+        <th scope="col">Id du Lieu</th>
+        <th scope="col">Lieu</th>
+      {% endif %}
       <th scope="col">Identifiant cinéma (Allociné)</th>
       <th scope="col">Identifiant interne Allociné</th>
     </tr>

--- a/api/src/pcapi/routes/backoffice/templates/pivots/get/boost.html
+++ b/api/src/pcapi/routes/backoffice/templates/pivots/get/boost.html
@@ -6,8 +6,13 @@
   <thead>
     <tr>
       <th scope="col"></th>
-      <th scope="col">Id du Lieu</th>
-      <th scope="col">Lieu</th>
+      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+        <th scope="col">Id du partenaire culturel</th>
+        <th scope="col">Partenaire culturel</th>
+      {% else %}
+        <th scope="col">Id du Lieu</th>
+        <th scope="col">Lieu</th>
+      {% endif %}
       <th scope="col">Identifiant cinéma (Boost)</th>
       <th scope="col">URL du cinéma (Boost)</th>
     </tr>

--- a/api/src/pcapi/routes/backoffice/templates/pivots/get/cgr.html
+++ b/api/src/pcapi/routes/backoffice/templates/pivots/get/cgr.html
@@ -6,8 +6,13 @@
   <thead>
     <tr>
       <th scope="col"></th>
-      <th scope="col">Id du Lieu</th>
-      <th scope="col">Lieu</th>
+      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+        <th scope="col">Id du partenaire culturel</th>
+        <th scope="col">Partenaire culturel</th>
+      {% else %}
+        <th scope="col">Id du Lieu</th>
+        <th scope="col">Lieu</th>
+      {% endif %}
       <th scope="col">Identifiant cinéma (CGR)</th>
       <th scope="col">URL du cinéma (CGR)</th>
     </tr>

--- a/api/src/pcapi/routes/backoffice/templates/pivots/get/cineoffice.html
+++ b/api/src/pcapi/routes/backoffice/templates/pivots/get/cineoffice.html
@@ -6,8 +6,13 @@
   <thead>
     <tr>
       <th scope="col"></th>
-      <th scope="col">Id du Lieu</th>
-      <th scope="col">Lieu</th>
+      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+        <th scope="col">Id du partenaire culturel</th>
+        <th scope="col">Partenaire culturel</th>
+      {% else %}
+        <th scope="col">Id du Lieu</th>
+        <th scope="col">Lieu</th>
+      {% endif %}
       <th scope="col">Identifiant cinéma (CDS)</th>
       <th scope="col">Nom de l'utilisateur (CDS)</th>
     </tr>

--- a/api/src/pcapi/routes/backoffice/templates/pivots/get/ems.html
+++ b/api/src/pcapi/routes/backoffice/templates/pivots/get/ems.html
@@ -6,8 +6,13 @@
   <thead>
     <tr>
       <th scope="col"></th>
-      <th scope="col">Id du Lieu</th>
-      <th scope="col">Lieu</th>
+      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+        <th scope="col">Id du partenaire culturel</th>
+        <th scope="col">Partenaire culturel</th>
+      {% else %}
+        <th scope="col">Id du Lieu</th>
+        <th scope="col">Lieu</th>
+      {% endif %}
       <th scope="col">Identifiant cinéma (EMS)</th>
       <th scope="col">Dernière synchronisation réussie</th>
     </tr>

--- a/api/src/pcapi/routes/backoffice/templates/pro/move_siret.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/move_siret.html
@@ -2,7 +2,15 @@
 {% extends "layouts/connected.html" %}
 {% block page %}
   <div class="pt-3 px-5">
-    <h2 class="fw-light">Déplacer un SIRET d’un lieu à un autre</h2>
+    <h2 class="fw-light">
+      Déplacer un SIRET d’un
+      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+        partenaire culturel
+      {% else %}
+        lieu
+      {% endif %}
+      à un autre
+    </h2>
     <div class="col-12 py-4">
       <form action="{{ dst }}" name={{ dst | action_to_name }} method="post">
         {{ build_form_fields_group(form) }}

--- a/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
@@ -1,9 +1,9 @@
 {% extends "layouts/connected.html" %}
-{% from "components/badges.html" import build_venue_badges %}
+{% from "components/badges.html" import build_venue_badges with context %}
 {% macro build_venue_card(venue, yearly_revenue) %}
   <div class="card">
     <div class="card-body">
-      <h5 class="mb-3">{{ build_venue_badges(venue, is_feature_active("WIP_ENABLE_OFFER_ADDRESS") ) }}</h5>
+      <h5 class="mb-3">{{ build_venue_badges(venue) }}</h5>
       <h5 class="card-title">{{ venue.name | upper }}</h5>
       <h6 class="card-subtitle mt-4 mb-3 text-muted">Venue ID : {{ venue.id }}</h6>
       <h6 class="card-subtitle mb-4 text-muted">SIRET : {{ venue.siret | empty_string_if_null }}</h6>
@@ -35,7 +35,15 @@
 {% endmacro %}
 {% block page %}
   <div class="pt-3 px-5">
-    <h2 class="fw-light">Déplacer un SIRET d’un lieu à un autre</h2>
+    <h2 class="fw-light">
+      Déplacer un SIRET d’un
+      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+        partenaire culturel
+      {% else %}
+        lieu
+      {% endif %}
+      à un autre
+    </h2>
     <div class="row mt-4">
       <div class="col-6">
         <p class="fw-bold">Source :</p>

--- a/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
@@ -3,7 +3,7 @@
 {% macro build_venue_card(venue, yearly_revenue) %}
   <div class="card">
     <div class="card-body">
-      <h5 class="mb-3">{{ build_venue_badges(venue) }}</h5>
+      <h5 class="mb-3">{{ build_venue_badges(venue, is_feature_active("WIP_ENABLE_OFFER_ADDRESS") ) }}</h5>
       <h5 class="card-title">{{ venue.name | upper }}</h5>
       <h6 class="card-subtitle mt-4 mb-3 text-muted">Venue ID : {{ venue.id }}</h6>
       <h6 class="card-subtitle mb-4 text-muted">SIRET : {{ venue.siret | empty_string_if_null }}</h6>

--- a/api/src/pcapi/routes/backoffice/templates/pro/search.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/search.html
@@ -12,7 +12,13 @@
     </div>
   {% endif %}
   {% call build_base_search() %}
-    Retrouve une structure ou un lieu par raison sociale, SIREN, SIRET,
+    Retrouve une structure ou un
+    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+      partenaire culturel
+    {% else %}
+      lieu
+    {% endif %}
+    par raison sociale, SIREN, SIRET,
     ID de son dossier DMS CB ou par l'identité du pro (nom, prénom,
     email rattaché au SIRET, numéro de téléphone).
   {% endcall %}

--- a/api/src/pcapi/routes/backoffice/templates/providers/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/providers/get.html
@@ -84,7 +84,15 @@
       </div>
       <div class="mt-4">
         {% call build_details_tabs_wrapper() %}
-          {{ build_details_tab("venues", "Lieux synchronisés", active_tab == 'venues') }}
+          {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+            {{ build_details_tab("venues", "Partenaires culturels synchronisés", active_tab == 'venues') }}
+          {% else %}
+            {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+              {{ build_details_tab("venues", "Partenaires culturels synchronisés", active_tab == 'venues') }}
+            {% else %}
+              {{ build_details_tab("venues", "Lieux synchronisés", active_tab == 'venues') }}
+            {% endif %}
+          {% endif %}
         {% endcall %}
         {% call build_details_tabs_content_wrapper() %}
           {% call build_details_tab_content("venues", active_tab == 'venues') %}

--- a/api/src/pcapi/routes/backoffice/templates/providers/get/stats.html
+++ b/api/src/pcapi/routes/backoffice/templates/providers/get/stats.html
@@ -5,13 +5,23 @@
       <div class="col-6">
         <h5 class="fs-2 card-title">{{ stats.active }}</h5>
         <p class="card-text fw-light small mb-0">
-          lieu{{ stats.active | pluralize('', 'x') }} avec une synchronisation <b>active</b>
+          {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+            partenaire{{ stats.active | pluralize('', 's') }} culturel{{ stats.active | pluralize('', 's') }}
+          {% else %}
+            lieu{{ stats.active | pluralize('', 'x') }}
+          {% endif %}
+          avec une synchronisation <b>active</b>
         </p>
       </div>
       <div class="col-6">
         <h5 class="fs-2 card-title">{{ stats.inactive }}</h5>
         <p class="card-text fw-light small mb-0">
-          lieu{{ stats.inactive | pluralize('', 'x') }} avec une synchronisation <b>inactive</b>
+          {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+            partenaire{{ stats.inactive | pluralize('', 's') }} culturel{{ stats.inactive | pluralize('', 's') }}
+          {% else %}
+            lieu{{ stats.inactive | pluralize('', 'x') }}
+          {% endif %}
+          avec une synchronisation <b>inactive</b>
         </p>
       </div>
     </div>

--- a/api/src/pcapi/routes/backoffice/templates/providers/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/providers/list.html
@@ -16,7 +16,13 @@
             <th scope="col"></th>
             <th scope="col">ID</th>
             <th scope="col">Partenaire technique</th>
-            <th scope="col">Lieux synchronisés au partenaire</th>
+            <th scope="col">
+              {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                Partenaires culturels synchronisés au partenaire
+              {% else %}
+                Lieux synchronisés au partenaire
+              {% endif %}
+            </th>
             <th scope="col">SIREN</th>
             <th scope="col">Ville</th>
             <th scope="col">Code postal</th>

--- a/api/src/pcapi/routes/backoffice/templates/tags/list_tags.html
+++ b/api/src/pcapi/routes/backoffice/templates/tags/list_tags.html
@@ -6,7 +6,14 @@
 {% extends "layouts/connected.html" %}
 {% block page %}
   <div class="pt-3 px-5">
-    <h2 class="fw-light">Tags offres et lieux</h2>
+    <h2 class="fw-light">
+      Tags offres et
+      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+        partenaires culturels
+      {% else %}
+        lieux
+      {% endif %}
+    </h2>
     <div class="mt-4">
       {% call tabs.build_details_tabs_wrapper() %}
         {{ tabs.build_details_tab("tags", "Tags", active_tab == 'tags') }}
@@ -15,10 +22,17 @@
       {% call tabs.build_details_tabs_content_wrapper() %}
         {% call tabs.build_details_tab_content("tags", active_tab == 'tags') %}
           {% if has_permission("MANAGE_OFFERS_AND_VENUES_TAGS") %}
-            <button class="btn btn-outline-primary lead fw-bold my-2"
-                    data-bs-toggle="modal"
-                    data-bs-target="#create-offer-venue-tag"
-                    type="button">Créer un tag offres et lieux</button>
+            {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+              <button class="btn btn-outline-primary lead fw-bold my-2"
+                      data-bs-toggle="modal"
+                      data-bs-target="#create-offer-venue-tag"
+                      type="button">Créer un tag offres et partenaires culturels</button>
+            {% else %}
+              <button class="btn btn-outline-primary lead fw-bold my-2"
+                      data-bs-toggle="modal"
+                      data-bs-target="#create-offer-venue-tag"
+                      type="button">Créer un tag offres et lieux</button>
+            {% endif %}
             {{ build_lazy_modal(url_for("backoffice_web.tags.get_create_tag_form") , "create-offer-venue-tag") }}
           {% endif %}
           <div class="mt-4">

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -21,7 +21,7 @@
             <h2 class="card-title text-primary">
               {{ links.build_venue_name_to_pc_pro_link(venue, is_feature_active("WIP_CONNECT_AS_EXTENDED") , has_permission("MANAGE_PRO_ENTITY"), public_name=false) }}
             </h2>
-            <span class="fs-5 ps-4">{{ build_venue_badges(venue) }}</span>
+            <span class="fs-5 ps-4">{{ build_venue_badges(venue, is_feature_active("WIP_ENABLE_OFFER_ADDRESS") ) }}</span>
             <div class="d-flex row-reverse justify-content-end flex-grow-1">
               {% if has_permission("MANAGE_PRO_ENTITY") and has_active_provider %}
                 {% set fully_sync_venue_modal_label_id = random_hash() %}

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -1,5 +1,5 @@
 {% import "components/clipboard.html" as clipboard %}
-{% from "components/badges.html" import build_venue_badges %}
+{% from "components/badges.html" import build_venue_badges with context %}
 {% from "components/forms.html" import build_form_fields_group with context %}
 {% from "components/generic_modal.html" import build_modal_form with context %}
 {% import "components/links.html" as links %}
@@ -21,7 +21,7 @@
             <h2 class="card-title text-primary">
               {{ links.build_venue_name_to_pc_pro_link(venue, is_feature_active("WIP_CONNECT_AS_EXTENDED") , has_permission("MANAGE_PRO_ENTITY"), public_name=false) }}
             </h2>
-            <span class="fs-5 ps-4">{{ build_venue_badges(venue, is_feature_active("WIP_ENABLE_OFFER_ADDRESS") ) }}</span>
+            <span class="fs-5 ps-4">{{ build_venue_badges(venue) }}</span>
             <div class="d-flex row-reverse justify-content-end flex-grow-1">
               {% if has_permission("MANAGE_PRO_ENTITY") and has_active_provider %}
                 {% set fully_sync_venue_modal_label_id = random_hash() %}
@@ -41,11 +41,25 @@
                             data-turbo="false">
                         <div class="modal-header"
                              id="fully-sync-venue-modal-label">
-                          <h5 class="modal-title">Resynchroniser toutes les offres du lieu {{ venue.common_name }}</h5>
+                          <h5 class="modal-title">
+                            Resynchroniser toutes les offres du
+                            {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                              partenaire culturel
+                            {% else %}
+                              lieu
+                            {% endif %}
+                            {{ venue.common_name }}
+                          </h5>
                         </div>
                         <div class="modal-body row">
                           <p>
-                            Tous les stocks des offres du lieu <strong>{{ venue.common_name }} ({{ venue.id }})</strong>
+                            Tous les stocks des offres du
+                            {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                              partenaire culturel
+                            {% else %}
+                              lieu
+                            {% endif %}
+                            <strong>{{ venue.common_name }} ({{ venue.id }})</strong>
                             seront synchronisés depuis le provider. Les stocks existants seront remplacés.
                           </p>
                           <p>
@@ -66,12 +80,21 @@
                 </div>
               {% endif %}
               {% if has_permission("MANAGE_PRO_ENTITY") %}
-                {{ build_modal_form("edit-venue", url_for("backoffice_web.venue.update_venue", venue_id=venue.id) , edit_venue_form, "Modifier les informations", "Modifier les informations du lieu", "Enregistrer") }}
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  {{ build_modal_form("edit-venue", url_for("backoffice_web.venue.update_venue", venue_id=venue.id) , edit_venue_form, "Modifier les informations", "Modifier les informations du partenaire culturel", "Enregistrer") }}
+                {% else %}
+                  {{ build_modal_form("edit-venue", url_for("backoffice_web.venue.update_venue", venue_id=venue.id) , edit_venue_form, "Modifier les informations", "Modifier les informations du lieu", "Enregistrer") }}
+                {% endif %}
               {% endif %}
               {% if has_permission("DELETE_PRO_ENTITY") %}
                 {% set delete_venue_modal_label_id = random_hash() %}
-                {% set form_description = "Le lieu <strong>"|safe + venue.common_name + "</strong> ("|safe + venue.id|string + ") sera définitivement supprimé de la base de données. Veuillez confirmer ce choix." %}
-                {{ build_modal_form("delete-venue", url_for("backoffice_web.venue.delete_venue", venue_id=venue.id) , delete_form, "Supprimer le lieu", "Supprimer le lieu " + venue.common_name, "Confirmer", form_description, "bi-trash3-fill") }}
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  {% set form_description = "Le partenaire culturel <strong>"|safe + venue.common_name + "</strong> ("|safe + venue.id|string + ") sera définitivement supprimé de la base de données. Veuillez confirmer ce choix." %}
+                  {{ build_modal_form("delete-venue", url_for("backoffice_web.venue.delete_venue", venue_id=venue.id) , delete_form, "Supprimer le partenaire culturel", "Supprimer le partenaire culturel " + venue.common_name, "Confirmer", form_description, "bi-trash3-fill") }}
+                {% else %}
+                  {% set form_description = "Le lieu <strong>"|safe + venue.common_name + "</strong> ("|safe + venue.id|string + ") sera définitivement supprimé de la base de données. Veuillez confirmer ce choix." %}
+                  {{ build_modal_form("delete-venue", url_for("backoffice_web.venue.delete_venue", venue_id=venue.id) , delete_form, "Supprimer le lieu", "Supprimer le lieu " + venue.common_name, "Confirmer", form_description, "bi-trash3-fill") }}
+                {% endif %}
               {% endif %}
             </div>
           </div>
@@ -79,12 +102,22 @@
             <p class="card-subtitle text-muted mb-3 h5">Nom d'usage : {{ venue.publicName }}</p>
           {% endif %}
           <p class="card-subtitle text-muted mb-3 h5">
-            Venue ID : {{ venue.id }} {{ clipboard.copy_to_clipboard(venue.id, "Copier l'ID du lieu") }}
+            {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+              Venue ID : {{ venue.id }} {{ clipboard.copy_to_clipboard(venue.id, "Copier l'ID du partenaire culturel") }}
+            {% else %}
+              Venue ID : {{ venue.id }} {{ clipboard.copy_to_clipboard(venue.id, "Copier l'ID du lieu") }}
+            {% endif %}
           </p>
           <p class="card-subtitle text-muted mb-3 h5">
             SIRET : {{ links.build_siret_to_external_link(venue) }}
             {% if venue.siret %}
-              <span class="ms-1 link-primary">{{ clipboard.copy_to_clipboard(venue.siret, "Copier le SIRET du lieu") }}</span>
+              <span class="ms-1 link-primary">
+                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                  {{ clipboard.copy_to_clipboard(venue.siret, "Copier le SIRET du partenaire culturel") }}
+                {% else %}
+                  {{ clipboard.copy_to_clipboard(venue.siret, "Copier le SIRET du lieu") }}
+                {% endif %}
+              </span>
             {% endif %}
             {% if venue.siret and has_permission("MOVE_SIRET") %}
               <button class="btn btn-link lead fw-bold mx-0 my-0 py-0"
@@ -193,7 +226,13 @@
                   {% elif venue.accessibilityProvider.externalAccessibilityId and not venue.accessibilityProvider.externalAccessibilityUrl %}
                     Attention, l'URL pour l'identifiant Acceslibre <i>{{ venue.accessibilityProvider.externalAccessibilityId }}</i> n'est pas renseignée
                   {% elif not venue.accessibilityProvider.externalAccessibilityId and not venue.accessibilityProvider.externalAccessibilityUrl %}
-                    Attention, l'URL et l'identifiant Acceslibre ne sont pas renseignés alors que le lieu est synchronisé
+                    Attention, l'URL et l'identifiant Acceslibre ne sont pas renseignés alors que le
+                    {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                      partenaire culturel
+                    {% else %}
+                      lieu
+                    {% endif %}
+                    est synchronisé
                   {% endif %}
                 </p>
               {% endif %}
@@ -228,12 +267,19 @@
                                 data-turbo="false">
                             <div class="modal-header"
                                  id="delete-venue-provider-modal-label">
-                              <h5 class="modal-title">Supprimer le lien entre le lieu {{ venue.common_name }} et le provider {{ venue_provider.provider.name }}</h5>
+                              <h5 class="modal-title">
+                                Supprimer le lien entre le
+                                {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                                  partenaire culturel
+                                {% else %}
+                                  lieu
+                                {% endif %}
+                                {{ venue.common_name }} et le provider {{ venue_provider.provider.name }}
+                              </h5>
                             </div>
                             <div class="modal-body row">
                               <p>
-                                Le lieu lien entre <strong>{{ venue.common_name }}</strong> et <strong>{{ venue_provider.provider.name }}</strong> sera définitivement supprimé
-                                de la base de données. Veuillez confirmer ce choix.
+                                Le lien entre <strong>{{ venue.common_name }}</strong> et <strong>{{ venue_provider.provider.name }}</strong> sera définitivement supprimé                                de la base de données. Veuillez confirmer ce choix.
                               </p>
                               {{ build_form_fields_group(delete_form) }}
                             </div>
@@ -304,7 +350,15 @@
                           {{ zendesk_sell_synchronisation_form.csrf_token }}
                           <div class="modal-header"
                                id="{{ sync_zsell_aria_described_by_id }}">
-                            <h5 class="modal-title">Synchroniser le lieu {{ venue.common_name }} sur Zendesk Sell</h5>
+                            <h5 class="modal-title">
+                              Synchroniser le
+                              {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                                partenaire culturel
+                              {% else %}
+                                lieu
+                              {% endif %}
+                              {{ venue.common_name }} sur Zendesk Sell
+                            </h5>
                           </div>
                           <div class="modal-body row">
                             <div class="d-flex align-items-center">

--- a/api/src/pcapi/routes/backoffice/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/list.html
@@ -5,7 +5,16 @@
 {% set can_edit = has_permission("MANAGE_PRO_ENTITY") %}
 {% block page %}
   <div class="pt-3 px-5">
-    <h2 class="fw-light">Actions sur les lieux</h2>
+    <h2 class="fw-light">
+      Actions sur les
+      <th scope="col">
+        {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+          partenaires culturels
+        {% else %}
+          lieux
+        {% endif %}
+      </th>
+    </h2>
     {{ build_filters_form(form, dst) }}
     <div>
       {% if rows %}
@@ -20,13 +29,23 @@
                  data-toggle-id="table-container-venues-edit-btn-group"
                  data-pc-table-multi-select-id="table-venues-multiselect"
                  data-input-ids-name="object_ids">
-              <button disabled
-                      type="button"
-                      class="btn btn-outline-primary"
-                      data-modal-selector="#batch-edit-venues-modal"
-                      data-mode="fetch"
-                      data-fetch-url="{{ url_for('backoffice_web.venue.get_batch_edit_venues_form') }}"
-                      data-use-confirmation-modal="true">Éditer les lieux</button>
+              {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                <button disabled
+                        type="button"
+                        class="btn btn-outline-primary"
+                        data-modal-selector="#batch-edit-venues-modal"
+                        data-mode="fetch"
+                        data-fetch-url="{{ url_for("backoffice_web.venue.get_batch_edit_venues_form") }}"
+                        data-use-confirmation-modal="true">Éditer les partenaires culturels</button>
+              {% else %}
+                <button disabled
+                        type="button"
+                        class="btn btn-outline-primary"
+                        data-modal-selector="#batch-edit-venues-modal"
+                        data-mode="fetch"
+                        data-fetch-url="{{ url_for("backoffice_web.venue.get_batch_edit_venues_form") }}"
+                        data-use-confirmation-modal="true">Éditer les lieux</button>
+              {% endif %}
             </div>
           {% endif %}
         </div>
@@ -45,7 +64,7 @@
               <th scope="col">Nom</th>
               <th scope="col">Nom d'usage</th>
               <th scope="col">Structure</th>
-              <th scope="col">Lieu permanent</th>
+              <th scope="col">Permanent</th>
               <th scope="col">Label</th>
               <th scope="col">Tags</th>
               <th scope="col">
@@ -78,7 +97,15 @@
                 <td>{{ venue.publicName | empty_string_if_null }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(venue.managingOfferer) }}</td>
                 <td>
-                  {% if venue.isPermanent %}<span class="visually-hidden">Lieu permanent</span><i class="bi bi-check-circle-fill"></i>{% endif %}
+                  {% if venue.isPermanent %}
+                    <span class="visually-hidden">
+                      {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
+                        Partenaire culturel permanent
+                      {% else %}
+                        Lieu permanent
+                      {% endif %}
+                    </span><i class="bi bi-check-circle-fill"></i>
+                  {% endif %}
                 </td>
                 <td>{{ venue.venueLabel.label }}</td>
                 <td>{{ venue.criteria | format_criteria | safe }}</td>

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -140,8 +140,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
     endpoint = "backoffice_web.public_accounts.search_public_accounts"
     needed_permission = perm_models.Permissions.READ_PUBLIC_ACCOUNT
 
-    # session + current user
-    expected_num_queries_when_no_query = 2
+    # session + current user + WIP_ENABLE_OFFER_ADDRESS
+    expected_num_queries_when_no_query = 3
 
     # + results + count
     expected_num_queries = expected_num_queries_when_no_query + 2
@@ -166,7 +166,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
         underage, _, _, _, _ = create_bunch_of_accounts()
         user_id = underage.id
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=str(user_id)))
             assert response.status_code == 303
 
@@ -221,7 +222,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
     def test_can_search_public_account_by_first_name(self, authenticated_client, query, expected_index):
         accounts = create_bunch_of_accounts()
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=query))
             assert response.status_code == 303
 
@@ -239,7 +241,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
     def test_can_search_public_account_by_name(self, authenticated_client, query):
         _, _, _, random, _ = create_bunch_of_accounts()
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=query))
             assert response.status_code == 303
 
@@ -257,7 +260,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
         _, _, _, random, _ = create_bunch_of_accounts()
         email = random.email
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=email))
             assert response.status_code == 303
 
@@ -301,7 +305,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
     def test_can_search_public_account_by_phone(self, authenticated_client, query):
         _, grant_18, _, _, _ = create_bunch_of_accounts()
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=query))
             assert response.status_code == 303
 
@@ -319,7 +324,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
         _, _, _, _, no_address = create_bunch_of_accounts()
         phone_number = no_address.phoneNumber
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=phone_number))
             assert response.status_code == 303
 
@@ -337,7 +343,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
     def test_can_search_public_account_by_both_first_name_and_name(self, authenticated_client, query):
         _, grant_18, _, _, _ = create_bunch_of_accounts()
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=query))
             assert response.status_code == 303
 
@@ -400,7 +407,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
         offerers_factories.UserOffererFactory(user=young_and_pro)
         email = young_and_pro.email
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=email))
             assert response.status_code == 303
 
@@ -468,7 +476,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
         db.session.flush()
 
         # Ensure that search result is redirected, no single card result with "4 résultats"
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=email))
             assert response.status_code == 303
 
@@ -489,7 +498,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
 
         db.session.flush()
 
-        with assert_num_queries(self.expected_num_queries_when_old_email_and_single_result):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries_when_old_email_and_single_result - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=old_email))
             assert response.status_code == 303
 
@@ -521,7 +531,8 @@ class SearchPublicAccountsTest(search_helpers.SearchHelper, GetEndpointHelper):
         public_user = users_factories.UserFactory(lastName=common_name)
         suspended_user = users_factories.BeneficiaryGrant18Factory(lastName=common_name, isActive=False)
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=common_name, filter=search_filter))
             assert response.status_code == 303
 

--- a/api/tests/routes/backoffice/admin_test.py
+++ b/api/tests/routes/backoffice/admin_test.py
@@ -31,8 +31,8 @@ class GetRolesTest(GetEndpointHelper):
     endpoint = "backoffice_web.get_roles"
     needed_permission = perm_models.Permissions.MANAGE_PERMISSIONS
 
-    # session + current user + roles + permissions
-    expected_num_queries = 4
+    # session + current user + roles + permissions + WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 5
 
     def test_can_list_roles_and_permissions(self, authenticated_client):
         perm_factories.RoleFactory(name="test_role_1")
@@ -212,7 +212,7 @@ class GetRolesHistoryTest(GetEndpointHelper):
 class ListFeatureFlagsTest(GetEndpointWithoutPermissionHelper):
     endpoint = "backoffice_web.list_feature_flags"
 
-    # user + session + list of feature flags
+    # user + session + list of feature flags + WIP_ENABLE_OFFER_ADDRESS FF
     expected_num_queries = 3
 
     def test_list_feature_flags(self, authenticated_client):
@@ -220,7 +220,8 @@ class ListFeatureFlagsTest(GetEndpointWithoutPermissionHelper):
         first_feature_flag.isActive = True
         db.session.flush()
 
-        with assert_num_queries(self.expected_num_queries):
+        # +1 for WIP_ENABLE_OFFER_ADDRESS FF in templates
+        with assert_num_queries(self.expected_num_queries + 1):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -232,7 +233,8 @@ class ListFeatureFlagsTest(GetEndpointWithoutPermissionHelper):
         first_feature_flag.isActive = False
         db.session.flush()
 
-        with assert_num_queries(self.expected_num_queries):
+        # +1 for WIP_ENABLE_OFFER_ADDRESS FF in templates
+        with assert_num_queries(self.expected_num_queries + 1):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -324,7 +326,8 @@ class SearchBoUsersTest(GetEndpointHelper):
     # - fetch authenticated user
     # - fetch results
     # - fetch count for pagination
-    expected_num_queries = 4
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 5
 
     def test_search_without_filter(self, authenticated_client, legit_user):
         user1 = users_factories.AdminFactory()
@@ -397,7 +400,7 @@ class SearchBoUsersTest(GetEndpointHelper):
         assert_user_equals(cards_text[0], users[0])
 
     def test_search_invalid(self, authenticated_client):
-        with assert_num_queries(2):  # only session + current user
+        with assert_num_queries(3):  # only session + current user + WIP_ENABLE_OFFER_ADDRESS FF
             response = authenticated_client.get(url_for(self.endpoint, q="%"))
             assert response.status_code == 400
 

--- a/api/tests/routes/backoffice/bank_account_test.py
+++ b/api/tests/routes/backoffice/bank_account_test.py
@@ -168,14 +168,16 @@ class GetBankAccountHistoryTest(GetEndpointHelper):
 
     # - session + authenticated user (2 queries)
     # - full history with joined data (1 query)
-    expected_num_queries = 3
+    # - WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 4
 
     def test_no_action(self, authenticated_client):
         bank_account = finance_factories.BankAccountFactory()
 
         url = url_for(self.endpoint, bank_account_id=bank_account.id)
 
-        with assert_num_queries(self.expected_num_queries):
+        # no WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/bank_account_test.py
+++ b/api/tests/routes/backoffice/bank_account_test.py
@@ -35,7 +35,8 @@ class GetBankAccountTest(GetEndpointHelper):
     # get session (1 query)
     # get user with profile and permissions (1 query)
     # get bank_account (1 query)
-    expected_num_queries = 3
+    # get the features WIP_ENABLE_OFFER_ADDRESS (1 query)
+    expected_num_queries = 4
 
     @mock.patch("pcapi.routes.backoffice.bank_account.blueprint.dms_api.get_dms_stats", lambda x: None)
     def test_get_bank_account(self, authenticated_client):

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -96,11 +96,11 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
     # - fetch session (1 query)
     # - fetch user (1 query)
     # - fetch collective bookings with extra data (1 query)
-    # - check finance incident feature flag
+    # - check finance incident or offer address feature flag
     expected_num_queries = 4
 
     def test_list_bookings_without_filter(self, authenticated_client, collective_bookings):
-        with assert_num_queries(self.expected_num_queries - 2):
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -270,7 +270,7 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
 
     def test_list_bookings_by_id_not_found(self, authenticated_client, collective_bookings):
         search_query = str(collective_bookings[-1].id * 1000)
-        with assert_num_queries(self.expected_num_queries - 1):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, q=search_query))
             assert response.status_code == 200
 
@@ -400,7 +400,7 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
         authenticated_client,
         collective_bookings,
     ):
-        with assert_num_queries(2):  # user_session + user
+        with assert_num_queries(3):  # user_session + user + offer address FF
             response = authenticated_client.get(
                 url_for(
                     self.endpoint,

--- a/api/tests/routes/backoffice/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice/collective_offer_templates_test.py
@@ -65,7 +65,8 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
     expected_num_queries = expected_num_queries_when_no_query + 2
 
     def test_list_collective_offer_templates_without_filter(self, authenticated_client, collective_offer_templates):
-        with assert_num_queries(self.expected_num_queries_when_no_query):
+        # +1 for WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(self.expected_num_queries_when_no_query + 1):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -281,7 +282,8 @@ class GetCollectiveOfferTemplateDetailTest(GetEndpointHelper):
             formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
         )
         url = url_for(self.endpoint, collective_offer_template_id=collectiveOfferTemplate.id)
-        with assert_num_queries(self.expected_num_queries):
+        # +1 query WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(self.expected_num_queries + 1):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -99,7 +99,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
         }
 
     def test_list_collective_offers_without_filter(self, authenticated_client, collective_offers):
-        with assert_num_queries(self.expected_num_queries - 2):
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -381,7 +381,9 @@ class ListCollectiveOffersTest(GetEndpointHelper):
         }
 
         # no connect as extended FF fetch if no offers
-        expected_num_queries = self.expected_num_queries if expected_offer_indexes else self.expected_num_queries - 1
+        # uncomment below once WIP_ENABLE_OFFER_ADDRESS FF is cleaned
+        # expected_num_queries = self.expected_num_queries if expected_offer_indexes else self.expected_num_queries - 1
+        expected_num_queries = self.expected_num_queries
         with assert_num_queries(expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 200
@@ -413,7 +415,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             "search-3-price": 21.20,
         }
 
-        with assert_num_queries(self.expected_num_queries - 1):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 200
 
@@ -655,7 +657,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             "search-0-operator": "INTERSECTS",
             "search-0-formats": [subcategories.EacFormat.PROJECTION_AUDIOVISUELLE.name],
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user + FF, before form validation
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -676,7 +678,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             "search-0-operator": operator,
             f"search-0-{operand}": "",
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user, before form validation + FF
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -692,7 +694,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             "search-4-search_field": "BOOKING_LIMIT_DATE",
             "search-4-operator": "DATE_TO",
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user + FF, before form validation
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -707,7 +709,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             "search-0-operator": "EQUALS",
             "search-0-string": "12, 34, A",
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user + FF, before form validation
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -1017,7 +1019,8 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
     # - fetch user (1 query)
     # - fetch CollectiveOffer
     # - _is_collective_offer_price_editable
-    expected_num_queries = 4
+    # - WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 5
 
     def test_nominal(self, legit_user, authenticated_client):
         start_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
@@ -1088,7 +1091,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         url = url_for(self.endpoint, collective_offer_id=pricing.collectiveBooking.collectiveStock.collectiveOffer.id)
         app.redis_client.set(finance_conf.REDIS_GENERATE_CASHFLOW_LOCK, "1", 600)
         try:
-            with assert_num_queries(3):
+            with assert_num_queries(4):
                 response = authenticated_client.get(url)
                 assert response.status_code == 200
         finally:

--- a/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
@@ -149,7 +149,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
     def test_list_rules_by_id_not_found(self, authenticated_client):
         rules = finance_factories.CustomReimbursementRuleFactory.create_batch(5)
         search_query = str(rules[-1].id * 1000)
-        with assert_num_queries(self.expected_num_queries - 1):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, q=search_query))
             assert response.status_code == 200
 
@@ -608,7 +608,8 @@ class GetReimburementStatsTest(GetEndpointHelper):
     # - fetch session (1 query)
     # - fetch user (1 query)
     # - fetch custom reimbursement rules statistics (1 query)
-    expected_num_queries = 3
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 4
 
     def test_get_data(self, authenticated_client):
         finance_factories.CustomReimbursementRuleFactory.create_batch(4, offerer=offerers_factories.OffererFactory())

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -132,7 +132,8 @@ class ListIncidentsTest(GetEndpointHelper):
     # Fetch Session
     # Fetch User
     # Fetch Finance Incidents
-    expected_num_queries = 3
+    # Fetch FF
+    expected_num_queries = 4
 
     def test_list_incidents_without_filter(self, authenticated_client):
         partial_booking_incident = finance_factories.IndividualBookingFinanceIncidentFactory(newTotalAmount=8.10)
@@ -331,6 +332,7 @@ class GetIncidentValidationFormTest(GetEndpointHelper):
 
     expected_num_queries = 2
     expected_num_queries += 1  # get incident info
+    expected_num_queries += 1  # get WIP_ENABLE_OFFER_ADDRESS FF
 
     def test_get_incident_validation_form(self, authenticated_client):
         booking_incident = finance_factories.IndividualBookingFinanceIncidentFactory()
@@ -1142,7 +1144,7 @@ class GetCommercialGestureTest(GetEndpointHelper):
         offerers_factories.VenueBankAccountLinkFactory(venue=finance_incident.venue, bankAccount=bank_account)
         url = url_for(self.endpoint, finance_incident_id=finance_incident.id)
 
-        with assert_num_queries(self.expected_num_queries - 1):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1230,7 +1232,7 @@ class GetOverpaymentCreationFormTest(PostEndpointHelper):
     endpoint = "backoffice_web.finance_incidents.get_individual_bookings_overpayment_creation_form"
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
-    expected_num_queries = 7
+    expected_num_queries = 8
 
     def test_get_overpayment_creation_for_one_booking_form(self, authenticated_client, invoiced_pricing):
         venue = offerers_factories.VenueFactory()
@@ -1239,7 +1241,8 @@ class GetOverpaymentCreationFormTest(PostEndpointHelper):
         booking = bookings_factories.ReimbursedBookingFactory(stock=stock, pricings=[invoiced_pricing])
         object_ids = str(booking.id)
 
-        with assert_num_queries(self.expected_num_queries):
+        # +1 fetch the WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(self.expected_num_queries + 1):
             response = self.post_to_endpoint(authenticated_client, form={"object_ids": object_ids})
             assert response.status_code == 200
 
@@ -1270,7 +1273,8 @@ class GetOverpaymentCreationFormTest(PostEndpointHelper):
         ]
         object_ids = ",".join([str(booking.id) for booking in selected_bookings])
 
-        with assert_num_queries(self.expected_num_queries):
+        # +1 fetch the WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(self.expected_num_queries + 1):
             response = self.post_to_endpoint(authenticated_client, form={"object_ids": object_ids})
             assert response.status_code == 200
 
@@ -1305,7 +1309,8 @@ class GetOverpaymentCreationFormTest(PostEndpointHelper):
         # don't query the number of BookingFinanceIncident with FinanceIncident's status in
         # (CREATED, VALIDATED)
         # but adds 1 query for rollback
-        with assert_num_queries(self.expected_num_queries):
+        # extra query for WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(self.expected_num_queries + 1):
             response = self.post_to_endpoint(authenticated_client, form={"object_ids": object_ids})
 
         assert (
@@ -1319,7 +1324,7 @@ class GetCollectiveBookingOverpaymentFormTest(PostEndpointHelper):
     endpoint_kwargs = {"collective_booking_id": 1}
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
-    expected_num_queries = 10
+    expected_num_queries = 11
 
     def test_get_form(self, authenticated_client, invoiced_collective_pricing):
         collective_booking = educational_factories.ReimbursedCollectiveBookingFactory(
@@ -1468,7 +1473,7 @@ class GetCommercialGestureCreationFormTest(PostEndpointHelper):
     endpoint = "backoffice_web.finance_incidents.get_individual_bookings_commercial_gesture_creation_form"
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
-    expected_num_queries = 7
+    expected_num_queries = 8
 
     def test_get_commercial_gesture_creation_for_one_booking_form(self, authenticated_client):
         venue = offerers_factories.VenueFactory(name="Etablissement")
@@ -1486,7 +1491,8 @@ class GetCommercialGestureCreationFormTest(PostEndpointHelper):
         )
         object_ids = str(booking.id)
 
-        with assert_num_queries(self.expected_num_queries):
+        # +1 fetch the WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(self.expected_num_queries + 1):
             response = self.post_to_endpoint(authenticated_client, form={"object_ids": object_ids})
             assert response.status_code == 200
 
@@ -1521,7 +1527,8 @@ class GetCommercialGestureCreationFormTest(PostEndpointHelper):
         )
         object_ids = f"{booking1.id},{booking2.id}"
 
-        with assert_num_queries(self.expected_num_queries):
+        # +1 fetch the WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(self.expected_num_queries + 1):
             response = self.post_to_endpoint(authenticated_client, form={"object_ids": object_ids})
             assert response.status_code == 200
 
@@ -1805,7 +1812,8 @@ class GetInvoiceGenerationTest(GetEndpointHelper):
     # Fetch Session
     # Fetch User
     # Fetch CashflowBatches
-    expected_num_queries = 3
+    # Fetch WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 4
 
     @pytest.mark.parametrize(
         "last_cashflow_status,is_queue_empty,expected_texts,unexpected_texts",

--- a/api/tests/routes/backoffice/fraud_test.py
+++ b/api/tests/routes/backoffice/fraud_test.py
@@ -46,7 +46,8 @@ class ListBlacklistedDomainNamesTest(GetEndpointHelper):
         # get user with profile and permissions (1 query)
         # get history (1 query)
         # get blacklisted domains (1 query)
-        with assert_num_queries(4):
+        # WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(5):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -71,7 +72,8 @@ class PrepareBlacklistDomainNamesTest(GetEndpointHelper):
         # get user with profile and permissions (1 query)
         # get beneficiary emails (1 query)
         # get pro users emails (1 query)
-        with assert_num_queries(4):
+        # WIP_ENABLE_OFFER_ADDRESS FF
+        with assert_num_queries(5):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/home_test.py
+++ b/api/tests/routes/backoffice/home_test.py
@@ -20,7 +20,8 @@ class HomePageTest:
     # - session
     # - authenticated user
     # - data inserted in cards (stats got in a single request)
-    expected_num_queries = 3
+    # - WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 4
 
     def test_view_home_page_as_anonymous(self, client):
         response = client.get(url_for("backoffice_web.home"))

--- a/api/tests/routes/backoffice/multiple_offers_test.py
+++ b/api/tests/routes/backoffice/multiple_offers_test.py
@@ -44,7 +44,7 @@ class MultipleOffersHomeTest(GetEndpointHelper):
     needed_permission = perm_models.Permissions.READ_OFFERS
 
     def test_get_search_form(self, authenticated_client):
-        with assert_num_queries(2):
+        with assert_num_queries(3):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -58,7 +58,8 @@ class SearchMultipleOffersTest(GetEndpointHelper):
     # - fetch user (1 query)
     # - fetch unique product (1 query)
     # - fetch offers with joinedload including extra data (1 query)
-    expected_num_queries = 4
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 5
 
     def test_search_product_with_offers(self, authenticated_client):
         provider = providers_factories.APIProviderFactory()
@@ -230,7 +231,7 @@ class SearchMultipleOffersTest(GetEndpointHelper):
         assert "Tag des offres ⚠️ 3 offres actives associées à cet EAN-13 seront affectées" in right_card
 
     def test_search_product_from_ean_with_invalid_ean(self, authenticated_client):
-        with assert_num_queries(2):
+        with assert_num_queries(3):
             response = authenticated_client.get(url_for(self.endpoint, ean="978-3-16-14840-0"))
             assert response.status_code == 400
 

--- a/api/tests/routes/backoffice/offer_price_limitation_rules_test.py
+++ b/api/tests/routes/backoffice/offer_price_limitation_rules_test.py
@@ -38,8 +38,8 @@ class ListRulesTest(GetEndpointHelper):
     endpoint = "backoffice_web.offer_price_limitation_rules.list_rules"
     needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
-    # session + current_user + rules
-    expected_num_queries = 3
+    # session + current_user + rules + WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 4
 
     def test_list_rules(self, authenticated_client, offer_price_limitation_rules):
 

--- a/api/tests/routes/backoffice/offer_validation_rules_test.py
+++ b/api/tests/routes/backoffice/offer_validation_rules_test.py
@@ -41,8 +41,8 @@ class ListRulesTest(GetEndpointHelper):
     endpoint = "backoffice_web.offer_validation_rules.list_rules"
     needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
-    # session + current_user
-    expected_num_queries = 3
+    # session + current_user + WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 4
     # offerer names and siren
     expected_num_queries_when_using_offerer = expected_num_queries + 1
     # venue names and siret
@@ -337,7 +337,7 @@ class GetCreateOfferValidationRuleFormTest(GetEndpointHelper):
     def test_get_create_form_test(self, legit_user, authenticated_client):
         form_url = url_for(self.endpoint)
 
-        with assert_num_queries(2):  # session + current user
+        with assert_num_queries(3):  # session + current user + WIP_ENABLE_OFFER_ADDRESS FF
             response = authenticated_client.get(form_url)
             assert response.status_code == 200
 
@@ -827,7 +827,7 @@ class GetEditOfferValidationRuleFormTest(GetEndpointHelper):
         )
         form_url = url_for(self.endpoint, rule_id=rule.id)
 
-        with assert_num_queries(4):  # session + current user + rule + sub rule
+        with assert_num_queries(5):  # session + current user + rule + sub rule + WIP_ENABLE_OFFER_ADDRESS FF
             response = authenticated_client.get(form_url)
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -1661,7 +1661,8 @@ class GetOffererCollectiveDmsApplicationsTest(GetEndpointHelper):
 
     # - session + authenticated user (2 queries)
     # - dms applications with joined data (1 query)
-    expected_num_queries = 3
+    # - WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+    expected_num_queries = 4
 
     def test_get_collective_dms_applications(self, authenticated_client):
         offerer = offerers_factories.OffererFactory(siren="123456789")
@@ -1840,7 +1841,8 @@ class ListOfferersToValidateTest(GetEndpointHelper):
         # - session + authenticated user (2 queries)
         # - validation status count (1 query)
         # - offerer tags filter (1 query)
-        expected_num_queries_when_no_query = 4
+        # - WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+        expected_num_queries_when_no_query = 5
         # - get results (1 query)
         # - get results count (1 query)
         expected_num_queries = expected_num_queries_when_no_query + 2
@@ -2839,7 +2841,8 @@ class ListUserOffererToValidateTest(GetEndpointHelper):
 
     # - session + authenticated user (2 queries)
     # - offerer tags filter (1 query)
-    expected_num_queries_when_no_query = 3
+    # - WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+    expected_num_queries_when_no_query = 4
     # - get results (1 query)
     # - get results count (1 query)
     expected_num_queries = expected_num_queries_when_no_query + 2
@@ -3787,7 +3790,8 @@ class ListOffererTagsTest(GetEndpointHelper):
     # - fetch session (1 query)
     # - fetch user (1 query)
     # - fetch categories and tags (2 queries)
-    expected_num_queries = 4
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 5
 
     def test_list_offerer_tags(self, authenticated_client):
         category = offerers_factories.OffererTagCategoryFactory(label="indépendant")

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -129,7 +129,7 @@ class ListOffersTest(GetEndpointHelper):
 
     def test_list_offers_without_filter(self, authenticated_client, offers):
         # no filter => no query to fetch offers
-        with assert_num_queries(self.expected_num_queries - 2):
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -531,7 +531,7 @@ class ListOffersTest(GetEndpointHelper):
             "search-3-operator": "GREATER_THAN_OR_EQUAL_TO",
             "search-3-price": 120000.20,
         }
-        with assert_num_queries(self.expected_num_queries - 1):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 200
 
@@ -880,7 +880,7 @@ class ListOffersTest(GetEndpointHelper):
             "search-2-operator": "IN",
             "search-2-validation": offers_models.OfferValidationStatus.PENDING.value,
         }
-        with assert_num_queries(self.expected_num_queries - 1):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 200
 
@@ -973,7 +973,7 @@ class ListOffersTest(GetEndpointHelper):
             "search-0-operator": "IN",
             "search-0-category": categories.LIVRE.id,
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user + FF, before form validation
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -993,7 +993,7 @@ class ListOffersTest(GetEndpointHelper):
             "search-0-operator": operator,
             f"search-0-{operand}": "",
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user, before form validation + FF
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -1009,7 +1009,7 @@ class ListOffersTest(GetEndpointHelper):
             "search-4-search_field": "BOOKING_LIMIT_DATE",
             "search-4-operator": "DATE_TO",
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user + FF, before form validation
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -1024,7 +1024,7 @@ class ListOffersTest(GetEndpointHelper):
             "search-0-operator": "IN",
             "search-0-criteria": "A",
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user + FF, before form validation
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -1036,7 +1036,7 @@ class ListOffersTest(GetEndpointHelper):
             "search-0-operator": "OUT",
             "search-0-category": "13",
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user + FF, before form validation
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -1058,7 +1058,7 @@ class ListOffersTest(GetEndpointHelper):
             "search-0-operator": "EQUALS",
             "search-0-string": value,
         }
-        with assert_num_queries(2):  # only session + current user, before form validation
+        with assert_num_queries(3):  # only session + current user + FF, before form validation
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
             assert response.status_code == 400
 
@@ -2011,7 +2011,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         offer = offers_factories.EventOfferFactory(venue=venue)
 
         url = url_for(self.endpoint, offer_id=offer.id, _external=True)
-        # Additional queries to check if "Modifier le lieu" should be displayed or not":
+        # Additional queries to check if "Modifier le partenaire culturel" should be displayed or not":
         # - _get_editable_stock
         # - count stocks with beginningDatetime in the past
         # - count reimbursed bookings

--- a/api/tests/routes/backoffice/operations_test.py
+++ b/api/tests/routes/backoffice/operations_test.py
@@ -32,8 +32,8 @@ class ListEventsTest(GetEndpointHelper):
     endpoint = "backoffice_web.operations.list_events"
     needed_permission = perm_models.Permissions.MANAGE_SPECIAL_EVENTS
 
-    # authenticated user + user session + list of special events + count
-    expected_num_queries = 4
+    # authenticated user + user session + list of special events + count + WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 5
 
     def test_list_events(self, authenticated_client, special_events):
         with assert_num_queries(self.expected_num_queries):

--- a/api/tests/routes/backoffice/pivots_test.py
+++ b/api/tests/routes/backoffice/pivots_test.py
@@ -34,7 +34,7 @@ class GetPivotsPageTest(GetEndpointHelper):
     needed_permission = perm_models.Permissions.MANAGE_TECH_PARTNERS
 
     def test_get_pivots_page(self, authenticated_client):
-        with assert_num_queries(2):
+        with assert_num_queries(3):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -47,7 +47,8 @@ class ListPivotsTest(GetEndpointHelper):
     # - fetch session (1 query)
     # - fetch user (1 query)
     # - fetch a single pivot with joinedload (1 query)
-    expected_num_queries = 3
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+    expected_num_queries = 4
 
     def test_list_pivots_allocine(self, authenticated_client):
         allocine_pivot = providers_factories.AllocinePivotFactory()
@@ -288,7 +289,8 @@ class GetCreatePivotFormTest(GetEndpointHelper):
 
     # - fetch session (1 query)
     # - fetch user (1 query)
-    expected_num_queries = 2
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+    expected_num_queries = 3
 
     def test_get_create_pivot_form_allocine(self, authenticated_client):
         with assert_num_queries(self.expected_num_queries):
@@ -477,14 +479,16 @@ class GetUpdatePivotFormTest(GetEndpointHelper):
     # - fetch pivot (1 query)
     # - fetch venue for form validate (1 query)
     # - fetch venue to fill autocomplete (1 query)
-    expected_num_queries = 6
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+    expected_num_queries = 7
 
     def test_get_update_pivot_form_allocine(self, authenticated_client):
         # - fetch session (1 query)
         # - fetch user (1 query)
         # - fetch pivot (1 query)
         # - fetch venue to fill autocomplete (1 query)
-        allocine_pivot_expected_num_queries = 4
+        # - fetch WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+        allocine_pivot_expected_num_queries = 5
 
         allocine_pivot = providers_factories.AllocinePivotFactory()
         pivot_id = allocine_pivot.id

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -813,7 +813,7 @@ class GetCreateOffererFormTest(GetEndpointHelper):
     def test_get_create_offerer_form(self, authenticated_client):
         url = url_for(self.endpoint)
 
-        with assert_num_queries(2):  # session + current user
+        with assert_num_queries(3):  # session + current user + WIP_ENABLE_OFFER_ADDRESS FF
             response = authenticated_client.get(url)
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -108,7 +108,8 @@ class SearchProUserTest:
 
     # - fetch session
     # - fetch authenticated user
-    expected_num_queries_when_no_query = 2
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries_when_no_query = 3
     # - fetch results
     # - fetch count for pagination
     expected_num_queries = expected_num_queries_when_no_query + 2
@@ -147,7 +148,8 @@ class SearchProUserTest:
         self._create_accounts()
 
         search_query = self.pro_accounts[5].id
-        with assert_num_queries(self.expected_num_queries):
+        # HTML not rendered -> WIP_ENABLE_OFFER_ADDRESS not loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=search_query, pro_type=TypeOptions.USER.name))
             assert response.status_code == 303
 
@@ -180,7 +182,8 @@ class SearchProUserTest:
         self._create_accounts()
 
         search_query = self.pro_accounts[2].email
-        with assert_num_queries(self.expected_num_queries):
+        # HTML not rendered -> WIP_ENABLE_OFFER_ADDRESS not loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=search_query, pro_type=TypeOptions.USER.name))
             assert response.status_code == 303
 
@@ -208,7 +211,8 @@ class SearchProUserTest:
     def test_can_search_pro_by_first_and_last_name(self, authenticated_client):
         self._create_accounts()
 
-        with assert_num_queries(self.expected_num_queries):
+        # HTML not rendered -> WIP_ENABLE_OFFER_ADDRESS not loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(
                 url_for(self.endpoint, q="Alice Dubois", pro_type=TypeOptions.USER.name)
             )
@@ -253,7 +257,8 @@ class SearchProUserTest:
         offerers_factories.UserOffererFactory(user=pro_beneficiary)
 
         search_query = pro_beneficiary.id
-        with assert_num_queries(self.expected_num_queries):
+        # HTML not rendered -> WIP_ENABLE_OFFER_ADDRESS not loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for(self.endpoint, q=search_query, pro_type=TypeOptions.USER.name))
             assert response.status_code == 303
 
@@ -453,7 +458,7 @@ class SearchOffererTest:
     @pytest.mark.parametrize(
         "query,departments,feature_flag_count",
         [
-            ("987654321", [], 0),
+            ("987654321", [], 1),  # WIP_ENABLE_OFFER_ADDRESS FF
             ("festival@example.com", [], 1),
             ("Festival de la Montagne", [], 1),
             ("Librairie", ["62"], 1),
@@ -560,7 +565,8 @@ class SearchVenueTest:
     def test_can_search_venue_by_booking_email_domain(self, authenticated_client):
         self._create_venues()
 
-        with assert_num_queries(self.expected_num_queries):
+        # +1 for WIP_ENABLE_OFFER_ADDRESS
+        with assert_num_queries(self.expected_num_queries + 1):
             response = authenticated_client.get(
                 url_for(self.endpoint, q="@librairie.fr", pro_type=TypeOptions.VENUE.name)
             )
@@ -695,8 +701,8 @@ class SearchVenueTest:
     @pytest.mark.parametrize(
         "query,departments,feature_flag_count",
         [
-            ("987654321", [], 0),
-            ("festival@example.com", [], 0),
+            ("987654321", [], 1),  # WIP_ENABLE_OFFER_ADDRESS FF
+            ("festival@example.com", [], 1),  # WIP_ENABLE_OFFER_ADDRESS FF
             ("Festival de la Montagne", [], 1),
             ("Plage", ["74", "77"], 1),
         ],
@@ -718,10 +724,12 @@ class SearchBankAccountTest:
 
     # session + current user (2 queries)
     # results + count in .paginate (2 queries)
-    expected_num_queries = 4
+    # WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+    expected_num_queries = 5
 
     def _search_for_one(self, authenticated_client, search_query: typing.Any, expected_id: int):
-        with assert_num_queries(self.expected_num_queries):
+        # HTML not rendered -> WIP_ENABLE_OFFER_ADDRESS not loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(
                 url_for(self.endpoint, q=str(search_query), pro_type=TypeOptions.BANK_ACCOUNT.name)
             )

--- a/api/tests/routes/backoffice/providers_test.py
+++ b/api/tests/routes/backoffice/providers_test.py
@@ -33,7 +33,8 @@ class ListProvidersPageTest(GetEndpointHelper):
     # - fetch session (1 query)
     # - fetch user (1 query)
     # - fetch providers and associated api keys (1 query)
-    expected_num_queries = 3
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+    expected_num_queries = 4
 
     def test_list_providers(self, authenticated_client):
         offerer = offerers_factories.OffererFactory(name="Aaaaaah je suis au début")
@@ -212,7 +213,8 @@ class GetProviderTest(GetEndpointHelper):
     # get session (1 query)
     # get user with profile and permissions (1 query)
     # get provider (1 query)
-    expected_num_queries = 3
+    # get WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+    expected_num_queries = 4
 
     def test_get_provider(self, authenticated_client):
         offerer = offerers_factories.OffererFactory(name="Le videur pro")
@@ -266,7 +268,8 @@ class GetProviderStatsTest(GetEndpointHelper):
         # get session (1 query)
         # get user with profile and permissions (1 query)
         # get provider counts (1 query)
-        with assert_num_queries(3):
+        # get WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+        with assert_num_queries(4):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -280,7 +283,8 @@ class GetProviderStatsTest(GetEndpointHelper):
         # get session (1 query)
         # get user with profile and permissions (1 query)
         # get provider counts (1 query)
-        with assert_num_queries(3):
+        # get WIP_ENABLE_OFFER_ADDRESS FF (1 query)
+        with assert_num_queries(4):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/redirect_test.py
+++ b/api/tests/routes/backoffice/redirect_test.py
@@ -19,7 +19,8 @@ pytestmark = [
 class SafeRedirectTest:
     # - session
     # - authenticated user
-    expected_num_queries = 2
+    # - WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 3
 
     def test_redirect_as_anonymous(self, client):
         response = client.get(url_for("backoffice_web.safe_redirect", url="https://example.com"))
@@ -31,7 +32,8 @@ class SafeRedirectTest:
     def test_redirect_safe_url(self, mock_check_url_is_safe, mock_request_url_scan, authenticated_client):
         url = "https://safe.example.com"
 
-        with assert_num_queries(self.expected_num_queries):
+        # redirect -> no FF loaded
+        with assert_num_queries(self.expected_num_queries - 1):
             response = authenticated_client.get(url_for("backoffice_web.safe_redirect", url=url))
             assert response.status_code == 303
 

--- a/api/tests/routes/backoffice/tags_test.py
+++ b/api/tests/routes/backoffice/tags_test.py
@@ -124,7 +124,8 @@ class ListTagsTest(GetEndpointHelper):
     # - fetch session and user (2 queries)
     # - fetch tags: rows and count (2 queries)
     # - fetch categories (1 query)
-    expected_num_queries = 5
+    # - fetch WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 6
 
     def test_list_tags(self, authenticated_client):
         categories = criteria_factories.CriterionCategoryFactory.create_batch(2)

--- a/api/tests/routes/backoffice/titelive_test.py
+++ b/api/tests/routes/backoffice/titelive_test.py
@@ -36,11 +36,11 @@ class SearchEanTest(GetEndpointHelper):
     endpoint_kwargs = {"ean": "9782070455379"}
     needed_permission = perm_models.Permissions.READ_OFFERS
 
-    # session + current user + query
-    expected_num_queries = 3
+    # session + current user + query + WIP_ENABLE_OFFER_ADDRESS FF
+    expected_num_queries = 4
 
     def test_search_ean_initial(self, authenticated_client):
-        with assert_num_queries(2):
+        with assert_num_queries(3):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 


### PR DESCRIPTION
Introduce lazy evaluated strings for BO's forms to allow renaming controlled by feature flag.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31909

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
