### PR TITLE
(PC-32159)[PRO] fix: loading selection duplication and check if 1 off…

### DIFF
--- a/pro/src/screens/CollectiveOfferSelectionDuplication/__specs__/CollectiveOfferSelectionDuplicationScreen.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSelectionDuplication/__specs__/CollectiveOfferSelectionDuplicationScreen.spec.tsx
@@ -1,4 +1,8 @@
-import { screen, waitFor } from '@testing-library/react'
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Formik } from 'formik'
 
@@ -66,6 +70,8 @@ describe('CollectiveOfferConfirmation', () => {
       initialValues,
       onSubmit,
     })
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
     expect(
       screen.getByText('Rechercher l’offre vitrine à dupliquer')

--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
+import { CollectiveOfferType as CollectiveOfferApiType } from 'apiClient/v1'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { GET_OFFERER_QUERY_KEY } from 'config/swrQueryKeys'
@@ -125,7 +126,6 @@ export const OfferTypeScreen = (): JSX.Element => {
         creationMode,
         periodBeginningDate,
         periodEndingDate,
-        collectiveOfferType,
         format,
       } = serializeApiCollectiveFilters(
         apiFilters,
@@ -141,7 +141,7 @@ export const OfferTypeScreen = (): JSX.Element => {
         creationMode,
         periodBeginningDate,
         periodEndingDate,
-        collectiveOfferType,
+        CollectiveOfferApiType.TEMPLATE,
         format
       )
 

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -279,7 +279,7 @@ describe('OfferType', () => {
         undefined,
         undefined,
         undefined,
-        undefined,
+        'template',
         undefined
       )
     })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32159

- ajouter un loader pour les offres qui sont entrains de charger au moment de l'arrivé sur la page de sélection de duplication 
- ne checker seulement si il existe des offres vitrines au moment de passer à l'étape suivante après avoir sélectionner "
Dupliquer les informations d’une offre vitrine" depuis le carrefour 
