### PR TITLE
(PC-32169)[BO] feat: any BO user can view his/her roles and permissions

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -365,14 +365,19 @@ def render_public_account_details(
         if utils.has_current_user_permission(perm_models.Permissions.EXTRACT_PUBLIC_ACCOUNT):
             if user.is_beneficiary or user.roles == []:
                 extract_user_form = empty_forms.EmptyForm()
+        if utils.has_current_user_permission(perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT):
+            kwargs.update(
+                {
+                    "password_reset_dst": url_for(".send_public_account_reset_password_email", user_id=user.id),
+                    "password_reset_form": empty_forms.EmptyForm(),
+                    "password_invalidation_dst": url_for(".invalidate_public_account_password", user_id=user.id),
+                    "password_invalidation_form": empty_forms.EmptyForm(),
+                }
+            )
         kwargs.update(
             {
                 "edit_account_form": edit_account_form,
                 "edit_account_dst": url_for(".update_public_account", user_id=user.id),
-                "password_reset_dst": url_for(".send_public_account_reset_password_email", user_id=user.id),
-                "password_reset_form": empty_forms.EmptyForm(),
-                "password_invalidation_dst": url_for(".invalidate_public_account_password", user_id=user.id),
-                "password_invalidation_form": empty_forms.EmptyForm(),
                 "manual_review_form": (
                     account_forms.ManualReviewForm()
                     if utils.has_current_user_permission(perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS)

--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/details/roles.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/details/roles.html
@@ -3,12 +3,18 @@
     <thead>
       <tr>
         <th scope="col">Rôle</th>
+        <th scope="col">Permissions</th>
       </tr>
     </thead>
     <tbody>
-      {% for role_name in roles | map(attribute="name") | sort %}
+      {% for role in roles | sort(attribute="name") %}
         <tr>
-          <td>{{ role_name }}</td>
+          <td class="w-50">{{ role.name }}</td>
+          <td class="w-50">
+            <ul>
+              {% for permission in role.permissions %}<li>{{ permission.name | format_permission_name }}</li>{% endfor %}
+            </ul>
+          </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
@@ -146,7 +146,7 @@
                 {% endif %}
               {% endif %}
             </div>
-            {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
+            {% if password_reset_form %}
               <div>
                 {{ build_modal_form("send-reset-password-email", password_reset_dst, password_reset_form,
                                 "Envoyer le mail de changement de mot de passe",
@@ -154,6 +154,8 @@
                                 "Confirmer l'envoi",
                                 "En confirmant, l'email de mot de passe perdu contenant un lien de réinitialisation valide 24 heures sera envoyé à " + user.email + ".") }}
               </div>
+            {% endif %}
+            {% if password_invalidation_form %}
               <div>
                 {{ build_modal_form("invalidate-account-password", password_invalidation_dst, password_invalidation_form, "Invalider le mot de passe", "Invalider le mot de passe", "Confirmer l'invalidation") }}
               </div>

--- a/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
@@ -17,7 +17,7 @@
   </nav>
 {% endmacro %}
 {% macro menu_section_item(title, path) %}
-  {% set url = url_for(path) %}
+  {% set url = url_for(path, **kwargs) %}
   {% set is_active = "active" if request.path == url else "" %}
   <a class="nav-link ps-5 py-1 g-0 {{ is_active }} rounded-0 text-reset"
      href="{{ url }}">{{ title }}</a>
@@ -150,6 +150,7 @@
               {% endif %}
               <div class="nav nav-pills flex-column">
                 {% call menu_section("Admin") %}
+                  {{ menu_section_item('Mon compte backoffice', 'backoffice_web.bo_users.get_bo_user', user_id=current_user.id, active_tab='roles') }}
                   {% if has_permission("MANAGE_PERMISSIONS") %}{{ menu_section_item('Gestion des rôles', 'backoffice_web.get_roles') }}{% endif %}
                   {% if has_permission("READ_ADMIN_ACCOUNTS") %}
                     {{ menu_section_item('Utilisateurs BackOffice', 'backoffice_web.bo_users.search_bo_users') }}


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32169

Exemple d'affichage pour un profil ayant les deux rôles fraude : 
![image](https://github.com/user-attachments/assets/b68732cf-ed51-4b13-bdf4-dde7c7b44b99)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
