### PR TITLE
(PC-31407)[PRO] fix: Fix alignment of trash button on activity page

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.module.scss
@@ -14,19 +14,30 @@
 }
 
 .form-row-actions {
-  margin-top: rem.torem(4px);
+  margin-bottom: rem.torem(36px);
+
+  @media (width <= 432px) {
+    &[data-error="true"] {
+      margin-bottom: rem.torem(50px);
+    }
+  }
 }
 
 .input-gap {
   display: flex;
   flex-wrap: nowrap;
   gap: rem.torem(8px);
+  align-items: end;
 }
 
 .first-row {
-  margin-top: calc(
-    #{forms.$label-space-before-input} + #{forms.$input-space-before-error} + #{fonts.$caption-line-height}
-  );
+  margin-bottom: rem.torem(36px);
+
+  @media (width <= 432px) {
+    &[data-error="true"] {
+      margin-bottom: rem.torem(52px);
+    }
+  }
 }
 
 .delete-button {

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -33,7 +33,7 @@ export interface ActivityFormProps {
 export const ActivityForm = ({
   venueTypes,
 }: ActivityFormProps): JSX.Element => {
-  const { values } = useFormikContext<ActivityFormValues>()
+  const { values, errors } = useFormikContext<ActivityFormValues>()
   const venueTypesOptions = buildVenueTypesOptions(venueTypes)
 
   return (
@@ -71,6 +71,7 @@ export const ActivityForm = ({
                 />
 
                 <div
+                  data-error={errors.socialUrls?.[index] ? 'true' : 'false'}
                   className={cn(styles['form-row-actions'], {
                     [styles['first-row']]: index === 0,
                   })}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31407

Avant:
<img width="531" alt="Capture d’écran 2024-10-03 à 10 43 15" src="https://github.com/user-attachments/assets/746ef0e9-802d-4bd1-986b-41cb31882cde">

Après
<img width="576" alt="Capture d’écran 2024-10-03 à 10 43 02" src="https://github.com/user-attachments/assets/3d242e63-8a9c-4867-ab9f-c57257122866">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
