### PR TITLE
(BSR)[API] fix: unconsistent stocks in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -306,7 +306,7 @@ def create_venues_across_cities() -> None:
                     offers_factories.StockFactory(quantity=random.randint(10, 100), offer=offer)
 
             for _ in range(3):
-                offers_factories.EventOfferFactory(
+                event_offer = offers_factories.EventOfferFactory(
                     venue=venue,
                     product=None,
                     subcategoryId=random.choice(list(subcategories_v2.EVENT_SUBCATEGORIES)),
@@ -317,7 +317,7 @@ def create_venues_across_cities() -> None:
                 for _ in range(random.randint(1, 10)):
                     offers_factories.EventStockFactory(
                         quantity=random.randint(10, 100),
-                        offer=offer,
+                        offer=event_offer,
                         beginningDatetime=datetime.datetime.utcnow()
                         + datetime.timedelta(
                             days=random.randint(30, 59),


### PR DESCRIPTION
## But de la pull request

Correction de données incohérentes dans la sandbox, conduisant à cette erreur ne pouvant a priori pas se produire en production :
https://sentry.passculture.team/organizations/sentry/issues/1619173/?project=5&referrer=slack

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
