### PR TITLE
(PC-31813)[API] fix: public api: isActive cannot be null

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -249,6 +249,8 @@ def edit_event(event_id: int, body: serialization.EventOfferEdition) -> serializ
             updates = body.dict(by_alias=True, exclude_unset=True)
             dc = updates.get("accessibility", {})
             extra_data = copy.deepcopy(offer.extraData)
+            is_active = get_field(offer, updates, "isActive")
+
             offer_body = offers_schemas.UpdateOffer(
                 audioDisabilityCompliant=get_field(offer, dc, "audioDisabilityCompliant"),
                 mentalDisabilityCompliant=get_field(offer, dc, "mentalDisabilityCompliant"),
@@ -263,7 +265,7 @@ def edit_event(event_id: int, body: serialization.EventOfferEdition) -> serializ
                     if "categoryRelatedFields" in updates
                     else extra_data
                 ),
-                isActive=get_field(offer, updates, "isActive"),
+                isActive=is_active if is_active is not None else offer.isActive,
                 idAtProvider=get_field(offer, updates, "idAtProvider"),
                 isDuo=get_field(offer, updates, "enableDoubleBookings", col="isDuo"),
                 withdrawalDetails=get_field(offer, updates, "itemCollectionDetails", col="withdrawalDetails"),


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31813

Avant : lors de l'édition d'une offre individuelle, on peut se retrouver à mettre à jour une offre avec `isActive` à `None` alors que la colonne ne peut pas l'être (=> erreur).
Après : on s'assure qu'on ne peut pas envoyer `None` comme valeur lors de la mise à jour. Si le champ `isActive` dans le JSON d'entrée vaut `null` ou s'il vaut nul parce qu'il n'a pas été renseigné, la colonne ne sera pas mise à jour.
