### PR TITLE
(PC-31759)[API] feat: add params to log offer list view in adage

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -176,7 +176,6 @@ def log_consult_playlist_element(
             "playlistId": body.playlistId,
             "from": body.iframeFrom,
             "queryId": body.queryId,
-            "isMobile": body.isMobile,
         },
         user_email=authenticated_information.email,
         uai=authenticated_information.uai,

--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -48,6 +48,7 @@ def log_offer_list_view_switch(
             "source": body.source,
             "from": body.iframeFrom,
             "queryId": body.queryId,
+            "isMobile": body.isMobile,
         },
         uai=authenticated_information.uai,
         user_role=AdageFrontRoles.REDACTOR if institution else AdageFrontRoles.READONLY,

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -21,6 +21,7 @@ class AdagePlaylistType(enum.Enum):
 
 class OfferListSwitch(AdageBaseModel):
     source: str
+    isMobile: bool | None
 
 
 class CatalogViewBody(AdageBaseModel):

--- a/api/src/pcapi/routes/adage_iframe/serialization/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/logs.py
@@ -46,7 +46,6 @@ class PlaylistBody(AdageBaseModel):
     playlistId: int
     elementId: int | None
     index: int | None
-    isMobile: bool | None
 
 
 class SearchBody(AdageBaseModel):

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -59,15 +59,15 @@ class LogsTest:
         }
 
     @pytest.mark.parametrize(
-        "playlist_type,element_id,index,offer_id,venue_id,domain_id,is_mobile",
+        "playlist_type,element_id,index,offer_id,venue_id,domain_id",
         [
-            ("offer", 34, 1, 34, None, None, None),
-            ("venue", 45, 2, None, 45, None, True),
-            ("domain", 56, None, None, None, 56, False),
+            ("offer", 34, 1, 34, None, None),
+            ("venue", 45, 2, None, 45, None),
+            ("domain", 56, None, None, None, 56),
         ],
     )
     def test_log_consult_playlist_element(
-        self, test_client, caplog, playlist_type, element_id, index, offer_id, venue_id, domain_id, is_mobile
+        self, test_client, caplog, playlist_type, element_id, index, offer_id, venue_id, domain_id
     ):
         with caplog.at_level(logging.INFO):
             response = test_client.post(
@@ -80,7 +80,6 @@ class LogsTest:
                     "index": index,
                     "playlistId": 99,
                     "playlistType": playlist_type,
-                    "isMobile": is_mobile,
                 },
             )
 
@@ -98,7 +97,6 @@ class LogsTest:
             "venueId": venue_id,
             "domainId": domain_id,
             "index": index,
-            "isMobile": is_mobile,
         }
 
     def test_log_has_seen_whole_playlist(self, test_client, caplog):

--- a/api/tests/routes/adage_iframe/post_logs_test.py
+++ b/api/tests/routes/adage_iframe/post_logs_test.py
@@ -42,7 +42,7 @@ class LogsTest:
         with caplog.at_level(logging.INFO):
             response = test_client.post(
                 url_for("adage_iframe.log_offer_list_view_switch"),
-                json={"source": "offer_switch", "iframeFrom": "playlist", "queryId": "1234"},
+                json={"source": "offer_switch", "iframeFrom": "playlist", "queryId": "1234", "isMobile": True},
             )
 
         assert response.status_code == 204
@@ -51,6 +51,7 @@ class LogsTest:
             "analyticsSource": "adage",
             "source": "offer_switch",
             "queryId": "1234",
+            "isMobile": True,
             "from": "playlist",
             "uai": UAI,
             "user_role": AdageFrontRoles.READONLY,

--- a/pro/src/apiClient/adage/models/OfferListSwitch.ts
+++ b/pro/src/apiClient/adage/models/OfferListSwitch.ts
@@ -5,6 +5,7 @@
 export type OfferListSwitch = {
   iframeFrom: string;
   isFromNoResult?: boolean | null;
+  isMobile?: boolean | null;
   queryId?: string | null;
   source: string;
 };

--- a/pro/src/apiClient/adage/models/PlaylistBody.ts
+++ b/pro/src/apiClient/adage/models/PlaylistBody.ts
@@ -8,7 +8,6 @@ export type PlaylistBody = {
   iframeFrom: string;
   index?: number | null;
   isFromNoResult?: boolean | null;
-  isMobile?: boolean | null;
   playlistId: number;
   playlistType: AdagePlaylistType;
   queryId?: string | null;

--- a/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/__spec__/App.spec.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react'
-import React from 'react'
 import { Configure } from 'react-instantsearch'
 
 import { AdageFrontRoles } from 'apiClient/adage'
@@ -81,6 +80,7 @@ vi.mock('apiClient/api', () => ({
     logTrackingFilter: vi.fn(),
     getCollectiveOffer: vi.fn(),
     logHasSeenAllPlaylist: vi.fn(),
+    logOfferListViewSwitch: vi.fn(),
   },
 }))
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -107,6 +107,17 @@ export const Offers = ({
     )
 
   useEffect(() => {
+    if (isMobileScreen !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      apiAdage.logOfferListViewSwitch({
+        iframeFrom: location.pathname,
+        source: adageViewType,
+        isMobile: isMobileScreen,
+      })
+    }
+  }, [isMobileScreen])
+
+  useEffect(() => {
     isMobileScreen && dispatch(setSearchView('grid'))
   }, [isMobileScreen, dispatch])
 
@@ -128,12 +139,16 @@ export const Offers = ({
 
   function toggleButtonClicked(button: ToggleButton) {
     const viewType = button.id === 'list' ? 'list' : 'grid'
+    const source = button.id === 'list' ? 'grid' : 'list'
     dispatch(setSearchView(viewType))
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    apiAdage.logOfferListViewSwitch({
-      iframeFrom: location.pathname,
-      source: viewType,
-    })
+    if (adageViewType !== viewType) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      apiAdage.logOfferListViewSwitch({
+        iframeFrom: location.pathname,
+        source,
+        isMobile: isMobileScreen,
+      })
+    }
   }
 
   function triggerOfferClickLog(

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/__specs__/OffersSuggestions.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSuggestions/__specs__/OffersSuggestions.spec.tsx
@@ -36,6 +36,7 @@ vi.mock('apiClient/api', () => ({
   apiAdage: {
     getCollectiveOfferTemplate: vi.fn(),
     getCollectiveOffer: vi.fn(),
+    logOfferListViewSwitch: vi.fn(),
   },
 }))
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31759

Ajout d'un paramètre pour savoir si la liste par défaut et en mode mobile ou non
Sur le log du switch du mode de vue pour la liste dans la recherche sur ADAGE

## Vérifications

- [ ] J'ai écrit les tests nécessaires