### PR TITLE
(BSR) feat: add a vscode launch config to run a local python file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs-build/
 # Certificates for local mutal TLS
 *.crt
 *.key
+
+# Script for VSCode local debugging
+/api/src/pcapi/scripts/local_debug_script.py

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,9 @@
                 "FLASK_RUN_IP": "0.0.0.0",
                 "FLASK_RUN_PORT": "5001"
             },
-            "args": ["run"]
+            "args": [
+                "run"
+            ]
         },
         {
             "name": "Flask backoffice server",
@@ -29,7 +31,9 @@
                 "FLASK_RUN_IP": "0.0.0.0",
                 "FLASK_RUN_PORT": "5002"
             },
-            "args": ["run"]
+            "args": [
+                "run"
+            ]
         },
         // Use these two configurations to attach to a running server
         // You will need the env var DEBUG_ACTIVATED=1
@@ -41,7 +45,10 @@
                     "remoteRoot": "${workspaceFolder}"
                 }
             ],
-            "connect": {"host": "localhost", "port": 10002},
+            "connect": {
+                "host": "localhost",
+                "port": 10002
+            },
             "request": "attach",
             "subProcess": true,
             "type": "debugpy",
@@ -55,11 +62,36 @@
                     "remoteRoot": "${workspaceFolder}"
                 }
             ],
-            "connect": {"host": "localhost", "port": 10003},
+            "connect": {
+                "host": "localhost",
+                "port": 10003
+            },
             "request": "attach",
             "subProcess": true,
             "type": "debugpy",
             "justMyCode": false
+        },
+        // Debug a local python script (without docker)
+        // To use the default path value, create the file api/src/pcapi/scripts/local_debug_script.py
+        // To access Flask app features, add this in your python file:
+        // from pcapi.app import app
+        // app.app_context().push()
+        {
+            "name": "Local python script",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${input:pythonScriptPath}",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/api",
+            "justMyCode": false,
+        }
+    ],
+    "inputs": [
+        {
+            "id": "pythonScriptPath",
+            "type": "promptString",
+            "default": "${workspaceFolder}/api/src/pcapi/scripts/local_debug_script.py",
+            "description": "Path to the python file to debug"
         }
     ]
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : 

Ajout d'une config de launch VSCode pour debug un script local python

La conf a un input pour le chemin vers le fichier, avec comme valeur par défaut `api/src/pcapi/scripts/local_debug_script.py` qui est ajouté au .gitignore. Pour que cette valeur par défaut de l'input fonctionne, créer d'abord le fichier en question

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
