### PR TITLE
(PC-32005)[PRO] fix: Rework collective offers form steps links.

### DIFF
--- a/pro/src/components/CollectiveOfferNavigation/__specs__/CollectiveOfferNavigation.spec.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/__specs__/CollectiveOfferNavigation.spec.tsx
@@ -131,9 +131,15 @@ describe('CollectiveOfferNavigation', () => {
   })
 
   it('should show different links if offer is template', async () => {
-    props.isTemplate = true
-    props.activeStep = CollectiveOfferStep.SUMMARY
-    renderCollectiveOfferNavigation(props)
+    renderCollectiveOfferNavigation({
+      ...props,
+      activeStep: CollectiveOfferStep.SUMMARY,
+      offer: getCollectiveOfferFactory({
+        institution: undefined,
+        collectiveStock: undefined,
+      }),
+      isTemplate: true,
+    })
 
     const listItems = await screen.findAllByRole('listitem')
     expect(listItems).toHaveLength(4)
@@ -148,8 +154,15 @@ describe('CollectiveOfferNavigation', () => {
   })
 
   it('should show links if stocks is the active step', () => {
-    props.activeStep = CollectiveOfferStep.STOCKS
-    renderCollectiveOfferNavigation(props)
+    renderCollectiveOfferNavigation({
+      ...props,
+      activeStep: CollectiveOfferStep.STOCKS,
+      offer: getCollectiveOfferFactory({
+        institution: undefined,
+        collectiveStock: undefined,
+      }),
+    })
+
     const links = screen.queryAllByRole('link')
     expect(links).toHaveLength(2)
     expect(links[0].getAttribute('href')).toBe(
@@ -161,21 +174,13 @@ describe('CollectiveOfferNavigation', () => {
   })
 
   it('should show links if visibility is the active step', () => {
-    props.activeStep = CollectiveOfferStep.VISIBILITY
-    renderCollectiveOfferNavigation(props)
-    const links = screen.queryAllByRole('link')
-    expect(links).toHaveLength(2)
-    expect(links[0].getAttribute('href')).toBe(
-      `/offre/collectif/${offerId}/creation`
-    )
-    expect(links[1].getAttribute('href')).toBe(
-      `/offre/${offerId}/collectif/stocks`
-    )
-  })
-
-  it('should show links if summary is the active step', () => {
-    props.activeStep = CollectiveOfferStep.SUMMARY
-    renderCollectiveOfferNavigation(props)
+    renderCollectiveOfferNavigation({
+      ...props,
+      activeStep: CollectiveOfferStep.VISIBILITY,
+      offer: getCollectiveOfferFactory({
+        institution: undefined,
+      }),
+    })
     const links = screen.queryAllByRole('link')
     expect(links).toHaveLength(3)
     expect(links[0].getAttribute('href')).toBe(
@@ -189,9 +194,55 @@ describe('CollectiveOfferNavigation', () => {
     )
   })
 
+  it('should show links if summary is the active step', () => {
+    renderCollectiveOfferNavigation({
+      ...props,
+      activeStep: CollectiveOfferStep.SUMMARY,
+      offer: getCollectiveOfferFactory({
+        institution: {
+          city: '',
+          id: 1,
+          institutionId: '2',
+          name: '',
+          phoneNumber: '',
+          postalCode: '',
+        },
+      }),
+    })
+    const links = screen.queryAllByRole('link')
+    expect(links).toHaveLength(5)
+    expect(links[0].getAttribute('href')).toBe(
+      `/offre/collectif/${offerId}/creation`
+    )
+    expect(links[1].getAttribute('href')).toBe(
+      `/offre/${offerId}/collectif/stocks`
+    )
+    expect(links[2].getAttribute('href')).toBe(
+      `/offre/${offerId}/collectif/visibilite`
+    )
+    expect(links[3].getAttribute('href')).toBe(
+      `/offre/${offerId}/collectif/creation/recapitulatif`
+    )
+    expect(links[4].getAttribute('href')).toBe(
+      `/offre/${offerId}/collectif/creation/apercu`
+    )
+  })
+
   it('should show links if confirmation is the active step', () => {
-    props.activeStep = CollectiveOfferStep.CONFIRMATION
-    renderCollectiveOfferNavigation(props)
+    renderCollectiveOfferNavigation({
+      ...props,
+      activeStep: CollectiveOfferStep.CONFIRMATION,
+      offer: getCollectiveOfferFactory({
+        institution: {
+          city: '',
+          id: 1,
+          institutionId: '2',
+          name: '',
+          phoneNumber: '',
+          postalCode: '',
+        },
+      }),
+    })
     const links = screen.queryAllByRole('link')
     expect(links).toHaveLength(5)
     expect(links[0].getAttribute('href')).toBe(
@@ -209,8 +260,12 @@ describe('CollectiveOfferNavigation', () => {
   })
 
   it('should show links if confirmation is the active step and the offer is template', () => {
-    props.activeStep = CollectiveOfferStep.CONFIRMATION
-    renderCollectiveOfferNavigation({ ...props, isTemplate: true })
+    renderCollectiveOfferNavigation({
+      ...props,
+      activeStep: CollectiveOfferStep.CONFIRMATION,
+      offer: getCollectiveOfferTemplateFactory(),
+      isTemplate: true,
+    })
     const links = screen.queryAllByRole('link')
     expect(links).toHaveLength(3)
   })
@@ -480,5 +535,40 @@ describe('CollectiveOfferNavigation', () => {
     })
 
     expect(screen.queryByTestId('stepper')).not.toBeInTheDocument()
+  })
+
+  it('should be able to go to the visibility ans stocks step if the institurion and stock are already filled', () => {
+    renderCollectiveOfferNavigation({
+      ...props,
+      offer: getCollectiveOfferFactory(),
+      isTemplate: false,
+      activeStep: CollectiveOfferStep.DETAILS,
+    })
+
+    expect(
+      screen.getByRole('link', { name: /Établissement et enseignant/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Dates et prix/ })
+    ).toBeInTheDocument()
+  })
+
+  it('should be able to go to the stocks step if the details are already filled', () => {
+    renderCollectiveOfferNavigation({
+      ...props,
+      offer: getCollectiveOfferFactory({
+        institution: undefined,
+        collectiveStock: undefined,
+      }),
+      activeStep: CollectiveOfferStep.DETAILS,
+    })
+
+    expect(
+      screen.queryByRole('link', { name: /Établissement et enseignant/ })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', { name: /Dates et prix/ })
+    ).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
+++ b/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
@@ -42,6 +42,7 @@ export const CollectiveOfferCreation = ({
           isTemplate={isTemplate}
           isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
           requestId={requestId}
+          offer={offer}
         >
           <OfferEducational
             userOfferers={offerEducationalFormData.offerers}

--- a/pro/src/pages/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/pages/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -20,6 +20,7 @@ export const CollectiveOfferPreviewCreation = ({
         isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
         isTemplate={isTemplate}
         isCreation
+        offer={offer}
       >
         <CollectiveOfferPreviewCreationScreen offer={offer} offerer={offerer} />
         <RouteLeavingGuardCollectiveOfferCreation when={false} />

--- a/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -175,6 +175,7 @@ export const CollectiveOfferStockCreation = ({
         isTemplate={isTemplate}
         isCreation={isCreation}
         requestId={requestId}
+        offer={offer}
       >
         <OfferEducationalStock
           initialValues={initialValues}

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
@@ -69,6 +69,7 @@ export const CollectiveOfferVisibility = ({
         isTemplate={isTemplate}
         isCreation={isCreation}
         requestId={requestId}
+        offer={offer}
       >
         <CollectiveOfferVisibilityScreen
           mode={Mode.CREATION}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32005

**Objectif**
Dans le formulaire de création d'offres collectives (résevables ou vitrines), pouvoir accéder via le Stepper aux étapes suivantes si on a déjà tout rempli pour y avoir accès. 
Par exemple, on crée une offre réservable et on valide l'étape de détail. Si on revient à l'étape de détail par la suite, on aura toujours au moins accès à l'étape de Date et prix.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
