### PR TITLE
PC 31823/fix public api null remaining quantity

### DIFF
--- a/api/documentation/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system.md
+++ b/api/documentation/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system.md
@@ -117,7 +117,7 @@ In case of success, here is the JSON we expect in return :
 
 | Key              | Type | Nullable | Explanation |
 | :---------------- | :------ | :----: | :-------- |
-| **remainingQuantity** | Integer | **`false`** | Number of tickets still available after this booking (for us to update our stock) |
+| **remainingQuantity** | Integer | **`true`** | Number of tickets still available after this booking (for us to update our stock). To indicate an unlimited quantity, set `remainingQuantity` to `null` (not to `"unlimited"`). Please note that this field is **mandatory**. |
 | **tickets** | Array | **`false`** | Booked tickets (should contain one or two items) |
 | **tickets[].barcode** | String | **`false`** | Ticket barcode **(⚠️ mandatory)** |
 | **tickets[].seat** | String | **`true`** | Ticket seat |

--- a/api/documentation/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system.md
+++ b/api/documentation/docs/understanding-our-api/managing-bookings/connection-with-ticketing-system.md
@@ -120,7 +120,7 @@ In case of success, here is the JSON we expect in return :
 | **remainingQuantity** | Integer | **`false`** | Number of tickets still available after this booking (for us to update our stock) |
 | **tickets** | Array | **`false`** | Booked tickets (should contain one or two items) |
 | **tickets[].barcode** | String | **`false`** | Ticket barcode **(⚠️ mandatory)** |
-| **tickets[].seat** | String | `true` | Ticket seat |
+| **tickets[].seat** | String | **`true`** | Ticket seat |
 
 ### 🚫 Error responses
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31823

Simple PR suite à une fausse alerte au bug (remainingQuantity peut être nul).

1. correction de la documentation (le modèle Pydantic dit que remainingQuantity peut être nul donc la documentation doit être mise à jour);
2. ajout de tests pour éviter une régression involontaires au niveau de ce champ.

Bonus : (tout) petit fix au niveau du style d'une colonne sur une page de la documentation.
