### PR TITLE
(BSR)[ADAGE] fix: Keep old enum value to ease the migration

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -214,6 +214,15 @@ class InstitutionRuralLevel(enum.Enum):
     RURAL_A_HABITAT_DISPERSE = "Rural à habitat dispersé"  # RURAL_AUTONOME_PEU_DENSE
     RURAL_A_HABITAT_TRES_DISPERSE = "Rural à habitat très dispersé"  # RURAL_AUTONOME_TRES_PEU_DENSE
 
+    # OLD Values for migration purpose
+    # FIXME: Remove those old values
+    URBAIN_DENSITE_INTERMEDIAIRE = "urbain densité intermédiaire"
+    RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE = "rural sous forte influence d'un pôle"
+    URBAIN_DENSE = "urbain dense"
+    RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE = "rural sous faible influence d'un pôle"
+    RURAL_AUTONOME_TRES_PEU_DENSE = "rural autonome très peu dense"
+    RURAL_AUTONOME_PEU_DENSE = "rural autonome peu dense"
+
 
 # Mapping from rurality level to distance in km
 PLAYLIST_RURALITY_MAX_DISTANCE_MAPPING = {
@@ -224,6 +233,14 @@ PLAYLIST_RURALITY_MAX_DISTANCE_MAPPING = {
     InstitutionRuralLevel.BOURGS_RURAUX: 60,
     InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE: 60,
     InstitutionRuralLevel.RURAL_A_HABITAT_TRES_DISPERSE: 60,
+    # OLD Values for migration purpose
+    # FIXME: Remove those old values
+    InstitutionRuralLevel.URBAIN_DENSE: 3,
+    InstitutionRuralLevel.URBAIN_DENSITE_INTERMEDIAIRE: 10,
+    InstitutionRuralLevel.RURAL_SOUS_FORTE_INFLUENCE_D_UN_POLE: 15,
+    InstitutionRuralLevel.RURAL_SOUS_FAIBLE_INFLUENCE_D_UN_POLE: 60,
+    InstitutionRuralLevel.RURAL_AUTONOME_PEU_DENSE: 60,
+    InstitutionRuralLevel.RURAL_AUTONOME_TRES_PEU_DENSE: 60,
 }
 
 


### PR DESCRIPTION
## But de la pull request

Slack discussion : https://passcultureteam.slack.com/archives/C01FVUFTXV1/p1727095682042309?thread_ts=1727093382.871289&cid=C01FVUFTXV1

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
