### PR TITLE
(PC-32039)[BO] feat: send reset password email from user details page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
@@ -25,15 +25,15 @@
             {% endif %}
           </h5>
           <div class="d-flex row-reverse justify-content-end flex-grow-1">
-            {% if edit_account_form %}
-              {{ build_modal_form("edit-account", edit_account_dst, edit_account_form, "Modifier les informations", "Modifier les informations", "Enregistrer") }}
-            {% endif %}
             {% if user.isActive %}
               <div class="mx-3 pt-2 pc-brevo-logo-link">
                 <a href="{{ url_for('backoffice_web.users.redirect_to_brevo_user_page', user_id=user.id) }}"
                    target="_blank"
                    rel="noreferrer noopener">{{ logo.brevo() }}</a>
               </div>
+            {% endif %}
+            {% if edit_account_form %}
+              {{ build_modal_form("edit-account", edit_account_dst, edit_account_form, "Modifier les informations", "Modifier les informations", "Enregistrer") }}
             {% endif %}
           </div>
         </div>

--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
@@ -148,6 +148,13 @@
             </div>
             {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
               <div>
+                {{ build_modal_form("send-reset-password-email", password_reset_dst, password_reset_form,
+                                "Envoyer le mail de changement de mot de passe",
+                                "Envoyer le mail de changement de mot de passe",
+                                "Confirmer l'envoi",
+                                "En confirmant, l'email de mot de passe perdu contenant un lien de réinitialisation valide 24 heures sera envoyé à " + user.email + ".") }}
+              </div>
+              <div>
                 {{ build_modal_form("invalidate-account-password", password_invalidation_dst, password_invalidation_form, "Invalider le mot de passe", "Invalider le mot de passe", "Confirmer l'invalidation") }}
               </div>
             {% endif %}


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32039

Et un second commit cosmétique pour aligner les boutons (demande du support jeunes).

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
