### PR TITLE
(PC-32204)[BO] fix: Use endDatetime to switch reservation from CONFIRMED -> USED

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -1023,7 +1023,7 @@ def auto_mark_as_used_after_event() -> None:
         .where(
             CollectiveBooking.status == CollectiveBookingStatus.CONFIRMED,
             CollectiveBooking.collectiveStockId == CollectiveStock.id,
-            CollectiveStock.beginningDatetime < threshold,
+            CollectiveStock.endDatetime < threshold,
         )
         .values(dateUsed=now, status=CollectiveBookingStatus.USED),
         execution_options={"synchronize_session": False},

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -135,10 +135,7 @@ def add_event(
         models.FinanceEventMotive.BOOKING_USED_AFTER_CANCELLATION,
     ):
         assert booking.dateUsed
-        if isinstance(booking, bookings_models.Booking):
-            value_date = booking.dateUsed
-        else:
-            value_date = booking.collectiveStock.pricing_datetime
+        value_date = booking.dateUsed
 
         pricing_point_id = booking.venue.current_pricing_point_id
         if pricing_point_id:

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1938,7 +1938,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     def test_create_finance_event_for_collective_booking(self):
         event_date = datetime.utcnow() - timedelta(days=3)
-        booking = educational_factories.CollectiveBookingFactory(collectiveStock__beginningDatetime=event_date)
+        booking = educational_factories.CollectiveBookingFactory(collectiveStock__endDatetime=event_date)
 
         api.auto_mark_as_used_after_event()
 
@@ -1947,7 +1947,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     def test_does_not_update_collective_booking_when_event_date_is_only_1_day_before(self):
         event_date = datetime.utcnow() - timedelta(days=1)
-        educational_factories.CollectiveBookingFactory(collectiveStock__beginningDatetime=event_date)
+        educational_factories.CollectiveBookingFactory(collectiveStock__endDatetime=event_date)
 
         api.auto_mark_as_used_after_event()
 

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -223,7 +223,6 @@ class PriceEventTest:
         assert pricing2.lines[1].category == models.PricingLineCategory.OFFERER_CONTRIBUTION
         assert pricing2.lines[1].amount == 5 * 100
 
-    @override_features(USE_END_DATE_FOR_COLLECTIVE_PRICING=False)
     def test_pricing_collective(self):
         event1 = self._make_collective_event(price=19_999)
         booking1 = event1.collectiveBooking
@@ -234,41 +233,7 @@ class PriceEventTest:
         assert pricing1.booking is None
         assert pricing1.venue == booking1.venue
         assert pricing1.pricingPoint == booking1.venue
-        assert pricing1.valueDate == booking1.collectiveStock.beginningDatetime
-        assert pricing1.amount == -(19_999 * 100)
-        assert pricing1.standardRule == "Remboursement total pour les offres éducationnelles"
-        assert pricing1.customRule is None
-        assert pricing1.revenue == 0
-        assert pricing1.lines[0].category == models.PricingLineCategory.OFFERER_REVENUE
-        assert pricing1.lines[0].amount == -(19_999 * 100)
-        assert pricing1.lines[1].category == models.PricingLineCategory.OFFERER_CONTRIBUTION
-        assert pricing1.lines[1].amount == 0
-
-        event2 = self._make_collective_event(price=100)
-        booking2 = event2.collectiveBooking
-        api.price_event(event2)
-        pricing2 = models.Pricing.query.filter_by(collectiveBooking=booking2).one()
-        assert pricing2.collectiveBooking == booking2
-        assert pricing2.amount == -(100 * 100)
-        assert pricing1.revenue == 0
-        assert pricing2.standardRule == "Remboursement total pour les offres éducationnelles"
-        assert pricing2.lines[0].category == models.PricingLineCategory.OFFERER_REVENUE
-        assert pricing2.lines[0].amount == -(100 * 100)
-        assert pricing2.lines[1].category == models.PricingLineCategory.OFFERER_CONTRIBUTION
-        assert pricing2.lines[1].amount == 0
-
-    @override_features(USE_END_DATE_FOR_COLLECTIVE_PRICING=True)
-    def test_pricing_collective_with_endDatetime(self):
-        event1 = self._make_collective_event(price=19_999)
-        booking1 = event1.collectiveBooking
-        api.price_event(event1)
-        pricing1 = models.Pricing.query.one()
-        assert pricing1.event == event1
-        assert pricing1.collectiveBooking == booking1
-        assert pricing1.booking is None
-        assert pricing1.venue == booking1.venue
-        assert pricing1.pricingPoint == booking1.venue
-        assert pricing1.valueDate == booking1.collectiveStock.endDatetime
+        assert pricing1.valueDate == booking1.dateUsed
         assert pricing1.amount == -(19_999 * 100)
         assert pricing1.standardRule == "Remboursement total pour les offres éducationnelles"
         assert pricing1.customRule is None
@@ -1024,7 +989,7 @@ class AddEventTest:
         assert event.collectiveBooking == booking
         assert event.status == models.FinanceEventStatus.READY
         assert event.motive == motive
-        assert event.valueDate == booking.collectiveStock.beginningDatetime
+        assert event.valueDate == booking.dateUsed
         assert event.venue == booking.venue
         assert event.pricingPoint == pricing_point
         assert event.pricingOrderingDate == booking.collectiveStock.beginningDatetime
@@ -1050,7 +1015,7 @@ class AddEventTest:
         assert event.collectiveBooking == booking
         assert event.status == models.FinanceEventStatus.READY
         assert event.motive == motive
-        assert event.valueDate == booking.collectiveStock.endDatetime
+        assert event.valueDate == booking.dateUsed
         assert event.venue == booking.venue
         assert event.pricingPoint == pricing_point
         assert event.pricingOrderingDate == booking.collectiveStock.endDatetime


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32204

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
