### PR TITLE
(PC-31957)[API] feat: include booking with partial finance incident in the beneficiary's credits

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -33,6 +33,7 @@ from pcapi.core.bookings.models import BookingStatusFilter
 from pcapi.core.bookings.models import ExternalBooking
 from pcapi.core.bookings.utils import convert_booking_dates_utc_to_venue_timezone
 from pcapi.core.categories import subcategories_v2 as subcategories
+from pcapi.core.finance.models import BookingFinanceIncident
 from pcapi.core.geography.models import Address
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import OffererAddress
@@ -278,7 +279,10 @@ def get_bookings_from_deposit(deposit_id: int) -> list[Booking]:
             Booking.depositId == deposit_id,
             Booking.status != BookingStatus.CANCELLED,
         )
-        .options(joinedload(Booking.stock).joinedload(Stock.offer))
+        .options(
+            joinedload(Booking.stock).joinedload(Stock.offer),
+            joinedload(Booking.incidents).joinedload(BookingFinanceIncident.incident),
+        )
         .all()
     )
 

--- a/api/src/pcapi/core/external/attributes/api.py
+++ b/api/src/pcapi/core/external/attributes/api.py
@@ -543,7 +543,8 @@ def get_user_bookings(user: users_models.User) -> list[bookings_models.Booking]:
                 offers_models.Offer.subcategoryId,
                 offers_models.Offer.name,
                 offers_models.Offer.extraData,
-            )
+            ),
+            joinedload(bookings_models.Booking.incidents).joinedload(finance_models.BookingFinanceIncident.incident),
         )
         .filter(
             bookings_models.Booking.userId == user.id,

--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -21,6 +21,7 @@ from werkzeug.exceptions import NotFound
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.external.attributes import api as external_attributes_api
 from pcapi.core.finance import api as finance_api
+from pcapi.core.finance import models as finance_models
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.history import api as history_api
@@ -284,9 +285,12 @@ def render_public_account_details(
         users_models.User.query.filter_by(id=user_id)
         .options(
             sa.orm.joinedload(users_models.User.deposits),
-            sa.orm.subqueryload(users_models.User.userBookings)
-            .joinedload(bookings_models.Booking.stock)
-            .joinedload(offers_models.Stock.offer),
+            sa.orm.subqueryload(users_models.User.userBookings).options(
+                sa.orm.joinedload(bookings_models.Booking.stock).joinedload(offers_models.Stock.offer),
+                sa.orm.joinedload(bookings_models.Booking.incidents).joinedload(
+                    finance_models.BookingFinanceIncident.incident
+                ),
+            ),
             sa.orm.subqueryload(users_models.User.userBookings)
             .joinedload(bookings_models.Booking.offerer)
             .load_only(offerers_models.Offerer.name),


### PR DESCRIPTION
## But de la pull request

Prise en compte des incidents finance partiels dans le calcul du crédit des bénéficiaires

Exemple: 
Un jeune ayant :
 - 1 réservation (40€) validée et remboursée à l'AC. Son status est "reimbursed"
 - 1 réservation validée (33€) et remboursée à l'AC puis totalement annulée (0€). Son status est "cancelled" donc pas incluse dans le crédit du jeune
 - 1 réservation validée (67€) et remboursée à l'AC puis partiellement annulée. On veut récupérer 40€ de l'AC, donc son nouveau prix est de 27€. **Son status reste "reimbursed" pas "cancelled"** 

Le crédit du jeune doit être à `300€ - 40€ - 27€ = 233€`

Dans le fonctionnement actuel, on ne prend en considération que les réservations complètement annulées il manquait le calcul des réservations dont on ne prend pas directement le montant depuis `total_amount` mais de `booking.incidents[0].newTotalAmount`

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31957

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
