### PR TITLE
(BSR)[PRO] test: Group in 1 run tests with sandbox and tests with Data Factory

### DIFF
--- a/.github/workflows/dev_on_pull_request_workflow.yml
+++ b/.github/workflows/dev_on_pull_request_workflow.yml
@@ -221,24 +221,9 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  test-pro-e2e:
-    name: "Tests pro E2E"
-    needs: [pcapi-init-job, build-pcapi]
-    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
-    if: |
-      always() &&
-      needs.pcapi-init-job.outputs.api-changed == 'true' || 
-      needs.pcapi-init-job.outputs.pro-changed == 'true'
-    with:
-      tag: ${{ needs.build-pcapi.result == 'skipped' && 'latest' || needs.pcapi-init-job.outputs.checksum-tag }}
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-
   # FIXME : (mageoffray, 19-09-2024)
   # this workflow is temporary and will be used to transitioned between
-  # e2e tests based on industrial sandbox and e2e tests based on micro sandboxes
+  # e2e tests based on e2e sandbox and e2e tests based on micro sandboxes
   test-pro-e2e-migration:
     name: "Tests pro E2E migrations"
     needs: [pcapi-init-job, build-pcapi]
@@ -246,6 +231,21 @@ jobs:
     if: |
       always() &&
       needs.pcapi-init-job.outputs.api-changed == 'true' ||
+      needs.pcapi-init-job.outputs.pro-changed == 'true'
+    with:
+      tag: ${{ needs.build-pcapi.result == 'skipped' && 'latest' || needs.pcapi-init-job.outputs.checksum-tag }}
+      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  
+  test-pro-e2e:
+    name: "Tests pro E2E"
+    needs: [pcapi-init-job, build-pcapi]
+    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+    if: |
+      always() &&
+      needs.pcapi-init-job.outputs.api-changed == 'true' || 
       needs.pcapi-init-job.outputs.pro-changed == 'true'
     with:
       tag: ${{ needs.build-pcapi.result == 'skipped' && 'latest' || needs.pcapi-init-job.outputs.checksum-tag }}

--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -224,10 +224,13 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  test-pro-e2e:
-    name: "Tests pro E2E"
+  # FIXME : (mageoffray, 19-09-2024)
+  # this workflow is temporary and will be used to transitioned between
+  # e2e tests based on e2e sandbox and e2e tests based on micro sandboxes
+  test-pro-e2e-migration:
+    name: "Tests pro E2E migrations"
     needs: [pcapi-init-job, build-pcapi]
-    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e_migration.yml
     if: |
       always() &&
       needs.pcapi-init-job.outputs.api-changed == 'true' ||
@@ -239,13 +242,10 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  # FIXME : (mageoffray, 19-09-2024)
-  # this workflow is temporary and will be used to transitioned between
-  # e2e tests based on industrial sandbox and e2e tests based on micro sandboxes
-  test-pro-e2e-migration:
-    name: "Tests pro E2E migrations"
+  test-pro-e2e:
+    name: "Tests pro E2E"
     needs: [pcapi-init-job, build-pcapi]
-    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e_migration.yml
+    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
     if: |
       always() &&
       needs.pcapi-init-job.outputs.api-changed == 'true' ||

--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -148,6 +148,7 @@ jobs:
           config-file: cypress/old_cypress.config.ts
           env: TAGS="@P0"
           record: ${{ github.ref == 'refs/heads/master' }} # for Cypress Cloud
+          group: 'Tests with yet-to-be-removed sandbox'
         env:
           CYPRESS_RECORD_KEY: ${{ steps.secrets.outputs.CYPRESS_CLOUD_RECORD_KEY }}
           CYPRESS_PROJECT_ID: ${{ steps.secrets.outputs.CYPRESS_CLOUD_PROJECT_ID }}

--- a/.github/workflows/dev_on_workflow_tests_pro_e2e_migration.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e_migration.yml
@@ -147,6 +147,7 @@ jobs:
           env: TAGS="@P0"
           record: ${{ github.ref == 'refs/heads/master' }} # for Cypress Cloud
           spec: "cypress/e2e/migrations/*"
+          group: 'Tests migrated with Data Factory'
         env:
           CYPRESS_RECORD_KEY: ${{ steps.secrets.outputs.CYPRESS_CLOUD_RECORD_KEY }}
           CYPRESS_PROJECT_ID: ${{ steps.secrets.outputs.CYPRESS_CLOUD_PROJECT_ID }}


### PR DESCRIPTION
## But de la pull request

Groupe les 2 résultats des tests avec sandbox et migration (les cas qui vont être migrés avec la Data Factory) pour fixer #14221
Ceci est important pour Cypress Cloud qui regroupera tous les résultats dans un seul run (et pas 2)
Voir https://cloud.cypress.io/projects/rit5sb/runs/902/specs

![CleanShot 2024-09-20 at 15 52 24@2x](https://github.com/user-attachments/assets/3be6b661-874b-4f9a-a942-6bfa4e35c6e0)

Au fur et à mesure de la migration faite par @Aliochka le premier groupe s'agrandira pendant que le second se videra


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
