### PR TITLE
(PC-31965)[API]fix: Le patch n'est pas fait sur la 1ère étape du formulaire de mise à jour d'offre si produit

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -298,6 +298,11 @@ class OfferMustHaveAccessibility(OfferEditionBaseException):
         super().__init__("global", "L’accessibilité de l’offre doit être définie")
 
 
+class OfferWithProductShouldNotUpdateExtraData(OfferEditionBaseException):
+    def __init__(self) -> None:
+        super().__init__("global", "Les extraData des offres avec produit ne sont pas modifialbles")
+
+
 class MoveOfferBaseException(Exception):
     pass
 

--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -7,11 +7,9 @@ from pydantic.v1 import validator
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import schemas as offerers_schemas
 from pcapi.core.offers import models as offers_models
-from pcapi.models import feature
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
-from pcapi.validation.routes.offers import check_offer_product_update
 
 
 class PostDraftOfferBodyModel(BaseModel):
@@ -44,12 +42,6 @@ class PatchDraftOfferBodyModel(BaseModel):
     def validate_name(cls, name: str, values: dict) -> str:
         check_offer_name_length_is_valid(name)
         return name
-
-    @validator("extra_data", pre=True)
-    def validate_extra_data(cls, extra_data: dict[str, typing.Any]) -> dict[str, typing.Any]:
-        if feature.FeatureToggle.WIP_EAN_CREATION.is_active():
-            check_offer_product_update(extra_data)
-        return extra_data
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -575,6 +575,11 @@ def check_offer_extra_data(
             errors.add_error(field, "Ce champ est obligatoire")
 
     try:
+        _check_offer_has_product(offer)
+    except exceptions.OfferWithProductShouldNotUpdateExtraData as e:
+        errors.add_client_error(e)
+
+    try:
         ean = extra_data.get(ExtraDataFieldEnum.EAN.value)
         if ean and (not offer or (offer.extraData and ean != offer.extraData.get(ExtraDataFieldEnum.EAN.value))):
             _check_ean_field(extra_data, ExtraDataFieldEnum.EAN.value)
@@ -618,6 +623,11 @@ def check_ean_does_not_exist(ean: str | None, venue: offerers_models.Venue) -> N
     if repository.has_active_offer_with_ean(ean, venue):
         if ean:
             raise exceptions.OfferAlreadyExists("ean")
+
+
+def _check_offer_has_product(offer: models.Offer | None) -> None:
+    if FeatureToggle.WIP_EAN_CREATION.is_active() and offer and offer.product is not None:
+        raise exceptions.OfferWithProductShouldNotUpdateExtraData()
 
 
 def check_product_cgu_and_offerer(

--- a/api/src/pcapi/validation/routes/offers.py
+++ b/api/src/pcapi/validation/routes/offers.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from pcapi.models.api_errors import ApiErrors
 
 
@@ -16,11 +14,4 @@ def check_collective_offer_name_length_is_valid(offer_name: str) -> None:
     if len(offer_name) > max_offer_name_length:
         api_error = ApiErrors()
         api_error.add_error("name", "Le titre de l’offre doit faire au maximum 110 caractères.")
-        raise api_error
-
-
-def check_offer_product_update(extra_data: dict[str, Any]) -> None:
-    if extra_data.get("ean", False):
-        api_error = ApiErrors()
-        api_error.add_error("ean", "Vous ne pouvez pas changer cette information")
         raise api_error

--- a/pro/src/screens/IndividualOffer/DetailsScreen/__specs__/DetailsScreen.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/__specs__/DetailsScreen.spec.tsx
@@ -462,6 +462,7 @@ describe('screens:IndividualOffer::Informations', () => {
       extraData: {
         author: 'Chuck Norris',
         gtl_id: '',
+        ean: '1234567891234',
         performer: 'Le Poing de Chuck',
         showSubType: 'PEGI 18',
         showType: 'Cinéma',

--- a/pro/src/screens/IndividualOffer/DetailsScreen/utils.ts
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/utils.ts
@@ -375,21 +375,13 @@ type PatchPayload = {
 }
 
 export function serializeDetailsPatchData(
-  formValues: DetailsFormValues,
-  isLastProviderOffer: boolean
+  formValues: DetailsFormValues
 ): PatchPayload {
-  let extraData
-  if (!isLastProviderOffer) {
-    // Always remove EAN from serializedExtraData.
-    extraData = serializeExtraData(formValues)
-    delete extraData.ean
-  }
-
   return {
     name: formValues.name,
     subcategoryId: formValues.subcategoryId,
     description: formValues.description,
     durationMinutes: serializeDurationMinutes(formValues.durationMinutes ?? ''),
-    extraData,
+    extraData: serializeExtraData(formValues),
   }
 }

--- a/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/InformationsScreen.tsx
@@ -85,6 +85,8 @@ export const InformationsScreen = ({
   ).filter((venue) => venue.managingOffererId === Number(offererId))
 
   const offerAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
+  const isSearchByEanEnabled = useActiveFeature('WIP_EAN_CREATION')
+
   // TODO : Find a cleaner way to achieve this :
   // The only way to infer event type (physical or numeric) and make it works for both creation AND edition, is to check CATEGORY_STATUS or if an offer has a "url" (meaning that it's not physical)
   // (This is because CATEGORY_STATUS is always ONLINE_OR_OFFLINE for edition)
@@ -141,6 +143,7 @@ export const InformationsScreen = ({
 
     // Submit
     try {
+      const shouldNotSendExtraData = isSearchByEanEnabled && !!offer?.productId
       const response = !offer
         ? await api.postOffer(serializePostOffer(formValues))
         : await api.patchOffer(
@@ -149,6 +152,7 @@ export const InformationsScreen = ({
               offer,
               formValues,
               shouldSendMail: sendWithdrawalMail,
+              shouldNotSendExtraData,
             })
           )
 

--- a/pro/src/screens/IndividualOffer/InformationsScreen/serializePatchOffer.ts
+++ b/pro/src/screens/IndividualOffer/InformationsScreen/serializePatchOffer.ts
@@ -49,12 +49,14 @@ interface SerializePatchOffer {
   offer: GetIndividualOfferResponseModel
   formValues: Partial<IndividualOfferFormValues>
   shouldSendMail?: boolean
+  shouldNotSendExtraData?: boolean
 }
 
 export const serializePatchOffer = ({
   offer,
   formValues,
   shouldSendMail = false,
+  shouldNotSendExtraData = false,
 }: SerializePatchOffer): PatchOfferBodyModel => {
   let sentValues: Partial<IndividualOfferFormValues> = formValues
   if (offer.lastProvider) {
@@ -103,7 +105,11 @@ export const serializePatchOffer = ({
       sentValues.accessibility &&
       sentValues.accessibility[AccessibilityEnum.AUDIO],
     description: sentValues.description,
-    extraData: serializeExtraData(sentValues),
+    ...(shouldNotSendExtraData
+      ? {}
+      : {
+          extraData: serializeExtraData(sentValues),
+        }),
     isNational: sentValues.isNational,
     isDuo: sentValues.isDuo,
     mentalDisabilityCompliant:

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
@@ -57,6 +57,7 @@ export const UsefulInformationScreen = ({
   const { mutate } = useSWRConfig()
   const { subCategories } = useIndividualOfferContext()
   const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
+  const isSearchByEanEnabled = useActiveFeature('WIP_EAN_CREATION')
 
   const [isWithdrawalMailDialogOpen, setIsWithdrawalMailDialogOpen] =
     useState<boolean>(false)
@@ -121,12 +122,14 @@ export const UsefulInformationScreen = ({
     }
 
     try {
+      const shouldNotSendExtraData = isSearchByEanEnabled && !!offer.productId
       const response = await api.patchOffer(
         offer.id,
         serializePatchOffer({
           offer,
           formValues,
           shouldSendMail: sendWithdrawalMail,
+          shouldNotSendExtraData,
         })
       )
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31965

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
