### PR TITLE
(PC-32158)[PRO] fix: Dont fetch bookable offers in duplication list.

### DIFF
--- a/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplicationScreen.tsx
@@ -4,12 +4,11 @@ import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import { CollectiveOfferResponseModel } from 'apiClient/v1'
+import { CollectiveOfferResponseModel, CollectiveOfferType } from 'apiClient/v1'
 import { AppLayout } from 'app/AppLayout'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { createOfferFromTemplate } from 'core/OfferEducational/utils/createOfferFromTemplate'
 import { DEFAULT_COLLECTIVE_TEMPLATE_SEARCH_FILTERS } from 'core/Offers/constants'
-import { CollectiveOfferTypeEnum } from 'core/Offers/types'
 import { computeCollectiveOffersUrl } from 'core/Offers/utils/computeCollectiveOffersUrl'
 import { serializeApiCollectiveFilters } from 'core/Offers/utils/serializer'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared/constants'
@@ -59,19 +58,16 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
         creationMode,
         periodBeginningDate,
         periodEndingDate,
-        collectiveOfferType,
         format,
       } = serializeApiCollectiveFilters(
         {
           ...DEFAULT_COLLECTIVE_TEMPLATE_SEARCH_FILTERS,
           nameOrIsbn: offerName,
-          collectiveOfferType: CollectiveOfferTypeEnum.TEMPLATE,
           offererId: queryOffererId ? queryOffererId : 'all',
           venueId: queryVenueId ? queryVenueId : 'all',
         },
         DEFAULT_COLLECTIVE_TEMPLATE_SEARCH_FILTERS
       )
-
       try {
         const offers = await api.getCollectiveOffers(
           nameOrIsbn,
@@ -82,7 +78,7 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
           creationMode,
           periodBeginningDate,
           periodEndingDate,
-          collectiveOfferType,
+          CollectiveOfferType.TEMPLATE,
           format
         )
 

--- a/pro/src/screens/CollectiveOfferSelectionDuplication/__specs__/CollectiveOfferSelectionDuplicationScreen.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/__specs__/CollectiveOfferSelectionDuplicationScreen.spec.tsx
@@ -119,7 +119,7 @@ describe('CollectiveOfferConfirmation', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
+      'template',
       undefined
     )
   })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32158

**Objectif**
Correction de la requête faite pour la liste des offres collectives à partir desquelles on peut créer une offre réservable.

Aujourd'hui on affiche toutes les offres (vitrines et réservables) dans cette liste, mais on ne peut que créer d'offre réservable à partir d'une offre réservable. Donc cans la page de ducplication, on ne veut **que** les offres vitrines.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
