### PR TITLE
(PC-32061)[PRO] fix: recap collective offer responsive for mobile

### DIFF
--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
@@ -1,6 +1,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/fonts-design-system.scss" as fonts-design-system;
+@use "styles/variables/_size.scss" as size;
 
 .eac-layout {
   position: relative;
@@ -28,5 +29,11 @@
 
   &-navigation {
     margin-bottom: rem.torem(32px);
+  }
+}
+
+@media (max-width: size.$tablet) {
+  .eac-layout-headings {
+    padding-top: rem.torem(56px);
   }
 }

--- a/pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.module.scss
+++ b/pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.module.scss
@@ -10,6 +10,7 @@
   display: inline-flex;
   padding: rem.torem(4px) rem.torem(8px);
   white-space: nowrap;
+  max-height: rem.torem(24px);
 }
 
 .status-label-icon {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32061

Page récap d'une offre collective en responsive pour le mobile

Avant : 
<img width="319" alt="Capture d’écran 2024-10-08 à 15 43 25" src="https://github.com/user-attachments/assets/75cec668-9046-4133-8d0d-fa844682b7c7">

Après :
<img width="319" alt="Capture d’écran 2024-10-08 à 15 42 36" src="https://github.com/user-attachments/assets/6f8a8aae-b0df-4db3-ae1f-ba96b0b0104f">

