### PR TITLE
(PC-31883)[PRO] feat: add params selected_offers for archivage events

### DIFF
--- a/pro/src/components/ArchiveConfirmationModal/ArchiveConfirmationModal.tsx
+++ b/pro/src/components/ArchiveConfirmationModal/ArchiveConfirmationModal.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from 'react-router-dom'
 
+import { CollectiveOfferResponseModel } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { ConfirmDialog } from 'components/Dialog/ConfirmDialog/ConfirmDialog'
 import { Events } from 'core/FirebaseEvents/constants'
@@ -9,20 +10,28 @@ interface OfferEducationalModalProps {
   onDismiss(): void
   onValidate(): void
   hasMultipleOffers?: boolean
+  selectedOffers?: CollectiveOfferResponseModel[]
 }
 
 export const ArchiveConfirmationModal = ({
   onDismiss,
   onValidate,
   hasMultipleOffers = false,
+  selectedOffers = [],
 }: OfferEducationalModalProps): JSX.Element => {
   const location = useLocation()
   const { logEvent } = useAnalytics()
 
   function onConfirmArchive() {
+    const collectiveOfferIds = selectedOffers.map((offer) =>
+      offer.id.toString()
+    )
+
     logEvent(Events.CLICKED_ARCHIVE_COLLECTIVE_OFFER, {
       from: location.pathname,
+      selected_offers: collectiveOfferIds,
     })
+
     onValidate()
   }
 

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -301,6 +301,7 @@ export function CollectiveOffersActionsBar({
             updateOfferStatus(CollectiveOfferDisplayedStatus.ARCHIVED)
           }
           hasMultipleOffers={selectedOffers.length > 1}
+          selectedOffers={selectedOffers}
         />
       )}
 

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveOffersActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveOffersActionsBar.spec.tsx
@@ -398,6 +398,41 @@ describe('ActionsBar', () => {
     })
   })
 
+  it('should call tracker event when archiving an offer', async () => {
+    renderActionsBar({
+      ...props,
+      selectedOffers: [
+        collectiveOfferFactory({
+          id: 1,
+          status: CollectiveOfferStatus.ACTIVE,
+          stocks,
+        }),
+        collectiveOfferFactory({
+          id: 2,
+          status: CollectiveOfferStatus.ACTIVE,
+          stocks,
+          isShowcase: true,
+        }),
+      ],
+    })
+
+    const archivingButton = screen.getByText('Archiver')
+    await userEvent.click(archivingButton)
+
+    const confirmArchivingButton = screen.getByText('Archiver les offres')
+    await userEvent.click(confirmArchivingButton)
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_ARCHIVE_COLLECTIVE_OFFER,
+      {
+        from: '/offres/collectives',
+        selected_offers: ['1', '2'],
+      }
+    )
+  })
+
   it('should archive offers on click on "Archiver"', async () => {
     renderActionsBar({
       ...props,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31883

Ajouter un paramètre qui renvoie les ids des offres qui ont été sélectionnées à l'EVENT d'archivage côté collectif

## Vérifications

- [x] J'ai écrit les tests nécessaires