### PR TITLE
(BSR)[PRO] fix: Add reload to correct e2e tests

### DIFF
--- a/pro/cypress/e2e/migrations/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/migrations/signupJourneyCreateOfferer.cy.ts
@@ -153,6 +153,9 @@ describe('Signup journey with new venue', () => {
       .should('not.be.visible')
     cy.url({ timeout: 10000 }).should('contain', '/accueil')
     cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
+
+    // TODO: Find a better way to wait for the offerer to be created
+    cy.reload()
     cy.wait('@getOfferers').its('response.statusCode').should('eq', 200)
     cy.findByText('First Venue').should('be.visible')
   })
@@ -291,6 +294,9 @@ describe('Signup journey with known venue', () => {
       .should('not.be.visible')
     cy.url({ timeout: 10000 }).should('contain', '/accueil')
     cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
+
+    // TODO: Find a better way to wait for the offerer to be created
+    cy.reload()
     cy.wait('@getOfferers').its('response.statusCode').should('eq', 200)
 
     // Then the attachment is in progress
@@ -340,6 +346,8 @@ describe('Signup journey with known venue', () => {
     // When I am redirected to homepage
     cy.url({ timeout: 10000 }).should('contain', '/accueil')
     cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
+
+    // TODO: Find a better way to wait for the offerer to be created
     cy.reload()
     cy.wait('@getOfferers').its('response.statusCode').should('eq', 200)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
