### PR TITLE
(BSR)[API] test: display more info on api error with e2e

### DIFF
--- a/api/src/pcapi/routes/internal/e2e.py
+++ b/api/src/pcapi/routes/internal/e2e.py
@@ -26,10 +26,12 @@ def get_sandbox(module_name, getter_name):  # type: ignore [no-untyped-def]
     try:
         obj = getter()
         return jsonify(obj)
-    except:
+    except Exception as e:
         errors = ApiErrors()
         errors.add_error(
             "query",
-            'Une erreur s\'est produite lors du calcul de "{} {}" pour la sandbox'.format(module_name, getter_name),
+            'Une erreur s\'est produite lors du calcul de "{} {}" pour la sandbox : {}'.format(
+                module_name, getter_name, e
+            ),
         )
         raise errors


### PR DESCRIPTION
## But de la pull request

BSR

Avoir plus de détails dans Cypress sur les erreurs des createurs de données

![image](https://github.com/user-attachments/assets/d9bc3dde-69be-4de2-af92-4e2e3f9f802d)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
