### PR TITLE
(PC-32068)[PRO] fix: forward /draft/offer POST api error regarding EAN as DetailsEanSearch input error

### DIFF
--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsEanSearch/DetailsEanSearch.spec.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsEanSearch/DetailsEanSearch.spec.tsx
@@ -45,6 +45,7 @@ const EanSearchWrappedWithFormik = ({
   productId = DEFAULT_DETAILS_FORM_VALUES.productId,
   subcategoryId = DEFAULT_DETAILS_FORM_VALUES.subcategoryId,
   initialEan = '',
+  eanSubmitError = '',
   onEanSearch = vi.fn(),
   resetForm = vi.fn(),
 }: DetailsEanSearchTestProps): JSX.Element => {
@@ -70,6 +71,7 @@ const EanSearchWrappedWithFormik = ({
         productId={mockedProductId}
         subcategoryId={mockedSubCategoryId}
         initialEan={initialEan}
+        eanSubmitError={eanSubmitError}
         onEanSearch={onEanSearch}
         resetForm={resetForm}
       />
@@ -231,6 +233,17 @@ describe('DetailsEanSearch', () => {
 
         await userEvent.click(clearButton)
         expect(resetForm.mock.calls.length).toBe(1)
+      })
+
+      it('should display an error message if POST API ends with an EAN err', () => {
+        const eanSubmitError = 'This EAN is already used'
+        renderDetailsEanSearch({
+          isDirtyDraftOffer: true,
+          wasEanSearchPerformedSuccessfully: true,
+          eanSubmitError,
+        })
+
+        expect(screen.queryByText(eanSubmitError)).toBeInTheDocument()
       })
     })
 

--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsEanSearch/DetailsEanSearch.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsEanSearch/DetailsEanSearch.tsx
@@ -23,6 +23,7 @@ export type DetailsEanSearchProps = {
   productId: string
   subcategoryId: string
   initialEan?: string
+  eanSubmitError?: string
   onEanSearch: (ean: string, product: Product) => Promise<void>
   resetForm: () => void
 }
@@ -32,6 +33,7 @@ export const DetailsEanSearch = ({
   productId,
   subcategoryId,
   initialEan,
+  eanSubmitError,
   onEanSearch,
   resetForm,
 }: DetailsEanSearchProps): JSX.Element => {
@@ -39,7 +41,7 @@ export const DetailsEanSearch = ({
   const inputRef = useRef<HTMLInputElement>(null)
   const [isFetchingProduct, setIsFetchingProduct] = useState(false)
   const [subcatError, setSubcatError] = useState<string | null>(null)
-  const [apiError, setApiError] = useState<string | null>(null)
+  const [productApiError, setProductApiError] = useState<string | null>(null)
   const [wasCleared, setWasCleared] = useState(false)
 
   const isProductBased = !!productId
@@ -56,7 +58,7 @@ export const DetailsEanSearch = ({
   const formikError = formik.errors.eanSearch
 
   useEffect(() => {
-    setApiError(null)
+    setProductApiError(null)
   }, [ean])
 
   useEffect(() => {
@@ -98,7 +100,7 @@ export const DetailsEanSearch = ({
           ? getError(err).ean?.[0] || fallbackMessage
           : fallbackMessage
         setIsFetchingProduct(false)
-        setApiError(errorMessage)
+        setProductApiError(errorMessage)
       }
     }
   }
@@ -108,6 +110,8 @@ export const DetailsEanSearch = ({
     resetForm()
     setWasCleared(true)
   }
+
+  const apiError = eanSubmitError || productApiError
 
   const shouldInputBeDisabled = isProductBased || isFetchingProduct
   const shouldInputBeRequired = !!subcatError

--- a/pro/src/screens/IndividualOffer/DetailsScreen/DetailsScreen.tsx
+++ b/pro/src/screens/IndividualOffer/DetailsScreen/DetailsScreen.tsx
@@ -284,6 +284,7 @@ export const DetailsScreen = ({ venues }: DetailsScreenProps): JSX.Element => {
           productId={formik.values.productId}
           subcategoryId={formik.values.subcategoryId}
           initialEan={offer?.extraData?.ean}
+          eanSubmitError={formik.status === 'apiError' ? formik.errors.ean : ''}
           onEanSearch={onEanSearch}
           resetForm={formik.resetForm}
         />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32068

## Objectifs
- Voir description du ticket Jira, mais ceci permet notamment de marquer le champ en erreur lorsque l'ean a déjà été utilisé avec une venue (contrainte de création d'offre basée sur un produit). 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
