### PR TITLE
(PC-31536)[PRO] feat: Display the venue name instead of the common one.

### DIFF
--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -109,7 +109,6 @@ class ManagedVenues(BaseModel):
 
         if venue.bankAccountLinks:
             venue.bankAccountId = venue.bankAccountLinks[0].bankAccountId
-        venue.name = venue.name
         venue.commonName = venue.common_name
         venue.hasPricingPoint = bool(venue.pricing_point_links)
 

--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -89,6 +89,7 @@ class LinkedVenues(BaseModel):
 
 class ManagedVenues(BaseModel):
     id: int
+    name: str
     commonName: str
     siret: str | None
     bankAccountId: int | None
@@ -108,6 +109,7 @@ class ManagedVenues(BaseModel):
 
         if venue.bankAccountLinks:
             venue.bankAccountId = venue.bankAccountLinks[0].bankAccountId
+        venue.name = venue.name
         venue.commonName = venue.common_name
         venue.hasPricingPoint = bool(venue.pricing_point_links)
 

--- a/pro/src/apiClient/v1/models/ManagedVenues.ts
+++ b/pro/src/apiClient/v1/models/ManagedVenues.ts
@@ -7,6 +7,7 @@ export type ManagedVenues = {
   commonName: string;
   hasPricingPoint: boolean;
   id: number;
+  name: string;
   siret?: string | null;
 };
 

--- a/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
+++ b/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from 'apiClient/v1'
 import * as useAnalytics from 'app/App/analytics/firebase'
 import { BankAccountEvents } from 'core/FirebaseEvents/constants'
+import { defaultManagedVenues } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { ReimbursementBankAccount } from '../ReimbursementBankAccount'
@@ -64,10 +65,9 @@ describe('ReimbursementBankAccount', () => {
 
     managedVenues = [
       {
+        ...defaultManagedVenues,
         bankAccountId: 1,
-        commonName: 'venue',
         hasPricingPoint: false,
-        id: 11,
       },
     ]
   })
@@ -120,10 +120,7 @@ describe('ReimbursementBankAccount', () => {
   it('should not render venues linked to bank account with only one bank account', () => {
     bankAccount.linkedVenues = []
     managedVenues.push({
-      bankAccountId: null,
-      commonName: 'second venue',
-      hasPricingPoint: false,
-      id: 12,
+      ...defaultManagedVenues,
     })
     renderReimbursementBankAccount(bankAccount, managedVenues)
 
@@ -159,10 +156,7 @@ describe('ReimbursementBankAccount', () => {
 
   it('should render with several venues not linked to bank account', () => {
     managedVenues.push({
-      bankAccountId: null,
-      commonName: 'second venue',
-      hasPricingPoint: false,
-      id: 12,
+      ...defaultManagedVenues,
     })
     renderReimbursementBankAccount(bankAccount, managedVenues)
 
@@ -185,10 +179,7 @@ describe('ReimbursementBankAccount', () => {
 
   it('should render with several venues not linked to bank account', () => {
     managedVenues.push({
-      bankAccountId: null,
-      commonName: 'second venue',
-      hasPricingPoint: false,
-      id: 12,
+      ...defaultManagedVenues,
     })
     renderReimbursementBankAccount(bankAccount, managedVenues)
 
@@ -200,10 +191,7 @@ describe('ReimbursementBankAccount', () => {
   it('should display error icon if one or more venues are not linked to an account', () => {
     bankAccount.linkedVenues = []
     managedVenues.push({
-      bankAccountId: 1,
-      commonName: 'second venue',
-      hasPricingPoint: false,
-      id: 12,
+      ...defaultManagedVenues,
     })
     renderReimbursementBankAccount(bankAccount, managedVenues, 1, true)
 

--- a/pro/src/pages/Reimbursements/BankInformations/PricingPointDialog/PricingPointDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/PricingPointDialog/PricingPointDialog.tsx
@@ -60,7 +60,7 @@ export const PricingPointDialog = ({
   const venuesOptions = [
     { label: 'Sélectionner un lieu dans la liste', value: '' },
     ...venues.map((venue) => ({
-      label: `${venue.commonName} - ${venue.siret}`,
+      label: `${venue.name} - ${venue.siret}`,
       value: venue.id.toString(),
     })),
   ]

--- a/pro/src/pages/Reimbursements/BankInformations/__specs__/LinkVenuesDialog.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/__specs__/LinkVenuesDialog.spec.tsx
@@ -5,8 +5,8 @@ import { api } from 'apiClient/api'
 import { BankAccountResponseModel, ManagedVenues } from 'apiClient/v1'
 import * as useNotification from 'hooks/useNotification'
 import {
-  defaultManagedVenues,
   defaultBankAccount,
+  defaultManagedVenues,
 } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -110,7 +110,7 @@ describe('LinkVenueDialog', () => {
       screen.getByLabelText(
         'Lieu avec SIRET utilisé pour le calcul de votre barème de remboursement *'
       ),
-      screen.getByRole('option', { name: 'Mon super lieu - 123456789' })
+      screen.getByRole('option', { name: 'RAISON SOCIALE - 123456789' })
     )
     await userEvent.click(
       screen.getByRole('button', { name: 'Valider la sélection' })
@@ -131,7 +131,7 @@ describe('LinkVenueDialog', () => {
       error: mockNotifyError,
     }))
     const managedVenues = [
-      { ...defaultManagedVenues, id: 1, hasPricingPoint: true },
+      { ...defaultManagedVenues, id: 1, hasPricingPoint: true, name: 'raison' },
       {
         ...defaultManagedVenues,
         id: 2,
@@ -152,7 +152,7 @@ describe('LinkVenueDialog', () => {
       screen.getByLabelText(
         'Lieu avec SIRET utilisé pour le calcul de votre barème de remboursement *'
       ),
-      screen.getByRole('option', { name: 'Mon super lieu - 123456789' })
+      screen.getByRole('option', { name: 'raison - 123456789' })
     )
     await userEvent.click(
       screen.getByRole('button', { name: 'Valider la sélection' })

--- a/pro/src/pages/Reimbursements/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/BankInformations.spec.tsx
@@ -7,12 +7,14 @@ import { api } from 'apiClient/api'
 import {
   BankAccountApplicationStatus,
   BankAccountResponseModel,
-  ManagedVenues,
 } from 'apiClient/v1'
 import * as useAnalytics from 'app/App/analytics/firebase'
 import { BankInformations } from 'pages/Reimbursements/BankInformations/BankInformations'
 import { ReimbursementsContextProps } from 'pages/Reimbursements/Reimbursements'
-import { defaultGetOffererResponseModel } from 'utils/individualApiFactories'
+import {
+  defaultGetOffererResponseModel,
+  defaultManagedVenues,
+} from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 import { sharedCurrentUserFactory } from 'utils/storeFactories'
 
@@ -31,12 +33,6 @@ const defaultBankAccountResponseModel: BankAccountResponseModel = {
   ],
   obfuscatedIban: 'XXXX-123',
   status: BankAccountApplicationStatus.ACCEPTE,
-}
-const defaultManagedVenues: ManagedVenues = {
-  commonName: 'wanted',
-  id: 1,
-  siret: 'costume',
-  hasPricingPoint: true,
 }
 
 const mockLogEvent = vi.fn()
@@ -73,7 +69,12 @@ describe('BankInformations', () => {
     vi.spyOn(api, 'getOffererBankAccountsAndAttachedVenues').mockResolvedValue({
       bankAccounts: [defaultBankAccountResponseModel],
       id: 1,
-      managedVenues: [defaultManagedVenues],
+      managedVenues: [
+        {
+          ...defaultManagedVenues,
+          commonName: 'wanted',
+        },
+      ],
     })
 
     vi.spyOn(router, 'useSearchParams').mockReturnValue([

--- a/pro/src/utils/individualApiFactories.ts
+++ b/pro/src/utils/individualApiFactories.ts
@@ -8,12 +8,12 @@ import {
   BookingRecapStatus,
   CategoryResponseModel,
   GetIndividualOfferWithAddressResponseModel,
-  GetOfferManagingOffererResponseModel,
-  GetOfferStockResponseModel,
-  GetOfferVenueResponseModel,
   GetOffererNameResponseModel,
   GetOffererResponseModel,
   GetOffererVenueResponseModel,
+  GetOfferManagingOffererResponseModel,
+  GetOfferStockResponseModel,
+  GetOfferVenueResponseModel,
   ListOffersOfferResponseModel,
   ListOffersStockResponseModel,
   ManagedVenues,
@@ -26,9 +26,9 @@ import {
   VenueTypeCode,
 } from 'apiClient/v1'
 import {
-  GetBookingResponse,
   BookingFormula,
   BookingOfferType,
+  GetBookingResponse,
 } from 'apiClient/v2'
 import { StocksEvent } from 'components/StocksEventList/StocksEventList'
 import { IndividualOfferContextValues } from 'context/IndividualOfferContext/IndividualOfferContext'
@@ -408,6 +408,7 @@ export const defaultBankAccount: BankAccountResponseModel = {
 
 export const defaultManagedVenues: ManagedVenues = {
   commonName: 'Mon super lieu',
+  name: 'RAISON SOCIALE',
   id: 1,
   siret: '123456789',
   hasPricingPoint: true,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31536

- Afficher le name au lieu du commonName dans le select des venues.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
