### PR TITLE
Pc 32079 spinner a11y amelioration

### DIFF
--- a/pro/src/index.html
+++ b/pro/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr" data-theme="pink">
+<html lang="fr" data-theme="blue">
   <head>
     <meta charset="utf-8" />
     <meta

--- a/pro/src/ui-kit/Spinner/Spinner.module.scss
+++ b/pro/src/ui-kit/Spinner/Spinner.module.scss
@@ -17,9 +17,19 @@
     }
   }
 
+  .content {
+    position: relative;
+  }
+
   .content::after {
-    content: attr(data-dots);
+    content: "";
+    animation: dots 3s infinite linear;
     position: absolute;
+
+    @media screen and (prefers-reduced-motion: reduce) {
+      content: "...";
+      animation: none;
+    }
   }
 }
 
@@ -30,5 +40,20 @@
 
   to {
     transform: rotate(359deg);
+  }
+}
+
+@keyframes dots {
+  0%,
+  100% {
+    content: ".";
+  }
+
+  33.3% {
+    content: "..";
+  }
+
+  66.6% {
+    content: "...";
   }
 }

--- a/pro/src/ui-kit/Spinner/Spinner.stories.tsx
+++ b/pro/src/ui-kit/Spinner/Spinner.stories.tsx
@@ -1,0 +1,16 @@
+import { StoryObj } from '@storybook/react'
+import { withRouter } from 'storybook-addon-react-router-v6'
+
+import { Spinner } from './Spinner'
+
+export default {
+  title: 'ui-kit/Spinner',
+  decorators: [withRouter],
+  component: Spinner,
+}
+
+export const Default: StoryObj<typeof Spinner> = {
+  args: {
+    message: 'Chargement en cours',
+  },
+}

--- a/pro/src/ui-kit/Spinner/Spinner.tsx
+++ b/pro/src/ui-kit/Spinner/Spinner.tsx
@@ -1,5 +1,4 @@
 import cn from 'classnames'
-import { useEffect, useState } from 'react'
 
 import strokePass from 'icons/stroke-pass.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -15,22 +14,6 @@ export const Spinner = ({
   message = 'Chargement en cours',
   className,
 }: SpinnerProps): JSX.Element => {
-  const [nbDots, setNbDots] = useState(3)
-  const [timer, setTimer] = useState<number | null>(null)
-
-  useEffect(() => {
-    if (timer) {
-      window.clearInterval(timer)
-    }
-    const newTimer = window.setInterval(() => {
-      setNbDots((oldVal) => (oldVal % 3) + 1)
-    }, 500)
-    setTimer(newTimer)
-    return () => {
-      window.clearInterval(newTimer)
-    }
-  }, [])
-
   return (
     <div
       className={cn(styles['loading-spinner'], className)}
@@ -42,12 +25,7 @@ export const Spinner = ({
         className={styles['loading-spinner-icon']}
       />
 
-      <div
-        className={styles['content']}
-        data-dots={Array(nbDots).fill('.').join('')}
-      >
-        {message}
-      </div>
+      <div className={styles['content']}>{message}</div>
     </div>
   )
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32079

Comportement implémenté en vidéo :

https://github.com/user-attachments/assets/1c09afc8-0c34-4633-9981-a5db17f6d2f0

L'animation des trois petits points `.` `..` `...` était gérée avec un `useEffect` React. Il est maintenant géré par une animation CSS, avec l'avantage de pouvoir la désactiver avec la règle `@prefers-reduced-motion: reduce`

J'en ai profité pour également ajouter `<Spinner>` dans le storybook.

> [!NOTE]
> Le second commit change le thème par défaut à "blue" (validé avec le Design)

## Vérifications

- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
