### PR TITLE
[NE PAS MERGER] (BSR)[PRO] test: start PC Pro for perf env

### DIFF
--- a/pro/src/.env.testing
+++ b/pro/src/.env.testing
@@ -1,7 +1,7 @@
-VITE_API_URL_OLD=https://backend.passculture-testing.beta.gouv.fr
-VITE_API_URL_NEW=https://backend.testing.passculture.team
-VITE_WEBAPP_URL=https://app.testing.passculture.team
-VITE_ENV_WORDING='de testing'
+VITE_API_URL_OLD=https://backend.perf.beta.gouv.fr
+VITE_API_URL_NEW=https://backend.perf.passculture.team
+VITE_WEBAPP_URL=https://app.perf.passculture.team
+VITE_ENV_WORDING='de perf'
 VITE_URL_FOR_MAINTENANCE=https://maintenance.passculture.app?source=https://pro.testing.passculture.team/
 VITE_SENTRY_SAMPLE_RATE=0.01
 VITE_SENTRY_SERVER_URL=https://50f5694849704813b4154c5868b73365@sentry.passculture.team/2


### PR DESCRIPTION
## But de la pull request

avoir une UI pour l'env de perf

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
