### PR TITLE
(BSR)[API] feat: public api: adage mock: use logger.exception

### DIFF
--- a/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
+++ b/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
@@ -291,8 +291,8 @@ class CancelCollectiveBookingTest(AdageMockEndpointHelper):
             expected_queries_count += 1  # 4. get collective stock (lock for update)
             expected_queries_count += 1  # 5. get collective booking (refresh)
             expected_queries_count += 1  # 6. does pricing exists for collective booking?
-            expected_queries_count += 1  # 7. get finance events for booking
-            expected_queries_count += 1  # 8. rollback
+            expected_queries_count += 1  # 7. rollback
+            expected_queries_count += 1  # 8. get collective booking (reloaded by the logger)
 
             with assert_num_queries(expected_queries_count):
                 self.assert_request_has_expected_result(


### PR DESCRIPTION
# Description

Utiliser logger.exception à la place de logger.error afin de ne pas perdre d'informations. En l'état, on sait quelle erreur est survenue mais on ne peut pas savoir d'où elle provient exactement.
