### PR TITLE
(BSR)[PRO] test: e2e format logs with logs steps

### DIFF
--- a/pro/cypress/e2e/migrations/adage.cy.ts
+++ b/pro/cypress/e2e/migrations/adage.cy.ts
@@ -3,7 +3,7 @@ describe('ADAGE discovery', () => {
   const offerName = 'Mon offre collective'
 
   beforeEach(() => {
-    // I go to adage login page with valid token
+    cy.stepLog({ message: 'I go to adage login page with valid token' })
     cy.visit('/connexion')
     cy.getFakeAdageToken()
     cy.request({
@@ -185,13 +185,14 @@ describe('ADAGE discovery', () => {
   })
 
   it('It should put an offer in favorite', () => {
-    // I open adage iframe
+    cy.stepLog({ message: 'I open adage iframe' })
     const adageToken = Cypress.env('adageToken')
+
     cy.visit(`/adage-iframe/recherche?token=${adageToken}`)
 
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I add first offer to favorites
+    cy.stepLog({ message: 'I add first offer to favorites' })
     cy.findByText(offerName).parent().click()
     cy.intercept({
       method: 'POST',
@@ -201,17 +202,16 @@ describe('ADAGE discovery', () => {
     cy.wait('@fav-offer', { responseTimeout: 30 * 1000 })
       .its('response.statusCode')
       .should('eq', 204)
-
     cy.findByTestId('global-notification-success').should(
       'contain',
       'Ajouté à vos favoris'
     )
 
-    // Then the first offer should be added to favorites
+    cy.stepLog({ message: 'the first offer should be added to favorites' })
     cy.contains('Mes Favoris').click()
     cy.contains(offerName).should('be.visible')
 
-    // Then we can remove it from favorites
+    cy.stepLog({ message: 'we can remove it from favorites' })
     cy.intercept({
       method: 'DELETE',
       url: '/adage-iframe/collective/template/**/favorites',
@@ -225,17 +225,17 @@ describe('ADAGE discovery', () => {
   })
 
   it('Should redirect to adage discovery', () => {
-    // I open adage iframe
+    cy.stepLog({ message: 'I open adage iframe' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe?token=${adageToken}`)
 
-    // Then the iframe should be displayed correctly
+    cy.stepLog({ message: 'the iframe should be displayed correctly' })
     cy.url().should('include', '/decouverte')
     cy.findAllByRole('link', { name: 'Découvrir (Onglet actif)' })
       .first()
       .should('have.attr', 'aria-current', 'page')
 
-    // Then the banner is displayed
+    cy.stepLog({ message: 'the banner is displayed' })
     cy.get('[class^=_discovery-banner]').contains(
       'Découvrez la part collective du pass Culture'
     )
@@ -243,13 +243,14 @@ describe('ADAGE discovery', () => {
 
   it('Should redirect to a page dedicated to the offer with an active header on the discovery tab', () => {
     // I open adage iframe
+    cy.stepLog({ message: 'I open adage iframe' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe?token=${adageToken}`)
 
-    // I click on an offer
+    cy.stepLog({ message: 'I click on an offer' })
     cy.findByText(offerName).parent().click()
 
-    // Then the iframe should be displayed correctly
+    cy.stepLog({ message: 'the iframe should be displayed correctly' })
     cy.url().should('include', '/decouverte')
     cy.findAllByRole('link', { name: 'Découvrir (Onglet actif)' })
       .first()
@@ -257,14 +258,16 @@ describe('ADAGE discovery', () => {
   })
 
   it('Should redirect to search page with filtered venue on click in venue card', () => {
-    // I open adage iframe
+    cy.stepLog({ message: 'I open adage iframe' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe?token=${adageToken}`)
 
-    // When I click on venue
+    cy.stepLog({ message: 'I click on venue' })
     cy.findByText('Mon lieu collectif').parent().click()
 
-    // Then the iframe search page should be displayed correctly
+    cy.stepLog({
+      message: 'the iframe search page should be displayed correctly',
+    })
     cy.url().should('include', '/recherche')
     cy.findByRole('link', { name: 'Rechercher (Onglet actif)' }).should(
       'have.attr',
@@ -272,19 +275,21 @@ describe('ADAGE discovery', () => {
       'page'
     )
 
-    // Venue filter should be there
+    cy.stepLog({ message: 'Venue filter should be there' })
     cy.findByText('Lieu : Mon lieu collectif').should('be.visible')
   })
 
   it('Should redirect to search page with filtered domain on click in domain card', () => {
-    // I open adage iframe
+    cy.stepLog({ message: 'I open adage iframe' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe?token=${adageToken}`)
 
-    // When I select first card domain
+    cy.stepLog({ message: 'I select first card domain' })
     cy.findAllByText('Danse').first().click()
 
-    // Then the iframe search page should be displayed correctly
+    cy.stepLog({
+      message: 'the iframe search page should be displayed correctly',
+    })
     cy.url().should('include', '/recherche')
     cy.findByRole('link', { name: 'Rechercher (Onglet actif)' }).should(
       'have.attr',
@@ -292,19 +297,21 @@ describe('ADAGE discovery', () => {
       'page'
     )
 
-    // And the "Danse" button should be displayed
+    cy.stepLog({ message: 'the "Danse" button should be displayed' })
     cy.get('button').contains('Danse')
   })
 
   it('Should not keep filters after page change', () => {
-    // I open adage iframe
+    cy.stepLog({ message: 'I open adage iframe' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe?token=${adageToken}`)
 
-    // When I click on venue
+    cy.stepLog({ message: 'I click on venue' })
     cy.findByText('Mon lieu collectif').parent().click()
 
-    // Then the iframe search page should be displayed correctly
+    cy.stepLog({
+      message: 'the iframe search page should be displayed correctly',
+    })
     cy.url().should('include', '/recherche')
     cy.findByRole('link', { name: 'Rechercher (Onglet actif)' }).should(
       'have.attr',
@@ -312,24 +319,26 @@ describe('ADAGE discovery', () => {
       'page'
     )
 
-    // When I go back to search page
+    cy.stepLog({ message: 'I go back to search page' })
     cy.findByText('Lieu : Mon lieu collectif').should('be.visible')
     cy.findByRole('link', { name: 'Découvrir' }).click()
     cy.findByRole('link', { name: 'Rechercher' }).click()
 
-    // The filter has disappear
+    cy.stepLog({ message: 'The filter has disappear' })
     cy.findByText('Lieu : Mon lieu collectif').should('not.exist')
   })
 
   it('Should not keep filter venue after page change', () => {
-    // I open adage iframe
+    cy.stepLog({ message: 'I open adage iframe' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe?token=${adageToken}`)
 
-    // When I click on venue
+    cy.stepLog({ message: 'I click on venue' })
     cy.findByText('Mon lieu collectif').parent().click()
 
-    // Then the iframe search page should be displayed correctly
+    cy.stepLog({
+      message: 'the iframe search page should be displayed correctly',
+    })
     cy.url().should('include', '/recherche')
     cy.findByRole('link', { name: 'Rechercher (Onglet actif)' }).should(
       'have.attr',
@@ -337,55 +346,55 @@ describe('ADAGE discovery', () => {
       'page'
     )
 
-    // When I go back to search page
+    cy.stepLog({ message: 'I go back to search page' })
     cy.findByText('Lieu : Mon lieu collectif').should('be.visible')
     cy.findByRole('link', { name: 'Découvrir' }).click()
     cy.findByRole('link', { name: 'Rechercher' }).click()
 
-    // The filter has disappear
+    cy.stepLog({ message: 'The filter has disappear' })
     cy.findByText('Lieu : Mon lieu collectif').should('not.exist')
   })
 
   it('Should save view type in search page', () => {
-    // I open adage iframe at search page
+    cy.stepLog({ message: 'I open adage iframe at search page' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe/recherche?token=${adageToken}`)
 
-    // Then offer descriptions are displayed
+    cy.stepLog({ message: 'offer descriptions are displayed' })
     cy.findAllByTestId('offer-listitem')
     cy.findAllByTestId('offer-description').should('exist')
 
-    // When I chose grid view
+    cy.stepLog({ message: 'I chose grid view' })
     cy.findAllByTestId('toggle-button').click()
 
-    // Then offer descriptions are not displayed
+    cy.stepLog({ message: 'offer descriptions are not displayed' })
     cy.findAllByTestId('offer-listitem')
     cy.findAllByTestId('offer-description').should('not.exist')
 
-    // I put my offer in favorite
+    cy.stepLog({ message: 'I put my offer in favorite' })
     cy.findByTestId('favorite-inactive').click()
 
-    // And I go to "Mes Favoris" menu
+    cy.stepLog({ message: 'I go to "Mes Favoris" menu' })
     cy.contains('Mes Favoris').click()
 
-    // Then offer descriptions are displayed
+    cy.stepLog({ message: 'offer descriptions are displayed' })
     cy.findAllByTestId('offer-listitem')
     cy.findAllByTestId('offer-description').should('exist')
 
-    // And I go to "Rechercher" menu
+    cy.stepLog({ message: 'I go to "Rechercher" menu' })
     cy.contains('Rechercher').click()
 
-    // Then offer descriptions are not displayed
+    cy.stepLog({ message: 'offer descriptions are not displayed' })
     cy.findAllByTestId('offer-listitem')
     cy.findAllByTestId('offer-description').should('not.exist')
   })
 
   it('Should save filter when page changing', () => {
-    // I open adage iframe
+    cy.stepLog({ message: 'I open adage iframe' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe?token=${adageToken}`)
 
-    // When I choose my filters
+    cy.stepLog({ message: 'I choose my filters' })
     cy.findByText('Mon lieu collectif').parent().click()
 
     cy.wait(500) // Click on "Domaine artistique" is too fast waiting api is not enough
@@ -397,13 +406,13 @@ describe('ADAGE discovery', () => {
     cy.findByLabelText('Concert').click()
     cy.findAllByRole('button', { name: 'Rechercher' }).first().click()
 
-    // And I go to "Mes Favoris" menu
+    cy.stepLog({ message: 'I go to "Mes Favoris" menu' })
     cy.contains('Mes Favoris').click()
 
-    // And I go to "Rechercher" menu
+    cy.stepLog({ message: 'I go to "Rechercher" menu' })
     cy.contains('Rechercher').click()
 
-    // Filters are selected',
+    cy.stepLog({ message: 'Filters are selected' })
     cy.findByRole('button', { name: 'Format (1)' }).click()
     cy.findByLabelText('Concert').should('be.checked')
 
@@ -414,20 +423,21 @@ describe('ADAGE discovery', () => {
   })
 
   it('Should save page when navigating the iframe', () => {
-    // I open adage iframe at search page
+    cy.stepLog({ message: 'I open adage iframe at search page' })
     const adageToken = Cypress.env('adageToken')
     cy.visit(`/adage-iframe/recherche?token=${adageToken}`)
 
-    // I go the the next page of searched offers
+    cy.stepLog({ message: 'I go the the next page of searched offers' })
     cy.findByTestId('next-page-button').click()
     cy.findByText('Page 2/19').should('be.visible')
 
-    // And I go to "Mes Favoris" menu
+    cy.stepLog({ message: 'I go to "Mes Favoris" menu' })
     cy.contains('Mes Favoris').click()
-    // And I go to "Rechercher" menu
+
+    cy.stepLog({ message: 'I go to "Rechercher" menu' })
     cy.contains('Rechercher').click()
 
-    // page has not changed
+    cy.stepLog({ message: 'page has not changed' })
     cy.findByText('Page 2/19').should('be.visible')
   })
 })

--- a/pro/cypress/e2e/migrations/createAccount.cy.ts
+++ b/pro/cypress/e2e/migrations/createAccount.cy.ts
@@ -2,7 +2,9 @@ describe('Account creation', () => {
   it('should create an account', () => {
     cy.visit('/inscription')
 
-    // I fill required information in create account form
+    cy.stepLog({
+      message: 'I fill required information in create account form',
+    })
     cy.findByLabelText('Nom *').type('LEMOINE')
     cy.findByLabelText('Prénom *').type('Jean')
     cy.findByLabelText('Adresse email *').type(
@@ -11,13 +13,13 @@ describe('Account creation', () => {
     cy.findByLabelText('Mot de passe *').type('ValidPassword12!')
     cy.findByPlaceholderText('6 12 34 56 78').type('612345678')
 
-    // I submit
+    cy.stepLog({ message: 'I submit' })
     cy.intercept({ method: 'POST', url: '/v2/users/signup/pro' }).as(
       'signupUser'
     )
     cy.findByText('Créer mon compte').click()
 
-    // Then my account should be created
+    cy.stepLog({ message: 'my account should be created' })
     cy.wait('@signupUser').its('response.statusCode').should('eq', 204)
     cy.url().should('contain', '/inscription/confirmation')
     cy.contains('Votre compte est en cours de création')

--- a/pro/cypress/e2e/migrations/createIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/migrations/createIndividualOffer.cy.ts
@@ -10,6 +10,7 @@ describe('Create individual offers', () => {
     }).then((response) => {
       login = response.body.user.email
     })
+    cy.stepLog({ message: 'I activate a feature flag "WIP_SPLIT_OFFER"' })
     cy.setFeatureFlags([{ name: 'WIP_SPLIT_OFFER', isActive: true }])
     cy.intercept({ method: 'GET', url: '/offers/*' }).as('getOffer')
     cy.intercept({ method: 'POST', url: '/offers/draft' }).as('postDraftOffer')
@@ -30,21 +31,24 @@ describe('Create individual offers', () => {
   })
 
   it('Should create an individual offer (event)', () => {
-    // When I go to the "Créer une offre" page
+    cy.stepLog({ message: 'I am logged in with account' })
     cy.login({
       email: login,
       password: password,
       redirectUrl: '/',
     })
     cy.findAllByTestId('spinner').should('not.exist')
+
+    cy.stepLog({
+      message: 'I want to create "Un évènement physique daté" offer',
+    })
     cy.findAllByText('Créer une offre').first().click()
 
-    // And I want to create "Un évènement physique daté" offer
     cy.findByText('Au grand public').click()
     cy.findByText('Un évènement physique daté').click()
     cy.findByText('Étape suivante').click()
 
-    // When I fill in event details
+    cy.stepLog({ message: 'I fill in event details' })
     cy.findByLabelText('Titre de l’offre *').type('Le Diner de Devs')
     cy.findByLabelText('Description').type(
       'Une PO invite des développeurs à dîner...'
@@ -54,19 +58,19 @@ describe('Create individual offers', () => {
     cy.findByLabelText('Type de spectacle *').select('Théâtre')
     cy.findByLabelText('Sous-type *').select('Comédie')
 
-    // When I validate event details step
+    cy.stepLog({ message: 'I validate event details step' })
     cy.findByText('Enregistrer et continuer').click()
     cy.wait(['@getOffer', '@postDraftOffer'])
 
-    // When I fill in event useful informations
+    cy.stepLog({ message: 'I fill in event useful informations' })
     cy.findByText('Retrait sur place (guichet, comptoir...)').click()
     cy.findByLabelText('Email de contact *').type('passculture@example.com')
 
-    // When I validate event useful informations step
+    cy.stepLog({ message: 'I validate event useful informations step' })
     cy.findByText('Enregistrer et continuer').click()
     cy.wait(['@getOffer', '@patchOffer'])
 
-    // When I fill in prices
+    cy.stepLog({ message: 'I fill in prices' })
     cy.findByLabelText('Intitulé du tarif *').should(
       'have.value',
       'Tarif unique'
@@ -101,13 +105,13 @@ describe('Create individual offers', () => {
 
     cy.findByText('Accepter les réservations “Duo“').should('exist')
 
-    // When I validate prices step
+    cy.stepLog({ message: 'I validate prices step' })
     cy.findByText('Enregistrer et continuer').click()
     cy.wait(['@patchOffer', '@getOffer', '@getStocks'], {
       responseTimeout: 60 * 1000 * 3,
     })
 
-    // When I fill in recurrence
+    cy.stepLog({ message: 'I fill in recurrence' })
     cy.findByText('Ajouter une ou plusieurs dates').click()
 
     cy.findByText('Toutes les semaines').click()
@@ -158,14 +162,14 @@ describe('Create individual offers', () => {
     // manque un data-testid ou un placeholder ou un label accessible
     cy.get('[name="bookingLimitDateInterval"]').type('3')
 
-    // When I validate recurrence step
+    cy.stepLog({ message: 'I validate recurrence step' })
     cy.findByText('Valider').click()
     cy.wait(['@postStocks'])
 
     cy.findByText('Enregistrer et continuer').click()
     cy.contains('Accepter les réservations "Duo" : Oui')
 
-    // When I publish my offer
+    cy.stepLog({ message: 'I publish my offer' })
     cy.findByText('Publier l’offre').click()
     cy.findByText('Plus tard').click()
     cy.wait('@publishOffer', {
@@ -175,7 +179,7 @@ describe('Create individual offers', () => {
     })
     cy.wait('@getOffer', { timeout: 60000 })
 
-    // When I go to the offers list
+    cy.stepLog({ message: 'I go to the offers list' })
     cy.findByText('Voir la liste des offres').click()
     cy.wait(
       [
@@ -190,7 +194,7 @@ describe('Create individual offers', () => {
       }
     )
 
-    // Then my new offer should be displayed
+    cy.stepLog({ message: 'my new offer should be displayed' })
     cy.url().should('contain', '/offres')
     cy.contains('Le Diner de Devs')
     cy.contains('396 dates')
@@ -201,7 +205,7 @@ describe('Create individual offers', () => {
     const offerDesc =
       'Une quête pour obtenir la question ultime sur la vie, l’univers et tout le reste.'
 
-    // When I go to the "Créer une offre" page
+    cy.stepLog({ message: 'I am logged in with account' })
     cy.login({
       email: login,
       password: password,
@@ -210,12 +214,12 @@ describe('Create individual offers', () => {
     cy.findAllByTestId('spinner').should('not.exist')
     cy.findAllByText('Créer une offre').first().click()
 
-    // And I want to create "Un bien physique" offer
+    cy.stepLog({ message: 'I want to create "Un bien physique" offer' })
     cy.findByText('Au grand public').click()
     cy.findByText('Un bien physique').click()
     cy.findByText('Étape suivante').click()
 
-    // When('I fill in details for physical offer', () => {
+    cy.stepLog({ message: 'I fill in details for physical offer' })
     cy.findByLabelText('Titre de l’offre *').type(offerTitle)
     cy.findByLabelText('Description').type(offerDesc)
 
@@ -240,7 +244,7 @@ describe('Create individual offers', () => {
     cy.findByText('Suivant').click()
     cy.findByText('Enregistrer').click()
 
-    // Then the details of offer should be correct
+    cy.stepLog({ message: 'the details of offer should be correct' })
     cy.findByLabelText('Titre de l’offre *').should('have.value', offerTitle)
     cy.findByLabelText('Description').should('have.text', offerDesc)
 
@@ -256,11 +260,11 @@ describe('Create individual offers', () => {
         .and('eq', 705)
     })
 
-    // When I validate offer details step
+    cy.stepLog({ message: 'I validate offer details step' })
     cy.findByText('Enregistrer et continuer').click()
     cy.wait(['@getOffer', '@postDraftOffer'])
 
-    // When I fill in useful informations for physical offer
+    cy.stepLog({ message: 'I fill in useful informations for physical offer' })
     cy.findByLabelText('Informations de retrait').type(
       'Seuls les dauphins et les souris peuvent le lire.'
     )
@@ -271,22 +275,22 @@ describe('Create individual offers', () => {
 
     cy.findByText('Être notifié par email des réservations').click()
 
-    // When I validate offer useful informations step
+    cy.stepLog({ message: 'I validate offer useful informations step' })
     cy.findByText('Enregistrer et continuer').click()
     cy.wait(['@getOffer', '@patchOffer'])
 
-    // When I fill in stocks
+    cy.stepLog({ message: 'I fill in stocks' })
     cy.get('#price').type('42')
     cy.get('#bookingLimitDatetime').type('2042-05-03')
     cy.get('#quantity').type('42')
 
-    // When I validate stocks step
+    cy.stepLog({ message: 'I validate stocks step' })
     cy.findByText('Enregistrer et continuer').click()
     cy.wait(['@patchOffer', '@postStocks', '@getOffer'], {
       responseTimeout: 30 * 1000,
     })
 
-    // When I publish my offer
+    cy.stepLog({ message: 'I publish my offer' })
     cy.findByText('Publier l’offre').click()
     cy.findByText('Plus tard').click()
     cy.wait('@publishOffer', {
@@ -296,7 +300,7 @@ describe('Create individual offers', () => {
     })
     cy.wait('@getOffer', { timeout: 60000 })
 
-    // When I go to the offers list
+    cy.stepLog({ message: 'I go to the offers list' })
     cy.findByText('Voir la liste des offres').click()
     cy.wait(
       [
@@ -311,7 +315,7 @@ describe('Create individual offers', () => {
       }
     )
 
-    // Then my new physical offer should be displayed
+    cy.stepLog({ message: 'my new physical offer should be displayed' })
     cy.contains('H2G2 Le Guide du voyageur galactique')
     cy.get('@ean').then((ean) => {
       cy.contains(ean.toString())

--- a/pro/cypress/e2e/migrations/editDigitalIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/migrations/editDigitalIndividualOffer.cy.ts
@@ -14,19 +14,20 @@ describe('Modify a digital individual offer', () => {
   })
 
   it('I should be able to modify the url of a digital offer', function () {
-    // I am logged in with account 2
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
       redirectUrl: '/',
     })
-    // I go to the "Offres" page
+
+    cy.stepLog({ message: 'I go to the "Offres" page' })
     cy.url().then((urlSource) => {
       cy.findAllByText('Offres').first().click()
       cy.url().should('not.equal', urlSource)
     })
 
-    // I open the first offer in the list
+    cy.stepLog({ message: 'I open the first offer in the list' })
     cy.findAllByTestId('offer-item-row')
       .first()
       .within(() => {
@@ -34,15 +35,15 @@ describe('Modify a digital individual offer', () => {
       })
     cy.url().should('contain', '/recapitulatif')
 
-    // I display Informations pratiques tab
+    cy.stepLog({ message: 'I display Informations pratiques tab' })
     cy.findByText('Informations pratiques').click()
     cy.url().should('contain', '/pratiques')
 
-    // I edit the offer displayed
+    cy.stepLog({ message: 'I edit the offer displayed' })
     cy.get('a[aria-label^="Modifier les détails de l’offre"]').click()
     cy.url().should('contain', '/edition/pratiques')
 
-    // I update the url link
+    cy.stepLog({ message: 'I update the url link' })
     const randomUrl = `http://myrandomurl.fr/`
     cy.get('input#url').clear().type(randomUrl)
     cy.findByText('Enregistrer les modifications').click()
@@ -55,7 +56,7 @@ describe('Modify a digital individual offer', () => {
     cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
     cy.contains('Offres individuelles')
 
-    // I open the first offer in the list
+    cy.stepLog({ message: 'I open the first offer in the list' })
     cy.findAllByTestId('offer-item-row')
       .first()
       .within(() => {
@@ -63,11 +64,13 @@ describe('Modify a digital individual offer', () => {
       })
     cy.url().should('contain', '/recapitulatif')
 
-    // I display Informations pratiques tab
+    cy.stepLog({ message: 'I display Informations pratiques tab' })
     cy.findByText('Informations pratiques').click()
     cy.url().should('contain', '/pratiques')
 
-    // the url updated is retrieved in the details of the offer
+    cy.stepLog({
+      message: 'the url updated is retrieved in the details of the offer',
+    })
     cy.contains('URL d’accès à l’offre : ' + randomUrl)
   })
 })

--- a/pro/cypress/e2e/migrations/navigation.cy.ts
+++ b/pro/cypress/e2e/migrations/navigation.cy.ts
@@ -13,6 +13,7 @@ describe('Navigation', () => {
   })
 
   it('I should see the top of the page when changing page', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
@@ -23,17 +24,17 @@ describe('Navigation', () => {
     cy.findByText('Ajouter un lieu')
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I scroll to my venue
+    cy.stepLog({ message: 'I scroll to my venue' })
     cy.findByText('Votre page partenaire').scrollIntoView().should('be.visible')
     cy.findByText('Vos adresses').scrollIntoView().should('be.visible')
     cy.get('[id=content-wrapper]').then((el) => {
       expect(el.get(0).scrollTop).to.be.greaterThan(0)
     })
 
-    // I want to update that venue
+    cy.stepLog({ message: 'I want to update that venue' })
     cy.get('a[aria-label^="Gérer la page Mon Lieu"]').click()
 
-    // I should be at the top of the page
+    cy.stepLog({ message: 'I should be at the top of the page' })
     cy.get('[id=top-page]').should('have.focus', { timeout: 1000 })
     cy.get('[id=content-wrapper]').then((el) => {
       expect(el.get(0).scrollTop).to.eq(0)

--- a/pro/cypress/e2e/migrations/searchCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/migrations/searchCollectiveOffer.cy.ts
@@ -18,27 +18,28 @@ describe('Search collective offers', () => {
   })
 
   it('A search with several filters should display expected results', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
       redirectUrl: '/',
     })
 
-    // I go to Offres collectives view
+    cy.stepLog({ message: 'I go to Offres collectives view' })
     cy.visit('/offres/collectives')
     cy.wait('@collectiveOffers')
 
-    // I select "Mon Lieu" in "Lieu"
+    cy.stepLog({ message: 'I select "Mon Lieu" in "Lieu"' })
     cy.findByLabelText('Lieu').select(venueName)
 
-    // I select "Projection audiovisuelle" in "Format"
+    cy.stepLog({ message: 'I select "Projection audiovisuelle" in "Format"' })
     cy.findByLabelText('Format').select('Projection audiovisuelle')
 
-    // I validate my collective filters
+    cy.stepLog({ message: 'I validate my collective filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@collectiveOffers')
 
-    // These 5 results should be displayed
+    cy.stepLog({ message: 'These 5 results should be displayed' })
     const data = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Status'],
       ['', '', offerName, venueName, 'Tous les établissements', 'publiée'],

--- a/pro/cypress/e2e/migrations/searchIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/migrations/searchIndividualOffer.cy.ts
@@ -53,6 +53,7 @@ describe('Search individual offers', () => {
   })
 
   it('A search with a name should display expected results', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
@@ -64,16 +65,16 @@ describe('Search individual offers', () => {
     })
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I search with the text "Une super offre"
+    cy.stepLog({ message: 'I search with the text "Une super offre"' })
     cy.findByPlaceholderText('Rechercher par nom d’offre ou par EAN-13').type(
       offerName1
     )
 
-    // I validate my filters
+    cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@searchOffers').its('response.statusCode').should('eq', 200)
 
-    // These results should be displayed
+    cy.stepLog({ message: 'These results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName1, venueName, '1 000', 'publiée'],
@@ -87,6 +88,8 @@ describe('Search individual offers', () => {
 
   it('A search with a EAN should display expected results', () => {
     const ean = '1234567891234'
+
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
@@ -98,16 +101,16 @@ describe('Search individual offers', () => {
     })
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I search with the text "1234567891234"
+    cy.stepLog({ message: 'I search with the text:' + ean })
     cy.findByPlaceholderText('Rechercher par nom d’offre ou par EAN-13').type(
       ean
     )
 
-    // I validate my filters
+    cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@searchOffers').its('response.statusCode').should('eq', 200)
 
-    // This results should be displayed
+    cy.stepLog({ message: 'These results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName2 + ean, venueName, '1 000', 'publiée'],
@@ -120,6 +123,7 @@ describe('Search individual offers', () => {
   })
 
   it('A search with "Catégories" filter should display expected results', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
@@ -131,14 +135,14 @@ describe('Search individual offers', () => {
     })
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I select "Instrument de musique" in "Catégories"
+    cy.stepLog({ message: 'I select "Instrument de musique" in "Catégories"' })
     cy.findByLabelText('Catégories').select('Instrument de musique')
 
-    // I validate my filters
+    cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@searchOffers').its('response.statusCode').should('eq', 200)
 
-    // These results should be displayed
+    cy.stepLog({ message: 'These results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName3, venueName, '1 000', 'publiée'],
@@ -151,6 +155,7 @@ describe('Search individual offers', () => {
   })
 
   it('A search by offer status should display expected results', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
@@ -162,16 +167,16 @@ describe('Search individual offers', () => {
     })
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I select "Publiée" in offer status
+    cy.stepLog({ message: 'I select "Publiée" in offer status' })
     cy.findByTestId('wrapper-status').within(() => {
       cy.get('select').select('Publiée')
     })
 
-    // I validate my filters
+    cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@searchOffers').its('response.statusCode').should('eq', 200)
 
-    // These results should be displayed
+    cy.stepLog({ message: 'These results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName6, venueName, '1 000', 'publiée'],
@@ -189,6 +194,7 @@ describe('Search individual offers', () => {
   })
 
   it('A search by date should display expected results', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
@@ -200,16 +206,16 @@ describe('Search individual offers', () => {
     })
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I select a date in one month
+    cy.stepLog({ message: 'I select a date in one month' })
     const dateSearch = format(addDays(new Date(), 30), 'yyyy-MM-dd')
     cy.findByLabelText('Début de la période').type(dateSearch)
     cy.findByLabelText('Fin de la période').type(dateSearch)
 
-    // I validate my filters
+    cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@searchOffers').its('response.statusCode').should('eq', 200)
 
-    // These results should be displayed
+    cy.stepLog({ message: 'These results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName4, venueName, '1 000', 'publiée'],
@@ -222,6 +228,7 @@ describe('Search individual offers', () => {
   })
 
   it('A search combining several filters should display expected results', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
@@ -234,31 +241,31 @@ describe('Search individual offers', () => {
 
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I search with the text "Livre"
+    cy.stepLog({ message: 'I search with the text "Livre"' })
     cy.findByPlaceholderText('Rechercher par nom d’offre ou par EAN-13').type(
       'incroyable'
     )
 
-    // I validate my filters)
+    cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@searchOffers').its('response.statusCode').should('eq', 200)
 
-    // I select "Livre" in "Catégories"
+    cy.stepLog({ message: 'I select "Livre" in "Catégories"' })
     cy.findByLabelText('Catégories').select('Livre')
 
-    // I select "Librairie 10" in "Lieu"
+    cy.stepLog({ message: 'I select "Librairie 10" in "Lieu"' })
     cy.findByLabelText('Lieu').select(venueName)
 
-    // I select "Publiée" in offer status
+    cy.stepLog({ message: 'I select "Publiée" in offer status' })
     cy.findByTestId('wrapper-status').within(() => {
       cy.get('select').select('Publiée')
     })
 
-    // I validate my filters
+    cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@searchOffers').its('response.statusCode').should('eq', 200)
 
-    // These 2 results should be displayed
+    cy.stepLog({ message: 'These 2 results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName6, venueName, '1 000', 'publiée'],
@@ -270,10 +277,10 @@ describe('Search individual offers', () => {
 
     expectOffersAreFound(expectedResults)
 
-    // I reset all filters
+    cy.stepLog({ message: 'I reset all filters' })
     cy.findByText('Réinitialiser les filtres').click()
 
-    // All filters are empty
+    cy.stepLog({ message: 'All filters are empty' })
     cy.findByPlaceholderText('Rechercher par nom d’offre ou par EAN-13').should(
       'be.empty'
     )
@@ -292,7 +299,7 @@ describe('Search individual offers', () => {
     cy.findByLabelText('Début de la période').invoke('val').should('be.empty')
     cy.findByLabelText('Fin de la période').invoke('val').should('be.empty')
 
-    // These results should be displayed
+    cy.stepLog({ message: 'These results should be displayed' })
     const expectedResults2 = [
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName7, venueName, '0', 'épuisée'],

--- a/pro/cypress/e2e/migrations/signupJourneyCreateOfferer.cy.ts
+++ b/pro/cypress/e2e/migrations/signupJourneyCreateOfferer.cy.ts
@@ -82,15 +82,17 @@ describe('Signup journey with new venue', () => {
   })
 
   it('Should sign up with a new account, create a new offerer with an unknown SIRET', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
       redirectUrl: '/',
     })
-    // When I start offerer creation
+
+    cy.stepLog({ message: 'I start offerer creation' })
     cy.findByText('Commencer').click()
 
-    // When I specify a venue with a SIRET
+    cy.stepLog({ message: 'I specify a venue with a SIRET' })
     cy.url().should('contain', '/parcours-inscription/structure')
     cy.findByLabelText('Numéro de SIRET à 14 chiffres *').type(mySiret)
     cy.findByText('Continuer').click()
@@ -108,7 +110,7 @@ describe('Signup journey with new venue', () => {
       }
     )
 
-    // When I fill identification form with a public name
+    cy.stepLog({ message: 'I fill identification form with a public name' })
     cy.url().should('contain', '/parcours-inscription/identification')
     cy.findByLabelText('Nom public').type('First Venue')
     cy.intercept({
@@ -119,7 +121,7 @@ describe('Signup journey with new venue', () => {
     cy.findByText('Étape suivante').click()
     cy.wait('@venue-types').its('response.statusCode').should('eq', 200)
 
-    // When I fill activity form without target audience
+    cy.stepLog({ message: 'I fill activity form without target audience' })
     cy.url().should('contain', '/parcours-inscription/activite')
     cy.findByLabelText('Activité principale *').select('Spectacle vivant')
     cy.findByText('Étape suivante').click()
@@ -127,27 +129,27 @@ describe('Signup journey with new venue', () => {
       'Veuillez sélectionner une des réponses ci-dessus'
     )
 
-    // Then an error message is raised
+    cy.stepLog({ message: 'an error message is raised' })
     cy.findByTestId('global-notification-error')
       .contains('Une ou plusieurs erreurs sont présentes dans le formulaire')
       .should('not.be.visible')
 
-    // When I fill in missing target audience
+    cy.stepLog({ message: 'I fill in missing target audience' })
     cy.url().should('contain', '/parcours-inscription/activite')
     cy.findByText('Au grand public').click()
     cy.findByText('Étape suivante').click()
 
-    // The next step is displayed
+    cy.stepLog({ message: 'the next step is displayed' })
     cy.url().should('contain', '/parcours-inscription/validation')
 
-    // When I validate the registration
+    cy.stepLog({ message: 'I validate the registration' })
     cy.intercept({ method: 'POST', url: '/offerers/new', times: 1 }).as(
       'createOfferer'
     )
     cy.findByText('Valider et créer ma structure').click()
     cy.wait('@createOfferer')
 
-    // Then the offerer is created
+    cy.stepLog({ message: 'the offerer is created' })
     cy.findAllByTestId('global-notification-success')
       .contains('Votre structure a bien été créée')
       .should('not.be.visible')
@@ -199,15 +201,17 @@ describe('Signup journey with known venue', () => {
   })
 
   it('Should sign up with a new account and a known offerer, create a new offerer in the space', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
       redirectUrl: '/',
     })
-    // When I start offerer creation
+
+    cy.stepLog({ message: 'I start offerer creation' })
     cy.findByText('Commencer').click()
 
-    // When I specify an offerer with a SIRET
+    cy.stepLog({ message: 'I specify an offerer with a SIRET' })
     cy.url().should('contain', '/parcours-inscription/structure')
     cy.findByLabelText('Numéro de SIRET à 14 chiffres *').type(mySiret)
     cy.findByText('Continuer').click()
@@ -225,7 +229,7 @@ describe('Signup journey with known venue', () => {
       }
     )
 
-    // When I add a new offerer
+    cy.stepLog({ message: 'I add a new offerer' })
     cy.url().should('contain', '/parcours-inscription/structure/rattachement')
     cy.intercept(
       'GET',
@@ -234,7 +238,7 @@ describe('Signup journey with known venue', () => {
     cy.findByText('Ajouter une nouvelle structure').click()
     cy.wait('@search5Address')
 
-    // When I fill identification form with a new address
+    cy.stepLog({ message: 'I fill identification form with a new address' })
     cy.url().should('contain', '/parcours-inscription/identification')
     cy.findByLabelText('Adresse postale *').clear()
     cy.findByLabelText('Adresse postale *').invoke(
@@ -257,7 +261,7 @@ describe('Signup journey with known venue', () => {
     cy.findByText('Étape suivante').click()
     cy.wait('@venue-types').its('response.statusCode').should('eq', 200)
 
-    // When I fill activity form without main activity
+    cy.stepLog({ message: 'I fill activity form without main activity' })
     cy.url().should('contain', '/parcours-inscription/activite')
     cy.findByLabelText('Activité principale *').select(
       'Sélectionnez votre activité principale'
@@ -268,27 +272,27 @@ describe('Signup journey with known venue', () => {
       'Veuillez sélectionner une activité principale'
     )
 
-    // Then An error message is raised
+    cy.stepLog({ message: 'an error message is raised' })
     cy.findByTestId('global-notification-error')
       .contains('Une ou plusieurs erreurs sont présentes dans le formulaire')
       .should('not.be.visible')
 
-    // When I fill in missing main activity
+    cy.stepLog({ message: 'I fill in missing main activity' })
     cy.url().should('contain', '/parcours-inscription/activite')
     cy.findByLabelText('Activité principale *').select('Spectacle vivant')
     cy.findByText('Étape suivante').click()
 
-    // Then The next step is displayed
+    cy.stepLog({ message: 'the next step is displayed' })
     cy.url().should('contain', '/parcours-inscription/validation')
 
-    // When I validate the registration
+    cy.stepLog({ message: 'I validate the registration' })
     cy.intercept({ method: 'POST', url: '/offerers/new', times: 1 }).as(
       'createOfferer'
     )
     cy.findByText('Valider et créer ma structure').click()
     cy.wait('@createOfferer')
 
-    // Then the offerer is created
+    cy.stepLog({ message: 'the offerer is created' })
     cy.findAllByTestId('global-notification-success')
       .contains('Votre structure a bien été créée')
       .should('not.be.visible')
@@ -299,23 +303,24 @@ describe('Signup journey with known venue', () => {
     cy.reload()
     cy.wait('@getOfferers').its('response.statusCode').should('eq', 200)
 
-    // Then the attachment is in progress
+    cy.stepLog({ message: 'the attachment is in progress' })
     cy.contains(
       'Le rattachement à votre structure est en cours de traitement par les équipes du pass Culture'
     ).should('be.visible')
   })
 
   it('Should sign up with a new account and a known offerer', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
       redirectUrl: '/',
     })
 
-    // When I start offerer creation
+    cy.stepLog({ message: 'I start offerer creation' })
     cy.findByText('Commencer').click()
 
-    // When I specify an offerer with a SIRET
+    cy.stepLog({ message: 'I specify an offerer with a SIRET' })
     cy.url().should('contain', '/parcours-inscription/structure')
     cy.findByLabelText('Numéro de SIRET à 14 chiffres *').type(mySiret)
     cy.findByText('Continuer').click()
@@ -333,17 +338,14 @@ describe('Signup journey with known venue', () => {
       }
     )
 
-    // When I chose to join the space
+    cy.stepLog({ message: 'I chose to join the space' })
     cy.contains('Rejoindre cet espace').click()
-
     cy.intercept({ method: 'POST', url: '/offerers' }).as('postOfferers')
     cy.findByTestId('confirm-dialog-button-confirm').click()
     cy.wait('@postOfferers').its('response.statusCode').should('eq', 201)
-
-    // Confirmation page
     cy.contains('Accéder à votre espace').click()
 
-    // When I am redirected to homepage
+    cy.stepLog({ message: 'I am redirected to homepage' })
     cy.url({ timeout: 10000 }).should('contain', '/accueil')
     cy.findAllByTestId('spinner', { timeout: 30 * 1000 }).should('not.exist')
 
@@ -351,7 +353,7 @@ describe('Signup journey with known venue', () => {
     cy.reload()
     cy.wait('@getOfferers').its('response.statusCode').should('eq', 200)
 
-    // Then the attachment is in progress
+    cy.stepLog({ message: 'the attachment is in progress' })
     cy.contains(
       'Le rattachement à votre structure est en cours de traitement par les équipes du pass Culture'
     ).should('be.visible')

--- a/pro/cypress/e2e/migrations/venue.cy.ts
+++ b/pro/cypress/e2e/migrations/venue.cy.ts
@@ -23,19 +23,19 @@ describe('Create and update venue', () => {
 
   it('A pro user can add a venue without SIRET', () => {
     const venueNameWithoutSiret = 'Lieu sans Siret'
-
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
     })
 
-    // I want to add a venue
+    cy.stepLog({ message: 'I want to add a venue' })
     cy.findByText('Ajouter un lieu', { timeout: 60 * 1000 }).click()
 
-    // I choose a venue which already has a Siret
+    cy.stepLog({ message: 'I choose a venue which already has a Siret' })
     cy.findByText('Ce lieu possède un SIRET').click()
 
-    // I add venue without Siret details
+    cy.stepLog({ message: 'I add venue without Siret details' })
     cy.findByLabelText('Commentaire du lieu sans SIRET *').type(
       'Commentaire du lieu sans SIRET'
     )
@@ -49,17 +49,17 @@ describe('Create and update venue', () => {
     cy.findByText('Visuel').click()
     cy.findByLabelText('Adresse email *').type('email@example.com')
 
-    // I validate venue step
+    cy.stepLog({ message: 'I validate venue step' })
     cy.findByText('Enregistrer et créer le lieu').click()
     cy.wait('@postVenues', { timeout: 60 * 1000 })
       .its('response.statusCode')
       .should('eq', 201)
 
-    // I skip offer creation
+    cy.stepLog({ message: 'I skip offer creation' })
     cy.findByText('Plus tard').click()
     cy.url().should('contain', 'accueil')
 
-    // I open my venue without Siret resume
+    cy.stepLog({ message: 'I open my venue without Siret resume' })
     cy.findByRole('link', {
       name: 'Gérer la page de ' + venueNameWithoutSiret,
     }).click()
@@ -67,7 +67,7 @@ describe('Create and update venue', () => {
     cy.findAllByTestId('spinner').should('not.exist')
     cy.contains(venueNameWithoutSiret).should('be.visible')
 
-    // I add an image to my venue
+    cy.stepLog({ message: 'I add an image to my venue' })
     cy.findByText('Ajouter une image').click()
     cy.get('input[type=file]').selectFile('cypress/data/dog.jpg', {
       force: true,
@@ -81,11 +81,13 @@ describe('Create and update venue', () => {
       'Prévisualisation de votre image dans l’application pass Culture'
     )
     cy.findByText('Enregistrer').click()
+
+    cy.stepLog({ message: 'I should see a success message' })
     cy.findByTestId('global-notification-success', {
       timeout: 30 * 1000,
     }).should('contain', 'Vos modifications ont bien été prises en compte')
 
-    // I should see details of my venue
+    cy.stepLog({ message: 'I should see details of my venue' })
     cy.contains(venueNameWithoutSiret)
     cy.findByText('Modifier l’image').should('be.visible')
   })
@@ -112,37 +114,38 @@ describe('Create and update venue', () => {
       })
     ).as('getSiretVenue')
 
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
     })
 
-    // I want to add a venue
+    cy.stepLog({ message: 'I want to add a venue' })
     cy.findByText('Ajouter un lieu', { timeout: 60 * 1000 }).click()
 
-    // I add a valid Siret
+    cy.stepLog({ message: 'I add a valid Siret' })
     cy.findByLabelText('SIRET du lieu *').type(siret + '{enter}')
     cy.wait(['@getSiretVenue', '@searchAddress'])
     cy.findByTestId('error-siret').should('not.exist')
 
-    // I add venue with Siret details
+    cy.stepLog({ message: 'I add venue with Siret details' })
     cy.findByLabelText('Nom public').type(venueNameWithSiret)
     cy.findByLabelText('Activité principale *').select('Festival')
     cy.findByText('Moteur').click()
     cy.findByText('Auditif').click()
     cy.findByLabelText('Adresse email *').type('email@example.com')
 
-    // I validate venue step
+    cy.stepLog({ message: 'I validate venue step' })
     cy.findByText('Enregistrer et créer le lieu').click()
     cy.wait('@postVenues', { timeout: 60 * 1000 })
       .its('response.statusCode')
       .should('eq', 201)
 
-    // I skip offer creation
+    cy.stepLog({ message: 'I skip offer creation' })
     cy.findByText('Plus tard').click()
     cy.url().should('contain', 'accueil')
 
-    // I should see my venue with Siret resume
+    cy.stepLog({ message: 'I should see my venue with Siret resume' })
     cy.reload() // newly created venue sometimes not displayed
     cy.findByRole('link', {
       name: 'Gérer la page de ' + venueNameWithSiret + '',
@@ -151,12 +154,13 @@ describe('Create and update venue', () => {
   })
 
   it('It should update a venue', () => {
+    cy.stepLog({ message: 'I am logged in' })
     cy.login({
       email: login,
       password: password,
     })
 
-    // I go to the venue page in Individual section
+    cy.stepLog({ message: 'I go to the venue page in Individual section' })
     cy.findByText('Votre page partenaire', { timeout: 60 * 1000 })
       .scrollIntoView()
       .should('be.visible')
@@ -165,7 +169,7 @@ describe('Create and update venue', () => {
     cy.findByText('À propos de votre activité').should('be.visible')
     cy.findByText('Modifier').click()
 
-    // I update Individual section data
+    cy.stepLog({ message: 'I update Individual section data' })
     cy.findAllByLabelText('Description')
       .clear()
       .type('On peut ajouter des choses, vraiment fantastique !!!')
@@ -175,14 +179,14 @@ describe('Create and update venue', () => {
     cy.findByText('Enregistrer').click()
     cy.wait('@patchVenue')
 
-    // Individual section data should be updated
+    cy.stepLog({ message: 'Individual section data should be updated' })
     cy.url().should('include', '/structures').and('include', '/lieux')
     cy.findByText('Vos informations pour le grand public').should('be.visible')
     cy.findByText(
       'On peut ajouter des choses, vraiment fantastique !!!'
     ).should('be.visible')
 
-    // I go to the venue page in Paramètres généraux
+    cy.stepLog({ message: 'I go to the venue page in Paramètres généraux' })
     cy.findAllByTestId('spinner').should('not.exist')
     cy.findByText('Paramètres généraux').click()
     cy.url()
@@ -191,7 +195,7 @@ describe('Create and update venue', () => {
       .and('include', '/parametres')
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I update Paramètres généraux data
+    cy.stepLog({ message: 'I update Paramètres généraux data' })
     cy.findByLabelText(
       'Label du ministère de la Culture ou du Centre national du cinéma et de l’image animée'
     ).select('Musée de France')
@@ -204,13 +208,13 @@ describe('Create and update venue', () => {
     cy.wait('@patchVenue')
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // I go to the venue page in Paramètres généraux
+    cy.stepLog({ message: 'I go to the venue page in Paramètres généraux' })
     cy.url().should('not.include', '/parametres')
     cy.findByText('Paramètres généraux').click()
     cy.url().should('include', '/parametres')
     cy.findAllByTestId('spinner').should('not.exist')
 
-    // Paramètres généraux data should be updated
+    cy.stepLog({ message: 'paramètres généraux data should be updated' })
     cy.findByText(
       'En main bien propres, avec un masque et un gel hydroalcoolique, didiou !'
     )

--- a/pro/cypress/support/commands.ts
+++ b/pro/cypress/support/commands.ts
@@ -111,4 +111,75 @@ Cypress.Commands.add(
   }
 )
 
+// Workaround to format log. See https://github.com/cypress-io/cypress/issues/2134
+// and https://github.com/cypress-io/cypress/issues/2134#issuecomment-1692593562
+
+/**
+ *  Helper function to convert hex colors to rgb
+ * @param {string} hex - hex color
+ * @returns {string}
+ *
+ * @example
+ * // returns "255 255 255"
+ * hex2rgb("#ffffff")
+ */
+function hex2rgb(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+
+  return `${r} ${g} ${b}`
+}
+
+const yellow = '#fbbf24' // Yellow
+export function createCustomLog() {
+  const logStyle = document.createElement('style')
+
+  logStyle.textContent = `
+        .command.command-name-ptf-STEP span.command-method {
+            margin-right: 0.5rem;
+            min-width: 10px;
+            border-radius: 0.125rem;
+            border-width: 1px;
+            padding-left: 0.375rem;
+            padding-right: 0.375rem;
+            padding-top: 0.125rem;
+            padding-bottom: 0.125rem;
+            text-transform: uppercase;
+
+            border-color: rgb(${hex2rgb(yellow)} / 1);
+            background-color: rgb(${hex2rgb(yellow)} / 0.2);
+            color: rgb(${hex2rgb(yellow)} / 1) !important;
+        }
+
+        .command.command-name-ptf-STEP span.command-message{
+            color: rgb(${hex2rgb(yellow)} / 1);
+            font-weight: normal;
+        }
+
+        .command.command-name-ptf-STEP span.command-message strong,
+        .command.command-name-ptf-STEP span.command-message em { 
+            color: rgb(${hex2rgb(yellow)} / 1);
+        }
+    ` // @ts-expect-error: Object is possibly 'null'.
+  Cypress.$(window.top.document.head).append(logStyle)
+}
+
+/**
+ * Print in Cypress UI/Cloud a message with a formatted style
+ * @param {string} log.message - The content of the message.
+ *
+ * @example
+ * cy.stepLog({ message: 'I do this' })
+ */
+
+Cypress.Commands.add('stepLog', ({ message }) => {
+  createCustomLog()
+  Cypress.log({
+    name: `ptf-STEP`,
+    displayName: `STEP`,
+    message,
+  })
+})
+
 export {}

--- a/pro/cypress/support/index.d.ts
+++ b/pro/cypress/support/index.d.ts
@@ -14,6 +14,8 @@ declare namespace Cypress {
     getFakeAdageToken(): Chainable
 
     setSliderValue(value: number): Chainable<void>
+
+    stepLog(params: { message: string }): Chainable
   }
 }
 


### PR DESCRIPTION
## But de la pull request

Avant, avec Cucumber, on retrouvait les différentes étapes (Given, When, Then) du Gherkin dans la vue des différentes étapes sur Cypress Cloud et dans l'ui Cypress qu'on lance en local.

![AvantAvecCucumber](https://github.com/user-attachments/assets/ce8291e1-9595-4ebf-9a6d-5dd9bfae2262)


Après avoir supprimé Cucumber, ces étapes n'apparaissent plus que dans le code (en commentaire) mais pas dans Cypress Cloud ni l'UI. C'est devenu difficile de suivre le déroulé.

![ApresMigrationSansCucumber](https://github.com/user-attachments/assets/ea6ceb6e-27e0-4138-8fb6-08c280039d91)


Dans cette PR, en rajoutant une commande `stepLog` on peut faire apparaitre ces steps pour plus de lisibilité.
Dans l'UI, avec un peu de couleur:

![CypressUI](https://github.com/user-attachments/assets/73d4d286-0506-451a-a37a-9ca23b471302)

Dans Cypress Cloud, on ne retrouve hélas pas les couleurs mais on a comme avant avec Cucumber (GIVEN, WHEN, THEN en majuscule)

![RajoutDeGivenWhenThen](https://github.com/user-attachments/assets/b8e72db0-3419-4bc2-b846-f0a9496ca06e)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
