### PR TITLE
(BSR)[PRO] test: fix flaky after cucumber migration

### DIFF
--- a/pro/cypress/e2e/migrations/createIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/migrations/createIndividualOffer.cy.ts
@@ -37,12 +37,12 @@ describe('Create individual offers', () => {
       password: password,
       redirectUrl: '/',
     })
-    cy.findAllByTestId('spinner').should('not.exist')
-
     cy.stepLog({
       message: 'I want to create "Un évènement physique daté" offer',
     })
-    cy.findAllByText('Créer une offre').first().click()
+    cy.findAllByText('Créer une offre', { timeout: 60 * 1000 })
+      .first()
+      .click()
 
     cy.findByText('Au grand public').click()
     cy.findByText('Un évènement physique daté').click()
@@ -181,18 +181,10 @@ describe('Create individual offers', () => {
 
     cy.stepLog({ message: 'I go to the offers list' })
     cy.findByText('Voir la liste des offres').click()
-    cy.wait(
-      [
-        '@getOfferersNames',
-        '@getOffer',
-        '@getCategories',
-        '@getVenuesForOfferer',
-      ],
-      {
-        requestTimeout: 60 * 1000 * 5,
-        responseTimeout: 60 * 1000 * 5,
-      }
-    )
+    cy.wait(['@getOfferersNames', '@getOffer', '@getCategories'], {
+      requestTimeout: 60 * 1000 * 3,
+      responseTimeout: 60 * 1000 * 3,
+    })
 
     cy.stepLog({ message: 'my new offer should be displayed' })
     cy.url().should('contain', '/offres')
@@ -211,8 +203,9 @@ describe('Create individual offers', () => {
       password: password,
       redirectUrl: '/',
     })
-    cy.findAllByTestId('spinner').should('not.exist')
-    cy.findAllByText('Créer une offre').first().click()
+    cy.findAllByText('Créer une offre', { timeout: 60 * 1000 })
+      .first()
+      .click()
 
     cy.stepLog({ message: 'I want to create "Un bien physique" offer' })
     cy.findByText('Au grand public').click()
@@ -277,7 +270,9 @@ describe('Create individual offers', () => {
 
     cy.stepLog({ message: 'I validate offer useful informations step' })
     cy.findByText('Enregistrer et continuer').click()
-    cy.wait(['@getOffer', '@patchOffer'])
+    cy.wait(['@getOffer', '@patchOffer', '@getStocks'], {
+      responseTimeout: 60 * 1000 * 3,
+    })
 
     cy.stepLog({ message: 'I fill in stocks' })
     cy.get('#price').type('42')
@@ -302,18 +297,11 @@ describe('Create individual offers', () => {
 
     cy.stepLog({ message: 'I go to the offers list' })
     cy.findByText('Voir la liste des offres').click()
-    cy.wait(
-      [
-        '@getOfferersNames',
-        '@getOffer',
-        '@getCategories',
-        '@getVenuesForOfferer',
-      ],
-      {
-        requestTimeout: 60 * 1000 * 5,
-        responseTimeout: 60 * 1000 * 5,
-      }
-    )
+    cy.url().should('contain', '/offres')
+    cy.wait(['@getOfferersNames', '@getOffer', '@getCategories'], {
+      requestTimeout: 60 * 1000 * 3,
+      responseTimeout: 60 * 1000 * 3,
+    })
 
     cy.stepLog({ message: 'my new physical offer should be displayed' })
     cy.contains('H2G2 Le Guide du voyageur galactique')


### PR DESCRIPTION
## But de la pull request

Depuis la migration de Cucumber vers Cypress basique, le cas `Should create an individual offer (thing)` était devenu flaky. Ces changements semblent corriger


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
