### PR TITLE
(PC-32188)[API] feat: do not require phone validation for credit activation

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -175,7 +175,11 @@ def get_phone_validation_subscription_item(
         elif fraud_repository.has_failed_phone_validation(user):
             status = models.SubscriptionItemStatus.KO
         elif is_eligibility_activable(user, eligibility):
-            status = models.SubscriptionItemStatus.TODO
+            has_user_filled_phone = user.phoneNumber is not None
+            if has_user_filled_phone:
+                status = models.SubscriptionItemStatus.OK
+            else:
+                status = models.SubscriptionItemStatus.TODO
         else:
             status = models.SubscriptionItemStatus.VOID
 

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -713,11 +713,18 @@ class SubscriptionItemTest:
             == subscription_models.SubscriptionItemStatus.OK
         )
 
-    def test_phone_validation_item_todo(self):
+    def test_phone_validation_item_with_eligible_user_todo(self):
         user = users_factories.UserFactory(dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE)
         assert (
             subscription_api.get_phone_validation_subscription_item(user, users_models.EligibilityType.AGE18).status
             == subscription_models.SubscriptionItemStatus.TODO
+        )
+
+    def test_phone_validation_item_with_eligible_user_done_without_validation(self):
+        user = users_factories.UserFactory(dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE, _phoneNumber="0123456789")
+        assert (
+            subscription_api.get_phone_validation_subscription_item(user, users_models.EligibilityType.AGE18).status
+            == subscription_models.SubscriptionItemStatus.OK
         )
 
     def test_phone_validation_item_ko(self):


### PR DESCRIPTION
To save money, beneficiaries' phone number are no longer validated for credit activation.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32188

## Vérifications

- [x] J'ai écrit les tests nécessaires
