### PR TITLE
(PC-31621)[PRO] build: bump search-insights dependency to fix sentry errors

### DIFF
--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -7650,9 +7650,9 @@ scheduler@^0.23.2:
     loose-envify "^1.1.0"
 
 search-insights@^2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.15.0.tgz#61c7db9d13218ee966937ad2462385b05c0df624"
-  integrity sha512-ch2sPCUDD4sbPQdknVl9ALSi9H7VyoeVbsxznYz6QV55jJ8CI3EtwpO1i84keN4+hF5IeHWIeGvc08530JkVXQ==
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.17.2.tgz#d13b2cabd44e15ade8f85f1c3b65c8c02138629a"
+  integrity sha512-zFNpOpUO+tY2D85KrxJ+aqwnIfdEGi06UH2+xEb+Bp9Mwznmauqc9djbnBibJO5mpfUPPa8st6Sx65+vbeO45g==
 
 seed-random@~2.2.0:
   version "2.2.0"


### PR DESCRIPTION

## But de la pull request

Tenter de corriger ces 3 erreurs sentry qui sont liées à search-insights (dépendance d'algolia) :
- https://passculture.atlassian.net/browse/PC-31621 - https://sentry.passculture.team/organizations/sentry/issues/1618124/?project=2&referrer=jira_integration
- https://passculture.atlassian.net/browse/PC-31886 - https://sentry.passculture.team/organizations/sentry/issues/1618422/?referrer=jira_integration
- https://passculture.atlassian.net/browse/PC-31517 - https://sentry.passculture.team/organizations/sentry/issues/1618070/?referrer=jira_integration

D'après le changelog https://github.com/algolia/search-insights.js/releases la màj en v2.17.2 touche au local storage qui semble être la cause des 3 erreurs

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
