### PR TITLE
(PC-32010)[API] fix: correctly set the commercial gesture's amount on multiple bookings

### DIFF
--- a/api/src/pcapi/core/mails/transactional/finance_incidents/finance_incident_notification.py
+++ b/api/src/pcapi/core/mails/transactional/finance_incidents/finance_incident_notification.py
@@ -79,10 +79,7 @@ def send_commercial_gesture_email(finance_incident: finance_models.FinanceIncide
                 "OFFER_NAME": offer.name,
                 "VENUE_NAME": venue.common_name,
                 "MONTANT_REMBOURSEMENT": finance_utils.to_euros(
-                    sum(
-                        (booking_incident.commercial_gesture_amount or 0)
-                        for booking_incident in offer_booking_incidents
-                    )
+                    sum((booking_incident.due_amount_by_offerer or 0) for booking_incident in offer_booking_incidents)
                 ),
                 "TOKEN_LIST": ", ".join(
                     [

--- a/api/src/pcapi/routes/backoffice/finance/finance_incidents_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/finance/finance_incidents_blueprint.py
@@ -255,10 +255,6 @@ def get_incident_overpayment(finance_incident_id: int) -> utils.BackofficeRespon
 @utils.permission_required(perm_models.Permissions.READ_INCIDENTS)
 def get_commercial_gesture(finance_incident_id: int) -> utils.BackofficeResponse:
     incident = _get_incident(finance_incident_id, kind=finance_models.IncidentType.COMMERCIAL_GESTURE)
-    commercial_gesture_amount = sum(
-        (booking_finance_incident.commercial_gesture_amount or 0)
-        for booking_finance_incident in incident.booking_finance_incidents
-    )
     bookings_total_amount = sum(
         (booking_incident.booking or booking_incident.collectiveBooking).total_amount
         for booking_incident in incident.booking_finance_incidents
@@ -267,7 +263,7 @@ def get_commercial_gesture(finance_incident_id: int) -> utils.BackofficeResponse
     return render_template(
         "finance/incidents/get_commercial_gesture.html",
         incident=incident,
-        commercial_gesture_amount=commercial_gesture_amount,
+        commercial_gesture_amount=incident.due_amount_by_offerer,
         bookings_total_amount=bookings_total_amount,
         active_tab=request.args.get("active_tab", "bookings"),
     )
@@ -829,7 +825,7 @@ def _get_finance_overpayment_incident_validation_form(
 def _get_finance_commercial_gesture_validation_form(
     finance_incident: finance_models.FinanceIncident,
 ) -> utils.BackofficeResponse:
-    commercial_gesture_amount = finance_utils.to_euros(finance_incident.commercial_gesture_amount)
+    commercial_gesture_amount = finance_utils.to_euros(finance_incident.due_amount_by_offerer)
     bank_account_link = finance_incident.venue.current_bank_account_link
     bank_account_details_str = "du lieu" if not bank_account_link else bank_account_link.bankAccount.label
     validation_url = "backoffice_web.finance_incidents.validate_finance_commercial_gesture"


### PR DESCRIPTION
## But de la pull request

Fix du calcul du montant des gestes commerciaux lors de la création sur plusieurs réservations

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32010

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~
