### PR TITLE
(BSR)[PRO] test: no group on non-master branches for Cypress Cloud E2E tests

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -148,7 +148,7 @@ jobs:
           config-file: cypress/old_cypress.config.ts
           env: TAGS="@P0"
           record: ${{ github.ref == 'refs/heads/master' }} # for Cypress Cloud
-          group: 'Tests with yet-to-be-removed sandbox'
+          group: ${{ github.ref == 'refs/heads/master' && 'Tests with yet-to-be-removed sandbox' || '' }}
         env:
           CYPRESS_RECORD_KEY: ${{ steps.secrets.outputs.CYPRESS_CLOUD_RECORD_KEY }}
           CYPRESS_PROJECT_ID: ${{ steps.secrets.outputs.CYPRESS_CLOUD_PROJECT_ID }}

--- a/.github/workflows/dev_on_workflow_tests_pro_e2e_migration.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e_migration.yml
@@ -147,7 +147,7 @@ jobs:
           env: TAGS="@P0"
           record: ${{ github.ref == 'refs/heads/master' }} # for Cypress Cloud
           spec: "cypress/e2e/migrations/*"
-          group: 'Tests migrated with Data Factory'
+          group: ${{ github.ref == 'refs/heads/master' && 'Tests migrated with Data Factory' || '' }}
         env:
           CYPRESS_RECORD_KEY: ${{ steps.secrets.outputs.CYPRESS_CLOUD_RECORD_KEY }}
           CYPRESS_PROJECT_ID: ${{ steps.secrets.outputs.CYPRESS_CLOUD_PROJECT_ID }}


### PR DESCRIPTION
## But de la pull request

[Corrige](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example) pour n'avoir l'option "group:" uniquement sur les builds master (suite de cette [PR](https://github.com/pass-culture/pass-culture-main/pull/14257)  faisant hélas échouer les builds de branche)

Le dernier Check a tout skippé car il ne contient aucun changement dans le code PRO mais un précédent avec fausse modification est bien passé.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
