### PR TITLE
(PC-31986)[API] feat: public api: adage mock: book offer

### DIFF
--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -11380,6 +11380,60 @@
                 ]
             }
         },
+        "/v2/collective/adage_mock/offer/{offer_id}/book": {
+            "post": {
+                "description": "Like this could happen within the Adage platform.\n\n**WARNING:** this endpoint is not available from the production environment as it is a mock meant to ease the test of your integrations.",
+                "operationId": "AdageMockBookOffer",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "offer_id",
+                        "required": true,
+                        "schema": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "This collective booking's status has been successfully updated"
+                    },
+                    "401": {
+                        "description": "Authentication is necessary to use this API."
+                    },
+                    "403": {
+                        "description": "Collective booking status updated has been refused"
+                    },
+                    "404": {
+                        "description": "The collective offer could not be found."
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "description": "You have made too many requests. (**rate limit: 200 requests/minute**)"
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "summary": "Mock collective offer booking",
+                "tags": [
+                    "Collective bookings Adage mock"
+                ]
+            }
+        },
         "/v2/collective/bookings/{booking_id}": {
             "patch": {
                 "description": "Cancel an collective event booking.",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31986

Ajout d'une nouvelle route pour réserver une offre collective, dans la série des mock Adage existants.

Pour rappel, il s'agit de routes dont le but est de simuler des actions sur des offres collectives. Le but est de permettre de débloquer les tests en intégration car Adage n'existe pas dans cet environnement et on ne peut donc que créer des offres (personne ne peut les réservers, les annuler, etc.).
