### PR TITLE
[BO] tests : offre individuelles : charger toutes les données une fois (+ bonus CSRF)

### DIFF
--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -1228,7 +1228,11 @@ class GetOverpaymentCreationFormTest(PostEndpointHelper):
     endpoint = "backoffice_web.finance_incidents.get_individual_bookings_overpayment_creation_form"
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
-    expected_num_queries = 7
+    # 1. get user's session
+    # 2. get user
+    # 3. get booking
+    # 4. check finance incident exists
+    expected_num_queries = 4
 
     def test_get_overpayment_creation_for_one_booking_form(self, authenticated_client, invoiced_pricing):
         venue = offerers_factories.VenueFactory()
@@ -1317,7 +1321,14 @@ class GetCollectiveBookingOverpaymentFormTest(PostEndpointHelper):
     endpoint_kwargs = {"collective_booking_id": 1}
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
-    expected_num_queries = 10
+    # 1. get booking
+    # 2. get user's session
+    # 3. get user
+    # 4. get collective booking (again, with more data)
+    # 5. get collective stock
+    # 6. get pricing
+    # 7. check finance incident exists
+    expected_num_queries = 7
 
     def test_get_form(self, authenticated_client, invoiced_collective_pricing):
         collective_booking = educational_factories.ReimbursedCollectiveBookingFactory(
@@ -1466,7 +1477,11 @@ class GetCommercialGestureCreationFormTest(PostEndpointHelper):
     endpoint = "backoffice_web.finance_incidents.get_individual_bookings_commercial_gesture_creation_form"
     needed_permission = perm_models.Permissions.MANAGE_INCIDENTS
 
-    expected_num_queries = 7
+    # 1. get user's session
+    # 2. get user
+    # 3. get booking
+    # 4. check finance incident exists
+    expected_num_queries = 4
 
     def test_get_commercial_gesture_creation_for_one_booking_form(self, authenticated_client):
         venue = offerers_factories.VenueFactory(name="Etablissement")

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -2237,7 +2237,7 @@ class GetBatchEditVenuesFormTest(PostEndpointHelper):
             "object_ids": ",".join(str(venue.id) for venue in venues),
         }
 
-        with assert_num_queries(self.fetch_csrf_num_queries + 3):  # session + current user + criteria
+        with assert_num_queries(3):  # session + current user + criteria
             response = self.post_to_endpoint(authenticated_client, form=form_data)
             assert response.status_code == 200
 


### PR DESCRIPTION
## But de la pull request

Explorer des pistes pour réduire le temps d'exécution des tests du BO.
Deux pistes sont proposées ici:

1. ne plus faire une requête http pour récupérer un jeton CSRF avant chaque requête http;
2. ne plus charger toutes les offres à chaque test mais une fois pour toute la classe.

La première option permet d'éviter des actions inutiles. Si elle permet de diminuer un peu le temps total d'exécution des tests, ce gain est minime.

La seconde piste n'a été appliqué que pour une classe de tests : récupérer une liste d'offre individuelle, avec plein de filtres possibles. Cela ajoute un peu de complexité sans être lourd (à mon sens) et permet une amélioration mesurable (environ 80s avant et 60s après en local). La question est de savoir si cette manière d'opérer peut facilement ailleurs s'appliquer ou si seules quelques classes de test peuvent être concernées.
