### PR TITLE
(PC-31996)[ADAGE] fix: Add the null value for rural level

### DIFF
--- a/api/src/pcapi/core/educational/api/institution.py
+++ b/api/src/pcapi/core/educational/api/institution.py
@@ -204,10 +204,11 @@ def synchronise_rurality_level() -> None:
 
     for rural_level, ids in ids_by_rurality_target.items():
         ids_to_update = ids - ids_by_rurality_actual.get(rural_level, set())
+        rural_level_enum = educational_models.InstitutionRuralLevel(rural_level) if rural_level else None
         if ids_to_update:
             educational_models.EducationalInstitution.query.filter(
                 educational_models.EducationalInstitution.id.in_(ids_to_update)
-            ).update({"ruralLevel": educational_models.InstitutionRuralLevel(rural_level)})
+            ).update({"ruralLevel": rural_level_enum})
 
     db.session.commit()
 

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -634,6 +634,9 @@ class SynchroniseRuralityLevelTest:
         et3 = educational_factories.EducationalInstitutionFactory(
             ruralLevel=educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE
         )
+        et4 = educational_factories.EducationalInstitutionFactory(
+            ruralLevel=educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE
+        )
 
         mock_path = "pcapi.connectors.big_query.TestingBackend.run_query"
         with mock.patch(mock_path) as mock_run_query:
@@ -650,13 +653,18 @@ class SynchroniseRuralityLevelTest:
                     "institution_id": str(et3.id),
                     "institution_rural_level": educational_models.InstitutionRuralLevel.GRANDS_CENTRES_URBAINS.value,
                 },
+                {
+                    "institution_id": str(et4.id),
+                    "institution_rural_level": None,
+                },
             ]
             institution_api.synchronise_rurality_level()
 
         institutions = educational_models.EducationalInstitution.query.order_by(
             educational_models.EducationalInstitution.id
         ).all()
-        assert [i.id for i in institutions] == [et1.id, et2.id, et3.id]
+        assert [i.id for i in institutions] == [et1.id, et2.id, et3.id, et4.id]
         assert institutions[0].ruralLevel == educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE
         assert institutions[1].ruralLevel == educational_models.InstitutionRuralLevel.RURAL_A_HABITAT_DISPERSE
         assert institutions[2].ruralLevel == educational_models.InstitutionRuralLevel.GRANDS_CENTRES_URBAINS
+        assert institutions[3].ruralLevel == None


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31996

Fix concerne https://sentry.passculture.team/organizations/sentry/issues/1618939/?referrer=slack

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
