### PR TITLE
(PC-32289)[API] fix: ensure any OA label is valid

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -324,7 +324,7 @@ def create_offer(
 def get_offerer_address_from_address(
     venue: offerers_models.Venue, address: offerers_schemas.AddressBodyModel
 ) -> offerers_models.OffererAddress:
-    if not address.label or address.label == venue.common_name:
+    if not address.label:
         address.label = None
     address_from_api = offerers_api.create_offerer_address_from_address_api(address)
     return offerers_api.get_or_create_offerer_address(


### PR DESCRIPTION
`isVenueAddress` addressed the issue to figure out whether or not an address is linked to a venue or not.
Therefore, we don't need the "hack" to check whether the label is equal to the venue's name or not.
Reminder, the venue's OA label is empty in the database BUT is filled with venue's common name which we get back when the front sends its data.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32289

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
