### PR TITLE
(PC-32062)[PRO] feat: Change Tabs component to use Radix Tabs

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -45,6 +45,7 @@
     "@firebase/remote-config": "0.4.9",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-tabs": "^1.1.0",
     "@reduxjs/toolkit": "^2.2.7",
     "@sentry/browser": "^8.28.0",
     "@sentry/react": "^8.32.0",

--- a/pro/src/components/CollectiveOfferNavigation/__specs__/CollectiveOfferNavigation.spec.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/__specs__/CollectiveOfferNavigation.spec.tsx
@@ -223,19 +223,22 @@ describe('CollectiveOfferNavigation', () => {
     props.isCreatingOffer = false
     renderCollectiveOfferNavigation(props)
 
-    const linkItems = await screen.findAllByRole('link')
+    const links = await screen.findAllByRole('link')
+    const tabs = await screen.findAllByRole('tab')
 
-    expect(linkItems).toHaveLength(4)
-    expect(linkItems[0].getAttribute('href')).toBe(
+    expect(links).toHaveLength(1)
+    expect(links[0].getAttribute('href')).toBe(
       `/offre/${offerId}/collectif/apercu`
     )
-    expect(linkItems[1].getAttribute('href')).toBe(
+    expect(tabs).toHaveLength(3)
+
+    expect(tabs[0].getAttribute('href')).toBe(
       `/offre/${offerId}/collectif/edition`
     )
-    expect(linkItems[2].getAttribute('href')).toBe(
+    expect(tabs[1].getAttribute('href')).toBe(
       `/offre/${offerId}/collectif/stocks/edition`
     )
-    expect(linkItems[3].getAttribute('href')).toBe(
+    expect(tabs[2].getAttribute('href')).toBe(
       `/offre/${offerId}/collectif/visibilite/edition`
     )
   })

--- a/pro/src/components/IndividualOfferNavigation/__specs__/IndividualOfferNavigation.spec.tsx
+++ b/pro/src/components/IndividualOfferNavigation/__specs__/IndividualOfferNavigation.spec.tsx
@@ -281,7 +281,7 @@ describe('test IndividualOfferNavigation', () => {
 
       expect(screen.getByText('Informations screen')).toBeInTheDocument()
       expect(
-        screen.getByRole('link', { name: 'Dates & Capacités' })
+        screen.getByRole('tab', { name: 'Dates & Capacités' })
       ).toBeInTheDocument()
     })
 

--- a/pro/src/ui-kit/Tabs/Tabs.module.scss
+++ b/pro/src/ui-kit/Tabs/Tabs.module.scss
@@ -53,12 +53,8 @@
 
     &.is-selected {
       border-bottom: rem.torem(2px) solid var(--color-primary);
-
-      .tabs-tab-link,
-      .tabs-tab-button {
-        color: var(--color-primary);
-        text-decoration: none;
-      }
+      color: var(--color-primary);
+      text-decoration: none;
 
       .tabs-tab-icon {
         fill: var(--color-primary);

--- a/pro/src/ui-kit/Tabs/Tabs.stories.tsx
+++ b/pro/src/ui-kit/Tabs/Tabs.stories.tsx
@@ -18,33 +18,13 @@ export const Default: StoryObj<typeof Tabs> = {
     tabs: [
       {
         label: 'Offres individuelles',
-        url: 'offres/indiv',
+        url: '#',
         key: 'individual',
         icon: strokeUserIcon,
       },
       {
         label: 'Offres collectives',
-        url: 'offres/collectives',
-        key: 'collective',
-        icon: strokeLibraryIcon,
-      },
-    ],
-  },
-}
-
-export const DefaultWithButton: StoryObj<typeof Tabs> = {
-  args: {
-    selectedKey: 'individual',
-    tabs: [
-      {
-        label: 'Offres individuelles',
-        onClick: () => {},
-        key: 'individual',
-        icon: strokeUserIcon,
-      },
-      {
-        label: 'Offres collectives',
-        onClick: () => {},
+        url: '#',
         key: 'collective',
         icon: strokeLibraryIcon,
       },

--- a/pro/src/ui-kit/Tabs/Tabs.tsx
+++ b/pro/src/ui-kit/Tabs/Tabs.tsx
@@ -1,27 +1,26 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs'
 import cn from 'classnames'
-import React, { ReactNode } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import React from 'react'
+import { Link } from 'react-router-dom'
 
-import { Button } from 'ui-kit/Button/Button'
-import { ButtonVariant } from 'ui-kit/Button/types'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './Tabs.module.scss'
 
 export interface Tab {
-  label: string | ReactNode
+  label: string | React.ReactNode
   key: string
   url?: string
-  onClick?: (e: React.MouseEvent) => void
   icon?: string
 }
 
-interface FilterTabsProps {
+interface TabsProps {
   nav?: string
   tabs: Tab[]
   selectedKey?: string
   className?: string
 }
+
 const NAV_ITEM_ICON_SIZE = '24'
 
 export const Tabs = ({
@@ -29,55 +28,38 @@ export const Tabs = ({
   selectedKey,
   tabs,
   className,
-}: FilterTabsProps): JSX.Element => {
-  const location = useLocation()
-  const content =
-    tabs.length > 0 ? (
-      <ul className={cn(styles['tabs'], className)}>
-        {tabs.map(({ key, label, url, icon, onClick }) => {
-          return (
-            <li
-              className={cn(styles['tabs-tab'], {
-                [styles['is-selected']]: selectedKey === key,
-              })}
-              key={`tab_${key}`}
-            >
-              {url ? (
-                <Link
-                  className={styles['tabs-tab-link']}
-                  key={`tab${url}`}
-                  to={url}
-                  aria-current={
-                    nav && location.pathname === url ? 'page' : undefined
-                  }
-                >
-                  {icon && (
-                    <SvgIcon
-                      src={icon}
-                      alt=""
-                      className={styles['tabs-tab-icon']}
-                      width={NAV_ITEM_ICON_SIZE}
-                    />
-                  )}
-                  <span className={styles['tabs-tab-label']}>{label}</span>
-                </Link>
-              ) : (
-                <Button
-                  variant={ButtonVariant.TERNARY}
-                  icon={icon}
-                  onClick={onClick}
-                  className={styles['tabs-tab-button']}
-                >
-                  {label}
-                </Button>
+}: TabsProps): JSX.Element => {
+  const content = (
+    <TabsPrimitive.Root
+      className={cn(styles['tabs-root'], className)}
+      value={selectedKey}
+    >
+      <TabsPrimitive.List className={styles['tabs']}>
+        {tabs.map(({ key, label, url, icon }) => (
+          <TabsPrimitive.Trigger
+            className={cn(styles['tabs-tab'], {
+              [styles['is-selected']]: selectedKey === key,
+            })}
+            key={key}
+            value={key}
+            asChild
+          >
+            <Link to={url ?? '#'} className={styles['tabs-tab-link']}>
+              {icon && (
+                <SvgIcon
+                  src={icon}
+                  alt=""
+                  className={styles['tabs-tab-icon']}
+                  width={NAV_ITEM_ICON_SIZE}
+                />
               )}
-            </li>
-          )
-        })}
-      </ul>
-    ) : (
-      <></>
-    )
+              <span className={styles['tabs-tab-label']}>{label}</span>
+            </Link>
+          </TabsPrimitive.Trigger>
+        ))}
+      </TabsPrimitive.List>
+    </TabsPrimitive.Root>
+  )
 
   return nav ? <nav aria-label={nav}>{content}</nav> : content
 }

--- a/pro/src/ui-kit/Tabs/__specs__/Tabs.spec.tsx
+++ b/pro/src/ui-kit/Tabs/__specs__/Tabs.spec.tsx
@@ -15,6 +15,7 @@ const renderTabs = (nav?: string) => {
         path="/offres"
         element={
           <Tabs
+            selectedKey="individual"
             tabs={[
               {
                 label: 'Offres individuelles',
@@ -44,7 +45,7 @@ describe('src | components | Tabs', () => {
   it('should render tabs', () => {
     renderTabs()
     expect(
-      screen.getByRole('link', {
+      screen.getByRole('tab', {
         name: 'Offres individuelles',
       })
     ).toHaveAttribute('href', '/offres')
@@ -64,20 +65,26 @@ describe('src | components | Tabs', () => {
       renderTabs('Offres individuelles et collectives')
 
       expect(
-        screen.getByRole('link', {
+        screen.getByRole('tab', {
           name: 'Offres individuelles',
         })
-      ).toHaveAttribute('aria-current', 'page')
+      ).toHaveAttribute('aria-selected', 'true')
+
+      expect(
+        screen.getByRole('tab', {
+          name: 'Offres individuelles',
+        })
+      ).toHaveAttribute('data-state', 'active')
     })
 
     it('should not indicate current page', () => {
       renderTabs('Offres individuelles et collectives')
 
       expect(
-        screen.getByRole('link', {
+        screen.getByRole('tab', {
           name: 'Offres collectives',
         })
-      ).not.toHaveAttribute('aria-current', 'page')
+      ).not.toHaveAttribute('aria-selected', 'true')
     })
   })
 })

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -1627,6 +1627,20 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
 
+"@radix-ui/react-tabs@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.0.tgz#0a6db1caed56776a1176aae68532060e301cc1c0"
+  integrity sha512-bZgOKB/LtZIij75FSuPzyEti/XBhJH52ExgtdVqjCIh+Nx/FW+LhnbXtbCzIi34ccyMsyOja8T0thCzoHFXNKA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-presence" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-roving-focus" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+
 "@radix-ui/react-use-callback-ref@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz#bce938ca413675bc937944b0d01ef6f4a6dc5bf1"
@@ -3836,7 +3850,6 @@ dequal@^2.0.2, dequal@^2.0.3:
 
 "design-system@https://github.com/pass-culture/design-system.git#v0.0.12":
   version "0.0.11"
-  uid f93a4fb798a1fbec87b60afe8097689ac5f4f2e9
   resolved "https://github.com/pass-culture/design-system.git#f93a4fb798a1fbec87b60afe8097689ac5f4f2e9"
 
 destroy@1.2.0:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32062

Change Tabs component to use Radix Tabs library

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
