### PR TITLE
(PC-32137)[PRO] fix: auto-focus on "skip/back to nav" link + aria-live announcing new page on redirect

### DIFF
--- a/pro/src/app/App/hook/__specs__/useFocus.spec.tsx
+++ b/pro/src/app/App/hook/__specs__/useFocus.spec.tsx
@@ -8,7 +8,7 @@ import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { useFocus } from '../useFocus'
 
-const FocusTopPage = (): null => {
+const FocusTopPageOrBackToNavLink = (): null => {
   useFocus()
   return null
 }
@@ -20,19 +20,34 @@ const renderUseFocusRoutes = (url = '/accueil') => {
         path="/accueil"
         element={
           <>
-            <SkipLinks />
             <span>Main page</span>
-            <Link to="/guichet">Guichet</Link>
+            <Link to="/page-without-back-to-nav">
+              Page Without "Back to Nav" link
+            </Link>
+            <Link to="/page-with-back-to-nav">
+              Page With "Back to Nav" link
+            </Link>
           </>
         }
       />
       <Route
-        path="/guichet"
+        path="/page-without-back-to-nav"
         element={
           <>
-            <FocusTopPage />
+            <FocusTopPageOrBackToNavLink />
             <SkipLinks />
-            <span>Guichet page</span>
+            <span>Page Without "Back to Nav" link</span>
+          </>
+        }
+      />
+      <Route
+        path="/page-with-back-to-nav"
+        element={
+          <>
+            <FocusTopPageOrBackToNavLink />
+            <SkipLinks />
+            <a id="back-to-nav-link" href="#" />
+            <span>Page With "Back to Nav" link</span>
           </>
         }
       />
@@ -42,9 +57,25 @@ const renderUseFocusRoutes = (url = '/accueil') => {
 }
 
 describe('useFocus', () => {
-  it('should focus on top of the page when user navigates to another page', async () => {
+  it('should focus on back to nav link when user navigates to another page', async () => {
     renderUseFocusRoutes()
-    await userEvent.click(screen.getByRole('link', { name: 'Guichet' }))
+    await userEvent.click(
+      screen.getByRole('link', { name: 'Page With "Back to Nav" link' })
+    )
+
+    screen.debug()
+
+    expect(document.activeElement?.id).toEqual('back-to-nav-link')
+    await userEvent.tab()
+    expect(document.activeElement?.id).not.toEqual('back-to-nav-link')
+  })
+
+  it('should focus on top of the page as a fallback', async () => {
+    renderUseFocusRoutes()
+    await userEvent.click(
+      screen.getByRole('link', { name: 'Page Without "Back to Nav" link' })
+    )
+
     expect(document.activeElement?.id).toEqual('top-page')
     await userEvent.tab()
     expect(document.activeElement?.id).not.toEqual('top-page')

--- a/pro/src/app/App/hook/useFocus.ts
+++ b/pro/src/app/App/hook/useFocus.ts
@@ -7,6 +7,12 @@ export const useFocus = (): void => {
   useEffect(() => {
     /* istanbul ignore next : E2E tested */
     document.getElementById('content-wrapper')?.scrollTo(0, 0)
-    document.getElementById('top-page')?.focus()
+
+    const backToNav = document.getElementById('back-to-nav-link')
+    if (backToNav) {
+      backToNav.focus()
+    } else {
+      document.getElementById('top-page')?.focus()
+    }
   }, [location.pathname])
 }

--- a/pro/src/app/App/layout/LateralPanel/LateralPanel.tsx
+++ b/pro/src/app/App/layout/LateralPanel/LateralPanel.tsx
@@ -61,6 +61,7 @@ export const LateralPanel = ({
   return (
     <nav
       id="lateral-panel"
+      tabIndex={-1}
       className={classnames({
         [styles['lateral-panel-wrapper']]: true,
         [styles['lateral-panel-wrapper-open']]: lateralPanelOpen,

--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -2,6 +2,7 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_size.scss" as size;
 @use "styles/variables/_z-index.scss" as zIndex;
+@use "styles/mixins/fonts-design-system.scss" as fonts-design-system;
 
 $connect-as-header-height: rem.torem(52px);
 
@@ -88,5 +89,30 @@ $connect-as-header-height: rem.torem(52px);
     align-items: center;
     justify-content: center;
     width: 100%;
+  }
+}
+
+.main-heading-wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: rem.torem(32px);
+}
+
+.main-heading {
+  @include fonts-design-system.title1;
+}
+
+.back-to-nav-link {
+  margin-left: rem.torem(16px);
+  opacity: 0;
+  height: rem.torem(24px);
+  width: rem.torem(24px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:active, &:focus {
+    opacity: 1;
   }
 }

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -21,10 +21,7 @@ export interface LayoutProps {
    * Name of the page to display in the main heading.
    * Make sure that only one heading is displayed per page.
    */
-  mainHeading?: {
-    text: string
-    className?: string
-  }
+  mainHeading?: string
   layout?: 'basic' | 'funnel' | 'without-nav' | 'sticky-actions'
 }
 
@@ -111,14 +108,7 @@ export const Layout = ({
               <main id="content">
                 {mainHeading && (
                   <div className={styles['main-heading-wrapper']}>
-                    <h1
-                      className={cn(
-                        styles['main-heading'],
-                        mainHeading.className
-                      )}
-                    >
-                      {mainHeading.text}
-                    </h1>
+                    <h1 className={styles['main-heading']}>{mainHeading}</h1>
                     <a
                       id="back-to-nav-link"
                       href={

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -6,6 +6,7 @@ import { Footer } from 'components/Footer/Footer'
 import { Header } from 'components/Header/Header'
 import { NewNavReview } from 'components/NewNavReview/NewNavReview'
 import { SkipLinks } from 'components/SkipLinks/SkipLinks'
+import fullGoTop from 'icons/full-go-top.svg'
 import fullInfoIcon from 'icons/full-info.svg'
 import { selectCurrentUser } from 'store/user/selectors'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -13,14 +14,26 @@ import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { LateralPanel } from './LateralPanel/LateralPanel'
 import styles from './Layout.module.scss'
 
-interface LayoutProps {
-  children?: React.ReactNode
-  pageName?: string
+export interface LayoutMainHeading {
+  text: string
   className?: string
+}
+
+export interface LayoutProps {
+  children?: React.ReactNode
+  /**
+   * Name of the page to display in the main heading.
+   * Make sure that only one heading is displayed per page.
+   */
+  mainHeading?: LayoutMainHeading
   layout?: 'basic' | 'funnel' | 'without-nav' | 'sticky-actions'
 }
 
-export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
+export const Layout = ({
+  children,
+  mainHeading,
+  layout = 'basic',
+}: LayoutProps) => {
   const currentUser = useSelector(selectCurrentUser)
   const [lateralPanelOpen, setLateralPanelOpen] = useState(false)
 
@@ -95,6 +108,29 @@ export const Layout = ({ children, layout = 'basic' }: LayoutProps) => {
               })}
             >
               <main id="content">
+                {mainHeading && (
+                  <div className={styles['main-heading-wrapper']}>
+                    <h1
+                      className={cn(
+                        styles['main-heading'],
+                        mainHeading.className
+                      )}
+                    >
+                      {mainHeading.text}
+                    </h1>
+                    <a
+                      id="back-to-nav-link"
+                      href="#lateral-panel"
+                      className={styles['back-to-nav-link']}
+                    >
+                      <SvgIcon
+                        src={fullGoTop}
+                        alt="Revenir à la barre de navigation"
+                        width="20"
+                      />
+                    </a>
+                  </div>
+                )}
                 {layout === 'funnel' || layout === 'without-nav' ? (
                   children
                 ) : (

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -14,18 +14,16 @@ import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 import { LateralPanel } from './LateralPanel/LateralPanel'
 import styles from './Layout.module.scss'
 
-export interface LayoutMainHeading {
-  text: string
-  className?: string
-}
-
 export interface LayoutProps {
   children?: React.ReactNode
   /**
    * Name of the page to display in the main heading.
    * Make sure that only one heading is displayed per page.
    */
-  mainHeading?: LayoutMainHeading
+  mainHeading?: {
+    text: string
+    className?: string
+  }
   layout?: 'basic' | 'funnel' | 'without-nav' | 'sticky-actions'
 }
 

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -6,6 +6,7 @@ import { Footer } from 'components/Footer/Footer'
 import { Header } from 'components/Header/Header'
 import { NewNavReview } from 'components/NewNavReview/NewNavReview'
 import { SkipLinks } from 'components/SkipLinks/SkipLinks'
+import { useMediaQuery } from 'hooks/useMediaQuery'
 import fullGoTop from 'icons/full-go-top.svg'
 import fullInfoIcon from 'icons/full-info.svg'
 import { selectCurrentUser } from 'store/user/selectors'
@@ -38,6 +39,8 @@ export const Layout = ({
   const openButtonRef = useRef<HTMLButtonElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const navPanel = useRef<HTMLDivElement>(null)
+
+  const isMobileScreen = useMediaQuery('(max-width: 46.5rem)')
 
   const shouldDisplayNewNavReview =
     Boolean(currentUser?.navState?.eligibilityDate) &&
@@ -118,7 +121,9 @@ export const Layout = ({
                     </h1>
                     <a
                       id="back-to-nav-link"
-                      href="#lateral-panel"
+                      href={
+                        isMobileScreen ? '#header-nav-toggle' : '#lateral-panel'
+                      }
                       className={styles['back-to-nav-link']}
                     >
                       <SvgIcon

--- a/pro/src/app/App/layout/OldLayout.module.scss
+++ b/pro/src/app/App/layout/OldLayout.module.scss
@@ -2,6 +2,7 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_size.scss" as size;
 @use "styles/variables/_z-index.scss" as zIndex;
+@use "styles/mixins/fonts-design-system.scss" as fonts-design-system;
 
 .container {
   position: relative;
@@ -54,4 +55,10 @@
     justify-content: center;
     width: 100%;
   }
+}
+
+.main-heading {
+  @include fonts-design-system.title1;
+
+  margin-bottom: rem.torem(32px);
 }

--- a/pro/src/app/App/layout/OldLayout.tsx
+++ b/pro/src/app/App/layout/OldLayout.tsx
@@ -13,11 +13,34 @@ import styles from './OldLayout.module.scss'
 
 interface OldLayoutProps {
   children?: React.ReactNode
+  /**
+   * Name of the page to display in the main heading.
+   * Make sure that only one heading is displayed per page.
+   */
+  mainHeading?: {
+    text: string
+    className?: string
+  }
   layout?: 'basic' | 'funnel' | 'without-nav' | 'sticky-actions'
 }
 
-export const OldLayout = ({ children, layout = 'basic' }: OldLayoutProps) => {
+export const OldLayout = ({
+  children,
+  mainHeading,
+  layout = 'basic',
+}: OldLayoutProps) => {
   const currentUser = useSelector(selectCurrentUser)
+  const renderMainHeading = () => {
+    if (!mainHeading) {
+      return null
+    }
+
+    return (
+      <h1 className={classnames(styles['main-heading'], mainHeading.className)}>
+        {mainHeading.text}
+      </h1>
+    )
+  }
 
   return (
     <>
@@ -39,7 +62,6 @@ export const OldLayout = ({ children, layout = 'basic' }: OldLayoutProps) => {
         </aside>
       )}
       {(layout === 'basic' || layout === 'sticky-actions') && <OldHeader />}
-
       <main
         id="content"
         className={classnames({
@@ -50,10 +72,14 @@ export const OldLayout = ({ children, layout = 'basic' }: OldLayoutProps) => {
         })}
       >
         {layout === 'funnel' || layout === 'without-nav' ? (
-          children
+          <>
+            {renderMainHeading()}
+            {children}
+          </>
         ) : (
           <div className={styles['page-content']}>
             <div className={styles['after-notification-content']}>
+              {renderMainHeading()}
               {children}
             </div>
           </div>

--- a/pro/src/app/App/layout/OldLayout.tsx
+++ b/pro/src/app/App/layout/OldLayout.tsx
@@ -17,10 +17,7 @@ interface OldLayoutProps {
    * Name of the page to display in the main heading.
    * Make sure that only one heading is displayed per page.
    */
-  mainHeading?: {
-    text: string
-    className?: string
-  }
+  mainHeading?: string
   layout?: 'basic' | 'funnel' | 'without-nav' | 'sticky-actions'
 }
 
@@ -35,11 +32,7 @@ export const OldLayout = ({
       return null
     }
 
-    return (
-      <h1 className={classnames(styles['main-heading'], mainHeading.className)}>
-        {mainHeading.text}
-      </h1>
-    )
+    return <h1 className={styles['main-heading']}>{mainHeading}</h1>
   }
 
   return (

--- a/pro/src/app/AppLayout.tsx
+++ b/pro/src/app/AppLayout.tsx
@@ -19,6 +19,8 @@ export const AppLayout = ({
       {children}
     </Layout>
   ) : (
-    <OldLayout layout={layout}>{children}</OldLayout>
+    <OldLayout mainHeading={mainHeading} layout={layout}>
+      {children}
+    </OldLayout>
   )
 }

--- a/pro/src/app/AppLayout.tsx
+++ b/pro/src/app/AppLayout.tsx
@@ -2,19 +2,22 @@ import React from 'react'
 
 import { useIsNewInterfaceActive } from 'hooks/useIsNewInterfaceActive'
 
-import { Layout } from './App/layout/Layout'
+import { Layout, LayoutProps } from './App/layout/Layout'
 import { OldLayout } from './App/layout/OldLayout'
 
-interface AppLayoutProps {
-  children?: React.ReactNode
-  layout?: 'basic' | 'funnel' | 'without-nav' | 'sticky-actions'
-}
+export type AppLayoutProps = LayoutProps
 
-export const AppLayout = ({ children, layout = 'basic' }: AppLayoutProps) => {
+export const AppLayout = ({
+  children,
+  mainHeading,
+  layout = 'basic',
+}: AppLayoutProps) => {
   const isNewSideBarNavigation = useIsNewInterfaceActive()
 
   return isNewSideBarNavigation ? (
-    <Layout layout={layout}>{children}</Layout>
+    <Layout mainHeading={mainHeading} layout={layout}>
+      {children}
+    </Layout>
   ) : (
     <OldLayout layout={layout}>{children}</OldLayout>
   )

--- a/pro/src/app/__specs__/AppLayout.spec.tsx
+++ b/pro/src/app/__specs__/AppLayout.spec.tsx
@@ -98,6 +98,26 @@ describe('src | AppLayout', () => {
       ).not.toBeInTheDocument()
     })
 
+    it('should render a heading & a back to nav link when main heading text is provided', () => {
+      const headingText = 'Ceci est un titre'
+      renderWithProviders(
+        <AppLayout mainHeading={headingText}>
+          <p>Sub component</p>
+        </AppLayout>,
+        {
+          user: sharedCurrentUserFactory(),
+        }
+      )
+
+      const heading = screen.getByRole('heading', { name: headingText })
+      expect(heading).toBeInTheDocument()
+
+      const backToNavLink = screen.getByRole('link', {
+        name: 'Revenir à la barre de navigation',
+      })
+      expect(backToNavLink).toBeInTheDocument()
+    })
+
     describe('on smaller screen sizes', () => {
       beforeEach(async () => {
         await renderApp(

--- a/pro/src/components/Header/Header.tsx
+++ b/pro/src/components/Header/Header.tsx
@@ -39,6 +39,7 @@ export const Header = forwardRef(
         <div className={styles['top-menu-content']}>
           {!disableHomeLink && (
             <Button
+              id="header-nav-toggle"
               ref={openButtonRef}
               aria-expanded={lateralPanelOpen}
               className={styles['burger-icon']}

--- a/pro/src/components/Header/OldHeader.tsx
+++ b/pro/src/components/Header/OldHeader.tsx
@@ -24,7 +24,7 @@ export const OldHeader = forwardRef(() => {
   const isOffererStatsActive = useActiveFeature('ENABLE_OFFERER_STATS')
   const location = useLocation()
   return (
-    <header className={styles['menu-v2']} id="header-navigation">
+    <header className={styles['menu-v2']}>
       <nav className={styles['nav']} aria-label="Menu principal">
         <div className={styles['nav-brand']}>
           <NavLink

--- a/pro/src/components/SkipLinks/SkipLinks.tsx
+++ b/pro/src/components/SkipLinks/SkipLinks.tsx
@@ -6,16 +6,10 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 
 import styles from './SkipLinks.module.scss'
 
-interface SkipLinksProps {
-  displayMenu?: boolean
-}
-
-export const SkipLinks = ({
-  displayMenu = false,
-}: SkipLinksProps): JSX.Element => {
+export const SkipLinks = (): JSX.Element => {
   const buttons: { anchor: string; label: string }[] = [
     { anchor: '#content', label: 'Aller au contenu' },
-  ].concat(displayMenu ? { anchor: '#header-navigation', label: 'Menu' } : [])
+  ]
 
   return (
     <>

--- a/pro/src/components/SkipLinks/__specs__/SkipLinks.spec.tsx
+++ b/pro/src/components/SkipLinks/__specs__/SkipLinks.spec.tsx
@@ -6,18 +6,15 @@ import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { SkipLinks } from '../SkipLinks'
 
-const renderApp = ({ displayMenu }: { displayMenu?: boolean }) =>
+const renderApp = () =>
   renderWithProviders(
     <Routes>
       <Route
         element={
           <div>
-            <SkipLinks displayMenu={displayMenu} />
-            <div id="header-navigation">
-              <a href="#">first focusable content element</a>
-            </div>
+            <SkipLinks />
             <div id="content">
-              <a href="#">second focusable content element</a>
+              <a href="#">focusable content element</a>
             </div>
           </div>
         }
@@ -29,13 +26,8 @@ const renderApp = ({ displayMenu }: { displayMenu?: boolean }) =>
 
 describe('SkipLinks', () => {
   it('should render', () => {
-    renderApp({})
+    renderApp()
     expect(screen.queryByText('Aller au contenu')).toBeInTheDocument()
     expect(screen.queryByText('Menu')).not.toBeInTheDocument()
-  })
-
-  it('should display menu', () => {
-    renderApp({ displayMenu: true })
-    expect(screen.queryByText('Menu')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Accessibility/AccessibilityLayout.tsx
+++ b/pro/src/pages/Accessibility/AccessibilityLayout.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from 'app/AppLayout'
+import { AppLayout, AppLayoutProps } from 'app/AppLayout'
 import { useCurrentUser } from 'hooks/useCurrentUser'
 import fullBackIcon from 'icons/full-back.svg'
 import logoPassCultureProFullIcon from 'icons/logo-pass-culture-pro-full.svg'
@@ -8,13 +8,15 @@ import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './AccessibilityLayout.module.scss'
 
+interface AccessibilityLayoutProps extends AppLayoutProps {
+  showBackToSignInButton?: boolean
+}
+
 export const AccessibilityLayout = ({
   children,
   showBackToSignInButton,
-}: {
-  children?: React.ReactNode
-  showBackToSignInButton?: boolean
-}) => {
+  mainHeading,
+}: AccessibilityLayoutProps) => {
   let isUserConnected = false
   try {
     const user = useCurrentUser()
@@ -24,9 +26,9 @@ export const AccessibilityLayout = ({
   }
 
   return isUserConnected ? (
-    <AppLayout>{children}</AppLayout>
+    <AppLayout mainHeading={mainHeading}>{children}</AppLayout>
   ) : (
-    <AppLayout layout="without-nav">
+    <AppLayout mainHeading={mainHeading} layout="without-nav">
       <header className={styles['logo-side']}>
         <SvgIcon
           className={logoStyles['logo-unlogged']}

--- a/pro/src/pages/Accessibility/AccessibilityMenu.module.scss
+++ b/pro/src/pages/Accessibility/AccessibilityMenu.module.scss
@@ -12,9 +12,3 @@
   justify-content: space-between;
   align-items: center;
 }
-
-.title-accessibility {
-  @include fonts-design-system.title1;
-
-  margin-bottom: rem.torem(32px);
-}

--- a/pro/src/pages/Accessibility/AccessibilityMenu.tsx
+++ b/pro/src/pages/Accessibility/AccessibilityMenu.tsx
@@ -8,7 +8,7 @@ import styles from './AccessibilityMenu.module.scss'
 export function AccessibilityMenu() {
   return (
     <AccessibilityLayout
-      mainHeading={{ text: 'Informations d’accessibilité' }}
+      mainHeading="Informations d’accessibilité"
       showBackToSignInButton
     >
       <div className={styles['menu-accessibility']}>

--- a/pro/src/pages/Accessibility/AccessibilityMenu.tsx
+++ b/pro/src/pages/Accessibility/AccessibilityMenu.tsx
@@ -7,11 +7,10 @@ import styles from './AccessibilityMenu.module.scss'
 
 export function AccessibilityMenu() {
   return (
-    <AccessibilityLayout showBackToSignInButton>
-      <h1 className={styles['title-accessibility']}>
-        Informations d’accessibilité
-      </h1>
-
+    <AccessibilityLayout
+      mainHeading={{ text: 'Informations d’accessibilité' }}
+      showBackToSignInButton
+    >
       <div className={styles['menu-accessibility']}>
         <ButtonLink
           to="/accessibilite/engagements"

--- a/pro/src/pages/Accessibility/Commitment.module.scss
+++ b/pro/src/pages/Accessibility/Commitment.module.scss
@@ -1,12 +1,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/fonts-design-system.scss" as fonts-design-system;
 
-.heading1-commitment {
-  @include fonts-design-system.title1;
-
-  margin-bottom: rem.torem(32px);
-}
-
 .heading2-commitment {
   @include fonts-design-system.title2;
 }

--- a/pro/src/pages/Accessibility/Commitment.tsx
+++ b/pro/src/pages/Accessibility/Commitment.tsx
@@ -8,12 +8,7 @@ import styles from './Commitment.module.scss'
 
 export const Commitment = () => {
   return (
-    <AccessibilityLayout
-      mainHeading={{
-        text: 'Les engagements du pass Culture pour l’accessibilité numérique',
-        className: styles['heading1-commitment'],
-      }}
-    >
+    <AccessibilityLayout mainHeading="Les engagements du pass Culture pour l’accessibilité numérique">
       <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>

--- a/pro/src/pages/Accessibility/Commitment.tsx
+++ b/pro/src/pages/Accessibility/Commitment.tsx
@@ -8,13 +8,15 @@ import styles from './Commitment.module.scss'
 
 export const Commitment = () => {
   return (
-    <AccessibilityLayout>
+    <AccessibilityLayout
+      mainHeading={{
+        text: 'Les engagements du pass Culture pour l’accessibilité numérique',
+        className: styles['heading1-commitment'],
+      }}
+    >
       <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>
-      <h1 className={styles['heading1-commitment']}>
-        Les engagements du pass Culture pour l’accessibilité numérique
-      </h1>
       <p className={styles['paragraph']}>
         <i>Date de publication : 21 mai 2024</i>
       </p>

--- a/pro/src/pages/Accessibility/Declaration.module.scss
+++ b/pro/src/pages/Accessibility/Declaration.module.scss
@@ -1,12 +1,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/fonts-design-system.scss" as fonts-design-system;
 
-.heading1-declaration {
-  @include fonts-design-system.title1;
-
-  margin-bottom: rem.torem(32px);
-}
-
 .heading2 {
   @include fonts-design-system.title2;
 }

--- a/pro/src/pages/Accessibility/Declaration.tsx
+++ b/pro/src/pages/Accessibility/Declaration.tsx
@@ -8,13 +8,15 @@ import styles from './Declaration.module.scss'
 
 export const Declaration = () => {
   return (
-    <AccessibilityLayout>
+    <AccessibilityLayout
+      mainHeading={{
+        text: 'Déclaration d’accessibilité',
+        className: styles['heading1-declaration'],
+      }}
+    >
       <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>
-      <h1 className={styles['heading1-declaration']}>
-        Déclaration d’accessibilité
-      </h1>
       <p className={styles['paragraph']}>
         Le pass Culture s’engage à rendre son site internet et ses applications
         mobiles accessibles conformément à l’article 47 de la loi n° 2005-102 du

--- a/pro/src/pages/Accessibility/Declaration.tsx
+++ b/pro/src/pages/Accessibility/Declaration.tsx
@@ -8,12 +8,7 @@ import styles from './Declaration.module.scss'
 
 export const Declaration = () => {
   return (
-    <AccessibilityLayout
-      mainHeading={{
-        text: 'Déclaration d’accessibilité',
-        className: styles['heading1-declaration'],
-      }}
-    >
+    <AccessibilityLayout mainHeading="Déclaration d’accessibilité">
       <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>

--- a/pro/src/pages/Accessibility/MultiyearScheme.module.scss
+++ b/pro/src/pages/Accessibility/MultiyearScheme.module.scss
@@ -1,12 +1,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/fonts-design-system.scss" as fonts-design-system;
 
-.heading1-scheme {
-  @include fonts-design-system.title1;
-
-  margin-bottom: rem.torem(32px);
-}
-
 .heading2 {
   @include fonts-design-system.title2;
 }

--- a/pro/src/pages/Accessibility/MultiyearScheme.tsx
+++ b/pro/src/pages/Accessibility/MultiyearScheme.tsx
@@ -6,12 +6,7 @@ import styles from './MultiyearScheme.module.scss'
 
 export const MultiyearScheme = () => {
   return (
-    <AccessibilityLayout
-      mainHeading={{
-        text: 'Schéma pluriannuel d’accessibilité 2024 - 2025',
-        className: styles['heading1-scheme'],
-      }}
-    >
+    <AccessibilityLayout mainHeading="Schéma pluriannuel d’accessibilité 2024 - 2025">
       <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>

--- a/pro/src/pages/Accessibility/MultiyearScheme.tsx
+++ b/pro/src/pages/Accessibility/MultiyearScheme.tsx
@@ -6,13 +6,15 @@ import styles from './MultiyearScheme.module.scss'
 
 export const MultiyearScheme = () => {
   return (
-    <AccessibilityLayout>
+    <AccessibilityLayout
+      mainHeading={{
+        text: 'Schéma pluriannuel d’accessibilité 2024 - 2025',
+        className: styles['heading1-scheme'],
+      }}
+    >
       <ButtonLink to="/accessibilite/" icon={fullBackIcon}>
         Retour vers la page Informations d’accessibilité
       </ButtonLink>
-      <h1 className={styles['heading1-scheme']}>
-        Schéma pluriannuel d’accessibilité 2024 - 2025
-      </h1>
       <h2 className={styles['heading2']}>INTRODUCTION</h2>
       <p className={styles['paragraph']}>
         L’article 47 de la loi n° 2005-102 du 11 février 2005 pour l’égalité des


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32137

## Objectifs

Objectifs

Cette tâche permet d’adresser la question des redirections (non annoncées) au sein des applications de type SPA.

“In general, we found that resetting focus to the top of the app would be very overwhelming, especially in large applications.” : c’est notre traitement actuel, il faut trouver une meilleure solution.

Permet au passage d’enrayer l’erreur suivante : https://dequeuniversity.com/rules/axe/4.10/link-name?application=AxeChrome , puisqu’un faux lien était déclaré pour réaliser un autofocus en haut des pages.

👎🏼 Solution 1 : 

On fait un auto-focus sur les `<h1>` sur des redirections de page (ne concerne donc pas les dialog). Ceci en partant du principe que toute page devrait avoir un `<h1>`.

L’élément `<h1>` n’étant pas un élément interactif, il faut lui attribuer un tabindex={-1}.

👍🏼 Solution 2 :

Plus inclusive que la Solution 1 qui était un bon support seulement pour les screen readers (voir screen magnification : “For the focus management techniques, horizontal scrolling presented an issue without a mobile viewport: if focus was sent to a wrapper or heading spanning a width much larger than the screen, mobile Chrome would scroll to the middle of it and cut off the beginning and end of the text…making it illegible.”.

On suit l’exemple d’implémentation proposée ici : https://marcy.codes/prototypes/routing/example-6-final.html#main-nav 

On crée un lien “skip/back to nav” qui serait juxtaposé aux headings et auto-focus aux redirections. Ce lien n’est visible que lorsqu’il est actif.

En complément on ajoute un aria-live (caché) qui annonce les titres de la page.

## Sources

[What we learned from user testing of accessible client-side routing techniques with Fable Tech Labs | Gatsby](https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
