### PR TITLE
(PC-32001)[API] fix: public api: indiv offer: patch offerVenue fixes

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -554,9 +554,9 @@ def edit_collective_offer_public(
 
             offer.institution = institution
         elif key == "offerVenue":
-            offer.offerVenue["venueId"] = value["venueId"] or None
-            offer.offerVenue["addressType"] = value["addressType"].value
-            offer.offerVenue["otherAddress"] = value["otherAddress"] or ""
+            offer.offerVenue["venueId"] = value.get("venueId")
+            offer.offerVenue["addressType"] = value.get("addressType")
+            offer.offerVenue["otherAddress"] = value.get("otherAddress", "")
         elif key == "bookingLimitDatetime" and value is None:
             offer.collectiveStock.bookingLimitDatetime = new_values.get(
                 "beginningDatetime", offer.collectiveStock.beginningDatetime


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32001

La mise à jour du champ `otherAddres` d'une offre individuelle ne devrait pas nécessiter la présence des trois champs possibles (`addressType`, `venueId` et `otherAddress`). Le client de l'API ne devrait renseigner que celles qui sont pertinentes (le type et l'id du lieu si l'activité se déroule dans un lieu connu de notre base de données, etc.).

Ce fix fait en sorte que les trois champs sont toujours remplis lors de l'écriture en base de données : en fonction du type de lieu, les champs qui n'ont pas d'intérêt ont une valeur par défaut.

### Notes

Les nouvelles introduites ne devraient jamais être générées (et donc capturables) puisqu'il y eu des vérifications en amont.
