### PR TITLE
(PC-32060)[PRO] fix: Removes icon={fullLinkIcon} in timeline links

### DIFF
--- a/pro/src/pages/VenueCreation/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/pages/VenueCreation/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -3,7 +3,6 @@ import { useAnalytics } from 'app/App/analytics/firebase'
 import { Callout } from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
 import { Events } from 'core/FirebaseEvents/constants'
-import fullLinkIcon from 'icons/full-link.svg'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { Timeline, TimelineStepType } from 'ui-kit/Timeline/Timeline'
@@ -88,7 +87,6 @@ export const CollectiveDmsTimeline = ({
           variant={ButtonVariant.TERNARY}
           to={collectiveDmsApplicationLink}
           isExternal
-          icon={fullLinkIcon}
           onClick={() =>
             logClickOnDmsLink(DMSApplicationstatus.EN_CONSTRUCTION)
           }
@@ -99,7 +97,6 @@ export const CollectiveDmsTimeline = ({
           variant={ButtonVariant.TERNARY}
           to={collectiveDmsContactSupport}
           isExternal
-          icon={fullLinkIcon}
         >
           Contacter les services des Ministères de l’Education Nationale et de
           la Culture
@@ -128,7 +125,6 @@ export const CollectiveDmsTimeline = ({
           variant={ButtonVariant.TERNARY}
           to={collectiveDmsApplicationLink}
           isExternal
-          icon={fullLinkIcon}
           onClick={() => logClickOnDmsLink(DMSApplicationstatus.EN_INSTRUCTION)}
         >
           Consulter ma messagerie sur Démarches Simplifiées
@@ -169,7 +165,6 @@ export const CollectiveDmsTimeline = ({
           variant={ButtonVariant.TERNARY}
           to={collectiveDmsApplicationLink}
           isExternal
-          icon={fullLinkIcon}
           onClick={() => logClickOnDmsLink(DMSApplicationstatus.ACCEPTE)}
         >
           Consulter ma messagerie sur Démarches Simplifiées

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.tsx
@@ -1,5 +1,4 @@
 import { addDays, isBefore, max } from 'date-fns'
-import React from 'react'
 
 import {
   CollectiveBookingBankAccountStatus,
@@ -11,7 +10,6 @@ import { useAnalytics } from 'app/App/analytics/firebase'
 import { BOOKING_STATUS } from 'core/Bookings/constants'
 import { CollectiveBookingsEvents } from 'core/FirebaseEvents/constants'
 import fullEditIcon from 'icons/full-edit.svg'
-import fullLinkIcon from 'icons/full-link.svg'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import {
@@ -182,7 +180,6 @@ export const CollectiveTimeLine = ({
                   variant={ButtonVariant.TERNARY}
                   to="https://aide.passculture.app/hc/fr/articles/4405297381788--Acteurs-Culturels-Que-faire-si-le-groupe-scolaire-n-est-pas-au-complet-ou-doit-annuler-sa-participation-"
                   isExternal
-                  icon={fullLinkIcon}
                 >
                   Je rencontre un problème à cette étape
                 </ButtonLink>
@@ -260,11 +257,11 @@ export const CollectiveTimeLine = ({
           <br />
           <br />
           Nous espérons que votre évènement s’est bien déroulé.
+          <br />
           <ButtonLink
             variant={ButtonVariant.TERNARY}
             to="https://aide.passculture.app/hc/fr/articles/4405297381788--Acteurs-Culturels-Que-faire-si-le-groupe-scolaire-n-est-pas-au-complet-ou-doit-annuler-sa-participation-"
             isExternal
-            icon={fullLinkIcon}
           >
             Je rencontre un problème à cette étape
           </ButtonLink>
@@ -324,7 +321,6 @@ export const CollectiveTimeLine = ({
           variant={ButtonVariant.TERNARY}
           to="https://aide.passculture.app/hc/fr/articles/4411992051601"
           isExternal
-          icon={fullLinkIcon}
         >
           Voir le calendrier des remboursements
         </ButtonLink>
@@ -387,7 +383,6 @@ export const CollectiveTimeLine = ({
         <ButtonLink
           variant={ButtonVariant.TERNARY}
           to={`remboursements/informations-bancaires?structure=${bookingDetails.offererId}`}
-          icon={fullLinkIcon}
           className={styles['button-important']}
         >
           Paramétrer les informations bancaires
@@ -412,7 +407,6 @@ export const CollectiveTimeLine = ({
           variant={ButtonVariant.TERNARY}
           to={`https://www.demarches-simplifiees.fr/dossiers/${bookingDetails.venueDMSApplicationId}/messagerie`}
           isExternal
-          icon={fullLinkIcon}
         >
           Voir le dossier en cours
         </ButtonLink>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32060

## Vérifications

- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

Le lien ne s'ouvre pas dans une nouvelle fenêtre (comportement souhaité car a11y compliant), il faut donc retirer tous les icônes indiquant le contraire pour rester cohérent.
<img width="416" alt="Capture d’écran 2024-09-30 à 11 42 59" src="https://github.com/user-attachments/assets/8c9962e7-b616-43de-9f71-b723e250ffb3">
