### PR TITLE
(BSR)[API] fix: joinedload venue in get_offer_and_extradata

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1083,6 +1083,7 @@ def get_offer_and_extradata(offer_id: int) -> models.Offer | None:
             )
             .joinedload(offerers_models.OffererAddress.address),
         )
+        .options(sa_orm.joinedload(models.Offer.venue))
         .one_or_none()
     )
 

--- a/api/tests/routes/pro/patch_publish_offer_test.py
+++ b/api/tests/routes/pro/patch_publish_offer_test.py
@@ -35,15 +35,14 @@ class Returns200Test:
     num_queries += 1  # 2 user
     num_queries += 1  # 3 offer
     num_queries += 1  # 4 user_offerer
-    num_queries += 1  # 5 offer+stock+offererAddress+Address+mediaton
+    num_queries += 1  # 5 offer+stock+offererAddress+Address+mediaton+venue
     num_queries += 1  # 6 available stock (date comparison)
-    num_queries += 1  # 7 venue
-    num_queries += 1  # 8 validation status
-    num_queries += 1  # 9 offerer_confidence
-    num_queries += 1  # 10 offerer_confidenc
-    num_queries += 1  # 11 offer_validation_rule + offer_validation_sub_rule
-    num_queries += 1  # 12 future_offer
-    num_queries += 1  # 13 update offer
+    num_queries += 1  # 7 validation status
+    num_queries += 1  # 8 offerer_confidence
+    num_queries += 1  # 9 offerer_confidenc
+    num_queries += 1  # 10 offer_validation_rule + offer_validation_sub_rule
+    num_queries += 1  # 11 future_offer
+    num_queries += 1  # 12 update offer
 
     @patch("pcapi.core.mails.transactional.send_first_venue_approved_offer_email_to_pro")
     @patch("pcapi.core.offers.api.rule_flags_offer", return_value=False)


### PR DESCRIPTION
## But de la pull request

This fixes the flacky tests.
Somehow SQLAlchemy sometimes loaded all the venue at once, sometime it only loaded the fields one at a time, creating a huge number of new DB queries.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
