### PR TITLE
(PC-31829)[PRO] fix: useSwr for academies in adage filter academies

### DIFF
--- a/pro/src/config/swrQueryKeys.ts
+++ b/pro/src/config/swrQueryKeys.ts
@@ -3,6 +3,7 @@
 export const GET_BOOKINGS_QUERY_KEY = 'getBookings'
 export const GET_CATEGORIES_QUERY_KEY = 'getCategories'
 export const GET_CLASSROOM_PLAYLIST_QUERY_KEY = 'getClassroomPlaylist'
+export const GET_COLLECTIVE_ACADEMIES = 'getCollectiveAcademies'
 export const GET_COLLECTIVE_BOOKING_BY_ID_QUERY_KEY = 'getCollectiveBookingById'
 export const GET_COLLECTIVE_FAVORITES = 'getCollectiveFavorites'
 export const GET_COLLECTIVE_OFFER_QUERY_KEY = 'getCollectiveOffer'

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/__specs__/OfferFilters.spec.tsx
@@ -15,6 +15,12 @@ import { OfferFilters } from '../OfferFilters'
 const handleSubmit = vi.fn()
 const mockSetLocalisationFilterState = vi.fn()
 
+vi.mock('apiClient/api', () => ({
+  apiAdage: {
+    getAcademies: vi.fn(),
+  },
+}))
+
 const renderOfferFilters = (
   initialValues: SearchFormValues,
   localisationFilterState = LocalisationFilterStates.NONE,

--- a/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.tsx
+++ b/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.tsx
@@ -8,7 +8,7 @@ import { BaseInput } from '../shared/BaseInput/BaseInput'
 
 import styles from './AdageMultiselect.module.scss'
 
-interface ItemProps {
+export interface ItemProps {
   label: string
   value: number | string | string[]
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31829

Utilisation de swr pour la requête qui permet de récupérer les academies pour résoudre une erreur sentry 

https://sentry.passculture.team/organizations/sentry/issues/1618482/?project=2&referrer=jira_integration

