### PR TITLE
(PC-32006)[PRO] fix: Use the exact same query key for swr cache in al…

### DIFF
--- a/pro/src/config/swrQueryKeys.ts
+++ b/pro/src/config/swrQueryKeys.ts
@@ -14,7 +14,7 @@ export const GET_COLLECTIVE_OFFER_TEMPLATES_QUERY_KEY =
 export const GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY =
   'getCollectiveOffersBookable'
 export const GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY =
-  'getTemplateCollectiveOffers'
+  'getCollectiveOffersTemplate'
 export const GET_COLLECTIVE_OFFERS_FOR_INSTITUTION_QUERY_KEY =
   'getCollectiveOffersForMyInstitution'
 export const GET_COLLECTIVE_OFFERS_QUERY_KEY = 'getCollectiveOffers'

--- a/pro/src/core/Offers/utils/__specs__/getCollectiveOffersSwrKeys.spec.ts
+++ b/pro/src/core/Offers/utils/__specs__/getCollectiveOffersSwrKeys.spec.ts
@@ -1,0 +1,65 @@
+import { DEFAULT_COLLECTIVE_SEARCH_FILTERS } from 'core/Offers/constants'
+
+import {
+  getCollectiveOffersSwrKeys,
+  GetCollectiveOffersSwrKeysProps,
+} from '../getCollectiveOffersSwrKeys'
+
+const props: GetCollectiveOffersSwrKeysProps = {
+  isInTemplateOffersPage: false,
+  isNewInterfaceActive: false,
+  isNewOffersAndBookingsActive: false,
+  selectedOffererId: 1,
+  urlSearchFilters: DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+}
+
+describe('getCollectiveOffersSwrKeys', () => {
+  it('should return the correct offers list type', () => {
+    expect(getCollectiveOffersSwrKeys(props)[0]).toEqual('getCollectiveOffers')
+
+    expect(
+      getCollectiveOffersSwrKeys({
+        ...props,
+        isNewOffersAndBookingsActive: true,
+      })[0]
+    ).toEqual('getCollectiveOffersBookable')
+
+    expect(
+      getCollectiveOffersSwrKeys({
+        ...props,
+        isNewOffersAndBookingsActive: true,
+        isInTemplateOffersPage: true,
+      })[0]
+    ).toEqual('getCollectiveOffersTemplate')
+  })
+
+  it('should omit the page number in search filters', () => {
+    expect(
+      getCollectiveOffersSwrKeys({
+        ...props,
+        urlSearchFilters: { ...props.urlSearchFilters, page: 1 },
+      })[1].page
+    ).toBeUndefined()
+  })
+
+  it('should add the offerer id if the new interface is active', () => {
+    expect(getCollectiveOffersSwrKeys(props)[1].offererId).toEqual('all')
+
+    expect(
+      getCollectiveOffersSwrKeys({
+        ...props,
+        isNewInterfaceActive: true,
+      })[1].offererId
+    ).toEqual(props.selectedOffererId?.toString())
+  })
+
+  it('should consider all offerers if no offerer is specified', () => {
+    expect(
+      getCollectiveOffersSwrKeys({
+        ...props,
+        selectedOffererId: null,
+        isNewInterfaceActive: true,
+      })[1].offererId
+    ).toEqual('all')
+  })
+})

--- a/pro/src/core/Offers/utils/getCollectiveOffersSwrKeys.ts
+++ b/pro/src/core/Offers/utils/getCollectiveOffersSwrKeys.ts
@@ -1,0 +1,52 @@
+import {
+  GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY,
+  GET_COLLECTIVE_OFFERS_QUERY_KEY,
+  GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY,
+} from 'config/swrQueryKeys'
+
+import {
+  DEFAULT_COLLECTIVE_BOOKABLE_SEARCH_FILTERS,
+  DEFAULT_COLLECTIVE_SEARCH_FILTERS,
+  DEFAULT_COLLECTIVE_TEMPLATE_SEARCH_FILTERS,
+} from '../constants'
+import { CollectiveSearchFiltersParams } from '../types'
+
+export type GetCollectiveOffersSwrKeysProps = {
+  isNewOffersAndBookingsActive: boolean
+  isInTemplateOffersPage: boolean
+  isNewInterfaceActive: boolean
+  urlSearchFilters: CollectiveSearchFiltersParams
+  selectedOffererId: number | null
+}
+
+//  Make sure that the exact same query key is used across collective offers list actions
+export function getCollectiveOffersSwrKeys({
+  isNewOffersAndBookingsActive,
+  isInTemplateOffersPage,
+  urlSearchFilters,
+  isNewInterfaceActive,
+  selectedOffererId,
+}: GetCollectiveOffersSwrKeysProps): [string, CollectiveSearchFiltersParams] {
+  const collectiveOffersListQueryKey = isNewOffersAndBookingsActive
+    ? isInTemplateOffersPage
+      ? GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY
+      : GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY
+    : GET_COLLECTIVE_OFFERS_QUERY_KEY
+
+  const defaultCollectiveFilters = isNewOffersAndBookingsActive
+    ? isInTemplateOffersPage
+      ? DEFAULT_COLLECTIVE_TEMPLATE_SEARCH_FILTERS
+      : DEFAULT_COLLECTIVE_BOOKABLE_SEARCH_FILTERS
+    : DEFAULT_COLLECTIVE_SEARCH_FILTERS
+
+  const apiFilters: CollectiveSearchFiltersParams = {
+    ...defaultCollectiveFilters,
+    ...urlSearchFilters,
+    ...(isNewInterfaceActive
+      ? { offererId: selectedOffererId?.toString() ?? 'all' }
+      : {}),
+    page: undefined,
+  }
+
+  return [collectiveOffersListQueryKey, apiFilters]
+}

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -6,8 +6,6 @@ import { api } from 'apiClient/api'
 import { CollectiveOfferType } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import {
-  GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY,
-  GET_COLLECTIVE_OFFERS_QUERY_KEY,
   GET_OFFERER_QUERY_KEY,
   GET_VENUES_QUERY_KEY,
 } from 'config/swrQueryKeys'
@@ -19,6 +17,7 @@ import {
 import { useQueryCollectiveSearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
 import { CollectiveSearchFiltersParams } from 'core/Offers/types'
 import { computeCollectiveOffersUrl } from 'core/Offers/utils/computeCollectiveOffersUrl'
+import { getCollectiveOffersSwrKeys } from 'core/Offers/utils/getCollectiveOffersSwrKeys'
 import { hasCollectiveSearchFilters } from 'core/Offers/utils/hasSearchFilters'
 import { serializeApiCollectiveFilters } from 'core/Offers/utils/serializer'
 import { useActiveFeature } from 'hooks/useActiveFeature'
@@ -84,6 +83,14 @@ export const CollectiveOffers = (): JSX.Element => {
   //  Admin users are not allowed to check all offers at once or to use the status filter for performance reasons. Unless there is a venue or offerer filter active.
   const isRestrictedAsAdmin = currentUser.isAdmin && !isFilterByVenueOrOfferer
 
+  const collectiveOffersQueryKeys = getCollectiveOffersSwrKeys({
+    isNewOffersAndBookingsActive,
+    isInTemplateOffersPage: false,
+    urlSearchFilters,
+    isNewInterfaceActive,
+    selectedOffererId,
+  })
+
   const apiFilters: CollectiveSearchFiltersParams = {
     ...defaultCollectiveFilters,
     ...urlSearchFilters,
@@ -95,12 +102,7 @@ export const CollectiveOffers = (): JSX.Element => {
   delete apiFilters.page
 
   const offersQuery = useSWR(
-    [
-      isNewOffersAndBookingsActive
-        ? GET_COLLECTIVE_OFFERS_BOOKABLE_QUERY_KEY
-        : GET_COLLECTIVE_OFFERS_QUERY_KEY,
-      apiFilters,
-    ],
+    collectiveOffersQueryKeys,
     () => {
       const {
         nameOrIsbn,

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveOffersActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/__specs__/CollectiveOffersActionsBar.spec.tsx
@@ -558,7 +558,7 @@ describe('ActionsBar', () => {
     await userEvent.click(screen.getByText('Publier'))
 
     expect(mockMutate).toHaveBeenCalledWith(
-      expect.arrayContaining(['getTemplateCollectiveOffers'])
+      expect.arrayContaining(['getCollectiveOffersTemplate'])
     )
   })
 })

--- a/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffers.tsx
+++ b/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffers.tsx
@@ -7,7 +7,6 @@ import { CollectiveOfferType } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import {
   GET_OFFERER_QUERY_KEY,
-  GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY,
   GET_VENUES_QUERY_KEY,
 } from 'config/swrQueryKeys'
 import {
@@ -17,6 +16,7 @@ import {
 import { useQueryCollectiveSearchFilters } from 'core/Offers/hooks/useQuerySearchFilters'
 import { CollectiveSearchFiltersParams } from 'core/Offers/types'
 import { computeCollectiveOffersUrl } from 'core/Offers/utils/computeCollectiveOffersUrl'
+import { getCollectiveOffersSwrKeys } from 'core/Offers/utils/getCollectiveOffersSwrKeys'
 import { hasCollectiveSearchFilters } from 'core/Offers/utils/hasSearchFilters'
 import { serializeApiCollectiveFilters } from 'core/Offers/utils/serializer'
 import { useCurrentUser } from 'hooks/useCurrentUser'
@@ -78,6 +78,14 @@ export const TemplateCollectiveOffers = (): JSX.Element => {
   //  Admin users are not allowed to check all offers at once or to use the status filter for performance reasons. Unless there is a venue or offerer filter active.
   const isRestrictedAsAdmin = currentUser.isAdmin && !isFilterByVenueOrOfferer
 
+  const collectiveOffersQueryKeys = getCollectiveOffersSwrKeys({
+    isNewOffersAndBookingsActive: true,
+    isInTemplateOffersPage: true,
+    urlSearchFilters,
+    isNewInterfaceActive,
+    selectedOffererId,
+  })
+
   const apiFilters: CollectiveSearchFiltersParams = {
     ...DEFAULT_COLLECTIVE_TEMPLATE_SEARCH_FILTERS,
     ...urlSearchFilters,
@@ -89,7 +97,7 @@ export const TemplateCollectiveOffers = (): JSX.Element => {
   delete apiFilters.page
 
   const offersQuery = useSWR(
-    [GET_COLLECTIVE_OFFERS_TEMPLATE_QUERY_KEY, apiFilters],
+    collectiveOffersQueryKeys,
     () => {
       const {
         nameOrIsbn,


### PR DESCRIPTION
…l collective offers components.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32006

**Objecyif**
Corriger le bug suivant : Quand on arrive sur la liste des offres collectives, avant d'avoir filtré sur quoi que ce soit, si on coche une des offre et qu'on l'archive via le bulk edit, on a un message de succès, mais le statut de l'offre ne change pas automatiquement.

Le problème est qu'avant d'avoir des filtres dans l'url, il y a une désynchro entre les filtres considérés par swr et les filtres utilisés dans les clés du mutate lors des updates des offres de la liste. Pour corriger et essayer de rendre le fonctionnement + robuste, j'ai extrait la logique qui construit les clés swr dans un utilitaire. 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
