### PR TITLE
(PC-32046)[API] feat: always ask for 18yo beneficiary phone number

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -172,8 +172,6 @@ def get_phone_validation_subscription_item(
             status = models.SubscriptionItemStatus.OK
         elif user.is_phone_validation_skipped:
             status = models.SubscriptionItemStatus.SKIPPED
-        elif not FeatureToggle.ENABLE_PHONE_VALIDATION.is_active():
-            status = models.SubscriptionItemStatus.NOT_ENABLED
         elif fraud_repository.has_failed_phone_validation(user):
             status = models.SubscriptionItemStatus.KO
         elif is_eligibility_activable(user, eligibility):
@@ -820,7 +818,7 @@ def get_subscription_steps_to_display(
 
 def _get_ordered_steps(user: users_models.User) -> list[models.SubscriptionStep]:
     ordered_steps = []
-    if user.eligibility == users_models.EligibilityType.AGE18 and FeatureToggle.ENABLE_PHONE_VALIDATION.is_active():
+    if user.eligibility == users_models.EligibilityType.AGE18:
         ordered_steps.append(models.SubscriptionStep.PHONE_VALIDATION)
     ordered_steps.append(models.SubscriptionStep.PROFILE_COMPLETION)
     if requires_identity_check_step(user):

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -1454,7 +1454,6 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.source == f"dossier FraudCheckType.EDUCONNECT [{identity_fraud_check.thirdPartyId}]"
         assert user.deposit.amount == 30
 
-    @override_features(ENABLE_PHONE_VALIDATION=False)
     def test_rejected_identity(self):
         user = self.eligible_user(validate_phone=False)
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -164,9 +164,7 @@ class AccountTest:
     def test_status_contains_subscription_status_when_eligible(self, client):
         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18))
 
-        expected_num_queries = (
-            6  # user + beneficiary_fraud_review + feature + beneficiary_fraud_check + deposit + booking
-        )
+        expected_num_queries = 5  # user + beneficiary_fraud_review + beneficiary_fraud_check + deposit + booking
 
         client.with_token(user.email)
         with assert_num_queries(expected_num_queries):

--- a/api/tests/routes/native/v1/banner_test.py
+++ b/api/tests/routes/native/v1/banner_test.py
@@ -69,7 +69,7 @@ class BannerTest:
         user = users_factories.UserFactory(dateOfBirth=dateOfBirth)
 
         client.with_token(email=user.email)
-        with assert_num_queries(self.expected_num_queries_without_subscription_check + 1):  # 1 FF checked
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):
             response = client.get("/native/v1/banner?isGeolocated=false")
             assert response.status_code == 200
 
@@ -176,9 +176,7 @@ class BannerTest:
         user = users_factories.ExUnderageBeneficiaryFactory()
 
         client.with_token(email=user.email)
-        with assert_num_queries(
-            self.expected_num_queries_without_subscription_check + 1
-        ):  # FF ENABLE_PHONE_VALIDATION checked
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):
             response = client.get("/native/v1/banner")
             assert response.status_code == 200
 
@@ -198,9 +196,7 @@ class BannerTest:
         assert user.age == 18
 
         client.with_token(email=user.email)
-        with assert_num_queries(
-            self.expected_num_queries_without_subscription_check + 1
-        ):  # FF ENABLE_PHONE_VALIDATION checked
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):
             response = client.get("/native/v1/banner")
             assert response.status_code == 200
 


### PR DESCRIPTION
The `ENABLE_PHONE_VALIDATION` feature flag is now only used to toggle between the phone validation screens in the native app.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32046