### PR TITLE
(PC-31961)[API] feat: Delete offers description when linked to a product

### DIFF
--- a/api/src/pcapi/scripts/delete_offer_description/main.py
+++ b/api/src/pcapi/scripts/delete_offer_description/main.py
@@ -5,6 +5,7 @@ import statistics
 import time
 
 import pytz
+import sqlalchemy as sa
 
 from pcapi.models import db
 
@@ -33,6 +34,8 @@ def show_timeouts() -> None:
 
 
 def delete_description(starting_id: int, ending_id: int, batch_size: int, not_dry: bool = False) -> None:
+    db.session.execute(sa.text("SET SESSION statement_timeout = '400s'"))
+    show_timeouts()
     elapsed_per_batch = []
     to_report = 0
     for i in range(starting_id, ending_id, batch_size):

--- a/api/src/pcapi/scripts/delete_offer_description/main.py
+++ b/api/src/pcapi/scripts/delete_offer_description/main.py
@@ -11,38 +11,38 @@ from pcapi.models import db
 
 logger = logging.getLogger(__name__)
 
-BATCH_SIZE = 1_000
+
 REPORT_EVERY = 100_000
 
 
-def _get_eta(end: int, current: int, elapsed_per_batch: list[int]) -> str:
+def _get_eta(end: int, current: int, elapsed_per_batch: list[int], batch_size: int) -> str:
     left_to_do = end - current
-    seconds_eta = left_to_do / BATCH_SIZE * statistics.mean(elapsed_per_batch)
+    seconds_eta = left_to_do / batch_size * statistics.mean(elapsed_per_batch)
     eta = datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds_eta)
     eta = eta.astimezone(pytz.timezone("Europe/Paris"))
     str_eta = eta.strftime("%d/%m/%Y %H:%M:%S")
     return str_eta
 
 
-def delete_description(starting_id: int, ending_id: int, not_dry: bool = False) -> None:
+def delete_description(starting_id: int, ending_id: int, batch_size: int, not_dry: bool = False) -> None:
     elapsed_per_batch = []
     to_report = 0
-    for i in range(starting_id, ending_id, BATCH_SIZE):
+    for i in range(starting_id, ending_id, batch_size):
         start_time = time.perf_counter()
         db.session.execute(
             """
             update offer set "description" = null
             where id between :start and :end and "productId" is not null
             """,
-            params={"start": i, "end": i + BATCH_SIZE},
+            params={"start": i, "end": i + batch_size},
         )
         if not_dry:
             db.session.commit()
         else:
             db.session.rollback()
         elapsed_per_batch.append(int(time.perf_counter() - start_time))
-        eta = _get_eta(ending_id, starting_id, elapsed_per_batch)
-        to_report += BATCH_SIZE
+        eta = _get_eta(ending_id, starting_id, elapsed_per_batch, batch_size)
+        to_report += batch_size
         if to_report >= REPORT_EVERY:
             to_report = 0
             logger.info("BATCH : id from %s | eta = %s", i, eta)
@@ -56,10 +56,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Delete description for offers linked to a product")
     parser.add_argument("--starting-id", type=int, default=0, help="starting offer id")
     parser.add_argument("--ending-id", type=int, default=0, help="ending offer id")
+    parser.add_argument("--batch-size", type=int, default=500)
     parser.add_argument("--not-dry", action="store_true", help="set to really process (dry-run by default)")
     args = parser.parse_args()
 
     if args.starting_id > args.ending_id:
         raise ValueError('"start" must be less than "end"')
 
-    delete_description(args.starting_id, args.ending_id, args.not_dry)
+    delete_description(args.starting_id, args.ending_id, args.batch_size, args.not_dry)

--- a/api/src/pcapi/scripts/delete_offer_description/main.py
+++ b/api/src/pcapi/scripts/delete_offer_description/main.py
@@ -24,6 +24,14 @@ def _get_eta(end: int, current: int, elapsed_per_batch: list[int], batch_size: i
     return str_eta
 
 
+def show_timeouts() -> None:
+    statement_timeout = db.session.execute("SHOW statement_timeout").scalar()
+    lock_timeout = db.session.execute("SHOW lock_timeout").scalar()
+
+    logger.info("Current statement_timeout: %s", statement_timeout)
+    logger.info("Current lock_timeout: %s", lock_timeout)
+
+
 def delete_description(starting_id: int, ending_id: int, batch_size: int, not_dry: bool = False) -> None:
     elapsed_per_batch = []
     to_report = 0
@@ -62,5 +70,5 @@ if __name__ == "__main__":
 
     if args.starting_id > args.ending_id:
         raise ValueError('"start" must be less than "end"')
-
+    show_timeouts()
     delete_description(args.starting_id, args.ending_id, args.batch_size, args.not_dry)

--- a/api/src/pcapi/scripts/delete_offer_description/main.py
+++ b/api/src/pcapi/scripts/delete_offer_description/main.py
@@ -1,0 +1,65 @@
+import argparse
+import datetime
+import logging
+import statistics
+import time
+
+import pytz
+
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 1_000
+REPORT_EVERY = 100_000
+
+
+def _get_eta(end: int, current: int, elapsed_per_batch: list[int]) -> str:
+    left_to_do = end - current
+    seconds_eta = left_to_do / BATCH_SIZE * statistics.mean(elapsed_per_batch)
+    eta = datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds_eta)
+    eta = eta.astimezone(pytz.timezone("Europe/Paris"))
+    str_eta = eta.strftime("%d/%m/%Y %H:%M:%S")
+    return str_eta
+
+
+def delete_description(starting_id: int, ending_id: int, not_dry: bool = False) -> None:
+    elapsed_per_batch = []
+    to_report = 0
+    for i in range(starting_id, ending_id, BATCH_SIZE):
+        start_time = time.perf_counter()
+        db.session.execute(
+            """
+            update offer set "description" = null
+            where id between :start and :end and "productId" is not null
+            """,
+            params={"start": i, "end": i + BATCH_SIZE},
+        )
+        if not_dry:
+            db.session.commit()
+        else:
+            db.session.rollback()
+        elapsed_per_batch.append(int(time.perf_counter() - start_time))
+        eta = _get_eta(ending_id, starting_id, elapsed_per_batch)
+        to_report += BATCH_SIZE
+        if to_report >= REPORT_EVERY:
+            to_report = 0
+            logger.info("BATCH : id from %s | eta = %s", i, eta)
+
+
+if __name__ == "__main__":
+    from pcapi.flask_app import app
+
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser(description="Delete description for offers linked to a product")
+    parser.add_argument("--starting-id", type=int, default=0, help="starting offer id")
+    parser.add_argument("--ending-id", type=int, default=0, help="ending offer id")
+    parser.add_argument("--not-dry", action="store_true", help="set to really process (dry-run by default)")
+    args = parser.parse_args()
+
+    if args.starting_id > args.ending_id:
+        raise ValueError('"start" must be less than "end"')
+
+    delete_description(args.starting_id, args.ending_id, args.not_dry)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31961

Delete description from offers when linked to a product.
We have 255_000_000 offers in our database, only 2_000_000 are not linked to a product. Save the pandas and pinguins by drastically reducing the space used by our offer table (not really, but one day). 
According to metabase this column takes 157 Gb (not sure about that)
<img width="1365" alt="Screenshot 2024-09-20 at 10 37 25" src="https://github.com/user-attachments/assets/a35c5629-8515-4eb1-a30f-9b40eb009199">

I'll add timing metrics once it will be tested on staging


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
