### PR TITLE
(BSR)[API] fix: public api: adage mock: return booked offer id

### DIFF
--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -11397,14 +11397,14 @@
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "This collective booking's status has been successfully updated"
+                    "200": {
+                        "description": "Your request was succesful."
                     },
                     "401": {
                         "description": "Authentication is necessary to use this API."
                     },
                     "403": {
-                        "description": "Collective booking status updated has been refused"
+                        "description": "You do not have the necessary rights to use this API."
                     },
                     "404": {
                         "description": "The collective offer could not be found."

--- a/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
+++ b/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
@@ -557,11 +557,14 @@ class BookCollectiveOfferTest(PublicAPIRestrictedEnvEndpointHelper):
         expected_num_queries += 1  # 24. get (same) offerer
 
         with assert_num_queries(expected_num_queries):
-            self.assert_request_has_expected_result(
+            response = self.assert_request_has_expected_result(
                 auth_client,
                 url_params={"offer_id": offer_id},
-                expected_status_code=204,
+                expected_status_code=200,
             )
+
+        assert response.json["bookingId"]
+        assert response.json["bookingStatus"] == models.CollectiveBookingStatus.PENDING.value
 
         db.session.refresh(offer)
         bookings = offer.collectiveStock.collectiveBookings
@@ -635,7 +638,7 @@ class BookCollectiveOfferTest(PublicAPIRestrictedEnvEndpointHelper):
             auth_client,
             url_params={"offer_id": offer.id},
             expected_status_code=403,
-            expected_error_json={"code": "OFFER_IS_NOT_BOOKABLE"},
+            expected_error_json={"code": "OFFER_IS_NOT_BOOKABLE_BECAUSE_BOOKING_EXISTS"},
         )
 
         # offer is sold out because of used booking.

--- a/api/tests/routes/public/helpers.py
+++ b/api/tests/routes/public/helpers.py
@@ -195,6 +195,8 @@ class PublicAPIRestrictedEnvEndpointHelper(PublicAPIVenueEndpointHelper):
                 assert response.json.get(key) == msg, f"[{key}] expected: {msg}, got: '{response.json.get(key)}'"
                 assert response.json.get(key) == msg, self._format_unexpected_json_error(response, key, msg)
 
+        return response
+
     def _format_wrong_status_code(self, response, expected_status):
         return f"expected: {expected_status}, got: {response.status_code}, json: '{response.json}'"
 


### PR DESCRIPTION
## But de la pull request

Fix: renvoyer l'identifiant de la réservations collective créée via la route du mock Adage dans l'API publique.
