### PR TITLE
(PC-32009)[PRO] feat: tracker achivage params

### DIFF
--- a/pro/src/components/ArchiveConfirmationModal/ArchiveConfirmationModal.tsx
+++ b/pro/src/components/ArchiveConfirmationModal/ArchiveConfirmationModal.tsx
@@ -9,6 +9,7 @@ import strokeThingIcon from 'icons/stroke-thing.svg'
 interface OfferEducationalModalProps {
   onDismiss(): void
   onValidate(): void
+  offerId?: number
   hasMultipleOffers?: boolean
   selectedOffers?: CollectiveOfferResponseModel[]
 }
@@ -18,6 +19,7 @@ export const ArchiveConfirmationModal = ({
   onValidate,
   hasMultipleOffers = false,
   selectedOffers = [],
+  offerId,
 }: OfferEducationalModalProps): JSX.Element => {
   const location = useLocation()
   const { logEvent } = useAnalytics()
@@ -29,7 +31,8 @@ export const ArchiveConfirmationModal = ({
 
     logEvent(Events.CLICKED_ARCHIVE_COLLECTIVE_OFFER, {
       from: location.pathname,
-      selected_offers: collectiveOfferIds,
+      selected_offers:
+        selectedOffers.length > 0 ? collectiveOfferIds : offerId?.toString(),
     })
 
     onValidate()

--- a/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
@@ -293,6 +293,7 @@ export const CollectiveOfferNavigation = ({
         <ArchiveConfirmationModal
           onDismiss={() => setIsArchiveModalOpen(false)}
           onValidate={archiveOffer}
+          offerId={offerId}
         />
       )}
     </>

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -401,6 +401,7 @@ export const CollectiveActionsCells = ({
           <ArchiveConfirmationModal
             onDismiss={() => setIsArchivedModalOpen(false)}
             onValidate={archiveOffer}
+            offerId={offer.id}
           />
         )}
       </div>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32009

Suite d'une PR qui envoyait seulement les ids des offres sélectionnées et archivé depuis l'actionbar, on le fait aussi pour envoyer l'id d'une offre archivée depuis la page de récap ou des boutons d'actions