### PR TITLE
(BSR)[API] chore: User `docker compose` instead of `docker-compose`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Le repo `main` contient les 4 projets suivants :
 
 - Docker
   - [docker](https://docs.docker.com/install/) (testé avec 19.03.12)
-  - [docker-compose](https://docs.docker.com/compose/install/#install-compose) (testé avec 1.26.2)
+  - [docker compose (inclus avec Docker Desktop)](https://docs.docker.com/compose/install/#install-compose) (testé avec 1.26.2)
 - [NVM](https://github.com/creationix/nvm) (Node Version Manager)
   - `curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash`
 - [Node](https://nodejs.org/en/download/)
@@ -72,7 +72,7 @@ Les README de chaque sous-projet détailleront leurs installations spécifiques.
 ### Lancer les applications
 
 Voici de brèves instructions pour lancer l'API et les différents frontends via le script `pc`, qui fait appel à
-docker-compose. On trouvera dans le [README](./api#readme) d'`api` d'autres
+docker compose. On trouvera dans le [README](./api#readme) d'`api` d'autres
 manières de lancer le backend.
 
 #### api

--- a/api/README.md
+++ b/api/README.md
@@ -1,9 +1,9 @@
 # PASS-CULTURE-API
 
-Voici le backend de l'application pass Culture; il est lancé via `docker-compose` en utilisant le fichier
+Voici le backend de l'application pass Culture; il est lancé via `docker compose` en utilisant le fichier
 `docker-compose-backend.yml` du répertoire parent de `api`: `pass-culture-main`.
 
-Plus de détails sur le lancement de l'infra docker-compose sont accessibles dans le
+Plus de détails sur le lancement de l'infra docker compose sont accessibles dans le
 [README de pass-culture-main](https://github.com/pass-culture/pass-culture-main#readme)
 
 ## OpenAPI
@@ -96,7 +96,7 @@ locale. Pour ça:
 
 ## Tests
 
-Une fois le le backend lancé, les tests peuvent être exécutés avec ou sans docker-compose
+Une fois le le backend lancé, les tests peuvent être exécutés avec ou sans docker compose
 
 ### 1. Lancement des tests avec docker compose
 
@@ -125,10 +125,10 @@ Troubleshoot :
 Si les tests ne se lancent pas avec Docker, il faut recréer la base de données de tests et relancer le cache redis 
 
 * Soit en démarrant les conteneurs de la base de données _pc-postgres-test_ (spécifique aux tests) et du cache
-  _redis_ via docker-compose
+  _redis_ via docker compose
 
 ```shell
-    docker-compose -f ../docker-compose-backend.yml up -d postgres-test redis
+    docker compose -f ../docker-compose-backend.yml up -d postgres-test redis
  ```
 
 * Soit en démarrant ces conteneurs via docker
@@ -256,7 +256,7 @@ Pour que les commandes soient enregistrées par Flask, il faut que le fichier `p
 Pour que les commandes soient exécutées, il faut ouvrir une PR sur le repo pass-culture/pass-culture-deployment
 Les infos sont dans le [README](https://github.com/pass-culture/pass-culture-deployment)
 
-## Lancement du backend sans utiliser docker-compose
+## Lancement du backend sans utiliser docker compose
 
 *Pour repasser sur docker par la suite, la __NOTE__ en fin de ce paragraphe est __importante__*
 

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - db_nw
     ports:
-      - 5434:5432 # This port is used outside docker-compose network (E2E tests and developers launching flask api on their local machines)
+      - 5434:5432 # This port is used outside docker compose network (E2E tests and developers launching flask api on their local machines)
     command: postgres -c logging_collector=on -c log_destination=stderr -c log_min_duration_statement=0 -c log_statement=all -c log_duration=on
 
   postgres-test:

--- a/infra/pc_scripts/logs.sh
+++ b/infra/pc_scripts/logs.sh
@@ -2,7 +2,7 @@
 
 function logs {
     if [[ "$ENV" == "development" ]]; then
-        export RUN="docker-compose -f \"$ROOT_PATH\"/docker-compose-backend.yml logs"
+        export RUN="docker compose -f \"$ROOT_PATH\"/docker-compose-backend.yml logs"
     else
       echo "Use GCP console or kubectl CLI to access k8s logs"
       exit

--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -1,37 +1,37 @@
 #!/bin/bash
 
 function start_backend {
-    docker_compose_major=$(docker-compose -v 2>&1 | sed "s/.*version v*\([0-9]\).\([0-9]*\).\([0-9]*\).*/\1/");
-    docker_compose_minor=$(docker-compose -v 2>&1 | sed "s/.*version v*\([0-9]\).\([0-9]*\).\([0-9]*\).*/\2/");
+    docker_compose_major=$(docker compose -v 2>&1 | sed "s/.*version v*\([0-9]\).\([0-9]*\).\([0-9]*\).*/\1/");
+    docker_compose_minor=$(docker compose -v 2>&1 | sed "s/.*version v*\([0-9]\).\([0-9]*\).\([0-9]*\).*/\2/");
     if [ "$docker_compose_major" -le "1" ] && [ "$docker_compose_minor" -le "23" ]; then
-        echo "This script requires docker-compose 1.24 or greater"
+        echo "This script requires docker compose 1.24 or greater"
         exit 1
     fi
-    RUN='cd $ROOT_PATH && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
+    RUN='cd $ROOT_PATH && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml build && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
 }
 
 function start_proxy_backend {
-    RUN='cd $ROOT_PATH && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build --build-arg="network_mode=proxy" && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
+    RUN='cd $ROOT_PATH && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml build --build-arg="network_mode=proxy" && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
 }
 
 function restart_proxy_backend {
     RUN='sudo rm -rf "$ROOT_PATH"/api/static/object_store_data;
-    docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes;
-    cd "$ROOT_PATH" && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build --build-arg="network_mode=proxy" && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up --force-recreate'
+    docker compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes;
+    cd "$ROOT_PATH" && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml build --build-arg="network_mode=proxy" && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml up --force-recreate'
 }
 
 function restart_backend {
     RUN='sudo rm -rf "$ROOT_PATH"/api/static/object_store_data;
-    docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes;
-    cd "$ROOT_PATH" && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build && docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up --force-recreate'
+    docker compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes;
+    cd "$ROOT_PATH" && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml build && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml up --force-recreate'
 }
 
 function rebuild_backend {
-    RUN='docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml build --no-cache;
+    RUN='docker compose -f "$ROOT_PATH"/docker-compose-backend.yml build --no-cache;
     sudo rm -rf $ROOT_PATH/api/static/object_store_data;
-    docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes'
+    docker compose -f "$ROOT_PATH"/docker-compose-backend.yml down --volumes'
 }
 
 function up_backend {
-    RUN='docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
+    RUN='docker compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
 }

--- a/infra/pc_scripts/test_backend.sh
+++ b/infra/pc_scripts/test_backend.sh
@@ -8,8 +8,8 @@ function test_backend {
     fi
     RUN='docker stop pc-postgres-pytest;
         docker rm -v pc-postgres-pytest;
-        docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up -d postgres-test;
-        while ! docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml logs postgres-test 2> /dev/null | grep -q "PostgreSQL init process complete; ready for start up."; do echo "waiting for test-database"; sleep 0.5; done;
+        docker compose -f "$ROOT_PATH"/docker-compose-backend.yml up -d postgres-test;
+        while ! docker compose -f "$ROOT_PATH"/docker-compose-backend.yml logs postgres-test 2> /dev/null | grep -q "PostgreSQL init process complete; ready for start up."; do echo "waiting for test-database"; sleep 0.5; done;
         docker exec -it pc-api bash -c "cd /usr/src/app/ && rm -rf static/object_store_data/thumbs/* && RUN_ENV=tests SQLALCHEMY_WARN_20=1 pytest -m \"not backoffice\" --durations=5 --color=yes -rsx -v $PYTEST_ARGS"
         '
 }
@@ -22,8 +22,8 @@ function test_backoffice {
     fi
     RUN='docker stop pc-postgres-pytest;
         docker rm -v pc-postgres-pytest;
-        docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml up -d postgres-test;
-        while ! docker-compose -f "$ROOT_PATH"/docker-compose-backend.yml logs postgres-test 2> /dev/null | grep -q "PostgreSQL init process complete; ready for start up."; do echo "waiting for test-database"; sleep 0.5; done;
+        docker compose -f "$ROOT_PATH"/docker-compose-backend.yml up -d postgres-test;
+        while ! docker compose -f "$ROOT_PATH"/docker-compose-backend.yml logs postgres-test 2> /dev/null | grep -q "PostgreSQL init process complete; ready for start up."; do echo "waiting for test-database"; sleep 0.5; done;
         docker exec -it pc-backoffice bash -c "cd /usr/src/app/ && rm -rf static/object_store_data/thumbs/* && RUN_ENV=tests SQLALCHEMY_WARN_20=1 pytest -m backoffice --durations=5 --color=yes -rsx -v $PYTEST_ARGS"
         '
 }

--- a/pc
+++ b/pc
@@ -30,7 +30,7 @@ Commands:
   psql-file             Execute requests from the specified file on the local database
   psql-test             Connect to the local test database
   python                Open a Python prompt the given environment
-  rebuild-backend       Force docker-compose to build the docker images
+  rebuild-backend       Force docker compose to build the docker images
   reset-all-db          Clear all data in the local database
   reset-db-no-docker    Clear all data in the local database (without docker)
   reset-db-test-no-docker  Clear test data in the local database (without docker)
@@ -169,11 +169,11 @@ elif [[ "$CMD" == "dump-db" ]]; then
   RUN='mkdir -p "$ROOT_PATH/db_dumps";
     docker exec pc-postgres pg_dump -d pass_culture -U pass_culture -F c > "$ROOT_PATH"/db_dumps/`date +%Y%m%d_%H%M%S`.pgdump'
 
-# Force docker-compose to build the docker images
+# Force docker compose to build the docker images
 elif [[ "$CMD" == "rebuild-backend" ]]; then
-  RUN='docker-compose -f "$ROOT_PATH/docker-compose-backend.yml" build --no-cache;
+  RUN='docker compose -f "$ROOT_PATH/docker-compose-backend.yml" build --no-cache;
     sudo rm -rf $ROOT_PATH/api/static/object_store_data;
-    docker-compose -f "$ROOT_PATH/docker-compose-backend.yml" down --volumes'
+    docker compose -f "$ROOT_PATH/docker-compose-backend.yml" down --volumes'
 
 # Execute request from specified file
 elif [[ "$CMD" == "psql-file" ]]; then


### PR DESCRIPTION
## But de la pull request

Utiliser `docker compose` au lieu de `docker-compose`
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
